### PR TITLE
feat: add project todo state model

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -103,6 +103,7 @@ import {
   ProjectTodoModel,
   ProjectTodoSourceModel,
 } from "@app/lib/resources/storage/models/project_todo";
+import { ProjectTodoStateModel } from "@app/lib/resources/storage/models/project_todo_state";
 import {
   RunModel,
   RunUsageModel,
@@ -227,6 +228,7 @@ export function loadAllModels() {
     ProjectTodoModel,
     ProjectTodoConversationModel,
     ProjectTodoSourceModel,
+    ProjectTodoStateModel,
   ];
 }
 

--- a/front/lib/resources/project_todo_state_resource.ts
+++ b/front/lib/resources/project_todo_state_resource.ts
@@ -1,0 +1,100 @@
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { ProjectTodoStateModel } from "@app/lib/resources/storage/models/project_todo_state";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { makeSId } from "@app/lib/resources/string_ids";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Ok, type Result } from "@app/types/shared/result";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ProjectTodoStateResource
+  extends ReadonlyAttributesType<ProjectTodoStateModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ProjectTodoStateResource extends BaseResource<ProjectTodoStateModel> {
+  static model: ModelStaticWorkspaceAware<ProjectTodoStateModel> =
+    ProjectTodoStateModel;
+
+  constructor(
+    model: ModelStatic<ProjectTodoStateModel>,
+    blob: Attributes<ProjectTodoStateModel>
+  ) {
+    super(ProjectTodoStateModel, blob);
+  }
+
+  // Returns the state for a given (space, user) pair, or null if the user has
+  // never opened the todos panel for this space.
+  static async fetchBySpace(
+    auth: Authenticator,
+    { spaceId }: { spaceId: ModelId },
+    transaction?: Transaction
+  ): Promise<ProjectTodoStateResource | null> {
+    const row = await ProjectTodoStateModel.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId,
+        userId: auth.getNonNullableUser().id,
+      },
+      transaction,
+    });
+
+    return row ? new this(ProjectTodoStateModel, row.get()) : null;
+  }
+
+  // Creates or updates the last-read timestamp for a (space, user) pair. Call
+  // this when the user opens or acknowledges the todos panel.
+  static async upsertBySpace(
+    auth: Authenticator,
+    { spaceId, lastReadAt }: { spaceId: ModelId; lastReadAt: Date },
+    transaction?: Transaction
+  ): Promise<ProjectTodoStateResource> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const [row] = await ProjectTodoStateModel.upsert(
+      {
+        workspaceId,
+        spaceId,
+        userId: auth.getNonNullableUser().id,
+        lastReadAt,
+      },
+      { transaction, returning: true }
+    );
+
+    return new this(ProjectTodoStateModel, row.get());
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction }
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        id: this.id,
+      },
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+
+  get sId(): string {
+    return ProjectTodoStateResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("project_todo_state", { id, workspaceId });
+  }
+}

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1596,6 +1596,7 @@ const KNOWN_SPACE_RELATED_MODELS = [
   "user_project_digest",
   "project_metadata",
   "webhook_sources_view",
+  "project_todo_state",
 ];
 
 describe("SpaceResource cleanup on delete", () => {

--- a/front/lib/resources/storage/models/project_todo_state.ts
+++ b/front/lib/resources/storage/models/project_todo_state.ts
@@ -1,0 +1,75 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
+
+export class ProjectTodoStateModel extends WorkspaceAwareModel<ProjectTodoStateModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare spaceId: ForeignKey<SpaceModel["id"]>;
+  declare userId: ForeignKey<UserModel["id"]>;
+  declare lastReadAt: Date;
+
+  declare space: NonAttribute<SpaceModel>;
+  declare user: NonAttribute<UserModel>;
+}
+
+ProjectTodoStateModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    lastReadAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    spaceId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    userId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      comment: "Owner of the state.",
+    },
+  },
+  {
+    modelName: "project_todo_state",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["workspaceId", "spaceId", "userId"],
+        unique: true,
+        concurrently: true,
+      },
+      { fields: ["spaceId"], concurrently: true },
+      { fields: ["userId"], concurrently: true },
+    ],
+  }
+);
+
+ProjectTodoStateModel.belongsTo(SpaceModel, {
+  foreignKey: { name: "spaceId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+
+ProjectTodoStateModel.belongsTo(UserModel, {
+  foreignKey: { name: "userId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+
+SpaceModel.hasMany(ProjectTodoStateModel, {
+  foreignKey: { name: "spaceId", allowNull: false },
+  as: "projectTodoStates",
+});

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -77,6 +77,7 @@ export const RESOURCES_PREFIX = {
 
   // Project todos.
   project_todo: "ptd",
+  project_todo_state: "pts",
 
   // Butler
   user_project_digest: "pje",

--- a/front/migrations/db/migration_558.sql
+++ b/front/migrations/db/migration_558.sql
@@ -1,0 +1,17 @@
+-- Migration created on Apr 01, 2026
+CREATE TABLE IF NOT EXISTS "project_todo_states"
+(
+    "createdAt"   TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt"   TIMESTAMP WITH TIME ZONE NOT NULL,
+    "lastReadAt"  TIMESTAMP WITH TIME ZONE NOT NULL,
+    "spaceId"     BIGINT                   NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "userId"      BIGINT                   NOT NULL REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "workspaceId" BIGINT                   NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "id"          BIGSERIAL,
+    PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY "project_todo_states_workspace_id_space_id_user_id" ON "project_todo_states" ("workspaceId", "spaceId", "userId");
+CREATE INDEX CONCURRENTLY "project_todo_states_space_id" ON "project_todo_states" ("spaceId");
+CREATE INDEX CONCURRENTLY "project_todo_states_user_id" ON "project_todo_states" ("userId");
+

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -209,6 +209,19 @@ export async function scrubSpaceActivity({
         throw metadataRes.error;
       }
     }
+    const projectTodoStates = await ProjectTodoResource.fetchBySpace(auth, {
+      spaceId: space.id,
+    });
+    await concurrentExecutor(
+      projectTodoStates,
+      async (todoState) => {
+        const result = await todoState.delete(auth, {});
+        if (result.isErr()) {
+          throw result.error;
+        }
+      },
+      { concurrency: 8 }
+    );
   }
 
   hardDeleteLogger.info({ space: space.sId, workspaceId }, "Deleting space");


### PR DESCRIPTION
## Description

We need to store when a user last saw the TODO, so we are able to get the before/after, to animate the state. We don't want to "just" display the latest version

Add the model to store the state of a TODO for the tuple (user, project). 


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
