### PR TITLE
[feat] - front(agents): YAML import

### DIFF
--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -43,8 +43,8 @@ async function importAgentConfiguration(
     });
   }
 
-  const editorSIds = yamlConfig.editors.map((e) => e.user_id);
-  if (editorSIds.length === 0) {
+  const editorIds = yamlConfig.editors.map((e) => e.user_id);
+  if (editorIds.length === 0) {
     return new Err({
       status_code: 400,
       api_error: {
@@ -54,7 +54,7 @@ async function importAgentConfiguration(
     });
   }
 
-  const editorUsers = await UserResource.fetchByIds(editorSIds);
+  const editorUsers = await UserResource.fetchByIds(editorIds);
   if (editorUsers.length === 0) {
     return new Err({
       status_code: 400,
@@ -65,7 +65,7 @@ async function importAgentConfiguration(
     });
   }
 
-  const authorId = editorUsers[0].id;
+  const authorModelId = editorUsers[0].id;
 
   const mcpConfigurationsResult =
     await AgentYAMLConverter.convertYAMLActionsToMCPConfigurations(
@@ -120,7 +120,7 @@ async function importAgentConfiguration(
   const agentConfigurationRes = await createOrUpgradeAgentConfiguration({
     auth,
     assistant,
-    authorId,
+    authorId: authorModelId,
   });
 
   if (agentConfigurationRes.isErr()) {

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -1,0 +1,128 @@
+import { AgentYAMLConverter } from "@app/lib/agent_yaml_converter/converter";
+import type { Authenticator } from "@app/lib/auth";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import uniqueId from "lodash/uniqueId";
+
+interface SkippedAction {
+  name: string;
+  reason: string;
+}
+
+export async function importAgentConfigurationFromYAML(
+  auth: Authenticator,
+  yamlContent: string
+): Promise<
+  Result<
+    {
+      agentConfiguration: AgentConfigurationType;
+      skippedActions: SkippedAction[];
+    },
+    APIErrorWithStatusCode
+  >
+> {
+  const isSaveAgentConfigurationsEnabled =
+    await KillSwitchResource.isKillSwitchEnabledCached(
+      "save_agent_configurations"
+    );
+  if (isSaveAgentConfigurationsEnabled) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Saving agent configurations is temporarily disabled, try again later.",
+      },
+    });
+  }
+
+  const yamlConfigResult = AgentYAMLConverter.fromYAMLString(yamlContent);
+  if (yamlConfigResult.isErr()) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid YAML format: ${yamlConfigResult.error.message}`,
+      },
+    });
+  }
+
+  const yamlConfig = yamlConfigResult.value;
+
+  const mcpConfigurationsResult =
+    await AgentYAMLConverter.convertYAMLActionsToMCPConfigurations(
+      auth,
+      yamlConfig.toolset
+    );
+
+  if (mcpConfigurationsResult.isErr()) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Error converting YAML actions: ${mcpConfigurationsResult.error.message}`,
+      },
+    });
+  }
+
+  const { configurations: mcpConfigurations, skipped: skippedActions } =
+    mcpConfigurationsResult.value;
+
+  const assistant = {
+    name: yamlConfig.agent.handle,
+    description: yamlConfig.agent.description,
+    instructions: yamlConfig.instructions,
+    pictureUrl: yamlConfig.agent.avatar_url ?? "",
+    status: "active" as const,
+    scope: yamlConfig.agent.scope,
+    model: {
+      modelId: yamlConfig.generation_settings.model_id,
+      providerId: yamlConfig.generation_settings.provider_id,
+      temperature: yamlConfig.generation_settings.temperature,
+      reasoningEffort: yamlConfig.generation_settings.reasoning_effort,
+      responseFormat: yamlConfig.generation_settings.response_format,
+    },
+    maxStepsPerRun: yamlConfig.agent.max_steps_per_run,
+    actions: mcpConfigurations,
+    templateId: null,
+    tags: yamlConfig.tags.map((tag) => ({
+      sId: uniqueId(),
+      name: tag.name,
+      kind: tag.kind,
+    })),
+    editors: yamlConfig.editors.map((editor) => ({
+      sId: editor.user_id,
+    })),
+    skills: (yamlConfig.skills ?? []).map((skill) => ({
+      sId: skill.sId,
+    })),
+    additionalRequestedSpaceIds: [],
+  };
+
+  const agentConfigurationRes = await createOrUpgradeAgentConfiguration({
+    auth,
+    assistant,
+  });
+
+  if (agentConfigurationRes.isErr()) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "assistant_saving_error",
+        message: `Error creating agent: ${agentConfigurationRes.error.message}`,
+      },
+    });
+  }
+
+  return new Ok({
+    agentConfiguration: agentConfigurationRes.value,
+    skippedActions: skippedActions.map(({ action, reason }) => ({
+      name: action.name,
+      reason,
+    })),
+  });
+}

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -1,6 +1,9 @@
 import { AgentYAMLConverter } from "@app/lib/agent_yaml_converter/converter";
+import type { AgentYAMLConfig } from "@app/lib/agent_yaml_converter/schemas";
+import { agentYAMLConfigSchema } from "@app/lib/agent_yaml_converter/schemas";
 import type { Authenticator } from "@app/lib/auth";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { APIErrorWithStatusCode } from "@app/types/error";
@@ -13,18 +16,18 @@ interface SkippedAction {
   reason: string;
 }
 
-export async function importAgentConfigurationFromYAML(
+type ImportResult = Result<
+  {
+    agentConfiguration: AgentConfigurationType;
+    skippedActions: SkippedAction[];
+  },
+  APIErrorWithStatusCode
+>;
+
+async function importAgentConfiguration(
   auth: Authenticator,
-  yamlContent: string
-): Promise<
-  Result<
-    {
-      agentConfiguration: AgentConfigurationType;
-      skippedActions: SkippedAction[];
-    },
-    APIErrorWithStatusCode
-  >
-> {
+  yamlConfig: AgentYAMLConfig
+): Promise<ImportResult> {
   const isSaveAgentConfigurationsEnabled =
     await KillSwitchResource.isKillSwitchEnabledCached(
       "save_agent_configurations"
@@ -40,18 +43,29 @@ export async function importAgentConfigurationFromYAML(
     });
   }
 
-  const yamlConfigResult = AgentYAMLConverter.fromYAMLString(yamlContent);
-  if (yamlConfigResult.isErr()) {
+  const editorSIds = yamlConfig.editors.map((e) => e.user_id);
+  if (editorSIds.length === 0) {
     return new Err({
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid YAML format: ${yamlConfigResult.error.message}`,
+        message: "At least one editor is required.",
       },
     });
   }
 
-  const yamlConfig = yamlConfigResult.value;
+  const editorUsers = await UserResource.fetchByIds(editorSIds);
+  if (editorUsers.length === 0) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "No valid editor users found.",
+      },
+    });
+  }
+
+  const authorId = editorUsers[0].id;
 
   const mcpConfigurationsResult =
     await AgentYAMLConverter.convertYAMLActionsToMCPConfigurations(
@@ -106,6 +120,7 @@ export async function importAgentConfigurationFromYAML(
   const agentConfigurationRes = await createOrUpgradeAgentConfiguration({
     auth,
     assistant,
+    authorId,
   });
 
   if (agentConfigurationRes.isErr()) {
@@ -125,4 +140,40 @@ export async function importAgentConfigurationFromYAML(
       reason,
     })),
   });
+}
+
+export async function importAgentConfigurationFromYAMLString(
+  auth: Authenticator,
+  yamlContent: string
+): Promise<ImportResult> {
+  const yamlConfigResult = AgentYAMLConverter.fromYAMLString(yamlContent);
+  if (yamlConfigResult.isErr()) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid YAML format: ${yamlConfigResult.error.message}`,
+      },
+    });
+  }
+
+  return importAgentConfiguration(auth, yamlConfigResult.value);
+}
+
+export async function importAgentConfigurationFromJSON(
+  auth: Authenticator,
+  body: unknown
+): Promise<ImportResult> {
+  const parsed = agentYAMLConfigSchema.safeParse(body);
+  if (!parsed.success) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid agent configuration: ${parsed.error.message}`,
+      },
+    });
+  }
+
+  return importAgentConfiguration(auth, parsed.data);
 }

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/import/yaml.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/import/yaml.ts
@@ -1,19 +1,17 @@
-import { importAgentConfigurationFromYAML } from "@app/lib/api/assistant/configuration/yaml_import";
+import { importAgentConfigurationFromJSON } from "@app/lib/api/assistant/configuration/yaml_import";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ImportAgentConfigurationFromYAMLResponseType } from "@dust-tt/client";
-import { ImportAgentConfigurationFromYAMLRequestSchema } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { fromError } from "zod-validation-error";
 
 /**
  * @swagger
  * /api/v1/w/{wId}/assistant/agent_configurations/import/yaml:
  *   post:
  *     summary: Import agent configuration from YAML
- *     description: Create a new agent configuration from a YAML definition.
+ *     description: Create a new agent configuration from a JSON body matching the agent YAML config schema.
  *     tags:
  *       - Agents
  *     parameters:
@@ -30,16 +28,88 @@ import { fromError } from "zod-validation-error";
  *           schema:
  *             type: object
  *             required:
- *               - yamlContent
+ *               - agent
+ *               - instructions
+ *               - generation_settings
+ *               - tags
+ *               - editors
+ *               - toolset
  *             properties:
- *               yamlContent:
+ *               agent:
+ *                 type: object
+ *                 required:
+ *                   - handle
+ *                   - description
+ *                   - scope
+ *                   - max_steps_per_run
+ *                   - visualization_enabled
+ *                 properties:
+ *                   handle:
+ *                     type: string
+ *                   description:
+ *                     type: string
+ *                   scope:
+ *                     type: string
+ *                     enum: [visible, hidden]
+ *                   avatar_url:
+ *                     type: string
+ *                   max_steps_per_run:
+ *                     type: number
+ *                   visualization_enabled:
+ *                     type: boolean
+ *               instructions:
  *                 type: string
- *                 description: The YAML content defining the agent configuration
+ *               generation_settings:
+ *                 type: object
+ *                 properties:
+ *                   model_id:
+ *                     type: string
+ *                   provider_id:
+ *                     type: string
+ *                   temperature:
+ *                     type: number
+ *                   reasoning_effort:
+ *                     type: string
+ *               tags:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   properties:
+ *                     name:
+ *                       type: string
+ *                     kind:
+ *                       type: string
+ *                       enum: [standard, protected]
+ *               editors:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   properties:
+ *                     user_id:
+ *                       type: string
+ *                     email:
+ *                       type: string
+ *                     full_name:
+ *                       type: string
+ *               toolset:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   properties:
+ *                     name:
+ *                       type: string
+ *                     description:
+ *                       type: string
+ *                     type:
+ *                       type: string
+ *                       enum: [MCP]
+ *                     configuration:
+ *                       type: object
  *     security:
  *       - BearerAuth: []
  *     responses:
  *       200:
- *         description: Successfully created agent configuration from YAML
+ *         description: Successfully created agent configuration
  *         content:
  *           application/json:
  *             schema:
@@ -57,7 +127,7 @@ import { fromError } from "zod-validation-error";
  *                       reason:
  *                         type: string
  *       400:
- *         description: Bad Request. Invalid YAML or request body.
+ *         description: Bad Request. Invalid request body.
  *       401:
  *         description: Unauthorized. Invalid or missing authentication token.
  *       405:
@@ -82,22 +152,7 @@ async function handler(
     });
   }
 
-  const bodyValidation =
-    ImportAgentConfigurationFromYAMLRequestSchema.safeParse(req.body);
-  if (!bodyValidation.success) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Invalid request body: ${fromError(bodyValidation.error).message}`,
-      },
-    });
-  }
-
-  const result = await importAgentConfigurationFromYAML(
-    auth,
-    bodyValidation.data.yamlContent
-  );
+  const result = await importAgentConfigurationFromJSON(auth, req.body);
 
   if (result.isErr()) {
     return apiError(req, res, result.error);

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/import/yaml.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/import/yaml.ts
@@ -162,7 +162,7 @@ async function handler(
 
   return res.status(200).json({
     agentConfiguration,
-    skippedActions: skippedActions.length > 0 ? skippedActions : undefined,
+    skippedActions,
   });
 }
 

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/import/yaml.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/import/yaml.ts
@@ -1,0 +1,114 @@
+import { importAgentConfigurationFromYAML } from "@app/lib/api/assistant/configuration/yaml_import";
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { ImportAgentConfigurationFromYAMLResponseType } from "@dust-tt/client";
+import { ImportAgentConfigurationFromYAMLRequestSchema } from "@dust-tt/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { fromError } from "zod-validation-error";
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/assistant/agent_configurations/import/yaml:
+ *   post:
+ *     summary: Import agent configuration from YAML
+ *     description: Create a new agent configuration from a YAML definition.
+ *     tags:
+ *       - Agents
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - yamlContent
+ *             properties:
+ *               yamlContent:
+ *                 type: string
+ *                 description: The YAML content defining the agent configuration
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully created agent configuration from YAML
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 agentConfiguration:
+ *                   $ref: '#/components/schemas/AgentConfiguration'
+ *                 skippedActions:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       name:
+ *                         type: string
+ *                       reason:
+ *                         type: string
+ *       400:
+ *         description: Bad Request. Invalid YAML or request body.
+ *       401:
+ *         description: Unauthorized. Invalid or missing authentication token.
+ *       405:
+ *         description: Method not supported. Only POST is expected.
+ *       500:
+ *         description: Internal Server Error.
+ */
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<ImportAgentConfigurationFromYAMLResponseType>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const bodyValidation =
+    ImportAgentConfigurationFromYAMLRequestSchema.safeParse(req.body);
+  if (!bodyValidation.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${fromError(bodyValidation.error).message}`,
+      },
+    });
+  }
+
+  const result = await importAgentConfigurationFromYAML(
+    auth,
+    bodyValidation.data.yamlContent
+  );
+
+  if (result.isErr()) {
+    return apiError(req, res, result.error);
+  }
+
+  const { agentConfiguration, skippedActions } = result.value;
+
+  return res.status(200).json({
+    agentConfiguration,
+    skippedActions: skippedActions.length > 0 ? skippedActions : undefined,
+  });
+}
+
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
@@ -1,13 +1,10 @@
 /** @ignoreswagger */
-import { AgentYAMLConverter } from "@app/lib/agent_yaml_converter/converter";
+import { importAgentConfigurationFromYAML } from "@app/lib/api/assistant/configuration/yaml_import";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { apiError } from "@app/logger/withlogging";
-import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import { AgentConfigurationSchema } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import uniqueId from "lodash/uniqueId";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
@@ -46,21 +43,6 @@ async function handler(
     });
   }
 
-  const isSaveAgentConfigurationsEnabled =
-    await KillSwitchResource.isKillSwitchEnabledCached(
-      "save_agent_configurations"
-    );
-  if (isSaveAgentConfigurationsEnabled) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "app_auth_error",
-        message:
-          "Saving agent configurations is temporarily disabled, try again later.",
-      },
-    });
-  }
-
   const bodyValidation =
     PostAgentConfigurationFromYAMLRequestBodySchema.safeParse(req.body);
   if (!bodyValidation.success) {
@@ -73,92 +55,20 @@ async function handler(
     });
   }
 
-  const { yamlContent } = bodyValidation.data;
-
-  const yamlConfigResult = AgentYAMLConverter.fromYAMLString(yamlContent);
-  if (yamlConfigResult.isErr()) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Invalid YAML format: ${yamlConfigResult.error.message}`,
-      },
-    });
-  }
-
-  const yamlConfig = yamlConfigResult.value;
-
-  const mcpConfigurationsResult =
-    await AgentYAMLConverter.convertYAMLActionsToMCPConfigurations(
-      auth,
-      yamlConfig.toolset
-    );
-
-  if (mcpConfigurationsResult.isErr()) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Error converting YAML actions: ${mcpConfigurationsResult.error.message}`,
-      },
-    });
-  }
-
-  const { configurations: mcpConfigurations, skipped: skippedActions } =
-    mcpConfigurationsResult.value;
-
-  const agent = {
-    name: yamlConfig.agent.handle,
-    description: yamlConfig.agent.description,
-    instructions: yamlConfig.instructions,
-    pictureUrl: yamlConfig.agent.avatar_url ?? "",
-    status: "active" as const,
-    scope: yamlConfig.agent.scope,
-    model: {
-      modelId: yamlConfig.generation_settings.model_id,
-      providerId: yamlConfig.generation_settings.provider_id,
-      temperature: yamlConfig.generation_settings.temperature,
-      reasoningEffort: yamlConfig.generation_settings.reasoning_effort,
-      responseFormat: yamlConfig.generation_settings.response_format,
-    },
-    maxStepsPerRun: yamlConfig.agent.max_steps_per_run,
-    actions: mcpConfigurations,
-    templateId: null,
-    tags: yamlConfig.tags.map((tag) => ({
-      sId: uniqueId(),
-      name: tag.name,
-      kind: tag.kind,
-    })),
-    editors: yamlConfig.editors.map((editor) => ({
-      sId: editor.user_id,
-    })),
-    skills: (yamlConfig.skills ?? []).map((skill) => ({
-      sId: skill.sId,
-    })),
-    additionalRequestedSpaceIds: [],
-  };
-
-  const agentConfigurationRes = await createOrUpgradeAgentConfiguration({
+  const result = await importAgentConfigurationFromYAML(
     auth,
-    assistant: agent,
-  });
+    bodyValidation.data.yamlContent
+  );
 
-  if (agentConfigurationRes.isErr()) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "assistant_saving_error",
-        message: `Error creating agent: ${agentConfigurationRes.error.message}`,
-      },
-    });
+  if (result.isErr()) {
+    return apiError(req, res, result.error);
   }
+
+  const { agentConfiguration, skippedActions } = result.value;
 
   return res.status(200).json({
-    agentConfiguration: agentConfigurationRes.value,
-    skippedActions: skippedActions.map(({ action, reason }) => ({
-      name: action.name,
-      reason,
-    })),
+    agentConfiguration,
+    skippedActions: skippedActions.length > 0 ? skippedActions : undefined,
   });
 }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
@@ -68,7 +68,7 @@ async function handler(
 
   return res.status(200).json({
     agentConfiguration,
-    skippedActions: skippedActions.length > 0 ? skippedActions : undefined,
+    skippedActions,
   });
 }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
@@ -1,5 +1,5 @@
 /** @ignoreswagger */
-import { importAgentConfigurationFromYAML } from "@app/lib/api/assistant/configuration/yaml_import";
+import { importAgentConfigurationFromYAMLString } from "@app/lib/api/assistant/configuration/yaml_import";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -55,7 +55,7 @@ async function handler(
     });
   }
 
-  const result = await importAgentConfigurationFromYAML(
+  const result = await importAgentConfigurationFromYAMLString(
     auth,
     bodyValidation.data.yamlContent
   );

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -547,6 +547,93 @@
         }
       }
     },
+    "/api/v1/w/{wId}/assistant/agent_configurations/import/yaml": {
+      "post": {
+        "summary": "Import agent configuration from YAML",
+        "description": "Create a new agent configuration from a YAML definition.",
+        "tags": [
+          "Agents"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "yamlContent"
+                ],
+                "properties": {
+                  "yamlContent": {
+                    "type": "string",
+                    "description": "The YAML content defining the agent configuration"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully created agent configuration from YAML",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "agentConfiguration": {
+                      "$ref": "#/components/schemas/AgentConfiguration"
+                    },
+                    "skippedActions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "reason": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Invalid YAML or request body."
+          },
+          "401": {
+            "description": "Unauthorized. Invalid or missing authentication token."
+          },
+          "405": {
+            "description": "Method not supported. Only POST is expected."
+          },
+          "500": {
+            "description": "Internal Server Error."
+          }
+        }
+      }
+    },
     "/api/v1/w/{wId}/assistant/agent_configurations/search": {
       "get": {
         "summary": "Search agents by name",

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -550,7 +550,7 @@
     "/api/v1/w/{wId}/assistant/agent_configurations/import/yaml": {
       "post": {
         "summary": "Import agent configuration from YAML",
-        "description": "Create a new agent configuration from a YAML definition.",
+        "description": "Create a new agent configuration from a JSON body matching the agent YAML config schema.",
         "tags": [
           "Agents"
         ],
@@ -572,12 +572,125 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "yamlContent"
+                  "agent",
+                  "instructions",
+                  "generation_settings",
+                  "tags",
+                  "editors",
+                  "toolset"
                 ],
                 "properties": {
-                  "yamlContent": {
-                    "type": "string",
-                    "description": "The YAML content defining the agent configuration"
+                  "agent": {
+                    "type": "object",
+                    "required": [
+                      "handle",
+                      "description",
+                      "scope",
+                      "max_steps_per_run",
+                      "visualization_enabled"
+                    ],
+                    "properties": {
+                      "handle": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "scope": {
+                        "type": "string",
+                        "enum": [
+                          "visible",
+                          "hidden"
+                        ]
+                      },
+                      "avatar_url": {
+                        "type": "string"
+                      },
+                      "max_steps_per_run": {
+                        "type": "number"
+                      },
+                      "visualization_enabled": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "instructions": {
+                    "type": "string"
+                  },
+                  "generation_settings": {
+                    "type": "object",
+                    "properties": {
+                      "model_id": {
+                        "type": "string"
+                      },
+                      "provider_id": {
+                        "type": "string"
+                      },
+                      "temperature": {
+                        "type": "number"
+                      },
+                      "reasoning_effort": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "standard",
+                            "protected"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "editors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "user_id": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "full_name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "toolset": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "MCP"
+                          ]
+                        },
+                        "configuration": {
+                          "type": "object"
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -591,7 +704,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successfully created agent configuration from YAML",
+            "description": "Successfully created agent configuration",
             "content": {
               "application/json": {
                 "schema": {
@@ -620,7 +733,7 @@
             }
           },
           "400": {
-            "description": "Bad Request. Invalid YAML or request body."
+            "description": "Bad Request. Invalid request body."
           },
           "401": {
             "description": "Unauthorized. Invalid or missing authentication token."

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1956,9 +1956,7 @@ export type GetAgentConfigurationYAMLExportResponseType = z.infer<
 
 export const ImportAgentConfigurationFromYAMLResponseSchema = z.object({
   agentConfiguration: LightAgentConfigurationSchema,
-  skippedActions: z
-    .array(z.object({ name: z.string(), reason: z.string() }))
-    .optional(),
+  skippedActions: z.array(z.object({ name: z.string(), reason: z.string() })),
 });
 
 export type ImportAgentConfigurationFromYAMLResponseType = z.infer<

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1954,14 +1954,6 @@ export type GetAgentConfigurationYAMLExportResponseType = z.infer<
   typeof GetAgentConfigurationYAMLExportResponseSchema
 >;
 
-export const ImportAgentConfigurationFromYAMLRequestSchema = z.object({
-  yamlContent: z.string(),
-});
-
-export type ImportAgentConfigurationFromYAMLRequestType = z.infer<
-  typeof ImportAgentConfigurationFromYAMLRequestSchema
->;
-
 export const ImportAgentConfigurationFromYAMLResponseSchema = z.object({
   agentConfiguration: LightAgentConfigurationSchema,
   skippedActions: z

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1954,6 +1954,25 @@ export type GetAgentConfigurationYAMLExportResponseType = z.infer<
   typeof GetAgentConfigurationYAMLExportResponseSchema
 >;
 
+export const ImportAgentConfigurationFromYAMLRequestSchema = z.object({
+  yamlContent: z.string(),
+});
+
+export type ImportAgentConfigurationFromYAMLRequestType = z.infer<
+  typeof ImportAgentConfigurationFromYAMLRequestSchema
+>;
+
+export const ImportAgentConfigurationFromYAMLResponseSchema = z.object({
+  agentConfiguration: LightAgentConfigurationSchema,
+  skippedActions: z
+    .array(z.object({ name: z.string(), reason: z.string() }))
+    .optional(),
+});
+
+export type ImportAgentConfigurationFromYAMLResponseType = z.infer<
+  typeof ImportAgentConfigurationFromYAMLResponseSchema
+>;
+
 export const GetAgentConfigurationsResponseSchema = z.object({
   agentConfigurations: LightAgentConfigurationSchema.array(),
 });


### PR DESCRIPTION
## Description

This PR adds a public API endpoint (`POST /api/v1/w/{wId}/assistant/agent_configurations/import/yaml`) to create agent configurations from JSON matching the agent YAML config schema. 

It refactors the existing internal YAML import logic into shared functions (`importAgentConfigurationFromYAMLString` and `importAgentConfigurationFromJSON`) to enable reuse across both the internal endpoint and the new public API. The public endpoint accepts JSON directly rather than raw YAML strings, and extracts the `authorId` from the first editor in the configuration to support agent creation via API calls with system keys.

## Tests

- [x] Tested locally with the new endpoint

## Risk

Low - this adds a new public API endpoint and refactors existing code into shared utility functions without changing behavior of the internal endpoint. The PR includes OpenAPI documentation updates.

## Deploy Plan

- Deploy front

Will deploy the docs once I add the `/api/v1/w/{wId}/assistant/agent_configurations/[cId]/import/yaml` endpoint