### PR TITLE
[front] GA `discover_skills`

### DIFF
--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -3,7 +3,6 @@ import { SkillBuilderIsDefaultSection } from "@app/components/skill_builder/Skil
 import { SkillBuilderNameSection } from "@app/components/skill_builder/SkillBuilderNameSection";
 import { SkillBuilderUserFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderUserFacingDescriptionSection";
 import { SkillEditorsSheet } from "@app/components/skill_builder/SkillEditorsSheet";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   Chip,
   Collapsible,
@@ -13,8 +12,6 @@ import {
 } from "@dust-tt/sparkle";
 
 export function SkillBuilderSettingsSection() {
-  const { hasFeature } = useFeatureFlags();
-
   return (
     <div className="space-y-5">
       <h2 className="heading-lg text-foreground dark:text-foreground-night">
@@ -35,25 +32,23 @@ export function SkillBuilderSettingsSection() {
           <SkillEditorsSheet />
         </div>
       </div>
-      {hasFeature("discover_skills") && (
-        <Collapsible defaultOpen>
-          <CollapsibleTrigger variant="secondary">
-            <div className="flex items-center gap-2">
-              <span className="text-base text-foreground dark:text-foreground-night">
-                Advanced
-              </span>
-              <Chip color="golden" size="xs">
-                Preview
-              </Chip>
-            </div>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <div className="pt-3">
-              <SkillBuilderIsDefaultSection />
-            </div>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
+      <Collapsible defaultOpen>
+        <CollapsibleTrigger variant="secondary">
+          <div className="flex items-center gap-2">
+            <span className="text-base text-foreground dark:text-foreground-night">
+              Advanced
+            </span>
+            <Chip color="golden" size="xs">
+              Preview
+            </Chip>
+          </div>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="pt-3">
+            <SkillBuilderIsDefaultSection />
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 }

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -43,8 +43,7 @@ export function SkillInfoTab({
   const [knowledgeItems, setKnowledgeItems] = useState<KnowledgeItem[]>([]);
   const { hasFeature } = useFeatureFlags();
 
-  const showDiscoverableSkills =
-    skill.sId === "discover_skills" && hasFeature("discover_skills");
+  const showDiscoverableSkills = skill.sId === "discover_skills";
 
   const { skills: discoverableSkills, isSkillsLoading: isDiscoverableLoading } =
     useSkills({

--- a/front/lib/resources/skill/global/discover_skills.ts
+++ b/front/lib/resources/skill/global/discover_skills.ts
@@ -1,5 +1,3 @@
-import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 
 // This skill allows discovering skills from the workspace. When equipped on an
@@ -18,9 +16,4 @@ export const discoverSkillsSkill = {
   version: 1,
   icon: "PuzzleIcon",
   isAutoEnabled: true,
-  isRestricted: async (auth: Authenticator) => {
-    const flags = await getFeatureFlags(auth);
-
-    return !flags.includes("discover_skills");
-  },
 } as const satisfies GlobalSkillDefinition;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -252,11 +252,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable reinforced agents: background analysis of conversations to suggest agent improvements",
     stage: "dust_only",
   },
-  discover_skills: {
-    description:
-      "Enable default skills discovery on global agents (do not enable for customers)",
-    stage: "dust_only",
-  },
   collapsible_messages: {
     description: "Enable collapsible messages in conversations",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -693,7 +693,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"
   | "discord_bot"
-  | "discover_skills"
   | "dust_academy"
   | "dust_internal_global_agents"
   | "dust_no_spa"


### PR DESCRIPTION
## Description

- This PR ungates the `discover_skills` global skill, making it available to all workspaces.
- Was previously behind the `discover_skills` feature flag.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
