### PR TITLE
[front] add max memory to redis locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
     image: redis
     ports:
       - 6379:6379
+    command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lfu
   apache-tika:
     image: apache/tika:2.9.2.1-full
     ports:


### PR DESCRIPTION
## Description

- This PR sets a max memory and a max memory policy (allkeys lfu) for Redis in a local environment.
- The current configuration we get by default is the following
```bash
 redis-cli CONFIG GET maxmemory && redis-cli CONFIG GET maxmemory-policy                                                                                                                     08:11:18 PM
1) "maxmemory"
2) "0"
1) "maxmemory-policy"
2) "noeviction"
``` 
- Our caching for the resources required by `fromSession` uses LFU: https://github.com/dust-tt/dust/pull/22388 and https://github.com/dust-tt/dust-infra/blob/main/environments/production/europe-west1/gcp/redis.tf, causing memory accumulation in development.

## Tests

- Tested locally.

## Risk

- None. not run in production.

## Deploy Plan

- No deploy, only affects local development.
