### PR TITLE
[front] frame error handling

### DIFF
--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -34,9 +34,21 @@ export function SharedFramePage() {
     });
 
   // Fetch the frame to check if the user is already authorized.
-  const { error: frameError, mutateFrame } = usePublicFrame({
+  // Both metadata and public frame hooks fire in parallel. If the share lives in another region, the
+  // metadata hook triggers a region redirect (setRegionInfo) which invalidates
+  // the SWR cache and re-fetches the frame against the correct region.
+  // We ignore the frame error while metadata is still loading/redirecting
+  // because it may be a stale cross-region 404.
+  const {
+    error: publicFrameError,
+    isFrameLoading,
+    mutateFrame,
+  } = usePublicFrame({
     shareToken: token,
   });
+
+  const frameError =
+    isShareMetadataLoading || isFrameLoading ? undefined : publicFrameError;
 
   // Show the email form when:
   // 1. Metadata says the scope requires email verification, AND


### PR DESCRIPTION
## Description
This PR is a part of fixing /frame returning 404 error while a file actually exists. We will wait until `useShareFrameMetadata` returns the data (it might be 400 redirect), and not showing an error until the value is resolved. I don't believe this is the root cause for everything but seems like it can fix one case? 🤔

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
