### PR TITLE
Add Poke plugin to bulk-delete agent suggestions

### DIFF
--- a/front/lib/api/poke/plugins/agents/clean_suggestions.ts
+++ b/front/lib/api/poke/plugins/agents/clean_suggestions.ts
@@ -1,0 +1,95 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import { mapToEnumValues } from "@app/types/poke/plugins";
+import { Err, Ok } from "@app/types/shared/result";
+import type {
+  AgentSuggestionSource,
+  AgentSuggestionState,
+} from "@app/types/suggestions/agent_suggestion";
+import {
+  AGENT_SUGGESTION_SOURCES,
+  AGENT_SUGGESTION_STATES,
+} from "@app/types/suggestions/agent_suggestion";
+
+export const cleanSuggestionsPlugin = createPlugin({
+  manifest: {
+    id: "clean-suggestions",
+    name: "Clean Suggestions",
+    description:
+      "Delete suggestions matching selected states and sources. Selections are ANDed: a suggestion must match one of the selected states AND one of the selected sources to be deleted.",
+    resourceTypes: ["agents"],
+    args: {
+      states: {
+        type: "enum",
+        label: "States",
+        description: "Select which suggestion states to delete",
+        values: mapToEnumValues(AGENT_SUGGESTION_STATES, (s) => ({
+          label: s,
+          value: s,
+        })),
+        multiple: true,
+      },
+      sources: {
+        type: "enum",
+        label: "Sources",
+        description: "Select which suggestion sources to delete",
+        values: mapToEnumValues(AGENT_SUGGESTION_SOURCES, (s) => ({
+          label: s,
+          value: s,
+        })),
+        multiple: true,
+      },
+    },
+  },
+  execute: async (auth, resource, args) => {
+    if (!resource) {
+      return new Err(new Error("Agent configuration not found"));
+    }
+
+    const selectedStates = (args.states || []) as AgentSuggestionState[];
+    const selectedSources = (args.sources || []) as AgentSuggestionSource[];
+
+    if (selectedStates.length === 0 || selectedSources.length === 0) {
+      return new Err(
+        new Error("You must select at least one state and one source.")
+      );
+    }
+
+    const suggestions =
+      await AgentSuggestionResource.listByAgentConfigurationId(
+        auth,
+        resource.sId,
+        {
+          states: selectedStates,
+          sources: selectedSources,
+        }
+      );
+
+    if (suggestions.length === 0) {
+      return new Ok({
+        display: "text",
+        value: "No suggestions matched the selected filters.",
+      });
+    }
+
+    const deleteResult = await AgentSuggestionResource.bulkDelete(
+      auth,
+      suggestions
+    );
+
+    if (deleteResult.isErr()) {
+      return new Err(deleteResult.error);
+    }
+
+    return new Ok({
+      display: "text",
+      value: `Deleted ${deleteResult.value} suggestion(s) matching states=[${selectedStates.join(", ")}] and sources=[${selectedSources.join(", ")}].`,
+    });
+  },
+  isApplicableTo: (_auth, resource) => {
+    if (!resource) {
+      return false;
+    }
+    return resource.status === "active";
+  },
+});

--- a/front/lib/api/poke/plugins/agents/index.ts
+++ b/front/lib/api/poke/plugins/agents/index.ts
@@ -1,4 +1,5 @@
 export * from "./agent_editors";
 export * from "./agent_reinforcement";
 export * from "./agent_retention";
+export * from "./clean_suggestions";
 export * from "./run_reinforced_agent";

--- a/front/lib/resources/agent_suggestion_resource.ts
+++ b/front/lib/resources/agent_suggestion_resource.ts
@@ -330,6 +330,35 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
   }
 
   /**
+   * Bulk delete a list of suggestion resources.
+   * Requires super user permissions.
+   */
+  static async bulkDelete(
+    auth: Authenticator,
+    suggestions: AgentSuggestionResource[]
+  ): Promise<Result<number, Error>> {
+    if (!auth.isDustSuperUser()) {
+      return new Err(new Error("Only super users can bulk delete suggestions"));
+    }
+
+    if (suggestions.length === 0) {
+      return new Ok(0);
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const ids = suggestions.map((s) => s.id);
+
+    const deletedCount = await AgentSuggestionModel.destroy({
+      where: {
+        workspaceId: owner.id,
+        id: ids,
+      },
+    });
+
+    return new Ok(deletedCount);
+  }
+
+  /**
    * WARNING: This method deletes ALL suggestions for a workspace.
    * Only workspace admins can perform this operation.
    * This is intended for internal use only (e.g., workspace deletion workflows).


### PR DESCRIPTION
## Description

Adds a "Clean Suggestions" Poke plugin for agents that lets admins select states (pending/approved/rejected/outdated) and sources (reinforcement/sidekick/synthetic) then deletes all matching suggestions in one operation.

<img width="899" height="470" alt="Screenshot 2026-03-31 at 13 08 18" src="https://github.com/user-attachments/assets/efbd49f2-310a-4c8c-b7a9-6af487f7eab3" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Poke only

## Deploy Plan

Front