### PR TITLE
feat: add todo diff

### DIFF
--- a/front/lib/butler/project_todo_diff.test.ts
+++ b/front/lib/butler/project_todo_diff.test.ts
@@ -1,0 +1,227 @@
+import type { TodoForDiff } from "@app/lib/butler/project_todo_diff";
+import {
+  computeProjectTodoDiff,
+  getLatestVersionPerSId,
+  getSnapshotAtCutoff,
+} from "@app/lib/butler/project_todo_diff";
+import { describe, expect, it } from "vitest";
+
+const T0 = new Date("2025-01-01T00:00:00Z"); // before cutoff
+const T1 = new Date("2025-06-01T00:00:00Z"); // cutoff
+const T2 = new Date("2025-12-01T00:00:00Z"); // after cutoff
+
+let _nextSId = 1;
+function nextSId(): string {
+  return `todo_${_nextSId++}`;
+}
+
+function makeRow(
+  overrides: Partial<TodoForDiff> & { sId?: string } = {}
+): TodoForDiff {
+  return {
+    sId: overrides.sId ?? nextSId(),
+    version: 1,
+    createdAt: T0,
+    status: "todo",
+    doneAt: null,
+    ...overrides,
+  };
+}
+
+// ── getLatestVersionPerSId ─────────────────────────────────────────────────────
+
+describe("getLatestVersionPerSId", () => {
+  it("returns the highest-version row for each sId", () => {
+    const sId = nextSId();
+    const v1 = makeRow({ sId, version: 1 });
+    const v2 = makeRow({ sId, version: 2, status: "done" });
+    const v3 = makeRow({ sId, version: 3, status: "in_progress" });
+
+    const result = getLatestVersionPerSId([v1, v3, v2]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(v3);
+  });
+
+  it("handles multiple distinct sIds", () => {
+    const a1 = makeRow({ sId: "a", version: 1 });
+    const a2 = makeRow({ sId: "a", version: 2 });
+    const b1 = makeRow({ sId: "b", version: 1 });
+
+    const result = getLatestVersionPerSId([a1, a2, b1]);
+
+    expect(result).toHaveLength(2);
+    expect(result.find((r) => r.sId === "a")).toBe(a2);
+    expect(result.find((r) => r.sId === "b")).toBe(b1);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(getLatestVersionPerSId([])).toHaveLength(0);
+  });
+});
+
+// ── getSnapshotAtCutoff ────────────────────────────────────────────────────────
+
+describe("getSnapshotAtCutoff", () => {
+  it("picks the latest version created at or before the cutoff", () => {
+    const sId = nextSId();
+    const v1 = makeRow({ sId, version: 1, createdAt: T0 }); // before cutoff
+    const v2 = makeRow({ sId, version: 2, createdAt: T2 }); // after cutoff
+
+    const snapshot = getSnapshotAtCutoff([v1, v2], T1);
+
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0]).toBe(v1);
+  });
+
+  it("excludes sIds whose first version was created after the cutoff", () => {
+    const row = makeRow({ createdAt: T2 });
+    expect(getSnapshotAtCutoff([row], T1)).toHaveLength(0);
+  });
+
+  it("includes a row created exactly at the cutoff", () => {
+    const row = makeRow({ createdAt: T1 });
+    expect(getSnapshotAtCutoff([row], T1)).toHaveLength(1);
+  });
+});
+
+// ── computeProjectTodoDiff ────────────────────────────────────────────────────
+
+describe("computeProjectTodoDiff", () => {
+  it("marks todos absent from before as added", () => {
+    const todo = makeRow();
+    const diff = computeProjectTodoDiff([], [todo]);
+
+    expect(diff.added).toContain(todo);
+    expect(diff.completed).toHaveLength(0);
+    expect(diff.updated).toHaveLength(0);
+    expect(diff.unchanged).toHaveLength(0);
+  });
+
+  it("marks todos with the same version as unchanged", () => {
+    const sId = nextSId();
+    const before = makeRow({ sId, version: 1 });
+    const after = makeRow({ sId, version: 1 });
+
+    const diff = computeProjectTodoDiff([before], [after]);
+
+    expect(diff.unchanged).toContain(after);
+    expect(diff.added).toHaveLength(0);
+    expect(diff.completed).toHaveLength(0);
+    expect(diff.updated).toHaveLength(0);
+  });
+
+  it("marks as completed when version bumped and status moved to done", () => {
+    const sId = nextSId();
+    const before = makeRow({ sId, version: 1, status: "todo" });
+    const after = makeRow({ sId, version: 2, status: "done", doneAt: T2 });
+
+    const diff = computeProjectTodoDiff([before], [after]);
+
+    expect(diff.completed).toContain(after);
+    expect(diff.added).toHaveLength(0);
+    expect(diff.updated).toHaveLength(0);
+    expect(diff.unchanged).toHaveLength(0);
+  });
+
+  it("marks as updated when version bumped but not completed", () => {
+    const sId = nextSId();
+    const before = makeRow({ sId, version: 1, status: "todo" });
+    const after = makeRow({ sId, version: 2, status: "in_progress" });
+
+    const diff = computeProjectTodoDiff([before], [after]);
+
+    expect(diff.updated).toContain(after);
+    expect(diff.completed).toHaveLength(0);
+  });
+
+  it("does not confuse completed→done before cutoff as completed", () => {
+    // Todo was already done in the before snapshot — same version in after → unchanged.
+    const sId = nextSId();
+    const before = makeRow({ sId, version: 2, status: "done", doneAt: T0 });
+    const after = makeRow({ sId, version: 2, status: "done", doneAt: T0 });
+
+    const diff = computeProjectTodoDiff([before], [after]);
+
+    expect(diff.unchanged).toContain(after);
+    expect(diff.completed).toHaveLength(0);
+  });
+
+  it("handles empty before and after", () => {
+    const diff = computeProjectTodoDiff([], []);
+    expect(diff.added).toHaveLength(0);
+    expect(diff.completed).toHaveLength(0);
+    expect(diff.updated).toHaveLength(0);
+    expect(diff.unchanged).toHaveLength(0);
+  });
+
+  it("correctly splits a mixed batch", () => {
+    const addedTodo = makeRow();
+    const completedSId = nextSId();
+    const updatedSId = nextSId();
+    const unchangedSId = nextSId();
+
+    const before = [
+      makeRow({ sId: completedSId, version: 1, status: "todo" }),
+      makeRow({ sId: updatedSId, version: 1, status: "todo" }),
+      makeRow({ sId: unchangedSId, version: 1 }),
+    ];
+
+    const after = [
+      addedTodo,
+      makeRow({ sId: completedSId, version: 2, status: "done", doneAt: T2 }),
+      makeRow({ sId: updatedSId, version: 2, status: "in_progress" }),
+      makeRow({ sId: unchangedSId, version: 1 }),
+    ];
+
+    const diff = computeProjectTodoDiff(before, after);
+
+    expect(diff.added).toHaveLength(1);
+    expect(diff.completed).toHaveLength(1);
+    expect(diff.updated).toHaveLength(1);
+    expect(diff.unchanged).toHaveLength(1);
+  });
+
+  it("preserves the original after-todo objects (no copying)", () => {
+    const todo = makeRow();
+    const diff = computeProjectTodoDiff([], [todo]);
+    expect(diff.added[0]).toBe(todo);
+  });
+});
+
+// ── end-to-end: getSnapshotAtCutoff + computeProjectTodoDiff ──────────────────
+
+describe("snapshot-based diff end-to-end", () => {
+  it("detects an edit made after the cutoff using version rows", () => {
+    const sId = nextSId();
+    const v1 = makeRow({ sId, version: 1, createdAt: T0, status: "todo" });
+    const v2 = makeRow({
+      sId,
+      version: 2,
+      createdAt: T2,
+      status: "in_progress",
+    });
+
+    const allRows = [v1, v2];
+    const afterTodos = getLatestVersionPerSId(allRows); // [v2]
+    const beforeTodos = getSnapshotAtCutoff(allRows, T1); // [v1]
+
+    const diff = computeProjectTodoDiff(beforeTodos, afterTodos);
+
+    expect(diff.updated).toHaveLength(1);
+    expect(diff.unchanged).toHaveLength(0);
+  });
+
+  it("marks a todo as added when all its versions were created after the cutoff", () => {
+    const sId = nextSId();
+    const v1 = makeRow({ sId, version: 1, createdAt: T2 });
+
+    const allRows = [v1];
+    const afterTodos = getLatestVersionPerSId(allRows);
+    const beforeTodos = getSnapshotAtCutoff(allRows, T1);
+
+    const diff = computeProjectTodoDiff(beforeTodos, afterTodos);
+
+    expect(diff.added).toHaveLength(1);
+  });
+});

--- a/front/lib/butler/project_todo_diff.ts
+++ b/front/lib/butler/project_todo_diff.ts
@@ -1,0 +1,158 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { ProjectTodoStateResource } from "@app/lib/resources/project_todo_state_resource";
+import type { ProjectTodoStatus } from "@app/types/project_todo";
+import type { ModelId } from "@app/types/shared/model_id";
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal shape required by the diff helpers. Using a structural interface keeps
+ * the pure functions easy to unit-test with plain objects.
+ */
+export interface TodoForDiff {
+  sId: string; // stable identity — same across all version rows of one todo
+  version: number; // edit counter; higher = newer
+  createdAt: Date; // when this specific version row was inserted
+  status: ProjectTodoStatus;
+  doneAt: Date | null;
+}
+
+export type ProjectTodoDiff<T extends TodoForDiff = ProjectTodoResource> = {
+  /** New todos that did not exist at the cutoff. */
+  added: T[];
+  /** Todos that existed before the cutoff and were marked done since. */
+  completed: T[];
+  /** Todos that existed before the cutoff and were updated (but not completed) since. */
+  updated: T[];
+  /** Todos that existed before the cutoff with no changes since. */
+  unchanged: T[];
+};
+
+// ── Snapshot helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Given a flat list of version rows (multiple rows per sId), return one row per
+ * sId — the one with the highest version number.
+ */
+export function getLatestVersionPerSId<
+  T extends Pick<TodoForDiff, "sId" | "version">,
+>(rows: T[]): T[] {
+  // GEN7: O(n) with a Map instead of nested loops.
+  const map = new Map<string, T>();
+  for (const row of rows) {
+    const current = map.get(row.sId);
+    if (!current || row.version > current.version) {
+      map.set(row.sId, row);
+    }
+  }
+  return [...map.values()];
+}
+
+/**
+ * From a flat list of all version rows, reconstruct the state that was visible
+ * at `cutoffAt`: for each sId, the latest version whose row was created at or
+ * before the cutoff.
+ */
+export function getSnapshotAtCutoff<
+  T extends Pick<TodoForDiff, "sId" | "version" | "createdAt">,
+>(allRows: T[], cutoffAt: Date): T[] {
+  const eligible = allRows.filter((r) => r.createdAt <= cutoffAt);
+  return getLatestVersionPerSId(eligible);
+}
+
+// ── Pure algorithm ─────────────────────────────────────────────────────────────
+
+/**
+ * Compute the diff between two snapshots joined by `sId`.
+ *
+ * Each todo in `afterTodos` is placed in exactly one bucket:
+ *  - added     — sId absent from beforeTodos (todo is new)
+ *  - completed — sId present in both; version bumped; now "done" but wasn't before
+ *  - updated   — sId present in both; version bumped; any other change
+ *  - unchanged — sId present in both; same version (no edit since cutoff)
+ *
+ * Both input arrays should contain at most one entry per sId (i.e. the latest
+ * version at the relevant point in time). Use `getLatestVersionPerSId` and
+ * `getSnapshotAtCutoff` to prepare them from raw version rows.
+ */
+export function computeProjectTodoDiff<T extends TodoForDiff>(
+  beforeTodos: T[],
+  afterTodos: T[]
+): ProjectTodoDiff<T> {
+  // GEN7: O(n) Map lookup.
+  const beforeMap = new Map(beforeTodos.map((t) => [t.sId, t]));
+
+  const added: T[] = [];
+  const completed: T[] = [];
+  const updated: T[] = [];
+  const unchanged: T[] = [];
+
+  for (const after of afterTodos) {
+    const before = beforeMap.get(after.sId);
+
+    if (!before) {
+      added.push(after);
+    } else if (after.version === before.version) {
+      unchanged.push(after);
+    } else if (after.status === "done" && before.status !== "done") {
+      completed.push(after);
+    } else {
+      updated.push(after);
+    }
+  }
+
+  return { added, completed, updated, unchanged };
+}
+
+// ── Data fetching ──────────────────────────────────────────────────────────────
+
+/**
+ * Raw data needed to drive the diff: every version row for the user's todos in
+ * this space, plus the last-read cutoff date.
+ *
+ * Separated from the algorithm so the pure functions can be unit-tested without
+ * database access.
+ */
+export interface ProjectTodoDiffData {
+  allRows: ProjectTodoResource[];
+  cutoffAt: Date | null;
+}
+
+export async function fetchProjectTodoDiffData(
+  auth: Authenticator,
+  { spaceId }: { spaceId: ModelId }
+): Promise<ProjectTodoDiffData> {
+  // Two independent DB reads — static 2-tuple, Promise.all is safe here.
+  const [allRows, state] = await Promise.all([
+    ProjectTodoResource.fetchAllVersionsBySpace(auth, {
+      spaceId,
+    }),
+    ProjectTodoStateResource.fetchBySpace(auth, { spaceId }),
+  ]);
+
+  return { allRows, cutoffAt: state?.lastReadAt ?? null };
+}
+
+// ── Orchestrator ───────────────────────────────────────────────────────────────
+
+/**
+ * Compute the todo diff for the authenticated user in a given space.
+ *
+ * For unit-testing, call `computeProjectTodoDiff` directly with plain objects,
+ * or use `getLatestVersionPerSId` / `getSnapshotAtCutoff` to prepare snapshots.
+ */
+export async function getProjectTodoDiff(
+  auth: Authenticator,
+  { spaceId }: { spaceId: ModelId }
+): Promise<ProjectTodoDiff> {
+  const { allRows, cutoffAt } = await fetchProjectTodoDiffData(auth, {
+    spaceId,
+  });
+
+  const afterTodos = getLatestVersionPerSId(allRows);
+  const beforeTodos =
+    cutoffAt !== null ? getSnapshotAtCutoff(allRows, cutoffAt) : [];
+
+  return computeProjectTodoDiff(beforeTodos, afterTodos);
+}

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/resources/storage/models/project_todo";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { ProjectTodoSourceType } from "@app/types/project_todo";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -35,14 +35,17 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     super(ProjectTodoModel, blob);
   }
 
+  // ── Creation ────────────────────────────────────────────────────────────────
+
   static async makeNew(
     auth: Authenticator,
-    blob: Omit<CreationAttributes<ProjectTodoModel>, "workspaceId">,
+    blob: Omit<CreationAttributes<ProjectTodoModel>, "workspaceId" | "sId">,
     transaction?: Transaction
   ): Promise<ProjectTodoResource> {
     const todo = await ProjectTodoModel.create(
       {
         ...blob,
+        sId: generateRandomModelSId(),
         workspaceId: auth.getNonNullableWorkspace().id,
       },
       { transaction }
@@ -50,6 +53,48 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
 
     return new this(ProjectTodoModel, todo.get());
   }
+
+  // Inserts a new version row for this logical todo, copying unchanged fields and
+  // applying the supplied updates. Mirrors the AgentConfiguration update pattern.
+  async createVersion(
+    auth: Authenticator,
+    updates: Partial<
+      Omit<
+        CreationAttributes<ProjectTodoModel>,
+        "workspaceId" | "sId" | "version"
+      >
+    >,
+    transaction?: Transaction
+  ): Promise<ProjectTodoResource> {
+    const newRow = await ProjectTodoModel.create(
+      {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        sId: this.sId,
+        version: this.version + 1,
+        spaceId: this.spaceId,
+        userId: this.userId,
+        createdByType: this.createdByType,
+        createdByUserId: this.createdByUserId ?? null,
+        createdByAgentConfigurationId:
+          this.createdByAgentConfigurationId ?? null,
+        markedAsDoneByType: this.markedAsDoneByType ?? null,
+        markedAsDoneByUserId: this.markedAsDoneByUserId ?? null,
+        markedAsDoneByAgentConfigurationId:
+          this.markedAsDoneByAgentConfigurationId ?? null,
+        category: this.category,
+        text: this.text,
+        status: this.status,
+        doneAt: this.doneAt ?? null,
+        actorRationale: this.actorRationale ?? null,
+        ...updates,
+      },
+      { transaction }
+    );
+
+    return new ProjectTodoResource(ProjectTodoModel, newRow.get());
+  }
+
+  // ── Fetching ─────────────────────────────────────────────────────────────────
 
   private static async baseFetch(
     auth: Authenticator,
@@ -76,17 +121,15 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
   }
 
-  static async fetchById(
+  // Fetches the latest version of a todo by its stable sId.
+  static async fetchBySId(
     auth: Authenticator,
     sId: string
   ): Promise<ProjectTodoResource | null> {
-    const modelId = getResourceIdFromSId(sId);
-    if (!modelId) {
-      return null;
-    }
-
     const results = await this.baseFetch(auth, {
-      where: { id: modelId },
+      where: { sId },
+      order: [["version", "DESC"]],
+      limit: 1,
     });
 
     return results[0] ?? null;
@@ -99,6 +142,21 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     return this.baseFetch(auth, {
       where: { spaceId },
       order: [["createdAt", "DESC"]],
+    });
+  }
+
+  // Returns every version row for (spaceId, userId), across all sIds. Used by the
+  // diff algorithm to reconstruct snapshots at arbitrary cutoff dates.
+  static async fetchAllVersionsBySpace(
+    auth: Authenticator,
+    { spaceId }: { spaceId: ModelId }
+  ): Promise<ProjectTodoResource[]> {
+    return this.baseFetch(auth, {
+      where: { spaceId, userId: auth.getNonNullableUser().id },
+      order: [
+        ["sId", "ASC"],
+        ["version", "ASC"],
+      ],
     });
   }
 
@@ -180,7 +238,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
   }
 
-  // ── Lifecycle ──────────────────────────────────────────────────────────
+  // ── Lifecycle ──────────────────────────────────────────────────────────────
 
   async delete(
     auth: Authenticator,
@@ -211,22 +269,5 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
 
     return new Ok(undefined);
-  }
-
-  get sId(): string {
-    return ProjectTodoResource.modelIdToSId({
-      id: this.id,
-      workspaceId: this.workspaceId,
-    });
-  }
-
-  static modelIdToSId({
-    id,
-    workspaceId,
-  }: {
-    id: ModelId;
-    workspaceId: ModelId;
-  }): string {
-    return makeSId("project_todo", { id, workspaceId });
   }
 }

--- a/front/lib/resources/storage/models/project_todo.ts
+++ b/front/lib/resources/storage/models/project_todo.ts
@@ -33,6 +33,9 @@ export class ProjectTodoModel extends WorkspaceAwareModel<ProjectTodoModel> {
   declare markedAsDoneByUserId: ForeignKey<UserModel["id"]> | null;
   declare markedAsDoneByAgentConfigurationId: string | null;
 
+  // Stable identity: same sId across all version rows of one logical todo.
+  declare sId: string;
+
   declare category: ProjectTodoCategory;
   declare text: string;
   declare version: number;
@@ -98,6 +101,12 @@ ProjectTodoModel.init(
       comment:
         "sId of the agent configuration when markedAsDoneByType is agent.",
     },
+    sId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      comment:
+        "Stable identifier shared across all version rows of the same logical todo.",
+    },
     category: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -133,6 +142,17 @@ ProjectTodoModel.init(
     modelName: "project_todo",
     sequelize: frontSequelize,
     indexes: [
+      {
+        name: "project_todos_sId_version_unique_idx",
+        fields: ["workspaceId", "sId", "version"],
+        unique: true,
+        concurrently: true,
+      },
+      {
+        name: "project_todos_sId_idx",
+        fields: ["sId"],
+        concurrently: true,
+      },
       {
         name: "project_todos_ws_space_user_version_idx",
         fields: ["workspaceId", "spaceId", "userId", "version"],

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -76,7 +76,6 @@ export const RESOURCES_PREFIX = {
   sandbox: "sbx",
 
   // Project todos.
-  project_todo: "ptd",
   project_todo_state: "pts",
 
   // Butler

--- a/front/migrations/db/migration_559.sql
+++ b/front/migrations/db/migration_559.sql
@@ -1,0 +1,19 @@
+-- Migration created on Apr 1, 2026
+-- Add sId as a stable identifier for project todos across versions.
+-- Each logical todo keeps the same sId regardless of how many times it is edited;
+-- (sId, version) is the unique key, mirroring the AgentConfiguration pattern.
+
+ALTER TABLE "project_todos"
+    ADD COLUMN "sId" VARCHAR(255);
+
+-- Backfill existing rows (dev data only — no production rows exist yet).
+UPDATE "project_todos"
+SET "sId" = id::text
+WHERE "sId" IS NULL;
+
+ALTER TABLE "project_todos"
+    ALTER COLUMN "sId" SET NOT NULL;
+
+CREATE UNIQUE INDEX CONCURRENTLY "project_todos_sId_version_unique_idx" ON "project_todos" ("workspaceId", "sId", "version");
+CREATE INDEX CONCURRENTLY "project_todos_sId_idx" ON "project_todos" ("sId");
+


### PR DESCRIPTION
## Description

Now that we have the data model for TODOs, let's see how the UI can work. For this we need a way to get a "diff" of the last current state and "now". 

This PRs adds 2 things:
* the diff function (with tests)
* an oversaw, we need a stable identifier between all version of a same TODO, that's the new `sId`. It's the same mechanism that we have with `AgentConfiguration`

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
