### PR TITLE
 fix(sparkle): respect textColor context in bold markdown text

### DIFF
--- a/sparkle/src/components/markdown/StrongBlock.tsx
+++ b/sparkle/src/components/markdown/StrongBlock.tsx
@@ -1,3 +1,4 @@
+import { useMarkdownStyle } from "@sparkle/components/markdown/MarkdownStyleContext";
 import {
   type MarkdownNode,
   sameNodePosition,
@@ -10,11 +11,11 @@ interface StrongBlockProps {
 }
 
 export const StrongBlock = memo(
-  ({ children }: StrongBlockProps) => (
-    <strong className="s-font-semibold s-text-foreground dark:s-text-foreground-night">
-      {children}
-    </strong>
-  ),
+  function StrongBlock({ children }: StrongBlockProps) {
+    const { textColor } = useMarkdownStyle();
+    return (
+      <strong className={`s-font-semibold ${textColor}`}>{children}</strong>
+    );
+  },
   (prev, next) => sameNodePosition(prev.node, next.node)
 );
-StrongBlock.displayName = "StrongBlock";


### PR DESCRIPTION
## Description

`StrongBlock` was hardcoding `s-text-foreground` for bold text color, ignoring the `textColor` from `MarkdownStyleContext`. This caused bold text to render with a different color than surrounding text when a custom `textColor` was passed to the `Markdown` component (e.g. `text-muted-foreground` used in the inline activity thinking steps).

The fix reads `textColor` from `useMarkdownStyle()` context, consistent with how `HeadingBlock`, `List`, and other markdown blocks  already work.


## Tests

Storybook. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy new sparkle version and then bump the version. 
