### PR TITLE
[front] fix: remove Preview chip on Skill Builder advanced settings

### DIFF
--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -32,9 +32,7 @@ export function SkillBuilderSettingsSection() {
         </div>
       </div>
       <Collapsible defaultOpen>
-        <CollapsibleTrigger variant="secondary">
-          Advanced
-        </CollapsibleTrigger>
+        <CollapsibleTrigger variant="secondary">Advanced</CollapsibleTrigger>
         <CollapsibleContent>
           <div className="pt-3">
             <SkillBuilderIsDefaultSection />

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -4,7 +4,6 @@ import { SkillBuilderNameSection } from "@app/components/skill_builder/SkillBuil
 import { SkillBuilderUserFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderUserFacingDescriptionSection";
 import { SkillEditorsSheet } from "@app/components/skill_builder/SkillEditorsSheet";
 import {
-  Chip,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -34,14 +33,7 @@ export function SkillBuilderSettingsSection() {
       </div>
       <Collapsible defaultOpen>
         <CollapsibleTrigger variant="secondary">
-          <div className="flex items-center gap-2">
-            <span className="text-base text-foreground dark:text-foreground-night">
-              Advanced
-            </span>
-            <Chip color="golden" size="xs">
-              Preview
-            </Chip>
-          </div>
+          Advanced
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="pt-3">


### PR DESCRIPTION
## Description

- This PR removes the Preview chip there is in Skill builder next to the Advanced settings section.
- This section contains a setting for making skills discoverable, which was GA in https://github.com/dust-tt/dust/pull/23579

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
