### PR TITLE
[front] add danger js rule for `front-sse` deploy on Authenticator changes

### DIFF
--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -341,6 +341,19 @@ async function checkDiffFiles() {
         "A `front-sse` deploy is required alongside the `front` deploy."
     );
   }
+
+  // Shared code used by front-sse — changes here require a front-sse deploy too.
+  const sseSharedFiles = ["front/lib/auth.ts"];
+  const modifiedSseSharedFiles = diffFiles.filter((path) =>
+    sseSharedFiles.includes(path)
+  );
+  if (modifiedSseSharedFiles.length > 0) {
+    warn(
+      "`front/lib/auth.ts` (Authenticator) has been modified. This code runs " +
+        "on `front-sse` pods as well. A `front-sse` deploy is required " +
+        "alongside the `front` deploy."
+    );
+  }
 }
 
 void checkDiffFiles();

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -244,7 +244,7 @@ async function checkWorkspaceAwareModels(filePaths: string[]) {
 /**
  * Triggers related checks based on modified files
  */
-async function warnTriggersWorkflowChanges() {
+function warnTriggersWorkflowChanges() {
   warn(
     `Files in \`front/temporal/agent_schedules/\` have been modified.
     Be careful modifying workflows/activities signatures.
@@ -321,7 +321,7 @@ async function checkDiffFiles() {
     return path.startsWith("front/temporal/agent_schedules/");
   });
   if (modifiedWorkflowFiles.length > 0) {
-    await warnTriggersWorkflowChanges();
+    warnTriggersWorkflowChanges();
   }
 
   // SSE endpoint files — changes here require a front-sse deploy too.

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -57,6 +57,8 @@ import type {
 } from "next";
 import type { Transaction } from "sequelize";
 
+// This code is used in front-sse.
+
 const { ACTIVATE_ALL_FEATURES_DEV = false } = process.env;
 
 const DUST_INTERNAL_EMAIL_REGEXP = /^[^@]+@dust\.tt$/;

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -57,8 +57,6 @@ import type {
 } from "next";
 import type { Transaction } from "sequelize";
 
-// This code is used in front-sse.
-
 const { ACTIVATE_ALL_FEATURES_DEV = false } = process.env;
 
 const DUST_INTERNAL_EMAIL_REGEXP = /^[^@]+@dust\.tt$/;


### PR DESCRIPTION
## Description

- Context in [thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1774976375064769).
- This PR adds a danger js warning on changes to the Authenticator to warn the developer that front-sse needs to also be deployed.

## Tests

- Tested with a dummy comment.

## Risk

- None.

## Deploy Plan

- No deploy required.