### PR TITLE
Add stricter typing for audit logs, reduce number of "internal" sources

### DIFF
--- a/front/admin/audit_log_schemas/tool.executed.json
+++ b/front/admin/audit_log_schemas/tool.executed.json
@@ -14,6 +14,7 @@
   "metadata": {
     "toolName": "string",
     "toolType": "string",
-    "conversationId": "string"
+    "conversationId": "string",
+    "origin": "string"
   }
 }

--- a/front/admin/audit_log_schemas/tool.executed.json
+++ b/front/admin/audit_log_schemas/tool.executed.json
@@ -14,7 +14,6 @@
   "metadata": {
     "toolName": "string",
     "toolType": "string",
-    "conversationId": "string",
-    "origin": "string"
+    "conversationId": "string"
   }
 }

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -17,7 +17,7 @@ import {
 } from "@app/lib/api/assistant/publishing_restrictions";
 import { agentConfigurationWasUpdatedBy } from "@app/lib/api/assistant/recent_authors";
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -864,12 +864,8 @@ export async function createAgentConfiguration(
         auth,
         action: isCreate ? "agent.created" : "agent.updated",
         targets: [
-          buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-          {
-            type: "agent",
-            id: agentConfiguration.sId,
-            name: agentConfiguration.name,
-          },
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("agent", agentConfiguration),
         ],
         context: getAuditLogContext(auth),
         metadata: {
@@ -1280,8 +1276,8 @@ export async function archiveAgentConfiguration(
       auth,
       action: "agent.archived",
       targets: [
-        buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-        { type: "agent", id: agentConfig.sId, name: agentConfig.name },
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("agent", agentConfig),
       ],
       context: getAuditLogContext(auth),
       metadata: {
@@ -1401,12 +1397,8 @@ export async function restoreAgentConfiguration(
       auth,
       action: "agent.restored",
       targets: [
-        buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-        {
-          type: "agent",
-          id: latestConfig.sId,
-          name: latestConfig.name,
-        },
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("agent", latestConfig),
       ],
       context: getAuditLogContext(auth),
       metadata: {
@@ -1724,8 +1716,8 @@ export async function updateAgentConfigurationScope(
     auth,
     action: "agent.scope_changed",
     targets: [
-      buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-      { type: "agent", id: agentConfig.sId, name: agentConfig.name },
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("agent", agentConfig),
     ],
     context: getAuditLogContext(auth),
     metadata: {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -875,22 +875,20 @@ export async function postUserMessage(
   });
 
   // Emit agent.executed for each agent being invoked.
-  if (auth.user()) {
-    for (const agentMessage of agentMessages) {
-      void emitAuditLogEvent({
-        auth,
-        action: "agent.executed",
-        targets: [
-          buildAuditLogTarget("workspace", conversation.owner),
-          buildAuditLogTarget("agent", agentMessage.configuration),
-        ],
-        metadata: {
-          conversationId: conversation.sId,
-          agentName: agentMessage.configuration.name,
-          origin: getAuditLogOrigin(auth),
-        },
-      });
-    }
+  for (const agentMessage of agentMessages) {
+    void emitAuditLogEvent({
+      auth,
+      action: "agent.executed",
+      targets: [
+        buildAuditLogTarget("workspace", conversation.owner),
+        buildAuditLogTarget("agent", agentMessage.configuration),
+      ],
+      metadata: {
+        conversationId: conversation.sId,
+        agentName: agentMessage.configuration.name,
+        origin: getAuditLogOrigin(auth),
+      },
+    });
   }
 
   // Run agent loop workflows after the transaction commits, to ensure messages are persisted.

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -36,7 +36,6 @@ import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types"
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
-  getAuditLogOrigin,
 } from "@app/lib/api/audit/workos_audit";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
@@ -886,7 +885,7 @@ export async function postUserMessage(
       metadata: {
         conversationId: conversation.sId,
         agentName: agentMessage.configuration.name,
-        origin: getAuditLogOrigin(auth),
+        origin: context.origin,
       },
     });
   }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -34,7 +34,7 @@ import {
 } from "@app/lib/api/assistant/streaming/events";
 import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types";
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogOrigin,
 } from "@app/lib/api/audit/workos_audit";
@@ -881,12 +881,8 @@ export async function postUserMessage(
         auth,
         action: "agent.executed",
         targets: [
-          buildWorkspaceTarget(conversation.owner),
-          {
-            type: "agent",
-            id: agentMessage.configuration.sId,
-            name: agentMessage.configuration.name,
-          },
+          buildAuditLogTarget("workspace", conversation.owner),
+          buildAuditLogTarget("agent", agentMessage.configuration),
         ],
         metadata: {
           conversationId: conversation.sId,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -218,14 +218,36 @@ export function buildAuditActor(auth: Authenticator): AuditLogActor {
   };
 }
 
+type AuditTargetType =
+  | "workspace"
+  | "user"
+  | "agent"
+  | "space"
+  | "data_source"
+  | "tool"
+  | "trigger"
+  | "api_key"
+  | "invitation"
+  | "group";
+
 /**
- * Builds a workspace audit target.
+ * Builds a typed audit log target.
+ */
+export function buildAuditLogTarget(
+  type: AuditTargetType,
+  resource: { sId: string; name: string }
+): AuditLogTarget {
+  return { type, id: resource.sId, name: resource.name };
+}
+
+/**
+ * @deprecated Use buildAuditLogTarget("workspace", workspace) instead.
  */
 export function buildWorkspaceTarget(workspace: {
   sId: string;
   name: string;
 }): AuditLogTarget {
-  return { type: "workspace", id: workspace.sId, name: workspace.name };
+  return buildAuditLogTarget("workspace", workspace);
 }
 
 /**

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -258,16 +258,6 @@ export function buildAuditLogTarget(
 }
 
 /**
- * @deprecated Use buildAuditLogTarget("workspace", workspace) instead.
- */
-export function buildWorkspaceTarget(workspace: {
-  sId: string;
-  name: string;
-}): AuditLogTarget {
-  return buildAuditLogTarget("workspace", workspace);
-}
-
-/**
  * Derives the origin of an audit event from the Authenticator.
  * - "web": user-initiated via browser (user present, client IP available)
  * - "api": API-key-initiated (key present)

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -205,16 +205,33 @@ export async function emitAuditLogEventDirect({
 
 /**
  * Builds the audit actor from an Authenticator.
+ * Uses the authenticated user when available, falls back to the API key.
  */
 export function buildAuditActor(auth: Authenticator): AuditLogActor {
-  const user = auth.getNonNullableUser();
+  const user = auth.user();
+  if (user) {
+    return {
+      type: "user",
+      id: user.sId,
+      name: user.fullName() ?? undefined,
+      metadata: {
+        email: user.email,
+      },
+    };
+  }
+
+  const key = auth.key();
+  if (key) {
+    return {
+      type: "api_key",
+      id: String(key.id),
+      name: key.name,
+    };
+  }
+
   return {
-    type: "user",
-    id: user.sId,
-    name: user.fullName() ?? undefined,
-    metadata: {
-      email: user.email,
-    },
+    type: "system",
+    id: "unknown",
   };
 }
 

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -223,7 +223,7 @@ export function buildAuditActor(auth: Authenticator): AuditLogActor {
   const key = auth.key();
   if (key) {
     return {
-      type: "api_key",
+      type: key.isSystem ? "system_key" : "api_key",
       id: String(key.id),
       name: key.name,
     };
@@ -231,7 +231,7 @@ export function buildAuditActor(auth: Authenticator): AuditLogActor {
 
   return {
     type: "system",
-    id: "unknown",
+    id: auth.authMethod(),
   };
 }
 

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -258,23 +258,6 @@ export function buildAuditLogTarget(
 }
 
 /**
- * Derives the origin of an audit event from the Authenticator.
- * - "web": user-initiated via browser (user present, client IP available)
- * - "api": API-key-initiated (key present)
- * - "trigger": trigger-initiated (user present but no client IP)
- * - "system": system/internal (no user, no key)
- */
-export function getAuditLogOrigin(auth: Authenticator): string {
-  if (auth.key()) {
-    return "api";
-  }
-  if (auth.user()) {
-    return auth.clientIp() ? "web" : "trigger";
-  }
-  return "system";
-}
-
-/**
  * Builds the audit log context with the client IP address.
  * When called with a request object, extracts the IP from headers.
  * Otherwise returns the IP from auth or "internal" as the location.

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -248,11 +248,22 @@ type AuditTargetType =
   | "group";
 
 /**
- * Builds a typed audit log target.
+ * Resource shape required for each audit target type.
+ * All currently use { sId, name }; individual types can be tightened
+ * to specific resource types (e.g., LightWorkspaceType) in the future.
  */
-export function buildAuditLogTarget(
-  type: AuditTargetType,
-  resource: { sId: string; name: string }
+type AuditTargetResourceMap = {
+  [K in AuditTargetType]: { sId: string; name: string };
+};
+
+/**
+ * Builds a typed audit log target.
+ * The generic constraint ensures the type string is a valid AuditTargetType
+ * and the resource matches the expected shape for that type.
+ */
+export function buildAuditLogTarget<T extends AuditTargetType>(
+  type: T,
+  resource: AuditTargetResourceMap[T]
 ): AuditLogTarget {
   return { type, id: resource.sId, name: resource.name };
 }

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -1,4 +1,5 @@
 import {
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -384,11 +385,9 @@ export async function handleMembershipInvitations(
         void emitAuditLogEvent({
           auth,
           action: "member.invited",
-          targets: successfulInvites.map((r) => ({
-            type: "user" as const,
-            id: r.email,
-            name: r.email,
-          })),
+          targets: successfulInvites.map((r) =>
+            buildAuditLogTarget("user", { sId: r.email, name: r.email })
+          ),
           context: getAuditLogContext(auth),
           metadata: {
             invitedCount: String(successfulInvites.length),

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -55,7 +55,10 @@ export async function revokeAndTrackMembership(
       action: "membership.revoked",
       targets: [
         buildAuditLogTarget("workspace", workspace),
-        buildAuditLogTarget("user", { sId: user.sId, name: user.fullName() }),
+        buildAuditLogTarget("user", {
+          sId: user.sId,
+          name: user.fullName() ?? "unknown",
+        }),
       ],
       context: getAuditLogContext(auth),
       metadata: {

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -1,5 +1,5 @@
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -54,8 +54,8 @@ export async function revokeAndTrackMembership(
       auth,
       action: "membership.revoked",
       targets: [
-        buildWorkspaceTarget(workspace),
-        { type: "user", id: user.sId, name: user.fullName() },
+        buildAuditLogTarget("workspace", workspace),
+        buildAuditLogTarget("user", { sId: user.sId, name: user.fullName() }),
       ],
       context: getAuditLogContext(auth),
       metadata: {

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -1,5 +1,5 @@
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import config from "@app/lib/api/config";
@@ -223,7 +223,7 @@ export async function createConnectionAndGetSetupUrl(
   void emitAuditLogEvent({
     auth,
     action: "oauth.initiated",
-    targets: [buildWorkspaceTarget(auth.getNonNullableWorkspace())],
+    targets: [buildAuditLogTarget("workspace", auth.getNonNullableWorkspace())],
     metadata: {
       provider: String(provider),
       connectionId: connection.connection_id,
@@ -316,7 +316,9 @@ export async function finalizeConnection(
     void emitAuditLogEvent({
       auth,
       action: "oauth.authorized",
-      targets: [buildWorkspaceTarget(auth.getNonNullableWorkspace())],
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      ],
       metadata: {
         provider: String(provider),
         connectionId,

--- a/front/lib/api/poke/plugins/data_sources/delete_data_source.ts
+++ b/front/lib/api/poke/plugins/data_sources/delete_data_source.ts
@@ -1,5 +1,5 @@
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import { softDeleteDataSourceAndLaunchScrubWorkflow } from "@app/lib/api/data_sources";
@@ -76,12 +76,8 @@ export const deleteDataSourcePlugin = createPlugin({
       auth,
       action: "datasource.deleted_admin",
       targets: [
-        buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-        {
-          type: "data_source",
-          id: dataSource.sId,
-          name: dataSource.name,
-        },
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("data_source", dataSource),
       ],
       metadata: {
         dataSourceName: dataSource.name,

--- a/front/lib/api/poke/plugins/global/relocate_user.ts
+++ b/front/lib/api/poke/plugins/global/relocate_user.ts
@@ -1,4 +1,7 @@
-import { emitAuditLogEvent } from "@app/lib/api/audit/workos_audit";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
 import { createPlugin } from "@app/lib/api/poke/types";
 import type { RegionType } from "@app/lib/api/regions/config";
 import {
@@ -86,7 +89,9 @@ export const relocateUserPlugin = createPlugin({
       void emitAuditLogEvent({
         auth,
         action: "user.relocated",
-        targets: [{ type: "user", id: userId, name: user.email }],
+        targets: [
+          buildAuditLogTarget("user", { sId: userId, name: user.email }),
+        ],
         metadata: {
           fromRegion: multiRegionsConfig.getCurrentRegion(),
           toRegion: String(newRegion[0]),

--- a/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
+++ b/front/lib/api/poke/plugins/workspaces/delete_workspace.ts
@@ -1,5 +1,5 @@
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -84,7 +84,7 @@ export const deleteWorkspacePlugin = createPlugin({
     void emitAuditLogEvent({
       auth,
       action: "workspace.deleted",
-      targets: [buildWorkspaceTarget(workspace)],
+      targets: [buildAuditLogTarget("workspace", workspace)],
       context: getAuditLogContext(auth),
       metadata: {
         relocated: String(workspaceHasBeenRelocated ?? false),

--- a/front/lib/api/poke/plugins/workspaces/invite_user.ts
+++ b/front/lib/api/poke/plugins/workspaces/invite_user.ts
@@ -1,5 +1,5 @@
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import { handleMembershipInvitations } from "@app/lib/api/invitation";
@@ -100,7 +100,9 @@ export const inviteUser = createPlugin({
       void emitAuditLogEvent({
         auth,
         action: "member.bulk_invited",
-        targets: [buildWorkspaceTarget(auth.getNonNullableWorkspace())],
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        ],
         metadata: {
           invitedEmails: successes.map((r) => r.email).join(","),
           count: String(successes.length),

--- a/front/lib/api/poke/plugins/workspaces/revoke_users.ts
+++ b/front/lib/api/poke/plugins/workspaces/revoke_users.ts
@@ -1,5 +1,5 @@
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import { revokeAndTrackMembership } from "@app/lib/api/membership";
@@ -61,7 +61,9 @@ export const revokeUsersPlugin = createPlugin({
       void emitAuditLogEvent({
         auth,
         action: "member.bulk_revoked",
-        targets: [buildWorkspaceTarget(auth.getNonNullableWorkspace())],
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        ],
         metadata: {
           revokedUserIds: successfulRevocations.map((r) => r.userId).join(","),
           count: String(successfulRevocations.length),

--- a/front/lib/api/poke/plugins/workspaces/user_identity_merge.ts
+++ b/front/lib/api/poke/plugins/workspaces/user_identity_merge.ts
@@ -1,5 +1,5 @@
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import { createPlugin } from "@app/lib/api/poke/types";
@@ -67,17 +67,15 @@ export const userIdentityMergePlugin = createPlugin({
       auth,
       action: "user.identity_merged",
       targets: [
-        buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-        {
-          type: "user",
-          id: mergeResult.value.primaryUser.sId,
-          name: mergeResult.value.primaryUser.fullName() ?? undefined,
-        },
-        {
-          type: "user",
-          id: mergeResult.value.secondaryUser.sId,
-          name: mergeResult.value.secondaryUser.fullName() ?? undefined,
-        },
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("user", {
+          sId: mergeResult.value.primaryUser.sId,
+          name: mergeResult.value.primaryUser.fullName() ?? "unknown",
+        }),
+        buildAuditLogTarget("user", {
+          sId: mergeResult.value.secondaryUser.sId,
+          name: mergeResult.value.secondaryUser.fullName() ?? "unknown",
+        }),
       ],
       metadata: {
         primaryUserId: mergeResult.value.primaryUser.sId,

--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -61,11 +61,14 @@ export async function createAndLogMembership({
     actor: {
       type: "user",
       id: user.sId,
-      name: user.fullName(),
+      name: user.fullName() ?? "unknown",
     },
     targets: [
       buildAuditLogTarget("workspace", w),
-      buildAuditLogTarget("user", { sId: user.sId, name: user.fullName() }),
+      buildAuditLogTarget("user", {
+        sId: user.sId,
+        name: user.fullName() ?? "unknown",
+      }),
     ],
     context: { location: "internal" },
     metadata: {

--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -1,5 +1,5 @@
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
 import { evaluateWorkspaceSeatAvailability } from "@app/lib/api/workspace";
@@ -64,8 +64,8 @@ export async function createAndLogMembership({
       name: user.fullName(),
     },
     targets: [
-      buildWorkspaceTarget(w),
-      { type: "user", id: user.sId, name: user.fullName() },
+      buildAuditLogTarget("workspace", w),
+      buildAuditLogTarget("user", { sId: user.sId, name: user.fullName() }),
     ],
     context: { location: "internal" },
     metadata: {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -89,6 +89,7 @@ export interface AuthenticatorType {
   subscriptionId: string | null;
   isByok: boolean;
   key?: KeyAuthType;
+  clientIp?: string;
 }
 
 /**
@@ -1192,6 +1193,7 @@ export class Authenticator {
       subscriptionId: this._subscription?.sId ?? null,
       isByok: this.plan()?.isByok ?? false,
       key: this._key,
+      clientIp: this._clientIp,
     };
   }
 
@@ -1236,18 +1238,22 @@ export class Authenticator {
       subscription
     );
 
-    return new Ok(
-      new Authenticator({
-        authMethod: authType.authMethod,
-        workspace,
-        user,
-        role: authType.role,
-        groupModelIds: groupIds,
-        subscription,
-        key: authType.key,
-        providersHealth,
-      })
-    );
+    const auth = new Authenticator({
+      authMethod: authType.authMethod,
+      workspace,
+      user,
+      role: authType.role,
+      groupModelIds: groupIds,
+      subscription,
+      key: authType.key,
+      providersHealth,
+    });
+
+    if (authType.clientIp) {
+      auth.setClientIp(authType.clientIp);
+    }
+
+    return new Ok(auth);
   }
 }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -120,6 +120,7 @@ export class Authenticator {
     subscription,
     key,
     providersHealth,
+    clientIp,
   }: {
     workspace?: WorkspaceResource | null;
     user?: UserResource | null;
@@ -129,6 +130,7 @@ export class Authenticator {
     subscription?: SubscriptionResource | null;
     key?: KeyAuthType;
     providersHealth?: ProvidersHealth | null;
+    clientIp?: string;
   }) {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     this._workspace = workspace || null;
@@ -141,6 +143,7 @@ export class Authenticator {
     this._authMethod = authMethod;
     this._key = key;
     this._providersHealth = providersHealth ?? null;
+    this._clientIp = clientIp;
     if (user) {
       tracer.setUser({
         id: user?.sId,
@@ -887,7 +890,7 @@ export class Authenticator {
   }
 
   exchangeKey(key: KeyAuthType) {
-    const auth = new Authenticator({
+    return new Authenticator({
       authMethod: this.authMethod(),
       key,
       role: this._role,
@@ -895,11 +898,8 @@ export class Authenticator {
       user: this._user,
       subscription: this._subscription,
       workspace: this._workspace,
+      clientIp: this._clientIp,
     });
-    if (this._clientIp) {
-      auth.setClientIp(this._clientIp);
-    }
-    return auth;
   }
 
   providersHealth(): ProvidersHealth | null {
@@ -1238,22 +1238,19 @@ export class Authenticator {
       subscription
     );
 
-    const auth = new Authenticator({
-      authMethod: authType.authMethod,
-      workspace,
-      user,
-      role: authType.role,
-      groupModelIds: groupIds,
-      subscription,
-      key: authType.key,
-      providersHealth,
-    });
-
-    if (authType.clientIp) {
-      auth.setClientIp(authType.clientIp);
-    }
-
-    return new Ok(auth);
+    return new Ok(
+      new Authenticator({
+        authMethod: authType.authMethod,
+        workspace,
+        user,
+        role: authType.role,
+        groupModelIds: groupIds,
+        subscription,
+        key: authType.key,
+        providersHealth,
+        clientIp: authType.clientIp,
+      })
+    );
   }
 }
 

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -21,7 +21,7 @@ import {
   parseSendgridDkimResults,
 } from "@app/lib/api/assistant/email/inbound_auth";
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -493,8 +493,11 @@ async function handler(
         auth,
         action: "trigger.email_received",
         targets: [
-          buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-          { type: "trigger", id: triggerRes.value.conversation.sId },
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("trigger", {
+            sId: triggerRes.value.conversation.sId,
+            name: triggerRes.value.conversation.sId,
+          }),
         ],
         context: getAuditLogContext(auth, req),
         metadata: {

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -1,5 +1,8 @@
 /** @ignoreswagger */
-import { emitAuditLogEventDirect } from "@app/lib/api/audit/workos_audit";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEventDirect,
+} from "@app/lib/api/audit/workos_audit";
 import config from "@app/lib/api/config";
 import { makeEnterpriseConnectionInitiateLoginUrl } from "@app/lib/api/enterprise_connection";
 import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
@@ -287,7 +290,9 @@ async function handler(
         id: user.sId,
         name: user.name,
       },
-      targets: [{ type: "user", id: user.sId, name: user.name }],
+      targets: [
+        buildAuditLogTarget("user", { sId: user.sId, name: user.name }),
+      ],
       context: { location: ip ?? "internal" },
       metadata: {
         isSSO: String(session.isSSO),

--- a/front/pages/api/poke/workspaces/[wId]/roles.ts
+++ b/front/pages/api/poke/workspaces/[wId]/roles.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -126,12 +126,11 @@ async function handler(
           auth,
           action: "membership.role_updated",
           targets: [
-            buildWorkspaceTarget(owner),
-            {
-              type: "user",
-              id: user.sId,
-              name: user.fullName() ?? undefined,
-            },
+            buildAuditLogTarget("workspace", owner),
+            buildAuditLogTarget("user", {
+              sId: user.sId,
+              name: user.fullName() ?? "unknown",
+            }),
           ],
           context: getAuditLogContext(auth, req),
           metadata: {

--- a/front/pages/api/w/[wId]/credentials/index.ts
+++ b/front/pages/api/w/[wId]/credentials/index.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -112,7 +112,7 @@ async function handler(
       void emitAuditLogEvent({
         auth,
         action: "credentials.created",
-        targets: [buildWorkspaceTarget(owner)],
+        targets: [buildAuditLogTarget("workspace", owner)],
         context: getAuditLogContext(auth, req),
         metadata: {
           provider: String(bodyValidation.right.provider),

--- a/front/pages/api/w/[wId]/domains.ts
+++ b/front/pages/api/w/[wId]/domains.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -126,7 +126,7 @@ async function handler(
       void emitAuditLogEvent({
         auth,
         action: "domain.removed",
-        targets: [buildWorkspaceTarget(workspace)],
+        targets: [buildAuditLogTarget("workspace", workspace)],
         context: getAuditLogContext(auth, req),
         metadata: {
           domain: body.domain,

--- a/front/pages/api/w/[wId]/dsync.ts
+++ b/front/pages/api/w/[wId]/dsync.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -126,7 +126,7 @@ async function handler(
       void emitAuditLogEvent({
         auth,
         action: "dsync.connection_deleted",
-        targets: [buildWorkspaceTarget(workspace)],
+        targets: [buildAuditLogTarget("workspace", workspace)],
         context: getAuditLogContext(auth, req),
         metadata: {
           directoryType: activeDirectory.type,

--- a/front/pages/api/w/[wId]/invitations/[iId]/index.ts
+++ b/front/pages/api/w/[wId]/invitations/[iId]/index.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -92,12 +92,11 @@ async function handler(
           auth,
           action: "invitation.revoked",
           targets: [
-            buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-            {
-              type: "invitation",
-              id: invitation.sId,
+            buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+            buildAuditLogTarget("invitation", {
+              sId: invitation.sId,
               name: invitation.inviteEmail,
-            },
+            }),
           ],
           context: getAuditLogContext(auth, req),
           metadata: {
@@ -111,12 +110,11 @@ async function handler(
           auth,
           action: "invitation.role_updated",
           targets: [
-            buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-            {
-              type: "invitation",
-              id: invitation.sId,
+            buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+            buildAuditLogTarget("invitation", {
+              sId: invitation.sId,
               name: invitation.inviteEmail,
-            },
+            }),
           ],
           context: getAuditLogContext(auth, req),
           metadata: {

--- a/front/pages/api/w/[wId]/keys/[id]/disable.ts
+++ b/front/pages/api/w/[wId]/keys/[id]/disable.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -65,8 +65,11 @@ async function handler(
         auth,
         action: "api_key.revoked",
         targets: [
-          buildWorkspaceTarget(owner),
-          { type: "api_key", id: String(key.id), name: key.name },
+          buildAuditLogTarget("workspace", owner),
+          buildAuditLogTarget("api_key", {
+            sId: String(key.id),
+            name: key.name,
+          }),
         ],
         context: getAuditLogContext(auth, req),
       });

--- a/front/pages/api/w/[wId]/keys/[id]/index.ts
+++ b/front/pages/api/w/[wId]/keys/[id]/index.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -106,8 +106,11 @@ async function handler(
         auth,
         action: "api_key.updated",
         targets: [
-          buildWorkspaceTarget(owner),
-          { type: "api_key", id: String(key.id), name: key.name },
+          buildAuditLogTarget("workspace", owner),
+          buildAuditLogTarget("api_key", {
+            sId: String(key.id),
+            name: key.name,
+          }),
         ],
         context: getAuditLogContext(auth, req),
         metadata: {

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -196,8 +196,11 @@ async function handler(
         auth,
         action: "api_key.created",
         targets: [
-          buildWorkspaceTarget(owner),
-          { type: "api_key", id: String(key.id), name: trimmedName },
+          buildAuditLogTarget("workspace", owner),
+          buildAuditLogTarget("api_key", {
+            sId: String(key.id),
+            name: trimmedName,
+          }),
         ],
         context: getAuditLogContext(auth, req),
         metadata: {

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -255,12 +255,11 @@ async function handler(
             auth,
             action: "membership.role_updated",
             targets: [
-              buildWorkspaceTarget(owner),
-              {
-                type: "user",
-                id: user.sId,
-                name: user.fullName() ?? undefined,
-              },
+              buildAuditLogTarget("workspace", owner),
+              buildAuditLogTarget("user", {
+                sId: user.sId,
+                name: user.fullName() ?? "unknown",
+              }),
             ],
             context: getAuditLogContext(auth, req),
             metadata: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -111,12 +111,8 @@ async function handler(
         auth,
         action: "datasource.updated",
         targets: [
-          buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-          {
-            type: "data_source",
-            id: dataSource.sId,
-            name: dataSource.name,
-          },
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("data_source", dataSource),
         ],
         context: getAuditLogContext(auth, req),
         metadata: {
@@ -179,12 +175,8 @@ async function handler(
         auth,
         action: "datasource.deleted",
         targets: [
-          buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-          {
-            type: "data_source",
-            id: dataSource.sId,
-            name: dataSource.name,
-          },
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("data_source", dataSource),
         ],
         context: getAuditLogContext(auth, req),
         metadata: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -198,12 +198,8 @@ async function handler(
           auth,
           action: "datasource.created",
           targets: [
-            buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-            {
-              type: "data_source",
-              id: dataSourceView.dataSource.sId,
-              name: dataSourceView.dataSource.name,
-            },
+            buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+            buildAuditLogTarget("data_source", dataSourceView.dataSource),
           ],
           context: getAuditLogContext(auth, req),
           metadata: {
@@ -611,8 +607,8 @@ const handleDataSourceWithProvider = async ({
     auth,
     action: "datasource.created",
     targets: [
-      buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-      { type: "data_source", id: dataSource.sId, name: dataSource.name },
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("data_source", dataSource),
     ],
     context: getAuditLogContext(auth, req),
     metadata: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -171,7 +171,7 @@
  */
 import { getDataSourceViewsUsageByCategory } from "@app/lib/api/agent_data_sources";
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -478,8 +478,8 @@ async function handler(
         auth,
         action: "space.deleted",
         targets: [
-          buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-          { type: "space", id: space.sId, name: space.name },
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("space", space),
         ],
         context: getAuditLogContext(auth, req),
         metadata: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/join.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/join.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -103,8 +103,8 @@ async function handler(
         auth,
         action: "project.joined",
         targets: [
-          buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-          { type: "space", id: space.sId, name: space.name },
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("space", space),
         ],
         context: getAuditLogContext(auth, req),
         metadata: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/leave.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -90,8 +90,8 @@ async function handler(
         auth,
         action: "project.left",
         targets: [
-          buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-          { type: "space", id: space.sId, name: space.name },
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("space", space),
         ],
         context: getAuditLogContext(auth, req),
         metadata: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -201,8 +201,8 @@ export async function handler(
         auth,
         action: "space.permissions_updated",
         targets: [
-          buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-          { type: "space", id: space.sId, name: space.name },
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("space", space),
         ],
         context: getAuditLogContext(auth, req),
         metadata: {

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -103,7 +103,7 @@
  *         description: Unauthorized
  */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -276,8 +276,8 @@ async function handler(
         auth,
         action: "space.created",
         targets: [
-          buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-          { type: "space", id: space.sId, name: space.name },
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("space", space),
         ],
         context: getAuditLogContext(auth, req),
         metadata: {

--- a/front/pages/api/w/[wId]/sso.ts
+++ b/front/pages/api/w/[wId]/sso.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -128,7 +128,7 @@ async function handler(
       void emitAuditLogEvent({
         auth,
         action: "sso.connection_deleted",
-        targets: [buildWorkspaceTarget(workspace)],
+        targets: [buildAuditLogTarget("workspace", workspace)],
         context: getAuditLogContext(auth, req),
         metadata: {
           connectionType: activeConnection.type,

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -110,7 +110,7 @@
  *         description: Invalid session_id
  */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
@@ -606,7 +606,10 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
         auth: loginFailedAuth,
         action: "user.login_failed",
         targets: [
-          buildWorkspaceTarget(loginFailedAuth.getNonNullableWorkspace()),
+          buildAuditLogTarget(
+            "workspace",
+            loginFailedAuth.getNonNullableWorkspace()
+          ),
         ],
         metadata: {
           reason: normalizeError(error).message,
@@ -640,11 +643,10 @@ async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
             name: user?.name ?? session.user.name,
           },
           targets: [
-            {
-              type: "user",
-              id: user?.sId ?? "unknown",
+            buildAuditLogTarget("user", {
+              sId: user?.sId ?? "unknown",
               name: user?.name ?? session.user.name,
-            },
+            }),
           ],
           context: { location: getClientIp(req) },
         });

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,7 +1,6 @@
 import {
   buildAuditLogTarget,
   emitAuditLogEventDirect,
-  getAuditLogOrigin,
 } from "@app/lib/api/audit/workos_audit";
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
 import type { AuthenticatorType } from "@app/lib/auth";
@@ -344,7 +343,6 @@ async function executeToolStreaming(
             toolName: action.toolConfiguration.name,
             toolType: action.toolConfiguration.mcpServerName,
             conversationId: conversation.sId,
-            origin: getAuditLogOrigin(auth),
           },
         });
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,5 +1,5 @@
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEventDirect,
   getAuditLogOrigin,
 } from "@app/lib/api/audit/workos_audit";
@@ -332,17 +332,12 @@ async function executeToolStreaming(
             name: agentConfiguration.name,
           },
           targets: [
-            buildWorkspaceTarget(conversation.owner),
-            {
-              type: "agent",
-              id: agentConfiguration.sId,
-              name: agentConfiguration.name,
-            },
-            {
-              type: "tool",
-              id: action.toolConfiguration.name,
+            buildAuditLogTarget("workspace", conversation.owner),
+            buildAuditLogTarget("agent", agentConfiguration),
+            buildAuditLogTarget("tool", {
+              sId: action.toolConfiguration.name,
               name: action.toolConfiguration.name,
-            },
+            }),
           ],
           context: { location: auth.clientIp() ?? "internal" },
           metadata: {

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,6 +1,7 @@
 import {
   buildWorkspaceTarget,
-  emitAuditLogEvent,
+  emitAuditLogEventDirect,
+  getAuditLogOrigin,
 } from "@app/lib/api/audit/workos_audit";
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
 import type { AuthenticatorType } from "@app/lib/auth";
@@ -322,30 +323,35 @@ async function executeToolStreaming(
           { asType: "tool" }
         );
 
-        if (auth.user()) {
-          void emitAuditLogEvent({
-            auth,
-            action: "tool.executed",
-            targets: [
-              buildWorkspaceTarget(conversation.owner),
-              {
-                type: "agent",
-                id: agentConfiguration.sId,
-                name: agentConfiguration.name,
-              },
-              {
-                type: "tool",
-                id: action.toolConfiguration.name,
-                name: action.toolConfiguration.name,
-              },
-            ],
-            metadata: {
-              toolName: action.toolConfiguration.name,
-              toolType: action.toolConfiguration.mcpServerName,
-              conversationId: conversation.sId,
+        void emitAuditLogEventDirect({
+          workspace: conversation.owner,
+          action: "tool.executed",
+          actor: {
+            type: "agent",
+            id: agentConfiguration.sId,
+            name: agentConfiguration.name,
+          },
+          targets: [
+            buildWorkspaceTarget(conversation.owner),
+            {
+              type: "agent",
+              id: agentConfiguration.sId,
+              name: agentConfiguration.name,
             },
-          });
-        }
+            {
+              type: "tool",
+              id: action.toolConfiguration.name,
+              name: action.toolConfiguration.name,
+            },
+          ],
+          context: { location: auth.clientIp() ?? "internal" },
+          metadata: {
+            toolName: action.toolConfiguration.name,
+            toolType: action.toolConfiguration.mcpServerName,
+            conversationId: conversation.sId,
+            origin: getAuditLogOrigin(auth),
+          },
+        });
 
         await updateResourceAndPublishEvent(auth, {
           event: {

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,4 +1,4 @@
-import { isClientSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
+import { isLightClientSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
   buildAuditLogTarget,
   emitAuditLogEventDirect,
@@ -342,7 +342,9 @@ async function executeToolStreaming(
           context: { location: auth.clientIp() ?? "internal" },
           metadata: {
             toolName: action.toolConfiguration.originalName,
-            toolType: isClientSideMCPToolConfiguration(action.toolConfiguration)
+            toolType: isLightClientSideMCPToolConfiguration(
+              action.toolConfiguration
+            )
               ? "remote"
               : "internal",
             conversationId: conversation.sId,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,3 +1,4 @@
+import { isClientSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
   buildAuditLogTarget,
   emitAuditLogEventDirect,
@@ -335,13 +336,15 @@ async function executeToolStreaming(
             buildAuditLogTarget("agent", agentConfiguration),
             buildAuditLogTarget("tool", {
               sId: action.toolConfiguration.name,
-              name: action.toolConfiguration.name,
+              name: action.toolConfiguration.originalName,
             }),
           ],
           context: { location: auth.clientIp() ?? "internal" },
           metadata: {
-            toolName: action.toolConfiguration.name,
-            toolType: action.toolConfiguration.mcpServerName,
+            toolName: action.toolConfiguration.originalName,
+            toolType: isClientSideMCPToolConfiguration(action.toolConfiguration)
+              ? "remote"
+              : "internal",
             conversationId: conversation.sId,
           },
         });

--- a/front/temporal/triggers/common/activities.ts
+++ b/front/temporal/triggers/common/activities.ts
@@ -9,7 +9,7 @@ import {
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import { Authenticator } from "@app/lib/auth";
@@ -203,8 +203,11 @@ export async function runTriggeredAgentsActivity({
     auth,
     action: "trigger.fired",
     targets: [
-      buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-      { type: "trigger", id: trigger.sId, name: trigger.name ?? trigger.sId },
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("trigger", {
+        sId: trigger.sId,
+        name: trigger.name ?? trigger.sId,
+      }),
     ],
     metadata: {
       triggerType: trigger.kind,

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -1,5 +1,5 @@
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
 import { createAndLogMembership } from "@app/lib/api/signup";
@@ -659,8 +659,8 @@ async function handleGroupUpsert(
       name: "Directory Sync",
     },
     targets: [
-      buildWorkspaceTarget(workspace),
-      { type: "group", id: group.sId, name: group.name },
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("group", group),
     ],
     context: { location: "system" },
     metadata: {
@@ -768,8 +768,11 @@ async function handleUserAddedToGroup(
         name: "Directory Sync",
       },
       targets: [
-        buildWorkspaceTarget(workspace),
-        { type: "user", id: user.sId, name: user.fullName() ?? undefined },
+        buildAuditLogTarget("workspace", workspace),
+        buildAuditLogTarget("user", {
+          sId: user.sId,
+          name: user.fullName() ?? "unknown",
+        }),
       ],
       context: { location: "system" },
       metadata: {
@@ -788,9 +791,12 @@ async function handleUserAddedToGroup(
       name: "Directory Sync",
     },
     targets: [
-      buildWorkspaceTarget(workspace),
-      { type: "group", id: group.sId, name: group.name },
-      { type: "user", id: user.sId, name: user.fullName() ?? undefined },
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("group", group),
+      buildAuditLogTarget("user", {
+        sId: user.sId,
+        name: user.fullName() ?? "unknown",
+      }),
     ],
     context: { location: "system" },
     metadata: {
@@ -879,9 +885,12 @@ async function handleUserRemovedFromGroup(
       name: "Directory Sync",
     },
     targets: [
-      buildWorkspaceTarget(workspace),
-      { type: "group", id: group.sId, name: group.name },
-      { type: "user", id: user.sId, name: user.fullName() ?? undefined },
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("group", group),
+      buildAuditLogTarget("user", {
+        sId: user.sId,
+        name: user.fullName() ?? "unknown",
+      }),
     ],
     context: { location: "system" },
     metadata: {
@@ -995,12 +1004,11 @@ async function handleCreateOrUpdateWorkOSUser(
         name: "Directory Sync",
       },
       targets: [
-        buildWorkspaceTarget(workspace),
-        {
-          type: "user",
-          id: createdOrUpdatedUser.sId,
-          name: createdOrUpdatedUser.fullName() ?? undefined,
-        },
+        buildAuditLogTarget("workspace", workspace),
+        buildAuditLogTarget("user", {
+          sId: createdOrUpdatedUser.sId,
+          name: createdOrUpdatedUser.fullName() ?? "unknown",
+        }),
       ],
       context: { location: "system" },
       metadata: {
@@ -1018,12 +1026,11 @@ async function handleCreateOrUpdateWorkOSUser(
         name: "Directory Sync",
       },
       targets: [
-        buildWorkspaceTarget(workspace),
-        {
-          type: "user",
-          id: createdOrUpdatedUser.sId,
-          name: createdOrUpdatedUser.fullName() ?? undefined,
-        },
+        buildAuditLogTarget("workspace", workspace),
+        buildAuditLogTarget("user", {
+          sId: createdOrUpdatedUser.sId,
+          name: createdOrUpdatedUser.fullName() ?? "unknown",
+        }),
       ],
       context: { location: "system" },
       metadata: {
@@ -1053,12 +1060,11 @@ async function handleCreateOrUpdateWorkOSUser(
       name: "Directory Sync",
     },
     targets: [
-      buildWorkspaceTarget(workspace),
-      {
-        type: "user",
-        id: createdOrUpdatedUser.sId,
-        name: createdOrUpdatedUser.fullName() ?? undefined,
-      },
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("user", {
+        sId: createdOrUpdatedUser.sId,
+        name: createdOrUpdatedUser.fullName() ?? "unknown",
+      }),
     ],
     context: { location: "system" },
     metadata: {
@@ -1168,8 +1174,11 @@ async function handleDeleteWorkOSUser(
       name: "Directory Sync",
     },
     targets: [
-      buildWorkspaceTarget(workspace),
-      { type: "user", id: user.sId, name: user.fullName() ?? undefined },
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("user", {
+        sId: user.sId,
+        name: user.fullName() ?? "unknown",
+      }),
     ],
     context: { location: "system" },
     metadata: {
@@ -1217,8 +1226,8 @@ async function handleGroupDelete(
       name: "Directory Sync",
     },
     targets: [
-      buildWorkspaceTarget(workspace),
-      { type: "group", id: groupSId, name: groupName },
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("group", { sId: groupSId, name: groupName }),
     ],
     context: { location: "system" },
     metadata: {


### PR DESCRIPTION
## Description
This is a follow-on from https://github.com/pulls?q=is%3Apr+author%3Asmb2268+archived%3Afalse+is%3Aclosed
It addresses a few of @aubin-tchoi's comments to more strictly type the audit log targets and unify the way we build their data
Also adds logic to maintain the clientIp when calls are routed through temporal so we have fewer instances of events reported as "internal" when we should know the source. To add more context to these ones, I also added the `origin.context` field to metadata that will indicate if something was started on the api, web, extension, a trigger, etc

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Verify events are logging as expected pre-refactor
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
deploy front, front-sse
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
