### PR TITLE
[WIP] LLM router: payload inspection tooling

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -38,6 +38,9 @@ import { normalizePrompt } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import assert from "assert";
 
+import * as fs from "fs";
+import * as path from "path";
+
 /**
  * Maps prompt tiers to Anthropic system blocks with cache breakpoints.
  *
@@ -190,6 +193,11 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     payload: BetaMessageStreamParams
   ): AsyncGenerator<LLMEvent> {
     try {
+      await fs.promises.writeFile(
+        path.join(__dirname, `payload_${Date.now().toString()}.json`),
+        JSON.stringify(payload, null, 2),
+        "utf8"
+      );
       const events = this.client.beta.messages.stream(payload);
 
       yield* streamLLMEvents(

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -31,6 +31,8 @@ import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { ApiError, GoogleGenAI, JobState } from "@google/genai";
 import assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
 import { z } from "zod";
 import { handleError } from "./utils/errors";
 
@@ -110,6 +112,24 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
         payload.conversation.messages.map((message) =>
           toContent(message, this.modelId)
         )
+      );
+
+      await fs.promises.writeFile(
+        path.join(__dirname, `google_payload_${Date.now().toString()}.json`),
+        JSON.stringify(
+          {
+            model: this.modelId,
+            contents,
+            config: this.buildGenerateContentConfig(
+              payload.specifications,
+              payload.prompt,
+              payload.forceToolCall
+            ),
+          },
+          null,
+          2
+        ),
+        "utf8"
       );
 
       const generateContentResponses =

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -33,6 +33,8 @@ import {
 } from "@mistralai/mistralai/models/components";
 import { MistralError } from "@mistralai/mistralai/models/errors/mistralerror";
 import assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
 import { z } from "zod";
 
 const mistralBatchOutputLineSchema = z.object({
@@ -112,6 +114,11 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
     payload: MistralChatStreamRequest
   ): AsyncGenerator<LLMEvent> {
     try {
+      await fs.promises.writeFile(
+        path.join(__dirname, `mistral_payload_${Date.now().toString()}.json`),
+        JSON.stringify(payload, null, 2),
+        "utf8"
+      );
       const completionEvents = await this.client.chat.stream(payload);
 
       yield* streamLLMEvents({

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -29,12 +29,14 @@ import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
+import * as fs from "fs";
 import { APIError, OpenAI, toFile } from "openai";
 import type {
   Response,
   ResponseCreateParamsBase,
   ResponseCreateParamsStreaming,
 } from "openai/resources/responses/responses";
+import * as path from "path";
 import { z } from "zod";
 
 const openAIBatchOutputLineSchema = z.object({
@@ -123,6 +125,11 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     payload: ResponseCreateParamsStreaming
   ): AsyncGenerator<LLMEvent> {
     try {
+      await fs.promises.writeFile(
+        path.join(__dirname, `responses_payload_${Date.now().toString()}.json`),
+        JSON.stringify(payload, null, 2),
+        "utf8"
+      );
       const events = await this.client.responses.create(payload);
       yield* streamLLMEvents(events, this.metadata);
     } catch (err) {

--- a/x/pierre/providers/.gitignore
+++ b/x/pierre/providers/.gitignore
@@ -1,0 +1,1 @@
+*_events_*.json

--- a/x/pierre/providers/anthropic.ts
+++ b/x/pierre/providers/anthropic.ts
@@ -1,0 +1,246 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { BetaMessageStreamParams } from "@anthropic-ai/sdk/resources/beta/messages";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const payload: BetaMessageStreamParams = {
+  model: "claude-sonnet-4-5-20250929",
+  thinking: {
+    type: "disabled",
+  },
+  system: [
+    {
+      type: "text",
+      text: "You are a helpful assistant.",
+      cache_control: {
+        type: "ephemeral",
+      },
+    },
+  ],
+  messages: [
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "<dust_system>\n- Sender: Pierre Milliotte (:mention_user[Pierre Milliotte]{sId=oZujjEmhUC}) <pierre@dust.tt>\n- Conversation: jH9X8WvHys\n- Sent at: Apr 01, 2026, 16:58:33 GMT+2\n- Source: web\n</dust_system>\n\n@claude-4.5-sonnet get me the weather in paris",
+        },
+      ],
+    },
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "<thinking>\n- User wants weather information for Paris, which is current data that requires a web search\n</thinking>",
+        },
+        {
+          type: "tool_use",
+          id: "toolu_011cQU9EHVRUKHrtYrVUnGfj",
+          name: "web_search_browse__websearch",
+          input: {
+            query: "weather in Paris today",
+          },
+        },
+      ],
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_011cQU9EHVRUKHrtYrVUnGfj",
+          content:
+            '[{"type":"resource","resource":{"uri":"https://weather.com/weather/today/l/1a8af5b9d8971c46dd5a52547f9221e22cd895d8d8639267a87df614d0912830","text":"Cloudy with occasional light rain...mainly this evening. Low 43F. Winds NNW at 5 to 10 mph. Chance of rain 60%.","title":"Weather Forecast and Conditions for Paris, France","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"ekx"}},{"type":"resource","resource":{"uri":"https://www.accuweather.com/en/fr/paris/623/weather-forecast/623","text":"Hourly Weather · 1 PM 53°. rain drop 7% · 2 PM 53°. rain drop 7% · 3 PM 53°. rain drop 7% · 4 PM 53°. rain drop 7% · 5 PM 54°. rain drop 7% · 6 PM 54°. rain drop 7%.","title":"Paris, Ville de Paris, France Weather Forecast","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"n1k"}},{"type":"resource","resource":{"uri":"https://weather.com/weather/tenday/l/1a8af5b9d8971c46dd5a52547f9221e22cd895d8d8639267a87df614d0912830","text":"Today. 54° / 48°. AM Showers. 33%. 7 mph ... A few showers this morning with overcast skies during the afternoon hours. High 54F. Winds NNW at 5 to 10 mph. Chance ...","title":"10-Day Weather Forecast for Paris, France","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"g8q"}},{"type":"resource","resource":{"uri":"https://weather.com/weather/hourbyhour/l/1a8af5b9d8971c46dd5a52547f9221e22cd895d8d8639267a87df614d0912830","text":"Hourly Weather Paris, France · as of 5:00 PM PDT · 10 am. 52°. Cloudy. 15%. 15%. 86%. 4 mph. 0 in · 11 am. 54°. Cloudy. 15%. 15%. 81%. 4 mph. 0 in · 12 pm. 55°.","title":"Hourly Weather Forecast for Paris, France","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"duj"}},{"type":"resource","resource":{"uri":"https://www.wunderground.com/forecast/fr/paris","text":"Paris Weather Forecasts. Weather Underground provides local & long-range weather forecasts, weatherreports, maps & tropical weather conditions for the Paris ...","title":"Paris, France 10-Day Weather Forecast","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"sil"}},{"type":"resource","resource":{"uri":"https://weather.yahoo.com/fr/ile-de-france/paris/","text":"Cloudy today with a high of 57°F and a low of 47°F.","title":"Paris, FR Weather Forecast, Conditions, and Maps","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"aqj"}},{"type":"resource","resource":{"uri":"https://www.timeanddate.com/weather/france/paris","text":"Forecast for the next 48 hours ; Paris-Orly: (9 mi). Drizzle. Fog. ; Paris-Aeroport Charles De Gaulle: (14 mi). Fog. (1 hour ago) ; Melun Airport: (22 mi). Drizzle ...","title":"Weather for Paris, Paris, France","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"cvs"}},{"type":"resource","resource":{"uri":"https://weather.com/weather/tenday/l/a5c27da38afe789545e3446ede0bfd5042030764469a6cd4fff4e9468c74d2a7","text":"Today. 53° / 47°. Mostly Cloudy. 24%. 8 mph ... Mainly cloudy. Slight chance of a rain shower. High 53F. Winds NNW at 5 to 10 mph. ... Cloudy. Low 47F. Winds NNW at ...","title":"10-Day Weather Forecast for Paris, Île-de-France, France","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"a31"}},{"type":"resource","resource":{"uri":"https://www.theweathernetwork.com/en/city/fr/ile-de-france/paris/current","text":"H: 12° L: 8°. Hourly. Full 72 hours · 1pm. Cloudy with showers. 10°. Feels 9. POP. 60%. 0.1mm. 2pm. Cloudy with showers. 11°. Feels 10. POP. 70%. 0.2mm.","title":"Paris, IDF, FR Current Weather","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"eks"}},{"type":"resource","resource":{"uri":"https://www.weatherbug.com/weather-forecast/now/paris-ile-del-france-fr","text":"Today ... Mostly cloudy. High temperature around 55F. Dew point will be around 46F with an average humidity of 77%. Winds will be 4 mph from the NW.","title":"Paris, Ile-del-France, FR Weather Today & Tomorrow - WeatherBug","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"bpe"}},{"type":"resource","resource":{"uri":"https://weather.metoffice.gov.uk/forecast/u09tvnxyj","text":"Today Today. Light rain;. 12° Maximum daytime temperature: 12 degrees Celsius; 9° Minimum nighttime temperature: 9 degrees Celsius; · Thu Thursday. Cloudy; · Fri ...","title":"Paris (France) weather - Met Office","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"dba"}},{"type":"resource","resource":{"uri":"https://www.accuweather.com/en/fr/paris/623/hourly-weather-forecast/623","text":"RealFeel Shade™51°. WindENE 6 mph. Air QualityPoor. Max UV Index1.2 (Low). Wind Gusts15 mph. Humidity77%. Indoor Humidity45% (Ideal Humidity).","title":"Paris, Ville de Paris, France Hourly Weather - AccuWeather","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"cx6"}},{"type":"resource","resource":{"uri":"https://weather.com/weather/today/l/d2a540efb4e9604b3c1d01b7851a1d9d2ab4c7b3ba428e5799936ac54404c035","text":"Today\'s Activities Forecast. Lower chances of showers will make early evening a preferred time for getting outside for the rest of the day.","title":"Weather Forecast and Conditions for Paris, Île-de-France, France","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"ch7"}},{"type":"resource","resource":{"uri":"https://weather.com/weather/today/l/02144e9a9a2fe048b3ecca9df91501293f98ee712846f78a5da25ba6690fd98c","text":"Clearing skies after some evening rain. Low 37F. Winds NNW at 10 to 15 mph. Chance of rain 90%. Humidity.","title":"Weather Forecast and Conditions for Paris, France | weather.com","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"as8"}},{"type":"resource","resource":{"uri":"https://www.wunderground.com/weather/fr/paris","text":"Cloudy this morning. A few showers developing during the afternoon. High 54F. Winds light and variable. Chance of rain 30%. icon. Tonight ...","title":"Paris, France Weather Conditions | Weather Underground","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"drk"}},{"type":"resource","resource":{"uri":"https://www.timeanddate.com/weather/france/paris/hourly","text":"Hour-by-hour Forecast in Paris — Graph ... Scattered clouds. Feels Like: 41 °F. Humidity: 88%. Precipitation: Rain: ...","title":"Hourly forecast for Paris, Paris, France - Weather - Time and Date","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"bs0"}}]',
+        },
+      ],
+    },
+  ],
+  temperature: 1,
+  tools: [
+    {
+      name: "web_search_browse__websearch",
+      description:
+        "A tool that performs a Google web search based on a string query.",
+      input_schema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "The query used to perform the Google search. If requested by the user, use the Google syntax `site:` to restrict the search to a particular website or domain.",
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+    },
+    {
+      name: "web_search_browse__webbrowser",
+      description:
+        "A tool to browse websites, you can provide a list of up to 16 urls to browse all at once.",
+      input_schema: {
+        type: "object",
+        properties: {
+          urls: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+            maxItems: 16,
+            description: "List of urls to browse (max: 16)",
+          },
+          screenshotMode: {
+            type: "string",
+            enum: ["none", "viewport", "fullPage"],
+            description:
+              "Screenshot mode: 'none' (default), 'viewport', or 'fullPage'.",
+          },
+          links: {
+            type: "boolean",
+            description: "If true, also retrieve outgoing links from the page.",
+          },
+        },
+        required: ["urls"],
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+    },
+    {
+      name: "common_utilities__generate_random_number",
+      description:
+        "Generate a random positive number between 1 and the provided maximum (inclusive).",
+      input_schema: {
+        type: "object",
+        properties: {
+          max: {
+            type: "integer",
+            exclusiveMinimum: 0,
+            description:
+              "Upper bound for the generated integer. Defaults to 1000000.",
+          },
+        },
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+    },
+    {
+      name: "common_utilities__generate_random_float",
+      description:
+        "Generate a random floating point number between 0 (inclusive) and 1 (exclusive).",
+      input_schema: {
+        type: "object",
+        properties: {},
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+    },
+    {
+      name: "common_utilities__wait",
+      description:
+        "Pause execution for the provided number of milliseconds (maximum 180000).",
+      input_schema: {
+        type: "object",
+        properties: {
+          duration_ms: {
+            type: "integer",
+            exclusiveMinimum: 0,
+            maximum: 180000,
+            description: "The time to wait in milliseconds, up to 3 minutes.",
+          },
+        },
+        required: ["duration_ms"],
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+    },
+    {
+      name: "common_utilities__get_current_time",
+      description:
+        "Return the current date and time in multiple convenient formats.",
+      input_schema: {
+        type: "object",
+        properties: {
+          include_formats: {
+            type: "array",
+            items: {
+              type: "string",
+              enum: ["iso", "utc", "timestamp", "locale"],
+              description: "Specify which formats to return. Defaults to all.",
+            },
+            maxItems: 4,
+          },
+        },
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+    },
+    {
+      name: "common_utilities__math_operation",
+      description: "Perform mathematical operations.",
+      input_schema: {
+        type: "object",
+        properties: {
+          expression: {
+            type: "string",
+            description: "The expression to evaluate. ",
+          },
+        },
+        required: ["expression"],
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+    },
+    {
+      name: "skill_management__enable_skill",
+      description:
+        "Enable a skill for the current conversation. The skill will be available for subsequent messages from the same agent in this conversation.",
+      input_schema: {
+        type: "object",
+        properties: {
+          skillName: {
+            type: "string",
+            description: "The name of the skill to enable",
+          },
+        },
+        required: ["skillName"],
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+    },
+  ],
+  max_tokens: 64000,
+  tool_choice: {
+    type: "auto",
+  },
+  stream: true,
+  betas: ["structured-outputs-2025-11-13"],
+  cache_control: {
+    type: "ephemeral",
+  },
+} as BetaMessageStreamParams;
+
+const client = new Anthropic({
+  apiKey: process.env.DUST_MANAGED_ANTHROPIC_API_KEY,
+});
+
+const call = async () => {
+  const events = client.beta.messages.stream(payload);
+
+  const logEvents = [];
+
+  for await (const event of events) {
+    logEvents.push(event);
+  }
+  await fs.promises.writeFile(
+    path.join(__dirname, `anthropic_events_${Date.now().toString()}.json`),
+    JSON.stringify(logEvents, null, 2),
+    "utf8"
+  );
+};
+
+call();

--- a/x/pierre/providers/google.ts
+++ b/x/pierre/providers/google.ts
@@ -1,0 +1,177 @@
+import type { GenerateContentParameters } from "@google/genai";
+import { GoogleGenAI } from "@google/genai";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const params: GenerateContentParameters = {
+  model: "gemini-3-pro-preview",
+  contents: [
+    {
+      role: "user",
+      parts: [
+        {
+          text: "<dust_system>\n- Sender: Pierre Milliotte (:mention_user[Pierre Milliotte]{sId=oZujjEmhUC}) <pierre@dust.tt>\n- Conversation: rYahuhjE5P\n- Sent at: Apr 01, 2026, 17:01:32 GMT+2\n- Source: web\n</dust_system>\n\n@gemini-pro get me the weather in paris",
+        },
+      ],
+    },
+    {
+      role: "model",
+      parts: [
+        {
+          text: "**Initiating the Inquiry**\n\nI've grasped the user's intent: they want Paris's current weather. My next step involves selecting the appropriate tool. It looks like `web_search_browse__websearch` will be the go-to resource for fetching this real-time data.\n\n\n",
+          thought: true,
+          thoughtSignature: "",
+        },
+        {
+          functionCall: {
+            id: "kph3bwtd",
+            name: "web_search_browse__websearch",
+            args: {
+              query: "current weather in Paris",
+            },
+          },
+          thoughtSignature:
+            "EpMECpAEAb4+9vs6OxSWR88lfg/dasncDkmITE7C0Bc0HAho2w4ywuaxIuHG6EkKqI9qM4uamFDfG8RrRO+B2DajJNNOadq7FVY+CQQa9qtC7/B6cEIJbspOmV0lCmBaTGnGzKKYjsabfUaZKTO0/QUKPrroXaCgTx/Pmm1EGM3bwGLXHrrnJ1G3l3GJx2MbPvGq3zzu+0LESyvvjdqh8cb9wbrB8QVd678/qrklWdny1tMTgeWhlQa5ve9zpfxHEjS4+SWASSXB8xP5uzRMuGrn86ZazbfJCeosvzh8tM4k+yjWEvREcOcCULbN9ZpT655g2gLBYCXYPmQRQ6TWkSDSdq6n0E/aTQAFDVMzyZLZey/Qb++Ujocqsr4SG0+CqZ58cJdKBsPvKcuwIlvEweo0kLKllbATX5yweKNZEYIyzacgMZlP6/CC/Rto4HS7Ce3qm6sdeb7UDCM0wr0a6jXLuiXyyIWDskOen5FsQVO97e8rq9KyMbRYnrgreHAonhnFEopp+lb2hYEdB7lm4vaj3CWvFvuB9MR880Jnv2SUb81l1oobJmMftAFezzSKqiweJWc6yWnWzxQWqyl4fFynJuDXWdu7v+2auboRCrfvnX+Ir+rQnc0/BRnF0JqkEAsMtRO167r2x6Dr7T8zPvMRJJl86UDsKVVJ116T68un0EcDGjgYwF72uNLYczHUrwvdaL+0",
+        },
+      ],
+    },
+    {
+      role: "user",
+      parts: [
+        {
+          functionResponse: {
+            response: {
+              output:
+                '[{"type":"resource","resource":{"uri":"https://weather.com/weather/today/l/1a8af5b9d8971c46dd5a52547f9221e22cd895d8d8639267a87df614d0912830","text":"Cloudy with occasional light rain...mainly this evening. Low 43F. Winds NNW at 5 to 10 mph. Chance of rain 60%.","title":"Weather Forecast and Conditions for Paris, France | weather.com","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"ekx"}},{"type":"resource","resource":{"uri":"https://www.accuweather.com/en/fr/paris/623/weather-forecast/623","text":"Hourly Weather · 1 PM 53°. rain drop 7% · 2 PM 53°. rain drop 7% · 3 PM 53°. rain drop 7% · 4 PM 53°. rain drop 7% · 5 PM 54°. rain drop 7% · 6 PM 54°. rain drop 7%.","title":"Paris, Ville de Paris, France Weather Forecast - AccuWeather","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"n1k"}},{"type":"resource","resource":{"uri":"https://weather.com/weather/tenday/l/1a8af5b9d8971c46dd5a52547f9221e22cd895d8d8639267a87df614d0912830","text":"Today. 54° / 48°. AM Showers. 33%. 7 mph ... A few showers this morning with overcast skies during the afternoon hours. High 54F. Winds NNW at 5 to 10 mph. Chance ...","title":"10-Day Weather Forecast for Paris, France","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"g8q"}},{"type":"resource","resource":{"uri":"https://www.wunderground.com/forecast/fr/paris","text":"Paris Weather Forecasts. Weather Underground provides local & long-range weather forecasts, weatherreports, maps & tropical weather conditions for the Paris ...","title":"Paris, France 10-Day Weather Forecast","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"duj"}},{"type":"resource","resource":{"uri":"https://www.theweathernetwork.com/en/city/fr/ile-de-france/paris/current","text":"H: 12° L: 8°. Hourly. Full 72 hours · 1pm. Cloudy with showers. 10°. Feels 9. POP. 60%. 0.1mm. 2pm. Cloudy with showers. 11°. Feels 10. POP. 70%. 0.2mm.","title":"Paris, IDF, FR Current Weather - The Weather Network","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"sil"}},{"type":"resource","resource":{"uri":"https://www.timeanddate.com/weather/france/paris","text":"Current weather in Paris and forecast for today, tomorrow, and next 14 days.","title":"Weather for Paris, Paris, France - Time and Date","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"aqj"}},{"type":"resource","resource":{"uri":"https://weather.yahoo.com/fr/ile-de-france/paris/","text":"Cloudy today with a high of 55°F and a low of 46°F.","title":"Paris, FR Weather Forecast, Conditions, and Maps","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"cvs"}},{"type":"resource","resource":{"uri":"https://weather.metoffice.gov.uk/forecast/u09tvnxyj","text":"Today Today. Light rain;. 12° Maximum daytime temperature: 12 degrees Celsius; 9° Minimum nighttime temperature: 9 degrees Celsius; · Thu Thursday. Cloudy; · Fri ...","title":"Paris (France) weather - Met Office","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"a31"}},{"type":"resource","resource":{"uri":"https://weather.com/weather/hourbyhour/l/1a8af5b9d8971c46dd5a52547f9221e22cd895d8d8639267a87df614d0912830","text":"Hourly Weather Paris, France · as of 5:00 PM PDT · 10 am. 52°. Cloudy. 15%. 15%. 86%. 4 mph. 0 in · 11 am. 54°. Cloudy. 15%. 15%. 81%. 4 mph. 0 in · 12 pm. 55°.","title":"Hourly Weather Forecast for Paris, France","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"eks"}},{"type":"resource","resource":{"uri":"https://www.bbc.com/weather/2988507","text":"14-day weather forecast for Paris.","title":"Paris - BBC Weather","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"bpe"}},{"type":"resource","resource":{"uri":"https://www.accuweather.com/en/fr/paris/623/hourly-weather-forecast/623","text":"2 PM ... Light jacket or sweater may be appropriate. LEARN MORE. rain drop 7%. Cloudy. RealFeel Shade™51°. WindENE 6 mph. Air QualityPoor. Max ...","title":"Paris, Ville de Paris, France Hourly Weather","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"dba"}},{"type":"resource","resource":{"uri":"https://www.weatherbug.com/weather-forecast/now/paris-ile-del-france-fr","text":"Today ... Mostly cloudy. High temperature around 55F. Dew point will be around 46F with an average humidity of 77%. Winds will be 4 mph from the NW.","title":"Paris, Ile-del-France, FR Weather Today & Tomorrow","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"cx6"}},{"type":"resource","resource":{"uri":"https://www.yr.no/en/forecast/hourly-table/2-2988507/France/%C3%8Ele-de-France%20Region/Paris%20Department/Paris?i=0","text":"Thursday 2 Apr. · Night: cloudy · Morning: cloudy · Afternoon: light rain showers · Evening: partly cloudy. Maximum minimum temperature:14°/7°. Precipitation ...","title":"Yr - Paris - Hourly weather forecast","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"ch7"}},{"type":"resource","resource":{"uri":"https://www.theweathernetwork.com/en/city/fr/ile-de-france/paris/14-days","text":"Mainly cloudy; light rain in the morning, then a few showers in the afternoon. Night. Partly cloudy. 4. °. Feels 4. Wind. Wind Gust. Humidity. 15 km/h N.","title":"Paris, IDF, FR 14 Days Weather","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"as8"}},{"type":"resource","resource":{"uri":"https://www.wunderground.com/hourly/fr/paris","text":"Showers following some early drizzle. High 54F. Winds light and variable. Chance of rain 60%. Sun. 7:32AM. 8:19PM. Moon.","title":"Paris, France Hourly Weather Forecast","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"drk"}},{"type":"resource","resource":{"uri":"https://www.timeanddate.com/weather/france/paris/ext","text":"Night Sky · TodayHourly14 DaysPastClimate. Currently: 48 °F. Fog. (Weather station: Villacoublay, France). See more current weather ... Paris time - Weather by ...","title":"Paris 14 Day Extended Forecast - France","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"bs0"}}]',
+            },
+            name: "web_search_browse__websearch",
+            id: "kph3bwtd",
+          },
+        },
+      ],
+    },
+  ],
+  config: {
+    temperature: 1,
+    tools: [
+      {
+        functionDeclarations: [
+          {
+            name: "web_search_browse__websearch",
+            description:
+              "A tool that performs a Google web search based on a string query.",
+            parametersJsonSchema: {
+              type: "object",
+              properties: {
+                query: {
+                  type: "string",
+                  description:
+                    "The query used to perform the Google search. If requested by the user, use the Google syntax `site:` to restrict the search to a particular website or domain.",
+                },
+              },
+              required: ["query"],
+              additionalProperties: false,
+              $schema: "http://json-schema.org/draft-07/schema#",
+            },
+          },
+        ],
+      },
+      {
+        functionDeclarations: [
+          {
+            name: "web_search_browse__webbrowser",
+            description:
+              "A tool to browse websites, you can provide a list of up to 16 urls to browse all at once.",
+            parametersJsonSchema: {
+              type: "object",
+              properties: {
+                urls: {
+                  type: "array",
+                  items: {
+                    type: "string",
+                  },
+                  maxItems: 16,
+                  description: "List of urls to browse (max: 16)",
+                },
+                screenshotMode: {
+                  type: "string",
+                  enum: ["none", "viewport", "fullPage"],
+                  description:
+                    "Screenshot mode: 'none' (default), 'viewport', or 'fullPage'.",
+                },
+                links: {
+                  type: "boolean",
+                  description:
+                    "If true, also retrieve outgoing links from the page.",
+                },
+              },
+              required: ["urls"],
+              additionalProperties: false,
+              $schema: "http://json-schema.org/draft-07/schema#",
+            },
+          },
+        ],
+      },
+      {
+        functionDeclarations: [
+          {
+            name: "common_utilities__get_current_time",
+            description:
+              "Return the current date and time in multiple convenient formats.",
+            parametersJsonSchema: {
+              type: "object",
+              properties: {
+                include_formats: {
+                  type: "array",
+                  items: {
+                    type: "string",
+                    enum: ["iso", "utc", "timestamp", "locale"],
+                    description:
+                      "Specify which formats to return. Defaults to all.",
+                  },
+                  maxItems: 4,
+                },
+              },
+              additionalProperties: false,
+              $schema: "http://json-schema.org/draft-07/schema#",
+            },
+          },
+        ],
+      },
+    ],
+    systemInstruction: {
+      text: 'You are a helpful assistant.',
+    },
+    candidateCount: 1,
+    thinkingConfig: {
+      thinkingBudget: 1024,
+      includeThoughts: true,
+    },
+  },
+} as GenerateContentParameters;
+
+const client = new GoogleGenAI({
+  apiKey: process.env.DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY,
+});
+
+const call = async () => {
+  const generateContentResponses =
+    await client.models.generateContentStream(params);
+
+  const logEvents = [];
+
+  for await (const event of generateContentResponses) {
+    logEvents.push(event);
+  }
+  await fs.promises.writeFile(
+    path.join(__dirname, `google_events_${Date.now().toString()}.json`),
+    JSON.stringify(logEvents, null, 2),
+    "utf8"
+  );
+};
+
+call();

--- a/x/pierre/providers/mistral.ts
+++ b/x/pierre/providers/mistral.ts
@@ -1,0 +1,257 @@
+import { Mistral } from "@mistralai/mistralai";
+import type { ChatCompletionStreamRequest } from "@mistralai/mistralai/models/components";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const payload: ChatCompletionStreamRequest = {
+  model: "mistral-large-latest",
+  messages: [
+    {
+      role: "system",
+      content:
+        'You are a helpful assistant.',
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "<dust_system>\n- Sender: Pierre Milliotte (:mention_user[Pierre Milliotte]{sId=oZujjEmhUC}) <pierre@dust.tt>\n- Conversation: 1LkzNYObhm\n- Sent at: Apr 01, 2026, 17:00:46 GMT+2\n- Source: web\n</dust_system>\n\n@mistral get me the weather in paris",
+        },
+      ],
+    },
+    {
+      role: "assistant",
+      toolCalls: [
+        {
+          id: "9Wi7e8G56",
+          function: {
+            name: "web_search_browse__websearch",
+            arguments: '{"query":"weather in Paris April 1 2026"}',
+          },
+        },
+      ],
+    },
+    {
+      role: "tool",
+      content:
+        '[{"type":"resource","resource":{"uri":"https://world-weather.info/forecast/france/paris/april-2026/","text":"Weather in Paris in April 2026. Paris Weather Forecast for April 2026 is ... Wednesday, 1 April. Day. +63°. 7.6. 30.4. 49%. +54°. 07:27 AM. 08:21 PM. Waxing ...","title":"Weather in Paris in April 2026 (Île-de-France) - World-Weather.info","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://www.accuweather.com/en/fr/europe/2608434/april-weather/2608434","text":"Get the monthly weather forecast for Europe, Ville de Paris, France, including daily high/low, historical averages, to help you plan ahead.","title":"2026 - Europe, Ville de Paris, France Monthly Weather | AccuWeather","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://www.weather25.com/europe/france/ile-de-france/paris?page=month&month=April","text":"The temperatures in Paris in April are quite cold with temperatures between 44°F and 60°F, warm clothes are a must. You can expect about 3 to 8 days of rain ...","title":"Paris weather in April 2026 | Paris 14 day weather - Weather25.com","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://www.facebook.com/WeatherAvenue/videos/paris-2026-1-april-2026s-weather-patchy-rain-nearby-8c/1298827858876530/","text":"Paris 2026: 1 April 2026\'s weather (Patchy rain nearby, 8°C) · 🌧️ 1 April 2026\'s weather in Paris: Patchy rain nearby. Rain 0 mm. Stay informed. # ...","title":"1 April 2026\'s weather in Paris: Patchy rain nearby. Rain 0 mm. Stay ...","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://en.climate-data.org/europe/france/ile-de-france/paris-44/t/april-4/","text":"The average temperature during this month is around 51.3°F (10.7°C), providing a mild and pleasant climate that is ideal for exploring the city\'s outdoor ...","title":"Weather Paris in April 2026: Temperature & Climate","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://www.predictwind.com/weather/france/le-de-france/paris/april","text":"The weather in this month is generally cool, with calm conditions and a dry climate. Temperature Trend (°C).","title":"Paris, France (april 2026) - Historical Weather - PredictWind","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://polymarket.com/event/highest-temperature-in-paris-on-april-1-2026","text":"The current frontrunner for \\"Highest temperature in Paris on April 1?\\" is \\"13°C\\" at 45%, meaning the market assigns a 45% chance to that outcome ...","title":"Highest temperature in Paris on April 1? - Polymarket","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://www.weather2travel.com/france/paris/april/","text":"Expect daytime maximum temperatures of 14°C in Paris, France in April based on long-term weather averages. There are 6 hours of sunshine per day on average.","title":"Paris weather in April 2026 | France: How hot? - Weather2Travel.com","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://www.parisdiscoveryguide.com/paris-in-april.html","text":"Although the average high temperature in Paris in April is 62°F (17°C) and the average low is 45°F (7°C), keep in mind that those are averages. When planning ...","title":"Best Things to Do in Paris in April 2026","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://www.weathertab.com/en/c/04/republic-of-france/ile-de-france/paris/","text":"Paris, Île-de-France Daily Weather Forecast for April 2026 ; 1. Wed. 75%. 51 to 61 °F 36 to 46 °F 8 to 18 °C 0 to 10 °C · Sunrise 7:28AM. Sunset 8:21PM. Waxing ...","title":"April 2026 Daily Weather Forecast for Paris, Île-de-France – Plan ...","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://www.holiday-weather.com/paris/averages/april/","text":"Daily highs tend to range from 13°C to 17°C throughout April, only exceeding 23°C or falling below 8°C one day out of every ten. Daily low temperatures ...","title":"Paris, Weather for April, France","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://www.accuweather.com/en/fr/eiffel-tower/70427_poi/april-weather/70427_poi","text":"Get the monthly weather forecast for Eiffel Tower, Ville de Paris, France, including daily high/low, historical averages, to help you plan ahead.","title":"Eiffel Tower, Ville de Paris, France Monthly Weather | AccuWeather","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://www.easeweather.com/europe/france/ile-de-france/paris/april","text":"The forecast for the first days of April 2026 in Paris predicts temperatures to be around 13 °C, close to the historical average. · In general, the average ...","title":"Weather in Paris in April 2026 - Detailed Forecast - EaseWeather","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://weatherspark.com/h/m/47913/2026/1/Historical-Weather-in-January-2026-in-Paris-France","text":"This report shows the past weather for Paris, providing a weather history for January 2026. It features all historical weather data series we have available, ...","title":"Paris January 2026 Historical Weather Data (France)","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://en.climate-data.org/europe/france-216/c/april-4/","text":"High temperatures in the first ten days average 15.7°C | 60.3°F, with lows at 3.9°C | 39°F. Mid-month highs rise to 16.3°C | 61.3°F, and lows to 4.7°C | 40.5°F.","title":"Weather France in April 2026: Temperature & Climate","mimeType":"application/vnd.dust.tool-output.websearch-result"}},{"type":"resource","resource":{"uri":"https://www.sortiraparis.com/en/news/in-paris/articles/342044-weather-in-paris-and-ile-de-france-will-the-springtime-weather-persist","text":"Temperatures will stay steady between 16 and 17°C, staying well above the seasonal average, which typically hovers around 10 to 13°C in March ...","title":"Weather in Paris and Île-de-France: Will the springlike conditions last?","mimeType":"application/vnd.dust.tool-output.websearch-result"}}]',
+      name: "web_search_browse__websearch",
+      toolCallId: "9Wi7e8G56",
+    },
+  ],
+  temperature: 0.7,
+  toolChoice: "auto",
+  tools: [
+    {
+      type: "function",
+      function: {
+        name: "web_search_browse__websearch",
+        description:
+          "A tool that performs a Google web search based on a string query.",
+        parameters: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description:
+                "The query used to perform the Google search. If requested by the user, use the Google syntax `site:` to restrict the search to a particular website or domain.",
+            },
+          },
+          required: ["query"],
+          additionalProperties: false,
+          $schema: "http://json-schema.org/draft-07/schema#",
+        },
+        strict: false,
+      },
+    },
+    {
+      type: "function",
+      function: {
+        name: "web_search_browse__webbrowser",
+        description:
+          "A tool to browse websites, you can provide a list of up to 16 urls to browse all at once.",
+        parameters: {
+          type: "object",
+          properties: {
+            urls: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+              maxItems: 16,
+              description: "List of urls to browse (max: 16)",
+            },
+            screenshotMode: {
+              type: "string",
+              enum: ["none", "viewport", "fullPage"],
+              description:
+                "Screenshot mode: 'none' (default), 'viewport', or 'fullPage'.",
+            },
+            links: {
+              type: "boolean",
+              description:
+                "If true, also retrieve outgoing links from the page.",
+            },
+          },
+          required: ["urls"],
+          additionalProperties: false,
+          $schema: "http://json-schema.org/draft-07/schema#",
+        },
+        strict: false,
+      },
+    },
+    {
+      type: "function",
+      function: {
+        name: "common_utilities__generate_random_number",
+        description:
+          "Generate a random positive number between 1 and the provided maximum (inclusive).",
+        parameters: {
+          type: "object",
+          properties: {
+            max: {
+              type: "integer",
+              exclusiveMinimum: 0,
+              description:
+                "Upper bound for the generated integer. Defaults to 1000000.",
+            },
+          },
+          additionalProperties: false,
+          $schema: "http://json-schema.org/draft-07/schema#",
+        },
+        strict: false,
+      },
+    },
+    {
+      type: "function",
+      function: {
+        name: "common_utilities__generate_random_float",
+        description:
+          "Generate a random floating point number between 0 (inclusive) and 1 (exclusive).",
+        parameters: {
+          type: "object",
+          properties: {},
+          $schema: "http://json-schema.org/draft-07/schema#",
+        },
+        strict: false,
+      },
+    },
+    {
+      type: "function",
+      function: {
+        name: "common_utilities__wait",
+        description:
+          "Pause execution for the provided number of milliseconds (maximum 180000).",
+        parameters: {
+          type: "object",
+          properties: {
+            duration_ms: {
+              type: "integer",
+              exclusiveMinimum: 0,
+              maximum: 180000,
+              description: "The time to wait in milliseconds, up to 3 minutes.",
+            },
+          },
+          required: ["duration_ms"],
+          additionalProperties: false,
+          $schema: "http://json-schema.org/draft-07/schema#",
+        },
+        strict: false,
+      },
+    },
+    {
+      type: "function",
+      function: {
+        name: "common_utilities__get_current_time",
+        description:
+          "Return the current date and time in multiple convenient formats.",
+        parameters: {
+          type: "object",
+          properties: {
+            include_formats: {
+              type: "array",
+              items: {
+                type: "string",
+                enum: ["iso", "utc", "timestamp", "locale"],
+                description:
+                  "Specify which formats to return. Defaults to all.",
+              },
+              maxItems: 4,
+            },
+          },
+          additionalProperties: false,
+          $schema: "http://json-schema.org/draft-07/schema#",
+        },
+        strict: false,
+      },
+    },
+    {
+      type: "function",
+      function: {
+        name: "common_utilities__math_operation",
+        description: "Perform mathematical operations.",
+        parameters: {
+          type: "object",
+          properties: {
+            expression: {
+              type: "string",
+              description: "The expression to evaluate. ",
+            },
+          },
+          required: ["expression"],
+          additionalProperties: false,
+          $schema: "http://json-schema.org/draft-07/schema#",
+        },
+        strict: false,
+      },
+    },
+    {
+      type: "function",
+      function: {
+        name: "skill_management__enable_skill",
+        description:
+          "Enable a skill for the current conversation. The skill will be available for subsequent messages from the same agent in this conversation.",
+        parameters: {
+          type: "object",
+          properties: {
+            skillName: {
+              type: "string",
+              description: "The name of the skill to enable",
+            },
+          },
+          required: ["skillName"],
+          additionalProperties: false,
+          $schema: "http://json-schema.org/draft-07/schema#",
+        },
+        strict: false,
+      },
+    },
+  ],
+  stream: true,
+} as ChatCompletionStreamRequest;
+
+const client = new Mistral({
+  apiKey: process.env.DUST_MANAGED_MISTRAL_API_KEY,
+});
+
+const call = async () => {
+  const completionEvents = await client.chat.stream(payload);
+
+  const logEvents = [];
+
+  for await (const event of completionEvents) {
+    logEvents.push(event);
+  }
+  await fs.promises.writeFile(
+    path.join(__dirname, `mistral_events_${Date.now().toString()}.json`),
+    JSON.stringify(logEvents, null, 2),
+    "utf8"
+  );
+};
+
+call();

--- a/x/pierre/providers/openai.ts
+++ b/x/pierre/providers/openai.ts
@@ -1,0 +1,168 @@
+import * as fs from "fs";
+import OpenAI from "openai";
+import type { ResponseCreateParamsStreaming } from "openai/resources/responses/responses.mjs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const payload: ResponseCreateParamsStreaming = {
+  model: "gpt-5.4",
+  input: [
+    {
+      role: "developer",
+      content: [
+        {
+          type: "input_text",
+          text: 'You are a helpful assistant.',
+        },
+      ],
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "input_text",
+          text: "<dust_system>\n- Sender: Pierre Milliotte (:mention_user[Pierre Milliotte]{sId=oZujjEmhUC}) <pierre@dust.tt>\n- Conversation: eOKGGvY5uM\n- Sent at: Apr 01, 2026, 16:30:04 GMT+2\n- Source: web\n</dust_system>\n\n@gpt5 get me the weather in madrid",
+        },
+      ],
+    },
+    {
+      type: "function_call",
+      call_id: "call_4TMO3pMamdhMQfsqEcYKJSHW",
+      name: "common_utilities__get_current_time",
+      arguments: '{"include_formats":["iso","locale"]}',
+    },
+    {
+      type: "function_call",
+      call_id: "call_MWcbf5u6d4NOZlrwzdmpo13M",
+      name: "web_search_browse__websearch",
+      arguments: '{"query":"current weather Madrid"}',
+    },
+    {
+      type: "function_call_output",
+      call_id: "call_4TMO3pMamdhMQfsqEcYKJSHW",
+      output:
+        "ISO: 2026-04-01T14:30:07.369Z\nLocale: 4/1/2026, 4:30:07 PM (Wednesday)",
+    },
+    {
+      type: "function_call_output",
+      call_id: "call_MWcbf5u6d4NOZlrwzdmpo13M",
+      output:
+        '[{"type":"resource","resource":{"uri":"https://www.accuweather.com/en/es/madrid/308526/weather-forecast/308526","text":"Current Weather. 12:29 PM. 58°F. Sunny. RealFeel® 59° · Looking Ahead. Pleasant Saturday. Madrid Weather Radar. Madrid Weather Radar. Static Radar Temporarily ...","title":"Madrid, Madrid, Spain Weather Forecast","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"ekx"}},{"type":"resource","resource":{"uri":"https://weather.com/weather/today/l/f620d7fe58f453124aa71caa578d94f09a298b74f2e9bd519413ad3d9ce6a771","text":"Partly cloudy. Scattered frost possible. Low 32F. Winds N at 5 to 10 mph. Humidity. 52%.","title":"Weather Forecast and Conditions for Madrid, Madrid, Spain","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"n1k"}},{"type":"resource","resource":{"uri":"https://www.wunderground.com/weather/es/madrid","text":"Mostly clear. Low 38F. N winds at 10 to 20 mph, decreasing to less than 5 mph. icon. TomorrowThu 04/ ...","title":"Madrid, Spain Weather Conditions","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"g8q"}},{"type":"resource","resource":{"uri":"https://weather.com/weather/tenday/l/f620d7fe58f453124aa71caa578d94f09a298b74f2e9bd519413ad3d9ce6a771","text":"Clear skies. Low 42F. Winds N at 10 to 15 mph. Humidity. 59%.","title":"10-Day Weather Forecast for Madrid, Madrid, Spain","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"duj"}},{"type":"resource","resource":{"uri":"https://www.bbc.com/weather/3117735","text":"Day by day forecast ; Tonight · A clear sky and a moderate breeze ; Wednesday 1st AprilWed 1st · Sunny and a gentle breeze · High20° 67° ; Thursday 2nd AprilThu 2nd.","title":"Madrid - BBC Weather","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"sil"}},{"type":"resource","resource":{"uri":"https://www.theweathernetwork.com/en/city/es/madrid/madrid/current","text":"H: 20° L: 6°. Hourly. Full 72 hours · 7am. Mainly clear. 9°. Feels 7. POP. 0%. 8am. Mainly sunny. 8°. Feels 6. POP. 0%. 9am. Mainly sunny. 10°. Feels 7.","title":"Madrid, MD, ES Current Weather","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"aqj"}},{"type":"resource","resource":{"uri":"https://weather.com/weather/today/l/Valdeacederas+Tetu%C3%A1n+Madrid+Spain?canonicalCityId=663174d0ea8ac456fd4372d2bc0bfac8","text":"Today. 67° / 37°. Sunny. 1%. 14 mph ... Plentiful sunshine. High 67F. Winds N at 10 to 20 mph. ... Clear skies. Low 37F. Winds N at 10 to 20 mph.","title":"Valdeacederas, Tetuán, Madrid, Spain Weather","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"cvs"}},{"type":"resource","resource":{"uri":"https://www.weatherbug.com/weather-forecast/now/madrid-madrid-sp","text":"Sunny. High temperature around 64F. Dew point will be around 34F with an average humidity of 49%. Winds will be 8 mph from the N. Tonight. Lo46° ...","title":"Madrid, Madrid, ES Weather Today & Tomorrow","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"a31"}},{"type":"resource","resource":{"uri":"https://www.wunderground.com/hourly/es/madrid","text":"Mainly clear skies. Low 38F. N winds at 10 to 20 mph, decreasing to less than 5 mph. Sun. 8:00AM. 8:39 ...","title":"Madrid, Spain Hourly Weather Forecast","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"eks"}},{"type":"resource","resource":{"uri":"https://www.timeanddate.com/weather/spain/madrid","text":"Weather in Madrid, Madrid, Spain ... Sunny. Feels Like: 54 °F Forecast: 66 / 35 °F Wind: 7 mph ↑ from North ...","title":"Weather for Madrid, Madrid, Spain","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"bpe"}},{"type":"resource","resource":{"uri":"https://www.timeanddate.com/weather/spain/madrid","text":"Weather in Madrid, Madrid, Spain ... Sunny. Feels Like: 54 °F Forecast: 66 / 35 °F Wind: 7 mph ↑ from North ...","title":"Weather for Madrid, Madrid, Spain - Time and Date","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"dba"}},{"type":"resource","resource":{"uri":"https://weather.com/weather/hourbyhour/l/66d93786ffcc98f9cd3bae34e03d05c3d4daa0178c2c4bffe4cfd354cda80400","text":"Hourly Weather Madrid, Madrid, Spain · as of 5:00 PM PDT · 3 am. 51°. Clear. 1%. 1%. 62%. 8 mph. 0 in · 4 am. 49°. Clear. 1%. 1%. 65%. 7 mph. 0 in · 5 am. 48°.","title":"Hourly Weather Forecast for Madrid, Madrid, Spain | weather.com","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"cx6"}},{"type":"resource","resource":{"uri":"https://www.accuweather.com/en/es/madrid/308526/current-weather/308526","text":"Madrid, Madrid · Current Weather. 6:07 AM. 49°F. Mostly clear. RealFeel® 45°. Chilly. RealFeel Guide. Chilly. 40° to 52°. Jacket or sweater ...","title":"Current Weather - Madrid - AccuWeather","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"ch7"}},{"type":"resource","resource":{"uri":"https://www.wunderground.com/hourly/es/madrid","text":"Mainly clear skies. Low 38F. N winds at 10 to 20 mph, decreasing to less than 5 mph. Sun. 8:00AM. 8:39 ...","title":"Madrid, Spain Hourly Weather Forecast","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"as8"}},{"type":"resource","resource":{"uri":"https://weather.metoffice.gov.uk/forecast/ezjmun1p8","text":"Madrid (Spain) weather ; Next hour. 14°C · 14 degrees Celsius ; Wednesday. 19°C · 19 degrees Celsius ; Thursday. 17°C · 17 degrees Celsius ; Friday. 20°C · 20 degrees ...","title":"Madrid (Spain) weather - Met Office","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"drk"}},{"type":"resource","resource":{"uri":"https://www.yr.no/en/forecast/hourly-table/2-3117732/Spain/Madrid/Madrid?i=0","text":"Thursday 9 Apr. Night: cloudy. Morning: cloudy. Afternoon: cloudy. Evening: partly cloudy. Maximum minimum temperature:18°/7°. Precipitation 0.2 mm. Wind ...","title":"Yr - Madrid - Hourly weather forecast","mimeType":"application/vnd.dust.tool-output.websearch-result","reference":"bs0"}}]',
+    },
+  ],
+  reasoning: {
+    effort: "none",
+    summary: "auto",
+  },
+  tools: [
+    {
+      type: "function",
+      strict: false,
+      name: "web_search_browse__websearch",
+      description:
+        "A tool that performs a Google web search based on a string query.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "The query used to perform the Google search. If requested by the user, use the Google syntax `site:` to restrict the search to a particular website or domain.",
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+    },
+    {
+      type: "function",
+      strict: false,
+      name: "web_search_browse__webbrowser",
+      description:
+        "A tool to browse websites, you can provide a list of up to 16 urls to browse all at once.",
+      parameters: {
+        type: "object",
+        properties: {
+          urls: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+            maxItems: 16,
+            description: "List of urls to browse (max: 16)",
+          },
+          screenshotMode: {
+            type: "string",
+            enum: ["none", "viewport", "fullPage"],
+            description:
+              "Screenshot mode: 'none' (default), 'viewport', or 'fullPage'.",
+          },
+          links: {
+            type: "boolean",
+            description: "If true, also retrieve outgoing links from the page.",
+          },
+        },
+        required: ["urls"],
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+    },
+    {
+      type: "function",
+      strict: false,
+      name: "common_utilities__get_current_time",
+      description:
+        "Return the current date and time in multiple convenient formats.",
+      parameters: {
+        type: "object",
+        properties: {
+          include_formats: {
+            type: "array",
+            items: {
+              type: "string",
+              enum: ["iso", "utc", "timestamp", "locale"],
+              description: "Specify which formats to return. Defaults to all.",
+            },
+            maxItems: 4,
+          },
+        },
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+    },
+  ],
+  text: {},
+  include: ["reasoning.encrypted_content"],
+  tool_choice: "auto",
+  stream: true,
+} as ResponseCreateParamsStreaming;
+
+const client = new OpenAI({
+  apiKey: process.env.DUST_MANAGED_OPENAI_API_KEY,
+  baseURL: "https://api.openai.com/v1",
+  defaultHeaders: {
+    "Content-Type": "application/json; charset=utf-8",
+    Accept: "application/json; charset=utf-8",
+  },
+});
+
+const call = async () => {
+  const events = await client.responses.create(payload);
+
+  const logEvents = [];
+
+  for await (const event of events) {
+    logEvents.push(event);
+  }
+  await fs.promises.writeFile(
+    path.join(__dirname, `openai_events_${Date.now().toString()}.json`),
+    JSON.stringify(logEvents, null, 2),
+    "utf8"
+  );
+};
+
+call();

--- a/x/pierre/providers/package-lock.json
+++ b/x/pierre/providers/package-lock.json
@@ -1,0 +1,1113 @@
+{
+  "name": "pierre-providers",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pierre-providers",
+      "version": "1.0.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@google/genai": "^1.48.0",
+        "@mistralai/mistralai": "^2.1.2",
+        "openai": "^6.33.0",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.2"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.48.0.tgz",
+      "integrity": "sha512-plonYK4ML2PrxsRD9SeqmFt76eREWkQdPCglOA6aYDzL1AAbE+7PUnT54SvpWGfws13L0AZEqGSpL7+1IPnTxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.1.2.tgz",
+      "integrity": "sha512-0NlXBNdTMmi4z0oSUWa8KseBHlli+/FkaUTaAyLYTJzkKh3mYM/D3DnJzRil8VD6QC7W3IteARjd3LnxAZGPUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.33.0.tgz",
+      "integrity": "sha512-xAYN1W3YsDXJWA5F277135YfkEk6H7D3D6vWwRhJ3OEkzRgcyK8z/P5P9Gyi/wB4N8kK9kM5ZjprfvyHagKmpw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/x/pierre/providers/package.json
+++ b/x/pierre/providers/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "pierre-providers",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "anthropic": "tsx anthropic.ts",
+    "openai": "tsx openai.ts",
+    "mistral": "tsx mistral.ts",
+    "google": "tsx google.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.81.0",
+    "@google/genai": "^1.48.0",
+    "@mistralai/mistralai": "^2.1.2",
+    "openai": "^6.33.0",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2"
+  }
+}


### PR DESCRIPTION
Add temporary debug instrumentation to capture raw provider payloads and standalone test scripts for each LLM provider.

- Dump raw request payloads to JSON files in each provider client (`anthropic`, `openai`, `mistral`, `google`) to inspect what is actually sent over the wire
- Add standalone `x/pierre/providers/` scripts to replay captured payloads directly against provider APIs, bypassing the Dust stack