### PR TITLE
feat: user message attachments above content

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1456,6 +1456,7 @@ function getCitations({
       <AttachmentCitation
         key={index}
         attachmentCitation={attachmentCitation}
+        compact
         owner={owner}
         conversationId={conversationId}
       />

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -20,6 +20,7 @@ import { useMessageFeedback } from "@app/hooks/useMessageFeedback";
 import { useReaction } from "@app/hooks/useReaction";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { classNames } from "@app/lib/utils";
+import { isSupportedImageContentType } from "@app/types/files";
 import type { UserType } from "@app/types/user";
 import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
 import React, { useMemo } from "react";
@@ -100,6 +101,17 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       isSubmittingThumb,
     };
 
+    const hasImageCitation =
+      isUserMessage(data) &&
+      data.contentFragments.some((fragment) => {
+        const attachmentCitation =
+          contentFragmentToAttachmentCitation(fragment);
+        return (
+          attachmentCitation.type === "file" &&
+          isSupportedImageContentType(attachmentCitation.contentType)
+        );
+      });
+
     const citations =
       isUserMessage(data) && data.contentFragments.length > 0
         ? data.contentFragments.map((contentFragment, index) => {
@@ -112,6 +124,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                 key={index}
                 attachmentCitation={attachmentCitation}
                 conversationId={context.conversation?.sId}
+                compact={!hasImageCitation}
               />
             );
           })

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -314,7 +314,7 @@ export function UserMessage({
           {isCurrentUser && isFirstInGroup && (
             <div className="inline-flex items-center justify-between gap-0.5 self-end">
               <ConversationMessageTitle
-                name={undefined}
+                name={"Me"}
                 timestamp={timestamp}
                 infoChip={
                   displayChip ? (
@@ -332,7 +332,7 @@ export function UserMessage({
                     </>
                   ) : undefined
                 }
-                renderName={() => null}
+                renderName={() => <div>Me</div>}
               />
             </div>
           )}

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -314,7 +314,7 @@ export function UserMessage({
           {isCurrentUser && isFirstInGroup && (
             <div className="inline-flex items-center justify-between gap-0.5 self-end">
               <ConversationMessageTitle
-                name={"Me"}
+                name={undefined}
                 timestamp={timestamp}
                 infoChip={
                   displayChip ? (
@@ -332,7 +332,7 @@ export function UserMessage({
                     </>
                   ) : undefined
                 }
-                renderName={() => <div>Me</div>}
+                renderName={() => null}
               />
             </div>
           )}
@@ -351,6 +351,7 @@ export function UserMessage({
                 citations={citations}
                 type="user"
                 className={cn(shouldShowBiggerUserMessage && "@sm:min-w-100")}
+                reversed={isCurrentUser}
               >
                 <div className="flex items-center gap-2">
                   {message.visibility === "pending" && <Spinner size="xs" />}

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -24,12 +24,13 @@ interface AttachmentCitationProps {
   owner: LightWorkspaceType;
   attachmentCitation: AttachmentCitation;
   conversationId?: string | null;
+  compact?: boolean;
 }
 
 export function AttachmentCitation({
   owner,
   attachmentCitation,
-  conversationId,
+  compact,
 }: AttachmentCitationProps) {
   const [viewerOpen, setViewerOpen] = useState(false);
 
@@ -82,6 +83,7 @@ export function AttachmentCitation({
           <Citation
             {...dialogOrDownloadProps}
             isLoading={isLoading}
+            compact={compact}
             containerClassName={cn("h-full", isImage && "min-h-24")}
             action={
               !isImage &&

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -82,7 +82,7 @@ export function AttachmentCitation({
           <Citation
             {...dialogOrDownloadProps}
             isLoading={isLoading}
-            containerClassName={cn("h-full", isImage && "aspect-video")}
+            containerClassName={cn("h-full", isImage && "min-h-24")}
             action={
               !isImage &&
               attachmentCitation.onRemove && (

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -8,8 +8,12 @@ import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
 import React, { type ReactNode } from "react";
 
+const CitationContext = React.createContext<{ compact: boolean }>({
+  compact: false,
+});
+
 const citationVariants = cva(
-  "s-relative s-flex s-min-w-24 s-flex-none s-flex-col s-overflow-hidden",
+  "s-relative s-flex s-min-w-24 s-flex-none s-overflow-hidden",
   {
     variants: {
       hasImage: {
@@ -18,15 +22,21 @@ const citationVariants = cva(
         false: "s-pt-[min(8%,theme(spacing.3))]",
         true: "s-border-0 s-p-0",
       },
+      compact: {
+        true: "s-flex-row s-flex-wrap s-items-center s-gap-x-2 s-pt-0",
+        false: "s-flex-col",
+      },
     },
     defaultVariants: {
       hasImage: false,
+      compact: false,
     },
   }
 );
 
 type CitationProps = CardProps & {
   children: React.ReactNode;
+  compact?: boolean;
   isLoading?: boolean;
   tooltip?: string;
 };
@@ -35,6 +45,7 @@ const Citation = React.forwardRef<HTMLDivElement, CitationProps>(
   (
     {
       children,
+      compact = false,
       variant = "secondary",
       isLoading,
       className,
@@ -64,7 +75,7 @@ const Citation = React.forwardRef<HTMLDivElement, CitationProps>(
     const contentWithDescription = (
       <>
         {children}
-        {!hasDescription && !hasImage && (
+        {!hasDescription && !hasImage && !compact && (
           <CitationDescription>&nbsp;</CitationDescription>
         )}
       </>
@@ -74,10 +85,12 @@ const Citation = React.forwardRef<HTMLDivElement, CitationProps>(
         ref={ref}
         variant={variant}
         size="sm"
-        className={cn(citationVariants({ hasImage }), className)}
+        className={cn(citationVariants({ hasImage, compact }), className)}
         {...props}
       >
-        {contentWithDescription}
+        <CitationContext.Provider value={{ compact }}>
+          {contentWithDescription}
+        </CitationContext.Provider>
         {isLoading && <CitationLoading />}
       </Card>
     );
@@ -218,10 +231,15 @@ const CitationIcons = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ children, className, ...props }, ref) => {
+  const { compact } = React.useContext(CitationContext);
   return (
     <div
       ref={ref}
-      className={cn("s-flex s-items-center s-gap-2 s-pb-1", className)}
+      className={cn(
+        "s-flex s-items-center s-gap-2",
+        !compact && "s-pb-1",
+        className
+      )}
       {...props}
     >
       {children}
@@ -256,6 +274,7 @@ interface CitationTitleProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const CitationTitle = React.forwardRef<HTMLDivElement, CitationTitleProps>(
   ({ children, className, ...props }, ref) => {
+    const { compact } = React.useContext(CitationContext);
     return (
       <div
         ref={ref}
@@ -264,6 +283,7 @@ const CitationTitle = React.forwardRef<HTMLDivElement, CitationTitleProps>(
           "s-line-clamp-1 s-overflow-hidden s-text-ellipsis s-break-all",
           "s-heading-sm",
           "s-text-foreground dark:s-text-foreground-night",
+          compact && "s-flex-1 s-min-w-0",
           className
         )}
         {...props}
@@ -284,6 +304,7 @@ const CitationDescription = React.forwardRef<
   HTMLDivElement,
   CitationDescriptionProps
 >(({ children, className, ...props }, ref) => {
+  const { compact } = React.useContext(CitationContext);
   return (
     <div
       ref={ref}
@@ -292,6 +313,7 @@ const CitationDescription = React.forwardRef<
         "s-line-clamp-1 s-overflow-hidden s-text-ellipsis",
         "s-text-xs s-font-normal",
         "s-text-muted-foreground dark:s-text-muted-foreground-night",
+        compact && "s-basis-full",
         className
       )}
       {...props}

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -123,25 +123,33 @@ const citationGridVariants = cva("s-grid s-gap-2", {
       grid: "s-grid-cols-2 @xxs:s-grid-cols-3 @xs:s-grid-cols-4 @md:s-grid-cols-5 @lg:s-grid-cols-6",
       list: "s-grid-cols-1",
     },
+    reversed: {
+      true: "s-rotate-180 [&>*]:s-rotate-180",
+      false: "",
+    },
   },
   defaultVariants: {
     variant: "grid",
+    reversed: false,
   },
 });
 
 interface CitationGridProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: CitationGridVariantType;
+  reversed?: boolean;
 }
 
 const CitationGrid = React.forwardRef<HTMLDivElement, CitationGridProps>(
-  ({ children, className, variant, ...props }, ref) => {
+  ({ children, className, variant, reversed, ...props }, ref) => {
     return (
       <div
         ref={ref}
         className={cn("s-min-w-60 s-@container", className)}
         {...props}
       >
-        <div className={citationGridVariants({ variant })}>{children}</div>
+        <div className={citationGridVariants({ variant, reversed })}>
+          {children}
+        </div>
       </div>
     );
   }

--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -22,7 +22,7 @@ const wrapperVariants = cva("s-flex s-flex-col s-@container @xs:s-flex-row", {
 const messageVariants = cva("s-flex s-rounded-2xl s-max-w-full", {
   variants: {
     type: {
-      user: "s-bg-muted-background dark:s-bg-muted-background-night s-px-4 s-py-3 s-gap-2 s-w-fit",
+      user: "s-gap-2 s-w-fit",
       agent: "s-w-full s-gap-3 s-py-4 s-flex-col",
     },
   },
@@ -63,20 +63,30 @@ interface ConversationMessageContentProps
 export const ConversationMessageContent = React.forwardRef<
   HTMLDivElement,
   ConversationMessageContentProps
->(({ children, citations, className, ...props }, ref) => {
+>(({ children, citations, className, type, ...props }, ref) => {
   return (
-    <div
-      ref={ref}
-      className={cn("s-flex s-min-w-0 s-flex-col s-gap-1", className)}
-      {...props}
-    >
-      <div className="s-text-base s-text-foreground dark:s-text-foreground-night">
-        {children}
-      </div>
-      {citations && citations.length > 0 && (
-        <CitationGrid>{citations}</CitationGrid>
+    <>
+      {type === "user" && citations && citations.length > 0 && (
+        <CitationGrid reversed>{citations}</CitationGrid>
       )}
-    </div>
+      <div
+        ref={ref}
+        className={cn(
+          "s-flex s-min-w-0 s-flex-col s-gap-1",
+          type === "user" &&
+            "s-rounded-2xl s-bg-muted-background dark:s-bg-muted-background-night s-px-4 s-py-3",
+          className
+        )}
+        {...props}
+      >
+        <div className="s-text-base s-text-foreground dark:s-text-foreground-night">
+          {children}
+        </div>
+        {type === "agent" && citations && citations.length > 0 && (
+          <CitationGrid>{citations}</CitationGrid>
+        )}
+      </div>
+    </>
   );
 });
 

--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -58,16 +58,17 @@ interface ConversationMessageContentProps
   citations?: React.ReactElement[];
   type: ConversationMessageType;
   infoChip?: React.ReactNode;
+  reversed?: boolean;
 }
 
 export const ConversationMessageContent = React.forwardRef<
   HTMLDivElement,
   ConversationMessageContentProps
->(({ children, citations, className, type, ...props }, ref) => {
+>(({ children, citations, className, type, reversed, ...props }, ref) => {
   return (
     <>
       {type === "user" && citations && citations.length > 0 && (
-        <CitationGrid reversed>{citations}</CitationGrid>
+        <CitationGrid reversed={reversed}>{citations}</CitationGrid>
       )}
       <div
         ref={ref}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7060

This PR improves the visual presentation of user message citations in conversations: they are now displayed above the message content bubble (instead of below), and non-image citations use a new compact layout.

### Commit 1: User message citations above content

- **`ConversationMessageContent`** conditionally renders citations differently based on whether the message is from a user or an agent. User message citations are rendered above the content bubble (using a reversed `CitationGrid`), while agent citations remain below. The bubble styling (background, padding, border radius) is moved to the inner content `div` so that citations sit outside of it.
- **`CitationGrid`**: Added a `reversed` prop to visually reverse the stacking order (see comments for why it was added)
- **`AttachmentCitation.tsx`**: Removed `aspect-video` for image citations. This avoids broken layouts in multi-row grids and fixes overflow issues currently present in production (see screenshot below). 
I dit not force a squared aspect ratio as I think it does not look good when images are mixed with other files in a grid spanning multiple rows. Open to challenge
- **`UserMessage.tsx`**: Displays `"Me"` as the sender name instead of nothing.
- I am not using compact citations for the input bar because the "X" button would sometimes appear above the title

### Commit 2: Proposal for compact citations

- Compact citations have the icon and title on the same line and the description on the second line.
- **`MessageItem.tsx`**: Citations are rendered in compact mode when no images are present, and in full mode when images are included.
- **`AgentMessage.tsx`**: Agent message citations are always rendered in compact mode.

## Screenshots

<img width="602" height="291" alt="Capture d’écran 2026-04-02 à 11 01 01" src="https://github.com/user-attachments/assets/8e759ca2-5737-4546-8a23-80a9944b0466" />
<img width="466" height="194" alt="Capture d’écran 2026-04-02 à 11 01 13" src="https://github.com/user-attachments/assets/b6499785-f6f5-49c2-950f-aa91dcb27192" />
<img width="531" height="245" alt="Capture d’écran 2026-04-02 à 11 01 23" src="https://github.com/user-attachments/assets/33f8c123-eaf6-47c5-922f-26823b774b2c" />
<img width="736" height="252" alt="Capture d’écran 2026-04-02 à 11 01 42" src="https://github.com/user-attachments/assets/b0831b8a-18d1-473b-9eb9-19b3de654236" />
<img width="874" height="312" alt="Capture d’écran 2026-04-02 à 11 01 47" src="https://github.com/user-attachments/assets/a9c59f87-8d2d-4618-823c-fa3153fd87c6" />
<img width="915" height="651" alt="Capture d’écran 2026-04-02 à 11 02 11" src="https://github.com/user-attachments/assets/dfb4e5c1-3c0c-4b51-8290-7644668dd6fa" />


The bug currently in prod caused by images with different aspect ratio is the following
<img width="458" height="285" alt="Capture d’écran 2026-04-02 à 11 11 31" src="https://github.com/user-attachments/assets/dd78fb34-f365-4b4f-b1af-c577d0c099d1" />


## Tests

Manually

## Risks

Low risk. UI-only changes affecting the visual layout of message citations. No data handling or business logic is modified.

## Deploy Plan

Standard deployment - no special considerations needed.