### PR TITLE
[front] - chore(API-keys): improve API key dialog space selection UX

### DIFF
--- a/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
+++ b/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuSearchbar,
   DropdownMenuTrigger,
   Input,
+  Label,
   PlusIcon,
   Sheet,
   SheetContainer,

--- a/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
+++ b/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
@@ -10,11 +10,11 @@ import type { ModelId } from "@app/types/shared/model_id";
 import {
   Button,
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
   DropdownMenuTrigger,
   Input,
-  Label,
   PlusIcon,
   Sheet,
   SheetContainer,
@@ -57,6 +57,7 @@ export const NewAPIKeyDialog = ({
   onCreate,
 }: NewAPIKeyDialogProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [spaceSearch, setSpaceSearch] = useState("");
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -131,7 +132,7 @@ export const NewAPIKeyDialog = ({
           disabled={isGenerating || isRevoking}
         />
       </SheetTrigger>
-      <SheetContent>
+      <SheetContent size="lg">
         <SheetHeader>
           <SheetTitle>New API Key</SheetTitle>
         </SheetHeader>
@@ -153,73 +154,85 @@ export const NewAPIKeyDialog = ({
               </BaseFormFieldSection>
 
               <div className="flex flex-col gap-2">
-                <Label>Default Space</Label>
-                <div>
-                  <Button
-                    label={GLOBAL_SPACE_NAME}
-                    size="sm"
-                    variant="outline"
-                    disabled={true}
-                    tooltip={`${GLOBAL_SPACE_NAME} is mandatory.`}
-                  />
-                </div>
-              </div>
-
-              <div className="flex flex-col gap-2">
-                <Label>Additional Spaces</Label>
-                {selectedGroupIds.length > 0 && (
-                  <div className="flex flex-wrap gap-1">
-                    {selectedGroupIds.map((gId) => {
-                      const group = groupsById[gId];
-                      if (!group) {
-                        return null;
-                      }
-                      return (
-                        <Button
-                          key={gId}
-                          label={prettifyGroupName(group)}
-                          icon={XMarkIcon}
-                          size="xs"
-                          variant="outline"
-                          onClick={() => removeGroupId(gId)}
-                        />
-                      );
-                    })}
-                  </div>
-                )}
+                <Label>Spaces</Label>
                 <div>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button
-                        label="Add spaces"
-                        size="sm"
                         variant="outline"
+                        label="Add Spaces"
+                        size="sm"
                         isSelect
                       />
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start">
-                      {nonGlobalGroups.map((group: GroupType) => {
-                        const isSelected = selectedGroupIds.includes(group.id);
-                        return (
-                          <DropdownMenuCheckboxItem
+                    <DropdownMenuContent
+                      className="w-72"
+                      align="start"
+                      dropdownHeaders={
+                        <DropdownMenuSearchbar
+                          name="spaceSearch"
+                          placeholder="Search spaces"
+                          value={spaceSearch}
+                          onChange={setSpaceSearch}
+                        />
+                      }
+                    >
+                      {nonGlobalGroups.filter((g) =>
+                        prettifyGroupName(g)
+                          .toLowerCase()
+                          .includes(spaceSearch.toLowerCase())
+                      ).length === 0 && (
+                        <div className="flex items-center justify-center py-4 text-sm">
+                          No spaces found
+                        </div>
+                      )}
+                      {nonGlobalGroups
+                        .filter(
+                          (g) =>
+                            !selectedGroupIds.includes(g.id) &&
+                            prettifyGroupName(g)
+                              .toLowerCase()
+                              .includes(spaceSearch.toLowerCase())
+                        )
+                        .map((group) => (
+                          <DropdownMenuItem
                             key={group.id}
                             label={prettifyGroupName(group)}
-                            checked={isSelected}
-                            onCheckedChange={() => {
-                              if (isSelected) {
-                                removeGroupId(group.id);
-                              } else {
-                                setSelectedGroupIds([
-                                  ...selectedGroupIds,
-                                  group.id,
-                                ]);
-                              }
-                            }}
+                            onSelect={(e) => e.preventDefault()}
+                            onClick={() =>
+                              setSelectedGroupIds([
+                                ...selectedGroupIds,
+                                group.id,
+                              ])
+                            }
                           />
-                        );
-                      })}
+                        ))}
                     </DropdownMenuContent>
                   </DropdownMenu>
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  <Button
+                    label={GLOBAL_SPACE_NAME}
+                    size="xs"
+                    variant="outline"
+                    disabled
+                  />
+                  {selectedGroupIds.map((gId) => {
+                    const group = groupsById[gId];
+                    if (!group) {
+                      return null;
+                    }
+                    return (
+                      <Button
+                        key={gId}
+                        label={prettifyGroupName(group)}
+                        icon={XMarkIcon}
+                        size="xs"
+                        variant="ghost"
+                        onClick={() => removeGroupId(gId)}
+                      />
+                    );
+                  })}
                 </div>
               </div>
 


### PR DESCRIPTION
## Description

Refactors the API key creation dialog to improve the space selection UX. This PR consolidates the "Default Space" and "Additional Spaces" sections into a single "Spaces" section with improved interaction patterns: replaces checkbox-based selection with a searchable dropdown for adding spaces, displays selected spaces as inline tags with remove buttons, and shows the global space as a non-removable tag alongside additional spaces.

## Tests

- [x] Locally

## Risk

Low - UI refactoring only, no backend or data model changes

## Deploy Plan

Deploy front