### PR TITLE
Add info in poke

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -127,6 +127,7 @@ export function WorkspacePage() {
 
   const {
     activeSubscription,
+    metronomeCustomerId,
     stripeSubscription,
     subscriptions,
     whitelistableFeatures,
@@ -205,6 +206,7 @@ export function WorkspacePage() {
               <TabsContent value="workspace">
                 <WorkspaceInfoTable
                   owner={owner}
+                  metronomeCustomerId={metronomeCustomerId}
                   workspaceVerifiedDomains={workspaceVerifiedDomains}
                   workspaceCreationDay={workspaceCreationDay}
                   extensionConfig={extensionConfig}

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -235,6 +235,20 @@ export function ActiveSubscriptionTable({
                   )}
                 </PokeTableCell>
               </PokeTableRow>
+              {subscription.metronomeContractId && (
+                <PokeTableRow>
+                  <PokeTableCell>Metronome Contract</PokeTableCell>
+                  <PokeTableCell>
+                    <LinkWrapper
+                      href={`https://app.metronome.com/${isDevelopment() ? "sandbox/" : ""}contracts/${subscription.metronomeContractId}`}
+                      target="_blank"
+                      className="text-xs text-highlight-400"
+                    >
+                      {subscription.metronomeContractId}
+                    </LinkWrapper>
+                  </PokeTableCell>
+                </PokeTableRow>
+              )}
               <PokeTableRow>
                 <PokeTableCell>Start Date</PokeTableCell>
                 <PokeTableCell>

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -9,6 +9,7 @@ import type { DataRetentionConfig } from "@app/lib/data_retention";
 import { usePokeWorkOSDSyncStatus } from "@app/lib/swr/poke";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import type { ExtensionConfigurationType } from "@app/types/extension";
+import { isDevelopment } from "@app/types/shared/env";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import type { WorkspaceDomain } from "@app/types/workspace";
@@ -16,6 +17,7 @@ import { Chip, LinkWrapper } from "@dust-tt/sparkle";
 
 export function WorkspaceInfoTable({
   owner,
+  metronomeCustomerId,
   workspaceVerifiedDomains,
   workspaceCreationDay,
   extensionConfig,
@@ -23,6 +25,7 @@ export function WorkspaceInfoTable({
   workosEnvironmentId,
 }: {
   owner: WorkspaceType;
+  metronomeCustomerId: string | null;
   workspaceVerifiedDomains: WorkspaceDomain[];
   workspaceCreationDay: string;
   extensionConfig: ExtensionConfigurationType | null;
@@ -104,6 +107,22 @@ export function WorkspaceInfoTable({
                   >
                     {owner.workOSOrganizationId}
                   </LinkWrapper>
+                )}
+              </PokeTableCell>
+            </PokeTableRow>
+            <PokeTableRow>
+              <PokeTableCell>Metronome</PokeTableCell>
+              <PokeTableCell>
+                {metronomeCustomerId ? (
+                  <LinkWrapper
+                    href={`https://app.metronome.com/${isDevelopment() ? "sandbox/" : ""}customers/${metronomeCustomerId}`}
+                    target="_blank"
+                    className="text-xs text-highlight-400"
+                  >
+                    {metronomeCustomerId}
+                  </LinkWrapper>
+                ) : (
+                  "Not provisioned"
                 )}
               </PokeTableCell>
             </PokeTableRow>

--- a/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
+++ b/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
@@ -25,6 +25,7 @@ export type PokeGetWorkspaceInfo = {
   activeSubscription: SubscriptionType;
   baseUrl: string;
   extensionConfig: ExtensionConfigurationType | null;
+  metronomeCustomerId: string | null;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
   stripeSubscription: Stripe.Subscription | null;
   subscriptions: SubscriptionType[];
@@ -100,6 +101,7 @@ async function handler(
 
       return res.status(200).json({
         activeSubscription,
+        metronomeCustomerId: workspaceResource.metronomeCustomerId ?? null,
         stripeSubscription,
         subscriptions,
         whitelistableFeatures: WHITELISTABLE_FEATURES,


### PR DESCRIPTION
## Description

Adds Metronome links in Poke for workspace and subscription visibility.

- **Workspace info tab**: Metronome customer link (links to `app.metronome.com/customers/{id}`, sandbox URL in dev)
- **Active subscription card**: Metronome contract link (shown only when `metronomeContractId` is set)
- **API**: `workspace-info` endpoint now returns `metronomeCustomerId`

## Risk

None — read-only UI additions.