### PR TITLE
fix(connectors): gracefully handle deleted BigQuery projects during sync

### DIFF
--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -175,9 +175,16 @@ export const fetchDatasets = async ({
     );
   } catch (error) {
     const e = normalizeError(error);
-    // Sometimes the service account has access to a multiple projects, but one of them has not enabled BigQuery.
-    // In that case, we return an empty array.
-    if (e.message.includes("has not enabled BigQuery")) {
+    // Sometimes the service account has access to a multiple projects, but one of them has not enabled BigQuery
+    // or the project has been deleted. In that case, we skip the project and return an empty array.
+    if (
+      e.message.includes("has not enabled BigQuery") ||
+      e.message.includes("has been deleted")
+    ) {
+      logger?.info(
+        { database: database.name, error: e.message },
+        "[BigQuery] Skipping project"
+      );
       return new Ok([]);
     }
     return new Err(e);


### PR DESCRIPTION
## Description

When a BigQuery project referenced by a service account is deleted, `fetchDatasets` throws a "Project has been deleted" error that propagates up and crashes the entire `syncBigQueryConnection` workflow. Temporal then retries indefinitely (we observed ~1795 attempts on a specific connector).

This adds the "has been deleted" error to the existing catch block in `fetchDatasets` that already handles "has not enabled BigQuery" — the deleted project is skipped and the sync continues for the remaining projects. Previously synced data from the deleted project is cleaned up by the `sync()` reconciliation since it no longer appears in the tree.

## Tests

Manually verified the error message pattern matches what we see in Datadog logs (`"Project #424242424242 has been deleted."`). The code path is identical to the existing "has not enabled BigQuery" handling which is already in production.

## Risk

Low. This only adds a new condition to an existing catch block. Worst case, a legitimately transient "deleted" error gets swallowed — but GCP project deletion is permanent, so this is always a terminal state.

## Deploy Plan

Standard deploy. Once deployed, stuck connector will stop retrying on its next attempt and the deleted project's data will be cleaned up.