### PR TITLE
fix: better ffa triggers AB support

### DIFF
--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -220,26 +220,6 @@ async function processTriggers({
     return new Err(new Error("A user is required to update triggers"));
   }
 
-  // Validate trigger names are unique
-  const allTriggerNames = [
-    ...formData.triggersToCreate.map((t) => t.name),
-    ...formData.triggersToUpdate.map((t) => t.name),
-  ];
-  const uniqueTriggerNames = new Set(allTriggerNames);
-  if (uniqueTriggerNames.size !== allTriggerNames.length) {
-    datadogLogger.error(
-      {
-        workspaceId: owner.sId,
-        agentConfigurationId,
-        triggerNames: allTriggerNames,
-      },
-      "[Agent builder] - Duplicate trigger names found"
-    );
-    return new Err(
-      new Error("Trigger names must be unique for a given agent.")
-    );
-  }
-
   // Process triggers in order: DELETE -> PATCH -> POST (batch operations)
   // 1. Batch delete triggers
   if (formData.triggersToDelete.length > 0) {

--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -1,3 +1,4 @@
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type {
   AgentBuilderFormData,
   AgentBuilderTriggerType,
@@ -15,6 +16,9 @@ import {
   BoltIcon,
   Button,
   CardGrid,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
   EmptyCTA,
   Hoverable,
   Spinner,
@@ -84,6 +88,8 @@ export function AgentBuilderTriggersBlock({
     [webhookSourceViews, accessibleSpaceIds]
   );
 
+  const { user } = useAgentBuilderContext();
+
   // Combine triggers for display, excluding those marked for deletion
   const allTriggers = [
     ...triggersToCreate.map((t, index) => ({
@@ -96,7 +102,14 @@ export function AgentBuilderTriggersBlock({
       index,
       source: "update" as const,
     })),
-  ];
+  ].map((item, displayIndex) => ({ ...item, displayIndex }));
+
+  const myTriggers = allTriggers.filter(
+    (item) => item.trigger.editor === user.id
+  );
+  const otherTriggers = allTriggers.filter(
+    (item) => item.trigger.editor !== user.id
+  );
 
   const handleAddTrigger = () => {
     setSheetMode({ type: "add" });
@@ -176,6 +189,25 @@ export function AgentBuilderTriggersBlock({
     });
   };
 
+  const renderTriggerCards = (items: typeof allTriggers) =>
+    items.map((item) => (
+      <TriggerCard
+        key={
+          item.trigger.sId
+            ? `card-${item.trigger.sId}`
+            : `${item.source}-${item.index}`
+        }
+        trigger={item.trigger}
+        webhookSourceView={accessibleWebhookSourceViews.find((view) =>
+          item.trigger.kind === "webhook"
+            ? view.sId === item.trigger.webhookSourceViewSId
+            : undefined
+        )}
+        onRemove={() => handleTriggerRemove(item.trigger, item.displayIndex)}
+        onEdit={() => handleTriggerEdit(item.trigger)}
+      />
+    ));
+
   return (
     <AgentBuilderSectionContainer
       title="Triggers"
@@ -221,25 +253,22 @@ export function AgentBuilderTriggersBlock({
             className="py-4"
           />
         ) : (
-          <CardGrid>
-            {allTriggers.map((item, displayIndex) => (
-              <TriggerCard
-                key={
-                  item.trigger.sId
-                    ? `card-${item.trigger.sId}`
-                    : `${item.source}-${item.index}`
-                }
-                trigger={item.trigger}
-                webhookSourceView={accessibleWebhookSourceViews.find((view) =>
-                  item.trigger.kind === "webhook"
-                    ? view.sId === item.trigger.webhookSourceViewSId
-                    : undefined
-                )}
-                onRemove={() => handleTriggerRemove(item.trigger, displayIndex)}
-                onEdit={() => handleTriggerEdit(item.trigger)}
-              />
-            ))}
-          </CardGrid>
+          <div className="flex flex-col gap-4">
+            {myTriggers.length > 0 && (
+              <CardGrid>{renderTriggerCards(myTriggers)}</CardGrid>
+            )}
+            {otherTriggers.length > 0 && (
+              <Collapsible defaultOpen={false}>
+                <CollapsibleTrigger
+                  label="Other members' triggers"
+                  variant="secondary"
+                />
+                <CollapsibleContent>
+                  <CardGrid>{renderTriggerCards(otherTriggers)}</CardGrid>
+                </CollapsibleContent>
+              </Collapsible>
+            )}
+          </div>
         )}
       </div>
 

--- a/front/lib/models/agent/triggers/triggers.ts
+++ b/front/lib/models/agent/triggers/triggers.ts
@@ -122,7 +122,7 @@ TriggerModel.init(
       },
     },
     indexes: [
-      { fields: ["workspaceId", "agentConfigurationId", "name"], unique: true },
+      { fields: ["workspaceId", "agentConfigurationId", "name"] },
       { fields: ["workspaceId", "webhookSourceViewId"] },
     ],
   }

--- a/front/migrations/db/migration_556.sql
+++ b/front/migrations/db/migration_556.sql
@@ -1,3 +1,3 @@
 -- Migration created on Apr 01, 2026
 DROP INDEX IF EXISTS "triggers_workspace_id_agent_configuration_id_name";
-CREATE INDEX "triggers_workspace_id_agent_configuration_id_name" ON "triggers" ("workspaceId", "agentConfigurationId", "name");
+CREATE INDEX CONCURRENTLY "triggers_workspace_id_agent_configuration_id_name" ON "triggers" ("workspaceId", "agentConfigurationId", "name");

--- a/front/migrations/db/migration_556.sql
+++ b/front/migrations/db/migration_556.sql
@@ -1,0 +1,3 @@
+-- Migration created on Apr 01, 2026
+DROP INDEX IF EXISTS "triggers_workspace_id_agent_configuration_id_name";
+CREATE INDEX "triggers_workspace_id_agent_configuration_id_name" ON "triggers" ("workspaceId", "agentConfigurationId", "name");


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Now that everyone can put triggers on the agents they can use, we need to adjust some stuff

This PR fixes 2 things : 
- makes the triggers_workspace_id_agent_configuration_id_name not unique to allow multiple triggers with the same name on the same agent
- distinguishes your own triggers from other people triggers in the agent builder, and collapses other people triggers in the AB by default, so that admin can introspect all triggers of an agent while not having a cluttered AB

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

Deploy front & run migration 556
