### PR TITLE
fix: members not shown in selection table

### DIFF
--- a/front/components/members/MemberSelectionTable.tsx
+++ b/front/components/members/MemberSelectionTable.tsx
@@ -81,37 +81,15 @@ export function MemberSelectionTable({
     }
   }
 
-  // Selected members resolved from the internal map, filtered by search text.
-  const selectedRows = useMemo(() => {
-    const selected = Array.from(selectedMemberIds)
-      .map((sId) => userMapRef.current.get(sId))
-      .filter((u): u is UserType => !!u);
-
-    if (!searchText) {
-      return getMemberTableRows(selected);
-    }
-
-    const lower = searchText.toLowerCase();
-    return getMemberTableRows(
-      selected.filter(
-        (u) =>
-          u.fullName.toLowerCase().includes(lower) ||
-          (u.email ?? "").toLowerCase().includes(lower)
-      )
-    );
-  }, [selectedMemberIds, searchText]);
-
-  // On page 0, prepend selected members and remove duplicates from API results.
-  // On other pages, only show unselected API results.
+  // Selected users first, then unselected
   const rows = useMemo(() => {
-    const unselected = getMemberTableRows(
-      members.filter((m) => !selectedMemberIds.has(m.sId))
+    const selectedMembers = members.filter((m) => selectedMemberIds.has(m.sId));
+    const unselectedMembers = members.filter(
+      (m) => !selectedMemberIds.has(m.sId)
     );
-    if (pagination.pageIndex === 0) {
-      return [...selectedRows, ...unselected];
-    }
-    return unselected;
-  }, [members, selectedMemberIds, selectedRows, pagination.pageIndex]);
+    const sortedMembers = [...selectedMembers, ...unselectedMembers];
+    return getMemberTableRows(sortedMembers);
+  }, [members, selectedMemberIds]);
 
   const rowSelectionState: RowSelectionState = useMemo(
     () =>


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7287

This PR fixes an issue where members were not being shown in the selection table on first render.

- The bug was caused by the `userMapRef` not being populated yet when `selectedRows` was computed, causing selected members to not be found in the map
- Removed the `selectedRows` memo that relied on the internal user map
- Simplified the `rows` memo to directly filter and display members from the API results
- Removed the condition that hid selected members from pages after the first page, which prevented displaying more than 25 selected people (uncertain if this limitation was intentional, it was introduced here https://github.com/dust-tt/dust/pull/22646/changes)

## Tests

Manually

## Risks

Low

## Deploy Plan

Standard deployment.
