### PR TITLE
Add pagination for conversations api

### DIFF
--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -46,7 +46,8 @@ export const getConversation = async (
   conversationId: string,
   includeDeleted: boolean = false,
   branchId: string | null = null,
-  lastInteractionsToFetchContentFor: number | null = null
+  lastInteractionsToFetchContentFor: number | null = null,
+  messagePagination?: { limit: number; lastRank: number | null }
 ) =>
   _getConversation(
     auth,
@@ -54,7 +55,8 @@ export const getConversation = async (
     includeDeleted,
     branchId,
     "full",
-    lastInteractionsToFetchContentFor
+    lastInteractionsToFetchContentFor,
+    messagePagination
   );
 
 export const getLightConversation = async (
@@ -70,14 +72,15 @@ async function _getConversation<V extends "light" | "full">(
   includeDeleted: boolean = false,
   branchId: string | null = null,
   viewType: V = "full" as V,
-  lastInteractionsToFetchContentFor: number | null = null
+  lastInteractionsToFetchContentFor: number | null = null,
+  messagePagination?: { limit: number; lastRank: number | null }
 ): Promise<
   Result<
-    V extends "light"
+    (V extends "light"
       ? LightConversationType
       : V extends "full"
         ? ConversationType
-        : never,
+        : never) & { hasMore?: boolean; lastValue?: number | null },
     ConversationError
   >
 > {
@@ -137,33 +140,46 @@ async function _getConversation<V extends "light" | "full">(
     };
   }
 
-  const messages = await MessageModel.findAll({
-    where,
-    order: [
-      ["rank", "ASC"],
-      ["version", "ASC"],
-    ],
-    include: [
-      {
-        model: UserMessageModel,
-        as: "userMessage",
-        required: false,
-      },
-      {
-        model: AgentMessageModel,
-        as: "agentMessage",
-        required: false,
-      },
-      // We skip ContentFragmentResource here for efficiency reasons (retrieving contentFragments
-      // along with messages in one query). Only once we move to a MessageResource will we be able
-      // to properly abstract this.
-      {
-        model: ContentFragmentModel,
-        as: "contentFragment",
-        required: false,
-      },
-    ],
-  });
+  let messages: MessageModel[];
+  let paginationHasMore: boolean | undefined;
+
+  if (messagePagination) {
+    const { hasMore, messages: paginatedMessages } =
+      await conversation.fetchMessagesForPage(auth, {
+        limit: messagePagination.limit,
+        lastRank: messagePagination.lastRank,
+      });
+    messages = paginatedMessages;
+    paginationHasMore = hasMore;
+  } else {
+    messages = await MessageModel.findAll({
+      where,
+      order: [
+        ["rank", "ASC"],
+        ["version", "ASC"],
+      ],
+      include: [
+        {
+          model: UserMessageModel,
+          as: "userMessage",
+          required: false,
+        },
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          required: false,
+        },
+        // We skip ContentFragmentResource here for efficiency reasons (retrieving contentFragments
+        // along with messages in one query). Only once we move to a MessageResource will we be able
+        // to properly abstract this.
+        {
+          model: ContentFragmentModel,
+          as: "contentFragment",
+          required: false,
+        },
+      ],
+    });
+  }
 
   let outputItemContentOnlyForAgentMessageIds: Set<ModelId> | null = null;
 
@@ -274,7 +290,10 @@ async function _getConversation<V extends "light" | "full">(
       })
     );
 
-    const conversationType: LightConversationType = {
+    const conversationType: LightConversationType & {
+      hasMore?: boolean;
+      lastValue?: number | null;
+    } = {
       id: conversation.id,
       created: conversation.createdAt.getTime(),
       updated: conversation.updatedAt.getTime(),
@@ -295,12 +314,18 @@ async function _getConversation<V extends "light" | "full">(
       branchId,
     };
 
+    if (paginationHasMore !== undefined) {
+      conversationType.hasMore = paginationHasMore;
+      conversationType.lastValue =
+        messagesWithRank.length > 0 ? messagesWithRank[0].rank : null;
+    }
+
     return new Ok(conversationType) as Result<
-      V extends "light"
+      (V extends "light"
         ? LightConversationType
         : V extends "full"
           ? ConversationType
-          : never,
+          : never) & { hasMore?: boolean; lastValue?: number | null },
       ConversationError
     >;
   } else {
@@ -333,7 +358,10 @@ async function _getConversation<V extends "light" | "full">(
       })
     );
 
-    const conversationType: ConversationType = {
+    const conversationType: ConversationType & {
+      hasMore?: boolean;
+      lastValue?: number | null;
+    } = {
       id: conversation.id,
       created: conversation.createdAt.getTime(),
       updated: conversation.updatedAt.getTime(),
@@ -355,12 +383,18 @@ async function _getConversation<V extends "light" | "full">(
       branchId,
     };
 
+    if (paginationHasMore !== undefined) {
+      conversationType.hasMore = paginationHasMore;
+      conversationType.lastValue =
+        messagesWithRank.length > 0 ? messagesWithRank[0].rank : null;
+    }
+
     return new Ok(conversationType) as Result<
-      V extends "light"
+      (V extends "light"
         ? LightConversationType
         : V extends "full"
           ? ConversationType
-          : never,
+          : never) & { hasMore?: boolean; lastValue?: number | null },
       ConversationError
     >;
   }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -16,7 +16,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
  * /api/v1/w/{wId}/assistant/conversations/{cId}:
  *   get:
  *     summary: Get a conversation
- *     description: Get a conversation in the workspace identified by {wId}.
+ *     description: Get a conversation in the workspace identified by {wId}. Supports optional pagination of message content via limit and lastValue query parameters.
  *     tags:
  *       - Conversations
  *     security:
@@ -32,6 +32,18 @@ import type { NextApiRequest, NextApiResponse } from "next";
  *         name: cId
  *         required: true
  *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         description: Maximum number of messages to return. When omitted, all messages are returned.
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: lastValue
+ *         required: false
+ *         description: Cursor value (message rank) from a previous response to fetch the next page of messages.
  *         schema:
  *           type: string
  *     responses:
@@ -123,22 +135,60 @@ async function handler(
     });
   }
 
-  const conversationRes = await getConversation(auth, cId);
-
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
-  }
-
-  const conversation = conversationRes.value;
-
   switch (req.method) {
     case "GET": {
-      return res.status(200).json({
+      // Build optional message pagination from query params.
+      // When omitted, all messages are returned (backward compatible).
+      const { limit, lastValue } = req.query;
+      const messagePagination =
+        typeof limit === "string"
+          ? {
+              limit: parseInt(limit, 10),
+              lastRank:
+                typeof lastValue === "string" ? parseInt(lastValue, 10) : null,
+            }
+          : undefined;
+
+      const conversationRes = await getConversation(
+        auth,
+        cId,
+        false,
+        null,
+        null,
+        messagePagination
+      );
+
+      if (conversationRes.isErr()) {
+        return apiErrorForConversation(req, res, conversationRes.error);
+      }
+
+      const {
+        hasMore,
+        lastValue: paginationLastValue,
+        ...conversation
+      } = conversationRes.value;
+
+      const response: GetConversationResponseType = {
         conversation: addBackwardCompatibleConversationFields(conversation),
-      });
+      };
+
+      if (hasMore !== undefined) {
+        response.hasMore = hasMore;
+        response.lastValue =
+          paginationLastValue !== undefined && paginationLastValue !== null
+            ? String(paginationLastValue)
+            : null;
+      }
+
+      return res.status(200).json(response);
     }
 
     case "PATCH": {
+      const conversationRes = await getConversation(auth, cId);
+      if (conversationRes.isErr()) {
+        return apiErrorForConversation(req, res, conversationRes.error);
+      }
+
       const r = PatchConversationRequestSchema.safeParse(req.body);
       if (!r.success) {
         return apiError(req, res, {
@@ -152,7 +202,7 @@ async function handler(
       const { read } = r.data;
       if (read) {
         await ConversationResource.markAsReadForAuthUser(auth, {
-          conversation,
+          conversation: conversationRes.value,
         });
       }
       return res.status(200).json({ success: true });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -524,6 +524,7 @@ async function handler(
           },
         });
       }
+
       const conversations =
         await ConversationResource.listPrivateConversationsForUser(auth);
       res.status(200).json({

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -938,7 +938,7 @@
     "/api/v1/w/{wId}/assistant/conversations/{cId}": {
       "get": {
         "summary": "Get a conversation",
-        "description": "Get a conversation in the workspace identified by {wId}.",
+        "description": "Get a conversation in the workspace identified by {wId}. Supports optional pagination of message content via limit and lastValue query parameters.",
         "tags": [
           "Conversations"
         ],
@@ -962,6 +962,24 @@
             "name": "cId",
             "required": true,
             "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "description": "Maximum number of messages to return. When omitted, all messages are returned.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "lastValue",
+            "required": false,
+            "description": "Cursor value (message rank) from a previous response to fetch the next page of messages.",
             "schema": {
               "type": "string"
             }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2046,6 +2046,8 @@ export type RetryMessageResponseType = z.infer<
 
 export const GetConversationResponseSchema = z.object({
   conversation: ConversationSchema,
+  hasMore: z.boolean().optional(),
+  lastValue: z.string().nullable().optional(),
 });
 
 export type GetConversationResponseType = z.infer<


### PR DESCRIPTION
## Description

Add optional pagination for conversation message content in the public v1 `GET /api/v1/w/{wId}/assistant/conversations/{cId}` endpoint.

Fixes https://github.com/dust-tt/tasks/issues/7247

Large conversations (4MB+) break the API because the full content is loaded and serialized. The private web API solved this with a separate paginated messages endpoint (PR #4390). This PR adds the same capability directly to the existing v1 endpoint via optional query params.

**Changes:**
- `GET /conversations/{cId}` now accepts optional `limit` and `lastValue` query params to paginate message content
- When no pagination params are passed, behavior is unchanged (full conversation returned)
- When pagination is used, response includes `hasMore` and `lastValue` for cursor-based pagination (by message rank, descending)
- Added `messagePagination` optional param to `getConversation()` — when provided, uses `fetchMessagesForPage()` instead of loading all messages
- SDK `GetConversationResponseSchema` updated with optional `hasMore`/`lastValue` fields

All changes are backward compatible — no fields removed, all new params are optional.

## Tests

Manual testing. No breaking change — existing clients without pagination params get identical behavior.

## Risk

Low. Fully backward compatible. When pagination params are omitted, the existing code path is used unchanged.

## Deploy Plan

Standard deploy, no migration needed.