### PR TITLE
Reinforced Agent: retry error on tool calls

### DIFF
--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -286,7 +286,7 @@ export async function aggregateSyntheticSuggestions(
 
   const { agentConfig, syntheticSuggestions, prompt } = ctx;
 
-  const createdCount = await runReinforcedAnalysis({
+  const result = await runReinforcedAnalysis({
     auth,
     agentConfig,
     prompt,
@@ -295,10 +295,10 @@ export async function aggregateSyntheticSuggestions(
     contextId: agentConfigurationId,
   });
 
-  if (createdCount > 0 && !disableNotifications) {
+  if (result.suggestionsCreated > 0 && !disableNotifications) {
     notifyAgentSuggestionsReady(auth, {
       agentConfiguration: agentConfig,
-      suggestionCount: createdCount,
+      suggestionCount: result.suggestionsCreated,
     });
     await createAgentSuggestionsConversations(auth, agentConfig);
   }
@@ -313,7 +313,8 @@ export async function aggregateSyntheticSuggestions(
     {
       agentConfigurationId,
       syntheticCount: syntheticSuggestions.length,
-      pendingCreated: createdCount,
+      pendingCreated: result.suggestionsCreated,
+      failedToolCalls: result.failedToolCalls.length,
     },
     "ReinforcedAgent: aggregated synthetic suggestions into pending"
   );

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -16,13 +16,19 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import type { ReinforcedOperationType } from "@app/lib/reinforced_agent/types";
 import {
+  ALL_TOOLS,
   type ExploratoryToolCallInfo,
-  type ExploratoryToolName,
   getReinforcementMetadata,
+  isExploratoryToolName,
+  isTerminalToolName,
+  type ProcessReinforcedEventsResult,
+  type ReinforcedOperationType,
+  type TerminalToolCallEvent,
+  type TerminalToolCallFailure,
   type TerminalToolCallInfo,
-  type TerminalToolName,
+  type TerminalToolCallSuccess,
+  TOOL_SCHEMAS,
 } from "@app/lib/reinforced_agent/types";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
@@ -34,30 +40,7 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-const TERMINAL_TOOLS: TerminalToolName[] = [
-  "suggest_prompt_edits",
-  "suggest_tools",
-  "suggest_skills",
-];
-
-const EXPLORATORY_TOOLS: ExploratoryToolName[] = [
-  "get_available_skills",
-  "get_available_tools",
-];
-
-const ALL_TOOLS = [...TERMINAL_TOOLS, ...EXPLORATORY_TOOLS];
-
-const TOOL_SCHEMAS: Record<TerminalToolName, z.ZodObject<z.ZodRawShape>> = {
-  suggest_prompt_edits: z.object(
-    AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_prompt_edits.schema
-  ),
-  suggest_tools: z.object(
-    AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_tools.schema
-  ),
-  suggest_skills: z.object(
-    AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_skills.schema
-  ),
-};
+export const REINFORCEMENT_AGENT_ID = "reinforcement";
 
 export function buildReinforcedSpecifications(): AgentActionSpecification[] {
   return ALL_TOOLS.map((toolName) => {
@@ -77,35 +60,27 @@ interface CategorizedToolCalls {
 }
 
 export function classifyToolCalls(events: LLMEvent[]): CategorizedToolCalls {
-  const terminalToolNames = new Set<string>(TERMINAL_TOOLS);
-  const exploratoryToolNames = new Set<string>(EXPLORATORY_TOOLS);
-
   const toolCallEvents = events.filter(
     (e): e is ToolCallEvent =>
       e.type === "tool_call" &&
-      (terminalToolNames.has(e.content.name) ||
-        exploratoryToolNames.has(e.content.name))
+      (isTerminalToolName(e.content.name) ||
+        isExploratoryToolName(e.content.name))
   );
 
-  return {
-    exploratoryToolCalls: toolCallEvents
-      .filter((e) => exploratoryToolNames.has(e.content.name))
-      .map((e) => ({
-        id: e.content.id,
-        name: e.content.name as ExploratoryToolName,
-        arguments: e.content.arguments,
-      })),
-    terminalToolCalls: toolCallEvents
-      .filter((e) => terminalToolNames.has(e.content.name))
-      .map((e) => ({
-        id: e.content.id,
-        name: e.content.name as TerminalToolName,
-        arguments: e.content.arguments,
-      })),
-  };
-}
+  const exploratoryToolCalls: ExploratoryToolCallInfo[] = [];
+  const terminalToolCalls: TerminalToolCallInfo[] = [];
 
-export const REINFORCEMENT_AGENT_ID = "reinforcement";
+  for (const e of toolCallEvents) {
+    const { id, name, arguments: args } = e.content;
+    if (isExploratoryToolName(name)) {
+      exploratoryToolCalls.push({ id, name, arguments: args });
+    } else if (isTerminalToolName(name)) {
+      terminalToolCalls.push({ id, name, arguments: args });
+    }
+  }
+
+  return { exploratoryToolCalls, terminalToolCalls };
+}
 
 export function getReinforcementDefaultOptions(
   reinforcedOperationType: ReinforcedOperationType,
@@ -217,7 +192,7 @@ export async function processReinforcedEvents({
   operationType: ReinforcedOperationType;
   contextId: string;
   conversation?: ConversationResource;
-}): Promise<number> {
+}): Promise<ProcessReinforcedEventsResult> {
   const errorEvents = events.filter((e) => e.type === "error");
   if (errorEvents.length > 0) {
     logger.error(
@@ -228,27 +203,37 @@ export async function processReinforcedEvents({
       },
       `ReinforcedAgent: batch LLM errors for ${operationType}`
     );
-    return 0;
+    return {
+      suggestionsCreated: 0,
+      successfulToolCalls: [],
+      failedToolCalls: [],
+    };
   }
 
-  const terminalToolNames = new Set<string>(TERMINAL_TOOLS);
   const toolCallEvents = events.filter(
-    (e) => e.type === "tool_call" && terminalToolNames.has(e.content.name)
+    (e): e is TerminalToolCallEvent =>
+      e.type === "tool_call" && isTerminalToolName(e.content.name)
   );
   if (toolCallEvents.length === 0) {
     logger.warn(
       { contextId },
       `ReinforcedAgent: no tool call in batch result for ${operationType}`
     );
-    return 0;
+    return {
+      suggestionsCreated: 0,
+      successfulToolCalls: [],
+      failedToolCalls: [],
+    };
   }
 
   let totalCreated = 0;
+  const successfulToolCalls: TerminalToolCallSuccess[] = [];
+  const failedToolCalls: TerminalToolCallFailure[] = [];
+
   for (const event of toolCallEvents) {
-    if (event.type !== "tool_call") {
-      continue;
-    }
-    totalCreated += await createSuggestionsFromToolCall({
+    const { id, name, arguments: args } = event.content;
+    const toolCall: TerminalToolCallInfo = { id, name, arguments: args };
+    const result = await createSuggestionsFromToolCall({
       auth,
       agentConfig,
       toolName: event.content.name,
@@ -258,9 +243,27 @@ export async function processReinforcedEvents({
       contextId,
       conversation,
     });
+    totalCreated += result.suggestionsCreated;
+    if (result.error) {
+      failedToolCalls.push({ toolCall, errorMessage: result.error });
+    } else {
+      successfulToolCalls.push({
+        toolCall,
+        message: `Successfully created ${result.suggestionsCreated} suggestion(s).`,
+      });
+    }
   }
 
-  return totalCreated;
+  return {
+    suggestionsCreated: totalCreated,
+    successfulToolCalls,
+    failedToolCalls,
+  };
+}
+
+interface ToolCallResult {
+  suggestionsCreated: number;
+  error?: string;
 }
 
 /**
@@ -284,12 +287,13 @@ async function createSuggestionsFromToolCall({
   operationType: ReinforcedOperationType;
   contextId: string;
   conversation?: ConversationResource;
-}): Promise<number> {
+}): Promise<ToolCallResult> {
   switch (toolName) {
     case "suggest_prompt_edits": {
       const parsed =
         TOOL_SCHEMAS.suggest_prompt_edits.safeParse(actionArguments);
       if (!parsed.success) {
+        const errorMessage = `Invalid arguments for ${toolName}: ${parsed.error.message}`;
         logger.warn(
           {
             agentConfigurationId: agentConfig.sId,
@@ -299,7 +303,7 @@ async function createSuggestionsFromToolCall({
           },
           `ReinforcedAgent: invalid LLM response shape for ${operationType}`
         );
-        return 0;
+        return { suggestionsCreated: 0, error: errorMessage };
       }
       const result = await createInstructionSuggestions({
         auth,
@@ -313,14 +317,18 @@ async function createSuggestionsFromToolCall({
           { agentConfigurationId: agentConfig.sId, contextId, toolName },
           `ReinforcedAgent: ${result.error}`
         );
-        return 0;
+        return {
+          suggestionsCreated: 0,
+          error: `Error creating suggestions: ${result.error}`,
+        };
       }
-      return result.value.length;
+      return { suggestionsCreated: result.value.length };
     }
 
     case "suggest_tools": {
       const parsed = TOOL_SCHEMAS.suggest_tools.safeParse(actionArguments);
       if (!parsed.success) {
+        const errorMessage = `Invalid arguments for ${toolName}: ${parsed.error.message}`;
         logger.warn(
           {
             agentConfigurationId: agentConfig.sId,
@@ -330,7 +338,7 @@ async function createSuggestionsFromToolCall({
           },
           `ReinforcedAgent: invalid LLM response shape for ${operationType}`
         );
-        return 0;
+        return { suggestionsCreated: 0, error: errorMessage };
       }
       const result = await createToolsSuggestions({
         auth,
@@ -344,14 +352,18 @@ async function createSuggestionsFromToolCall({
           { agentConfigurationId: agentConfig.sId, contextId, toolName },
           `ReinforcedAgent: ${result.error}`
         );
-        return 0;
+        return {
+          suggestionsCreated: 0,
+          error: `Error creating suggestions: ${result.error}`,
+        };
       }
-      return result.value.length;
+      return { suggestionsCreated: result.value.length };
     }
 
     case "suggest_skills": {
       const parsed = TOOL_SCHEMAS.suggest_skills.safeParse(actionArguments);
       if (!parsed.success) {
+        const errorMessage = `Invalid arguments for ${toolName}: ${parsed.error.message}`;
         logger.warn(
           {
             agentConfigurationId: agentConfig.sId,
@@ -361,7 +373,7 @@ async function createSuggestionsFromToolCall({
           },
           `ReinforcedAgent: invalid LLM response shape for ${operationType}`
         );
-        return 0;
+        return { suggestionsCreated: 0, error: errorMessage };
       }
       const result = await createSkillsSuggestions({
         auth,
@@ -375,9 +387,12 @@ async function createSuggestionsFromToolCall({
           { agentConfigurationId: agentConfig.sId, contextId, toolName },
           `ReinforcedAgent: ${result.error}`
         );
-        return 0;
+        return {
+          suggestionsCreated: 0,
+          error: `Error creating suggestions: ${result.error}`,
+        };
       }
-      return result.value.length;
+      return { suggestionsCreated: result.value.length };
     }
 
     default:
@@ -385,7 +400,7 @@ async function createSuggestionsFromToolCall({
         { agentConfigurationId: agentConfig.sId, contextId, toolName },
         `ReinforcedAgent: unexpected tool name for ${operationType}`
       );
-      return 0;
+      return { suggestionsCreated: 0 };
   }
 }
 
@@ -396,8 +411,6 @@ async function createSuggestionsFromToolCall({
  *
  * For multi-step conversations (exploratory tools), the loop is handled at the
  * Temporal workflow level via analyzeConversationStepActivity + runRetryableToolActivity.
- *
- * Returns the number of suggestions created.
  */
 export async function runReinforcedAnalysis({
   auth,
@@ -415,14 +428,18 @@ export async function runReinforcedAnalysis({
   operationType: ReinforcedOperationType;
   contextId: string;
   conversation?: ConversationResource;
-}): Promise<number> {
+}): Promise<ProcessReinforcedEventsResult> {
   const llm = await getReinforcedLLM(auth, operationType);
   if (!llm) {
     logger.error(
       { contextId },
       `ReinforcedAgent: no whitelisted model available for ${operationType}`
     );
-    return 0;
+    return {
+      suggestionsCreated: 0,
+      successfulToolCalls: [],
+      failedToolCalls: [],
+    };
   }
 
   const llmParams = buildReinforcedLLMParams(prompt);

--- a/front/lib/reinforced_agent/run_reinforced_analysis.ts
+++ b/front/lib/reinforced_agent/run_reinforced_analysis.ts
@@ -11,7 +11,7 @@ import {
   writeBatchUserMessages,
 } from "@app/lib/api/llm/batch_llm";
 import type { LLM } from "@app/lib/api/llm/llm";
-import type { LLMEvent, ToolCallEvent } from "@app/lib/api/llm/types/events";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { getLargeWhitelistedModel } from "@app/lib/assistant";
@@ -60,22 +60,23 @@ interface CategorizedToolCalls {
 }
 
 export function classifyToolCalls(events: LLMEvent[]): CategorizedToolCalls {
-  const toolCallEvents = events.filter(
-    (e): e is ToolCallEvent =>
-      e.type === "tool_call" &&
-      (isTerminalToolName(e.content.name) ||
-        isExploratoryToolName(e.content.name))
-  );
-
   const exploratoryToolCalls: ExploratoryToolCallInfo[] = [];
   const terminalToolCalls: TerminalToolCallInfo[] = [];
 
-  for (const e of toolCallEvents) {
+  for (const e of events) {
+    if (e.type !== "tool_call") {
+      continue;
+    }
     const { id, name, arguments: args } = e.content;
     if (isExploratoryToolName(name)) {
       exploratoryToolCalls.push({ id, name, arguments: args });
     } else if (isTerminalToolName(name)) {
       terminalToolCalls.push({ id, name, arguments: args });
+    } else {
+      logger.warn(
+        { toolCallId: id, toolName: name },
+        "ReinforcedAgent: received tool call with unrecognized name"
+      );
     }
   }
 

--- a/front/lib/reinforced_agent/tool_execution.ts
+++ b/front/lib/reinforced_agent/tool_execution.ts
@@ -242,6 +242,7 @@ export async function storeTerminalToolCallResults(
     await action.createOutputItems(auth, [
       { content: { type: "text", text: message } },
     ]);
+    await action.markAsSucceeded({ executionDurationMs: 0 });
   }
 
   for (const { toolCall, errorMessage } of failedToolCalls) {
@@ -260,6 +261,7 @@ export async function storeTerminalToolCallResults(
     await action.createOutputItems(auth, [
       { content: { type: "text", text: errorMessage } },
     ]);
+    // TODO(reinforced agent) Do not hardcode execution time to 0.
     await action.markAsErrored({ executionDurationMs: 0 });
   }
 }

--- a/front/lib/reinforced_agent/tool_execution.ts
+++ b/front/lib/reinforced_agent/tool_execution.ts
@@ -1,8 +1,17 @@
-import { AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
+import {
+  AGENT_SIDEKICK_CONTEXT_TOOL_NAME,
+  AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
-import type { ExploratoryToolCallInfo } from "@app/lib/reinforced_agent/types";
+import type {
+  ExploratoryToolCallInfo,
+  ReinforcedToolCallInfo,
+  TerminalToolCallFailure,
+  TerminalToolCallSuccess,
+} from "@app/lib/reinforced_agent/types";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { AgentFunctionCallContentType } from "@app/types/assistant/agent_message_content";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -28,6 +37,112 @@ export interface ReinforcedToolActionInfo {
 }
 
 /**
+ * Fetch function_call step contents for an agent message and index them by call ID.
+ */
+async function fetchStepContentByCallId(
+  auth: Authenticator,
+  agentMessageModelId: ModelId
+): Promise<
+  Map<
+    string,
+    AgentStepContentResource & { value: AgentFunctionCallContentType }
+  >
+> {
+  const stepContents = await AgentStepContentResource.fetchByAgentMessages(
+    auth,
+    { agentMessageIds: [agentMessageModelId], latestVersionsOnly: true }
+  );
+
+  const functionCallStepContents = stepContents.filter(
+    (
+      s
+    ): s is AgentStepContentResource & {
+      value: AgentFunctionCallContentType;
+    } => s.type === "function_call"
+  );
+
+  return new Map(functionCallStepContents.map((s) => [s.value.value.id, s]));
+}
+
+/**
+ * Resolve the MCPServerViewResource sId for the agent_sidekick_context internal server.
+ */
+async function getAgentSidekickContextViewId(
+  auth: Authenticator
+): Promise<string> {
+  const view = await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+    auth,
+    AGENT_SIDEKICK_CONTEXT_TOOL_NAME
+  );
+  if (!view) {
+    throw new Error(
+      "MCPServerView not found for agent_sidekick_context internal server"
+    );
+  }
+  return view.sId;
+}
+
+/**
+ * Create an AgentMCPActionResource for a reinforced tool call.
+ */
+async function createReinforcedAction(
+  auth: Authenticator,
+  {
+    toolCall,
+    agentMessageModelId,
+    stepContentId,
+    mcpServerViewId,
+  }: {
+    toolCall: ReinforcedToolCallInfo;
+    agentMessageModelId: ModelId;
+    stepContentId: ModelId;
+    mcpServerViewId: string;
+  }
+): Promise<AgentMCPActionResource> {
+  const meta = AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA[toolCall.name];
+
+  return AgentMCPActionResource.makeNew(auth, {
+    agentMessageId: agentMessageModelId,
+    augmentedInputs: toolCall.arguments,
+    citationsAllocated: 0,
+    mcpServerConfigurationId: "agent_sidekick_context",
+    status: "ready_allowed_explicitly",
+    stepContentId,
+    stepContext: {
+      citationsCount: 0,
+      citationsOffset: 0,
+      resumeState: null,
+      retrievalTopK: 0,
+      websearchResultCount: 0,
+    },
+    toolConfiguration: {
+      id: -1,
+      sId: generateRandomModelSId(),
+      type: "mcp_configuration",
+      name: toolCall.name,
+      originalName: toolCall.name,
+      mcpServerName: "agent_sidekick_context",
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId,
+      dustAppConfiguration: null,
+      internalMCPServerId: "agent_sidekick_context",
+      secretName: null,
+      dustProject: null,
+      availability: "auto",
+      permission: meta.stake,
+      toolServerId: "agent_sidekick_context",
+      retryPolicy: "no_retry",
+    },
+    version: 0,
+  });
+}
+
+/**
  * Create AgentMCPActionResource records for each exploratory tool call.
  * Returns the info needed by the workflow to call runRetryableToolActivity.
  */
@@ -47,25 +162,11 @@ export async function prepareReinforcedToolActions(
     conversationId: string;
   }
 ): Promise<ReinforcedToolActionInfo> {
-  // Find step content for each function call.
-  const stepContents = await AgentStepContentResource.fetchByAgentMessages(
-    auth,
-    { agentMessageIds: [agentMessageModelId], latestVersionsOnly: true }
-  );
+  const [stepContentByCallId, mcpServerViewId] = await Promise.all([
+    fetchStepContentByCallId(auth, agentMessageModelId),
+    getAgentSidekickContextViewId(auth),
+  ]);
 
-  const functionCallStepContents = stepContents.filter(
-    (
-      s
-    ): s is AgentStepContentResource & {
-      value: AgentFunctionCallContentType;
-    } => s.type === "function_call"
-  );
-
-  const stepContentByCallId = new Map(
-    functionCallStepContents.map((s) => [s.value.value.id, s])
-  );
-
-  // Create AgentMCPActionResource for each exploratory tool call.
   const actionIds: ModelId[] = [];
   for (const tc of exploratoryToolCalls) {
     const stepContent = stepContentByCallId.get(tc.id);
@@ -75,46 +176,11 @@ export async function prepareReinforcedToolActions(
       );
     }
 
-    const meta = AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA[tc.name];
-
-    const action = await AgentMCPActionResource.makeNew(auth, {
-      agentMessageId: agentMessageModelId,
-      augmentedInputs: tc.arguments,
-      citationsAllocated: 0,
-      mcpServerConfigurationId: "agent_sidekick_context",
-      status: "ready_allowed_explicitly",
+    const action = await createReinforcedAction(auth, {
+      toolCall: tc,
+      agentMessageModelId,
       stepContentId: stepContent.id,
-      stepContext: {
-        citationsCount: 0,
-        citationsOffset: 0,
-        resumeState: null,
-        retrievalTopK: 0,
-        websearchResultCount: 0,
-      },
-      toolConfiguration: {
-        id: -1,
-        sId: generateRandomModelSId(),
-        type: "mcp_configuration",
-        name: tc.name,
-        originalName: tc.name,
-        mcpServerName: "agent_sidekick_context",
-        dataSources: null,
-        tables: null,
-        childAgentId: null,
-        timeFrame: null,
-        jsonSchema: null,
-        additionalConfiguration: {},
-        mcpServerViewId: "",
-        dustAppConfiguration: null,
-        internalMCPServerId: "agent_sidekick_context",
-        secretName: null,
-        dustProject: null,
-        availability: "auto",
-        permission: meta.stake,
-        toolServerId: "agent_sidekick_context",
-        retryPolicy: "no_retry",
-      },
-      version: 0,
+      mcpServerViewId,
     });
 
     actionIds.push(action.id);
@@ -135,4 +201,65 @@ export async function prepareReinforcedToolActions(
     actionIds,
     exploratoryToolCalls,
   };
+}
+
+/**
+ * Store results for all terminal tool calls in the reinforcement conversation.
+ * Creates AgentMCPActionResource records with output items so the rendering pipeline
+ * picks them up as function results. This allows the LLM to see which calls succeeded
+ * and which failed, so it can retry only the failed ones on the next iteration.
+ */
+export async function storeTerminalToolCallResults(
+  auth: Authenticator,
+  {
+    successfulToolCalls,
+    failedToolCalls,
+    agentMessageModelId,
+  }: {
+    successfulToolCalls: TerminalToolCallSuccess[];
+    failedToolCalls: TerminalToolCallFailure[];
+    agentMessageModelId: ModelId;
+  }
+): Promise<void> {
+  const [stepContentByCallId, mcpServerViewId] = await Promise.all([
+    fetchStepContentByCallId(auth, agentMessageModelId),
+    getAgentSidekickContextViewId(auth),
+  ]);
+
+  for (const { toolCall, message } of successfulToolCalls) {
+    const stepContent = stepContentByCallId.get(toolCall.id);
+    if (!stepContent) {
+      continue;
+    }
+
+    const action = await createReinforcedAction(auth, {
+      toolCall,
+      agentMessageModelId,
+      stepContentId: stepContent.id,
+      mcpServerViewId,
+    });
+
+    await action.createOutputItems(auth, [
+      { content: { type: "text", text: message } },
+    ]);
+  }
+
+  for (const { toolCall, errorMessage } of failedToolCalls) {
+    const stepContent = stepContentByCallId.get(toolCall.id);
+    if (!stepContent) {
+      continue;
+    }
+
+    const action = await createReinforcedAction(auth, {
+      toolCall,
+      agentMessageModelId,
+      stepContentId: stepContent.id,
+      mcpServerViewId,
+    });
+
+    await action.createOutputItems(auth, [
+      { content: { type: "text", text: errorMessage } },
+    ]);
+    await action.markAsErrored({ executionDurationMs: 0 });
+  }
 }

--- a/front/lib/reinforced_agent/types.ts
+++ b/front/lib/reinforced_agent/types.ts
@@ -1,3 +1,7 @@
+import { AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
+import type { ToolCallEvent } from "@app/lib/api/llm/types/events";
+import { z } from "zod";
+
 export const MAX_REINFORCED_ANALYSIS_STEPS = 4;
 
 export type ExploratoryToolName =
@@ -8,6 +12,51 @@ export type TerminalToolName =
   | "suggest_prompt_edits"
   | "suggest_tools"
   | "suggest_skills";
+
+export const TERMINAL_TOOLS: TerminalToolName[] = [
+  "suggest_prompt_edits",
+  "suggest_tools",
+  "suggest_skills",
+];
+
+export const EXPLORATORY_TOOLS: ExploratoryToolName[] = [
+  "get_available_skills",
+  "get_available_tools",
+];
+
+export const ALL_TOOLS = [...TERMINAL_TOOLS, ...EXPLORATORY_TOOLS];
+
+const TERMINAL_TOOL_SET: ReadonlySet<string> = new Set(TERMINAL_TOOLS);
+const EXPLORATORY_TOOL_SET: ReadonlySet<string> = new Set(EXPLORATORY_TOOLS);
+
+export function isTerminalToolName(name: string): name is TerminalToolName {
+  return TERMINAL_TOOL_SET.has(name);
+}
+
+export function isExploratoryToolName(
+  name: string
+): name is ExploratoryToolName {
+  return EXPLORATORY_TOOL_SET.has(name);
+}
+
+export const TOOL_SCHEMAS: Record<
+  TerminalToolName,
+  z.ZodObject<z.ZodRawShape>
+> = {
+  suggest_prompt_edits: z.object(
+    AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_prompt_edits.schema
+  ),
+  suggest_tools: z.object(
+    AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_tools.schema
+  ),
+  suggest_skills: z.object(
+    AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA.suggest_skills.schema
+  ),
+};
+
+export interface TerminalToolCallEvent extends ToolCallEvent {
+  content: ToolCallEvent["content"] & { name: TerminalToolName };
+}
 
 export interface ExploratoryToolCallInfo {
   id: string;
@@ -24,6 +73,22 @@ export interface TerminalToolCallInfo {
 export type ReinforcedToolCallInfo =
   | ExploratoryToolCallInfo
   | TerminalToolCallInfo;
+
+export interface TerminalToolCallSuccess {
+  toolCall: TerminalToolCallInfo;
+  message: string;
+}
+
+export interface TerminalToolCallFailure {
+  toolCall: TerminalToolCallInfo;
+  errorMessage: string;
+}
+
+export interface ProcessReinforcedEventsResult {
+  suggestionsCreated: number;
+  successfulToolCalls: TerminalToolCallSuccess[];
+  failedToolCalls: TerminalToolCallFailure[];
+}
 
 export type ReinforcedOperationType =
   | "reinforced_agent_analyze_conversation"

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -37,6 +37,7 @@ import {
 import {
   prepareReinforcedToolActions,
   type ReinforcedToolActionInfo,
+  storeTerminalToolCallResults,
 } from "@app/lib/reinforced_agent/tool_execution";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -290,7 +291,7 @@ export async function analyzeConversationStepActivity({
       auth,
       conversationId
     );
-    await processReinforcedEvents({
+    const result = await processReinforcedEvents({
       auth,
       agentConfig,
       events,
@@ -299,6 +300,19 @@ export async function analyzeConversationStepActivity({
       contextId: conversationId,
       conversation: analysedConversation ?? undefined,
     });
+
+    // Store results for all terminal tool calls so the conversation is complete.
+    await storeTerminalToolCallResults(auth, {
+      successfulToolCalls: result.successfulToolCalls,
+      failedToolCalls: result.failedToolCalls,
+      agentMessageModelId: storedResult.agentMessageModelId,
+    });
+
+    // If any failed, let the LLM retry on the next step.
+    if (result.failedToolCalls.length > 0) {
+      return { isTerminal: false, reinforcementConversationId };
+    }
+
     return { isTerminal: true, reinforcementConversationId };
   }
 
@@ -498,7 +512,7 @@ export async function checkBatchStatusActivity({
 export interface ConversationContinuationInfo {
   analysedConversationId: string;
   reinforcementConversationId: string;
-  toolActionInfo: ReinforcedToolActionInfo;
+  toolActionInfo?: ReinforcedToolActionInfo;
 }
 
 /**
@@ -584,7 +598,7 @@ export async function processConversationAnalysisBatchResultActivity({
 
     // If terminal tools were called, process suggestions.
     if (terminalToolCalls.length > 0 || exploratoryToolCalls.length === 0) {
-      const createdCount = await processReinforcedEvents({
+      const result = await processReinforcedEvents({
         auth,
         agentConfig,
         events,
@@ -593,7 +607,25 @@ export async function processConversationAnalysisBatchResultActivity({
         contextId: analysedConvId,
         conversation: conversationById.get(analysedConvId),
       });
-      totalCreated += createdCount;
+      totalCreated += result.suggestionsCreated;
+
+      // Store results for all terminal tool calls so the conversation is complete.
+      const storedInfo = storedResultInfo.get(reinforcementConvId);
+      if (storedInfo) {
+        await storeTerminalToolCallResults(auth, {
+          successfulToolCalls: result.successfulToolCalls,
+          failedToolCalls: result.failedToolCalls,
+          agentMessageModelId: storedInfo.agentMessageModelId,
+        });
+
+        // If any failed, add to continuations so the LLM can retry.
+        if (result.failedToolCalls.length > 0) {
+          continuations.push({
+            analysedConversationId: analysedConvId,
+            reinforcementConversationId: reinforcementConvId,
+          });
+        }
+      }
     } else {
       // Only exploratory tools — prepare actions for the workflow to execute.
       const storedInfo = storedResultInfo.get(reinforcementConvId);
@@ -747,7 +779,7 @@ export async function processAggregationBatchResultActivity({
 
   let createdCount = 0;
   if (events) {
-    createdCount = await processReinforcedEvents({
+    const result = await processReinforcedEvents({
       auth,
       agentConfig,
       events,
@@ -755,6 +787,8 @@ export async function processAggregationBatchResultActivity({
       operationType: "reinforced_agent_aggregate_suggestions",
       contextId: "n/a",
     });
+    // TODO(reinforced agent) Fabien: Support tool call and retry in aggregation too
+    createdCount = result.suggestionsCreated;
   }
 
   if (createdCount > 0 && !disableNotifications) {

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -237,13 +237,23 @@ export async function reinforcedAgentForAgentWorkflow({
       // Execute exploratory tools via the agent loop's retryable tool activity.
       // Results are stored in the reinforcement conversations in DB.
       for (const c of continuations) {
+        if (!c.toolActionInfo) {
+          // Only terminal tool call errors, to tool to execute
+          continue;
+        }
         const { authType, agentLoopArgs, actionIds } = c.toolActionInfo;
         for (const actionId of actionIds) {
-          await runRetryableToolActivity(authType, {
-            actionId,
-            runAgentArgs: agentLoopArgs,
-            step: 0,
-          });
+          try {
+            await runRetryableToolActivity(authType, {
+              actionId,
+              runAgentArgs: agentLoopArgs,
+              step: 0,
+            });
+          } catch {
+            // Tool execution failed after all retries.
+            // The AgentMCPActionResource exists but has no output — the rendering
+            // pipeline will inject a placeholder error for the LLM to see.
+          }
         }
       }
 
@@ -325,8 +335,13 @@ async function analyzeConversationWithMultiStep({
 
     reinforcementConversationId = result.reinforcementConversationId;
 
-    if (result.isTerminal || !result.toolActionInfo) {
+    if (result.isTerminal) {
       return;
+    }
+
+    if (!result.toolActionInfo) {
+      // Only terminal tool call failure: no exploratory tool to run
+      continue;
     }
 
     const { authType, agentLoopArgs, actionIds } = result.toolActionInfo;
@@ -334,11 +349,17 @@ async function analyzeConversationWithMultiStep({
     // Execute each exploratory tool via the agent loop's retryable tool activity.
     // Results are stored in the reinforcement conversation DB.
     for (const actionId of actionIds) {
-      await runRetryableToolActivity(authType, {
-        actionId,
-        runAgentArgs: agentLoopArgs,
-        step: 0,
-      });
+      try {
+        await runRetryableToolActivity(authType, {
+          actionId,
+          runAgentArgs: agentLoopArgs,
+          step: 0,
+        });
+      } catch {
+        // Tool execution failed after all retries.
+        // The AgentMCPActionResource exists but has no output — the rendering
+        // pipeline will inject a placeholder error for the LLM to see.
+      }
     }
 
     // Next iteration will render the conversation from DB, picking up the tool results.

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -238,7 +238,7 @@ export async function reinforcedAgentForAgentWorkflow({
       // Results are stored in the reinforcement conversations in DB.
       for (const c of continuations) {
         if (!c.toolActionInfo) {
-          // Only terminal tool call errors, to tool to execute
+          // Only terminal tool call errors, no tool to execute
           continue;
         }
         const { authType, agentLoopArgs, actionIds } = c.toolActionInfo;


### PR DESCRIPTION
## Description

 - Fix tool calls for exploratory tools (list skills and list tools)
 - Allow retrying the tool call, even suggestions, when it fails

Main idea of the changes:
 - we store all tool call, even terminal ones
 - if any of the terminal tool call fails we continue the conversation 


## Tests

Tested locally by amulating random failure in suggest tool calls

<img width="700" height="800" alt="image" src="https://github.com/user-attachments/assets/76d2b98f-73f5-4207-ae81-9ca0a04ef7dd" />


## Risk

low

## Deploy Plan

deploy front
