### PR TITLE
Move metronomeContractId to subscription

### DIFF
--- a/extension/ui/components/auth/AuthProvider.tsx
+++ b/extension/ui/components/auth/AuthProvider.tsx
@@ -44,6 +44,7 @@ const EXTENSION_SUBSCRIPTION: SubscriptionType = {
   status: "active",
   trialing: false,
   stripeSubscriptionId: null,
+  metronomeContractId: null,
   startDate: null,
   endDate: null,
   paymentFailingSince: null,

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -44,6 +44,7 @@ export function createMockAuthenticator(): Authenticator {
       endDate: null,
       planId: -1,
       stripeSubscriptionId: null,
+      metronomeContractId: null,
       requestCancelAt: null,
       workspaceId: -1,
       createdAt: new Date(),

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -43,7 +43,6 @@ export class PlanModel extends BaseModel<PlanModel> {
   declare isSCIMAllowed: boolean;
   declare isAuditLogsAllowed: boolean;
   declare isByok: boolean;
-  declare metronomePackageAlias: string | null;
   declare maxDataSourcesCount: number;
   declare maxDataSourcesDocumentsCount: number;
   declare maxDataSourcesDocumentsSizeMb: number;
@@ -157,11 +156,6 @@ PlanModel.init(
       type: DataTypes.BOOLEAN,
       defaultValue: false,
     },
-    metronomePackageAlias: {
-      type: DataTypes.STRING,
-      allowNull: true,
-      defaultValue: null,
-    },
     maxDataSourcesCount: {
       type: DataTypes.INTEGER,
       allowNull: false,
@@ -201,6 +195,7 @@ export class SubscriptionModel extends WorkspaceAwareModel<SubscriptionModel> {
   declare plan: NonAttribute<PlanModel>;
 
   declare stripeSubscriptionId: string | null;
+  declare metronomeContractId: string | null;
 
   // not necessary for business logic, but helpful
   // for analytics and business operations.
@@ -249,6 +244,11 @@ SubscriptionModel.init(
     stripeSubscriptionId: {
       type: DataTypes.STRING,
       allowNull: true,
+    },
+    metronomeContractId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
     },
     requestCancelAt: {
       type: DataTypes.DATE,

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -54,7 +54,6 @@ export const FREE_NO_PLAN_DATA: PlanAttributes = {
   trialPeriodDays: 0,
   canUseProduct: false,
   isByok: false,
-  metronomePackageAlias: null,
 };
 
 /**
@@ -89,7 +88,6 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     trialPeriodDays: 0,
     canUseProduct: false,
     isByok: false,
-    metronomePackageAlias: null,
   },
   {
     code: FREE_UPGRADED_PLAN_CODE,
@@ -118,7 +116,6 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
-    metronomePackageAlias: null,
   },
   {
     code: FREE_TRIAL_PHONE_PLAN_CODE,
@@ -147,7 +144,6 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
-    metronomePackageAlias: null,
   },
 ];
 

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -1,4 +1,4 @@
-import type { PlanType } from "@app/types/plan";
+import type { PlanType, SubscriptionType } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
 
 // Current free plans:
@@ -68,8 +68,8 @@ export function isProOrBusinessPlanCode(plan?: PlanType) {
   return isProPlan(plan) || isBusinessPlan(plan);
 }
 
-export function isMetronomeBilled(plan: PlanType): boolean {
-  return plan.metronomePackageAlias != null;
+export function isMetronomeBilled(subscription: SubscriptionType): boolean {
+  return subscription.metronomeContractId != null;
 }
 
 /**

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -58,7 +58,6 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 14,
     canUseProduct: true,
     isByok: false,
-    metronomePackageAlias: null,
   });
   PRO_PLANS_DATA.push({
     code: PRO_PLAN_SEAT_39_CODE,
@@ -87,7 +86,6 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 14,
     canUseProduct: true,
     isByok: false,
-    metronomePackageAlias: null,
   });
   PRO_PLANS_DATA.push({
     code: FREE_BYOK_PLAN_CODE,
@@ -116,7 +114,6 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: true,
-    metronomePackageAlias: null,
   });
   PRO_PLANS_DATA.push({
     code: FREE_BYOK_TRANSITIONING_PLAN_CODE,
@@ -145,7 +142,6 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: true,
-    metronomePackageAlias: null,
   });
 }
 

--- a/front/lib/plans/renderers.ts
+++ b/front/lib/plans/renderers.ts
@@ -53,7 +53,6 @@ export function renderPlanFromModel({
     trialPeriodDays: plan.trialPeriodDays,
     isByok: plan.isByok,
     isAuditLogsAllowed: plan.isAuditLogsAllowed,
-    metronomePackageAlias: plan.metronomePackageAlias ?? null,
   };
 }
 
@@ -73,6 +72,7 @@ export function renderSubscriptionFromModels({
     sId: activeSubscription?.sId || null,
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     stripeSubscriptionId: activeSubscription?.stripeSubscriptionId || null,
+    metronomeContractId: activeSubscription?.metronomeContractId ?? null,
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     startDate: activeSubscription?.startDate?.getTime() || null,
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -83,6 +83,7 @@ type CachedSubscription = {
   status: SubscriptionStatusType;
   trialing: boolean;
   stripeSubscriptionId: string | null;
+  metronomeContractId: string | null;
   startDate: number;
   endDate: number | null;
   paymentFailingSince: number | null;
@@ -152,6 +153,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       status: subscription.status,
       trialing: subscription.trialing ?? false,
       stripeSubscriptionId: subscription.stripeSubscriptionId,
+      metronomeContractId: subscription.metronomeContractId ?? null,
       startDate: subscription.startDate?.getTime() ?? Date.now(),
       endDate: subscription.endDate?.getTime() ?? null,
       paymentFailingSince: subscription.paymentFailingSince?.getTime() ?? null,
@@ -185,6 +187,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         : null,
       planId: data.planId,
       stripeSubscriptionId: data.stripeSubscriptionId,
+      metronomeContractId: data.metronomeContractId ?? null,
       requestCancelAt: data.requestCancelAt
         ? new Date(data.requestCancelAt)
         : null,
@@ -928,6 +931,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       sId: this.sId || null,
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       stripeSubscriptionId: this.stripeSubscriptionId || null,
+      metronomeContractId: this.metronomeContractId ?? null,
       startDate: this.startDate?.getTime() || null,
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       endDate: this.endDate?.getTime() || null,
@@ -955,6 +959,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       paymentFailingSince: null,
       planId: -1,
       stripeSubscriptionId: null,
+      metronomeContractId: null,
       requestCancelAt: null,
     };
   }

--- a/front/migrations/db/migration_560.sql
+++ b/front/migrations/db/migration_560.sql
@@ -1,0 +1,4 @@
+-- Migration: Add metronomeContractId to subscriptions
+-- Part of Metronome billing integration (F9) — run BEFORE deploy
+
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS "metronomeContractId" VARCHAR(255) DEFAULT NULL;

--- a/front/migrations/db/migration_561.sql
+++ b/front/migrations/db/migration_561.sql
@@ -1,0 +1,4 @@
+-- Migration: Drop metronomePackageAlias from plans
+-- Part of Metronome billing integration (F9) — run AFTER deploy
+
+ALTER TABLE plans DROP COLUMN IF EXISTS "metronomePackageAlias";

--- a/front/scripts/seed/byok/seed.ts
+++ b/front/scripts/seed/byok/seed.ts
@@ -36,7 +36,6 @@ const FREE_BYOK_PLAN_DATA: PlanAttributes = {
   trialPeriodDays: 0,
   canUseProduct: true,
   isByok: true,
-  metronomePackageAlias: null,
 };
 
 makeScript({}, async ({ execute }, logger) => {

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -70,7 +70,6 @@ export type PlanType = {
   trialPeriodDays: number;
   isByok: boolean;
   isAuditLogsAllowed: boolean;
-  metronomePackageAlias?: string | null;
 };
 
 export type SubscriptionType = {
@@ -81,6 +80,7 @@ export type SubscriptionType = {
   trialing: boolean;
   // `null` means that this is a free plan. Otherwise, it's a paid plan.
   stripeSubscriptionId: string | null;
+  metronomeContractId: string | null;
   startDate: number | null;
   endDate: number | null;
   paymentFailingSince: number | null;


### PR DESCRIPTION
## Description

Implements #23581 — Moves Metronome billing backend indicator from Plan to Subscription.

After design review, the billing backend (Stripe vs Metronome) should be determined by the **Subscription**, not the Plan — same pattern as `stripeSubscriptionId`. Plans are billing-agnostic; the same plan (e.g., Pro $29) can be billed through either system.

**Removed `metronomePackageAlias` from PlanModel:**
- Dropped from model declaration, init, `PlanType`, `renderPlanFromModel`
- Removed from all plan data objects (free_plans, pro_plans, byok seed)

**Added `metronomeContractId` to SubscriptionModel:**
- Nullable string column (same pattern as `stripeSubscriptionId`)
- Exposed on `SubscriptionType`, `CachedSubscription`, `SubscriptionResource.toJSON()`
- Set when a Metronome contract is provisioned for a workspace

**Updated `isMetronomeBilled`:**
- Was: `isMetronomeBilled(plan: PlanType)` checking `plan.metronomePackageAlias`
- Now: `isMetronomeBilled(subscription: SubscriptionType)` checking `subscription.metronomeContractId`

## Tests

Type-checked. Test fixtures updated.

## Risk

Low — `metronomePackageAlias` was always `null` on all plans (never set in production). No behavioral change.

## Deploy Plan

1. Run migration 559 — adds `metronomeContractId` column to `subscriptions` table
2. Deploy code
3. Run migration 560 — drops `metronomePackageAlias` column from `plans` table