### PR TITLE
[front] enh: improve skill discoverability dialog content

### DIFF
--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -66,13 +66,12 @@ export function SkillBuilderIsDefaultSection() {
               be able to find and enable it on their own.
               <ul className="mt-3 list-disc space-y-1 pl-5">
                 <li>
-                  This will expose the skill to every member of your workspace
+                  This will expose the skill to your entire workspace
                   through the Discover Skills skill.
                 </li>
                 <li>
-                  Do not enable this for skills that are still experimental or
-                  under active development — agents may start using them in real
-                  conversations.
+                  Experimental or in-progress skills should not be made
+                  discoverable.
                 </li>
               </ul>
             </DialogDescription>

--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -66,8 +66,8 @@ export function SkillBuilderIsDefaultSection() {
               be able to find and enable it on their own.
               <ul className="mt-3 list-disc space-y-1 pl-5">
                 <li>
-                  This will expose the skill to your entire workspace
-                  through the Discover Skills skill.
+                  This will expose the skill to your entire workspace through
+                  the Discover Skills skill.
                 </li>
                 <li>
                   Experimental or in-progress skills should not be made

--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -64,6 +64,17 @@ export function SkillBuilderIsDefaultSection() {
               This skill will be set as default. Agents with&nbsp;
               <span className="font-semibold">Discover Skills</span>&nbsp; will
               be able to find and enable it on their own.
+              <ul className="mt-3 list-disc space-y-1 pl-5">
+                <li>
+                  This will expose the skill to every member of your workspace
+                  through the Discover Skills skill.
+                </li>
+                <li>
+                  Do not enable this for skills that are still experimental or
+                  under active development — agents may start using them in real
+                  conversations.
+                </li>
+              </ul>
             </DialogDescription>
           </DialogHeader>
           <DialogFooter
@@ -73,7 +84,7 @@ export function SkillBuilderIsDefaultSection() {
             }}
             rightButtonProps={{
               label: "Confirm",
-              variant: "primary",
+              variant: "warning",
               onClick: handleConfirm,
             }}
           />


### PR DESCRIPTION
## Description

- This PR iterates on the content of the dialog that opens when making a skill discoverable.
- Changes the color of the confirmation button to red and adds a more comprehensive description of what this action entices.

<img width="1307" height="1277" alt="Screenshot 2026-04-01 at 3 37 34 PM" src="https://github.com/user-attachments/assets/e28170d2-6be5-4ff8-a65e-276d97f664c6" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
