### PR TITLE
Add runIds hash to deduplicate multiple events for same message

### DIFF
--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -4,8 +4,24 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+import { createHash } from "crypto";
 
 import type { MetronomeEvent } from "./types";
+
+const MAX_TRANSACTION_ID_LENGTH = 128;
+
+/**
+ * If a transaction_id exceeds Metronome's 128-char limit, keep the first
+ * (128 - 13) chars as a readable prefix and append a 12-char hash suffix
+ * for uniqueness.
+ */
+function truncateTransactionId(id: string): string {
+  if (id.length <= MAX_TRANSACTION_ID_LENGTH) {
+    return id;
+  }
+  const hash = createHash("sha256").update(id).digest("hex").slice(0, 12);
+  return `${id.slice(0, MAX_TRANSACTION_ID_LENGTH - 13)}-${hash}`;
+}
 
 // ---------------------------------------------------------------------------
 // AWU message tier
@@ -187,10 +203,11 @@ export function getToolCategory(
  * Usages are grouped by (providerId, modelId) — one event per model used
  * with aggregated token counts and cost.
  *
- * transaction_id pattern: llm-{workspaceId}-{agentMessageId}-{runKey}-{providerId}-{modelId}
+ * transaction_id pattern: llm-{workspaceId}-{conversationId}-{agentMessageId}-{runKey}-{providerId}-{modelId}
  */
 export function buildLlmUsageEvents({
   workspaceId,
+  conversationId,
   userId,
   agentMessageId,
   parentAgentMessageId,
@@ -203,6 +220,7 @@ export function buildLlmUsageEvents({
   timestamp,
 }: {
   workspaceId: string;
+  conversationId: string;
   userId: string | null;
   agentMessageId: string;
   parentAgentMessageId: string | null;
@@ -251,7 +269,7 @@ export function buildLlmUsageEvents({
   }
 
   return [...groups.values()].map((group) => ({
-    transaction_id: `llm-${workspaceId}-${agentMessageId}-${runKey}-${group.providerId}-${group.modelId}`,
+    transaction_id: `llm-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${group.providerId}-${group.modelId}`,
     customer_id: workspaceId,
     event_type: "llm_usage",
     timestamp,
@@ -295,10 +313,12 @@ export interface ToolAction {
  * Actions are grouped by (toolName, internalMCPServerName, mcpServerId, status)
  * — one event per group with `count` and `total_execution_duration_ms`.
  *
- * transaction_id pattern: tool-{workspaceId}-{agentMessageId}-{runKey}-{toolName}-{mcpServerId}-{status}
+ * transaction_id pattern: tool-{workspaceId}-{conversationId}-{agentMessageId}-{runKey}-{toolHash}
+ * toolHash is a 12-char SHA-256 of toolName|mcpServerId|status to keep under 128 chars.
  */
 export function buildToolUseEvents({
   workspaceId,
+  conversationId,
   userId,
   agentMessageId,
   parentAgentMessageId,
@@ -311,6 +331,7 @@ export function buildToolUseEvents({
   timestamp,
 }: {
   workspaceId: string;
+  conversationId: string;
   userId: string | null;
   agentMessageId: string;
   parentAgentMessageId: string | null;
@@ -343,7 +364,9 @@ export function buildToolUseEvents({
   }
 
   return [...groups.values()].map(({ action, count, totalDurationMs }) => ({
-    transaction_id: `tool-${workspaceId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`,
+    transaction_id: truncateTransactionId(
+      `tool-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`
+    ),
     customer_id: workspaceId,
     event_type: "tool_use",
     timestamp,

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -187,13 +187,14 @@ export function getToolCategory(
  * Usages are grouped by (providerId, modelId) — one event per model used
  * with aggregated token counts and cost.
  *
- * transaction_id pattern: llm-{workspaceId}-{agentMessageId}-{providerId}-{modelId}
+ * transaction_id pattern: llm-{workspaceId}-{agentMessageId}-{runKey}-{providerId}-{modelId}
  */
 export function buildLlmUsageEvents({
   workspaceId,
   userId,
   agentMessageId,
   parentAgentMessageId,
+  runKey,
   runUsages,
   origin,
   isProgrammaticUsage,
@@ -205,6 +206,7 @@ export function buildLlmUsageEvents({
   userId: string | null;
   agentMessageId: string;
   parentAgentMessageId: string | null;
+  runKey: string;
   runUsages: RunUsageType[];
   origin: UserMessageOrigin;
   isProgrammaticUsage: boolean;
@@ -249,7 +251,7 @@ export function buildLlmUsageEvents({
   }
 
   return [...groups.values()].map((group) => ({
-    transaction_id: `llm-${workspaceId}-${agentMessageId}-${group.providerId}-${group.modelId}`,
+    transaction_id: `llm-${workspaceId}-${agentMessageId}-${runKey}-${group.providerId}-${group.modelId}`,
     customer_id: workspaceId,
     event_type: "llm_usage",
     timestamp,
@@ -293,13 +295,14 @@ export interface ToolAction {
  * Actions are grouped by (toolName, internalMCPServerName, mcpServerId, status)
  * — one event per group with `count` and `total_execution_duration_ms`.
  *
- * transaction_id pattern: tool-{workspaceId}-{agentMessageId}-{toolName}-{mcpServerId}-{status}
+ * transaction_id pattern: tool-{workspaceId}-{agentMessageId}-{runKey}-{toolName}-{mcpServerId}-{status}
  */
 export function buildToolUseEvents({
   workspaceId,
   userId,
   agentMessageId,
   parentAgentMessageId,
+  runKey,
   actions,
   origin,
   isProgrammaticUsage,
@@ -311,6 +314,7 @@ export function buildToolUseEvents({
   userId: string | null;
   agentMessageId: string;
   parentAgentMessageId: string | null;
+  runKey: string;
   actions: ToolAction[];
   origin: UserMessageOrigin;
   isProgrammaticUsage: boolean;
@@ -339,7 +343,7 @@ export function buildToolUseEvents({
   }
 
   return [...groups.values()].map(({ action, count, totalDurationMs }) => ({
-    transaction_id: `tool-${workspaceId}-${agentMessageId}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`,
+    transaction_id: `tool-${workspaceId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`,
     customer_id: workspaceId,
     event_type: "tool_use",
     timestamp,

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -36,6 +36,7 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import { isDevelopment } from "@app/types/shared/env";
+import { createHash } from "crypto";
 
 export async function recordUsageActivity(workspaceId: string) {
   const workspace = await WorkspaceResource.fetchById(workspaceId);
@@ -297,12 +298,20 @@ export async function emitMetronomeUsageEventsActivity(
   );
   const messageTier = classifyMessageTier({ modelIds, toolCategories });
 
+  // Deterministic short hash of runIds — ensures different runs of the same
+  // message produce different transaction_ids (e.g., error then success finalization).
+  const runKey = createHash("sha256")
+    .update(agentMessage.runIds.sort().join("-"))
+    .digest("hex")
+    .slice(0, 12);
+
   // Build and ingest events.
   const llmEvents = buildLlmUsageEvents({
     workspaceId: workspace.sId,
     userId,
     agentMessageId,
     parentAgentMessageId,
+    runKey,
     runUsages,
     origin: userMessageOrigin,
     isProgrammaticUsage: programmatic,
@@ -316,6 +325,7 @@ export async function emitMetronomeUsageEventsActivity(
     userId,
     agentMessageId,
     parentAgentMessageId,
+    runKey,
     actions: toolActions,
     origin: userMessageOrigin,
     isProgrammaticUsage: programmatic,

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -212,7 +212,7 @@ export async function emitMetronomeUsageEventsActivity(
   }
   const auth = authResult.value;
   const workspace = auth.getNonNullableWorkspace();
-  const { agentMessageId, userMessageId } = agentLoopArgs;
+  const { agentMessageId, conversationId, userMessageId } = agentLoopArgs;
   const userMessageOrigin = agentLoopArgs.userMessageOrigin ?? "web";
 
   // Query agent message with its run IDs.
@@ -301,13 +301,14 @@ export async function emitMetronomeUsageEventsActivity(
   // Deterministic short hash of runIds — ensures different runs of the same
   // message produce different transaction_ids (e.g., error then success finalization).
   const runKey = createHash("sha256")
-    .update(agentMessage.runIds.sort().join("-"))
+    .update([...agentMessage.runIds].sort().join("-"))
     .digest("hex")
     .slice(0, 12);
 
   // Build and ingest events.
   const llmEvents = buildLlmUsageEvents({
     workspaceId: workspace.sId,
+    conversationId,
     userId,
     agentMessageId,
     parentAgentMessageId,
@@ -322,6 +323,7 @@ export async function emitMetronomeUsageEventsActivity(
 
   const toolEvents = buildToolUseEvents({
     workspaceId: workspace.sId,
+    conversationId,
     userId,
     agentMessageId,
     parentAgentMessageId,


### PR DESCRIPTION
## Description

Fixes duplicate Metronome events for the same agent message.

The agent loop can finalize the same message multiple times (error → retry → success), each with different `runIds`. Previously, the transaction_id didn't include run information, so all finalizations produced the same key — Metronome deduplicated them, losing legitimate events from different runs.

**Fix**: include a `runKey` (12-char SHA-256 hash of sorted runIds) in all transaction_ids:
- `llm-{workspaceId}-{agentMessageId}-{runKey}-{providerId}-{modelId}`
- `tool-{workspaceId}-{agentMessageId}-{runKey}-{toolName}-{mcpServerId}-{status}`

Different runs → different hash → different transaction_ids → all events kept by Metronome.

Same run retried by Temporal → same hash → same transaction_id → correctly deduplicated.

## Tests

Type-checked. Hash is deterministic for the same set of runIds.

## Risk

None — only changes event transaction_ids. No impact on billing logic.

## Deploy Plan

No special steps. New events will have the updated transaction_id format immediately.