### PR TITLE
Reinforced Agent: better naming for langfuse traces

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -398,7 +398,7 @@ export abstract class LLM<TPayload = unknown> {
       const payload = this.buildStreamRequestPayload(params);
 
       const generation = startObservation(
-        "llm-batch-input",
+        `llm-batch-input-${customId}`,
         {
           input: payload,
           model: this.modelId,
@@ -478,7 +478,7 @@ export abstract class LLM<TPayload = unknown> {
       const buffer = new LLMTraceBuffer(traceId, workspaceId, this.context!);
 
       const generation = startObservation(
-        "llm-batch-completion",
+        `llm-batch-completion-${customId}`,
         {
           input: { batchCustomId: customId },
           model: this.modelId,


### PR DESCRIPTION
## Description

Conversation ids are added to the span name so we know which input/ouput are related:

<img width="406" height="196" alt="image" src="https://github.com/user-attachments/assets/201af443-1657-4d5b-8e0f-72ea8969cdb3" />


## Tests

tested locally

## Risk

low

## Deploy Plan

deploy front 
