### PR TITLE
[front] fix: remove user requirement in public endpoint to sync skills

### DIFF
--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -184,7 +184,11 @@ export async function importSkillsFromFiles(
             sourceMetadata: { filePath: skill.skillMdPath },
             isDefault: false,
           },
-          { mcpServerViews: [], fileAttachments }
+          {
+            mcpServerViews: [],
+            fileAttachments,
+            addCurrentUserAsEditor: auth.user() !== null,
+          }
         );
 
         await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {


### PR DESCRIPTION
## Description

- The GitHub action to sync skills using the public API endpoint currently fails on an `auth.getNonNullableUser()`.
- This is due to the behavior of skill's `makeNew`, that adds the current user as editor by default.
- This PR fixes that. Will also cause the skills to have no editor and to appear as being created by Dust at first.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
