### PR TITLE
[Front] fix(productboard): update note type enum to match Productboard API v2 changes

### DIFF
--- a/front/lib/api/actions/servers/productboard/client.ts
+++ b/front/lib/api/actions/servers/productboard/client.ts
@@ -128,7 +128,7 @@ export class ProductboardClient {
   }
 
   async createNote(params: {
-    type: "simple" | "conversation";
+    type: "textNote" | "conversationNote";
     fields: Record<string, unknown>;
     relationships?: Array<{
       type: "customer" | "link";

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -12,9 +12,9 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
       "Create a note in Productboard to capture customer feedback, insights, or support conversations.",
     schema: {
       type: z
-        .enum(["simple", "conversation"])
+        .enum(["textNote", "conversationNote"])
         .describe(
-          "Note type: 'simple' for plain feedback, 'conversation' for chat/email threads"
+          "Note type: 'textNote' for plain feedback, 'conversationNote' for chat/email threads"
         ),
       fields: z
         .object({})
@@ -345,8 +345,8 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
     schema: {
       entity_type: z
         .enum([
-          "simple",
-          "conversation",
+          "textNote",
+          "conversationNote",
           "product",
           "component",
           "feature",
@@ -360,7 +360,7 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
           "user",
         ])
         .describe(
-          "Entity type to get configuration for. Note types: 'simple', 'conversation'. Entity types: 'product', 'component', 'feature', etc."
+          "Entity type to get configuration for. Note types: 'textNote', 'conversationNote'. Entity types: 'product', 'component', 'feature', etc."
         ),
     },
     stake: "never_ask",
@@ -378,7 +378,7 @@ Productboard uses a configuration-driven API. Always start by calling get_config
 
 ### Entity Types Reference
 
-**Notes:** Use \`entity_type='simple'\` or \`entity_type='conversation'\`
+**Notes:** Use \`entity_type='textNote'\` or \`entity_type='conversationNote'\`
 **Entities:** Use \`entity_type='product'\`, \`'component'\`, \`'feature'\`, \`'subfeature'\`, \`'initiative'\`, \`'objective'\`, \`'keyResult'\`, \`'release'\`, \`'releaseGroup'\`, \`'company'\`, or \`'user'\`
 
 ### Required Workflow for Creating

--- a/front/lib/api/actions/servers/productboard/tools/index.ts
+++ b/front/lib/api/actions/servers/productboard/tools/index.ts
@@ -410,7 +410,7 @@ export function createProductboardTools(): ToolDefinition[] {
 
       let config: ProductboardConfiguration;
 
-      if (entity_type === "simple" || entity_type === "conversation") {
+      if (entity_type === "textNote" || entity_type === "conversationNote") {
         const result = await client.getNotesConfigurations();
         if (result.isErr()) {
           return new Err(
@@ -441,7 +441,7 @@ export function createProductboardTools(): ToolDefinition[] {
       }
 
       const isNoteType =
-        entity_type === "simple" || entity_type === "conversation";
+        entity_type === "textNote" || entity_type === "conversationNote";
       const text = isNoteType
         ? renderNoteConfigurationsList([config])
         : renderEntityConfigurationsList([config]);

--- a/front/lib/api/actions/servers/productboard/types.ts
+++ b/front/lib/api/actions/servers/productboard/types.ts
@@ -41,7 +41,7 @@ export const ProductboardNoteRelationshipSchema = z.object({
 export const ProductboardNoteSchema = z
   .object({
     id: z.string(),
-    type: z.enum(["simple", "conversation", "opportunity"]),
+    type: z.enum(["textNote", "conversationNote", "opportunityNote"]),
     fields: z.record(z.string(), z.unknown()).optional(),
     relationships: z
       .object({
@@ -277,9 +277,9 @@ export const ProductboardConfigurationSchema = z
       "releaseGroup",
       "company",
       "user",
-      "simple",
-      "conversation",
-      "opportunity",
+      "textNote",
+      "conversationNote",
+      "opportunityNote",
     ]),
     fields: z.record(z.string(), ProductboardConfigFieldSchema),
     relationships: z


### PR DESCRIPTION
## Summary

Productboard changed their API note type values on March 27, 2026 (legacy aliases removed April 8):
- `simple` → `textNote`
- `conversation` → `conversationNote`  
- `opportunity` → `opportunityNote`

This broke all `query_notes` calls with Zod validation errors.

Updates the Zod schemas, tool metadata, client types, and server instructions to use the new canonical values.

Closes https://github.com/dust-tt/tasks/issues/7263

## Test plan

- [x] Tested locally — `query_notes` calls now succeed