### PR TITLE
Fix weird markdown with code block on Inline Activity thinking

### DIFF
--- a/front/components/assistant/conversation/actions/inline/TimelineRow.tsx
+++ b/front/components/assistant/conversation/actions/inline/TimelineRow.tsx
@@ -40,7 +40,7 @@ export function TimelineRow({
 
       {/* Content */}
       {children && (
-        <div className="flex min-h-6 flex-wrap items-start gap-1.5 pb-1">
+        <div className="flex min-h-6 min-w-0 flex-wrap items-start gap-1.5 overflow-x-auto pb-1">
           {children}
         </div>
       )}


### PR DESCRIPTION
## Description

- When agent thinking content contains code blocks or long lines, text overflows horizontally in the inline activity timeline with no way to scroll
- Added min-w-0 overflow-x-auto to the TimelineRow content div so overflowing content gets a horizontal scrollbar (matching the Message Breakdown panel behavior)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
