### PR TITLE
Teams transcripts tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -342,8 +342,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "write_worksheet": "high",
   },
   "microsoft_teams": {
+    "get_transcript_content": "low",
     "list_channels": "never_ask",
     "list_chats": "never_ask",
+    "list_meetings": "never_ask",
     "list_messages": "never_ask",
     "list_teams": "never_ask",
     "list_users": "never_ask",

--- a/front/lib/api/actions/servers/microsoft/utils.ts
+++ b/front/lib/api/actions/servers/microsoft/utils.ts
@@ -99,6 +99,22 @@ export interface TeamsChannel {
   webUrl: string;
 }
 
+export interface TeamsMeeting {
+  id: string;
+  meetingId: string;
+  subject: string;
+  start: { dateTime: string; timeZone: string };
+  end: { dateTime: string; timeZone: string };
+  organizer: { emailAddress: { name: string; address: string } };
+  attendees: {
+    emailAddress: { name: string; address: string };
+    type: string;
+  }[];
+  onlineMeeting: { joinUrl: string } | null;
+  webLink: string;
+  isOnlineMeeting: boolean;
+}
+
 export interface TeamsUser {
   id: string;
   displayName: string;

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -200,6 +200,55 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
       done: "Post Teams message",
     },
   },
+  list_meetings: {
+    description:
+      "List online meetings from the authenticated user's calendar within a date range. Returns meeting details including subject, organizer, attendees, times, and meeting ID. The meeting ID can be used with get_transcript_content to retrieve meeting transcripts. Supports filtering by subject and participant. Supports pagination to retrieve all results.",
+    schema: {
+      fromDate: z
+        .string()
+        .describe(
+          "ISO 8601 date string for the start of the date range (e.g., '2024-01-01T00:00:00Z')."
+        ),
+      toDate: z
+        .string()
+        .describe(
+          "ISO 8601 date string for the end of the date range (e.g., '2024-12-31T23:59:59Z')."
+        ),
+      subjectFilter: z
+        .string()
+        .optional()
+        .describe(
+          "Filter meetings by subject (case-insensitive partial match)."
+        ),
+      participantFilter: z
+        .string()
+        .optional()
+        .describe(
+          "Filter meetings by participant name or email (case-insensitive partial match on organizer or attendees)."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing Teams meetings",
+      done: "List Teams meetings",
+    },
+  },
+  get_transcript_content: {
+    description:
+      "Get the transcript content of a Microsoft Teams online meeting. Requires the join URL of the meeting (obtained from list_meetings). Returns the transcript text if available.",
+    schema: {
+      joinUrl: z
+        .string()
+        .describe(
+          "The join URL of the online meeting. Use list_meetings to get this value."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Fetching meeting transcript",
+      done: "Fetch meeting transcript",
+    },
+  },
 });
 
 export const MICROSOFT_TEAMS_SERVER = {
@@ -212,7 +261,7 @@ export const MICROSOFT_TEAMS_SERVER = {
       provider: "microsoft_tools",
       supported_use_cases: ["personal_actions"],
       scope:
-        "User.Read User.ReadBasic.All Team.ReadBasic.All Channel.ReadBasic.All Chat.Read Chat.ReadWrite ChatMessage.Read ChatMessage.Send ChannelMessage.Read.All ChannelMessage.Send offline_access",
+        "User.Read User.ReadBasic.All Team.ReadBasic.All Channel.ReadBasic.All Chat.Read Chat.ReadWrite ChatMessage.Read ChatMessage.Send ChannelMessage.Read.All ChannelMessage.Send OnlineMeetings.Read OnlineMeetingTranscript.Read.All offline_access",
       availableScopes: [
         {
           value: "Chat.Read",
@@ -261,6 +310,17 @@ export const MICROSOFT_TEAMS_SERVER = {
           value: "User.ReadBasic.All",
           label: "Read user directory",
           description: "List and search users in the organization.",
+        },
+        {
+          value: "OnlineMeetings.Read",
+          label: "Read online meetings",
+          description: "Read online meeting details to access transcripts.",
+        },
+        {
+          value: "OnlineMeetingTranscript.Read.All",
+          label: "Read meeting transcripts",
+          description:
+            "Read transcripts of online meetings the user has access to.",
         },
         {
           value: "User.Read",

--- a/front/lib/api/actions/servers/microsoft_teams/microsoft_teams_rendering.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/microsoft_teams_rendering.ts
@@ -1,6 +1,7 @@
 import type {
   TeamsChannel,
   TeamsChat,
+  TeamsMeeting,
   TeamsUser,
 } from "@app/lib/api/actions/servers/microsoft/utils";
 
@@ -75,6 +76,39 @@ export function renderChats(chats: TeamsChat[]): string {
 
       if (chat.tenantId) {
         lines.push(`Tenant ID: ${chat.tenantId}`);
+      }
+
+      return lines.join("\n");
+    })
+    .join("\n-----\n");
+}
+
+export function renderMeetings(meetings: TeamsMeeting[]): string {
+  if (meetings.length === 0) {
+    return "No meetings found.";
+  }
+
+  return meetings
+    .map((meeting) => {
+      const lines = [
+        `ID: ${meeting.id}`,
+        `Subject: ${meeting.subject}`,
+        `Start: ${meeting.start.dateTime} (${meeting.start.timeZone})`,
+        `End: ${meeting.end.dateTime} (${meeting.end.timeZone})`,
+        `Organizer: ${meeting.organizer.emailAddress.name} (${meeting.organizer.emailAddress.address})`,
+      ];
+
+      if (meeting.attendees?.length > 0) {
+        const attendeeList = meeting.attendees
+          .map((a) => `${a.emailAddress.name} (${a.emailAddress.address})`)
+          .join(", ");
+        lines.push(`Attendees: ${attendeeList}`);
+      }
+
+      lines.push(`Web Link: ${meeting.webLink}`);
+
+      if (meeting.onlineMeeting?.joinUrl) {
+        lines.push(`Join URL: ${meeting.onlineMeeting.joinUrl}`);
       }
 
       return lines.join("\n");

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -4,6 +4,7 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import type {
   TeamsChannel,
   TeamsChat,
+  TeamsMeeting,
   TeamsMessage,
   TeamsUser,
 } from "@app/lib/api/actions/servers/microsoft/utils";
@@ -12,6 +13,7 @@ import { MICROSOFT_TEAMS_TOOLS_METADATA } from "@app/lib/api/actions/servers/mic
 import {
   renderChannels,
   renderChats,
+  renderMeetings,
   renderUsers,
 } from "@app/lib/api/actions/servers/microsoft_teams/microsoft_teams_rendering";
 import config from "@app/lib/api/config";
@@ -487,6 +489,163 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
     } catch (err) {
       return new Err(
         new MCPError(normalizeError(err).message || "Failed to post message")
+      );
+    }
+  },
+
+  list_meetings: async (
+    { fromDate, toDate, subjectFilter, participantFilter },
+    { authInfo }
+  ) => {
+    const client = await getGraphClient(authInfo);
+    if (!client) {
+      return new Err(
+        new MCPError("Failed to authenticate with Microsoft Graph")
+      );
+    }
+
+    try {
+      let apiCall = client
+        .api("/me/calendarView")
+        .query({
+          startDateTime: fromDate,
+          endDateTime: toDate,
+        })
+        .select(
+          "id,subject,start,end,organizer,attendees,onlineMeeting,webLink,isOnlineMeeting"
+        )
+        .orderby("start/dateTime asc")
+        .top(10);
+
+      if (subjectFilter) {
+        apiCall = apiCall.filter(
+          `contains(subject, '${subjectFilter.replace(/'/g, "''")}')`
+        );
+      }
+
+      const response = await apiCall.get();
+
+      let meetings: TeamsMeeting[] = (
+        (response.value as TeamsMeeting[]) ?? []
+      ).filter((m) => m.isOnlineMeeting);
+
+      if (participantFilter) {
+        const query = participantFilter.toLowerCase();
+        meetings = meetings.filter((m) => {
+          const organizerMatch =
+            m.organizer?.emailAddress?.name?.toLowerCase().includes(query) ||
+            m.organizer?.emailAddress?.address?.toLowerCase().includes(query);
+          const attendeeMatch = m.attendees?.some(
+            (a) =>
+              a.emailAddress?.name?.toLowerCase().includes(query) ||
+              a.emailAddress?.address?.toLowerCase().includes(query)
+          );
+          return organizerMatch || attendeeMatch;
+        });
+      }
+
+      let result = renderMeetings(meetings);
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: result,
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(normalizeError(err).message || "Failed to list meetings")
+      );
+    }
+  },
+
+  get_transcript_content: async ({ joinUrl }, { authInfo }) => {
+    const client = await getGraphClient(authInfo);
+    if (!client) {
+      return new Err(
+        new MCPError("Failed to authenticate with Microsoft Graph")
+      );
+    }
+
+    try {
+      // Resolve the online meeting from its join URL.
+      const meetingResponse = await client
+        .api("/me/onlineMeetings")
+        .filter(`JoinWebUrl eq '${joinUrl}'`)
+        .get();
+
+      const onlineMeetings = meetingResponse.value ?? [];
+      if (onlineMeetings.length === 0) {
+        return new Err(
+          new MCPError(
+            "No online meeting found for this join URL. Ensure you are the organizer or a participant."
+          )
+        );
+      }
+
+      const meetingId = onlineMeetings[0].id;
+
+      // List transcripts for this meeting.
+      const transcriptsResponse = await client
+        .api(`/me/onlineMeetings/${meetingId}/transcripts`)
+        .get();
+
+      const transcripts = transcriptsResponse.value ?? [];
+      if (transcripts.length === 0) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: "No transcripts available for this meeting. Transcription may not have been enabled during the meeting.",
+          },
+        ]);
+      }
+
+      // Get the content of the most recent transcript in text format.
+      const transcriptId = transcripts[transcripts.length - 1].id;
+      const contentResponse = await client
+        .api(
+          `/me/onlineMeetings/${meetingId}/transcripts/${transcriptId}/content`
+        )
+        .query({ $format: "text/vtt" })
+        .responseType("text" as any)
+        .get();
+
+      let text: string;
+      if (typeof contentResponse === "string") {
+        text = contentResponse;
+      } else if (
+        contentResponse &&
+        typeof contentResponse.text === "function"
+      ) {
+        text = await contentResponse.text();
+      } else if (contentResponse instanceof ReadableStream) {
+        const reader = contentResponse.getReader();
+        const chunks: string[] = [];
+        const decoder = new TextDecoder();
+        let done = false;
+        while (!done) {
+          const result = await reader.read();
+          done = result.done;
+          if (result.value) {
+            chunks.push(decoder.decode(result.value, { stream: !done }));
+          }
+        }
+        text = chunks.join("");
+      } else {
+        text = String(contentResponse);
+      }
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text,
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(
+          normalizeError(err).message || "Failed to get transcript content"
+        )
       );
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -231,7 +231,7 @@
     },
     "extension": {
       "name": "@dust-tt/extension",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",


### PR DESCRIPTION
## Description

This PR is the same as #23532 but without `prompt: "consent"` for the microsoft_tools provider.
This parameter forced admin consent for every Microsoft tools use.

## Tests

Manually tested retrieving meetings and fetching transcripts for accessible meetings.

## Risk

Low. However, calls to the new transcript tools will silently fail if no admin consent has been granted.

## Deploy Plan

Deploy front.