### PR TITLE
[front] - feature(analytics): add CSV export for assistant messages analytics

### DIFF
--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -84,7 +84,7 @@ export async function exportTable({
           const r = await fetchAvailableSkills(q);
           return r.isOk()
             ? new Ok(r.value.map((s) => ({ name: s.skillName })))
-            : new Err(r.error);
+            : r;
         },
         fetchMetrics: fetchSkillUsageMetrics,
       });
@@ -99,7 +99,7 @@ export async function exportTable({
           const r = await fetchAvailableTools(q);
           return r.isOk()
             ? new Ok(r.value.map((t) => ({ name: t.serverName })))
-            : new Err(r.error);
+            : r;
         },
         fetchMetrics: fetchToolUsageMetrics,
       });

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -4,6 +4,10 @@ import {
 } from "@app/lib/api/analytics/agents_export";
 import { sanitizeCsvCell } from "@app/lib/api/analytics/csv_utils";
 import {
+  fetchMessageExportRows,
+  MESSAGE_EXPORT_HEADERS,
+} from "@app/lib/api/analytics/messages_export";
+import {
   fetchUserExportRows,
   USER_EXPORT_HEADERS,
 } from "@app/lib/api/analytics/users_export";
@@ -25,6 +29,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
+import type { estypes } from "@elastic/elasticsearch";
 import { stringify } from "csv-stringify/sync";
 
 type AnalyticsExportTable =
@@ -34,18 +39,12 @@ type AnalyticsExportTable =
   | "agents"
   | "users"
   | "skill_usage"
-  | "tool_usage";
+  | "tool_usage"
+  | "messages";
 
-interface SkillUsageExportRow {
+interface UsageExportRow {
   date: string;
-  skillName: string;
-  executions: number;
-  uniqueUsers: number;
-}
-
-interface ToolUsageExportRow {
-  date: string;
-  toolName: string;
+  name: string;
   executions: number;
   uniqueUsers: number;
 }
@@ -75,9 +74,37 @@ export async function exportTable({
     case "users":
       return exportUsers({ startDate, endDate, timezone, owner });
     case "skill_usage":
-      return exportSkillUsage({ startDate, endDate, timezone, owner });
+      return exportItemUsage({
+        startDate,
+        endDate,
+        timezone,
+        owner,
+        headerLabel: "skillName",
+        fetchItems: async (q) => {
+          const r = await fetchAvailableSkills(q);
+          return r.isOk()
+            ? new Ok(r.value.map((s) => ({ name: s.skillName })))
+            : new Err(r.error);
+        },
+        fetchMetrics: fetchSkillUsageMetrics,
+      });
     case "tool_usage":
-      return exportToolUsage({ startDate, endDate, timezone, owner });
+      return exportItemUsage({
+        startDate,
+        endDate,
+        timezone,
+        owner,
+        headerLabel: "toolName",
+        fetchItems: async (q) => {
+          const r = await fetchAvailableTools(q);
+          return r.isOk()
+            ? new Ok(r.value.map((t) => ({ name: t.serverName })))
+            : new Err(r.error);
+        },
+        fetchMetrics: fetchToolUsageMetrics,
+      });
+    case "messages":
+      return exportMessages({ startDate, endDate, timezone, owner });
     default:
       assertNever(table);
   }
@@ -276,16 +303,33 @@ async function exportUsers({
   );
 }
 
-async function exportSkillUsage({
+async function exportItemUsage({
   startDate,
   endDate,
   timezone,
   owner,
+  headerLabel,
+  fetchItems,
+  fetchMetrics,
 }: {
   startDate: string;
   endDate: string;
   timezone: string;
   owner: WorkspaceType;
+  headerLabel: string;
+  fetchItems: (
+    q: estypes.QueryDslQueryContainer
+  ) => Promise<Result<{ name: string }[], Error>>;
+  fetchMetrics: (
+    q: estypes.QueryDslQueryContainer,
+    name: string,
+    tz: string
+  ) => Promise<
+    Result<
+      { date: string; executionCount: number; uniqueUsers: number }[],
+      Error
+    >
+  >;
 }): Promise<Result<string, Error>> {
   const baseQuery = buildAgentAnalyticsBaseQuery({
     workspaceId: owner.sId,
@@ -293,31 +337,27 @@ async function exportSkillUsage({
     endDate,
   });
 
-  const skillsResult = await fetchAvailableSkills(baseQuery);
-  if (skillsResult.isErr()) {
+  const itemsResult = await fetchItems(baseQuery);
+  if (itemsResult.isErr()) {
     return new Err(
       new Error(
-        `Failed to retrieve available skills: ${skillsResult.error.message}`
+        `Failed to retrieve available ${headerLabel}s: ${itemsResult.error.message}`
       )
     );
   }
 
   const nestedRows = await concurrentExecutor(
-    skillsResult.value,
-    async (skill) => {
-      const usageResult = await fetchSkillUsageMetrics(
-        baseQuery,
-        skill.skillName,
-        timezone
-      );
+    itemsResult.value,
+    async (item) => {
+      const usageResult = await fetchMetrics(baseQuery, item.name, timezone);
       if (usageResult.isErr()) {
         throw new Error(
-          `Failed to retrieve skill usage for ${skill.skillName}: ${usageResult.error.message}`
+          `Failed to retrieve ${headerLabel} usage for ${item.name}: ${usageResult.error.message}`
         );
       }
       return usageResult.value.map((point) => ({
         date: point.date,
-        skillName: skill.skillName,
+        name: item.name,
         executions: point.executionCount,
         uniqueUsers: point.uniqueUsers,
       }));
@@ -325,30 +365,28 @@ async function exportSkillUsage({
     { concurrency: 8 }
   );
 
-  const rows: SkillUsageExportRow[] = nestedRows.flat();
+  const rows: UsageExportRow[] = nestedRows.flat();
 
   rows.sort((a, b) => {
     const dateCompare = a.date.localeCompare(b.date);
     if (dateCompare !== 0) {
       return dateCompare;
     }
-    return a.skillName.localeCompare(b.skillName);
+    return a.name.localeCompare(b.name);
   });
 
-  const headers: (keyof SkillUsageExportRow)[] = [
-    "date",
-    "skillName",
-    "executions",
-    "uniqueUsers",
-  ];
-  const csvData = rows.map((row) =>
-    headers.map((h) => sanitizeCsvCell(row[h]))
-  );
+  const headers: string[] = ["date", headerLabel, "executions", "uniqueUsers"];
+  const csvData = rows.map((row) => [
+    sanitizeCsvCell(row.date),
+    sanitizeCsvCell(row.name),
+    row.executions,
+    row.uniqueUsers,
+  ]);
 
   return new Ok(stringify([headers, ...csvData], { header: false }));
 }
 
-async function exportToolUsage({
+async function exportMessages({
   startDate,
   endDate,
   timezone,
@@ -359,63 +397,25 @@ async function exportToolUsage({
   timezone: string;
   owner: WorkspaceType;
 }): Promise<Result<string, Error>> {
-  const baseQuery = buildAgentAnalyticsBaseQuery({
+  const result = await fetchMessageExportRows({
     workspaceId: owner.sId,
+    workspaceModelId: owner.id,
     startDate,
     endDate,
+    timezone,
   });
 
-  const toolsResult = await fetchAvailableTools(baseQuery);
-  if (toolsResult.isErr()) {
+  if (result.isErr()) {
     return new Err(
-      new Error(
-        `Failed to retrieve available tools: ${toolsResult.error.message}`
-      )
+      new Error(`Failed to retrieve message export: ${result.error.message}`)
     );
   }
 
-  const nestedRows = await concurrentExecutor(
-    toolsResult.value,
-    async (tool) => {
-      const usageResult = await fetchToolUsageMetrics(
-        baseQuery,
-        tool.serverName,
-        timezone
-      );
-      if (usageResult.isErr()) {
-        throw new Error(
-          `Failed to retrieve tool usage for ${tool.serverName}: ${usageResult.error.message}`
-        );
-      }
-      return usageResult.value.map((point) => ({
-        date: point.date,
-        toolName: tool.serverName,
-        executions: point.executionCount,
-        uniqueUsers: point.uniqueUsers,
-      }));
-    },
-    { concurrency: 8 }
+  const csvData = result.value.map((row) =>
+    MESSAGE_EXPORT_HEADERS.map((h) => sanitizeCsvCell(row[h]))
   );
 
-  const rows: ToolUsageExportRow[] = nestedRows.flat();
-
-  rows.sort((a, b) => {
-    const dateCompare = a.date.localeCompare(b.date);
-    if (dateCompare !== 0) {
-      return dateCompare;
-    }
-    return a.toolName.localeCompare(b.toolName);
-  });
-
-  const headers: (keyof ToolUsageExportRow)[] = [
-    "date",
-    "toolName",
-    "executions",
-    "uniqueUsers",
-  ];
-  const csvData = rows.map((row) =>
-    headers.map((h) => sanitizeCsvCell(row[h]))
+  return new Ok(
+    stringify([MESSAGE_EXPORT_HEADERS, ...csvData], { header: false })
   );
-
-  return new Ok(stringify([headers, ...csvData], { header: false }));
 }

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -2,6 +2,7 @@ import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import { UserResource } from "@app/lib/resources/user_resource";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
@@ -67,7 +68,7 @@ async function fetchAllMessageDocuments(
       return new Err(new Error(result.error.message));
     }
 
-    const hits = result.value.hits.hits;
+    const { hits } = result.value.hits;
     for (const hit of hits) {
       if (hit._source) {
         allDocs.push(hit._source);
@@ -87,7 +88,7 @@ async function fetchAllMessageDocuments(
 
 async function fetchAgentMetadata(
   agentIds: string[],
-  workspaceModelId: number
+  workspaceModelId: ModelId
 ): Promise<Map<string, { name: string; settings: string }>> {
   if (agentIds.length === 0) {
     return new Map();
@@ -108,6 +109,7 @@ async function fetchAgentMetadata(
     FROM "agent_configurations" ac
     WHERE ac."workspaceId" = :wId
       AND ac."sId" IN (:agentIds)
+      AND ac."status" = 'active'
     `,
     {
       type: QueryTypes.SELECT,
@@ -139,7 +141,7 @@ export async function fetchMessageExportRows({
   timezone,
 }: {
   workspaceId: string;
-  workspaceModelId: number;
+  workspaceModelId: ModelId;
   startDate: string;
   endDate: string;
   timezone: string;

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -1,0 +1,194 @@
+import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
+import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+import moment from "moment-timezone";
+import { QueryTypes } from "sequelize";
+
+const PAGE_SIZE = 10000;
+
+interface AgentMessageDocument extends ElasticsearchBaseDocument {
+  message_id: string;
+  timestamp: string;
+  agent_id: string;
+  conversation_id: string;
+  user_id: string;
+  context_origin: string;
+  status: string;
+}
+
+interface AgentMetaRow {
+  sId: string;
+  name: string;
+  settings: string;
+}
+
+export interface MessageExportRow {
+  messageId: string;
+  createdAt: string;
+  assistantId: string;
+  assistantName: string;
+  assistantSettings: string;
+  conversationId: string;
+  userId: string;
+  userEmail: string;
+  source: string;
+}
+
+export const MESSAGE_EXPORT_HEADERS: (keyof MessageExportRow)[] = [
+  "messageId",
+  "createdAt",
+  "assistantId",
+  "assistantName",
+  "assistantSettings",
+  "conversationId",
+  "userId",
+  "userEmail",
+  "source",
+];
+
+async function fetchAllMessageDocuments(
+  query: estypes.QueryDslQueryContainer
+): Promise<Result<AgentMessageDocument[], Error>> {
+  const allDocs: AgentMessageDocument[] = [];
+  let searchAfter: estypes.SortResults | undefined;
+
+  while (true) {
+    const result = await searchAnalytics<AgentMessageDocument>(query, {
+      size: PAGE_SIZE,
+      sort: [{ timestamp: "asc" }, { message_id: "asc" }],
+      search_after: searchAfter,
+    });
+
+    if (result.isErr()) {
+      return new Err(new Error(result.error.message));
+    }
+
+    const hits = result.value.hits.hits;
+    for (const hit of hits) {
+      if (hit._source) {
+        allDocs.push(hit._source);
+      }
+    }
+
+    if (hits.length < PAGE_SIZE) {
+      break;
+    }
+
+    const lastHit = hits[hits.length - 1];
+    searchAfter = lastHit.sort;
+  }
+
+  return new Ok(allDocs);
+}
+
+async function fetchAgentMetadata(
+  agentIds: string[],
+  workspaceModelId: number
+): Promise<Map<string, { name: string; settings: string }>> {
+  if (agentIds.length === 0) {
+    return new Map();
+  }
+
+  const readReplica = getFrontReplicaDbConnection();
+  // biome-ignore lint/plugin/noRawSql: Matches existing Activity Report query pattern.
+  const agents = await readReplica.query<AgentMetaRow>(
+    `
+    SELECT ac."sId",
+           ac."name",
+           CASE
+             WHEN ac."status" = 'draft' THEN 'draft'
+             WHEN ac."scope" = 'visible' THEN 'published'
+             WHEN ac."scope" = 'hidden' THEN 'unpublished'
+             ELSE 'unknown'
+           END AS "settings"
+    FROM "agent_configurations" ac
+    WHERE ac."workspaceId" = :wId
+      AND ac."sId" IN (:agentIds)
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: { wId: workspaceModelId, agentIds },
+    }
+  );
+
+  return new Map(
+    agents.map((a) => [a.sId, { name: a.name, settings: a.settings }])
+  );
+}
+
+async function fetchUserEmails(
+  userIds: string[]
+): Promise<Map<string, string>> {
+  if (userIds.length === 0) {
+    return new Map();
+  }
+
+  const users = await UserResource.fetchByIds(userIds);
+  return new Map(users.map((u) => [u.sId, u.email]));
+}
+
+export async function fetchMessageExportRows({
+  workspaceId,
+  workspaceModelId,
+  startDate,
+  endDate,
+  timezone,
+}: {
+  workspaceId: string;
+  workspaceModelId: number;
+  startDate: string;
+  endDate: string;
+  timezone: string;
+}): Promise<Result<MessageExportRow[], Error>> {
+  const query: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [
+        { term: { workspace_id: workspaceId } },
+        { term: { status: "succeeded" } },
+        { range: { timestamp: { gte: startDate, lte: endDate } } },
+      ],
+    },
+  };
+
+  const docsResult = await fetchAllMessageDocuments(query);
+  if (docsResult.isErr()) {
+    return new Err(docsResult.error);
+  }
+
+  const docs = docsResult.value;
+
+  const uniqueAgentIds = [
+    ...new Set(docs.map((d) => d.agent_id).filter(Boolean)),
+  ];
+  const uniqueUserIds = [
+    ...new Set(docs.map((d) => d.user_id).filter(Boolean)),
+  ];
+
+  const [agentMeta, userEmails] = await Promise.all([
+    fetchAgentMetadata(uniqueAgentIds, workspaceModelId),
+    fetchUserEmails(uniqueUserIds),
+  ]);
+
+  const rows: MessageExportRow[] = docs.map((doc) => {
+    const agent = agentMeta.get(doc.agent_id);
+    return {
+      messageId: doc.message_id,
+      createdAt: moment(doc.timestamp)
+        .tz(timezone)
+        .format("YYYY-MM-DD HH:mm:ss"),
+      assistantId: doc.agent_id,
+      assistantName: agent?.name ?? doc.agent_id,
+      assistantSettings: agent?.settings ?? "unknown",
+      conversationId: doc.conversation_id,
+      userId: doc.user_id,
+      userEmail: userEmails.get(doc.user_id) ?? "",
+      source: doc.context_origin ?? "",
+    };
+  });
+
+  return new Ok(rows);
+}

--- a/front/pages/api/v1/w/[wId]/analytics/export.test.ts
+++ b/front/pages/api/v1/w/[wId]/analytics/export.test.ts
@@ -71,6 +71,36 @@ vi.mock("@app/lib/api/assistant/observability/tool_usage", async () => ({
   fetchToolUsageMetrics: vi.fn(async () => new Ok([])),
 }));
 
+vi.mock("@app/lib/api/analytics/messages_export", async () => ({
+  MESSAGE_EXPORT_HEADERS: [
+    "messageId",
+    "createdAt",
+    "assistantId",
+    "assistantName",
+    "assistantSettings",
+    "conversationId",
+    "userId",
+    "userEmail",
+    "source",
+  ],
+  fetchMessageExportRows: vi.fn(
+    async () =>
+      new Ok([
+        {
+          messageId: "msg-1",
+          createdAt: "2024-06-01 10:00:00",
+          assistantId: "agent-1",
+          assistantName: "TestAgent",
+          assistantSettings: "published",
+          conversationId: "conv-1",
+          userId: "user-1",
+          userEmail: "alice@example.com",
+          source: "web",
+        },
+      ])
+  ),
+}));
+
 describe(
   "public api authentication tests",
   createPublicApiAuthenticationTests(handler)
@@ -267,5 +297,19 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
     expect(res._getStatusCode()).toBe(200);
     const csv = res._getData();
     expect(csv).toContain("date,toolName,executions,uniqueUsers");
+  });
+
+  it("returns CSV for messages table", async () => {
+    const { req, res } = await setupTest({ table: "messages" });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const csv = res._getData();
+    expect(csv).toContain(
+      "messageId,createdAt,assistantId,assistantName,assistantSettings,conversationId,userId,userEmail,source"
+    );
+    expect(csv).toContain("msg-1");
+    expect(csv).toContain("alice@example.com");
   });
 });

--- a/front/pages/api/w/[wId]/analytics/users-export.ts
+++ b/front/pages/api/w/[wId]/analytics/users-export.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/lib/api/analytics/users_export";
 import {
   buildAgentAnalyticsBaseQuery,
+  daysToDateRange,
   timezoneSchema,
 } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -57,15 +58,16 @@ async function handler(
         days: q.data.days,
       });
 
-      const now = new Date();
-      const startDate = new Date(now);
-      startDate.setDate(startDate.getDate() - q.data.days);
+      const { startDate, endDate } = daysToDateRange(
+        q.data.days,
+        q.data.timezone
+      );
 
       const result = await fetchUserExportRows({
         baseQuery,
         owner,
-        startDate,
-        endDate: now,
+        startDate: new Date(startDate),
+        endDate: new Date(endDate),
         timezone: q.data.timezone,
       });
 

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2791,6 +2791,7 @@ const AnalyticsExportTableSchema = z.enum([
   "users",
   "skill_usage",
   "tool_usage",
+  "messages",
 ]);
 
 const AnalyticsDateSchema = z


### PR DESCRIPTION
## Description

This PR adds CSV export functionality for assistant messages analytics. The new `messages` table type in the analytics export API allows workspace admins to download detailed message-level data including message ID, timestamps, assistant metadata (ID, name, settings), conversation ID, user information (ID, email), and message source. Follows the established pattern from previous analytics exports and generalizes the `skill_usage` and `tool_usage` export logic into a reusable `exportItemUsage` helper to reduce code duplication.

## Tests

- [x] Added test coverage in `export.test.ts` verifying CSV headers and data format for the new messages table
- [x] Locally

## Risk

Low. The feature follows the existing analytics export pattern and is restricted to workspace admins.

## Deploy Plan

Deploy front