### PR TITLE
[Tool Calls] Stream tool call starts before execution

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -340,6 +340,7 @@ export function AgentMessage({
             break;
           }
           case "end-of-stream":
+          case "tool_call_started":
           case "tool_error":
           case "tool_notification":
           case "tool_params":
@@ -1257,6 +1258,7 @@ function AgentMessageContent({
           agentMessage={agentMessage}
           lastAgentStateClassification={agentMessage.streaming.agentState}
           completedSteps={agentMessage.streaming.inlineActivitySteps}
+          pendingToolCalls={agentMessage.streaming.pendingToolCalls}
         />
       ) : (
         <AgentMessageActions
@@ -1264,6 +1266,7 @@ function AgentMessageContent({
           lastAgentStateClassification={agentMessage.streaming.agentState}
           actionProgress={agentMessage.streaming.actionProgress}
           owner={owner}
+          pendingToolCalls={agentMessage.streaming.pendingToolCalls}
         />
       )}
       <AgentMessageInteractiveContentGeneratedFiles files={interactiveFiles} />

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -267,6 +267,10 @@ function AgentActionsPanelContent({
 
   const streamActionProgress =
     messageStreamState?.streaming.actionProgress ?? new Map();
+  const pendingToolCallNames =
+    messageStreamState?.streaming.pendingToolCalls.map(
+      (toolCall) => toolCall.name
+    ) ?? [];
   return (
     <div className="flex h-full flex-col bg-background dark:bg-background-night">
       <AgentActionsPanelHeader
@@ -305,13 +309,18 @@ function AgentActionsPanelContent({
               <PanelAgentStep
                 stepNumber={currentStreamingStep}
                 reasoningContent={
-                  lastChainOfThoughtRef.current.step === currentStreamingStep
-                    ? lastChainOfThoughtRef.current.content
-                    : "Thinking..."
+                  pendingToolCallNames.length === 0
+                    ? lastChainOfThoughtRef.current.step ===
+                      currentStreamingStep
+                      ? lastChainOfThoughtRef.current.content
+                      : "Thinking..."
+                    : undefined
                 }
                 isStreaming={
+                  pendingToolCallNames.length === 0 &&
                   messageStreamState.streaming.agentState === "thinking"
                 }
+                pendingToolCallNames={pendingToolCallNames}
                 streamingActions={
                   messageStreamState.streaming.agentState === "acting"
                     ? messageStreamState.actions.filter((action) => {

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -1,9 +1,11 @@
 import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
 import { MCPImageGenerationGroupedDetails } from "@app/components/actions/mcp/details/MCPImageGenerationActionDetails";
+import { getPendingToolCallLabel } from "@app/components/assistant/conversation/actions/inline/types";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import type {
   ActionProgressState,
   AgentStateClassification,
+  PendingToolCall,
 } from "@app/components/assistant/conversation/types";
 import { GENERATE_IMAGE_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
@@ -27,6 +29,7 @@ interface AgentMessageActionsProps {
   lastAgentStateClassification: AgentStateClassification;
   actionProgress: ActionProgressState;
   owner: LightWorkspaceType;
+  pendingToolCalls: PendingToolCall[];
 }
 
 export function AgentMessageActions({
@@ -34,6 +37,7 @@ export function AgentMessageActions({
   lastAgentStateClassification,
   actionProgress,
   owner,
+  pendingToolCalls,
 }: AgentMessageActionsProps) {
   const { openPanel, currentPanel, data } = useConversationSidePanelContext();
 
@@ -53,6 +57,7 @@ export function AgentMessageActions({
 
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const chainOfThought = agentMessage.chainOfThought || "";
+  const hasPendingToolCalls = pendingToolCalls.length > 0;
 
   const firstRender = useRef<boolean>(true);
   const onClick = () => {
@@ -115,7 +120,18 @@ export function AgentMessageActions({
         <div>
           <ContentMessage variant="primary" className="min-h-fit p-3">
             <div className="flex w-full flex-row">
-              {!chainOfThought ? (
+              {hasPendingToolCalls ? (
+                <div className="flex flex-col gap-y-1">
+                  {pendingToolCalls.map((toolCall) => (
+                    <span
+                      key={toolCall.key}
+                      className="text-sm text-muted-foreground dark:text-muted-foreground-night"
+                    >
+                      {getPendingToolCallLabel(toolCall.name)}
+                    </span>
+                  ))}
+                </div>
+              ) : !chainOfThought ? (
                 <AnimatedText variant="primary">Thinking...</AnimatedText>
               ) : (
                 <Markdown
@@ -136,9 +152,8 @@ export function AgentMessageActions({
               )}
               <span className="flex-grow"></span>
               <div className="w-8 self-start pl-4 pt-0.5">
-                {lastAgentStateClassification === "thinking" && (
-                  <Spinner size="xs" />
-                )}
+                {(lastAgentStateClassification === "thinking" ||
+                  hasPendingToolCalls) && <Spinner size="xs" />}
               </div>
             </div>
           </ContentMessage>

--- a/front/components/assistant/conversation/actions/PanelAgentStep.tsx
+++ b/front/components/assistant/conversation/actions/PanelAgentStep.tsx
@@ -1,4 +1,5 @@
 import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
+import { getPendingToolCallLabel } from "@app/components/assistant/conversation/actions/inline/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type { ParsedContentItem } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -10,6 +11,7 @@ interface AgentStepProps {
   reasoningContent?: string;
   isStreaming?: boolean;
   streamingActions?: AgentMCPActionWithOutputType[];
+  pendingToolCallNames?: string[];
   streamActionProgress: Map<number, any>;
   owner: LightWorkspaceType;
   messageStatus: "created" | "succeeded" | "failed" | "cancelled";
@@ -22,6 +24,7 @@ export function PanelAgentStep({
   reasoningContent,
   isStreaming = false,
   streamingActions = [],
+  pendingToolCallNames = [],
   streamActionProgress,
   owner,
   messageStatus,
@@ -42,6 +45,23 @@ export function PanelAgentStep({
               textColor="text-muted-foreground dark:text-muted-foreground-night"
               isLastMessage={false}
             />
+          </ContentMessage>
+        </div>
+      )}
+
+      {pendingToolCallNames.length > 0 && (
+        <div className="transition-all duration-300 animate-in fade-in slide-in-from-bottom-1">
+          <ContentMessage variant="primary" size="lg">
+            <div className="flex flex-col gap-1">
+              {pendingToolCallNames.map((toolName, index) => (
+                <span
+                  key={`${toolName}-${index}`}
+                  className="text-sm text-muted-foreground dark:text-muted-foreground-night"
+                >
+                  {getPendingToolCallLabel(toolName)}
+                </span>
+              ))}
+            </div>
           </ContentMessage>
         </div>
       )}

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -1,9 +1,13 @@
 import { TimelineRow } from "@app/components/assistant/conversation/actions/inline/TimelineRow";
-import { getActionOneLineLabel } from "@app/components/assistant/conversation/actions/inline/types";
+import {
+  getActionOneLineLabel,
+  getPendingToolCallLabel,
+} from "@app/components/assistant/conversation/actions/inline/types";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import type {
   AgentStateClassification,
   InlineActivityStep,
+  PendingToolCall,
 } from "@app/components/assistant/conversation/types";
 import type {
   LightAgentMessageType,
@@ -25,6 +29,7 @@ interface InlineActivityStepsProps {
   agentMessage: LightAgentMessageType | LightAgentMessageWithActionsType;
   lastAgentStateClassification: AgentStateClassification;
   completedSteps: InlineActivityStep[];
+  pendingToolCalls: PendingToolCall[];
 }
 
 /**
@@ -38,6 +43,7 @@ export function InlineActivitySteps({
   agentMessage,
   lastAgentStateClassification,
   completedSteps,
+  pendingToolCalls,
 }: InlineActivityStepsProps) {
   const isAgentMessageWithActions =
     isLightAgentMessageWithActionsType(agentMessage);
@@ -59,6 +65,7 @@ export function InlineActivitySteps({
     lastAgentStateClassification === "done" || agentMessage.status === "failed";
   const isThinking = lastAgentStateClassification === "thinking";
   const isActing = lastAgentStateClassification === "acting";
+  const hasPendingToolCalls = pendingToolCalls.length > 0;
 
   if (isDone && completedSteps.length === 0) {
     return null;
@@ -66,12 +73,15 @@ export function InlineActivitySteps({
 
   // Show active thinking whenever the agent is thinking.
   // Dedup in appendThinkingStep handles duplicate content at capture time.
-  const showActiveThinking = isThinking;
+  const showActiveThinking = isThinking && !hasPendingToolCalls;
   const activeAction =
     isActing && isAgentMessageWithActions ? actions[actions.length - 1] : null;
 
   const hasContent =
-    completedSteps.length > 0 || showActiveThinking || activeAction;
+    completedSteps.length > 0 ||
+    showActiveThinking ||
+    activeAction ||
+    hasPendingToolCalls;
   if (!hasContent) {
     return null;
   }
@@ -128,6 +138,23 @@ export function InlineActivitySteps({
             }
           })}
 
+          {pendingToolCalls.map((toolCall, index) => {
+            const isLastPendingToolCall =
+              index === pendingToolCalls.length - 1 && !activeAction && !isDone;
+
+            return (
+              <TimelineRow
+                key={toolCall.key}
+                spinner={isLastPendingToolCall}
+                isLast={isLastPendingToolCall}
+              >
+                <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                  {getPendingToolCallLabel(toolCall.name)}
+                </span>
+              </TimelineRow>
+            );
+          })}
+
           {/* Active thinking (streaming CoT) */}
           {showActiveThinking && (
             <TimelineRow
@@ -161,9 +188,10 @@ export function InlineActivitySteps({
           )}
 
           {/* Pending spinner — shown when between transitions (not done, nothing active) */}
-          {!isDone && !showActiveThinking && !activeAction && (
-            <TimelineRow spinner isLast />
-          )}
+          {!isDone &&
+            !showActiveThinking &&
+            !activeAction &&
+            !hasPendingToolCalls && <TimelineRow spinner isLast />}
 
           {/* Done marker */}
           {isDone && completedSteps.length > 0 && (

--- a/front/components/assistant/conversation/actions/inline/types.ts
+++ b/front/components/assistant/conversation/actions/inline/types.ts
@@ -12,3 +12,7 @@ export function getActionOneLineLabel(
     ? asDisplayName(action.functionCallName)
     : "Tool";
 }
+
+export function getPendingToolCallLabel(toolName: string): string {
+  return `Preparing to call ${asDisplayName(toolName)}`;
+}

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -182,6 +182,7 @@ export function createPlaceholderAgentMessage({
       isRetrying: false,
       lastUpdated: new Date(),
       actionProgress: new Map(),
+      pendingToolCalls: [],
       useFullChainOfThought: false,
     },
   };

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -46,6 +46,11 @@ export type ActionProgressState = Map<
   }
 >;
 
+export interface PendingToolCall {
+  key: string;
+  name: string;
+}
+
 export type InlineActivityStep =
   | { type: "thinking"; content: string; id: string }
   | { type: "action"; action: AgentMCPActionWithOutputType; id: string };
@@ -56,6 +61,7 @@ export type MessageTemporaryState = LightAgentMessageWithActionsType & {
     isRetrying: boolean;
     lastUpdated: Date;
     actionProgress: ActionProgressState;
+    pendingToolCalls: PendingToolCall[];
     useFullChainOfThought: boolean;
     inlineActivitySteps: InlineActivityStep[];
   };
@@ -168,6 +174,7 @@ export const makeInitialMessageStreamState = (
       inlineActivitySteps: [],
       isRetrying: false,
       lastUpdated: new Date(),
+      pendingToolCalls: [],
       useFullChainOfThought: false,
     },
   };

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -49,6 +49,8 @@ export type ActionProgressState = Map<
 export interface PendingToolCall {
   key: string;
   name: string;
+  toolCallId?: string;
+  toolCallIndex?: number;
 }
 
 export type InlineActivityStep =

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -1,0 +1,98 @@
+import type { PendingToolCall } from "@app/components/assistant/conversation/types";
+import {
+  removePendingToolCall,
+  upsertPendingToolCall,
+} from "@app/hooks/useAgentMessageStream";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import { describe, expect, it } from "vitest";
+
+function createActionIdentity({
+  functionCallId,
+  functionCallName,
+}: {
+  functionCallId: string;
+  functionCallName: string;
+}) {
+  return {
+    functionCallId,
+    functionCallName,
+  } satisfies Pick<
+    AgentMCPActionWithOutputType,
+    "functionCallId" | "functionCallName"
+  >;
+}
+
+describe("useAgentMessageStream pending tool calls", () => {
+  it("should merge a pending tool call when the call id arrives later", () => {
+    const initialPendingToolCalls = upsertPendingToolCall([], {
+      toolCallIndex: 0,
+      toolName: "create_interactive_content_file",
+    });
+
+    const pendingToolCalls = upsertPendingToolCall(initialPendingToolCalls, {
+      toolCallId: "call_123",
+      toolCallIndex: 0,
+      toolName: "create_interactive_content_file",
+    });
+
+    expect(pendingToolCalls).toEqual<PendingToolCall[]>([
+      {
+        key: "tool-call-0",
+        name: "create_interactive_content_file",
+        toolCallId: "call_123",
+        toolCallIndex: 0,
+      },
+    ]);
+  });
+
+  it("should remove only the matching pending tool call when an action starts", () => {
+    const pendingToolCalls: PendingToolCall[] = [
+      {
+        key: "call_123",
+        name: "create_interactive_content_file",
+        toolCallId: "call_123",
+      },
+      {
+        key: "call_456",
+        name: "search_knowledge",
+        toolCallId: "call_456",
+      },
+    ];
+
+    expect(
+      removePendingToolCall(
+        pendingToolCalls,
+        createActionIdentity({
+          functionCallId: "call_123",
+          functionCallName: "create_interactive_content_file",
+        })
+      )
+    ).toEqual<PendingToolCall[]>([
+      {
+        key: "call_456",
+        name: "search_knowledge",
+        toolCallId: "call_456",
+      },
+    ]);
+  });
+
+  it("should fall back to a unique tool name when the pending tool call has no id yet", () => {
+    const pendingToolCalls: PendingToolCall[] = [
+      {
+        key: "tool-call-0",
+        name: "create_interactive_content_file",
+        toolCallIndex: 0,
+      },
+    ];
+
+    expect(
+      removePendingToolCall(
+        pendingToolCalls,
+        createActionIdentity({
+          functionCallId: "call_123",
+          functionCallName: "create_interactive_content_file",
+        })
+      )
+    ).toEqual<PendingToolCall[]>([]);
+  });
+});

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -2,6 +2,7 @@ import type {
   AgentMessageStateWithControlEvent,
   InlineActivityStep,
   MessageTemporaryState,
+  PendingToolCall,
   VirtuosoMessage,
   VirtuosoMessageListContext,
 } from "@app/components/assistant/conversation/types";
@@ -161,6 +162,24 @@ function appendThinkingStep(
     }
   }
   return [...steps, { type: "thinking", content: cotContent, id }];
+}
+
+function getPendingToolCallKey({
+  toolCallId,
+  toolCallIndex,
+  toolName,
+}: {
+  toolCallId?: string;
+  toolCallIndex?: number;
+  toolName: string;
+}): string {
+  if (toolCallId) {
+    return toolCallId;
+  }
+  if (toolCallIndex !== undefined) {
+    return `tool-call-${toolCallIndex}`;
+  }
+  return `tool-call-${toolName}`;
 }
 
 interface UseAgentMessageStreamParams {
@@ -333,6 +352,7 @@ export function useAgentMessageStream({
                     ([id]) => id !== action.id
                   )
                 ),
+                pendingToolCalls: [],
               },
             };
           });
@@ -362,6 +382,47 @@ export function useAgentMessageStream({
                 ...m.streaming,
                 agentState: "acting",
                 inlineActivitySteps: steps,
+                pendingToolCalls: [],
+              },
+            };
+          });
+          break;
+
+        case "tool_call_started":
+          const startedToolCall = eventPayload.data;
+          const cotAtToolCallStart = chainOfThought.current;
+          chainOfThought.current = "";
+          methods.data.map((m) => {
+            if (!isMessageTemporayState(m) || m.sId !== sId) {
+              return m;
+            }
+
+            const pendingToolCall: PendingToolCall = {
+              key: getPendingToolCallKey(startedToolCall),
+              name: startedToolCall.toolName,
+            };
+
+            const pendingToolCalls = m.streaming.pendingToolCalls.some(
+              (toolCall) => toolCall.key === pendingToolCall.key
+            )
+              ? m.streaming.pendingToolCalls
+              : [...m.streaming.pendingToolCalls, pendingToolCall];
+
+            const steps = cotAtToolCallStart
+              ? appendThinkingStep(
+                  m.streaming.inlineActivitySteps,
+                  cotAtToolCallStart,
+                  `thinking-tool-call-${Date.now()}`
+                )
+              : m.streaming.inlineActivitySteps;
+
+            return {
+              ...m,
+              chainOfThought: "",
+              streaming: {
+                ...m.streaming,
+                inlineActivitySteps: steps,
+                pendingToolCalls,
               },
             };
           });
@@ -400,6 +461,7 @@ export function useAgentMessageStream({
                 ...m.streaming,
                 agentState: "done",
                 inlineActivitySteps: steps,
+                pendingToolCalls: [],
               },
             };
           });
@@ -425,6 +487,7 @@ export function useAgentMessageStream({
                   streaming: {
                     ...m.streaming,
                     agentState: "done",
+                    pendingToolCalls: [],
                   },
                 }
               : m
@@ -455,6 +518,7 @@ export function useAgentMessageStream({
                 ...m.streaming,
                 agentState: "done",
                 inlineActivitySteps: steps,
+                pendingToolCalls: [],
               },
             };
           });

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -182,6 +182,111 @@ function getPendingToolCallKey({
   return `tool-call-${toolName}`;
 }
 
+function getPendingToolCallMatchIndex(
+  pendingToolCalls: PendingToolCall[],
+  {
+    toolCallId,
+    toolCallIndex,
+    toolName,
+  }: {
+    toolCallId?: string;
+    toolCallIndex?: number;
+    toolName: string;
+  }
+): number {
+  return pendingToolCalls.findIndex((pendingToolCall) => {
+    if (toolCallId && pendingToolCall.toolCallId === toolCallId) {
+      return true;
+    }
+
+    if (
+      toolCallIndex !== undefined &&
+      pendingToolCall.toolCallIndex === toolCallIndex
+    ) {
+      return true;
+    }
+
+    return (
+      !toolCallId &&
+      toolCallIndex === undefined &&
+      !pendingToolCall.toolCallId &&
+      pendingToolCall.toolCallIndex === undefined &&
+      pendingToolCall.name === toolName
+    );
+  });
+}
+
+export function upsertPendingToolCall(
+  pendingToolCalls: PendingToolCall[],
+  {
+    toolCallId,
+    toolCallIndex,
+    toolName,
+  }: {
+    toolCallId?: string;
+    toolCallIndex?: number;
+    toolName: string;
+  }
+): PendingToolCall[] {
+  const matchIndex = getPendingToolCallMatchIndex(pendingToolCalls, {
+    toolCallId,
+    toolCallIndex,
+    toolName,
+  });
+
+  const nextPendingToolCall: PendingToolCall = {
+    key:
+      matchIndex !== -1
+        ? pendingToolCalls[matchIndex].key
+        : getPendingToolCallKey({ toolCallId, toolCallIndex, toolName }),
+    name: toolName,
+    ...(toolCallId ? { toolCallId } : {}),
+    ...(toolCallIndex !== undefined ? { toolCallIndex } : {}),
+  };
+
+  if (matchIndex === -1) {
+    return [...pendingToolCalls, nextPendingToolCall];
+  }
+
+  return pendingToolCalls.map((pendingToolCall, index) =>
+    index === matchIndex
+      ? {
+          ...pendingToolCall,
+          ...nextPendingToolCall,
+        }
+      : pendingToolCall
+  );
+}
+
+export function removePendingToolCall(
+  pendingToolCalls: PendingToolCall[],
+  action: Pick<
+    AgentMCPActionWithOutputType,
+    "functionCallId" | "functionCallName"
+  >
+): PendingToolCall[] {
+  const pendingToolCallWithIdIndex = pendingToolCalls.findIndex(
+    (pendingToolCall) => pendingToolCall.toolCallId === action.functionCallId
+  );
+  if (pendingToolCallWithIdIndex !== -1) {
+    return pendingToolCalls.filter(
+      (_, index) => index !== pendingToolCallWithIdIndex
+    );
+  }
+
+  const pendingToolCallsWithSameName = pendingToolCalls.filter(
+    (pendingToolCall) => pendingToolCall.name === action.functionCallName
+  );
+
+  if (pendingToolCallsWithSameName.length !== 1) {
+    return pendingToolCalls;
+  }
+
+  return pendingToolCalls.filter(
+    (pendingToolCall) => pendingToolCall !== pendingToolCallsWithSameName[0]
+  );
+}
+
 interface UseAgentMessageStreamParams {
   agentMessage: MessageTemporaryState;
   conversationId: string | null;
@@ -352,7 +457,10 @@ export function useAgentMessageStream({
                     ([id]) => id !== action.id
                   )
                 ),
-                pendingToolCalls: [],
+                pendingToolCalls: removePendingToolCall(
+                  m.streaming.pendingToolCalls,
+                  action
+                ),
               },
             };
           });
@@ -382,7 +490,10 @@ export function useAgentMessageStream({
                 ...m.streaming,
                 agentState: "acting",
                 inlineActivitySteps: steps,
-                pendingToolCalls: [],
+                pendingToolCalls: removePendingToolCall(
+                  m.streaming.pendingToolCalls,
+                  toolParams.action
+                ),
               },
             };
           });
@@ -397,16 +508,10 @@ export function useAgentMessageStream({
               return m;
             }
 
-            const pendingToolCall: PendingToolCall = {
-              key: getPendingToolCallKey(startedToolCall),
-              name: startedToolCall.toolName,
-            };
-
-            const pendingToolCalls = m.streaming.pendingToolCalls.some(
-              (toolCall) => toolCall.key === pendingToolCall.key
-            )
-              ? m.streaming.pendingToolCalls
-              : [...m.streaming.pendingToolCalls, pendingToolCall];
+            const pendingToolCalls = upsertPendingToolCall(
+              m.streaming.pendingToolCalls,
+              startedToolCall
+            );
 
             const steps = cotAtToolCallStart
               ? appendThinkingStep(

--- a/front/hooks/useChildAgentStream.ts
+++ b/front/hooks/useChildAgentStream.ts
@@ -68,6 +68,7 @@ function childAgentStreamReducer(
     // Events we don't use for the child stream display.
     case "end-of-stream":
     case "agent_action_success":
+    case "tool_call_started":
     case "tool_params":
     case "tool_notification":
     case "agent_context_pruned":

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -1,6 +1,8 @@
-import type { AgentActionRunningEvents } from "@app/lib/actions/mcp";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
-import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types";
+import type {
+  AgentMessageEvents,
+  ConversationEvents,
+} from "@app/lib/api/assistant/streaming/types";
 import type { EventPayload } from "@app/lib/api/redis-hybrid-manager";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
@@ -10,12 +12,6 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { makeAgentLoopWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 import { cancelAgentLoopSignal } from "@app/temporal/agent_loop/signals";
-import type {
-  AgentActionSuccessEvent,
-  AgentErrorEvent,
-  AgentGenerationCancelledEvent,
-} from "@app/types/assistant/agent";
-import type { GenerationTokensEvent } from "@app/types/assistant/generation";
 
 export async function* getConversationEvents({
   conversationId,
@@ -144,13 +140,7 @@ export async function* getMessagesEvents(
 ): AsyncGenerator<
   {
     eventId: string;
-    data: (
-      | AgentErrorEvent
-      | AgentActionRunningEvents
-      | AgentActionSuccessEvent
-      | AgentGenerationCancelledEvent
-      | GenerationTokensEvent
-    ) & {
+    data: AgentMessageEvents & {
       step: number;
     };
   },

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -114,6 +114,7 @@ function isMessageEventParams(
     case "agent_generation_cancelled":
     case "agent_message_success":
     case "generation_tokens":
+    case "tool_call_started":
     case "tool_approve_execution":
     case "tool_error":
     case "tool_file_auth_required":

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -10,6 +10,7 @@ import type {
   AgentGenerationCancelledEvent,
   AgentMessageDoneEvent,
   AgentMessageSuccessEvent,
+  AgentToolCallStartedEvent,
   ToolErrorEvent,
 } from "@app/types/assistant/agent";
 import type {
@@ -29,6 +30,7 @@ export type AgentMessageEvents =
   | AgentErrorEvent
   | AgentGenerationCancelledEvent
   | AgentMessageSuccessEvent
+  | AgentToolCallStartedEvent
   | GenerationTokensEvent
   | ToolErrorEvent
   | ToolFileAuthRequiredEvent

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -433,6 +433,7 @@ function eventToStoredStepContent(
     case "success":
     case "text_delta":
     case "token_usage":
+    case "tool_call_started":
     case "tool_call_delta":
       return null;
     default:

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -117,7 +117,11 @@ function* handleMessageStreamEvent(
      * content_block_stop (marks the end of the content block)
      */
     case "content_block_start":
-      handleContentBlockStart(messageStreamEvent, stateContainer);
+      yield* handleContentBlockStart(
+        messageStreamEvent,
+        stateContainer,
+        metadata
+      );
       break;
     case "content_block_delta":
       yield* handleContentBlockDelta(
@@ -145,10 +149,11 @@ function* handleMessageStreamEvent(
   }
 }
 
-function handleContentBlockStart(
+function* handleContentBlockStart(
   event: Extract<BetaRawMessageStreamEvent, { type: "content_block_start" }>,
-  stateContainer: { state: StreamState }
-): void {
+  stateContainer: { state: StreamState },
+  metadata: LLMClientMetadata
+): Generator<LLMEvent> {
   assert(
     stateContainer.state === null,
     `A content block is already being processed, cannot start a new one at index ${event.index}`
@@ -162,8 +167,8 @@ function handleContentBlockStart(
         accumulator: "",
         accumulatorType: blockType === "text" ? "text" : "reasoning",
       };
-      break;
-    case "tool_use":
+      return;
+    case "tool_use": {
       stateContainer.state = {
         currentBlockIndex: event.index,
         accumulator: "",
@@ -173,10 +178,20 @@ function handleContentBlockStart(
           name: event.content_block.name,
         },
       };
-      break;
+      yield {
+        type: "tool_call_started",
+        content: {
+          id: event.content_block.id,
+          index: event.index,
+          name: event.content_block.name,
+        },
+        metadata,
+      };
+      return;
+    }
     case "redacted_thinking":
       // "Redacted thinking" provides no actionable information, as everything is encrypted
-      break;
+      return;
     case "server_tool_use":
     case "web_search_tool_result":
     case "web_fetch_tool_result":
@@ -189,7 +204,7 @@ function handleContentBlockStart(
     case "container_upload":
     case "compaction":
       // We don't use these Anthropic tools
-      break;
+      return;
     default:
       assertNever(blockType);
   }

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
@@ -11,6 +11,18 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     },
   },
   {
+    type: "tool_call_started",
+    content: {
+      id: "EmptyToolCall1",
+      index: 0,
+      name: "test_tool",
+    },
+    metadata: {
+      clientId: "anthropic" as const,
+      modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+    },
+  },
+  {
     type: "tool_call_delta",
     metadata: {
       clientId: "anthropic" as const,

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
@@ -41,6 +41,18 @@ export const toolUseLLMEvents: LLMEvent[] = [
     },
   },
   {
+    type: "tool_call_started",
+    content: {
+      id: "DdHr7L197",
+      index: 1,
+      name: "web_search_browse__websearch",
+    },
+    metadata: {
+      clientId: "anthropic" as const,
+      modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+    },
+  },
+  {
     type: "tool_call_delta",
     metadata: {
       clientId: "anthropic" as const,

--- a/front/lib/api/llm/types/events.ts
+++ b/front/lib/api/llm/types/events.ts
@@ -29,6 +29,16 @@ export interface ReasoningDeltaEvent {
   metadata: LLMClientMetadata & { encrypted_content?: string };
 }
 
+export interface ToolCallStartedEvent {
+  type: "tool_call_started";
+  content: {
+    id?: string;
+    index?: number;
+    name: string;
+  };
+  metadata: LLMClientMetadata;
+}
+
 // Tool call deltas are not streamed to the UI but they are used internally
 // as heartbeat to know the LLM is still active.
 export interface ToolCallDeltaEvent {
@@ -112,6 +122,7 @@ export type LLMEvent =
   | ResponseIdEvent
   | TextDeltaEvent
   | ReasoningDeltaEvent
+  | ToolCallStartedEvent
   | ToolCallDeltaEvent
   | ToolCallEvent
   | TextGeneratedEvent

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
@@ -1,0 +1,203 @@
+import { createAsyncGenerator } from "@app/lib/api/llm/utils";
+import { streamLLMEvents } from "@app/lib/api/llm/utils/openai_like/chat/openai_to_events";
+import type { ChatCompletionChunk } from "openai/resources/chat/completions";
+import { describe, expect, it } from "vitest";
+
+const metadata = {
+  clientId: "openai",
+  modelId: "gpt-5",
+} as const;
+
+const toolCallChunks = [
+  {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              function: {
+                name: "create_interactive_content_file",
+              },
+            },
+          ],
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_123",
+            },
+          ],
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              function: {
+                arguments: '{"prompt":"hi"}',
+              },
+            },
+          ],
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: "tool_calls",
+        logprobs: null,
+      },
+    ],
+    usage: {
+      prompt_tokens: 1,
+      completion_tokens: 2,
+      total_tokens: 3,
+    },
+  },
+] satisfies ChatCompletionChunk[];
+
+describe("streamLLMEvents", () => {
+  it("should emit a tool call start before the first arguments chunk", async () => {
+    const result = [];
+
+    for await (const event of streamLLMEvents(
+      createAsyncGenerator(toolCallChunks),
+      metadata
+    )) {
+      result.push(event);
+    }
+
+    expect(result).toEqual([
+      {
+        type: "interaction_id",
+        content: {
+          modelInteractionId: "chatcmpl_test",
+        },
+        metadata,
+      },
+      {
+        type: "tool_call_started",
+        content: {
+          index: 0,
+          name: "create_interactive_content_file",
+        },
+        metadata,
+      },
+      {
+        type: "tool_call_delta",
+        metadata,
+      },
+      {
+        type: "tool_call_started",
+        content: {
+          id: "call_123",
+          index: 0,
+          name: "create_interactive_content_file",
+        },
+        metadata,
+      },
+      {
+        type: "tool_call_delta",
+        metadata,
+      },
+      {
+        type: "tool_call_delta",
+        metadata,
+      },
+      {
+        type: "token_usage",
+        content: {
+          inputTokens: 1,
+          outputTokens: 2,
+          totalTokens: 3,
+          cachedTokens: undefined,
+        },
+        metadata,
+      },
+      {
+        type: "tool_call",
+        content: {
+          id: "call_123",
+          name: "create_interactive_content_file",
+          arguments: {
+            prompt: "hi",
+          },
+        },
+        metadata,
+      },
+      {
+        type: "success",
+        aggregated: [
+          {
+            type: "tool_call",
+            content: {
+              id: "call_123",
+              name: "create_interactive_content_file",
+              arguments: {
+                prompt: "hi",
+              },
+            },
+            metadata,
+          },
+        ],
+        textGenerated: undefined,
+        reasoningGenerated: undefined,
+        toolCalls: [
+          {
+            type: "tool_call",
+            content: {
+              id: "call_123",
+              name: "create_interactive_content_file",
+              arguments: {
+                prompt: "hi",
+              },
+            },
+            metadata,
+          },
+        ],
+        metadata,
+      },
+    ]);
+  });
+});

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
@@ -16,7 +16,7 @@ export async function* streamLLMEvents(
   let reasoningDelta = "";
   const toolCalls: Map<
     number,
-    { id: string; name: string; arguments: string }
+    { id: string; name: string; arguments: string; hasEmittedStart: boolean }
   > = new Map();
   let hasYieldedResponseId = false;
   let hasError = false;
@@ -81,6 +81,7 @@ export async function* streamLLMEvents(
             id: "",
             name: "",
             arguments: "",
+            hasEmittedStart: false,
           });
         }
 
@@ -95,6 +96,23 @@ export async function* streamLLMEvents(
         }
         if (toolCallDelta.function?.arguments) {
           toolCall.arguments += toolCallDelta.function.arguments;
+        }
+
+        if (
+          !toolCall.hasEmittedStart &&
+          toolCall.name.length > 0 &&
+          toolCallDelta.function?.arguments !== undefined
+        ) {
+          toolCall.hasEmittedStart = true;
+          yield {
+            type: "tool_call_started",
+            content: {
+              ...(toolCall.id ? { id: toolCall.id } : {}),
+              index,
+              name: toolCall.name,
+            },
+            metadata,
+          };
         }
       }
       yield { type: "tool_call_delta", metadata };

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
@@ -16,7 +16,12 @@ export async function* streamLLMEvents(
   let reasoningDelta = "";
   const toolCalls: Map<
     number,
-    { id: string; name: string; arguments: string; hasEmittedStart: boolean }
+    {
+      id: string;
+      name: string;
+      arguments: string;
+      startEmissionState: "none" | "without_id" | "with_id";
+    }
   > = new Map();
   let hasYieldedResponseId = false;
   let hasError = false;
@@ -81,7 +86,7 @@ export async function* streamLLMEvents(
             id: "",
             name: "",
             arguments: "",
-            hasEmittedStart: false,
+            startEmissionState: "none",
           });
         }
 
@@ -98,12 +103,17 @@ export async function* streamLLMEvents(
           toolCall.arguments += toolCallDelta.function.arguments;
         }
 
-        if (
-          !toolCall.hasEmittedStart &&
+        const shouldEmitStartWithoutId =
+          toolCall.startEmissionState === "none" &&
           toolCall.name.length > 0 &&
-          toolCallDelta.function?.arguments !== undefined
-        ) {
-          toolCall.hasEmittedStart = true;
+          !toolCall.id;
+        const shouldEmitStartWithId =
+          toolCall.startEmissionState !== "with_id" &&
+          toolCall.name.length > 0 &&
+          toolCall.id.length > 0;
+
+        if (shouldEmitStartWithoutId || shouldEmitStartWithId) {
+          toolCall.startEmissionState = toolCall.id ? "with_id" : "without_id";
           yield {
             type: "tool_call_started",
             content: {

--- a/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
@@ -234,6 +234,22 @@ function toEvents({
 
       return [reasoningDelta("\n\n", metadata)];
     }
+    case "response.output_item.added":
+      if (event.item.type !== "function_call") {
+        return [];
+      }
+
+      return [
+        {
+          type: "tool_call_started",
+          content: {
+            id: event.item.call_id,
+            index: event.output_index,
+            name: event.item.name,
+          },
+          metadata,
+        },
+      ];
     case "response.function_call_arguments.delta":
       return [{ type: "tool_call_delta", metadata }];
     default:

--- a/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/function_call.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/function_call.ts
@@ -2,6 +2,18 @@ import type { LLMEvent } from "@app/lib/api/llm/types/events";
 
 export const functionCallLLMEvents: LLMEvent[] = [
   {
+    type: "tool_call_started",
+    content: {
+      id: "call_TNG5uqSoWvdMD4MFV6wKCwZT",
+      index: 0,
+      name: "common_utilities__math_operation",
+    },
+    metadata: {
+      clientId: "openai",
+      modelId: "gpt-5",
+    },
+  },
+  {
     type: "tool_call_delta",
     metadata: {
       clientId: "openai",
@@ -10,6 +22,18 @@ export const functionCallLLMEvents: LLMEvent[] = [
   },
   {
     type: "tool_call_delta",
+    metadata: {
+      clientId: "openai",
+      modelId: "gpt-5",
+    },
+  },
+  {
+    type: "tool_call_started",
+    content: {
+      id: "call_XoBlcEPygqXN28I2McKpLSfF",
+      index: 1,
+      name: "web_search_browse__websearch",
+    },
     metadata: {
       clientId: "openai",
       modelId: "gpt-5",

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -1090,6 +1090,7 @@
  *         propertyName: type
  *       oneOf:
  *         - $ref: '#/components/schemas/PrivateGenerationTokensEvent'
+ *         - $ref: '#/components/schemas/PrivateToolCallStartedEvent'
  *         - $ref: '#/components/schemas/PrivateAgentActionSuccessEvent'
  *         - $ref: '#/components/schemas/PrivateAgentMessageSuccessEvent'
  *         - $ref: '#/components/schemas/PrivateAgentErrorEvent'
@@ -1123,6 +1124,27 @@
  *         delimiterClassification:
  *           type: string
  *           description: Present when classification is opening_delimiter or closing_delimiter
+ *         step:
+ *           type: integer
+ *     PrivateToolCallStartedEvent:
+ *       type: object
+ *       required: [type, created, configurationId, messageId, toolName]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [tool_call_started]
+ *         created:
+ *           type: integer
+ *         configurationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         toolCallId:
+ *           type: string
+ *         toolCallIndex:
+ *           type: integer
+ *         toolName:
+ *           type: string
  *         step:
  *           type: integer
  *     PrivateAgentActionSuccessEvent:

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -10177,6 +10177,9 @@
             "$ref": "#/components/schemas/PrivateGenerationTokensEvent"
           },
           {
+            "$ref": "#/components/schemas/PrivateToolCallStartedEvent"
+          },
+          {
             "$ref": "#/components/schemas/PrivateAgentActionSuccessEvent"
           },
           {
@@ -10253,6 +10256,45 @@
           "delimiterClassification": {
             "type": "string",
             "description": "Present when classification is opening_delimiter or closing_delimiter"
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateToolCallStartedEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "configurationId",
+          "messageId",
+          "toolName"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "tool_call_started"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolCallIndex": {
+            "type": "integer"
+          },
+          "toolName": {
+            "type": "string"
           },
           "step": {
             "type": "integer"

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -170,6 +170,7 @@ export async function getOutputFromLLMStream(
   const actions: Output["actions"] = [];
   let generation = "";
   let nativeChainOfThought = "";
+  const startedToolCallKeys = new Set<string>();
 
   const logContext = {
     workspaceId: conversation.owner.sId,
@@ -230,6 +231,34 @@ export async function getOutputFromLLMStream(
           });
 
           nativeChainOfThought += event.content.delta;
+          continue;
+        }
+        case "tool_call_started": {
+          const startedToolCallKey =
+            event.content.id ??
+            `tool-call-${event.content.index ?? startedToolCallKeys.size}`;
+          if (startedToolCallKeys.has(startedToolCallKey)) {
+            continue;
+          }
+
+          startedToolCallKeys.add(startedToolCallKey);
+
+          await updateResourceAndPublishEvent(auth, {
+            event: {
+              type: "tool_call_started",
+              created: Date.now(),
+              configurationId: agentConfiguration.sId,
+              messageId: agentMessage.sId,
+              ...(event.content.id ? { toolCallId: event.content.id } : {}),
+              ...(event.content.index !== undefined
+                ? { toolCallIndex: event.content.index }
+                : {}),
+              toolName: event.content.name,
+            },
+            agentMessage,
+            conversation,
+            step,
+          });
           continue;
         }
         case "tool_call_delta":

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -350,6 +350,16 @@ export type AgentDisabledErrorEvent = {
   };
 };
 
+export type AgentToolCallStartedEvent = {
+  type: "tool_call_started";
+  created: number;
+  configurationId: string;
+  messageId: string;
+  toolCallId?: string;
+  toolCallIndex?: number;
+  toolName: string;
+};
+
 // Event sent once the action is completed, we're moving to generating a message if applicable.
 export type AgentActionSuccessEvent = {
   type: "agent_action_success";


### PR DESCRIPTION
## Description
- Add a new `tool_call_started` streaming event to the normalized LLM event layer and publish it through the agent loop before `tool_params`.
- Emit the event from OpenAI chat, OpenAI Responses, and Anthropic when the provider exposes the tool name early, then surface a pending "Preparing to call …" state in the conversation UI.
- This closes the stale gap before long-running tool executions such as interactive content / frame creation begin.
- Local `front/admin/checks.sh` is currently blocked by an unrelated `front/lib/plans/pro_plans.ts` type error and missing `lint` / `format` scripts, so validation here is limited to focused adapter tests.

## Risks
Blast radius: streaming state for tool-using agent messages in the front conversation UI and agent loop.
Risk: standard

## Deploy Plan
- deploy front

## Test
- [x] `./lib/api/llm/utils/openai_like/responses/test/openai_to_events.test.ts`
- [x] `./lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts`