### PR TITLE
[front] fix: Never cache tokens in gcsfuse

### DIFF
--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -195,6 +195,9 @@ function buildMountCommand({
 }): string {
   const flags = [
     `--token-url http://127.0.0.1:9876`,
+    // Disable token caching so gcsfuse fetches fresh token from server on every GCS API request.
+    // This ensures gcsfuse never uses stale credentials, eliminating 401 errors after token expiry.
+    `--reuse-token-from-url=false`,
     `--only-dir ${prefix}`,
     `--implicit-dirs`,
     `-o allow_other`,

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -298,7 +298,7 @@ SHELLEOF`,
   .withToolManifest()
   .register({
     imageName: "dust-base",
-    tag: "0.7.0",
+    tag: "0.7.1",
   });
 
 const IMAGES: readonly SandboxImage[] = [DUST_BASE_IMAGE];


### PR DESCRIPTION
## Description

Currently, gcsfuse caches token, with its own TTL logic, based on how much time has passed, which is not correlated to our token lifetime.
On top of that, time drift occurs when resuming a sandbox.
This can lead to gcsfuse holding an outdated token, without refreshing it, and the sbx filesystem to be completely broken. ([logs](https://app.datadoghq.eu/logs?query=service%3Asandbox-runner%20conversation_id%3Ady7txnndc2&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice%2Cconversation_id&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1775055767396&to_ts=1775059367396&live=true))

Because of those points, I think the simplest approach is the best here. We just don't cache the token.
For context, the token is fetched from a process running that does a cat of a file we mint everytime we run a command.

We will need to make this a bit more sophisticated once we implement background commands, but we're not there yet.

## Tests

[Tested locally.
](https://app.datadoghq.eu/logs?query=service%3Asandbox-runner%20%40conversation_id%3ATk8NaZZNsk&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Cconversation_id&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1774982868163&to_ts=1775069268163&live=true)
## Risk

Low

## Deploy Plan

- [ ] Deploy front