### PR TITLE
[front] fix: upsert current user as editor on skill updates

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1642,6 +1642,24 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return this.editorGroup?.getActiveMembers(auth) ?? null;
   }
 
+  private async upsertCurrentUserAsEditor(auth: Authenticator): Promise<void> {
+    const user = auth.user();
+    if (!this.editorGroup || !user) {
+      return;
+    }
+
+    if (!this.editorGroup.canWrite(auth)) {
+      return;
+    }
+
+    const isMember = await this.editorGroup.isMember(user);
+    if (!isMember) {
+      await this.editorGroup.dangerouslyAddMember(auth, {
+        user: user.toJSON(),
+      });
+    }
+  }
+
   async fetchEditedByUser(auth: Authenticator): Promise<UserResource | null> {
     if (this.editedBy === null) {
       return null;
@@ -1818,6 +1836,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     if (fileAttachments) {
       await this.setFileAttachments(auth, fileAttachments);
     }
+
+    await this.upsertCurrentUserAsEditor(auth);
   }
 
   /**


### PR DESCRIPTION
## Description

- This PR patches the update flow for skills by adding the current user as editor if not already the case.
- For context, we'll be able to import skills programmatically (API-key based, not tied to a user) so we'll have more skills created without an editor. This is a way to populate it easily.
- Only applies to admins editing at a skill they are not an editor of, in any other cases the user would not be able to edit the skill.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
