### PR TITLE
[Front] feat(byok): replace hardcoded model configs with whitelisted model helpers

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -25,6 +25,7 @@ import { useSidekickMCPServer } from "@app/components/agent_builder/sidekick/use
 import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgentBuilderForm";
 import {
   getDefaultAgentFormData,
+  getDefaultLargeModel,
   transformAgentConfigurationToFormData,
   transformDuplicateAgentToFormData,
   transformTemplateToFormData,
@@ -48,6 +49,7 @@ import { useAgentConfigurationActions } from "@app/lib/swr/actions";
 import { useEditors } from "@app/lib/swr/agent_editors";
 import { useAgentTriggers } from "@app/lib/swr/agent_triggers";
 import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr/assistants";
+import { useModels } from "@app/lib/swr/models";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -147,6 +149,8 @@ export default function AgentBuilder({
     agentConfigurationId: agentConfiguration?.sId ?? null,
   });
 
+  const { models: availableModels } = useModels({ owner });
+
   const { slackChannels: slackChannelsLinkedWithAgent } =
     useSlackChannelsLinkedWithAgent({
       workspaceId: owner.sId,
@@ -235,11 +239,11 @@ export default function AgentBuilder({
     }
 
     if (assistantTemplate) {
-      return transformTemplateToFormData(assistantTemplate, user, owner);
+      return transformTemplateToFormData(assistantTemplate, user);
     }
 
-    return getDefaultAgentFormData({ owner, user });
-  }, [agentConfiguration, duplicateAgentId, assistantTemplate, user, owner]);
+    return getDefaultAgentFormData({ user });
+  }, [agentConfiguration, duplicateAgentId, assistantTemplate, user]);
 
   const form = useForm<AgentBuilderFormData>({
     resolver: zodResolver(agentBuilderFormSchema),
@@ -253,6 +257,8 @@ export default function AgentBuilder({
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   useEffect(() => {
     const currentValues = form.getValues();
+
+    const defaultModel = getDefaultLargeModel(availableModels);
 
     form.reset({
       ...currentValues,
@@ -277,6 +283,17 @@ export default function AgentBuilder({
             : [user],
         slackChannels: agentSlackChannels,
       },
+      // For new agents, update model settings once available models are loaded.
+      ...(!agentConfiguration && {
+        generationSettings: {
+          ...currentValues.generationSettings,
+          modelSettings: {
+            modelId: defaultModel.modelId,
+            providerId: defaultModel.providerId,
+          },
+          reasoningEffort: defaultModel.defaultReasoningEffort,
+        },
+      }),
     });
   }, [
     triggers,
@@ -293,6 +310,7 @@ export default function AgentBuilder({
     editors,
     agentConfiguration,
     agentSlackChannels,
+    availableModels,
   ]);
 
   const { showDialog, ...dialogProps } = useAwaitableDialog({

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -25,7 +25,7 @@ import { useSidekickMCPServer } from "@app/components/agent_builder/sidekick/use
 import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgentBuilderForm";
 import {
   getDefaultAgentFormData,
-  getDefaultLargeModel,
+  getDefaultModel,
   transformAgentConfigurationToFormData,
   transformDuplicateAgentToFormData,
   transformTemplateToFormData,
@@ -258,7 +258,7 @@ export default function AgentBuilder({
   useEffect(() => {
     const currentValues = form.getValues();
 
-    const defaultModel = getDefaultLargeModel(availableModels);
+    const defaultModel = getDefaultModel(availableModels);
 
     form.reset({
       ...currentValues,

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -3,17 +3,19 @@ import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder
 import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/types/assistant/creativity";
-import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
-import { GEMINI_3_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
-import { MISTRAL_LARGE_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
-import { GPT_5_4_MODEL_CONFIG } from "@app/types/assistant/models/openai";
-import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
+import {
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_4_6_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
+import { GEMINI_3_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
+import { MISTRAL_LARGE_MODEL_ID } from "@app/types/assistant/models/mistral";
+import { GPT_5_4_MODEL_ID } from "@app/types/assistant/models/openai";
 import type {
   ModelConfigurationType,
-  ModelProviderIdType,
+  ModelIdType,
 } from "@app/types/assistant/models/types";
-import { GROK_4_MODEL_CONFIG } from "@app/types/assistant/models/xai";
-import type { UserType, WorkspaceType } from "@app/types/user";
+import { GROK_4_MODEL_ID } from "@app/types/assistant/models/xai";
+import type { UserType } from "@app/types/user";
 import uniqueId from "lodash/uniqueId";
 
 /**
@@ -59,57 +61,37 @@ export function transformAgentConfigurationToFormData(
   };
 }
 
-// TODO(BYOK): For BYOK workspaces, this should also check healthy provider credentials.
-// Needs a new endpoint + SWR hook to fetch BYOK-aware whitelisted providers.
-function isProviderWhitelistedSync(
-  owner: WorkspaceType,
-  providerId: ModelProviderIdType
-): boolean {
-  if (providerId === "noop") {
-    return true;
-  }
-  const whiteListedProviders = owner.whiteListedProviders ?? MODEL_PROVIDER_IDS;
-  return whiteListedProviders.includes(providerId);
-}
+const PREFERRED_LARGE_MODEL_IDS: ModelIdType[] = [
+  CLAUDE_SONNET_4_6_MODEL_ID,
+  GPT_5_4_MODEL_ID,
+  GEMINI_3_PRO_MODEL_ID,
+  MISTRAL_LARGE_MODEL_ID,
+  GROK_4_MODEL_ID,
+];
 
-function getLargeWhitelistedModelSync(
-  owner: WorkspaceType
-): ModelConfigurationType | null {
-  if (isProviderWhitelistedSync(owner, "anthropic")) {
-    return CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
+export function getDefaultLargeModel(
+  availableModels: ModelConfigurationType[]
+): ModelConfigurationType {
+  for (const modelId of PREFERRED_LARGE_MODEL_IDS) {
+    const model = availableModels.find((m) => m.modelId === modelId);
+    if (model) {
+      return model;
+    }
   }
-  if (isProviderWhitelistedSync(owner, "openai")) {
-    return GPT_5_4_MODEL_CONFIG;
-  }
-  if (isProviderWhitelistedSync(owner, "google_ai_studio")) {
-    return GEMINI_3_PRO_MODEL_CONFIG;
-  }
-  if (isProviderWhitelistedSync(owner, "mistral")) {
-    return MISTRAL_LARGE_MODEL_CONFIG;
-  }
-  if (isProviderWhitelistedSync(owner, "xai")) {
-    return GROK_4_MODEL_CONFIG;
-  }
-  return null;
+
+  const fallbackModel = availableModels.find((m) => m.largeModel);
+
+  return fallbackModel ?? CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
 }
 
 export function getDefaultAgentFormData({
   user,
-  owner,
 }: {
   user: UserType;
-  owner: WorkspaceType;
 }): AgentBuilderFormData {
-  const preferredModel = CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
-  const fallbackModel = getLargeWhitelistedModelSync(owner);
-
-  // We use the preferred model unless the provider is deactivated for the workspace but we have a fallback model.
-  // (We have no fallback model if all providers are deactivated which can be done in the workspace settings).
-  const modelConfiguration =
-    !isProviderWhitelistedSync(owner, preferredModel.providerId) &&
-    fallbackModel
-      ? fallbackModel
-      : preferredModel;
+  // Static fallback — overridden by the useEffect in AgentBuilder once available
+  // models are loaded.
+  const defaultModel = CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
 
   return {
     agentSettings: {
@@ -125,11 +107,11 @@ export function getDefaultAgentFormData({
     instructions: "",
     generationSettings: {
       modelSettings: {
-        modelId: modelConfiguration.modelId,
-        providerId: modelConfiguration.providerId,
+        modelId: defaultModel.modelId,
+        providerId: defaultModel.providerId,
       },
       temperature: 0.7,
-      reasoningEffort: modelConfiguration.defaultReasoningEffort,
+      reasoningEffort: defaultModel.defaultReasoningEffort,
       responseFormat: undefined,
     },
     actions: [],
@@ -148,12 +130,10 @@ export function getDefaultAgentFormData({
  */
 export function transformTemplateToFormData(
   template: FetchAgentTemplateResponse,
-  user: UserType,
-  owner: WorkspaceType
+  user: UserType
 ): AgentBuilderFormData {
   const defaultFormData = getDefaultAgentFormData({
     user,
-    owner,
   });
 
   return {

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -69,7 +69,12 @@ const PREFERRED_LARGE_MODEL_IDS: ModelIdType[] = [
   GROK_4_MODEL_ID,
 ];
 
-export function getDefaultLargeModel(
+/**
+ * Returns the best available model from the user's allowed models, matching
+ * against a preferred order. Falls back to any large model, then any model,
+ * then a hardcoded default.
+ */
+export function getDefaultModel(
   availableModels: ModelConfigurationType[]
 ): ModelConfigurationType {
   for (const modelId of PREFERRED_LARGE_MODEL_IDS) {
@@ -79,7 +84,9 @@ export function getDefaultLargeModel(
     }
   }
 
-  const fallbackModel = availableModels.find((m) => m.largeModel);
+  const fallbackModel =
+    availableModels.find((m) => m.largeModel) ??
+    availableModels.find((m) => !m.largeModel);
 
   return fallbackModel ?? CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
 }

--- a/front/components/pages/workspace/developers/ProvidersPage.tsx
+++ b/front/components/pages/workspace/developers/ProvidersPage.tsx
@@ -35,8 +35,6 @@ export function Providers({ owner }: ProvidersProps) {
   );
   const [isModelProvider, setIsModelProvider] = useState(true);
 
-  // TODO(BYOK): For BYOK workspaces, this should also filter by healthy provider credentials.
-  // Needs a new endpoint + SWR hook to fetch BYOK-aware whitelisted providers.
   const appWhiteListedProviders = owner.whiteListedProviders
     ? [...owner.whiteListedProviders, "azure_openai"]
     : APP_MODEL_PROVIDER_IDS;

--- a/front/hooks/useProvidersSelection.ts
+++ b/front/hooks/useProvidersSelection.ts
@@ -19,8 +19,6 @@ export function useProvidersSelection(
     useState<ProvidersSelection>(ALL_PROVIDERS_SELECTED);
   const sendNotifications = useSendNotification();
 
-  // TODO(BYOK): For BYOK workspaces, this should also filter by healthy provider credentials.
-  // Needs a new endpoint + SWR hook to fetch BYOK-aware whitelisted providers.
   const enabledProviders: Readonly<ModelProviderIdType[]> =
     workspace?.whiteListedProviders ?? MODEL_PROVIDER_IDS;
 

--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
@@ -36,7 +36,7 @@ export async function summarizeWithLLM({
 }): Promise<Result<string, Error>> {
   const toSummarize = content.slice(0, MAX_CHARACTERS_TO_SUMMARIZE);
 
-  const model = await getFastModelConfigForSummarization(auth);
+  const model = getFastModelConfigForSummarization(auth);
   if (!model) {
     return new Err(
       new Error("Failed to find a whitelisted model to generate summary")
@@ -96,9 +96,9 @@ export async function summarizeWithLLM({
   return new Ok(summary);
 }
 
-async function getFastModelConfigForSummarization(
+function getFastModelConfigForSummarization(
   auth: Authenticator
-): Promise<ModelConfigurationType | null> {
+): ModelConfigurationType | null {
   const providers = getWhitelistedProviders(auth);
 
   if (providers.has("anthropic")) {

--- a/front/lib/api/assistant/agent_suggestion.ts
+++ b/front/lib/api/assistant/agent_suggestion.ts
@@ -1,12 +1,8 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import {
-  getSmallWhitelistedModel,
-  getWhitelistedProviders,
-} from "@app/lib/assistant";
+import { getFastestWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import { GEMINI_2_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -85,17 +81,11 @@ export async function getSuggestedAgentsForContent(
 ): Promise<Result<LightAgentConfigurationType[], Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  let model = await getSmallWhitelistedModel(auth);
+  const model = getFastestWhitelistedModel(auth);
   if (!model) {
     return new Err(
       new Error("Error suggesting agents: failed to find a whitelisted model.")
     );
-  }
-
-  // TODO(daphne): See if we can put Flash 2 as the default model.
-  const providers = getWhitelistedProviders(auth);
-  if (providers.has("google_ai_studio")) {
-    model = GEMINI_2_5_FLASH_MODEL_CONFIG;
   }
 
   const formattedAgents = JSON.stringify(

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -165,7 +165,7 @@ async function generateConversationTitle(
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const model = await getFastModelConfig(auth);
+  const model = getFastModelConfig(auth);
   if (!model) {
     return new Err(
       new Error("Failed to find a whitelisted model to generate title")
@@ -244,9 +244,9 @@ async function generateConversationTitle(
   return new Err(new Error("No title found in LLM response"));
 }
 
-async function getFastModelConfig(
+function getFastModelConfig(
   auth: Authenticator
-): Promise<ModelConfigurationType | null> {
+): ModelConfigurationType | null {
   const providers = getWhitelistedProviders(auth);
 
   if (providers.has("openai")) {

--- a/front/lib/api/assistant/suggestions/description.ts
+++ b/front/lib/api/assistant/suggestions/description.ts
@@ -1,10 +1,10 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
+import { getFastestWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { BuilderSuggestionInputType } from "@app/types/api/internal/assistant";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
-import { GPT_3_5_TURBO_MODEL_ID } from "@app/types/assistant/models/openai";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -53,12 +53,21 @@ export async function getBuilderDescriptionSuggestions(
   auth: Authenticator,
   inputs: BuilderSuggestionInputType
 ): Promise<Result<SuggestionResults, Error>> {
+  const model = getFastestWhitelistedModel(auth);
+  if (!model) {
+    return new Err(
+      new Error(
+        "Failed to find a whitelisted model for description suggestions"
+      )
+    );
+  }
+
   const res = await runMultiActionsAgent(
     auth,
     {
       functionCall: FUNCTION_NAME,
-      modelId: GPT_3_5_TURBO_MODEL_ID,
-      providerId: "openai",
+      modelId: model.modelId,
+      providerId: model.providerId,
       temperature: 0.5,
       useCache: false,
     },

--- a/front/lib/api/assistant/suggestions/emoji.ts
+++ b/front/lib/api/assistant/suggestions/emoji.ts
@@ -1,11 +1,11 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
+import { getFastestWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { BuilderSuggestionInputType } from "@app/types/api/internal/assistant";
 import { BuilderEmojiSuggestionsResponseBodySchema } from "@app/types/api/internal/assistant";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
-import { GPT_3_5_TURBO_MODEL_ID } from "@app/types/assistant/models/openai";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isLeft } from "fp-ts/lib/Either";
@@ -86,12 +86,19 @@ export async function getBuilderEmojiSuggestions(
   auth: Authenticator,
   inputs: BuilderSuggestionInputType
 ): Promise<Result<SuggestionResults, Error>> {
+  const model = getFastestWhitelistedModel(auth);
+  if (!model) {
+    return new Err(
+      new Error("Failed to find a whitelisted model for emoji suggestions")
+    );
+  }
+
   const res = await runMultiActionsAgent(
     auth,
     {
       functionCall: FUNCTION_NAME,
-      modelId: GPT_3_5_TURBO_MODEL_ID,
-      providerId: "openai",
+      modelId: model.modelId,
+      providerId: model.providerId,
       temperature: 0.7,
       useCache: false,
     },

--- a/front/lib/api/assistant/suggestions/instructions.ts
+++ b/front/lib/api/assistant/suggestions/instructions.ts
@@ -1,13 +1,13 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
+import { getSmallWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { BuilderSuggestionInputType } from "@app/types/api/internal/assistant";
 import type {
   ModelConversationTypeMultiActions,
   ModelMessageTypeMultiActionsWithoutContentFragment,
 } from "@app/types/assistant/generation";
-import { GPT_5_MINI_MODEL_ID } from "@app/types/assistant/models/openai";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isStringArray } from "@app/types/shared/utils/general";
@@ -110,12 +110,21 @@ export async function getBuilderInstructionsSuggestions(
   auth: Authenticator,
   inputs: BuilderSuggestionInputType
 ): Promise<Result<SuggestionResults, Error>> {
+  const model = getSmallWhitelistedModel(auth);
+  if (!model) {
+    return new Err(
+      new Error(
+        "Failed to find a whitelisted model for instruction suggestions"
+      )
+    );
+  }
+
   const res = await runMultiActionsAgent(
     auth,
     {
       functionCall: FUNCTION_NAME,
-      modelId: GPT_5_MINI_MODEL_ID,
-      providerId: "openai",
+      modelId: model.modelId,
+      providerId: model.providerId,
       temperature: 0.7,
       useCache: false,
     },

--- a/front/lib/api/assistant/suggestions/name.ts
+++ b/front/lib/api/assistant/suggestions/name.ts
@@ -1,6 +1,7 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
+import { getFastestWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type { BuilderSuggestionInputType } from "@app/types/api/internal/assistant";
@@ -8,7 +9,6 @@ import type {
   ModelConversationTypeMultiActions,
   UserMessageTypeModel,
 } from "@app/types/assistant/generation";
-import { MISTRAL_SMALL_MODEL_ID } from "@app/types/assistant/models/mistral";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isStringArray } from "@app/types/shared/utils/general";
@@ -103,12 +103,19 @@ export async function getBuilderNameSuggestions(
     "- The name should immediately convey what the agent does.";
   const conversation: ModelConversationTypeMultiActions =
     getConversationContext(inputs);
+  const model = getFastestWhitelistedModel(auth);
+  if (!model) {
+    return new Err(
+      new Error("Failed to find a whitelisted model for name suggestions")
+    );
+  }
+
   const res = await runMultiActionsAgent(
     auth,
     {
       functionCall: FUNCTION_NAME,
-      modelId: MISTRAL_SMALL_MODEL_ID,
-      providerId: "mistral",
+      modelId: model.modelId,
+      providerId: model.providerId,
       temperature: 0.7,
       useCache: false,
     },

--- a/front/lib/api/assistant/suggestions/tags.ts
+++ b/front/lib/api/assistant/suggestions/tags.ts
@@ -1,10 +1,10 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
+import { getFastestWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { BuilderSuggestionInputType } from "@app/types/api/internal/assistant";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
-import { GPT_4_1_MINI_MODEL_ID } from "@app/types/assistant/models/openai";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -108,12 +108,19 @@ export async function getBuilderTagSuggestions(
   // check both client input AND server auth until frontend bug is fixed.
   const isAdminInput = "isAdmin" in inputs ? inputs.isAdmin : false;
 
+  const model = getFastestWhitelistedModel(auth);
+  if (!model) {
+    return new Err(
+      new Error("Failed to find a whitelisted model for tag suggestions")
+    );
+  }
+
   const res = await runMultiActionsAgent(
     auth,
     {
       functionCall: FUNCTION_NAME,
-      modelId: GPT_4_1_MINI_MODEL_ID,
-      providerId: "openai",
+      modelId: model.modelId,
+      providerId: model.providerId,
       temperature: 0.7,
       useCache: false,
     },

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -337,11 +337,7 @@ describe("filterCustomAvailableAndWhitelistedModels", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     const model = createMockModel({ providerId: "openai", largeModel: false });
 
-    const result = await filterCustomAvailableAndWhitelistedModels(
-      [model],
-      [],
-      auth
-    );
+    const result = filterCustomAvailableAndWhitelistedModels([model], [], auth);
     expect(result).toContain(model);
   });
 
@@ -355,11 +351,7 @@ describe("filterCustomAvailableAndWhitelistedModels", () => {
       largeModel: false,
     });
 
-    const result = await filterCustomAvailableAndWhitelistedModels(
-      [model],
-      [],
-      auth
-    );
+    const result = filterCustomAvailableAndWhitelistedModels([model], [], auth);
     expect(result).toHaveLength(0);
   });
 
@@ -372,11 +364,7 @@ describe("filterCustomAvailableAndWhitelistedModels", () => {
       largeModel: false,
     });
 
-    const result = await filterCustomAvailableAndWhitelistedModels(
-      [model],
-      [],
-      auth
-    );
+    const result = filterCustomAvailableAndWhitelistedModels([model], [], auth);
     expect(result).toHaveLength(0);
   });
 
@@ -389,7 +377,7 @@ describe("filterCustomAvailableAndWhitelistedModels", () => {
       largeModel: false,
     });
 
-    const result = await filterCustomAvailableAndWhitelistedModels(
+    const result = filterCustomAvailableAndWhitelistedModels(
       [model],
       ["deepseek_feature"],
       auth
@@ -411,7 +399,7 @@ describe("filterCustomAvailableAndWhitelistedModels", () => {
       largeModel: false,
     });
 
-    const result = await filterCustomAvailableAndWhitelistedModels(
+    const result = filterCustomAvailableAndWhitelistedModels(
       [openaiModel, xaiModel],
       [],
       auth
@@ -427,11 +415,7 @@ describe("filterCustomAvailableAndWhitelistedModels", () => {
       largeModel: false,
     });
 
-    const result = await filterCustomAvailableAndWhitelistedModels(
-      [model],
-      [],
-      auth
-    );
+    const result = filterCustomAvailableAndWhitelistedModels([model], [], auth);
     expect(result).toContain(model);
   });
 });

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -345,6 +345,11 @@ export class Authenticator {
       ]);
     }
 
+    const providersHealth = await this.fetchByokProvidersHealth(
+      workspace,
+      subscription
+    );
+
     return new Authenticator({
       authMethod: "session",
       workspace,
@@ -352,6 +357,7 @@ export class Authenticator {
       role: user?.isDustSuperUser ? "admin" : "none",
       groupModelIds: groups.map((g) => g.id),
       subscription,
+      providersHealth,
     });
   }
   /**

--- a/front/pages/api/w/[wId]/models.ts
+++ b/front/pages/api/w/[wId]/models.ts
@@ -28,12 +28,12 @@ async function handler(
       const featureFlags = await getFeatureFlags(auth);
       // Include both standard models and custom models (from GCS at build time)
       const allUsedModels = [...USED_MODEL_CONFIGS, ...CUSTOM_MODEL_CONFIGS];
-      const models = await filterCustomAvailableAndWhitelistedModels(
+      const models = filterCustomAvailableAndWhitelistedModels(
         allUsedModels,
         featureFlags,
         auth
       );
-      const reasoningModels = await filterCustomAvailableAndWhitelistedModels(
+      const reasoningModels = filterCustomAvailableAndWhitelistedModels(
         REASONING_MODEL_CONFIGS,
         featureFlags,
         auth


### PR DESCRIPTION
## Description

BYOK workspaces only have access to providers they've configured credentials for. Several codepaths (builder suggestions, conversation titles, agent suggestions, web summarization, default agent model) were hardcoding specific model IDs/configs, bypassing the whitelisted provider logic entirely — breaking for BYOK users.

Replace all hardcoded model selections with the existing `getSmallWhitelistedModel`, `getFastestWhitelistedModel`, and `getLargeWhitelistedModel` helpers. For the frontend agent builder, use `useModels` (which already returns BYOK-filtered models) to pick the default model.

Also removes unnecessary `async`/`await` on synchronous functions (`getFastModelConfig`, `getFastModelConfigForSummarization`, `filterCustomAvailableAndWhitelistedModels`).

Closes: https://github.com/dust-tt/tasks/issues/7288

## Tests

Local

- [x] On a BYOK workspace with only one provider configured, open the agent builder → default model should match the configured provider
- [x] Create a new agent → name/description/emoji/tag suggestions should work (not fail with "no whitelisted model")
- [x] Send a message in a new conversation → title generation should work
- [x] Use an agent with web browse tool → summarization should work