### PR TITLE
Group tools/llm events

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -24,8 +24,11 @@ function getClient(): Metronome {
 // Event ingestion
 // ---------------------------------------------------------------------------
 
+const METRONOME_INGEST_BATCH_SIZE = 100;
+
 /**
  * Send usage events to Metronome's ingest API.
+ * Batches into chunks of 100 (Metronome's max per request).
  * Throws on failure so callers (e.g. Temporal activities) can retry.
  */
 export async function ingestMetronomeEvents(
@@ -35,7 +38,11 @@ export async function ingestMetronomeEvents(
     return;
   }
 
-  await getClient().v1.usage.ingest({ usage: events });
+  const client = getClient();
+  for (let i = 0; i < events.length; i += METRONOME_INGEST_BATCH_SIZE) {
+    const batch = events.slice(i, i + METRONOME_INGEST_BATCH_SIZE);
+    await client.v1.usage.ingest({ usage: batch });
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -182,12 +182,13 @@ export function getToolCategory(
 // ---------------------------------------------------------------------------
 
 /**
- * Build a single Metronome llm_usage event for an agent message, aggregating
- * all LLM calls (tokens, cost) into one event.
+ * Build aggregated Metronome llm_usage events for an agent message.
+ * Usages are grouped by (providerId, modelId) — one event per model used
+ * with aggregated token counts and cost.
  *
- * transaction_id pattern: llm-{workspaceId}-{agentMessageId}
+ * transaction_id pattern: llm-{workspaceId}-{agentMessageId}-{providerId}-{modelId}
  */
-export function buildLlmUsageEvent({
+export function buildLlmUsageEvents({
   workspaceId,
   userId,
   agentMessageId,
@@ -209,24 +210,45 @@ export function buildLlmUsageEvent({
   messageTier: MessageTier;
   isSubAgentMessage: boolean;
   timestamp: string;
-}): MetronomeEvent {
-  const promptTokens = runUsages.reduce((sum, u) => sum + u.promptTokens, 0);
-  const completionTokens = runUsages.reduce(
-    (sum, u) => sum + u.completionTokens,
-    0
-  );
-  const cachedTokens = runUsages.reduce(
-    (sum, u) => sum + (u.cachedTokens ?? 0),
-    0
-  );
-  const cacheCreationTokens = runUsages.reduce(
-    (sum, u) => sum + (u.cacheCreationTokens ?? 0),
-    0
-  );
-  const costMicroUsd = runUsages.reduce((sum, u) => sum + u.costMicroUsd, 0);
+}): MetronomeEvent[] {
+  // Group by (providerId, modelId).
+  const groups = new Map<
+    string,
+    {
+      providerId: string;
+      modelId: string;
+      promptTokens: number;
+      completionTokens: number;
+      cachedTokens: number;
+      cacheCreationTokens: number;
+      costMicroUsd: number;
+    }
+  >();
 
-  return {
-    transaction_id: `llm-${workspaceId}-${agentMessageId}`,
+  for (const usage of runUsages) {
+    const key = `${usage.providerId}|${usage.modelId}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.promptTokens += usage.promptTokens;
+      existing.completionTokens += usage.completionTokens;
+      existing.cachedTokens += usage.cachedTokens ?? 0;
+      existing.cacheCreationTokens += usage.cacheCreationTokens ?? 0;
+      existing.costMicroUsd += usage.costMicroUsd;
+    } else {
+      groups.set(key, {
+        providerId: usage.providerId,
+        modelId: usage.modelId,
+        promptTokens: usage.promptTokens,
+        completionTokens: usage.completionTokens,
+        cachedTokens: usage.cachedTokens ?? 0,
+        cacheCreationTokens: usage.cacheCreationTokens ?? 0,
+        costMicroUsd: usage.costMicroUsd,
+      });
+    }
+  }
+
+  return [...groups.values()].map((group) => ({
+    transaction_id: `llm-${workspaceId}-${agentMessageId}-${group.providerId}-${group.modelId}`,
     customer_id: workspaceId,
     event_type: "llm_usage",
     timestamp,
@@ -237,26 +259,27 @@ export function buildLlmUsageEvent({
       ...(parentAgentMessageId
         ? { parent_agent_message_id: parentAgentMessageId }
         : {}),
-      prompt_tokens: promptTokens,
-      completion_tokens: completionTokens,
-      cached_tokens: cachedTokens,
-      cache_creation_tokens: cacheCreationTokens,
+      provider_id: group.providerId,
+      model_id: group.modelId,
+      prompt_tokens: group.promptTokens,
+      completion_tokens: group.completionTokens,
+      cached_tokens: group.cachedTokens,
+      cache_creation_tokens: group.cacheCreationTokens,
       // Provider cost without markup — markup is applied in Metronome rate card.
-      cost_micro_usd: costMicroUsd,
+      cost_micro_usd: group.costMicroUsd,
       is_programmatic_usage: isProgrammaticUsage ? "true" : "false",
       message_tier: messageTier,
       is_sub_agent_message: isSubAgentMessage ? "true" : "false",
       origin,
     },
-  };
+  }));
 }
 
 // ---------------------------------------------------------------------------
 // Tool use events
 // ---------------------------------------------------------------------------
 
-interface ToolAction {
-  sId: string;
+export interface ToolAction {
   toolName: string;
   mcpServerId: string | null;
   internalMCPServerName: InternalMCPServerNameType | null;
@@ -265,9 +288,11 @@ interface ToolAction {
 }
 
 /**
- * Build one Metronome event per MCP action within an agent message.
+ * Build aggregated Metronome tool_use events for an agent message.
+ * Actions are grouped by (toolName, internalMCPServerName, mcpServerId, status)
+ * — one event per group with `count` and `total_execution_duration_ms`.
  *
- * transaction_id pattern: tool-{workspaceId}-{actionSId}
+ * transaction_id pattern: tool-{workspaceId}-{agentMessageId}-{toolName}-{mcpServerId}-{status}
  */
 export function buildToolUseEvents({
   workspaceId,
@@ -292,8 +317,28 @@ export function buildToolUseEvents({
   isSubAgentMessage: boolean;
   timestamp: string;
 }): MetronomeEvent[] {
-  return actions.map((action) => ({
-    transaction_id: `tool-${workspaceId}-${action.sId}`,
+  // Group actions by (toolName, internalMCPServerName, mcpServerId, status).
+  const groups = new Map<
+    string,
+    { action: ToolAction; count: number; totalDurationMs: number }
+  >();
+  for (const action of actions) {
+    const key = `${action.toolName}|${action.internalMCPServerName ?? ""}|${action.mcpServerId ?? ""}|${action.status}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.count++;
+      existing.totalDurationMs += action.executionDurationMs ?? 0;
+    } else {
+      groups.set(key, {
+        action,
+        count: 1,
+        totalDurationMs: action.executionDurationMs ?? 0,
+      });
+    }
+  }
+
+  return [...groups.values()].map(({ action, count, totalDurationMs }) => ({
+    transaction_id: `tool-${workspaceId}-${agentMessageId}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`,
     customer_id: workspaceId,
     event_type: "tool_use",
     timestamp,
@@ -312,7 +357,8 @@ export function buildToolUseEvents({
       // aggregate all tool categories into a single "Tool Usage" invoice line.
       tool_group: "tools",
       status: action.status,
-      execution_duration_ms: action.executionDurationMs ?? 0,
+      count,
+      total_execution_duration_ms: totalDurationMs,
       is_programmatic_usage: isProgrammaticUsage ? "true" : "false",
       message_tier: messageTier,
       is_sub_agent_message: isSubAgentMessage ? "true" : "false",

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -6,7 +6,7 @@ import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { ingestMetronomeEvents } from "@app/lib/metronome/client";
 import {
-  buildLlmUsageEvent,
+  buildLlmUsageEvents,
   buildToolUseEvents,
   classifyMessageTier,
   getToolCategory,
@@ -277,7 +277,6 @@ export async function emitMetronomeUsageEventsActivity(
   const toolActions = mcpActions.map((a) => {
     const json = a.toJSON();
     return {
-      sId: json.sId,
       toolName: json.toolName,
       mcpServerId: json.mcpServerId,
       internalMCPServerName: json.internalMCPServerName,
@@ -294,7 +293,7 @@ export async function emitMetronomeUsageEventsActivity(
   const messageTier = classifyMessageTier({ modelIds, toolCategories });
 
   // Build and ingest events.
-  const llmEvent = buildLlmUsageEvent({
+  const llmEvents = buildLlmUsageEvents({
     workspaceId: workspace.sId,
     userId,
     agentMessageId,
@@ -320,5 +319,5 @@ export async function emitMetronomeUsageEventsActivity(
     timestamp,
   });
 
-  await ingestMetronomeEvents([llmEvent, ...toolEvents]);
+  await ingestMetronomeEvents([...llmEvents, ...toolEvents]);
 }


### PR DESCRIPTION
## Description

Optimizes Metronome event volume by aggregating events within each agent message.

**LLM usage events** — grouped by `(provider_id, model_id)`. Multiple calls to the same model within a message produce one event with aggregated token counts and cost. Keeps `provider_id`/`model_id` for dimensional pricing.

**Tool use events** — grouped by `(tool_name, mcp_server_id, status)`. Identical tool invocations (e.g. 100 web searches) produce one event with:
- `count` — number of invocations
- `total_execution_duration_ms` — sum of execution times

**Ingest batching** — events are chunked into batches of 100 (Metronome's max per request) to avoid 400 errors on messages with many tool calls.

Transaction ID patterns updated to reflect grouping:
- `llm-{workspaceId}-{agentMessageId}-{providerId}-{modelId}`
- `tool-{workspaceId}-{agentMessageId}-{toolName}-{mcpServerId}-{status}`

## Tests

Type-checked. Deterministic transaction IDs ensure idempotent retries.

## Risk

Low — changes event granularity but total billed amounts are identical. Grouped events are strictly additive (same totals, fewer rows).

## Deploy Plan

No special steps. Transparent change — Metronome aggregates on the same properties regardless.