### PR TITLE
[front] feat: add skill selection in import endpoint

### DIFF
--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -20,6 +20,17 @@ import path from "path";
 
 const IMPORT_CONCURRENCY = 4;
 
+const IMPORT_CONFLICT_STRATEGIES = ["error", "skip", "override"] as const;
+
+export type ImportConflictStrategyType =
+  (typeof IMPORT_CONFLICT_STRATEGIES)[number];
+
+export function isImportConflictStrategy(
+  value: string
+): value is ImportConflictStrategyType {
+  return IMPORT_CONFLICT_STRATEGIES.includes(value as ImportConflictStrategyType);
+}
+
 type FileImportSource = Extract<SkillSourceType, "api" | "local_file">;
 
 type ImportSkillsResult = {
@@ -48,7 +59,7 @@ export async function importSkillsFromFiles(
     uploadedFiles: formidable.File[];
     names?: string[];
     source?: FileImportSource;
-    onConflict?: "error" | "skip";
+    onConflict?: ImportConflictStrategyType;
   }
 ): Promise<Result<ImportSkillsResult, Error>> {
   const allSkills: ZipDetectedSkill[] = [];
@@ -122,7 +133,11 @@ export async function importSkillsFromFiles(
     async (skill) => {
       const existing = existingSkillsMap.get(skill.name) ?? null;
 
-      if (existing && existing.source !== source) {
+      if (
+        existing &&
+        existing.source !== source &&
+        onConflict !== "override"
+      ) {
         skipped.push({
           name: skill.name,
           message: `A different skill named "${skill.name}" already exists.`,

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -28,7 +28,9 @@ export type ImportConflictStrategyType =
 export function isImportConflictStrategy(
   value: string
 ): value is ImportConflictStrategyType {
-  return IMPORT_CONFLICT_STRATEGIES.includes(value as ImportConflictStrategyType);
+  return IMPORT_CONFLICT_STRATEGIES.includes(
+    value as ImportConflictStrategyType
+  );
 }
 
 type FileImportSource = Extract<SkillSourceType, "api" | "local_file">;
@@ -133,11 +135,7 @@ export async function importSkillsFromFiles(
     async (skill) => {
       const existing = existingSkillsMap.get(skill.name) ?? null;
 
-      if (
-        existing &&
-        existing.source !== source &&
-        onConflict !== "override"
-      ) {
+      if (existing && existing.source !== source && onConflict !== "override") {
         skipped.push({
           name: skill.name,
           message: `A different skill named "${skill.name}" already exists.`,

--- a/front/pages/api/v1/w/[wId]/skills/index.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.ts
@@ -1,6 +1,9 @@
 /** @ignoreswagger */
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { importSkillsFromFiles } from "@app/lib/api/skills/detection/files/import_skills";
+import {
+  importSkillsFromFiles,
+  isImportConflictStrategy,
+} from "@app/lib/api/skills/detection/files/import_skills";
 import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_skills";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -42,13 +45,14 @@ async function handler(
     });
   }
 
+  let fields: formidable.Fields;
   let files: formidable.Files;
   try {
     const form = formidable({
       multiples: true,
       maxFileSize: MAX_ZIP_SIZE_BYTES,
     });
-    [, files] = await form.parse(req);
+    [fields, files] = await form.parse(req);
   } catch (err) {
     return apiError(req, res, {
       status_code: 400,
@@ -70,10 +74,24 @@ async function handler(
     });
   }
 
+  const names = fields.names;
+
+  const onConflict = fields.onConflict?.[0] ?? "error";
+  if (!isImportConflictStrategy(onConflict)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid onConflict value: "${onConflict}". Must be one of: error, skip, override.`,
+      },
+    });
+  }
+
   const result = await importSkillsFromFiles(auth, {
     uploadedFiles,
+    names,
     source: "api",
-    onConflict: "error",
+    onConflict,
   });
   if (result.isErr()) {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/skills/index.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.ts
@@ -74,7 +74,7 @@ async function handler(
     });
   }
 
-  const names = fields.names;
+  const { names } = fields;
 
   const onConflict = fields.onConflict?.[0] ?? "error";
   if (!isImportConflictStrategy(onConflict)) {


### PR DESCRIPTION
## Description

This PR iterates on the public API endpoint to import skills to Dust.
- Expose two fields for passing down names of the skills to sync and for selecting the on conflict strategy (error, skip or override).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
