### PR TITLE
Playground/sessions ac

### DIFF
--- a/sparkle/playground/package-lock.json
+++ b/sparkle/playground/package-lock.json
@@ -60,6 +60,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "emoji-mart": "^5.5.2",
+        "framer-motion": "^11.18.2",
         "lottie-react": "^2.4.0",
         "lottie-web": "^5.12.2",
         "mermaid": "^11.4.1",
@@ -123,7 +124,7 @@
         "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=22.22.0"
+        "node": ">=24.14.0"
       },
       "peerDependencies": {
         "react": "^18.3.1",

--- a/sparkle/playground/src/components/InputBar.tsx
+++ b/sparkle/playground/src/components/InputBar.tsx
@@ -5,6 +5,12 @@ import {
   Button,
   cn,
   DocumentIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
   Icon,
   ImageIcon,
   ImageZoomDialog,
@@ -16,6 +22,9 @@ import {
   SheetContent,
   SheetHeader,
   SheetTitle,
+  SpaceOpenIcon,
+  StopIcon,
+  TableIcon,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -24,11 +33,81 @@ import { RichTextArea, type RichTextAreaHandle } from "./RichTextArea";
 
 type DroppedFile = { id: string; file: File; objectUrl?: string };
 
+export type PillAgent = {
+  id: string;
+  name: string;
+  emoji: string;
+  backgroundColor: string;
+};
+
+const PILL_AGENTS: PillAgent[] = [
+  {
+    id: "gpt4",
+    name: "@gpt4",
+    emoji: "🤖",
+    backgroundColor: "s-bg-indigo-100",
+  },
+  {
+    id: "claude",
+    name: "@claude",
+    emoji: "🧠",
+    backgroundColor: "s-bg-amber-100",
+  },
+  {
+    id: "helper",
+    name: "@helper",
+    emoji: "💡",
+    backgroundColor: "s-bg-green-100",
+  },
+  { id: "dust", name: "@dust", emoji: "✨", backgroundColor: "s-bg-rose-100" },
+  {
+    id: "translator",
+    name: "@translator",
+    emoji: "💬",
+    backgroundColor: "s-bg-green-200",
+  },
+  {
+    id: "codereviewer",
+    name: "@codereviewer",
+    emoji: "🔍",
+    backgroundColor: "s-bg-sky-100",
+  },
+  {
+    id: "writer",
+    name: "@writer",
+    emoji: "✍️",
+    backgroundColor: "s-bg-violet-100",
+  },
+  {
+    id: "analyst",
+    name: "@analyst",
+    emoji: "📊",
+    backgroundColor: "s-bg-orange-100",
+  },
+  {
+    id: "researcher",
+    name: "@researcher",
+    emoji: "🔬",
+    backgroundColor: "s-bg-teal-100",
+  },
+  {
+    id: "designer",
+    name: "@designer",
+    emoji: "🎨",
+    backgroundColor: "s-bg-pink-100",
+  },
+];
+
 interface InputBarProps {
   placeholder?: string;
   className?: string;
   instructionReference?: { start: number; end: number } | null;
   onInstructionInserted?: () => void;
+  onSend?: (message: string, agent: PillAgent | null) => void;
+  isThinking?: boolean;
+  thinkingAgent?: PillAgent | null;
+  selectedAgent?: PillAgent | null;
+  onAgentChange?: (agent: PillAgent | null) => void;
 }
 
 export function InputBar({
@@ -36,10 +115,30 @@ export function InputBar({
   className,
   instructionReference,
   onInstructionInserted,
+  onSend,
+  isThinking = false,
+  thinkingAgent = null,
+  selectedAgent: controlledAgent,
+  onAgentChange,
 }: InputBarProps) {
   const [isFocused, setIsFocused] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
   const [droppedFiles, setDroppedFiles] = useState<DroppedFile[]>([]);
+  const [internalAgent, setInternalAgent] = useState<PillAgent | null>(null);
+
+  // Use controlled agent if provided, otherwise internal state
+  const selectedAgent =
+    controlledAgent !== undefined ? controlledAgent : internalAgent;
+  const setSelectedAgent = useCallback(
+    (agent: PillAgent | null) => {
+      if (onAgentChange) {
+        onAgentChange(agent);
+      } else {
+        setInternalAgent(agent);
+      }
+    },
+    [onAgentChange]
+  );
   const [selectedDroppedFile, setSelectedDroppedFile] =
     useState<DroppedFile | null>(null);
   const [isImageZoomOpen, setIsImageZoomOpen] = useState(false);
@@ -154,6 +253,22 @@ export function InputBar({
     onInstructionInserted?.();
   }, [instructionReference, onInstructionInserted]);
 
+  // Whether the user switched agent while another is thinking
+  const agentSwitchedDuringThinking =
+    isThinking &&
+    thinkingAgent &&
+    selectedAgent &&
+    selectedAgent.id !== thinkingAgent.id;
+  const isSendDisabled = !!agentSwitchedDuringThinking;
+
+  const handleSend = useCallback(() => {
+    if (isSendDisabled) return;
+    const content = richTextAreaRef.current?.getContent() ?? "";
+    if (!content.trim()) return;
+    onSend?.(content, selectedAgent);
+    richTextAreaRef.current?.clearContent();
+  }, [onSend, selectedAgent, isSendDisabled]);
+
   const showFocusStyle = isFocused || isDragOver;
 
   return (
@@ -166,19 +281,17 @@ export function InputBar({
       onDrop={handleDrop}
       className={cn(
         "s-relative s-w-full s-max-w-4xl s-z-10",
-        "s-rounded-3xl s-border s-bg-primary-50/70 dark:s-bg-primary-900/70 s-backdrop-blur-md s-transition-all",
+        "s-rounded-3xl s-border s-bg-primary-50/70 dark:s-bg-primary-900/70 s-backdrop-blur-md",
+        "s-transition-all s-duration-100 s-ease-in",
         showFocusStyle
-          ? "s-border-highlight-300 dark:s-border-highlight-300-night s-ring-2 s-ring-highlight-300/50 dark:s-ring-highlight-700/60"
-          : "s-border-border dark:s-border-border-night",
+          ? "s-border-highlight-300 dark:s-border-highlight-300-night s-ring-2 s-ring-highlight-300/50 dark:s-ring-highlight-700/60 s-scale-[1.02] s-shadow-[0_16px_50px_rgba(59,130,246,0.12),0_8px_25px_rgba(0,0,0,0.08)]"
+          : "s-border-border dark:s-border-border-night s-scale-100 s-shadow-none",
         className
       )}
     >
-      <div className="s-flex s-w-full s-flex-col">
+      <div className="s-flex s-w-full s-flex-col s-gap-4 s-p-4">
         {droppedFiles.length > 0 && (
-          <NewCitationGrid
-            className="s-pt-2 s-px-2 s-pb-0 s-w-full"
-            justify="start"
-          >
+          <NewCitationGrid className="s-pb-0 s-w-full" justify="start">
             {droppedFiles.map(({ id, file, objectUrl }) => (
               <NewCitation
                 key={id}
@@ -207,12 +320,25 @@ export function InputBar({
           ref={richTextAreaRef}
           placeholder={placeholder}
           onFocus={handleFocus}
+          onAgentMentioned={(agent) => {
+            setSelectedAgent({
+              id: agent.id,
+              name: `@${agent.label}`,
+              emoji: agent.emoji ?? "🤖",
+              backgroundColor: agent.backgroundColor ?? "s-bg-muted-background",
+            });
+            // Remove the @mention from the editor content after a tick
+            // (let the mention extension finish inserting first)
+            setTimeout(() => {
+              richTextAreaRef.current?.removeMentions();
+            }, 0);
+          }}
           variant="compact"
           showFormattingMenu
           showAskSidekickMenu={false}
-          className="placeholder:s-text-muted-foreground dark:placeholder:s-text-muted-foreground-night"
+          className="placeholder:s-text-muted-foreground/30 dark:placeholder:s-text-muted-foreground-night/30 s-pl-1 s-font-medium [&_.is-editor-empty:first-child::before]:!s-not-italic [&_.is-editor-empty:first-child::before]:!s-opacity-30 [&_.is-editor-empty:first-child::before]:!s-font-medium"
         />
-        <div className="s-flex s-w-full s-gap-2 s-p-2 s-pl-4">
+        <div className="s-flex s-w-full s-gap-2">
           <Button
             variant="outline"
             icon={PlusIcon}
@@ -220,25 +346,77 @@ export function InputBar({
             tooltip="Attach a document"
             className="md:s-hidden"
           />
-          <div className="s-hidden s-gap-0 md:s-flex">
-            <Button
-              variant="ghost-secondary"
-              icon={AttachmentIcon}
-              size="xs"
-              tooltip="Attach a document"
-            />
-            <Button
-              variant="ghost-secondary"
-              icon={BoltIcon}
-              size="xs"
-              tooltip="Add functionality"
-            />
-            <Button
-              variant="ghost-secondary"
-              icon={RobotIcon}
-              size="xs"
-              tooltip="Mention an Agent"
-            />
+          <div className="s-hidden s-gap-2 md:s-flex">
+            {/* Agent pill */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className="s-flex s-items-center s-gap-1.5 s-rounded-full s-border s-border-border/60 s-bg-white s-px-3 s-py-1 s-text-sm s-font-medium s-text-muted-foreground s-transition-colors hover:s-bg-muted-background hover:s-text-foreground dark:s-border-border-night/60 dark:s-bg-background-night dark:s-text-muted-foreground-night dark:hover:s-bg-muted-background-night dark:hover:s-text-foreground-night">
+                  {selectedAgent ? (
+                    <span
+                      className={cn(
+                        "s-flex s-h-4 s-w-4 s-items-center s-justify-center s-rounded-full s-text-[10px]",
+                        selectedAgent.backgroundColor
+                      )}
+                    >
+                      {selectedAgent.emoji}
+                    </span>
+                  ) : (
+                    <Icon visual={RobotIcon} size="xs" />
+                  )}
+                  {selectedAgent ? selectedAgent.name : "Agent"}
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuLabel label="Mention an agent" />
+                {PILL_AGENTS.map((agent) => (
+                  <DropdownMenuItem
+                    key={agent.id}
+                    label={agent.name}
+                    icon={RobotIcon}
+                    onClick={() => setSelectedAgent(agent)}
+                  />
+                ))}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem label="Search agents..." icon={PlusIcon} />
+              </DropdownMenuContent>
+            </DropdownMenu>
+            {/* Capabilities pill */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className="s-flex s-items-center s-gap-1.5 s-rounded-full s-border s-border-border/60 s-bg-white s-px-3 s-py-1 s-text-sm s-font-medium s-text-muted-foreground s-transition-colors hover:s-bg-muted-background hover:s-text-foreground dark:s-border-border-night/60 dark:s-bg-background-night dark:s-text-muted-foreground-night dark:hover:s-bg-muted-background-night dark:hover:s-text-foreground-night">
+                  <Icon visual={BoltIcon} size="xs" />
+                  Capabilities
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuLabel label="Capabilities" />
+                <DropdownMenuItem label="Web search" icon={BoltIcon} />
+                <DropdownMenuItem label="Browse URLs" icon={BoltIcon} />
+                <DropdownMenuItem label="Generate images" icon={ImageIcon} />
+                <DropdownMenuSeparator />
+                <DropdownMenuItem label="Tables & queries" icon={TableIcon} />
+              </DropdownMenuContent>
+            </DropdownMenu>
+            {/* Attach pill */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className="s-flex s-items-center s-gap-1.5 s-rounded-full s-border s-border-border/60 s-bg-white s-px-3 s-py-1 s-text-sm s-font-medium s-text-muted-foreground s-transition-colors hover:s-bg-muted-background hover:s-text-foreground dark:s-border-border-night/60 dark:s-bg-background-night dark:s-text-muted-foreground-night dark:hover:s-bg-muted-background-night dark:hover:s-text-foreground-night">
+                  <Icon visual={AttachmentIcon} size="xs" />
+                  Attach
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuLabel label="Attach from" />
+                <DropdownMenuItem label="Upload file" icon={PlusIcon} />
+                <DropdownMenuSeparator />
+                <DropdownMenuItem label="Company Data" icon={SpaceOpenIcon} />
+                <DropdownMenuItem label="Engineering" icon={SpaceOpenIcon} />
+                <DropdownMenuItem
+                  label="Sales & Support"
+                  icon={SpaceOpenIcon}
+                />
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
           <div className="s-grow" />
           <div className="s-flex s-items-center s-gap-2 md:s-gap-1">
@@ -248,13 +426,35 @@ export function InputBar({
               size="xs"
               isRounded
             />
-            <Button
-              variant="highlight"
-              icon={ArrowUpIcon}
-              size="xs"
-              tooltip="Send message"
-              isRounded
-            />
+            {isThinking && !isSendDisabled ? (
+              <Button
+                variant="outline"
+                icon={StopIcon}
+                size="xs"
+                tooltip="Stop generating"
+                isRounded
+              />
+            ) : isSendDisabled ? (
+              <span title="Wait for the first agent to finish before changing">
+                <Button
+                  variant="highlight"
+                  icon={ArrowUpIcon}
+                  size="xs"
+                  isRounded
+                  disabled
+                  tooltip="Wait for the first agent to finish before changing"
+                />
+              </span>
+            ) : (
+              <Button
+                variant="highlight"
+                icon={ArrowUpIcon}
+                size="xs"
+                tooltip="Send message"
+                isRounded
+                onClick={handleSend}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/sparkle/playground/src/components/RichTextArea.tsx
+++ b/sparkle/playground/src/components/RichTextArea.tsx
@@ -13,6 +13,7 @@ import { cva } from "class-variance-authority";
 import tippy, { type Instance as TippyInstance } from "tippy.js";
 import React, {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -68,6 +69,14 @@ const SuggestionList = forwardRef<SuggestionListHandle, SuggestionProps>(
       const item = items[index];
       if (item) {
         command(item);
+        if (item.type === "agent" && _onAgentMentionedRef) {
+          _onAgentMentionedRef({
+            id: item.id,
+            label: item.label,
+            emoji: item.avatarEmoji,
+            backgroundColor: item.avatarColor,
+          });
+        }
       }
     };
 
@@ -89,6 +98,11 @@ const SuggestionList = forwardRef<SuggestionListHandle, SuggestionProps>(
 
         if (event.key === "Enter") {
           selectItem(selectedIndex);
+          return true;
+        }
+
+        if (event.key === "Tab") {
+          selectItem(0);
           return true;
         }
 
@@ -404,6 +418,16 @@ const SuggestionSelectionHighlight = Extension.create({
   },
 });
 
+// Module-level ref for the agent mention callback (set by the component instance).
+let _onAgentMentionedRef:
+  | ((agent: {
+      id: string;
+      label: string;
+      emoji?: string;
+      backgroundColor?: string;
+    }) => void)
+  | null = null;
+
 const getMentionItems = (query: string): MentionItem[] => {
   const normalized = query.trim().toLowerCase();
 
@@ -550,7 +574,7 @@ const richTextAreaVariants = cva(
           "s-min-h-40"
         ),
         compact: cn(
-          "s-p-5",
+          "s-p-0",
           "s-bg-transparent s-border-0 s-rounded-none",
           "focus-visible:s-ring-0 focus-visible:s-border-0",
           "s-min-h-0"
@@ -577,6 +601,9 @@ export type RichTextAreaHandle = {
   insertMention: (options: { id: string; label: string }) => void;
   insertInstructionSnippet: (options: { id: string; label: string }) => void;
   setContent: (text: string) => void;
+  getContent: () => string;
+  clearContent: () => void;
+  removeMentions: () => void;
   applyRandomSuggestions: (changes: string[]) => void;
   hasSuggestions: () => boolean;
   acceptAllSuggestions: () => void;
@@ -598,6 +625,12 @@ type RichTextAreaProps = {
   onTextChange?: (value: string) => void;
   onFocus?: () => void;
   onBlur?: () => void;
+  onAgentMentioned?: (agent: {
+    id: string;
+    label: string;
+    emoji?: string;
+    backgroundColor?: string;
+  }) => void;
   scrollContainer?: HTMLElement | null;
   readOnly?: boolean;
   defaultValue?: string;
@@ -619,6 +652,7 @@ export const RichTextArea = forwardRef<RichTextAreaHandle, RichTextAreaProps>(
       onTextChange,
       onFocus,
       onBlur,
+      onAgentMentioned,
       scrollContainer,
       readOnly,
       defaultValue,
@@ -628,6 +662,9 @@ export const RichTextArea = forwardRef<RichTextAreaHandle, RichTextAreaProps>(
     },
     ref
   ) => {
+    // Wire up the module-level agent mention callback.
+    _onAgentMentionedRef = onAgentMentioned ?? null;
+
     const hasTopBar = Boolean(topBar);
     const editorVariant =
       hasTopBar && variant === "default" ? "embedded" : variant;
@@ -815,6 +852,34 @@ export const RichTextArea = forwardRef<RichTextAreaHandle, RichTextAreaProps>(
         });
       };
     }, [editor]);
+
+    const getContent = useCallback(() => {
+      if (!editor) return "";
+      return editor.getText();
+    }, [editor]);
+
+    const clearContent = useCallback(() => {
+      if (!editor) return;
+      editor.commands.clearContent();
+    }, [editor]);
+
+    const removeMentions = useCallback(() => {
+      if (!editor) return;
+      const { doc, tr } = editor.state;
+      const mentionPositions: { from: number; to: number }[] = [];
+      doc.descendants((node, pos) => {
+        if (node.type.name === "mention") {
+          mentionPositions.push({ from: pos, to: pos + node.nodeSize });
+        }
+      });
+      // Remove in reverse order to preserve positions
+      for (let i = mentionPositions.length - 1; i >= 0; i--) {
+        const { from, to } = mentionPositions[i];
+        tr.delete(from, to);
+      }
+      editor.view.dispatch(tr);
+    }, [editor]);
+
     const applyRandomSuggestions = useMemo(() => {
       return (changes: string[]) => {
         if (!editor || changes.length === 0) {
@@ -1037,6 +1102,9 @@ export const RichTextArea = forwardRef<RichTextAreaHandle, RichTextAreaProps>(
         insertMention,
         insertInstructionSnippet,
         setContent,
+        getContent,
+        clearContent,
+        removeMentions,
         applyRandomSuggestions,
         hasSuggestions,
         acceptAllSuggestions,
@@ -1047,6 +1115,9 @@ export const RichTextArea = forwardRef<RichTextAreaHandle, RichTextAreaProps>(
         insertMention,
         insertInstructionSnippet,
         setContent,
+        getContent,
+        clearContent,
+        removeMentions,
         applyRandomSuggestions,
         hasSuggestions,
         acceptAllSuggestions,

--- a/sparkle/playground/src/stories/Home.tsx
+++ b/sparkle/playground/src/stories/Home.tsx
@@ -507,7 +507,7 @@ function DustHome() {
         {/* Input centered vertically */}
         <div className="s-flex s-flex-1 s-w-full s-items-center s-justify-center">
           <div className="s-flex s-w-full s-max-w-3xl s-flex-col s-gap-8">
-            <Page.Header title={`Hello, ${user.firstName}!`} />
+            <Page.Header title={`Konichiwa, ${user.firstName}!`} />
             <div className="s-w-full s-rounded-3xl s-bg-white s-shadow-[0_8px_30px_rgba(0,0,0,0.08)]">
               <InputBar
                 placeholder="Ask a question"

--- a/sparkle/playground/src/stories/Home.tsx
+++ b/sparkle/playground/src/stories/Home.tsx
@@ -1,0 +1,783 @@
+import "@dust-tt/sparkle/styles/allotment.css";
+
+import {
+  ArrowDownIcon,
+  DustLogoSquareGray,
+  AssistantCard,
+  AssistantCardMore,
+  Avatar,
+  Button,
+  CardGrid,
+  ChatBubbleBottomCenterTextIcon,
+  ChatBubbleLeftRightIcon,
+  CheckDoubleIcon,
+  Cog6ToothIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  LogoutIcon,
+  MoreIcon,
+  NavigationList,
+  NavigationListCollapsibleSection,
+  NavigationListCompactLabel,
+  NavigationListItem,
+  NavigationListItemAction,
+  Page,
+  PencilSquareIcon,
+  PlanetIcon,
+  PlusIcon,
+  RobotIcon,
+  ScrollArea,
+  ScrollBar,
+  SearchInput,
+  SidebarLayout,
+  type SidebarLayoutRef,
+  SpaceOpenIcon,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  TrashIcon,
+  UserIcon,
+} from "@dust-tt/sparkle";
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import { ConversationView } from "../components/ConversationView";
+import { InputBar, type PillAgent } from "../components/InputBar";
+import {
+  type Agent,
+  type Conversation,
+  type Space,
+  type User,
+  getAgentById,
+  mockAgents,
+  mockConversations,
+  mockSpaces,
+  mockUsers,
+} from "../data";
+
+// ── Fake data ─────────────────────────────────────────────────────────────────
+
+const CURRENT_USER: User = mockUsers[0];
+
+const AGENT_TAGS = [
+  { id: "most_popular", name: "Most popular" },
+  { id: "engineering", name: "Engineering" },
+  { id: "sales", name: "Sales & Support" },
+  { id: "others", name: "Others" },
+];
+
+const AGENT_TAG_MAP: Record<string, string[]> = {
+  most_popular: [
+    "agent-1",
+    "agent-5",
+    "agent-7",
+    "agent-11",
+    "agent-12",
+    "agent-14",
+  ],
+  engineering: ["agent-2", "agent-6", "agent-8", "agent-3"],
+  sales: ["agent-4", "agent-9", "agent-10", "agent-13"],
+  others: ["agent-15", "agent-16", "agent-17", "agent-18"],
+};
+
+const SPACES: Space[] = mockSpaces.slice(0, 8);
+
+function buildConversations(): Conversation[] {
+  const now = new Date();
+  return mockConversations.slice(0, 25).map((c, i) => ({
+    ...c,
+    updatedAt: new Date(
+      now.getTime() - i * (i < 3 ? 3600000 : i < 8 ? 86400000 : 86400000 * i)
+    ),
+  }));
+}
+
+const ALL_CONVERSATIONS = buildConversations();
+
+// A few inbox items (first 3 conversations with statuses).
+const INBOX_ITEMS = ALL_CONVERSATIONS.slice(0, 3).map((c, i) => ({
+  conversation: c,
+  status: (["unread", "blocked", "idle"] as const)[i % 3],
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function groupByDate(conversations: Conversation[]) {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const lastWeek = new Date(now);
+  lastWeek.setDate(lastWeek.getDate() - 7);
+  const lastMonth = new Date(now);
+  lastMonth.setDate(lastMonth.getDate() - 30);
+
+  const groups = {
+    today: [] as Conversation[],
+    yesterday: [] as Conversation[],
+    lastWeek: [] as Conversation[],
+    lastMonth: [] as Conversation[],
+    older: [] as Conversation[],
+  };
+
+  conversations.forEach((c) => {
+    const d = c.updatedAt;
+    if (d >= now) groups.today.push(c);
+    else if (d >= yesterday) groups.yesterday.push(c);
+    else if (d >= lastWeek) groups.lastWeek.push(c);
+    else if (d >= lastMonth) groups.lastMonth.push(c);
+    else groups.older.push(c);
+  });
+
+  return groups;
+}
+
+function getAgentPictureUrl(agent: Agent): string {
+  // Generate a deterministic placeholder picture URL from the agent's emoji.
+  return `https://api.dicebear.com/7.x/bottts-neutral/svg?seed=${encodeURIComponent(agent.name)}`;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+function DustHome() {
+  const [selectedConversationId, setSelectedConversationId] = useState<
+    string | null
+  >(null);
+  const [searchText, setSearchText] = useState("");
+  const [agentTab, setAgentTab] = useState("all");
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [sortLabel] = useState("By popularity");
+  const [isThinking, setIsThinking] = useState(false);
+  const [thinkingAgent, setThinkingAgent] = useState<PillAgent | null>(null);
+  const [selectedAgent, setSelectedAgent] = useState<PillAgent | null>(null);
+  const [chatMessages, setChatMessages] = useState<
+    {
+      role: "user" | "assistant";
+      content: string;
+      agent?: { name: string; emoji: string; backgroundColor: string };
+    }[]
+  >([]);
+  const sidebarRef = useRef<SidebarLayoutRef>(null);
+
+  const user = CURRENT_USER;
+
+  const handleSend = useCallback((message: string, agent: PillAgent | null) => {
+    // Add user message
+    setChatMessages((prev) => [...prev, { role: "user", content: message }]);
+
+    const respondingAgent = agent ?? {
+      id: "dust",
+      name: "@dust",
+      emoji: "✨",
+      backgroundColor: "s-bg-rose-100",
+    };
+    setThinkingAgent(respondingAgent);
+    setIsThinking(true);
+
+    // Simulate a really long thinking (8 seconds)
+    setTimeout(() => {
+      setChatMessages((prev) => [
+        ...prev,
+        {
+          role: "assistant",
+          content:
+            "I've analyzed your request carefully. Here's what I found after thorough consideration of all the relevant factors and data points available to me. Let me walk you through my reasoning step by step to ensure complete transparency in how I arrived at this conclusion.",
+          agent: respondingAgent,
+        },
+      ]);
+      setIsThinking(false);
+      setThinkingAgent(null);
+    }, 8000);
+  }, []);
+
+  // Filter conversations by search.
+  const filteredConversations = useMemo(() => {
+    if (!searchText.trim()) return ALL_CONVERSATIONS;
+    const lower = searchText.toLowerCase();
+    return ALL_CONVERSATIONS.filter((c) =>
+      c.title.toLowerCase().includes(lower)
+    );
+  }, [searchText]);
+
+  const grouped = useMemo(
+    () => groupByDate(filteredConversations),
+    [filteredConversations]
+  );
+
+  const selectedConversation = useMemo(
+    () =>
+      ALL_CONVERSATIONS.find((c) => c.id === selectedConversationId) ?? null,
+    [selectedConversationId]
+  );
+
+  // Agents for the current tab / tag.
+  const displayedAgents = useMemo(() => {
+    if (agentTab === "all") {
+      if (selectedTag) {
+        const ids = AGENT_TAG_MAP[selectedTag] ?? [];
+        return ids.map((id) => getAgentById(id)).filter(Boolean) as Agent[];
+      }
+      return mockAgents.slice(0, 18);
+    }
+    if (agentTab === "favorites") {
+      return mockAgents.slice(0, 6);
+    }
+    // editable_by_me
+    return mockAgents.slice(4, 10);
+  }, [agentTab, selectedTag]);
+
+  // ── Sidebar ─────────────────────────────────────────────────────────────
+
+  const conversationMoreMenu = (conv: Conversation) => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <NavigationListItemAction />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem
+          label="Rename"
+          icon={PencilSquareIcon}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        />
+        <DropdownMenuItem
+          label="Delete"
+          icon={TrashIcon}
+          variant="warning"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  const renderConversationItem = (conv: Conversation) => (
+    <NavigationListItem
+      key={conv.id}
+      label={conv.title}
+      selected={conv.id === selectedConversationId}
+      moreMenu={conversationMoreMenu(conv)}
+      onClick={() => setSelectedConversationId(conv.id)}
+    />
+  );
+
+  const sidebarContent = (
+    <div className="s-flex s-min-w-0 s-grow s-flex-col s-bg-muted-background dark:s-bg-muted-background-night">
+      {/* ── Navigation tabs ── */}
+      <Tabs
+        defaultValue="conversations"
+        className="s-flex s-min-h-0 s-flex-1 s-flex-col"
+      >
+        <div className="s-border-b s-border-separator s-px-2 dark:s-border-separator-night">
+          <TabsList>
+            <TabsTrigger
+              value="conversations"
+              label="Chat"
+              icon={ChatBubbleLeftRightIcon}
+            />
+            <TabsTrigger value="spaces" label="Spaces" icon={PlanetIcon} />
+            <TabsTrigger value="admin" icon={Cog6ToothIcon} />
+          </TabsList>
+        </div>
+
+        {/* ── Chat tab content ── */}
+        <TabsContent
+          value="conversations"
+          className="s-flex s-min-h-0 s-flex-1 s-flex-col"
+        >
+          {/* Search + New */}
+          <div className="s-z-50 s-flex s-justify-end s-gap-2 s-p-2">
+            <SearchInput
+              name="conv-search"
+              value={searchText}
+              onChange={setSearchText}
+              placeholder="Search"
+              className="s-flex-1"
+            />
+            <Button
+              variant="primary"
+              size="sm"
+              icon={ChatBubbleBottomCenterTextIcon}
+              label="New"
+              onClick={() => setSelectedConversationId(null)}
+            />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm" icon={MoreIcon} />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuLabel label="Agents" />
+                <DropdownMenuItem
+                  icon={PlusIcon}
+                  label="Build an agent"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                />
+                <DropdownMenuItem
+                  icon={RobotIcon}
+                  label="Manage agents"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                />
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          {/* Conversation list */}
+          <div className="s-h-full s-w-full s-overflow-y-auto">
+            {/* Inbox section */}
+            {INBOX_ITEMS.length > 0 && (
+              <NavigationListCollapsibleSection
+                label={`Inbox (${INBOX_ITEMS.length})`}
+                className="s-border-b s-border-t s-border-border s-bg-background/50 s-px-2 s-pb-2 dark:s-border-border-night dark:s-bg-background-night/50"
+                defaultOpen
+                action={
+                  <Button
+                    size="mini"
+                    variant="ghost"
+                    icon={CheckDoubleIcon}
+                    tooltip="Mark all as read"
+                  />
+                }
+              >
+                {INBOX_ITEMS.map(({ conversation, status }) => (
+                  <NavigationListItem
+                    key={conversation.id}
+                    label={conversation.title}
+                    selected={conversation.id === selectedConversationId}
+                    status={
+                      status === "unread"
+                        ? undefined
+                        : status === "blocked"
+                          ? "blocked"
+                          : "idle"
+                    }
+                    moreMenu={conversationMoreMenu(conversation)}
+                    onClick={() => setSelectedConversationId(conversation.id)}
+                  />
+                ))}
+              </NavigationListCollapsibleSection>
+            )}
+
+            {/* Conversations by date */}
+            <NavigationList className="s-px-2">
+              <NavigationListCollapsibleSection
+                label="Conversations"
+                defaultOpen
+              >
+                {/* Today – no sticky label for first group */}
+                {grouped.today.map(renderConversationItem)}
+
+                {grouped.yesterday.length > 0 && (
+                  <>
+                    <NavigationListCompactLabel label="Yesterday" isSticky />
+                    {grouped.yesterday.map(renderConversationItem)}
+                  </>
+                )}
+                {grouped.lastWeek.length > 0 && (
+                  <>
+                    <NavigationListCompactLabel label="Last week" isSticky />
+                    {grouped.lastWeek.map(renderConversationItem)}
+                  </>
+                )}
+                {grouped.lastMonth.length > 0 && (
+                  <>
+                    <NavigationListCompactLabel label="Last month" isSticky />
+                    {grouped.lastMonth.map(renderConversationItem)}
+                  </>
+                )}
+                {grouped.older.length > 0 && (
+                  <>
+                    <NavigationListCompactLabel label="Older" isSticky />
+                    {grouped.older.map(renderConversationItem)}
+                  </>
+                )}
+
+                {filteredConversations.length === 0 && (
+                  <div className="s-flex s-h-20 s-items-center s-justify-center s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
+                    No conversations found
+                  </div>
+                )}
+              </NavigationListCollapsibleSection>
+            </NavigationList>
+          </div>
+        </TabsContent>
+
+        {/* ── Spaces tab content ── */}
+        <TabsContent
+          value="spaces"
+          className="s-flex s-min-h-0 s-flex-1 s-flex-col"
+        >
+          <NavigationList className="s-px-3">
+            {SPACES.map((space) => (
+              <NavigationListItem
+                key={space.id}
+                label={space.name}
+                icon={SpaceOpenIcon}
+              />
+            ))}
+          </NavigationList>
+        </TabsContent>
+
+        {/* ── Admin tab content ── */}
+        <TabsContent
+          value="admin"
+          className="s-flex s-min-h-0 s-flex-1 s-flex-col"
+        >
+          <NavigationList className="s-px-3">
+            <NavigationListItem label="Members" icon={UserIcon} />
+            <NavigationListItem label="Plans & billing" icon={Cog6ToothIcon} />
+          </NavigationList>
+        </TabsContent>
+      </Tabs>
+
+      {/* ── User footer ── */}
+      <div className="s-flex s-items-center s-border-t s-px-2 s-py-2 s-border-border-dark dark:s-border-border-dark-night s-text-foreground dark:s-text-foreground-night">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="s-flex s-min-w-0 s-items-center s-gap-2 s-rounded-md s-px-1 s-py-1 hover:s-bg-muted-background-hover dark:hover:s-bg-muted-background-hover-night">
+              <Avatar
+                size="xs"
+                name={user.fullName}
+                visual={user.portrait}
+                isRounded
+              />
+              <span className="s-heading-sm s-truncate">{user.fullName}</span>
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            <DropdownMenuLabel label={user.fullName} />
+            <DropdownMenuSeparator />
+            <DropdownMenuItem label="Profile" icon={UserIcon} />
+            <DropdownMenuItem label="Settings" icon={Cog6ToothIcon} />
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              label="Sign out"
+              icon={LogoutIcon}
+              variant="warning"
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <div className="s-flex-1" />
+        <Button
+          variant="ghost-secondary"
+          size="icon"
+          icon={MoreIcon}
+          tooltip="Help & feedback"
+        />
+      </div>
+    </div>
+  );
+
+  // ── Main content ────────────────────────────────────────────────────────
+
+  const agentSectionRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const scrollToAgents = useCallback(() => {
+    agentSectionRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  const newConversationContent = (
+    <div
+      ref={scrollContainerRef}
+      className="s-h-full s-overflow-y-auto s-scroll-smooth s-snap-y s-snap-mandatory"
+    >
+      {/* ── Page 1: Hero – centered greeting + input ── */}
+      <div
+        className="s-relative s-flex s-h-full s-min-h-full s-snap-start s-snap-always s-flex-col s-items-center s-px-4 md:s-px-8"
+        style={{ backgroundColor: "#FDFDFD" }}
+      >
+        {/* Logo at top third */}
+        <div className="s-absolute s-top-[20%] s-left-1/2 -s-translate-x-1/2">
+          <DustLogoSquareGray className="s-h-16 s-w-16 s-opacity-40" />
+        </div>
+        {/* Input centered vertically */}
+        <div className="s-flex s-flex-1 s-w-full s-items-center s-justify-center">
+          <div className="s-flex s-w-full s-max-w-3xl s-flex-col s-gap-8">
+            <Page.Header title={`Hello, ${user.firstName}!`} />
+            <div className="s-w-full s-rounded-3xl s-bg-white s-shadow-[0_8px_30px_rgba(0,0,0,0.08)]">
+              <InputBar
+                placeholder="Ask a question"
+                className="!s-bg-transparent !s-shadow-none"
+                onSend={handleSend}
+                isThinking={isThinking}
+                thinkingAgent={thinkingAgent}
+                selectedAgent={selectedAgent}
+                onAgentChange={setSelectedAgent}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Down arrow – bottom center */}
+        <div className="s-absolute s-bottom-6 s-left-1/2 -s-translate-x-1/2">
+          <button
+            onClick={scrollToAgents}
+            className="s-flex s-h-10 s-w-10 s-items-center s-justify-center s-rounded-full s-border s-border-border s-bg-background s-text-muted-foreground s-shadow-sm s-transition-all hover:s-bg-muted-background hover:s-text-foreground dark:s-border-border-night dark:s-bg-background-night dark:s-text-muted-foreground-night dark:hover:s-bg-muted-background-night dark:hover:s-text-foreground-night s-animate-bounce"
+          >
+            <ArrowDownIcon className="s-h-5 s-w-5" />
+          </button>
+        </div>
+      </div>
+
+      {/* ── Page 2: Agent browser – below the fold ── */}
+      <div
+        ref={agentSectionRef}
+        className="s-flex s-min-h-full s-snap-start s-snap-always s-flex-col s-items-center s-px-4 s-py-8 md:s-px-8"
+      >
+        <div className="s-flex s-w-full s-max-w-3xl s-flex-col s-gap-4">
+          <Page.SectionHeader title="Chat with..." />
+
+          {/* Search + Create + Sort */}
+          <div className="s-flex s-w-full s-flex-row s-items-center s-gap-2">
+            <SearchInput
+              name="agent-search"
+              placeholder="Search agents..."
+              value=""
+              onChange={() => {}}
+              className="s-flex-1"
+            />
+            <Button
+              variant="primary"
+              icon={PlusIcon}
+              label="Create"
+              size="sm"
+            />
+            <Button
+              variant="primary"
+              icon={RobotIcon}
+              label="Manage agents"
+              size="sm"
+            />
+          </div>
+
+          {/* Agent tabs */}
+          <div className="s-w-full">
+            <ScrollArea>
+              <Tabs
+                value={agentTab}
+                onValueChange={(v) => {
+                  setAgentTab(v);
+                  setSelectedTag(null);
+                }}
+              >
+                <TabsList>
+                  <TabsTrigger value="favorites" label="Favorites" />
+                  <TabsTrigger value="all" label="All agents" />
+                  <TabsTrigger value="editable_by_me" label="Editable by me" />
+                  <div className="s-ml-auto" />
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        isSelect
+                        variant="outline"
+                        label={sortLabel}
+                        size="sm"
+                      />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent>
+                      <DropdownMenuItem label="By popularity" />
+                      <DropdownMenuItem label="Alphabetical" />
+                      <DropdownMenuItem label="Recently updated" />
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </TabsList>
+              </Tabs>
+              <ScrollBar orientation="horizontal" className="s-hidden" />
+            </ScrollArea>
+          </div>
+
+          {/* Tag filter buttons (shown on "All agents" tab) */}
+          {agentTab === "all" && (
+            <div className="s-flex s-flex-wrap s-items-center s-gap-2">
+              {AGENT_TAGS.map((tag) => (
+                <Button
+                  key={tag.id}
+                  size="xs"
+                  variant={selectedTag === tag.id ? "primary" : "outline"}
+                  label={tag.name}
+                  onClick={() =>
+                    setSelectedTag(selectedTag === tag.id ? null : tag.id)
+                  }
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Agent grid */}
+          <CardGrid>
+            {displayedAgents.map((agent) => (
+              <AssistantCard
+                key={agent.id}
+                title={agent.name}
+                pictureUrl={getAgentPictureUrl(agent)}
+                subtitle="By Dust"
+                description={agent.description}
+                onClick={() => setSelectedConversationId(null)}
+                action={
+                  <AssistantCardMore
+                    onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                      e.stopPropagation();
+                    }}
+                  />
+                }
+              />
+            ))}
+          </CardGrid>
+
+          {/* Bottom spacer */}
+          <div className="s-h-8 s-shrink-0" />
+        </div>
+      </div>
+    </div>
+  );
+
+  // ── Inline chat view (after sending a message from home) ─────────────
+  const inlineChatContent = (
+    <div className="s-flex s-h-full s-flex-col">
+      {/* Messages area */}
+      <div className="s-flex-1 s-overflow-y-auto s-px-4 s-py-6 md:s-px-8">
+        <div className="s-mx-auto s-flex s-max-w-3xl s-flex-col s-gap-6">
+          {chatMessages.map((msg, i) => (
+            <div
+              key={i}
+              className={`s-flex s-gap-3 ${msg.role === "user" ? "s-justify-end" : "s-justify-start"}`}
+            >
+              {msg.role === "assistant" && msg.agent && (
+                <div
+                  className={`s-flex s-h-8 s-w-8 s-shrink-0 s-items-center s-justify-center s-rounded-full s-text-base ${msg.agent.backgroundColor}`}
+                >
+                  {msg.agent.emoji}
+                </div>
+              )}
+              <div
+                className={`s-max-w-[75%] s-rounded-2xl s-px-4 s-py-3 s-text-sm ${
+                  msg.role === "user"
+                    ? "s-bg-highlight-100 s-text-foreground dark:s-bg-highlight-100-night dark:s-text-foreground-night"
+                    : "s-bg-muted-background s-text-foreground dark:s-bg-muted-background-night dark:s-text-foreground-night"
+                }`}
+              >
+                {msg.role === "assistant" && msg.agent && (
+                  <div className="s-mb-1 s-text-xs s-font-semibold s-text-muted-foreground dark:s-text-muted-foreground-night">
+                    {msg.agent.name}
+                  </div>
+                )}
+                {msg.content}
+              </div>
+              {msg.role === "user" && (
+                <Avatar
+                  size="xs"
+                  name={user.fullName}
+                  visual={user.portrait}
+                  isRounded
+                />
+              )}
+            </div>
+          ))}
+
+          {/* Thinking indicator */}
+          {isThinking && thinkingAgent && (
+            <div className="s-flex s-gap-3 s-justify-start">
+              <div
+                className={`s-flex s-h-8 s-w-8 s-shrink-0 s-items-center s-justify-center s-rounded-full s-text-base ${thinkingAgent.backgroundColor}`}
+              >
+                {thinkingAgent.emoji}
+              </div>
+              <div className="s-max-w-[75%] s-rounded-2xl s-bg-muted-background s-px-4 s-py-3 s-text-sm s-text-foreground dark:s-bg-muted-background-night dark:s-text-foreground-night">
+                <div className="s-mb-1 s-text-xs s-font-semibold s-text-muted-foreground dark:s-text-muted-foreground-night">
+                  {thinkingAgent.name}
+                </div>
+                <div className="s-flex s-items-center s-gap-2 s-text-muted-foreground dark:s-text-muted-foreground-night">
+                  <span className="s-animate-pulse">Thinking</span>
+                  <span className="s-flex s-gap-1">
+                    <span
+                      className="s-h-1.5 s-w-1.5 s-animate-bounce s-rounded-full s-bg-muted-foreground"
+                      style={{ animationDelay: "0ms" }}
+                    />
+                    <span
+                      className="s-h-1.5 s-w-1.5 s-animate-bounce s-rounded-full s-bg-muted-foreground"
+                      style={{ animationDelay: "150ms" }}
+                    />
+                    <span
+                      className="s-h-1.5 s-w-1.5 s-animate-bounce s-rounded-full s-bg-muted-foreground"
+                      style={{ animationDelay: "300ms" }}
+                    />
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Input bar pinned at bottom */}
+      <div className="s-border-t s-border-border s-px-4 s-py-3 dark:s-border-border-night md:s-px-8">
+        <div className="s-mx-auto s-max-w-3xl">
+          <div
+            className="s-w-full s-rounded-3xl s-bg-white s-shadow-[0_8px_30px_rgba(0,0,0,0.08)]"
+            style={{ border: "1px solid #F0F0F0" }}
+          >
+            <InputBar
+              placeholder="Ask a follow-up..."
+              className="!s-bg-transparent !s-shadow-none"
+              onSend={handleSend}
+              isThinking={isThinking}
+              thinkingAgent={thinkingAgent}
+              selectedAgent={selectedAgent}
+              onAgentChange={setSelectedAgent}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  const mainContent = selectedConversation ? (
+    <ConversationView
+      conversation={selectedConversation}
+      locutor={user}
+      users={mockUsers}
+      agents={mockAgents}
+      conversationsWithMessages={ALL_CONVERSATIONS.filter((c) => c.messages)}
+    />
+  ) : chatMessages.length > 0 ? (
+    inlineChatContent
+  ) : (
+    newConversationContent
+  );
+
+  return (
+    <div className="s-flex s-h-screen s-w-full s-bg-background dark:s-bg-background-night">
+      <SidebarLayout
+        ref={sidebarRef}
+        sidebar={sidebarContent}
+        content={
+          <div className="s-relative s-flex s-h-full s-w-full s-flex-1 s-flex-col s-overflow-hidden s-bg-background s-text-foreground dark:s-bg-background-night dark:s-text-foreground-night">
+            {mainContent}
+          </div>
+        }
+        defaultSidebarWidth={320}
+        minSidebarWidth={260}
+        maxSidebarWidth={400}
+        collapsible
+      />
+    </div>
+  );
+}
+
+export default function Home() {
+  return <DustHome />;
+}


### PR DESCRIPTION
Add a full Home page playground showcasing the Dust authenticated experience:
- Two-page snap scroll layout (hero + agent browser)
- Sidebar with conversations, spaces, and admin tabs
- InputBar with agent/capabilities/attach pill dropdowns
- Agent selection via pills or @mention with emoji avatars
- Inline chat view with fake thinking simulation
- Focus animation (scale, shadow, highlight border)
- Lifted agent state across input bar instances

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
