### PR TITLE
[front] fix: remove redundant `ScrollArea` in detected skills

### DIFF
--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -12,7 +12,6 @@ import {
   InformationCircleIcon,
   Label,
   PuzzleIcon,
-  ScrollArea,
   Spinner,
 } from "@dust-tt/sparkle";
 import { useMemo } from "react";
@@ -105,7 +104,7 @@ export function DetectedSkillsList({
               />
             </ContextItem.List>
           )}
-          <ScrollArea className="max-h-64">
+          <div className="max-h-64 overflow-y-auto">
             <ContextItem.List>
               {detectedSkills.map((skill) => (
                 <ContextItem
@@ -142,7 +141,7 @@ export function DetectedSkillsList({
                 />
               ))}
             </ContextItem.List>
-          </ScrollArea>
+          </div>
         </div>
       )}
     </>


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/23543.
- This PR removes nested `ScrollArea`s in the detected skill list, causing the innermost one to not be scrollable.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
