### PR TITLE
Add poke plugin to update remote MCP URL

### DIFF
--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -59,9 +59,19 @@ export function PluginForm({
       Object.entries(manifest.args).map(([key, arg]) => {
         switch (arg.type) {
           case "text":
-            return [key, ""];
+            return [
+              key,
+              arg.async && asyncArgs?.[key] !== undefined
+                ? (asyncArgs[key] as string)
+                : "",
+            ];
           case "string":
-            return [key, ""];
+            return [
+              key,
+              arg.async && asyncArgs?.[key] !== undefined
+                ? (asyncArgs[key] as string)
+                : "",
+            ];
           case "number":
             return [
               key,

--- a/front/lib/api/poke/plugins/mcp_server_views/index.ts
+++ b/front/lib/api/poke/plugins/mcp_server_views/index.ts
@@ -1,1 +1,2 @@
 export * from "./get-mcp-server-view-credentials";
+export * from "./update-mcp-url";

--- a/front/lib/api/poke/plugins/mcp_server_views/update-mcp-url.ts
+++ b/front/lib/api/poke/plugins/mcp_server_views/update-mcp-url.ts
@@ -1,0 +1,84 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const getMcpUrlPlugin = createPlugin({
+  manifest: {
+    id: "update-mcp-url",
+    name: "Update MCP Server URL",
+    description: "View the current URL of a remote MCP server and update it.",
+    warning:
+      "⚠️ Only use this to update the URL of the same MCP server (e.g. domain migration, path change). Do NOT use this to point to a completely different MCP server.",
+    resourceTypes: ["mcp_server_views"],
+    args: {
+      url: {
+        type: "string",
+        label: "URL",
+        description: "The URL of the MCP server.",
+        async: true,
+      },
+    },
+  },
+  isApplicableTo: (_auth, resource) => {
+    return !!resource && resource.serverType === "remote";
+  },
+  populateAsyncArgs: async (auth, mcpServerView) => {
+    if (!mcpServerView || !mcpServerView.remoteMCPServerId) {
+      return new Err(new Error("MCP server view not found."));
+    }
+
+    const remoteServer = await RemoteMCPServerResource.findByPk(
+      auth,
+      mcpServerView.remoteMCPServerId
+    );
+
+    if (!remoteServer) {
+      return new Err(new Error("Remote MCP server not found."));
+    }
+
+    return new Ok({
+      url: remoteServer.url,
+    });
+  },
+  execute: async (auth, mcpServerView, args) => {
+    if (!mcpServerView) {
+      return new Err(new Error("MCP server view not found."));
+    }
+
+    if (mcpServerView.serverType !== "remote") {
+      return new Err(
+        new Error("This plugin is only applicable to remote MCP servers.")
+      );
+    }
+
+    if (!mcpServerView.remoteMCPServerId) {
+      return new Err(new Error("Remote MCP server view has no server ID."));
+    }
+
+    const remoteServer = await RemoteMCPServerResource.findByPk(
+      auth,
+      mcpServerView.remoteMCPServerId
+    );
+
+    if (!remoteServer) {
+      return new Err(new Error("Remote MCP server not found."));
+    }
+
+    const { url } = args;
+    const previousUrl = remoteServer.url;
+
+    if (url.trim() === previousUrl) {
+      return new Ok({
+        display: "text",
+        value: "URL unchanged.",
+      });
+    }
+
+    await remoteServer.updateUrl(auth, url.trim());
+
+    return new Ok({
+      display: "text",
+      value: "URL updated successfully.",
+    });
+  },
+});

--- a/front/lib/resources/remote_mcp_servers_resource.test.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.test.ts
@@ -7,6 +7,30 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { describe, expect, it } from "vitest";
 
+describe("RemoteMCPServerResource.updateUrl", () => {
+  it("updates the URL of a remote MCP server", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    await SpaceFactory.system(workspace);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      url: "https://old.example.com/mcp",
+      name: "Test Server",
+    });
+
+    expect(server.url).toBe("https://old.example.com/mcp");
+
+    const result = await server.updateUrl(auth, "https://new.example.com/mcp");
+    expect(result.isOk()).toBe(true);
+
+    const refreshed = (await RemoteMCPServerResource.findByPk(
+      auth,
+      server.id
+    ))!;
+    expect(refreshed.url).toBe("https://new.example.com/mcp");
+  });
+});
+
 describe("RemoteMCPServerResource.updateMetadata", () => {
   it("deletes stale tool metadata when cachedTools are updated", async () => {
     const workspace = await WorkspaceFactory.basic();

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -352,6 +352,27 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     return new Ok(undefined);
   }
 
+  async updateUrl(
+    auth: Authenticator,
+    newUrl: string
+  ): Promise<Result<undefined, DustError<"unauthorized">>> {
+    const canAdministrate =
+      await SpaceResource.canAdministrateSystemSpace(auth);
+
+    if (!canAdministrate) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "The user is not authorized to update the URL of a remote MCP server"
+        )
+      );
+    }
+
+    await this.update({ url: newUrl });
+
+    return new Ok(undefined);
+  }
+
   async markAsErrored(
     auth: Authenticator,
     {


### PR DESCRIPTION
## Description

Solves https://github.com/dust-tt/tasks/issues/7299

Add a poke plugin to update the URL
The plugin displays the current URL

<img width="1100" height="500" alt="image" src="https://github.com/user-attachments/assets/8cbb0108-8a6a-4560-9908-cdb89311fc81" />


## Tests

local test of the plugin
unit test for the new resource method

## Risk

low

## Deploy Plan

deploy front
