### PR TITLE
[BYOK] Add Google AI Studio as a BYOK provider

### DIFF
--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -37,6 +37,7 @@ pub enum CredentialProvider {
     // BYOK model providers
     Openai,
     Anthropic,
+    GoogleAiStudio,
 }
 
 impl From<ConnectionProvider> for CredentialProvider {
@@ -267,6 +268,9 @@ impl Credential {
                 vec!["api_key"]
             }
             CredentialProvider::Anthropic => {
+                vec!["api_key"]
+            }
+            CredentialProvider::GoogleAiStudio => {
                 vec!["api_key"]
             }
         };

--- a/front/components/pages/workspace/model_providers/KeyConfigurationSheet.tsx
+++ b/front/components/pages/workspace/model_providers/KeyConfigurationSheet.tsx
@@ -21,6 +21,7 @@ import { useState } from "react";
 const PROVIDER_ID_TO_DOCS_LINK: Record<ByokModelProviderIdType, string> = {
   openai: "https://developers.openai.com/api/docs/quickstart",
   anthropic: "https://platform.claude.com/docs/en/api/overview",
+  google_ai_studio: "https://ai.google.dev/gemini-api/docs/api-key",
 };
 
 interface ProviderInfoProps {

--- a/front/lib/api/llm/clients/google/utils/errors.ts
+++ b/front/lib/api/llm/clients/google/utils/errors.ts
@@ -13,6 +13,12 @@ export const handleError = (
   return new EventError(categorizeGenAIError(err, metadata), metadata);
 };
 
+export const isGoogleAuthenticationErrorMessage = (
+  message: string
+): boolean => {
+  return message.toLowerCase().includes("api key not valid");
+};
+
 // Yes, this is mainly duplicated between all providers. We know for sure each provider has a different error handling and http status code.
 // So we want to be able to tweak this by provider
 function categorizeGenAIError(
@@ -22,19 +28,23 @@ function categorizeGenAIError(
   const normalized = normalizeError(originalError);
   const statusCode = originalError.status;
 
-  if (statusCode === 400) {
+  if (
+    statusCode === 401 ||
+    (statusCode === 400 &&
+      isGoogleAuthenticationErrorMessage(normalized.message))
+  ) {
     return {
-      type: "invalid_request_error",
-      message: `Invalid request to ${metadata.clientId}. ${normalized.message}`,
+      type: "authentication_error",
+      message: `Authentication failed for ${metadata.clientId}. ${normalized.message}`,
       isRetryable: false,
       originalError,
     };
   }
 
-  if (statusCode === 401) {
+  if (statusCode === 400) {
     return {
-      type: "authentication_error",
-      message: `Authentication failed for ${metadata.clientId}. ${normalized.message}`,
+      type: "invalid_request_error",
+      message: `Invalid request to ${metadata.clientId}. ${normalized.message}`,
       isRetryable: false,
       originalError,
     };

--- a/front/lib/api/provider_credentials.ts
+++ b/front/lib/api/provider_credentials.ts
@@ -8,6 +8,7 @@ import {
   type ApiKeyCredentialContentSchema,
   type LLMCredentialsType,
   PROVIDER_TO_CREDENTIAL_KEY,
+  type ProviderCredentialKey,
 } from "@app/types/provider_credential";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { EnvironmentConfig } from "@app/types/shared/utils/config";
@@ -44,9 +45,13 @@ export async function getLlmCredentials(
   const env = (key: string) =>
     EnvironmentConfig.getOptionalEnvVariable(key) ?? "";
 
-  const DUST_MANAGED_BYOK_PROVIDERS_API_KEYS = {
+  const DUST_MANAGED_BYOK_PROVIDERS_API_KEYS: Record<
+    ProviderCredentialKey,
+    string
+  > = {
     ANTHROPIC_API_KEY: env("DUST_MANAGED_ANTHROPIC_API_KEY"),
     OPENAI_API_KEY: env("DUST_MANAGED_OPENAI_API_KEY"),
+    GOOGLE_AI_STUDIO_API_KEY: env("DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY"),
   };
 
   const DUST_MANAGED_OTHER_PROVIDERS_API_KEYS = {
@@ -139,6 +144,10 @@ function mapOauthCredentialsToLlmCredentials(
         break;
       }
       case "anthropic": {
+        result[PROVIDER_TO_CREDENTIAL_KEY[providerId]] = content.api_key;
+        break;
+      }
+      case "google_ai_studio": {
         result[PROVIDER_TO_CREDENTIAL_KEY[providerId]] = content.api_key;
         break;
       }

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import config from "@app/lib/api/config";
+import { isGoogleAuthenticationErrorMessage } from "@app/lib/api/llm/clients/google/utils/errors";
 import type { Authenticator } from "@app/lib/auth";
 import { ProviderCredentialModel } from "@app/lib/models/provider_credential";
 import { notifyProviderCredentialsHealthUpdated } from "@app/lib/notifications/workflows/provider-credential-updated";
@@ -26,6 +27,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { redactString } from "@app/types/shared/utils/string_utils";
+import { GoogleGenAI } from "@google/genai";
 import assert from "assert";
 import OpenAI from "openai";
 import type { Attributes, ModelStatic } from "sequelize";
@@ -517,6 +519,19 @@ async function isCredentialHealthy({
 
       return true;
     }
+    case "google_ai_studio": {
+      const client = new GoogleGenAI({
+        apiKey: credentials.api_key,
+      });
+
+      try {
+        await client.models.list();
+      } catch (_error) {
+        return false;
+      }
+
+      return true;
+    }
     default:
       assertNever(provider);
   }
@@ -551,6 +566,19 @@ async function hasCredentialAuthError({
         return false;
       } catch (error) {
         return error instanceof OpenAI.AuthenticationError;
+      }
+    }
+    case "google_ai_studio": {
+      const client = new GoogleGenAI({
+        apiKey: credentials.api_key,
+      });
+      try {
+        await client.models.list();
+        return false;
+      } catch (error) {
+        const normalized = normalizeError(error);
+
+        return isGoogleAuthenticationErrorMessage(normalized.message);
       }
     }
     default:

--- a/front/types/assistant/models/providers.ts
+++ b/front/types/assistant/models/providers.ts
@@ -24,6 +24,7 @@ export const MODEL_PROVIDER_IDS = [
 export const BYOK_MODEL_PROVIDER_IDS = [
   "anthropic",
   "openai",
+  "google_ai_studio",
 ] as const satisfies ModelProviderIdType[];
 
 export function getProviderDisplayName(

--- a/front/types/provider_credential.ts
+++ b/front/types/provider_credential.ts
@@ -47,4 +47,8 @@ export type ApiKeyCredentialsType = z.infer<
 export const PROVIDER_TO_CREDENTIAL_KEY = {
   openai: "OPENAI_API_KEY",
   anthropic: "ANTHROPIC_API_KEY",
+  google_ai_studio: "GOOGLE_AI_STUDIO_API_KEY",
 } as const satisfies Record<ByokModelProviderIdType, keyof LLMCredentialsType>;
+
+export type ProviderCredentialKey =
+  (typeof PROVIDER_TO_CREDENTIAL_KEY)[keyof typeof PROVIDER_TO_CREDENTIAL_KEY];


### PR DESCRIPTION
## Description

Adds Google AI Studio as a BYOK model provider alongside OpenAI and Anthropic: registers the `GoogleAiStudio` credential provider in core, maps `GOOGLE_AI_STUDIO_API_KEY`, adds health-check support via the GenAI SDK, and wires it end-to-end through the key configuration UI.

Also fixes a Google AI Studio error-categorisation bug: the SDK returns HTTP 400 (not 401) for invalid API keys, so auth errors now match on message text when the status is 400.

## Tests

Tested manually: saving a valid/invalid Google AI Studio API key via the key configuration sheet, verifying health-check rejection and OAuth credential storage.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front` and `core`