### PR TITLE
feat: hide select all members checkbox when search has one result

### DIFF
--- a/front/components/members/MemberSelectionTable.tsx
+++ b/front/components/members/MemberSelectionTable.tsx
@@ -139,7 +139,9 @@ export function MemberSelectionTable({
 
   const columns: ColumnDef<MemberRowData>[] = useMemo(() => {
     return [
-      createSelectionColumn<MemberRowData>(),
+      createSelectionColumn<MemberRowData>({
+        hideSelectAll: !!searchText && rows.length <= 1,
+      }),
       {
         accessorKey: "fullName",
         header: "Name",
@@ -160,7 +162,7 @@ export function MemberSelectionTable({
       },
       ...(extraColumns ?? []),
     ];
-  }, [extraColumns]);
+  }, [extraColumns, rows.length, searchText]);
 
   return (
     <>

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -1278,29 +1278,36 @@ DataTable.Caption = function Caption({
   );
 };
 
-export function createSelectionColumn<TData>(): ColumnDef<TData> {
+interface SelectionColumnOptions {
+  hideSelectAll?: boolean;
+}
+
+export function createSelectionColumn<TData>({
+  hideSelectAll = false,
+}: SelectionColumnOptions = {}): ColumnDef<TData> {
   return {
     id: "select",
     enableSorting: false,
     enableHiding: false,
-    header: ({ table }) => (
-      <Checkbox
-        size="xs"
-        checked={
-          table.getIsAllRowsSelected()
-            ? true
-            : table.getIsSomeRowsSelected()
-              ? "partial"
-              : false
-        }
-        onCheckedChange={(state) => {
-          if (state === "indeterminate") {
-            return;
+    header: ({ table }) =>
+      !hideSelectAll ? (
+        <Checkbox
+          size="xs"
+          checked={
+            table.getIsAllRowsSelected()
+              ? true
+              : table.getIsSomeRowsSelected()
+                ? "partial"
+                : false
           }
-          table.toggleAllRowsSelected(state);
-        }}
-      />
-    ),
+          onCheckedChange={(state) => {
+            if (state === "indeterminate") {
+              return;
+            }
+            table.toggleAllRowsSelected(state);
+          }}
+        />
+      ) : null,
     cell: ({ row }) => (
       <div className="s-flex s-h-full s-w-full s-items-center">
         <Checkbox


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7012

This PR improves the member selection UI by hiding the "select all" checkbox when a search query returns only one result.

- Modified the `createSelectionColumn` function to accept an optional `hideSelectAll` parameter
- Applied this parameter in `MemberSelectionTable` to conditionally hide the select all checkbox when `searchText` is active and there are 1 or fewer rows


When first opening the sheet the members are not displayed correctly. This will be fixed in another pr.

## Tests

Manually

## Risks

Low - UI change only that affects the visibility of a single checkbox in a specific edge case scenario

## Deploy Plan

Standard deployment
