### PR TITLE
Tracking: PostHog landing metadata

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -14,7 +14,7 @@ import {
   getPostHogCookieDomain,
 } from "@app/lib/utils/anonymous_id";
 import {
-  getStoredReferrer,
+  getStoredLandingContext,
   getStoredUTMParams,
   MARKETING_PARAMS,
 } from "@app/lib/utils/utm";
@@ -224,19 +224,23 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
           }
         }
 
-        // Inject stored referrer so the real external referrer (e.g.
-        // google.com) is preserved instead of the stale signin.dust.tt
-        // that posthog-js computes after the auth redirect.
-        const storedReferrer = getStoredReferrer();
-        if (storedReferrer) {
-          setOnceProps["$initial_referrer"] = storedReferrer;
-          try {
-            setOnceProps["$initial_referring_domain"] = new URL(
-              storedReferrer
-            ).hostname;
-          } catch {
-            // Malformed referrer URL — skip the domain.
+        // Inject first-touch landing context so the real values survive
+        // the dust.tt -> signin -> app.dust.tt auth redirect flow.
+        const landing = getStoredLandingContext();
+        if (landing) {
+          if (landing.referrer) {
+            setOnceProps["$initial_referrer"] = landing.referrer;
+            try {
+              setOnceProps["$initial_referring_domain"] = new URL(
+                landing.referrer
+              ).hostname;
+            } catch {
+              // Malformed referrer URL.
+            }
           }
+          setOnceProps["$initial_host"] = landing.host;
+          setOnceProps["$initial_current_url"] = landing.url;
+          setOnceProps["$initial_pathname"] = landing.pathname;
         }
 
         if (Object.keys(setOnceProps).length > 0) {
@@ -305,17 +309,22 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
         }
       }
 
-      // Include the original external referrer (from the _dust_referrer cookie).
-      const storedReferrer = getStoredReferrer();
-      if (storedReferrer) {
-        firstTouchProps["first_referrer"] = storedReferrer;
-        try {
-          firstTouchProps["first_referring_domain"] = new URL(
-            storedReferrer
-          ).hostname;
-        } catch {
-          // Ignore malformed referrer URLs.
+      // Include first-touch landing context.
+      const landing = getStoredLandingContext();
+      if (landing) {
+        if (landing.referrer) {
+          firstTouchProps["first_referrer"] = landing.referrer;
+          try {
+            firstTouchProps["first_referring_domain"] = new URL(
+              landing.referrer
+            ).hostname;
+          } catch {
+            // Malformed referrer URL.
+          }
         }
+        firstTouchProps["first_host"] = landing.host;
+        firstTouchProps["first_landing_url"] = landing.url;
+        firstTouchProps["first_landing_pathname"] = landing.pathname;
       }
 
       if (Object.keys(firstTouchProps).length > 0) {

--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -223,6 +223,22 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
             setOnceProps[`$initial_${param}`] = storedValue;
           }
         }
+
+        // Inject stored referrer so the real external referrer (e.g.
+        // google.com) is preserved instead of the stale signin.dust.tt
+        // that posthog-js computes after the auth redirect.
+        const storedReferrer = getStoredReferrer();
+        if (storedReferrer) {
+          setOnceProps["$initial_referrer"] = storedReferrer;
+          try {
+            setOnceProps["$initial_referring_domain"] = new URL(
+              storedReferrer
+            ).hostname;
+          } catch {
+            // Malformed referrer URL — skip the domain.
+          }
+        }
+
         if (Object.keys(setOnceProps).length > 0) {
           event.$set_once = {
             ...event.$set_once,

--- a/front/hooks/useStripUtmParams.ts
+++ b/front/hooks/useStripUtmParams.ts
@@ -6,7 +6,7 @@ import {
   MARKETING_PARAMS,
   persistClickIdCookies,
   persistDustAidFromURL,
-  persistReferrerCookie,
+  persistLandingContext,
   persistUTMCookies,
 } from "@app/lib/utils/utm";
 import { useEffect } from "react";
@@ -36,8 +36,8 @@ export function useStripUtmParams() {
       // Re-establish anonymous device ID from email CTA links (?dust_aid=...).
       persistDustAidFromURL();
 
-      // Capture the original external referrer in a cross-subdomain cookie.
-      persistReferrerCookie();
+      // Capture first-touch landing context (referrer, host, url, pathname).
+      persistLandingContext();
 
       const params = Object.fromEntries(
         new URLSearchParams(window.location.search)

--- a/front/lib/utils/utm.ts
+++ b/front/lib/utils/utm.ts
@@ -180,55 +180,78 @@ export const getStoredUTMParams = (): UTMParams => {
   }
 };
 
-const REFERRER_COOKIE = "_dust_referrer";
-const REFERRER_COOKIE_EXPIRY_DAYS = 30;
+const LANDING_COOKIE = "_dust_landing";
+const LANDING_COOKIE_EXPIRY_DAYS = 30;
 
-// Persist `document.referrer` in a cross-subdomain cookie (first-touch only).
-// Only written when the referrer is external (not *.dust.tt) and the cookie
-// does not already exist, so the original traffic source survives the
-// dust.tt → signin → app.dust.tt auth flow.
-export function persistReferrerCookie(): void {
-  if (typeof document === "undefined") {
+interface LandingContext {
+  referrer: string | null;
+  host: string;
+  url: string;
+  pathname: string;
+}
+
+// Persist first-touch landing context in a single cross-subdomain cookie.
+// Survives the dust.tt -> signin -> app.dust.tt auth redirect flow.
+export function persistLandingContext(): void {
+  if (typeof window === "undefined") {
     return;
   }
 
-  if (getStoredReferrer()) {
+  if (getStoredLandingContext()) {
     return;
   }
 
-  const referrer = document.referrer;
-  if (!referrer) {
-    return;
-  }
-
-  try {
-    const host = new URL(referrer).hostname;
-    if (host === "localhost" || host.endsWith(".dust.tt")) {
-      return;
+  let referrer: string | null = null;
+  if (document.referrer) {
+    try {
+      const refHost = new URL(document.referrer).hostname;
+      if (refHost !== "localhost" && !refHost.endsWith(".dust.tt")) {
+        referrer = document.referrer;
+      }
+    } catch {
+      // Malformed referrer.
     }
-  } catch {
-    return;
   }
+
+  const context: LandingContext = {
+    referrer,
+    host: window.location.hostname,
+    url: window.location.href,
+    pathname: window.location.pathname,
+  };
 
   const domain = getRootCookieDomain();
   const domainPart = domain ? `; domain=${domain}` : "";
   const expires = new Date(
-    Date.now() + REFERRER_COOKIE_EXPIRY_DAYS * 24 * 60 * 60 * 1000
+    Date.now() + LANDING_COOKIE_EXPIRY_DAYS * 24 * 60 * 60 * 1000
   ).toUTCString();
 
-  document.cookie = `${REFERRER_COOKIE}=${encodeURIComponent(referrer)}; expires=${expires}; path=/${domainPart}; SameSite=Lax; Secure`;
+  document.cookie = `${LANDING_COOKIE}=${encodeURIComponent(JSON.stringify(context))}; expires=${expires}; path=/${domainPart}; SameSite=Lax; Secure`;
 }
 
-// Read the stored referrer from the cross-subdomain `_dust_referrer` cookie.
-export function getStoredReferrer(): string | null {
+export function getStoredLandingContext(): LandingContext | null {
   if (typeof document === "undefined") {
     return null;
   }
 
-  const prefix = `${REFERRER_COOKIE}=`;
+  const prefix = `${LANDING_COOKIE}=`;
   const cookie = document.cookie.split("; ").find((c) => c.startsWith(prefix));
+  if (!cookie) {
+    return null;
+  }
 
-  return cookie ? decodeURIComponent(cookie.slice(prefix.length)) : null;
+  try {
+    return JSON.parse(
+      decodeURIComponent(cookie.slice(prefix.length))
+    ) as LandingContext;
+  } catch {
+    return null;
+  }
+}
+
+// Convenience helper for call sites that only need the referrer.
+export function getStoredReferrer(): string | null {
+  return getStoredLandingContext()?.referrer ?? null;
 }
 
 // Append UTM parameters to URLs.


### PR DESCRIPTION
## Description

Continues https://github.com/dust-tt/dust/pull/23547.

The `before_send` hook was only injecting UTM params into `$set_once`. Other initial person properties ($initial_referrer, $initial_host, $initial_current_url, $initial_pathname) were  still getting overwritten with post-redirect values (e.g. signin.dust.tt instead of google.com).
This consolidates the per-referrer _dust_referrer cookie into a single _dust_landing cookie  that captures the full first-touch landing context (referrer, host, url, pathname) and injects all of them into `$set_once` via the existing `before_send` hook

## Tests

Will test changes manually after deploying.

## Risk

Low, tracking changes only.

## Deploy Plan
