### PR TITLE
[front] remove new conv button

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -315,13 +315,6 @@ function SearchResults({
           defaultOpen
           action={
             <>
-              <Button
-                size="xmini"
-                icon={ChatBubbleBottomCenterPlusIcon}
-                variant="ghost"
-                tooltip="New Conversation"
-                href={getConversationRoute(owner.sId)}
-              />
               <DropdownMenu modal={false}>
                 <DropdownMenuTrigger asChild>
                   <Button
@@ -1425,15 +1418,6 @@ function NavigationListWithInbox({
           defaultOpen
           action={
             <>
-              <Button
-                size="xmini"
-                icon={ChatBubbleBottomCenterPlusIcon}
-                variant="ghost"
-                aria-label="New Conversation"
-                tooltip="New Conversation"
-                href={getConversationRoute(owner.sId)}
-                onClick={handleNewClick}
-              />
               <DropdownMenu modal={false}>
                 <DropdownMenuTrigger asChild>
                   <Button


### PR DESCRIPTION
## Description
This PR closes https://github.com/dust-tt/tasks/issues/7261

before:
<img width="614" height="74" alt="CleanShot 2026-04-01 at 17 43 26@2x" src="https://github.com/user-attachments/assets/783de920-66b4-4534-b27a-2c7ec7816da5" />

after:
<img width="614" height="94" alt="CleanShot 2026-04-01 at 17 43 07@2x" src="https://github.com/user-attachments/assets/3dfc2750-9744-49eb-b4ca-90596df87f15" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
