### PR TITLE
Add tab metadata in Markdown content

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/extension",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Dust Chrome Extension",
   "scripts": {
     "clean": "rm -rf build/*",

--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/platforms/firefox/manifests/manifest.base.json
+++ b/extension/platforms/firefox/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/ui/hooks/useFileUploaderService.ts
+++ b/extension/ui/hooks/useFileUploaderService.ts
@@ -115,7 +115,20 @@ export function useFileUploaderService(
           );
 
           if (tabContent && tabContent.content) {
-            const file = new File([tabContent.content], title, {
+            const parts = [];
+            if (tabContent.title) {
+              parts.push(`Title: ${tabContent.title}`);
+            }
+            if (tabContent.url) {
+              parts.push(`URL: ${tabContent.url}`);
+            }
+            if (parts.length > 0) {
+              // Add a visual separator between metadata and content
+              parts.push("");
+            }
+            parts.push(tabContent.content);
+
+            const file = new File([parts.join("\n")], title, {
               type: "text/markdown",
             });
 


### PR DESCRIPTION
## Description

Fixes the issue where page URL was missing from markdown content captured via the Chrome extension. When uploading tab content as markdown, the PR now prepends a metadata header containing the page title and URL before the actual content. This ensures agents can always extract the source URL from captured pages, regardless of whether the content is `.txt` or `.md` format.

Related to #7291.

## Tests

Manually tested by capturing page content in the extension and verifying that the markdown file now includes the title and URL