### PR TITLE
[BYOK] Improve UX when embedding API key is missing

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -13,6 +13,7 @@ import {
 } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
+import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { SubscriptionType } from "@app/types/plan";
 import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
@@ -249,16 +250,33 @@ function UnhealthyCredentialsBanner({
     return null;
   }
 
+  const title = "Your workspace is not operational";
+  const footer = isAdmin(owner) ? (
+    <LinkWrapper href={`/w/${owner.sId}/model-providers`} className="underline">
+      Model providers
+    </LinkWrapper>
+  ) : (
+    <>Contact your workspace admin.</>
+  );
+  const variant =
+    subscription.plan.code === FREE_BYOK_TRANSITIONING_PLAN_CODE
+      ? "info"
+      : "warning";
+
   const hasConfiguredProviders = Object.keys(providersHealth).length > 0;
+  const hasConfiguredEmbeddingProvider =
+    providersHealth[DEFAULT_EMBEDDING_PROVIDER_ID] !== undefined;
   const isWorkspaceHealthy = Object.values(providersHealth).every(Boolean);
 
-  if (hasConfiguredProviders && isWorkspaceHealthy) {
-    return null;
-  }
-
-  const description = !hasConfiguredProviders
-    ? "No provider credentials configured. Please set up at least one model provider."
-    : "The following model providers have invalid credentials: " +
+  let description: string | null = null;
+  if (!hasConfiguredProviders) {
+    description =
+      "No provider credentials configured. Please set up at least one model provider.";
+  } else if (!hasConfiguredEmbeddingProvider) {
+    description = "Please set up your OpenAI credentials.";
+  } else if (!isWorkspaceHealthy) {
+    description =
+      "The following model providers have invalid credentials: " +
       Object.entries(providersHealth)
         .filter(([_, isHealthy]) => !isHealthy)
         .map(
@@ -267,23 +285,15 @@ function UnhealthyCredentialsBanner({
         )
         .join(", ") +
       ".";
-  const footer = isAdmin(owner) ? (
-    <LinkWrapper href={`/w/${owner.sId}/model-providers`} className="underline">
-      Model providers
-    </LinkWrapper>
-  ) : (
-    <>Contact your workspace admin.</>
-  );
+  } else {
+    return null;
+  }
 
   return (
     <StatusBanner
-      title="Your workspace is not operational"
+      title={title}
       description={description}
-      variant={
-        subscription.plan.code === FREE_BYOK_TRANSITIONING_PLAN_CODE
-          ? "info"
-          : "warning"
-      }
+      variant={variant}
       footer={footer}
     />
   );

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -572,7 +572,7 @@ export async function upsertDocument({
   } catch (err) {
     logger.error(
       { error: normalizeError(err) },
-      "Failed to get LLM credentials"
+      "Failed to get LLM credentials to upsert document"
     );
     return new Err(
       new DustError(
@@ -633,7 +633,7 @@ export async function handleDataSourceSearch({
   } catch (err) {
     logger.error(
       { error: normalizeError(err) },
-      "Failed to get LLM credentials"
+      "Failed to get LLM credentials to search data source"
     );
     return new Err({
       name: "dust_error",
@@ -1112,7 +1112,7 @@ export async function createDataSourceWithoutProvider(
       } catch (err) {
         logger.error(
           { error: normalizeError(err) },
-          "Failed to get LLM credentials"
+          "Failed to get LLM credentials to create data source"
         );
         return new Err({
           name: "dust_error",

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -62,6 +62,7 @@ import type { PlanType } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { validateUrl } from "@app/types/shared/utils/url_utils";
 import type { WorkspaceType } from "@app/types/user";
 import type {
@@ -72,7 +73,6 @@ import type {
 } from "@dust-tt/client";
 import assert from "assert";
 import type { Transaction } from "sequelize";
-
 import { ConversationResource } from "../resources/conversation_resource";
 
 /**
@@ -568,7 +568,11 @@ export async function upsertDocument({
   let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
   try {
     credentials = await getLlmCredentials(auth);
-  } catch {
+  } catch (err) {
+    logger.error(
+      { error: normalizeError(err) },
+      "Failed to get LLM credentials"
+    );
     return new Err(
       new DustError(
         "invalid_request_error",
@@ -625,7 +629,11 @@ export async function handleDataSourceSearch({
   let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
   try {
     credentials = await getLlmCredentials(auth);
-  } catch {
+  } catch (err) {
+    logger.error(
+      { error: normalizeError(err) },
+      "Failed to get LLM credentials"
+    );
     return new Err({
       name: "dust_error",
       code: "data_source_error",
@@ -1100,7 +1108,11 @@ export async function createDataSourceWithoutProvider(
       let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
       try {
         credentials = await getLlmCredentials(auth);
-      } catch {
+      } catch (err) {
+        logger.error(
+          { error: normalizeError(err) },
+          "Failed to get LLM credentials"
+        );
         return new Err({
           name: "dust_error",
           code: "invalid_request_error",

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -635,11 +635,12 @@ export async function handleDataSourceSearch({
       { error: normalizeError(err) },
       "Failed to get LLM credentials to search data source"
     );
-    return new Err({
-      name: "dust_error",
-      code: "data_source_error",
-      message: MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE,
-    });
+    return new Err(
+      new DustError(
+        "data_source_error",
+        MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE
+      )
+    );
   }
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
@@ -1114,11 +1115,12 @@ export async function createDataSourceWithoutProvider(
           { error: normalizeError(err) },
           "Failed to get LLM credentials to create data source"
         );
-        return new Err({
-          name: "dust_error",
-          code: "invalid_request_error",
-          message: MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE,
-        });
+        return new Err(
+          new DustError(
+            "invalid_request_error",
+            MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE
+          )
+        );
       }
 
       const dustDataSource = await coreAPI.createDataSource({

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -59,6 +59,7 @@ import type {
 import { isDataSourceNameValid } from "@app/types/data_source";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { PlanType } from "@app/types/plan";
+import type { LLMCredentialsType } from "@app/types/provider_credential";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -565,7 +566,7 @@ export async function upsertDocument({
     );
   }
 
-  let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+  let credentials: LLMCredentialsType;
   try {
     credentials = await getLlmCredentials(auth);
   } catch (err) {
@@ -626,7 +627,7 @@ export async function handleDataSourceSearch({
     Omit<DustError, "code"> & { code: "data_source_error" }
   >
 > {
-  let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+  let credentials: LLMCredentialsType;
   try {
     credentials = await getLlmCredentials(auth);
   } catch (err) {
@@ -1105,7 +1106,7 @@ export async function createDataSourceWithoutProvider(
         });
       }
 
-      let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+      let credentials: LLMCredentialsType;
       try {
         credentials = await getLlmCredentials(auth);
       } catch (err) {

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -3,7 +3,10 @@
 import { default as apiConfig, default as config } from "@app/lib/api/config";
 import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import { sendGitHubDeletionEmail } from "@app/lib/api/email";
-import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import {
+  getLlmCredentials,
+  MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE,
+} from "@app/lib/api/provider_credentials";
 import { upsertTableFromCsv } from "@app/lib/api/tables";
 import {
   getMembers,
@@ -562,7 +565,17 @@ export async function upsertDocument({
     );
   }
 
-  const credentials = await getLlmCredentials(auth);
+  let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+  try {
+    credentials = await getLlmCredentials(auth);
+  } catch {
+    return new Err(
+      new DustError(
+        "invalid_request_error",
+        MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE
+      )
+    );
+  }
 
   // Create document with the Dust internal API.
   const upsertRes = await coreAPI.upsertDataSourceDocument({
@@ -609,7 +622,16 @@ export async function handleDataSourceSearch({
     Omit<DustError, "code"> & { code: "data_source_error" }
   >
 > {
-  const credentials = await getLlmCredentials(auth);
+  let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+  try {
+    credentials = await getLlmCredentials(auth);
+  } catch {
+    return new Err({
+      name: "dust_error",
+      code: "data_source_error",
+      message: MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE,
+    });
+  }
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const data = await coreAPI.searchDataSource(
@@ -1075,7 +1097,16 @@ export async function createDataSourceWithoutProvider(
         });
       }
 
-      const credentials = await getLlmCredentials(auth);
+      let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+      try {
+        credentials = await getLlmCredentials(auth);
+      } catch {
+        return new Err({
+          name: "dust_error",
+          code: "invalid_request_error",
+          message: MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE,
+        });
+      }
 
       const dustDataSource = await coreAPI.createDataSource({
         projectId: dustProject.value.project.project_id.toString(),

--- a/front/lib/api/projects/connector.ts
+++ b/front/lib/api/projects/connector.ts
@@ -142,7 +142,7 @@ export async function createDataSourceAndConnectorForProject(
         } catch (err) {
           logger.error(
             { error: normalizeError(err) },
-            "Failed to get LLM credentials"
+            "Failed to get LLM credentials to create data source and connector"
           );
           return new Err(new Error(MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE));
         }

--- a/front/lib/api/projects/connector.ts
+++ b/front/lib/api/projects/connector.ts
@@ -10,7 +10,10 @@ import {
   fetchProjectDataSourceView,
   getProjectConversationsDatasourceName,
 } from "@app/lib/api/projects/data_sources";
-import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import {
+  getLlmCredentials,
+  MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE,
+} from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { getOrCreateSystemApiKey } from "@app/lib/auth";
 import { isConnectorProviderAssistantDefaultSelected } from "@app/lib/connector_providers";
@@ -131,7 +134,12 @@ export async function createDataSourceAndConnectorForProject(
         coreProjectId = dustProject.value.project.project_id.toString();
 
         // Create Core API data source
-        const credentials = await getLlmCredentials(auth);
+        let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+        try {
+          credentials = await getLlmCredentials(auth);
+        } catch {
+          return new Err(new Error(MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE));
+        }
 
         const dustDataSource = await coreAPI.createDataSource({
           projectId: coreProjectId,

--- a/front/lib/api/projects/connector.ts
+++ b/front/lib/api/projects/connector.ts
@@ -27,6 +27,7 @@ import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embed
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { CoreAPI, EMBEDDING_CONFIGS } from "@app/types/core/core_api";
 import { DEFAULT_QDRANT_CLUSTER } from "@app/types/core/data_source";
+import type { LLMCredentialsType } from "@app/types/provider_credential";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -135,7 +136,7 @@ export async function createDataSourceAndConnectorForProject(
         coreProjectId = dustProject.value.project.project_id.toString();
 
         // Create Core API data source
-        let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+        let credentials: LLMCredentialsType;
         try {
           credentials = await getLlmCredentials(auth);
         } catch (err) {

--- a/front/lib/api/projects/connector.ts
+++ b/front/lib/api/projects/connector.ts
@@ -30,6 +30,7 @@ import { DEFAULT_QDRANT_CLUSTER } from "@app/types/core/data_source";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
@@ -137,7 +138,11 @@ export async function createDataSourceAndConnectorForProject(
         let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
         try {
           credentials = await getLlmCredentials(auth);
-        } catch {
+        } catch (err) {
+          logger.error(
+            { error: normalizeError(err) },
+            "Failed to get LLM credentials"
+          );
           return new Err(new Error(MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE));
         }
 

--- a/front/lib/api/projects/search.ts
+++ b/front/lib/api/projects/search.ts
@@ -81,7 +81,7 @@ export async function searchProjectConversations(
   } catch (err) {
     logger.error(
       { error: normalizeError(err) },
-      "Failed to get LLM credentials"
+      "Failed to get LLM credentials to search project conversations"
     );
     return new Err(
       new DustError(

--- a/front/lib/api/projects/search.ts
+++ b/front/lib/api/projects/search.ts
@@ -11,6 +11,7 @@ import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export interface SearchProjectConversationsOptions {
   query: string;
@@ -76,7 +77,11 @@ export async function searchProjectConversations(
   let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
   try {
     credentials = await getLlmCredentials(auth);
-  } catch {
+  } catch (err) {
+    logger.error(
+      { error: normalizeError(err) },
+      "Failed to get LLM credentials"
+    );
     return new Err(
       new DustError(
         "invalid_request_error",

--- a/front/lib/api/projects/search.ts
+++ b/front/lib/api/projects/search.ts
@@ -9,6 +9,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
+import type { LLMCredentialsType } from "@app/types/provider_credential";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -74,7 +75,7 @@ export async function searchProjectConversations(
   }));
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+  let credentials: LLMCredentialsType;
   try {
     credentials = await getLlmCredentials(auth);
   } catch (err) {

--- a/front/lib/api/projects/search.ts
+++ b/front/lib/api/projects/search.ts
@@ -1,5 +1,8 @@
 import { default as config } from "@app/lib/api/config";
-import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import {
+  getLlmCredentials,
+  MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE,
+} from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -24,7 +27,12 @@ export interface ConversationSearchResult {
 export async function searchProjectConversations(
   auth: Authenticator,
   options: SearchProjectConversationsOptions
-): Promise<Result<ConversationSearchResult[], DustError<"core_api_error">>> {
+): Promise<
+  Result<
+    ConversationSearchResult[],
+    DustError<"core_api_error" | "invalid_request_error">
+  >
+> {
   const { query, spaceIds, topK } = options;
 
   if (spaceIds.length === 0) {
@@ -65,7 +73,17 @@ export async function searchProjectConversations(
   }));
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const credentials = await getLlmCredentials(auth);
+  let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+  try {
+    credentials = await getLlmCredentials(auth);
+  } catch {
+    return new Err(
+      new DustError(
+        "invalid_request_error",
+        MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE
+      )
+    );
+  }
   const searchResult = await coreAPI.bulkSearchDataSources(
     query,
     topK,

--- a/front/lib/api/provider_credentials.ts
+++ b/front/lib/api/provider_credentials.ts
@@ -18,6 +18,9 @@ import type { z } from "zod";
 // Fraction of requests that use BYOK credentials during the transition period.
 const BYOK_TRANSITION_BYOK_KEYS_RATIO = 0.2; // 20%
 
+export const MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE =
+  "An OpenAI API key is required to perform this action. Please configure it in your workspace settings or contact an admin.";
+
 /**
  * Returns LLM credentials for the workspace.
  *

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -657,7 +657,7 @@ async function handler(
         } catch (err) {
           logger.error(
             { error: normalizeError(err) },
-            "Failed to get LLM credentials"
+            "Failed to get LLM credentials to upsert document"
           );
           return apiError(req, res, {
             status_code: 400,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -20,6 +20,7 @@ import { CoreAPI } from "@app/types/core/core_api";
 import { sectionFullText } from "@app/types/core/data_source";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { fileSizeToHumanReadable } from "@app/types/files";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { safeSubstring } from "@app/types/shared/utils/string_utils";
 import { validateUrl } from "@app/types/shared/utils/url_utils";
 import type {
@@ -652,7 +653,11 @@ async function handler(
         let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
         try {
           credentials = await getLlmCredentials(auth);
-        } catch {
+        } catch (err) {
+          logger.error(
+            { error: normalizeError(err) },
+            "Failed to get LLM credentials"
+          );
           return apiError(req, res, {
             status_code: 400,
             api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -20,6 +20,7 @@ import { CoreAPI } from "@app/types/core/core_api";
 import { sectionFullText } from "@app/types/core/data_source";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { fileSizeToHumanReadable } from "@app/types/files";
+import type { LLMCredentialsType } from "@app/types/provider_credential";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { safeSubstring } from "@app/types/shared/utils/string_utils";
 import { validateUrl } from "@app/types/shared/utils/url_utils";
@@ -650,7 +651,7 @@ async function handler(
           },
         });
       } else {
-        let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+        let credentials: LLMCredentialsType;
         try {
           credentials = await getLlmCredentials(auth);
         } catch (err) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -1,7 +1,10 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import { computeWorkspaceOverallSizeCached } from "@app/lib/api/data_sources";
-import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import {
+  getLlmCredentials,
+  MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE,
+} from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes_constants";
 import { DATASOURCE_QUOTA_PER_SEAT } from "@app/lib/plans/usage/types";
@@ -646,7 +649,18 @@ async function handler(
           },
         });
       } else {
-        const credentials = await getLlmCredentials(auth);
+        let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+        try {
+          credentials = await getLlmCredentials(auth);
+        } catch {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE,
+            },
+          });
+        }
 
         // Create document with the Dust internal API.
         const upsertRes = await coreAPI.upsertDataSourceDocument({

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -47,6 +47,7 @@ import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { PlanType } from "@app/types/plan";
 import { sendUserOperationMessage } from "@app/types/shared/user_operation";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { ioTsParsePayload } from "@app/types/shared/utils/iots_utils";
 import type { WorkspaceType } from "@app/types/user";
 import { isLeft } from "fp-ts/lib/Either";
@@ -407,7 +408,11 @@ const handleDataSourceWithProvider = async ({
   let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
   try {
     credentials = await getLlmCredentials(auth);
-  } catch {
+  } catch (err) {
+    logger.error(
+      { error: normalizeError(err) },
+      "Failed to get LLM credentials"
+    );
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -46,6 +46,7 @@ import { CONNECTOR_PROVIDERS } from "@app/types/data_source";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { PlanType } from "@app/types/plan";
+import type { LLMCredentialsType } from "@app/types/provider_credential";
 import { sendUserOperationMessage } from "@app/types/shared/user_operation";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { ioTsParsePayload } from "@app/types/shared/utils/iots_utils";
@@ -405,7 +406,7 @@ const handleDataSourceWithProvider = async ({
     });
   }
 
-  let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+  let credentials: LLMCredentialsType;
   try {
     credentials = await getLlmCredentials(auth);
   } catch (err) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -11,7 +11,10 @@ import {
   registerSlackWebhookRouterEntry,
 } from "@app/lib/api/data_sources";
 import { checkConnectionOwnership } from "@app/lib/api/oauth";
-import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import {
+  getLlmCredentials,
+  MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE,
+} from "@app/lib/api/provider_credentials";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags, getOrCreateSystemApiKey } from "@app/lib/auth";
@@ -401,7 +404,18 @@ const handleDataSourceWithProvider = async ({
     });
   }
 
-  const credentials = await getLlmCredentials(auth);
+  let credentials: Awaited<ReturnType<typeof getLlmCredentials>>;
+  try {
+    credentials = await getLlmCredentials(auth);
+  } catch {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE,
+      },
+    });
+  }
 
   const dustDataSource = await coreAPI.createDataSource({
     projectId: dustProject.value.project.project_id.toString(),

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -412,7 +412,7 @@ const handleDataSourceWithProvider = async ({
   } catch (err) {
     logger.error(
       { error: normalizeError(err) },
-      "Failed to get LLM credentials"
+      "Failed to get LLM credentials to create data source"
     );
     return apiError(req, res, {
       status_code: 400,


### PR DESCRIPTION
## Description

When `getLlmCredentials` throws because an OpenAI embedding API key is not configured,
API endpoints (upsert document, create data source, search) now return a user-friendly
400 error instead of crashing. The sidebar banner also gains a dedicated case for missing
embedding credentials, distinct from other unhealthy providers.

## Tests

Tested manually on a BYOK workspace without an OpenAI key configured.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`