### PR TITLE
[front] fix use of `useFetcher` in skills hooks

### DIFF
--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -4,7 +4,6 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import type { DetectedSkillSummary } from "@app/lib/skill_detection";
 import {
   emptyArray,
-  getErrorFromResponse,
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
@@ -227,13 +226,13 @@ export function useArchiveSkill({
 
   const doArchive = async () => {
     if (!skill.sId) {
-      return;
+      return false;
     }
-    const res = await fetcher(`/api/w/${owner.sId}/skills/${skill.sId}`, {
-      method: "DELETE",
-    });
+    try {
+      await fetcher(`/api/w/${owner.sId}/skills/${skill.sId}`, {
+        method: "DELETE",
+      });
 
-    if (res.ok) {
       void mutateArchivedSkills();
       void mutateActiveSkills();
       void mutateSuggestedSkills();
@@ -243,16 +242,15 @@ export function useArchiveSkill({
         title: `Successfully archived ${skill.name}`,
         description: `${skill.name} was successfully archived.`,
       });
-    } else {
-      const errorData = await getErrorFromResponse(res);
-
+      return true;
+    } catch (err) {
       sendNotification({
         type: "error",
         title: `Error archiving ${skill.name}`,
-        description: `Error: ${errorData.message}`,
+        description: `Error: ${isAPIErrorResponse(err) ? err.error.message : "An unexpected error occurred."}`,
       });
+      return false;
     }
-    return res.ok;
   };
 
   return doArchive;
@@ -283,16 +281,16 @@ export function useRestoreSkill({
 
   const doRestore = async () => {
     if (!skill.sId) {
-      return;
+      return false;
     }
-    const res = await fetcher(
-      `/api/w/${owner.sId}/skills/${skill.sId}/restore`,
-      {
-        method: "POST",
-      }
-    );
+    try {
+      await fetcher(
+        `/api/w/${owner.sId}/skills/${skill.sId}/restore`,
+        {
+          method: "POST",
+        }
+      );
 
-    if (res.ok) {
       void mutateArchivedSkills();
       void mutateActiveSkills();
 
@@ -301,16 +299,15 @@ export function useRestoreSkill({
         title: `Successfully restored ${skill.name}`,
         description: `${skill.name} was successfully restored.`,
       });
-    } else {
-      const errorData = await getErrorFromResponse(res);
-
+      return true;
+    } catch (err) {
       sendNotification({
         type: "error",
         title: `Error restoring ${skill.name}`,
-        description: `Error: ${errorData.message}`,
+        description: `Error: ${isAPIErrorResponse(err) ? err.error.message : "An unexpected error occurred."}`,
       });
+      return false;
     }
-    return res.ok;
   };
 
   return doRestore;
@@ -486,10 +483,10 @@ export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
     async (formData: ImportFormValues, files: File[]) => {
       setIsImporting(true);
       try {
-        let res: Response;
+        let data: ImportSkillsResponseBody;
         switch (formData.importType) {
           case "repository": {
-            res = await fetcher(`/api/w/${owner.sId}/skills/import`, {
+            data = await fetcher(`/api/w/${owner.sId}/skills/import`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
@@ -507,7 +504,7 @@ export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
             for (const name of formData.selectedSkillNames) {
               body.append("names", name);
             }
-            res = await fetcher(`/api/w/${owner.sId}/skills/import/upload`, {
+            data = await fetcher(`/api/w/${owner.sId}/skills/import/upload`, {
               method: "POST",
               body,
             });
@@ -515,21 +512,19 @@ export function useImportSkills({ owner }: { owner: LightWorkspaceType }) {
           }
         }
 
-        if (!res.ok) {
-          const errorData = await getErrorFromResponse(res);
-          sendNotification({
-            type: "error",
-            title: "Import failed",
-            description: errorData.message,
-          });
-          return { successCount: 0, errors: [errorData.message] };
-        }
-
-        const data: ImportSkillsResponseBody = await res.json();
-
         void mutateActiveSkills();
 
         return notifyImportResult(data, sendNotification);
+      } catch (err) {
+        const message = isAPIErrorResponse(err)
+          ? err.error.message
+          : "Failed to import skills.";
+        sendNotification({
+          type: "error",
+          title: "Import failed",
+          description: message,
+        });
+        return { successCount: 0, errors: [message] };
       } finally {
         setIsImporting(false);
       }
@@ -565,18 +560,13 @@ export function useDetectSkillsFromFiles({
       }
 
       try {
-        const res = await fetcher(`/api/w/${owner.sId}/skills/detect/upload`, {
-          method: "POST",
-          body: formData,
-        });
-
-        if (!res.ok) {
-          const errorData = await getErrorFromResponse(res);
-          setDetectError(errorData.message);
-          return;
-        }
-
-        const data: DetectSkillsResponseBody = await res.json();
+        const data: DetectSkillsResponseBody = await fetcher(
+          `/api/w/${owner.sId}/skills/detect/upload`,
+          {
+            method: "POST",
+            body: formData,
+          }
+        );
         setDetectedSkills(data.skills);
       } catch (err) {
         setDetectError(

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -2,11 +2,7 @@ import type { ImportFormValues } from "@app/components/skills/import/formSchema"
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { DetectedSkillSummary } from "@app/lib/skill_detection";
-import {
-  emptyArray,
-  useFetcher,
-  useSWRWithDefaults,
-} from "@app/lib/swr/swr";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   GetSkillsResponseBody,
   GetSkillsWithRelationsResponseBody,
@@ -284,12 +280,9 @@ export function useRestoreSkill({
       return false;
     }
     try {
-      await fetcher(
-        `/api/w/${owner.sId}/skills/${skill.sId}/restore`,
-        {
-          method: "POST",
-        }
-      );
+      await fetcher(`/api/w/${owner.sId}/skills/${skill.sId}/restore`, {
+        method: "POST",
+      });
 
       void mutateArchivedSkills();
       void mutateActiveSkills();


### PR DESCRIPTION
## Description

- This PR fixes incorrect uses of the `useFetcher` hook in the hooks relative to skills.
- The `fetcher` we get from context does not return a `Response` but processes it instead in `resHandler`.

## Tests

- Tested locally

## Risk

- Low.

## Deploy Plan

- Deploy front.
