### PR TITLE
[Front] feat(llm): show BYOK-specific error messages for unhealthy provider keys

### DIFF
--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -246,6 +246,29 @@ const USERFACING_CLIENT_ID: Record<ModelProviderIdType, string> = {
 };
 
 /**
+ * Returns BYOK-specific user-friendly error messages for errors that require
+ * workspace administrator intervention. Falls back to the generic message for
+ * error types that do not require intervention.
+ */
+export const getByokUserFacingLLMErrorMessage = (
+  type: LLMErrorType,
+  lLMClientMetadata: LLMClientMetadata
+): string => {
+  const userFacingProvider: string =
+    USERFACING_CLIENT_ID[lLMClientMetadata.clientId];
+  switch (type) {
+    case "authentication_error":
+      return `Your workspace's ${userFacingProvider} credentials are invalid. Please contact your workspace administrator to update them.`;
+    case "permission_error":
+      return `Your workspace's ${userFacingProvider} credentials do not have access to the requested model. Please contact your workspace administrator.`;
+    case "rate_limit_error":
+      return `Your workspace's ${userFacingProvider} usage limits have been exceeded. Please contact your workspace administrator.`;
+    default:
+      return getUserFacingLLMErrorMessage(type, lLMClientMetadata);
+  }
+};
+
+/**
  * Returns LLM error types to user-friendly error messages.
  */
 export const getUserFacingLLMErrorMessage = (

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -38,7 +38,10 @@ import {
 } from "@app/lib/api/assistant/skill_actions";
 import { getLLM } from "@app/lib/api/llm";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
-import { getUserFacingLLMErrorMessage } from "@app/lib/api/llm/types/errors";
+import {
+  getByokUserFacingLLMErrorMessage,
+  getUserFacingLLMErrorMessage,
+} from "@app/lib/api/llm/types/errors";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
@@ -613,23 +616,29 @@ export async function runModel(
         const errorDustRunId = llm?.getTraceId();
         const currentAttempt = Context.current().info.attempt;
         const isLastAttempt = currentAttempt >= RUN_MODEL_MAX_RETRIES;
+        const plan = auth.getNonNullablePlan();
 
         if (
-          type === "authentication_error" &&
-          auth.getNonNullablePlan().isByok &&
-          isByokProviderId(model.providerId)
+          plan.isByok &&
+          isByokProviderId(model.providerId) &&
+          (type === "authentication_error" || type === "permission_error")
         ) {
           await ProviderCredentialResource.markAsUnhealthy(auth, {
             providerId: model.providerId,
           });
         }
 
+        const errorMessage =
+          plan.isByok && isByokProviderId(model.providerId)
+            ? getByokUserFacingLLMErrorMessage(type, metadata)
+            : getUserFacingLLMErrorMessage(type, metadata);
+
         if (!isRetryable || isLastAttempt) {
           // Non-retryable errors or last retry attempt: surface error to user.
           await publishAgentError(
             {
               code: "multi_actions_error",
-              message: getUserFacingLLMErrorMessage(type, metadata),
+              message: errorMessage,
               metadata: null,
             },
             errorDustRunId
@@ -638,9 +647,7 @@ export async function runModel(
         }
 
         // Throw to let Temporal handle the retry via its retry policy.
-        throw new Error(
-          `LLM error (${type}): ${getUserFacingLLMErrorMessage(type, metadata)}`
-        );
+        throw new Error(`LLM error (${type}): ${errorMessage}`);
       }
       case "shouldReturnNull":
         return null;


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/6970

When a BYOK workspace's provider key causes an LLM error (401 authentication, 403 permission, 429 rate limit), users see a generic message that doesn't help them understand the issue is on their side. This change surfaces BYOK-specific messages directing users to contact their workspace administrator.

Also extends `markAsUnhealthy` to trigger on `permission_error` (403), not just `authentication_error` (401).

## Test

<img width="1669" height="654" alt="image" src="https://github.com/user-attachments/assets/b9ed86c4-ee04-4f26-bda7-a04e7f8c71d3" />
