### PR TITLE
[front] fix: hide Slack preferences in agent builder for non-builder users

### DIFF
--- a/front/components/agent_builder/settings/AccessSection.tsx
+++ b/front/components/agent_builder/settings/AccessSection.tsx
@@ -6,6 +6,7 @@ import { SettingSectionContainer } from "@app/components/agent_builder/shared/Se
 import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
 import { getPublishingRestrictionForOwner } from "@app/lib/api/assistant/publishing_restrictions";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { isBuilder } from "@app/types/user";
 import {
   Button,
   DropdownMenu,
@@ -117,7 +118,7 @@ export function AccessSection() {
           </DropdownMenuContent>
         </DropdownMenu>
 
-        {scope.value === "visible" && slackDataSource && (
+        {scope.value === "visible" && slackDataSource && isBuilder(owner) && (
           <>
             <Button
               variant="outline"


### PR DESCRIPTION
## Description

Users with the `user` role were seeing the "Slack preferences" button in the agent builder, but the underlying `linked_slack_channels` API endpoint requires the `builder` role. This caused a 403 error on save, surfaced as "An error occurred while linking Slack channels."

This gates the Slack preferences UI behind `isBuilder(owner)` so only builders and admins see it — matching the API's permission model.

## Tests

- Verified typecheck passes
- Non-builder users will no longer see the Slack preferences button in the agent builder
- Builder/admin users are unaffected

## Risk

Low — this only hides a UI element for users who couldn't use it anyway (the API would reject their requests).

## Deploy Plan

Standard front deploy.