### PR TITLE
[front] - refactor(agent): pass `authorId`

### DIFF
--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -47,6 +47,7 @@ describe("createAgentConfiguration with pending agent", () => {
       requestedSpaceIds: [],
       tags: [],
       editors: [user.toJSON()],
+      authorId: user.id,
     });
 
     expect(result.isOk()).toBe(true);
@@ -91,6 +92,7 @@ describe("createAgentConfiguration with pending agent", () => {
       requestedSpaceIds: [],
       tags: [],
       editors: [user.toJSON()],
+      authorId: user.id,
     });
 
     expect(result.isOk()).toBe(true);
@@ -140,6 +142,7 @@ describe("createAgentConfiguration with pending agent", () => {
       requestedSpaceIds: [],
       tags: [],
       editors: [user.toJSON()],
+      authorId: user.id,
     });
 
     expect(result.isErr()).toBe(true);
@@ -177,6 +180,7 @@ describe("createAgentConfiguration with pending agent", () => {
       requestedSpaceIds: [],
       tags: [],
       editors: [user.toJSON()],
+      authorId: user.id,
     });
 
     expect(result.isOk()).toBe(true);
@@ -232,6 +236,7 @@ describe("createAgentConfiguration with pending agent", () => {
       requestedSpaceIds: [],
       tags: [],
       editors: [user.toJSON()],
+      authorId: user.id,
     });
 
     expect(result.isOk()).toBe(true);

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -136,6 +136,7 @@ export async function createPendingAgentConfiguration(
 
     const group = await GroupResource.makeNewAgentEditorsGroup(auth, agent, {
       transaction: t,
+      authorId: user.id,
     });
     await auth.refresh({ transaction: t });
     if (!group.canWrite(auth)) {
@@ -425,6 +426,7 @@ export async function createAgentConfiguration(
     requestedSpaceIds,
     tags,
     editors,
+    authorId,
     reinforcement,
   }: {
     name: string;
@@ -440,6 +442,7 @@ export async function createAgentConfiguration(
     requestedSpaceIds: number[];
     tags: TagType[];
     editors: UserType[];
+    authorId: ModelId;
     reinforcement?: AgentReinforcementMode;
   },
   transaction?: Transaction
@@ -447,11 +450,6 @@ export async function createAgentConfiguration(
   const owner = auth.workspace();
   if (!owner) {
     throw new Error("Unexpected `auth` without `workspace`.");
-  }
-
-  const user = auth.user();
-  if (!user) {
-    throw new Error("Unexpected `auth` without `user`.");
   }
 
   const isValidPictureUrl =
@@ -539,7 +537,7 @@ export async function createAgentConfiguration(
             where: {
               workspaceId: owner.id,
               agentConfiguration: agentConfigurationId,
-              userId: user.id,
+              userId: authorId,
             },
             transaction: t,
           }),
@@ -551,7 +549,7 @@ export async function createAgentConfiguration(
           // Handle pending agent: update in place (don't bump version, preserve id for FK relationships)
           // Otherwise: archive old versions and bump version
           if (existingAgent.status === "pending") {
-            if (existingAgent.authorId === user.id) {
+            if (existingAgent.authorId === authorId) {
               const timeToCreationMs =
                 Date.now() - existingAgent.createdAt.getTime();
               logger.info(
@@ -609,7 +607,7 @@ export async function createAgentConfiguration(
             reasoningEffort: model.reasoningEffort,
             maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
             pictureUrl,
-            authorId: user.id,
+            authorId,
             templateId: template?.id,
             requestedSpaceIds: requestedSpaceIds,
             responseFormat: model.responseFormat,
@@ -655,7 +653,7 @@ export async function createAgentConfiguration(
             maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
             pictureUrl,
             workspaceId: owner.id,
-            authorId: user.id,
+            authorId,
             templateId: template?.id,
             requestedSpaceIds: requestedSpaceIds,
             responseFormat: model.responseFormat,
@@ -706,14 +704,14 @@ export async function createAgentConfiguration(
         }
 
         assert(
-          editors.some((e) => e.sId === auth.user()?.sId) || isAdmin(owner),
-          "Unexpected: current user must be in editor group or admin"
+          editors.some((e) => e.id === authorId) || isAdmin(owner),
+          "Unexpected: author must be in editor group or admin"
         );
         if (!existingAgent) {
           const group = await GroupResource.makeNewAgentEditorsGroup(
             auth,
             agentConfigurationInstance,
-            { transaction: t }
+            { transaction: t, authorId }
           );
           await auth.refresh({ transaction: t });
           // No need to check on permission here since it was done a few lines above.
@@ -979,6 +977,7 @@ export async function createGenericAgentConfiguration(
     requestedSpaceIds: [],
     tags: [],
     editors: [user.toJSON()], // Only the current user as editor
+    authorId: user.id,
   });
 
   if (result.isErr()) {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -251,9 +251,8 @@ export class GroupResource extends BaseResource<GroupModel> {
   static async makeNewAgentEditorsGroup(
     auth: Authenticator,
     agent: AgentConfigurationModel,
-    { transaction }: { transaction?: Transaction } = {}
+    { transaction, authorId }: { transaction?: Transaction; authorId: ModelId }
   ) {
-    const user = auth.getNonNullableUser();
     const workspace = auth.getNonNullableWorkspace();
 
     if (agent.workspaceId !== workspace.id) {
@@ -270,7 +269,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         name: `${AGENT_GROUP_PREFIX} ${agent.name} (${agent.sId})`,
         kind: "agent_editors",
       },
-      { transaction, memberIds: [user.id] }
+      { transaction, memberIds: [authorId] }
     );
 
     // Associate the group with the agent configuration.

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -153,6 +153,7 @@ import {
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { LightAgentConfigurationSchema } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -389,10 +390,12 @@ export async function createOrUpgradeAgentConfiguration({
   auth,
   assistant,
   agentConfigurationId,
+  authorId,
 }: {
   auth: Authenticator;
   assistant: PostOrPatchAgentConfigurationRequestBody["assistant"];
   agentConfigurationId?: string;
+  authorId?: ModelId;
 }): Promise<Result<AgentConfigurationType, Error>> {
   const { actions } = assistant;
 
@@ -488,6 +491,13 @@ export async function createOrUpgradeAgentConfiguration({
     );
   }
 
+  const resolvedAuthorId = authorId ?? auth.user()?.id;
+  if (!resolvedAuthorId) {
+    return new Err(
+      new Error("An author must be provided when no user is authenticated.")
+    );
+  }
+
   const agentConfigurationRes = await createAgentConfiguration(auth, {
     name: assistant.name,
     description: assistant.description,
@@ -502,6 +512,7 @@ export async function createOrUpgradeAgentConfiguration({
     requestedSpaceIds: allRequestedSpaceIds,
     tags: assistant.tags,
     editors,
+    authorId: resolvedAuthorId,
   });
 
   if (agentConfigurationRes.isErr()) {

--- a/front/scripts/seed/factories/seedAgent.ts
+++ b/front/scripts/seed/factories/seedAgent.ts
@@ -61,6 +61,7 @@ export async function seedAgent(
       requestedSpaceIds: [],
       tags: [],
       editors,
+      authorId: user.id,
     });
 
     if (result.isErr()) {

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -48,6 +48,7 @@ export class AgentConfigurationFactory {
       requestedSpaceIds: [],
       tags: [], // Added missing tags property
       editors: [user.toJSON()],
+      authorId: user.id,
     });
 
     if (result.isErr()) {
@@ -91,6 +92,7 @@ export class AgentConfigurationFactory {
       requestedSpaceIds: [],
       tags: [],
       editors: [user.toJSON()],
+      authorId: user.id,
       agentConfigurationId: agentId,
     });
 


### PR DESCRIPTION
## Description

Decouples agent authorship from authenticated user by requiring `authorId` to be passed explicitly through all agent configuration creation and upgrade functions. Previously, the author was always derived from `auth.user()`, which prevented agent creation when no authenticated user exists (e.g., API calls with system keys). This refactor makes authorship explicit and allows proper handling of pending agent updates by checking `authorId` instead of the current user.

## Tests

- [x] Locally

## Risk

Medium - this is a refactor that makes an implicit parameter explicit. The behavior remains the same for all existing code paths since `authorId` defaults to `auth.user()?.id` when not provided in the API endpoint.

## Deploy Plan

Deploy front