### PR TITLE
[front] single agent input UI 

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -78,9 +78,9 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
       title: `Single agent input ${next ? "enabled" : "disabled"}`,
       description: "Reload the page to apply.",
       type: "success",
-    })
-  }
-  
+    });
+  };
+
   const { clearAllDraftsFromUser } = useConversationDrafts({
     workspaceId: owner.sId,
     userId: user.sId,

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -68,8 +68,8 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
       type: "success",
     });
   }, [sendNotification]);
-  const [singleAgentInput, setSingleAgentInput] = useState(
-    isSingleAgentInputEnabled
+  const [singleAgentInput, setSingleAgentInput] = useState(() =>
+    isSingleAgentInputEnabled()
   );
   const handleToggleSingleAgentInput = () => {
     const next = toggleSingleAgentInput();

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -7,9 +7,11 @@ import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   forceUserRole,
   isInlineActivityEnabled,
+  isSingleAgentInputEnabled,
   sendOnboardingConversation,
   showDebugTools,
   toggleInlineActivity,
+  toggleSingleAgentInput,
 } from "@app/lib/development";
 import { useAppRouter } from "@app/lib/platform";
 import type { SubscriptionType } from "@app/types/plan";
@@ -66,6 +68,19 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
       type: "success",
     });
   }, [sendNotification]);
+  const [singleAgentInput, setSingleAgentInput] = useState(
+    isSingleAgentInputEnabled
+  );
+  const handleToggleSingleAgentInput = () => {
+    const next = toggleSingleAgentInput();
+    setSingleAgentInput(next);
+    sendNotification({
+      title: `Single agent input ${next ? "enabled" : "disabled"}`,
+      description: "Reload the page to apply.",
+      type: "success",
+    })
+  }
+  
   const { clearAllDraftsFromUser } = useConversationDrafts({
     workspaceId: owner.sId,
     userId: user.sId,
@@ -278,6 +293,11 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
                   <DropdownMenuItem
                     label={`${inlineActivity ? "Disable" : "Enable"} Inline Activity`}
                     onClick={handleToggleInlineActivity}
+                    icon={TestTubeIcon}
+                  />
+                  <DropdownMenuItem
+                    label={`${singleAgentInput ? "Disable" : "Enable"} Single Agent Input`}
+                    onClick={handleToggleSingleAgentInput}
                     icon={TestTubeIcon}
                   />
                   {owner.role === "admin" && (

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -11,8 +11,10 @@ import { useConversationSidePanelContext } from "@app/components/assistant/conve
 import { ConversationViewer } from "@app/components/assistant/conversation/ConversationViewer";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import type { InputBarAction } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { isSingleAgentInputEnabled } from "@app/lib/development";
 import type { DustError } from "@app/lib/error";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
@@ -133,7 +135,14 @@ function PreviewContent({
                 draftAgent ? [toRichAgentMentionType(draftAgent)] : []
               }
               draftKey={`agent-${draftAgent?.name}-builder-preview`}
-              actions={["attachment"]}
+              actions={
+                [
+                  "attachment",
+                  ...(isSingleAgentInputEnabled()
+                    ? ["agents-list" as InputBarAction]
+                    : []),
+                ] satisfies InputBarAction[]
+              }
               disableAutoFocus
               isFloating={false}
               shouldUseDraft={false}

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -11,7 +11,6 @@ import { useConversationSidePanelContext } from "@app/components/assistant/conve
 import { ConversationViewer } from "@app/components/assistant/conversation/ConversationViewer";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
-import type { InputBarAction } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { isSingleAgentInputEnabled } from "@app/lib/development";
@@ -136,12 +135,9 @@ function PreviewContent({
               }
               draftKey={`agent-${draftAgent?.name}-builder-preview`}
               actions={
-                [
-                  "attachment",
-                  ...(isSingleAgentInputEnabled()
-                    ? ["agents-list" as InputBarAction]
-                    : []),
-                ] satisfies InputBarAction[]
+                isSingleAgentInputEnabled()
+                  ? ["attachment", "agents-list"]
+                  : ["attachment"]
               }
               disableAutoFocus
               isFloating={false}

--- a/front/components/agent_builder/AgentBuilderSidekick.tsx
+++ b/front/components/agent_builder/AgentBuilderSidekick.tsx
@@ -12,6 +12,7 @@ import {
   sidekickSuggestionDirective,
 } from "@app/components/markdown/suggestion/SidekickSuggestionDirective";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { isSingleAgentInputEnabled } from "@app/lib/development";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -84,6 +85,7 @@ function SidekickContent({
       actionsToShow: [
         "attachment",
         ...(subscription.plan.isByok ? [] : ["voice" as const]),
+        ...(isSingleAgentInputEnabled() ? ["agents-list" as const] : []),
       ] satisfies InputBarAction[],
       clientSideMCPServerIds,
       skipToolsValidation: true,

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -83,8 +83,12 @@ export const InputBar = React.memo(function InputBar({
     DataSourceViewContentNode[]
   >([]);
 
-  const { selectedAgent, getAndClearPendingInputText, fileUploaderService } =
-    useContext(InputBarContext);
+  const {
+    getAndClearSelectedAgent,
+    singleAgentSelection,
+    getAndClearPendingInputText,
+    fileUploaderService,
+  } = useContext(InputBarContext);
 
   // We use this specific hook because this component is involved in the new conversation page.
   const { agentConfigurations } = useUnifiedAgentConfigurations({
@@ -110,6 +114,10 @@ export const InputBar = React.memo(function InputBar({
     }
   }, [droppedFiles, setDroppedFiles, fileUploaderService]);
 
+  const selectedAgent = useMemo(
+    () => getAndClearSelectedAgent(),
+    [getAndClearSelectedAgent]
+  );
   const pendingInputText = useMemo(
     () => getAndClearPendingInputText(),
     [getAndClearPendingInputText]
@@ -197,11 +205,11 @@ export const InputBar = React.memo(function InputBar({
     // since it's no longer in the editor as a mention node.
     const shouldInjectSelectedAgent =
       singleAgentInput &&
-      selectedAgent &&
-      !rawMentions.some((m) => m.id === selectedAgent.id);
+      singleAgentSelection &&
+      !rawMentions.some((m) => m.id === singleAgentSelection.id);
 
     const allMentions = shouldInjectSelectedAgent
-      ? [selectedAgent, ...rawMentions]
+      ? [singleAgentSelection, ...rawMentions]
       : rawMentions;
     const mentions = _.uniqBy(allMentions, "id");
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -85,7 +85,7 @@ export const InputBar = React.memo(function InputBar({
 
   const {
     getAndClearSelectedAgent,
-    singleAgentSelection,
+    selectedSingleAgent,
     getAndClearPendingInputText,
     fileUploaderService,
   } = useContext(InputBarContext);
@@ -205,11 +205,11 @@ export const InputBar = React.memo(function InputBar({
     // since it's no longer in the editor as a mention node.
     const shouldInjectSelectedAgent =
       singleAgentInput &&
-      singleAgentSelection &&
-      !rawMentions.some((m) => m.id === singleAgentSelection.id);
+      selectedSingleAgent &&
+      !rawMentions.some((m) => m.id === selectedSingleAgent.id);
 
     const allMentions = shouldInjectSelectedAgent
-      ? [singleAgentSelection, ...rawMentions]
+      ? [selectedSingleAgent, ...rawMentions]
       : rawMentions;
     const mentions = _.uniqBy(allMentions, "id");
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -83,11 +83,8 @@ export const InputBar = React.memo(function InputBar({
     DataSourceViewContentNode[]
   >([]);
 
-  const {
-    selectedAgent,
-    getAndClearPendingInputText,
-    fileUploaderService,
-  } = useContext(InputBarContext);
+  const { selectedAgent, getAndClearPendingInputText, fileUploaderService } =
+    useContext(InputBarContext);
 
   // We use this specific hook because this component is involved in the new conversation page.
   const { agentConfigurations } = useUnifiedAgentConfigurations({

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -85,7 +85,6 @@ export const InputBar = React.memo(function InputBar({
 
   const {
     selectedAgent,
-    setSelectedAgent,
     getAndClearPendingInputText,
     fileUploaderService,
   } = useContext(InputBarContext);
@@ -203,7 +202,7 @@ export const InputBar = React.memo(function InputBar({
       singleAgentInput &&
       selectedAgent &&
       !rawMentions.some((m) => m.id === selectedAgent.id);
-      
+
     const allMentions = shouldInjectSelectedAgent
       ? [selectedAgent, ...rawMentions]
       : rawMentions;

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -13,6 +13,7 @@ import {
   useConversationTools,
 } from "@app/hooks/conversations";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { isSingleAgentInputEnabled } from "@app/lib/development";
 import type { DustError } from "@app/lib/error";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { TRACKING_AREAS, trackEvent } from "@app/lib/tracking";
@@ -32,7 +33,7 @@ import type { SpaceType } from "@app/types/space";
 import type { UserType, WorkspaceType } from "@app/types/user";
 // biome-ignore lint/plugin/noBulkLodash: existing usage
 import _ from "lodash";
-import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 
 const DEFAULT_INPUT_BAR_ACTIONS = [...INPUT_BAR_ACTIONS];
 
@@ -83,9 +84,8 @@ export const InputBar = React.memo(function InputBar({
   >([]);
 
   const {
-    animate,
-    setAnimate,
-    getAndClearSelectedAgent,
+    selectedAgent,
+    setSelectedAgent,
     getAndClearPendingInputText,
     fileUploaderService,
   } = useContext(InputBarContext);
@@ -114,43 +114,10 @@ export const InputBar = React.memo(function InputBar({
     }
   }, [droppedFiles, setDroppedFiles, fileUploaderService]);
 
-  const [isAnimating, setIsAnimating] = useState<boolean>(false);
-  const animationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const selectedAgent = useMemo(
-    () => getAndClearSelectedAgent(),
-    [getAndClearSelectedAgent]
-  );
   const pendingInputText = useMemo(
     () => getAndClearPendingInputText(),
     [getAndClearPendingInputText]
   );
-  useEffect(() => {
-    if (animate && !isAnimating) {
-      setAnimate(false);
-      setIsAnimating(true);
-
-      // Clear any existing timeout to ensure animations do not overlap.
-      if (animationTimeoutRef.current) {
-        clearTimeout(animationTimeoutRef.current);
-      }
-
-      // Set timeout to set setIsAnimating to false after the duration.
-      animationTimeoutRef.current = setTimeout(() => {
-        setIsAnimating(false);
-        // Reset the ref after the timeout clears.
-        animationTimeoutRef.current = null;
-      }, 700);
-    }
-  }, [animate, isAnimating, setAnimate]);
-
-  // Cleanup timeout on component unmount.
-  useEffect(() => {
-    return () => {
-      if (animationTimeoutRef.current) {
-        clearTimeout(animationTimeoutRef.current);
-      }
-    };
-  }, []);
 
   // Tools selection
 
@@ -229,7 +196,16 @@ export const InputBar = React.memo(function InputBar({
     }
 
     const { mentions: rawMentions, markdown } = markdownAndMentions;
-    const mentions = _.uniqBy(rawMentions, "id");
+    const singleAgentInput = isSingleAgentInputEnabled();
+    // When single-agent input is enabled, inject the selected agent into mentions
+    // since it's no longer in the editor as a mention node.
+    const allMentions =
+      singleAgentInput &&
+      selectedAgent &&
+      !rawMentions.some((m) => m.id === selectedAgent.id)
+        ? [selectedAgent, ...rawMentions]
+        : rawMentions;
+    const mentions = _.uniqBy(allMentions, "id");
 
     const uploadedFiles = fileUploaderService.getFileBlobs();
     const mentionedAgents = agentConfigurations.filter((a) =>
@@ -289,6 +265,7 @@ export const InputBar = React.memo(function InputBar({
           clearDraft();
           resetEditorText();
           fileUploaderService.resetUpload();
+          setSelectedAgent(null);
         }
       } finally {
         setLoading(false);
@@ -315,6 +292,7 @@ export const InputBar = React.memo(function InputBar({
         clearDraft();
         fileUploaderService.resetUpload();
         setAttachedNodes([]);
+        setSelectedAgent(null);
 
         await submitPromise;
       } finally {
@@ -362,7 +340,7 @@ export const InputBar = React.memo(function InputBar({
                 "focus-within:border-highlight-300",
                 "dark:focus-within:border-highlight-300-night"
               ),
-          isAnimating ? "duration-600 animate-shake" : "duration-300"
+          "duration-300"
         )}
       >
         <div className="relative flex w-full flex-1 flex-col">

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -199,12 +199,14 @@ export const InputBar = React.memo(function InputBar({
     const singleAgentInput = isSingleAgentInputEnabled();
     // When single-agent input is enabled, inject the selected agent into mentions
     // since it's no longer in the editor as a mention node.
-    const allMentions =
+    const shouldInjectSelectedAgent =
       singleAgentInput &&
       selectedAgent &&
-      !rawMentions.some((m) => m.id === selectedAgent.id)
-        ? [selectedAgent, ...rawMentions]
-        : rawMentions;
+      !rawMentions.some((m) => m.id === selectedAgent.id);
+      
+    const allMentions = shouldInjectSelectedAgent
+      ? [selectedAgent, ...rawMentions]
+      : rawMentions;
     const mentions = _.uniqBy(allMentions, "id");
 
     const uploadedFiles = fileUploaderService.getFileBlobs();
@@ -265,7 +267,6 @@ export const InputBar = React.memo(function InputBar({
           clearDraft();
           resetEditorText();
           fileUploaderService.resetUpload();
-          setSelectedAgent(null);
         }
       } finally {
         setLoading(false);
@@ -292,7 +293,6 @@ export const InputBar = React.memo(function InputBar({
         clearDraft();
         fileUploaderService.resetUpload();
         setAttachedNodes([]);
-        setSelectedAgent(null);
 
         await submitPromise;
       } finally {

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -31,7 +31,7 @@ interface InputBarButtonsProps {
   editorService: ReturnType<typeof useCustomEditor>["editorService"];
   fileInputRef: React.MutableRefObject<HTMLInputElement | null>;
   fileUploaderService: FileUploaderService;
-  handleAgentSelect: (mention: RichMention) => void;
+  handleSingleAgentSelect: (mention: RichMention) => void;
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
@@ -56,7 +56,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   editorService,
   fileInputRef,
   fileUploaderService,
-  handleAgentSelect,
+  handleSingleAgentSelect,
   onMCPServerViewSelect,
   onNodeSelect,
   onNodeUnselect,
@@ -76,7 +76,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       size={buttonSize}
       onItemClick={(c) => {
         if (singleAgentInput) {
-          handleAgentSelect(toRichAgentMentionType(c));
+          handleSingleAgentSelect(toRichAgentMentionType(c));
         } else {
           editorService.insertMention(toRichAgentMentionType(c));
         }

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -1,0 +1,171 @@
+import { AgentPicker } from "@app/components/assistant/AgentPicker";
+import { CapabilitiesPicker } from "@app/components/assistant/CapabilitiesPicker";
+import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
+import type { InputBarAction } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
+import type useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
+import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type {
+  RichAgentMention,
+  RichMention,
+} from "@app/types/assistant/mentions";
+import { toRichAgentMentionType } from "@app/types/assistant/mentions";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { DataSourceViewContentNode } from "@app/types/data_source_view";
+import { getSupportedFileExtensions } from "@app/types/files";
+import type { SpaceType } from "@app/types/space";
+import type { UserType, WorkspaceType } from "@app/types/user";
+import { Avatar, Button, RobotIcon } from "@dust-tt/sparkle";
+import React from "react";
+
+interface InputBarButtonsProps {
+  actions: InputBarAction[];
+  allAgents: LightAgentConfigurationType[];
+  attachedNodes: DataSourceViewContentNode[];
+  buttonSize: "xs" | "sm";
+  clientType: string;
+  conversation?: ConversationWithoutContentType;
+  disableInput: boolean;
+  editorService: ReturnType<typeof useCustomEditor>["editorService"];
+  fileInputRef: React.MutableRefObject<HTMLInputElement | null>;
+  fileUploaderService: FileUploaderService;
+  handleAgentSelect: (mention: RichMention) => void;
+  onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
+  onNodeSelect: (node: DataSourceViewContentNode) => void;
+  onNodeUnselect: (node: DataSourceViewContentNode) => void;
+  onSkillSelect: (skill: SkillType) => void;
+  owner: WorkspaceType;
+  selectedAgent: RichAgentMention | null;
+  selectedMCPServerViews: MCPServerViewType[];
+  selectedSkills: SkillType[];
+  singleAgentInput: boolean;
+  space: SpaceType | undefined;
+  user: UserType | null;
+}
+
+export const InputBarButtons = React.memo(function InputBarButtons({
+  actions,
+  allAgents,
+  attachedNodes,
+  buttonSize,
+  clientType,
+  conversation,
+  disableInput,
+  editorService,
+  fileInputRef,
+  fileUploaderService,
+  handleAgentSelect,
+  onMCPServerViewSelect,
+  onNodeSelect,
+  onNodeUnselect,
+  onSkillSelect,
+  owner,
+  selectedAgent,
+  selectedMCPServerViews,
+  selectedSkills,
+  singleAgentInput,
+  space,
+  user,
+}: InputBarButtonsProps) {
+  const agentButton = (actions.includes("agents-list") ||
+    actions.includes("agents-list-with-actions")) && (
+    <AgentPicker
+      owner={owner}
+      size={buttonSize}
+      onItemClick={(c) => {
+        if (singleAgentInput) {
+          handleAgentSelect(toRichAgentMentionType(c));
+        } else {
+          editorService.insertMention(toRichAgentMentionType(c));
+        }
+      }}
+      agents={allAgents}
+      showDropdownArrow={false}
+      showFooterButtons={
+        actions.includes("agents-list-with-actions") &&
+        clientType !== "extension"
+      }
+      disabled={disableInput}
+      pickerButton={
+        singleAgentInput ? (
+          selectedAgent ? (
+            <Button
+              variant="ghost-secondary"
+              size={buttonSize}
+              icon={() => (
+                <Avatar size="xxs" visual={selectedAgent.pictureUrl} />
+              )}
+              label={selectedAgent.label}
+            />
+          ) : (
+            <Button
+              variant="ghost-secondary"
+              size={buttonSize}
+              icon={RobotIcon}
+              label="Agent"
+            />
+          )
+        ) : undefined
+      }
+    />
+  );
+  const toolsButton = actions.includes("capabilities") && (
+    <CapabilitiesPicker
+      owner={owner}
+      user={user}
+      selectedMCPServerViews={selectedMCPServerViews}
+      onSelect={onMCPServerViewSelect}
+      selectedSkills={selectedSkills}
+      onSkillSelect={onSkillSelect}
+      disabled={disableInput}
+      buttonSize={buttonSize}
+    />
+  );
+  const attachmentButton = actions.includes("attachment") &&
+    clientType !== "extension" && (
+      <>
+        <input
+          accept={getSupportedFileExtensions().join(",")}
+          onChange={async (e) => {
+            await fileUploaderService.handleFileChange(e);
+            if (fileInputRef.current) {
+              fileInputRef.current.value = "";
+            }
+            editorService.focusEnd();
+          }}
+          ref={fileInputRef}
+          style={{ display: "none" }}
+          type="file"
+          multiple={true}
+        />
+        <InputBarAttachmentsPicker
+          fileUploaderService={fileUploaderService}
+          owner={owner}
+          isLoading={false}
+          onNodeSelect={onNodeSelect}
+          onNodeUnselect={onNodeUnselect}
+          attachedNodes={attachedNodes}
+          disabled={disableInput}
+          buttonSize={buttonSize}
+          conversation={conversation}
+          space={space}
+          type="dropdown"
+        />
+      </>
+    );
+  return singleAgentInput ? (
+    <>
+      {agentButton}
+      {toolsButton}
+      {attachmentButton}
+    </>
+  ) : (
+    <>
+      {attachmentButton}
+      {toolsButton}
+      {agentButton}
+    </>
+  );
+});

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -150,7 +150,7 @@ const InputBarContainer = ({
 
   // Callback for the editor's @ mention suggestion — sets the selected agent
   // without focusing (the editor already has focus when the user types @).
-  const onAgentSelect = (mention: RichMention) => {
+  const onSingleAgentSelect = (mention: RichMention) => {
     if (isRichAgentMention(mention)) {
       setSelectedSingleAgent(mention);
     }
@@ -330,7 +330,7 @@ const InputBarContainer = ({
     disableAutoFocus,
     disableUserMentions,
     onUrlDetected: handleUrlDetected,
-    onAgentSelect,
+    onAgentSelect: onSingleAgentSelect,
     singleAgentInputEnabled: singleAgentInput,
     owner,
     conversationId: conversation?.sId,
@@ -414,7 +414,7 @@ const InputBarContainer = ({
             if (singleAgentInput) {
               const agent = allAgents.find((a) => a.sId === message.id);
               if (agent) {
-                handleAgentSelect(toRichAgentMentionType(agent));
+                handleSingleAgentSelect(toRichAgentMentionType(agent));
               }
             } else {
               editorService.insertMention({
@@ -580,7 +580,7 @@ const InputBarContainer = ({
   // the input bar), we grab it back.
   const { animate, captureActions } = useContext(InputBarContext);
 
-  const handleAgentSelect = useCallback(
+  const handleSingleAgentSelect = useCallback(
     (mention: RichMention) => {
       if (isRichAgentMention(mention)) {
         setSelectedSingleAgent(mention);
@@ -869,7 +869,7 @@ const InputBarContainer = ({
                     editorService={editorService}
                     fileInputRef={fileInputRef}
                     fileUploaderService={fileUploaderService}
-                    handleAgentSelect={handleAgentSelect}
+                    handleSingleAgentSelect={handleSingleAgentSelect}
                     onMCPServerViewSelect={onMCPServerViewSelect}
                     onNodeSelect={onNodeSelect}
                     onNodeUnselect={onNodeUnselect}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -145,13 +145,14 @@ const InputBarContainer = ({
   const { subscription } = useAuth();
   const isMobile = useIsMobile();
   const singleAgentInput = isSingleAgentInputEnabled();
-  const { setSelectedAgent } = useContext(InputBarContext);
+  const { singleAgentSelection, setSingleAgentSelection } =
+    useContext(InputBarContext);
 
   // Callback for the editor's @ mention suggestion — sets the selected agent
   // without focusing (the editor already has focus when the user types @).
   const onAgentSelect = (mention: RichMention) => {
     if (isRichAgentMention(mention)) {
-      setSelectedAgent(mention);
+      setSingleAgentSelection(mention);
     }
   };
 
@@ -582,11 +583,11 @@ const InputBarContainer = ({
   const handleAgentSelect = useCallback(
     (mention: RichMention) => {
       if (isRichAgentMention(mention)) {
-        setSelectedAgent(mention);
+        setSingleAgentSelection(mention);
         editorService.focusEnd();
       }
     },
-    [setSelectedAgent, editorService]
+    [setSingleAgentSelection, editorService]
   );
 
   const isMac = useMemo(() => {
@@ -874,7 +875,7 @@ const InputBarContainer = ({
                     onNodeUnselect={onNodeUnselect}
                     onSkillSelect={onSkillSelect}
                     owner={owner}
-                    selectedAgent={selectedAgent}
+                    selectedAgent={singleAgentSelection}
                     selectedMCPServerViews={selectedMCPServerViews}
                     selectedSkills={selectedSkills}
                     singleAgentInput={singleAgentInput}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -404,7 +404,6 @@ const InputBarContainer = ({
     owner,
     fileUploaderService,
     onTranscribeComplete: (transcript) => {
-      let lastAgentMention: RichAgentMention | null = null;
       for (const message of transcript) {
         switch (message.type) {
           case "text":
@@ -414,7 +413,7 @@ const InputBarContainer = ({
             if (singleAgentInput) {
               const agent = allAgents.find((a) => a.sId === message.id);
               if (agent) {
-                lastAgentMention = toRichAgentMentionType(agent);
+                handleAgentSelect(toRichAgentMentionType(agent));
               }
             } else {
               editorService.insertMention({
@@ -428,9 +427,6 @@ const InputBarContainer = ({
           default:
             assertNever(message);
         }
-      }
-      if (singleAgentInput && lastAgentMention) {
-        handleAgentSelect(lastAgentMention);
       }
     },
     onError: (error) => {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -153,14 +153,11 @@ const InputBarContainer = ({
 
   // Callback for the editor's @ mention suggestion — sets the selected agent
   // without focusing (the editor already has focus when the user types @).
-  const onAgentSelect = useCallback(
-    (mention: RichMention) => {
-      if (isRichAgentMention(mention)) {
-        setSelectedAgent(mention);
-      }
-    },
-    [setSelectedAgent]
-  );
+  const onAgentSelect = (mention: RichMention) => {
+    if (isRichAgentMention(mention)) {
+      setSelectedAgent(mention);
+    }
+  };
 
   const [nodeOrUrlCandidate, setNodeOrUrlCandidate] = useState<
     UrlCandidate | NodeCandidate | null

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -145,14 +145,14 @@ const InputBarContainer = ({
   const { subscription } = useAuth();
   const isMobile = useIsMobile();
   const singleAgentInput = isSingleAgentInputEnabled();
-  const { singleAgentSelection, setSingleAgentSelection } =
+  const { selectedSingleAgent, setSelectedSingleAgent } =
     useContext(InputBarContext);
 
   // Callback for the editor's @ mention suggestion — sets the selected agent
   // without focusing (the editor already has focus when the user types @).
   const onAgentSelect = (mention: RichMention) => {
     if (isRichAgentMention(mention)) {
-      setSingleAgentSelection(mention);
+      setSelectedSingleAgent(mention);
     }
   };
 
@@ -583,11 +583,11 @@ const InputBarContainer = ({
   const handleAgentSelect = useCallback(
     (mention: RichMention) => {
       if (isRichAgentMention(mention)) {
-        setSingleAgentSelection(mention);
+        setSelectedSingleAgent(mention);
         editorService.focusEnd();
       }
     },
-    [setSingleAgentSelection, editorService]
+    [setSelectedSingleAgent, editorService]
   );
 
   const isMac = useMemo(() => {
@@ -875,7 +875,7 @@ const InputBarContainer = ({
                     onNodeUnselect={onNodeUnselect}
                     onSkillSelect={onSkillSelect}
                     owner={owner}
-                    selectedAgent={singleAgentSelection}
+                    selectedAgent={selectedSingleAgent}
                     selectedMCPServerViews={selectedMCPServerViews}
                     selectedSkills={selectedSkills}
                     singleAgentInput={singleAgentInput}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,6 +1,5 @@
-import { AgentPicker } from "@app/components/assistant/AgentPicker";
-import { CapabilitiesPicker } from "@app/components/assistant/CapabilitiesPicker";
 import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
+import { InputBarButtons } from "@app/components/assistant/conversation/input_bar/InputBarButtons";
 import {
   getDisplayNameFromPastedFileId,
   getPastedFileName,
@@ -38,7 +37,6 @@ import {
 } from "@app/types/assistant/mentions";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
-import { getSupportedFileExtensions } from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { SpaceType } from "@app/types/space";
@@ -47,7 +45,6 @@ import { isBuilder } from "@app/types/user";
 import {
   ArrowUpIcon,
   AttachmentIcon,
-  Avatar,
   Button,
   CameraIcon,
   Chip,
@@ -59,7 +56,6 @@ import {
   DropdownMenuTrigger,
   GlobeAltIcon,
   PlusIcon,
-  RobotIcon,
   TextIcon,
   Toolbar,
   VoicePicker,
@@ -865,112 +861,30 @@ const InputBarContainer = ({
                     className={cn("flex", !isMobile && "hidden")}
                     onClick={() => setIsToolbarOpen(!isToolbarOpen)}
                   />
-                  {(() => {
-                    const agentButton = (actions.includes("agents-list") ||
-                      actions.includes("agents-list-with-actions")) && (
-                      <AgentPicker
-                        owner={owner}
-                        size={buttonSize}
-                        onItemClick={(c) => {
-                          if (singleAgentInput) {
-                            handleAgentSelect(toRichAgentMentionType(c));
-                          } else {
-                            editorService.insertMention(
-                              toRichAgentMentionType(c)
-                            );
-                          }
-                        }}
-                        agents={allAgents}
-                        showDropdownArrow={false}
-                        showFooterButtons={
-                          actions.includes("agents-list-with-actions") &&
-                          clientType !== "extension"
-                        }
-                        disabled={disableInput}
-                        pickerButton={
-                          singleAgentInput ? (
-                            selectedAgent ? (
-                              <Button
-                                variant="ghost-secondary"
-                                size={buttonSize}
-                                icon={() => (
-                                  <Avatar
-                                    size="xxs"
-                                    visual={selectedAgent.pictureUrl}
-                                  />
-                                )}
-                                label={selectedAgent.label}
-                              />
-                            ) : (
-                              <Button
-                                variant="ghost-secondary"
-                                size={buttonSize}
-                                icon={RobotIcon}
-                                label="Agent"
-                              />
-                            )
-                          ) : undefined
-                        }
-                      />
-                    );
-                    const toolsButton = actions.includes("capabilities") && (
-                      <CapabilitiesPicker
-                        owner={owner}
-                        user={user}
-                        selectedMCPServerViews={selectedMCPServerViews}
-                        onSelect={onMCPServerViewSelect}
-                        selectedSkills={selectedSkills}
-                        onSkillSelect={onSkillSelect}
-                        disabled={disableInput}
-                        buttonSize={buttonSize}
-                      />
-                    );
-                    const attachmentButton = actions.includes("attachment") &&
-                      clientType !== "extension" && (
-                        <>
-                          <input
-                            accept={getSupportedFileExtensions().join(",")}
-                            onChange={async (e) => {
-                              await fileUploaderService.handleFileChange(e);
-                              if (fileInputRef.current) {
-                                fileInputRef.current.value = "";
-                              }
-                              editorService.focusEnd();
-                            }}
-                            ref={fileInputRef}
-                            style={{ display: "none" }}
-                            type="file"
-                            multiple={true}
-                          />
-                          <InputBarAttachmentsPicker
-                            fileUploaderService={fileUploaderService}
-                            owner={owner}
-                            isLoading={false}
-                            onNodeSelect={onNodeSelect}
-                            onNodeUnselect={onNodeUnselect}
-                            attachedNodes={attachedNodes}
-                            disabled={disableInput}
-                            buttonSize={buttonSize}
-                            conversation={conversation}
-                            space={space}
-                            type="dropdown"
-                          />
-                        </>
-                      );
-                    return singleAgentInput ? (
-                      <>
-                        {agentButton}
-                        {toolsButton}
-                        {attachmentButton}
-                      </>
-                    ) : (
-                      <>
-                        {attachmentButton}
-                        {toolsButton}
-                        {agentButton}
-                      </>
-                    );
-                  })()}
+                  <InputBarButtons
+                    actions={actions}
+                    allAgents={allAgents}
+                    attachedNodes={attachedNodes}
+                    buttonSize={buttonSize}
+                    clientType={clientType}
+                    conversation={conversation}
+                    disableInput={disableInput}
+                    editorService={editorService}
+                    fileInputRef={fileInputRef}
+                    fileUploaderService={fileUploaderService}
+                    handleAgentSelect={handleAgentSelect}
+                    onMCPServerViewSelect={onMCPServerViewSelect}
+                    onNodeSelect={onNodeSelect}
+                    onNodeUnselect={onNodeUnselect}
+                    onSkillSelect={onSkillSelect}
+                    owner={owner}
+                    selectedAgent={selectedAgent}
+                    selectedMCPServerViews={selectedMCPServerViews}
+                    selectedSkills={selectedSkills}
+                    singleAgentInput={singleAgentInput}
+                    space={space}
+                    user={user}
+                  />
                 </div>
               )}
               <div className="grow" />

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -20,6 +20,7 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
+import { isSingleAgentInputEnabled } from "@app/lib/development";
 import { getSkillIcon } from "@app/lib/skill";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -31,7 +32,10 @@ import type {
   RichAgentMention,
   RichMention,
 } from "@app/types/assistant/mentions";
-import { toRichAgentMentionType } from "@app/types/assistant/mentions";
+import {
+  isRichAgentMention,
+  toRichAgentMentionType,
+} from "@app/types/assistant/mentions";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { getSupportedFileExtensions } from "@app/types/files";
@@ -43,6 +47,7 @@ import { isBuilder } from "@app/types/user";
 import {
   ArrowUpIcon,
   AttachmentIcon,
+  Avatar,
   Button,
   CameraIcon,
   Chip,
@@ -54,6 +59,7 @@ import {
   DropdownMenuTrigger,
   GlobeAltIcon,
   PlusIcon,
+  RobotIcon,
   TextIcon,
   Toolbar,
   VoicePicker,
@@ -142,6 +148,19 @@ const InputBarContainer = ({
 }: InputBarContainerProps) => {
   const { subscription } = useAuth();
   const isMobile = useIsMobile();
+  const singleAgentInput = isSingleAgentInputEnabled();
+  const { setSelectedAgent } = useContext(InputBarContext);
+
+  // Callback for the editor's @ mention suggestion — sets the selected agent
+  // without focusing (the editor already has focus when the user types @).
+  const onAgentSelect = useCallback(
+    (mention: RichMention) => {
+      if (isRichAgentMention(mention)) {
+        setSelectedAgent(mention);
+      }
+    },
+    [setSelectedAgent]
+  );
 
   const [nodeOrUrlCandidate, setNodeOrUrlCandidate] = useState<
     UrlCandidate | NodeCandidate | null
@@ -317,6 +336,8 @@ const InputBarContainer = ({
     disableAutoFocus,
     disableUserMentions,
     onUrlDetected: handleUrlDetected,
+    onAgentSelect,
+    singleAgentInputEnabled: singleAgentInput,
     owner,
     conversationId: conversation?.sId,
     spaceId: space?.sId,
@@ -390,21 +411,33 @@ const InputBarContainer = ({
     owner,
     fileUploaderService,
     onTranscribeComplete: (transcript) => {
+      let lastAgentMention: RichAgentMention | null = null;
       for (const message of transcript) {
         switch (message.type) {
           case "text":
             editorService.insertText(message.text);
             break;
-          case "mention":
-            editorService.insertMention({
-              type: "agent",
-              id: message.id,
-              label: message.name,
-            });
+          case "mention": {
+            if (singleAgentInput) {
+              const agent = allAgents.find((a) => a.sId === message.id);
+              if (agent) {
+                lastAgentMention = toRichAgentMentionType(agent);
+              }
+            } else {
+              editorService.insertMention({
+                type: "agent",
+                id: message.id,
+                label: message.name,
+              });
+            }
             break;
+          }
           default:
             assertNever(message);
         }
+      }
+      if (singleAgentInput && lastAgentMention) {
+        handleAgentSelect(lastAgentMention);
       }
     },
     onError: (error) => {
@@ -556,6 +589,16 @@ const InputBarContainer = ({
   // When input bar animation is requested, it means the new button was clicked (removing focus from
   // the input bar), we grab it back.
   const { animate, captureActions } = useContext(InputBarContext);
+
+  const handleAgentSelect = useCallback(
+    (mention: RichMention) => {
+      if (isRichAgentMention(mention)) {
+        setSelectedAgent(mention);
+        editorService.focusEnd();
+      }
+    },
+    [setSelectedAgent, editorService]
+  );
 
   const isMac = useMemo(() => {
     if (typeof window === "undefined") {
@@ -825,67 +868,112 @@ const InputBarContainer = ({
                     className={cn("flex", !isMobile && "hidden")}
                     onClick={() => setIsToolbarOpen(!isToolbarOpen)}
                   />
-                  {actions.includes("attachment") &&
-                    clientType !== "extension" && (
+                  {(() => {
+                    const agentButton = (actions.includes("agents-list") ||
+                      actions.includes("agents-list-with-actions")) && (
+                      <AgentPicker
+                        owner={owner}
+                        size={buttonSize}
+                        onItemClick={(c) => {
+                          if (singleAgentInput) {
+                            handleAgentSelect(toRichAgentMentionType(c));
+                          } else {
+                            editorService.insertMention(
+                              toRichAgentMentionType(c)
+                            );
+                          }
+                        }}
+                        agents={allAgents}
+                        showDropdownArrow={false}
+                        showFooterButtons={
+                          actions.includes("agents-list-with-actions") &&
+                          clientType !== "extension"
+                        }
+                        disabled={disableInput}
+                        pickerButton={
+                          singleAgentInput ? (
+                            selectedAgent ? (
+                              <Button
+                                variant="ghost-secondary"
+                                size={buttonSize}
+                                icon={() => (
+                                  <Avatar
+                                    size="xxs"
+                                    visual={selectedAgent.pictureUrl}
+                                  />
+                                )}
+                                label={selectedAgent.label}
+                              />
+                            ) : (
+                              <Button
+                                variant="ghost-secondary"
+                                size={buttonSize}
+                                icon={RobotIcon}
+                                label="Agent"
+                              />
+                            )
+                          ) : undefined
+                        }
+                      />
+                    );
+                    const toolsButton = actions.includes("capabilities") && (
+                      <CapabilitiesPicker
+                        owner={owner}
+                        user={user}
+                        selectedMCPServerViews={selectedMCPServerViews}
+                        onSelect={onMCPServerViewSelect}
+                        selectedSkills={selectedSkills}
+                        onSkillSelect={onSkillSelect}
+                        disabled={disableInput}
+                        buttonSize={buttonSize}
+                      />
+                    );
+                    const attachmentButton = actions.includes("attachment") &&
+                      clientType !== "extension" && (
+                        <>
+                          <input
+                            accept={getSupportedFileExtensions().join(",")}
+                            onChange={async (e) => {
+                              await fileUploaderService.handleFileChange(e);
+                              if (fileInputRef.current) {
+                                fileInputRef.current.value = "";
+                              }
+                              editorService.focusEnd();
+                            }}
+                            ref={fileInputRef}
+                            style={{ display: "none" }}
+                            type="file"
+                            multiple={true}
+                          />
+                          <InputBarAttachmentsPicker
+                            fileUploaderService={fileUploaderService}
+                            owner={owner}
+                            isLoading={false}
+                            onNodeSelect={onNodeSelect}
+                            onNodeUnselect={onNodeUnselect}
+                            attachedNodes={attachedNodes}
+                            disabled={disableInput}
+                            buttonSize={buttonSize}
+                            conversation={conversation}
+                            space={space}
+                            type="dropdown"
+                          />
+                        </>
+                      );
+                    return singleAgentInput ? (
                       <>
-                        <input
-                          accept={getSupportedFileExtensions().join(",")}
-                          onChange={async (e) => {
-                            await fileUploaderService.handleFileChange(e);
-                            if (fileInputRef.current) {
-                              fileInputRef.current.value = "";
-                            }
-                            editorService.focusEnd();
-                          }}
-                          ref={fileInputRef}
-                          style={{ display: "none" }}
-                          type="file"
-                          multiple={true}
-                        />
-                        <InputBarAttachmentsPicker
-                          fileUploaderService={fileUploaderService}
-                          owner={owner}
-                          isLoading={false}
-                          onNodeSelect={onNodeSelect}
-                          onNodeUnselect={onNodeUnselect}
-                          attachedNodes={attachedNodes}
-                          disabled={disableInput}
-                          buttonSize={buttonSize}
-                          conversation={conversation}
-                          space={space}
-                          type="dropdown"
-                        />
+                        {agentButton}
+                        {toolsButton}
+                        {attachmentButton}
                       </>
-                    )}
-                  {actions.includes("capabilities") && (
-                    <CapabilitiesPicker
-                      owner={owner}
-                      user={user}
-                      selectedMCPServerViews={selectedMCPServerViews}
-                      onSelect={onMCPServerViewSelect}
-                      selectedSkills={selectedSkills}
-                      onSkillSelect={onSkillSelect}
-                      disabled={disableInput}
-                      buttonSize={buttonSize}
-                    />
-                  )}
-                  {(actions.includes("agents-list") ||
-                    actions.includes("agents-list-with-actions")) && (
-                    <AgentPicker
-                      owner={owner}
-                      size={buttonSize}
-                      onItemClick={(c) => {
-                        editorService.insertMention(toRichAgentMentionType(c));
-                      }}
-                      agents={allAgents}
-                      showDropdownArrow={false}
-                      showFooterButtons={
-                        actions.includes("agents-list-with-actions") &&
-                        clientType !== "extension"
-                      }
-                      disabled={disableInput}
-                    />
-                  )}
+                    ) : (
+                      <>
+                        {attachmentButton}
+                        {toolsButton}
+                        {agentButton}
+                      </>
+                    );
+                  })()}
                 </div>
               )}
               <div className="grow" />

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -15,7 +15,7 @@ import {
 
 export const InputBarContext = createContext<{
   animate: boolean;
-  getAndClearSelectedAgent: () => RichAgentMention | null;
+  selectedAgent: RichAgentMention | null;
   setAnimate: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
   getAndClearPendingInputText: () => string | null;
@@ -27,7 +27,7 @@ export const InputBarContext = createContext<{
   };
 }>({
   animate: false,
-  getAndClearSelectedAgent: () => null,
+  selectedAgent: null,
   setAnimate: () => {},
   setSelectedAgent: () => {},
   getAndClearPendingInputText: () => null,
@@ -84,14 +84,6 @@ export function InputBarContextProvider({
     [setSelectedAgent]
   );
 
-  // Immediately clear the selected agent and return the previous selected agent to avoid sticky agent mentions.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
-  const getAndClearSelectedAgent = useCallback(() => {
-    const previousSelectedAgent = selectedAgent;
-    setSelectedAgent(null);
-    return previousSelectedAgent;
-  }, [selectedAgent, setSelectedAgent]);
-
   const getAndClearPendingInputText = useCallback(() => {
     const text = pendingInputText;
     setPendingInputTextState(null);
@@ -106,7 +98,7 @@ export function InputBarContextProvider({
     () => ({
       animate,
       setAnimate,
-      getAndClearSelectedAgent,
+      selectedAgent,
       setSelectedAgent: setSelectedAgentOuter,
       getAndClearPendingInputText,
       setPendingInputText,
@@ -115,7 +107,7 @@ export function InputBarContextProvider({
     }),
     [
       animate,
-      getAndClearSelectedAgent,
+      selectedAgent,
       setSelectedAgentOuter,
       getAndClearPendingInputText,
       setPendingInputText,

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -18,8 +18,8 @@ export const InputBarContext = createContext<{
   getAndClearSelectedAgent: () => RichAgentMention | null;
   setAnimate: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
-  singleAgentSelection: RichAgentMention | null;
-  setSingleAgentSelection: (agentMention: RichAgentMention | null) => void;
+  selectedSingleAgent: RichAgentMention | null;
+  setSelectedSingleAgent: (agentMention: RichAgentMention | null) => void;
   getAndClearPendingInputText: () => string | null;
   setPendingInputText: (text: string | null) => void;
   fileUploaderService: FileUploaderService;
@@ -32,8 +32,8 @@ export const InputBarContext = createContext<{
   getAndClearSelectedAgent: () => null,
   setAnimate: () => {},
   setSelectedAgent: () => {},
-  singleAgentSelection: null,
-  setSingleAgentSelection: () => {},
+  selectedSingleAgent: null,
+  setSelectedSingleAgent: () => {},
   getAndClearPendingInputText: () => null,
   setPendingInputText: () => {},
   fileUploaderService: {
@@ -71,7 +71,7 @@ export function InputBarContextProvider({
   );
 
   // Persistent agent selection for single-agent input mode (displayed in the agent picker button).
-  const [singleAgentSelection, setSingleAgentSelection] =
+  const [selectedSingleAgent, setSelectedSingleAgent] =
     useState<RichAgentMention | null>(null);
 
   // Useful when a component needs to pre-fill the input bar with text (e.g. butler suggestions).
@@ -116,8 +116,8 @@ export function InputBarContextProvider({
       setAnimate,
       getAndClearSelectedAgent,
       setSelectedAgent: setSelectedAgentOuter,
-      singleAgentSelection,
-      setSingleAgentSelection,
+      selectedSingleAgent,
+      setSelectedSingleAgent,
       getAndClearPendingInputText,
       setPendingInputText,
       captureActions,
@@ -127,7 +127,7 @@ export function InputBarContextProvider({
       animate,
       getAndClearSelectedAgent,
       setSelectedAgentOuter,
-      singleAgentSelection,
+      selectedSingleAgent,
       getAndClearPendingInputText,
       setPendingInputText,
       captureActions,

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -15,9 +15,11 @@ import {
 
 export const InputBarContext = createContext<{
   animate: boolean;
-  selectedAgent: RichAgentMention | null;
+  getAndClearSelectedAgent: () => RichAgentMention | null;
   setAnimate: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
+  singleAgentSelection: RichAgentMention | null;
+  setSingleAgentSelection: (agentMention: RichAgentMention | null) => void;
   getAndClearPendingInputText: () => string | null;
   setPendingInputText: (text: string | null) => void;
   fileUploaderService: FileUploaderService;
@@ -27,9 +29,11 @@ export const InputBarContext = createContext<{
   };
 }>({
   animate: false,
-  selectedAgent: null,
+  getAndClearSelectedAgent: () => null,
   setAnimate: () => {},
   setSelectedAgent: () => {},
+  singleAgentSelection: null,
+  setSingleAgentSelection: () => {},
   getAndClearPendingInputText: () => null,
   setPendingInputText: () => {},
   fileUploaderService: {
@@ -66,6 +70,10 @@ export function InputBarContextProvider({
     null
   );
 
+  // Persistent agent selection for single-agent input mode (displayed in the agent picker button).
+  const [singleAgentSelection, setSingleAgentSelection] =
+    useState<RichAgentMention | null>(null);
+
   // Useful when a component needs to pre-fill the input bar with text (e.g. butler suggestions).
   const [pendingInputText, setPendingInputTextState] = useState<string | null>(
     null
@@ -84,6 +92,14 @@ export function InputBarContextProvider({
     [setSelectedAgent]
   );
 
+  // Immediately clear the selected agent and return the previous selected agent to avoid sticky agent mentions.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
+  const getAndClearSelectedAgent = useCallback(() => {
+    const previousSelectedAgent = selectedAgent;
+    setSelectedAgent(null);
+    return previousSelectedAgent;
+  }, [selectedAgent, setSelectedAgent]);
+
   const getAndClearPendingInputText = useCallback(() => {
     const text = pendingInputText;
     setPendingInputTextState(null);
@@ -98,8 +114,10 @@ export function InputBarContextProvider({
     () => ({
       animate,
       setAnimate,
-      selectedAgent,
+      getAndClearSelectedAgent,
       setSelectedAgent: setSelectedAgentOuter,
+      singleAgentSelection,
+      setSingleAgentSelection,
       getAndClearPendingInputText,
       setPendingInputText,
       captureActions,
@@ -107,8 +125,9 @@ export function InputBarContextProvider({
     }),
     [
       animate,
-      selectedAgent,
+      getAndClearSelectedAgent,
       setSelectedAgentOuter,
+      singleAgentSelection,
       getAndClearPendingInputText,
       setPendingInputText,
       captureActions,

--- a/front/components/editor/input_bar/mentionSuggestion.tsx
+++ b/front/components/editor/input_bar/mentionSuggestion.tsx
@@ -21,6 +21,8 @@ export function createMentionSuggestion({
   spaceId,
   select,
   includeCurrentUser = false,
+  onAgentSelect,
+  singleAgentInputEnabled,
 }: {
   owner: WorkspaceType;
   conversationId?: string | null;
@@ -30,12 +32,35 @@ export function createMentionSuggestion({
     agents: boolean;
     users: boolean;
   };
+  onAgentSelect?: (mention: RichMention) => void;
+  singleAgentInputEnabled?: boolean;
 }) {
   return {
     pluginKey: mentionPluginKey,
     // Ensure queries can contain spaces (e.g., @Sales Team → decomposes to
     // text and keeps the dropdown active over the full label).
     allowSpaces: true,
+
+    // Override the default command to intercept agent mentions and redirect them
+    // to the picker button instead of inserting them into the editor.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    command: ({ editor, range, props }: any) => {
+      const mention = props as RichMention;
+      if (mention.type === "agent" && singleAgentInputEnabled && onAgentSelect) {
+        // Delete the @query text without inserting a mention node.
+        editor.chain().focus().deleteRange(range).run();
+        onAgentSelect(mention);
+      } else {
+        // Default: insert mention node (user mentions).
+        editor
+          .chain()
+          .focus()
+          .deleteRange(range)
+          .insertContent({ type: "mention", attrs: props })
+          .insertContent(" ")
+          .run();
+      }
+    },
 
     render: () => {
       let component: ReactRenderer<

--- a/front/components/editor/input_bar/mentionSuggestion.tsx
+++ b/front/components/editor/input_bar/mentionSuggestion.tsx
@@ -46,7 +46,11 @@ export function createMentionSuggestion({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     command: ({ editor, range, props }: any) => {
       const mention = props as RichMention;
-      if (mention.type === "agent" && singleAgentInputEnabled && onAgentSelect) {
+      if (
+        mention.type === "agent" &&
+        singleAgentInputEnabled &&
+        onAgentSelect
+      ) {
         // Delete the @query text without inserting a mention node.
         editor.chain().focus().deleteRange(range).run();
         onAgentSelect(mention);

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -176,6 +176,8 @@ export interface CustomEditorProps {
   disableAutoFocus: boolean;
   disableUserMentions?: boolean;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
+  onAgentSelect?: (mention: RichMention) => void;
+  singleAgentInputEnabled?: boolean;
   owner: WorkspaceType;
   conversationId?: string | null;
   spaceId?: string;
@@ -196,6 +198,8 @@ export const buildEditorExtensions = ({
   disableUserMentions,
   onInlineText,
   onUrlDetected,
+  onAgentSelect,
+  singleAgentInputEnabled,
 }: {
   owner: WorkspaceType;
   conversationId?: string | null;
@@ -203,6 +207,8 @@ export const buildEditorExtensions = ({
   disableUserMentions?: boolean;
   onInlineText?: (fileId: string, textContent: string) => void;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
+  onAgentSelect?: (mention: RichMention) => void;
+  singleAgentInputEnabled?: boolean;
 }) => {
   const extensions = [
     KeyboardShortcutsExtension,
@@ -276,6 +282,8 @@ export const buildEditorExtensions = ({
           agents: true,
           users: !disableUserMentions,
         },
+        onAgentSelect,
+        singleAgentInputEnabled,
       }),
     }),
     EmojiExtension,
@@ -310,6 +318,8 @@ const useCustomEditor = ({
   disableAutoFocus,
   disableUserMentions,
   onUrlDetected,
+  onAgentSelect,
+  singleAgentInputEnabled,
   owner,
   conversationId,
   spaceId,
@@ -327,6 +337,8 @@ const useCustomEditor = ({
         disableUserMentions,
         onInlineText,
         onUrlDetected,
+        onAgentSelect,
+        singleAgentInputEnabled,
       }),
       shouldRerenderOnTransaction: true, // necessary to update the editor state (and so the toolbar icons "activation") in real time
       editorProps: {

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -17,7 +17,7 @@ const useHandleMentions = (
 ) => {
   const stickyMentionsTextContent = useRef<string | null>(null);
   const singleAgentInput = isSingleAgentInputEnabled();
-  const { setSingleAgentSelection } = useContext(InputBarContext);
+  const { setSelectedSingleAgent } = useContext(InputBarContext);
 
   // In single agent mode, sync the selected agent from sticky mentions
   // so the agent picker button shows the correct agent on existing conversations,
@@ -27,8 +27,8 @@ const useHandleMentions = (
       return;
     }
     const agentMention = stickyMentions?.find(isRichAgentMention) ?? null;
-    setSingleAgentSelection(agentMention);
-  }, [singleAgentInput, stickyMentions, setSingleAgentSelection]);
+    setSelectedSingleAgent(agentMention);
+  }, [singleAgentInput, stickyMentions, setSelectedSingleAgent]);
 
   useEffect(() => {
     if (!stickyMentions || stickyMentions.length === 0) {

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -1,10 +1,12 @@
 import type { EditorService } from "@app/components/editor/input_bar/useCustomEditor";
 import { isSingleAgentInputEnabled } from "@app/lib/development";
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type {
   RichAgentMention,
   RichMention,
 } from "@app/types/assistant/mentions";
-import { useEffect, useRef } from "react";
+import { isRichAgentMention } from "@app/types/assistant/mentions";
+import { useContext, useEffect, useRef } from "react";
 
 const useHandleMentions = (
   editorService: EditorService,
@@ -15,6 +17,18 @@ const useHandleMentions = (
 ) => {
   const stickyMentionsTextContent = useRef<string | null>(null);
   const singleAgentInput = isSingleAgentInputEnabled();
+  const { setSelectedAgent } = useContext(InputBarContext);
+
+  // In single agent mode, sync the selected agent from sticky mentions
+  // so the agent picker button shows the correct agent on existing conversations,
+  // and clears it when navigating to a new conversation.
+  useEffect(() => {
+    if (!singleAgentInput) {
+      return;
+    }
+    const agentMention = stickyMentions?.find(isRichAgentMention) ?? null;
+    setSelectedAgent(agentMention);
+  }, [singleAgentInput, stickyMentions, setSelectedAgent]);
 
   useEffect(() => {
     if (!stickyMentions || stickyMentions.length === 0) {

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -1,4 +1,5 @@
 import type { EditorService } from "@app/components/editor/input_bar/useCustomEditor";
+import { isSingleAgentInputEnabled } from "@app/lib/development";
 import type {
   RichAgentMention,
   RichMention,
@@ -13,6 +14,7 @@ const useHandleMentions = (
   pendingInputText?: string | null
 ) => {
   const stickyMentionsTextContent = useRef<string | null>(null);
+  const singleAgentInput = isSingleAgentInputEnabled();
 
   useEffect(() => {
     if (!stickyMentions || stickyMentions.length === 0) {
@@ -31,7 +33,14 @@ const useHandleMentions = (
     if (editorIsEmpty || onlyContainsPreviousStickyMention) {
       const mentionsToInsert: RichMention[] = [];
 
-      mentionsToInsert.push(...stickyMentions);
+      if (singleAgentInput) {
+        // Only insert user mentions into the editor; agent mentions are handled via selectedAgent.
+        mentionsToInsert.push(
+          ...stickyMentions.filter((m) => m.type !== "agent")
+        );
+      } else {
+        mentionsToInsert.push(...stickyMentions);
+      }
 
       if (mentionsToInsert.length !== 0) {
         queueMicrotask(() => {
@@ -41,26 +50,32 @@ const useHandleMentions = (
         });
       }
     }
-  }, [editorService, stickyMentions, disableAutoFocus]);
+  }, [editorService, stickyMentions, disableAutoFocus, singleAgentInput]);
 
   useEffect(() => {
-    if (selectedAgent) {
-      if (!editorService.hasMention(selectedAgent)) {
-        // Schedule insertion to avoid synchronous editor updates during React render/effects.
-        queueMicrotask(() => {
-          editorService.insertMention(selectedAgent);
-          // If there's pending input text (e.g. from a butler suggestion), insert it after the mention.
-          if (pendingInputText) {
-            editorService.insertText(pendingInputText);
-          }
-        });
+    if (singleAgentInput) {
+      if (pendingInputText) {
+        queueMicrotask(() => editorService.insertText(pendingInputText));
+      }
+    } else {
+      if (selectedAgent) {
+        if (!editorService.hasMention(selectedAgent)) {
+          // Schedule insertion to avoid synchronous editor updates during React render/effects.
+          queueMicrotask(() => {
+            editorService.insertMention(selectedAgent);
+            // If there's pending input text (e.g. from a butler suggestion), insert it after the mention.
+            if (pendingInputText) {
+              editorService.insertText(pendingInputText);
+            }
+          });
+        } else if (pendingInputText) {
+          queueMicrotask(() => editorService.insertText(pendingInputText));
+        }
       } else if (pendingInputText) {
         queueMicrotask(() => editorService.insertText(pendingInputText));
       }
-    } else if (pendingInputText) {
-      queueMicrotask(() => editorService.insertText(pendingInputText));
     }
-  }, [selectedAgent, pendingInputText, editorService]);
+  }, [selectedAgent, pendingInputText, editorService, singleAgentInput]);
 
   return { stickyMentionsTextContent };
 };

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -66,29 +66,22 @@ const useHandleMentions = (
     }
   }, [editorService, stickyMentions, disableAutoFocus, singleAgentInput]);
 
+  // Insert the selected agent mention into the editor (non-single-agent mode only)
+  // and any pending input text (e.g. from butler suggestions).
+  // Scheduled via queueMicrotask to avoid synchronous editor updates during React render/effects.
   useEffect(() => {
-    if (singleAgentInput) {
+    queueMicrotask(() => {
+      if (
+        !singleAgentInput &&
+        selectedAgent &&
+        !editorService.hasMention(selectedAgent)
+      ) {
+        editorService.insertMention(selectedAgent);
+      }
       if (pendingInputText) {
-        queueMicrotask(() => editorService.insertText(pendingInputText));
+        editorService.insertText(pendingInputText);
       }
-    } else {
-      if (selectedAgent) {
-        if (!editorService.hasMention(selectedAgent)) {
-          // Schedule insertion to avoid synchronous editor updates during React render/effects.
-          queueMicrotask(() => {
-            editorService.insertMention(selectedAgent);
-            // If there's pending input text (e.g. from a butler suggestion), insert it after the mention.
-            if (pendingInputText) {
-              editorService.insertText(pendingInputText);
-            }
-          });
-        } else if (pendingInputText) {
-          queueMicrotask(() => editorService.insertText(pendingInputText));
-        }
-      } else if (pendingInputText) {
-        queueMicrotask(() => editorService.insertText(pendingInputText));
-      }
-    }
+    });
   }, [selectedAgent, pendingInputText, editorService, singleAgentInput]);
 
   return { stickyMentionsTextContent };

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -17,7 +17,7 @@ const useHandleMentions = (
 ) => {
   const stickyMentionsTextContent = useRef<string | null>(null);
   const singleAgentInput = isSingleAgentInputEnabled();
-  const { setSelectedAgent } = useContext(InputBarContext);
+  const { setSingleAgentSelection } = useContext(InputBarContext);
 
   // In single agent mode, sync the selected agent from sticky mentions
   // so the agent picker button shows the correct agent on existing conversations,
@@ -27,8 +27,8 @@ const useHandleMentions = (
       return;
     }
     const agentMention = stickyMentions?.find(isRichAgentMention) ?? null;
-    setSelectedAgent(agentMention);
-  }, [singleAgentInput, stickyMentions, setSelectedAgent]);
+    setSingleAgentSelection(agentMention);
+  }, [singleAgentInput, stickyMentions, setSingleAgentSelection]);
 
   useEffect(() => {
     if (!stickyMentions || stickyMentions.length === 0) {
@@ -48,7 +48,7 @@ const useHandleMentions = (
       const mentionsToInsert: RichMention[] = [];
 
       if (singleAgentInput) {
-        // Only insert user mentions into the editor; agent mentions are handled via selectedAgent.
+        // Only insert user mentions into the editor; agent mentions are handled via singleAgentSelection.
         mentionsToInsert.push(
           ...stickyMentions.filter((m) => m.type !== "agent")
         );
@@ -66,24 +66,24 @@ const useHandleMentions = (
     }
   }, [editorService, stickyMentions, disableAutoFocus, singleAgentInput]);
 
-  // Insert the selected agent mention into the editor (non-single-agent mode only)
-  // and any pending input text (e.g. from butler suggestions).
-  // Scheduled via queueMicrotask to avoid synchronous editor updates during React render/effects.
   useEffect(() => {
-    queueMicrotask(() => {
-      if (
-        !singleAgentInput &&
-        selectedAgent &&
-        !editorService.hasMention(selectedAgent)
-      ) {
-        editorService.insertMention(selectedAgent);
-        setSelectedAgent(null);
+    if (selectedAgent) {
+      if (!editorService.hasMention(selectedAgent)) {
+        // Schedule insertion to avoid synchronous editor updates during React render/effects.
+        queueMicrotask(() => {
+          editorService.insertMention(selectedAgent);
+          // If there's pending input text (e.g. from a butler suggestion), insert it after the mention.
+          if (pendingInputText) {
+            editorService.insertText(pendingInputText);
+          }
+        });
+      } else if (pendingInputText) {
+        queueMicrotask(() => editorService.insertText(pendingInputText));
       }
-      if (pendingInputText) {
-        editorService.insertText(pendingInputText);
-      }
-    });
-  }, [selectedAgent, pendingInputText, editorService, singleAgentInput]);
+    } else if (pendingInputText) {
+      queueMicrotask(() => editorService.insertText(pendingInputText));
+    }
+  }, [selectedAgent, pendingInputText, editorService]);
 
   return { stickyMentionsTextContent };
 };

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -1,6 +1,6 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { EditorService } from "@app/components/editor/input_bar/useCustomEditor";
 import { isSingleAgentInputEnabled } from "@app/lib/development";
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type {
   RichAgentMention,
   RichMention,

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -77,6 +77,7 @@ const useHandleMentions = (
         !editorService.hasMention(selectedAgent)
       ) {
         editorService.insertMention(selectedAgent);
+        setSelectedAgent(null);
       }
       if (pendingInputText) {
         editorService.insertText(pendingInputText);

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -23,6 +23,21 @@ export function toggleInlineActivity(): boolean {
   return next;
 }
 
+const SINGLE_AGENT_INPUT_KEY = "dust_single_agent_input";
+
+export function isSingleAgentInputEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return localStorage.getItem(SINGLE_AGENT_INPUT_KEY) === "true";
+}
+
+export function toggleSingleAgentInput(): boolean {
+  const next = !isSingleAgentInputEnabled();
+  localStorage.setItem(SINGLE_AGENT_INPUT_KEY, next ? "true" : "false");
+  return next;
+}
+
 export async function forceUserRole(
   user: UserType,
   owner: LightWorkspaceType,


### PR DESCRIPTION
## Description
This PR is a part of updating UI to support single agent mode. It has a local feature flag you can enable via user menu. Once you type an agent name, it will automatically remove from the input bar and show it in the selector. You can switch it by typing again or choose from the selector. Nothing should change for non single agent mode. 

Note that this PR does NOT include
- draft restoration logic (it won't restore anything right now)
- preventing you sending a new message when switching to another agent 
- disabling agent options when mentioning a human


https://github.com/user-attachments/assets/2ed13c67-1bee-4d4e-bf5d-3ccaccc9bf3b


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
