### PR TITLE
feat: click inline activity tool to open its detail in side panel

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -16,6 +16,7 @@ type OpenPanelParams =
   | {
       type: "actions";
       messageId: string;
+      actionId?: string;
     }
   | {
       type: "interactive_content";
@@ -105,16 +106,20 @@ export function ConversationSidePanelProvider({
 
       switch (params.type) {
         case AGENT_ACTIONS_SIDE_PANEL_TYPE: {
+          const newData = params.actionId
+            ? `${params.messageId}@${params.actionId}`
+            : params.messageId;
+
           /**
-           * If the panel is already open for the same messageId,
+           * If the panel is already open for the same data,
            * we close it.
            */
-          if (params.messageId === data) {
+          if (newData === data) {
             closePanel();
             return;
           }
 
-          setData(params.messageId);
+          setData(newData);
           break;
         }
 

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -1,3 +1,4 @@
+import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
 import { AgentActionsPanelHeader } from "@app/components/assistant/conversation/actions/AgentActionsPanelHeader";
 import { AgentActionSummary } from "@app/components/assistant/conversation/actions/AgentActionsPanelSummary";
 import { PanelAgentStep } from "@app/components/assistant/conversation/actions/PanelAgentStep";
@@ -374,7 +375,14 @@ export function AgentActionsPanel({
   conversation,
   owner,
 }: AgentActionsPanelProps) {
-  const { onPanelClosed, data: messageId } = useConversationSidePanelContext();
+  const { onPanelClosed, data: rawData } = useConversationSidePanelContext();
+
+  // data can be "messageId" or "messageId@actionId" for single-action view.
+  // TODO: Clean up once inline activity is rolled out -- the single-action view
+  // should fetch only the action it needs, not the full message.
+  const [messageId, targetActionId] = rawData?.includes("@")
+    ? [rawData.split("@")[0], rawData.split("@")[1]]
+    : [rawData, undefined];
 
   const {
     message: fullAgentMessage,
@@ -432,6 +440,32 @@ export function AgentActionsPanel({
         </div>
       </AgentActionsPanelHeader>
     );
+  }
+
+  // Single action detail view when an action is targeted from inline activity.
+  if (targetActionId) {
+    const action = fullAgentMessage.actions.find(
+      (a) => a.sId === targetActionId
+    );
+    if (action) {
+      return (
+        <div className="flex h-full flex-col bg-background dark:bg-background-night">
+          <AgentActionsPanelHeader
+            title="Tool detail"
+            onClose={onPanelClosed}
+          />
+          <div className="flex-1 overflow-y-auto p-4 pb-12">
+            <MCPActionDetails
+              displayContext="sidebar"
+              action={action}
+              lastNotification={null}
+              owner={owner}
+              messageStatus={fullAgentMessage.status}
+            />
+          </div>
+        </div>
+      );
+    }
   }
 
   // Use key to force remount when the message changes for proper state reset.

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -381,7 +381,7 @@ export function AgentActionsPanel({
   // TODO: Clean up once inline activity is rolled out -- the single-action view
   // should fetch only the action it needs, not the full message.
   const [messageId, targetActionId] = rawData?.includes("@")
-    ? [rawData.split("@")[0], rawData.split("@")[1]]
+    ? rawData.split("@")
     : [rawData, undefined];
 
   const {

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -127,15 +127,15 @@ export function InlineActivitySteps({
         className="self-start text-muted-foreground dark:text-muted-foreground-night hover:text-foreground dark:hover:text-foreground-night transition-colors duration-200 flex gap-1 items-center"
         onClick={toggleCollapse}
       >
+        {headerLabel ?? <AnimatedText>Thinking…</AnimatedText>}
         <span
           className={cn(
             "transition-transform duration-200 ease-out",
-            !isCollapsed && "rotate-90"
+            isCollapsed ? "rotate-0" : "rotate-90"
           )}
         >
           <Icon size="xs" visual={ChevronRightIcon} />
         </span>
-        {headerLabel ?? <AnimatedText>Thinking…</AnimatedText>}
       </button>
 
       <div
@@ -143,7 +143,7 @@ export function InlineActivitySteps({
         style={getCollapseAnimationStyle(isCollapsed)}
       >
         <div className="overflow-hidden">
-          <div className="flex flex-col gap-2 ml-4">
+          <div className="flex flex-col gap-2">
             {completedSteps.map((step, index) => {
               const isLast =
                 index === completedSteps.length - 1 &&
@@ -190,8 +190,13 @@ export function InlineActivitySteps({
                       }
                     >
                       <TimelineRow icon={actionIcon} isLast={isLast}>
-                        <span className="text-muted-foreground dark:text-muted-foreground-night">
+                        <span className="text-muted-foreground dark:text-muted-foreground-night flex items-center gap-1">
                           {step.label}
+                          <Icon
+                            size="xs"
+                            visual={ChevronRightIcon}
+                            className="shrink-0 opacity-50"
+                          />
                         </span>
                       </TimelineRow>
                     </div>

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -84,13 +84,6 @@ export function InlineActivitySteps({
     }
   }, [isDone]);
 
-  const openBreakdownPanel = () => {
-    openPanel({
-      type: "actions",
-      messageId: agentMessage.sId,
-    });
-  };
-
   const isThinking = lastAgentStateClassification === "thinking";
   const isActing = lastAgentStateClassification === "acting";
 
@@ -150,10 +143,7 @@ export function InlineActivitySteps({
         style={getCollapseAnimationStyle(isCollapsed)}
       >
         <div className="overflow-hidden">
-          <div
-            className="cursor-pointer flex flex-col gap-2 ml-4"
-            onClick={openBreakdownPanel}
-          >
+          <div className="flex flex-col gap-2 ml-4">
             {completedSteps.map((step, index) => {
               const isLast =
                 index === completedSteps.length - 1 &&
@@ -188,15 +178,23 @@ export function InlineActivitySteps({
                     : ToolsIcon;
 
                   return (
-                    <TimelineRow
+                    <div
                       key={step.id}
-                      icon={actionIcon}
-                      isLast={isLast}
+                      className="cursor-pointer"
+                      onClick={() =>
+                        openPanel({
+                          type: "actions",
+                          messageId: agentMessage.sId,
+                          actionId: step.actionId,
+                        })
+                      }
                     >
-                      <span className="text-muted-foreground dark:text-muted-foreground-night">
-                        {step.label}
-                      </span>
-                    </TimelineRow>
+                      <TimelineRow icon={actionIcon} isLast={isLast}>
+                        <span className="text-muted-foreground dark:text-muted-foreground-night">
+                          {step.label}
+                        </span>
+                      </TimelineRow>
+                    </div>
                   );
                 }
                 default:

--- a/front/components/assistant/conversation/actions/inline/TimelineRow.tsx
+++ b/front/components/assistant/conversation/actions/inline/TimelineRow.tsx
@@ -29,7 +29,7 @@ export function TimelineRow({
             <Icon
               visual={icon}
               size="xs"
-              className="s-text-faint dark:s-text-faint-night"
+              className="text-faint dark:text-faint-night"
             />
           ) : null}
         </div>

--- a/front/components/assistant/conversation/actions/inline/TimelineRow.tsx
+++ b/front/components/assistant/conversation/actions/inline/TimelineRow.tsx
@@ -29,7 +29,7 @@ export function TimelineRow({
             <Icon
               visual={icon}
               size="xs"
-              className="text-muted-foreground dark:text-muted-foreground-night"
+              className="s-text-faint dark:s-text-faint-night"
             />
           ) : null}
         </div>

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -322,6 +322,7 @@ export function useAgentMessageStream({
                     type: "action" as const,
                     label: getActionOneLineLabel(action),
                     id: `action-${action.id}`,
+                    actionId: action.sId,
                     internalMCPServerName: action.internalMCPServerName,
                   },
                 ];

--- a/front/lib/api/assistant/activity_steps.ts
+++ b/front/lib/api/assistant/activity_steps.ts
@@ -88,6 +88,7 @@ export async function contentsToActivitySteps(
           type: "action",
           label: getActionOneLineLabel(matchingAction),
           id: `action-${matchingAction.id}`,
+          actionId: matchingAction.sId,
           internalMCPServerName: matchingAction.internalMCPServerName,
         });
       }

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -424,6 +424,9 @@
  *                 description: Action display label (action steps only)
  *               id:
  *                 type: string
+ *               actionId:
+ *                 type: string
+ *                 description: Action string identifier (action steps only)
  *         reactions:
  *           type: array
  *           items:

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -9074,6 +9074,10 @@
                 },
                 "id": {
                   "type": "string"
+                },
+                "actionId": {
+                  "type": "string",
+                  "description": "Action string identifier (action steps only)"
                 }
               }
             }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -253,6 +253,7 @@ export type InlineActivityStep =
       type: "action";
       label: string;
       id: string;
+      actionId: string;
       internalMCPServerName: InternalMCPServerNameType | null;
     };
 


### PR DESCRIPTION
## Description

When inline activity is enabled, clicking a tool step in the inline timeline now opens the side panel showing only that tool's detail (MCPActionDetails). Thinking steps are not clickable since their content is already visible inline.

This builds on the previous PR that computed activitySteps server-side for completed messages. 

The main additions are:
- 1. A new `actionId` field on the action variant of `InlineActivityStep`, carrying the action's string identifier so we can match it to the full action object when opening the panel.
- 2. The side panel context's `OpenPanelParams` for the "actions" type now accepts an optional `actionId`. When provided, the panel renders a single-action detail view instead of the full breakdown. The action ID is encoded in the existing hash param data as `messageId@actionId`. This encoding will be cleaned up once inline activity is rolled out since the single-action view should fetch only the action it needs, not the full message.
- 3. In `InlineActivitySteps`, only action/tool rows are clickable. Each passes its `actionId` to `openPanel`. Clicking the same tool  again toggles the panel closed.

The existing full breakdown panel is unchanged and still used by other entry points.


## Tests

- [x] Enable inline activity toggle (User menu > Dev Tools > "Enable Inline Activity")
- [x] Click a tool in the inline timeline, verify the panel opens showing only that tool's detail
- [x] Click the same tool again, verify the panel closes
- [x] Click a different tool, verify the panel switches to that tool's detail
- [x] Verify thinking steps are not clickable
- [x] Open the full breakdown from another entry point (e.g. the activity chip with inline activity disabled), verify it still
  shows all steps

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 