### PR TITLE
fix(connectors): skip Microsoft drives with malformed or deleted drive IDs

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -31,6 +31,7 @@ import {
   isGeneralExceptionError,
   isItemNotFoundError,
   isJSONParsingError,
+  isMalformedDriveError,
 } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
 import {
   deleteFile,
@@ -1235,8 +1236,11 @@ export async function fetchDeltaForRootNodesInDrive({
     results = resultsFromDelta;
     deltaLink = deltaLinkFromDelta;
   } catch (error) {
-    if (isItemNotFoundError(error)) {
-      logger.info({ error: error.message }, "Node not found, skipping");
+    if (isItemNotFoundError(error) || isMalformedDriveError(error)) {
+      logger.info(
+        { error: error.message, driveId },
+        "Drive not found or malformed, skipping"
+      );
       return { gcsFilePath: null };
     }
     throw error;

--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -28,6 +28,17 @@ export function isItemNotFoundError(err: unknown): err is GraphError {
   );
 }
 
+// 400 with "malformed" in the message indicates a drive ID that is invalid or
+// refers to a deleted drive. The Graph API returns this instead of a 404 when
+// the drive ID format is recognized but the drive no longer exists.
+export function isMalformedDriveError(err: unknown): err is GraphError {
+  return (
+    err instanceof GraphError &&
+    err.statusCode === 400 &&
+    err.message.includes("malformed")
+  );
+}
+
 // 423 Locked with code "notAllowed" indicates a SharePoint site has been blocked
 // by an administrator. This is an external permission restriction that cannot
 // be resolved in-product.


### PR DESCRIPTION
## Description

When a SharePoint drive is deleted, the Microsoft Graph delta API returns a 400 "malformed drive id" error instead of a 404. The `fetchDeltaForRootNodesInDrive` activity only catches 404 (`isItemNotFoundError`), so the 400 falls through and causes infinite Temporal retries. We observed ~1744 retry attempts on a connector .

This adds a `isMalformedDriveError` check alongside the existing `isItemNotFoundError` check, so malformed/deleted drives are skipped gracefully (returning `{ gcsFilePath: null }`) instead of retrying forever.

## Tests

Verified the error message pattern matches what we see in Datadog logs: "The provided drive id appears to be malformed, or does not represent a valid drive." The code path mirrors the existing `isItemNotFoundError` handling.

## Risk

Low. Only adds a new condition to an existing catch block. A malformed drive ID is a permanent state — skipping it is the correct behavior.

## Deploy Plan

Standard deploy. Once deployed, connector 27538 will stop retrying on its next attempt.