### PR TITLE
Send metronome events

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -26,7 +26,7 @@ function getClient(): Metronome {
 
 /**
  * Send usage events to Metronome's ingest API.
- * Fire-and-forget: logs errors but never throws.
+ * Throws on failure so callers (e.g. Temporal activities) can retry.
  */
 export async function ingestMetronomeEvents(
   events: MetronomeEvent[]
@@ -35,14 +35,7 @@ export async function ingestMetronomeEvents(
     return;
   }
 
-  try {
-    await getClient().v1.usage.ingest({ usage: events });
-  } catch (err) {
-    logger.warn(
-      { error: normalizeError(err), eventCount: events.length },
-      "[Metronome] Failed to call ingest API"
-    );
-  }
+  await getClient().v1.usage.ingest({ usage: events });
 }
 
 // ---------------------------------------------------------------------------

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -182,11 +182,12 @@ export function getToolCategory(
 // ---------------------------------------------------------------------------
 
 /**
- * Build one Metronome event per LLM model call within an agent message.
+ * Build a single Metronome llm_usage event for an agent message, aggregating
+ * all LLM calls (tokens, cost) into one event.
  *
- * transaction_id pattern: llm-{workspaceId}-{agentMessageId}-{modelId}-{index}
+ * transaction_id pattern: llm-{workspaceId}-{agentMessageId}
  */
-export function buildLlmUsageEvents({
+export function buildLlmUsageEvent({
   workspaceId,
   userId,
   agentMessageId,
@@ -208,9 +209,24 @@ export function buildLlmUsageEvents({
   messageTier: MessageTier;
   isSubAgentMessage: boolean;
   timestamp: string;
-}): MetronomeEvent[] {
-  return runUsages.map((usage, index) => ({
-    transaction_id: `llm-${workspaceId}-${agentMessageId}-${index}`,
+}): MetronomeEvent {
+  const promptTokens = runUsages.reduce((sum, u) => sum + u.promptTokens, 0);
+  const completionTokens = runUsages.reduce(
+    (sum, u) => sum + u.completionTokens,
+    0
+  );
+  const cachedTokens = runUsages.reduce(
+    (sum, u) => sum + (u.cachedTokens ?? 0),
+    0
+  );
+  const cacheCreationTokens = runUsages.reduce(
+    (sum, u) => sum + (u.cacheCreationTokens ?? 0),
+    0
+  );
+  const costMicroUsd = runUsages.reduce((sum, u) => sum + u.costMicroUsd, 0);
+
+  return {
+    transaction_id: `llm-${workspaceId}-${agentMessageId}`,
     customer_id: workspaceId,
     event_type: "llm_usage",
     timestamp,
@@ -221,20 +237,18 @@ export function buildLlmUsageEvents({
       ...(parentAgentMessageId
         ? { parent_agent_message_id: parentAgentMessageId }
         : {}),
-      provider_id: usage.providerId,
-      model_id: usage.modelId,
-      prompt_tokens: usage.promptTokens,
-      completion_tokens: usage.completionTokens,
-      cached_tokens: usage.cachedTokens ?? 0,
-      cache_creation_tokens: usage.cacheCreationTokens ?? 0,
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      cached_tokens: cachedTokens,
+      cache_creation_tokens: cacheCreationTokens,
       // Provider cost without markup — markup is applied in Metronome rate card.
-      cost_micro_usd: usage.costMicroUsd,
+      cost_micro_usd: costMicroUsd,
       is_programmatic_usage: isProgrammaticUsage ? "true" : "false",
       message_tier: messageTier,
       is_sub_agent_message: isSubAgentMessage ? "true" : "false",
       origin,
     },
-  }));
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/front/scripts/provision_metronome_customers.ts
+++ b/front/scripts/provision_metronome_customers.ts
@@ -1,0 +1,96 @@
+import { createMetronomeCustomer } from "@app/lib/metronome/client";
+import { SubscriptionModel } from "@app/lib/models/plan";
+import { getStripeSubscription } from "@app/lib/plans/stripe";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import type { LightWorkspaceType } from "@app/types/user";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
+
+async function provisionCustomer(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+) {
+  // Try to get Stripe customer ID from the active subscription.
+  let stripeCustomerId = "";
+  const subscription = await SubscriptionModel.findOne({
+    where: { workspaceId: workspace.id, status: "active" },
+  });
+  if (subscription?.stripeSubscriptionId) {
+    const stripeSubscription = await getStripeSubscription(
+      subscription.stripeSubscriptionId
+    );
+    if (
+      stripeSubscription?.customer &&
+      typeof stripeSubscription.customer === "string"
+    ) {
+      stripeCustomerId = stripeSubscription.customer;
+    }
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      workspaceName: workspace.name,
+      stripeCustomerId: stripeCustomerId || "(none)",
+    },
+    `${execute ? "" : "[DRYRUN] "}Provisioning Metronome customer`
+  );
+
+  if (!execute) {
+    return;
+  }
+
+  const result = await createMetronomeCustomer({
+    workspaceId: workspace.sId,
+    workspaceName: workspace.name,
+    stripeCustomerId,
+  });
+
+  if (result.isOk()) {
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId: result.value.metronomeCustomerId,
+      },
+      "Metronome customer provisioned"
+    );
+  } else {
+    logger.error(
+      { workspaceId: workspace.sId, error: result.error.message },
+      "Failed to provision Metronome customer"
+    );
+  }
+}
+
+makeScript(
+  {
+    workspaceId: {
+      alias: "w",
+      describe: "Workspace sId to provision. Omit to provision all workspaces.",
+      type: "string" as const,
+    },
+  },
+  async (args, logger) => {
+    if (args.workspaceId) {
+      const workspace = await WorkspaceResource.fetchById(args.workspaceId);
+      if (!workspace) {
+        logger.error({ workspaceId: args.workspaceId }, "Workspace not found");
+        return;
+      }
+      await provisionCustomer(
+        renderLightWorkspaceType({ workspace }),
+        args.execute,
+        logger
+      );
+    } else {
+      await runOnAllWorkspaces(
+        (workspace) => provisionCustomer(workspace, args.execute, logger),
+        { concurrency: 4 }
+      );
+    }
+  }
+);

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -22,7 +22,10 @@ import {
 import { handleMentions } from "@app/temporal/agent_loop/activities/mentions";
 import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
 import { snapshotAgentMessageSkills } from "@app/temporal/agent_loop/activities/snapshot_skills";
-import { launchTrackProgrammaticUsage } from "@app/temporal/agent_loop/activities/usage_tracking";
+import {
+  launchEmitMetronomeUsageEvents,
+  launchTrackProgrammaticUsage,
+} from "@app/temporal/agent_loop/activities/usage_tracking";
 import { signalButlerComplete } from "@app/temporal/butler/client";
 import { signalProjectTodoComplete } from "@app/temporal/project_todo/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
@@ -112,6 +115,7 @@ export async function finalizeSuccessfulAgentLoopActivity(
     snapshotAgentMessageSkills(authType, agentLoopArgs),
     launchAgentMessageAnalytics(authType, agentLoopArgs),
     launchTrackProgrammaticUsage(authType, agentLoopArgs),
+    launchEmitMetronomeUsageEvents(authType, agentLoopArgs),
     conversationUnreadNotificationActivity(authType, agentLoopArgs),
     handleMentions(authType, agentLoopArgs),
     sendEmailReplyOnCompletion(authType, agentLoopArgs),
@@ -145,6 +149,7 @@ export async function finalizeCancelledAgentLoopActivity(
     snapshotAgentMessageSkills(authType, agentLoopArgs),
     launchAgentMessageAnalytics(authType, agentLoopArgs),
     launchTrackProgrammaticUsage(authType, agentLoopArgs),
+    launchEmitMetronomeUsageEvents(authType, agentLoopArgs),
     sendEmailReplyOnError(
       authType,
       agentLoopArgs,
@@ -164,6 +169,7 @@ export async function finalizeErroredAgentLoopActivity(
     snapshotAgentMessageSkills(authType, agentLoopArgs),
     launchAgentMessageAnalytics(authType, agentLoopArgs),
     launchTrackProgrammaticUsage(authType, agentLoopArgs),
+    launchEmitMetronomeUsageEvents(authType, agentLoopArgs),
     sendEmailReplyOnError(
       authType,
       agentLoopArgs,

--- a/front/temporal/agent_loop/activities/usage_tracking.ts
+++ b/front/temporal/agent_loop/activities/usage_tracking.ts
@@ -1,7 +1,11 @@
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { launchTrackProgrammaticUsageWorkflow } from "@app/temporal/usage_queue/client";
+import {
+  launchEmitMetronomeUsageEventsWorkflow,
+  launchTrackProgrammaticUsageWorkflow,
+} from "@app/temporal/usage_queue/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
 /**
@@ -34,6 +38,41 @@ export async function launchTrackProgrammaticUsage(
         workspaceId: authType.workspaceId,
       },
       "Failed to launch agent message analytics workflow"
+    );
+  }
+}
+
+/**
+ * Launch Metronome usage events workflow in fire-and-forget mode.
+ * Gated by the `metronome_billing` feature flag — no workflow started if unset.
+ */
+export async function launchEmitMetronomeUsageEvents(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    return;
+  }
+
+  const enabled = await hasFeatureFlag(authResult.value, "metronome_billing");
+  if (!enabled) {
+    return;
+  }
+
+  const result = await launchEmitMetronomeUsageEventsWorkflow({
+    authType,
+    agentLoopArgs,
+  });
+
+  if (result.isErr()) {
+    logger.warn(
+      {
+        agentMessageId: agentLoopArgs.agentMessageId,
+        error: result.error,
+        workspaceId: authType.workspaceId,
+      },
+      "[Metronome] Failed to launch usage events workflow"
     );
   }
 }

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -4,6 +4,13 @@ import {
 } from "@app/lib/api/programmatic_usage/tracking";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
+import { ingestMetronomeEvents } from "@app/lib/metronome/client";
+import {
+  buildLlmUsageEvent,
+  buildToolUseEvents,
+  classifyMessageTier,
+  getToolCategory,
+} from "@app/lib/metronome/events";
 import {
   AgentMessageModel,
   MessageModel,
@@ -13,7 +20,11 @@ import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { reportUsageForSubscriptionItems } from "@app/lib/plans/usage";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import mainLogger from "@app/logger/logger";
 import logger from "@app/logger/logger";
@@ -174,4 +185,140 @@ export async function trackProgrammaticUsageActivity(
   }
 
   return { tracked: false, origin: userMessageOrigin };
+}
+
+/**
+ * Emit Metronome llm_usage and tool_use events for an agent message.
+ * Called for ALL messages (not just programmatic) — always-on, fire-and-forget.
+ * Metronome failures don't affect the agent loop.
+ */
+export async function emitMetronomeUsageEventsActivity(
+  authType: AuthenticatorType,
+  { agentLoopArgs }: { agentLoopArgs: AgentLoopArgs }
+): Promise<void> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    logger.warn(
+      { error: authResult.error.code },
+      "[Metronome] Failed to deserialize authenticator for usage events"
+    );
+    return;
+  }
+  const auth = authResult.value;
+  const workspace = auth.getNonNullableWorkspace();
+  const { agentMessageId, userMessageId } = agentLoopArgs;
+  const userMessageOrigin = agentLoopArgs.userMessageOrigin ?? "web";
+
+  // Query agent message with its run IDs.
+  const agentMessageRow = await MessageModel.findOne({
+    where: {
+      sId: agentMessageId,
+      workspaceId: workspace.id,
+    },
+    include: [
+      {
+        model: AgentMessageModel,
+        as: "agentMessage",
+        required: true,
+      },
+    ],
+  });
+
+  const agentMessage = agentMessageRow?.agentMessage;
+  if (!agentMessage || !agentMessage.runIds) {
+    return;
+  }
+
+  // Get user ID for the event.
+  const userMessageRow = await MessageModel.findOne({
+    where: {
+      sId: userMessageId,
+      workspaceId: workspace.id,
+    },
+    include: [
+      {
+        model: UserMessageModel,
+        as: "userMessage",
+        required: true,
+        include: [{ model: UserModel, required: false }],
+      },
+    ],
+  });
+
+  const userId = userMessageRow?.userMessage?.user?.sId ?? null;
+
+  // Sub-agent messages have agenticMessageType set (e.g. "run_agent", "agent_handover").
+  // agenticOriginMessageId is the sId of the parent agent message that spawned this one.
+  const userMessage = userMessageRow?.userMessage;
+  const parentAgentMessageId = userMessage?.agenticOriginMessageId ?? null;
+  const isSubAgentMessage = userMessage?.agenticMessageType !== null;
+
+  const programmatic = isProgrammaticUsage(auth, { userMessageOrigin });
+  const timestamp = agentMessageRow.createdAt.toISOString();
+
+  // Get LLM run usages.
+  const runs = await RunResource.listByDustRunIds(auth, {
+    dustRunIds: agentMessage.runIds,
+  });
+  const runUsages = (
+    await concurrentExecutor(
+      runs,
+      (run) => {
+        return run.listRunUsages(auth);
+      },
+      { concurrency: 10 }
+    )
+  ).flat();
+
+  // Get MCP actions.
+  const mcpActions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
+    agentMessage.id,
+  ]);
+  const toolActions = mcpActions.map((a) => {
+    const json = a.toJSON();
+    return {
+      sId: json.sId,
+      toolName: json.toolName,
+      mcpServerId: json.mcpServerId,
+      internalMCPServerName: json.internalMCPServerName,
+      status: json.status,
+      executionDurationMs: json.executionDurationMs,
+    };
+  });
+
+  // Classify message tier.
+  const modelIds = runUsages.map((u) => u.modelId);
+  const toolCategories = toolActions.map((a) =>
+    getToolCategory(a.internalMCPServerName)
+  );
+  const messageTier = classifyMessageTier({ modelIds, toolCategories });
+
+  // Build and ingest events.
+  const llmEvent = buildLlmUsageEvent({
+    workspaceId: workspace.sId,
+    userId,
+    agentMessageId,
+    parentAgentMessageId,
+    runUsages,
+    origin: userMessageOrigin,
+    isProgrammaticUsage: programmatic,
+    messageTier,
+    isSubAgentMessage,
+    timestamp,
+  });
+
+  const toolEvents = buildToolUseEvents({
+    workspaceId: workspace.sId,
+    userId,
+    agentMessageId,
+    parentAgentMessageId,
+    actions: toolActions,
+    origin: userMessageOrigin,
+    isProgrammaticUsage: programmatic,
+    messageTier,
+    isSubAgentMessage,
+    timestamp,
+  });
+
+  await ingestMetronomeEvents([llmEvent, ...toolEvents]);
 }

--- a/front/temporal/usage_queue/client.ts
+++ b/front/temporal/usage_queue/client.ts
@@ -3,8 +3,12 @@ import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/usage_queue/config";
-import { makeTrackProgrammaticUsageWorkflowId } from "@app/temporal/usage_queue/helpers";
 import {
+  makeMetronomeUsageEventsWorkflowId,
+  makeTrackProgrammaticUsageWorkflowId,
+} from "@app/temporal/usage_queue/helpers";
+import {
+  emitMetronomeUsageEventsWorkflow,
   trackProgrammaticUsageWorkflow,
   updateWorkspaceUsageWorkflow,
 } from "@app/temporal/usage_queue/workflows";
@@ -118,6 +122,55 @@ export async function launchTrackProgrammaticUsageWorkflow({
           error: e,
         },
         "Failed starting agent analytics workflow"
+      );
+    }
+
+    return new Err(normalizeError(e));
+  }
+}
+
+export async function launchEmitMetronomeUsageEventsWorkflow({
+  authType,
+  agentLoopArgs,
+}: {
+  authType: AuthenticatorType;
+  agentLoopArgs: AgentLoopArgs;
+}): Promise<Result<undefined, Error>> {
+  const { workspaceId } = authType;
+  const { agentMessageId, conversationId } = agentLoopArgs;
+
+  const client = await getTemporalClientForFrontNamespace();
+
+  const workflowId = makeMetronomeUsageEventsWorkflowId({
+    agentMessageId,
+    conversationId,
+    workspaceId,
+  });
+
+  try {
+    await client.workflow.start(emitMetronomeUsageEventsWorkflow, {
+      args: [authType, { agentLoopArgs }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      searchAttributes: {
+        conversationId: [conversationId],
+        workspaceId: workspaceId ? [workspaceId] : undefined,
+      },
+      memo: {
+        agentMessageId,
+        workspaceId,
+      },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    if (!(e instanceof WorkflowExecutionAlreadyStartedError)) {
+      logger.error(
+        {
+          workflowId,
+          agentMessageId,
+          error: e,
+        },
+        "[Metronome] Failed starting usage events workflow"
       );
     }
 

--- a/front/temporal/usage_queue/helpers.ts
+++ b/front/temporal/usage_queue/helpers.ts
@@ -9,3 +9,15 @@ export function makeTrackProgrammaticUsageWorkflowId({
 }): string {
   return `usage-tracking-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
+
+export function makeMetronomeUsageEventsWorkflowId({
+  agentMessageId,
+  conversationId,
+  workspaceId,
+}: {
+  agentMessageId: string;
+  conversationId: string;
+  workspaceId: string;
+}): string {
+  return `metronome-usage-${workspaceId}-${conversationId}-${agentMessageId}`;
+}

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -14,6 +14,12 @@ const { trackProgrammaticUsageActivity } = proxyActivities<typeof activities>({
   },
 });
 
+const { emitMetronomeUsageEventsActivity } = proxyActivities<typeof activities>(
+  {
+    startToCloseTimeout: "5 minutes",
+  }
+);
+
 export async function updateWorkspaceUsageWorkflow(workspaceId: string) {
   // Sleep for one hour before computing usage.
   await sleep(60 * 60 * 1000);
@@ -30,6 +36,19 @@ export async function trackProgrammaticUsageWorkflow(
   }
 ): Promise<void> {
   await trackProgrammaticUsageActivity(authType, {
+    agentLoopArgs,
+  });
+}
+
+export async function emitMetronomeUsageEventsWorkflow(
+  authType: AuthenticatorType,
+  {
+    agentLoopArgs,
+  }: {
+    agentLoopArgs: AgentLoopArgs;
+  }
+): Promise<void> {
+  await emitMetronomeUsageEventsActivity(authType, {
     agentLoopArgs,
   });
 }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -270,6 +270,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable the Poke MCP server for cross-workspace data access.",
     stage: "dust_only",
   },
+  metronome_billing: {
+    description:
+      "Enable Metronome usage event emission (llm_usage, tool_use) for this workspace.",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -717,6 +717,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_usage_mcp"
   | "power_bi_mcp"
   | "reinforced_agents"
+  | "metronome_billing"
   | "poke_mcp"
   | "restrict_agents_publishing"
   | "restrict_agents_publishing_to_admins"


### PR DESCRIPTION
## Description

Implements dust-tt/tasks#7513 — Integrates Metronome event emission into the agent loop finalization flow.

Hooks `llm_usage` and `tool_use` event emission into the existing Temporal usage tracking infrastructure:

- New `emitMetronomeUsageEventsActivity` in `usage_queue/activities.ts` — queries RunUsages (LLM token costs) and MCP actions (tool invocations), classifies message tier (basic/advanced), builds Metronome events, and ingests them
- New `emitMetronomeUsageEventsWorkflow` + `launchEmitMetronomeUsageEventsWorkflow` — dedicated Temporal workflow with default retry policy (deterministic `transaction_id`s ensure idempotent retries)
- Wired into all 3 finalization paths (`finalizeSuccessful`, `finalizeCancelled`, `finalizeErrored`) via `launchEmitMetronomeUsageEvents`
- **Gated by `metronome_billing` feature flag** — no workflow started if the flag is not set on the workspace

Event details:
- **One `llm_usage` event per message** with aggregated tokens and cost across all LLM calls
- **One `tool_use` event per MCP action**
- **Sub-agent detection** via `agenticMessageType` / `agenticOriginMessageId` on user messages — sets `is_sub_agent_message` and `parent_agent_message_id`
- **Timestamp** uses agent message creation time (stable across retries)
- Events emitted for **all messages** (not just programmatic) on flagged workspaces

## Tests

Type-checked. When `metronome_billing` feature flag is not set, no workflow is started.

## Risk

Low — gated by feature flag (`dust_only` stage). New code path runs in a separate Temporal workflow, isolated from existing billing.

## Deploy Plan

1. Deploy code (no impact — feature flag is off by default)
2. Set `METRONOME_API_KEY` in environment
3. Enable `metronome_billing` feature flag on target workspaces via Poke