### PR TITLE
feat: display more avatars in project and fix plus display

### DIFF
--- a/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
+++ b/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
@@ -76,7 +76,7 @@ export function ProjectHeaderActions({
                 visual: member.image ?? undefined,
                 isRounded: true,
               }))}
-              nbVisibleItems={3}
+              nbVisibleItems={8}
               size="sm"
             />
           </div>

--- a/sparkle/src/components/Avatar.tsx
+++ b/sparkle/src/components/Avatar.tsx
@@ -394,8 +394,17 @@ Avatar.Stack = function ({
                     style={{
                       transform: `scale(${
                         onTop === "first"
-                          ? 1 - (visibleAvatars.length - 1 - i) * 0.06
-                          : 1 - (visibleAvatars.length - i) * 0.06
+                          ? 1 -
+                            (visibleAvatars.length +
+                              (remainingCount > 0 ? 1 : 0) -
+                              1 -
+                              i) *
+                              0.06
+                          : 1 -
+                            (visibleAvatars.length +
+                              (remainingCount > 0 ? 1 : 0) -
+                              i) *
+                              0.06
                       })`,
                     }}
                   >
@@ -420,14 +429,31 @@ Avatar.Stack = function ({
                   transition: transitionSettings,
                 }}
               >
-                <Avatar
-                  size={size}
-                  name={
-                    "+" +
-                    String(Number(remainingCount) < 10 ? remainingCount : "")
-                  }
-                  clickable
-                />
+                {hasMagnifier ? (
+                  <div
+                    style={{
+                      transform: `scale(${onTop === "first" ? 1 : 1 - 0.06})`,
+                    }}
+                  >
+                    <Avatar
+                      size={size}
+                      name={
+                        "+" +
+                        String(
+                          Number(remainingCount) < 10 ? remainingCount : ""
+                        )
+                      }
+                    />
+                  </div>
+                ) : (
+                  <Avatar
+                    size={size}
+                    name={
+                      "+" +
+                      String(Number(remainingCount) < 10 ? remainingCount : "")
+                    }
+                  />
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7009

This PR increases the number of visible avatars in project headers and fixes the scaling issue of the plus indicator in avatar stacks.

- Increased the number of visible avatars from 3 to 8 in `ProjectHeaderActions`
- Fixed avatar stack scaling calculation to properly account for the plus avatar when computing transforms

<img width="348" height="371" alt="Capture d’écran 2026-03-31 à 14 43 29" src="https://github.com/user-attachments/assets/afb4d95b-e091-4e40-9bcf-8d40dc847b58" />

## Tests

Manually

## Risks

Low - UI-only changes that improve visual display. No data or logic changes.

## Deploy Plan

Standard deployment
