### PR TITLE
[front] enh: add gradient on detected skill list

### DIFF
--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -7,6 +7,7 @@ import {
 import {
   Checkbox,
   Chip,
+  cn,
   ContentMessage,
   ContextItem,
   InformationCircleIcon,
@@ -176,9 +177,13 @@ export function DetectedSkillsList({
                 />
               ))}
             </ContextItem.List>
-            {canScrollDown && (
-              <div className="pointer-events-none sticky bottom-0 left-0 right-0 -mt-12 h-12 bg-gradient-to-t from-background via-background/60 to-transparent dark:from-background-night dark:via-background-night/60" />
-            )}
+            <div
+              className={cn(
+                "pointer-events-none sticky bottom-0 left-0 right-0 -mt-12 h-12 bg-gradient-to-t",
+                "from-background via-background/60 to-transparent transition-opacity dark:from-background-night dark:via-background-night/60",
+                canScrollDown ? "opacity-100" : "opacity-0"
+              )}
+            />
           </div>
         </div>
       )}

--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -7,9 +7,9 @@ import {
 import {
   Checkbox,
   Chip,
+  cn,
   ContentMessage,
   ContextItem,
-  cn,
   InformationCircleIcon,
   Label,
   PuzzleIcon,
@@ -133,52 +133,53 @@ export function DetectedSkillsList({
               />
             </ContextItem.List>
           )}
-          <div className="relative max-h-64 overflow-hidden">
-            <div ref={scrollCallbackRef} className="max-h-64 overflow-y-auto">
-              <ContextItem.List>
-                {detectedSkills.map((skill) => (
-                  <ContextItem
-                    key={skill.name}
-                    title={
-                      <Label
-                        className="text-sm font-normal"
-                        htmlFor={skill.name}
-                      >
-                        {skill.name}
-                      </Label>
-                    }
-                    visual={
-                      <div className="flex items-center gap-2">
-                        <Checkbox
-                          id={skill.name}
-                          size="xs"
-                          checked={selectedField.value.includes(skill.name)}
-                          disabled={!isImportableSkillStatus(skill.status)}
-                          onCheckedChange={() => toggleSkill(skill.name)}
-                        />
-                        <ContextItem.Visual visual={PuzzleIcon} />
-                      </div>
-                    }
-                    action={
-                      skill.status !== "ready" ? (
-                        <Chip
-                          label={STATUS_CHIP_LABEL[skill.status]}
-                          size="xs"
-                          color={
-                            skill.status === "skill_already_exists"
-                              ? "info"
-                              : "warning"
-                          }
-                        />
-                      ) : undefined
-                    }
-                  />
-                ))}
-              </ContextItem.List>
-            </div>
+          <div
+            ref={scrollCallbackRef}
+            className="relative max-h-64 overflow-y-auto"
+          >
+            <ContextItem.List>
+              {detectedSkills.map((skill) => (
+                <ContextItem
+                  key={skill.name}
+                  title={
+                    <Label
+                      className="text-sm font-normal"
+                      htmlFor={skill.name}
+                    >
+                      {skill.name}
+                    </Label>
+                  }
+                  visual={
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id={skill.name}
+                        size="xs"
+                        checked={selectedField.value.includes(skill.name)}
+                        disabled={!isImportableSkillStatus(skill.status)}
+                        onCheckedChange={() => toggleSkill(skill.name)}
+                      />
+                      <ContextItem.Visual visual={PuzzleIcon} />
+                    </div>
+                  }
+                  action={
+                    skill.status !== "ready" ? (
+                      <Chip
+                        label={STATUS_CHIP_LABEL[skill.status]}
+                        size="xs"
+                        color={
+                          skill.status === "skill_already_exists"
+                            ? "info"
+                            : "warning"
+                        }
+                      />
+                    ) : undefined
+                  }
+                />
+              ))}
+            </ContextItem.List>
             <div
               className={cn(
-                "pointer-events-none absolute -bottom-px left-0 right-0 h-12 bg-gradient-to-t",
+                "pointer-events-none sticky -bottom-px left-0 right-0 -mt-12 h-12 bg-gradient-to-t",
                 "from-background via-background/60 to-transparent transition-opacity duration-300 dark:from-background-night dark:via-background-night/60",
                 canScrollDown ? "opacity-100" : "opacity-0"
               )}

--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -181,7 +181,7 @@ export function DetectedSkillsList({
             </div>
             <div
               className={cn(
-                "pointer-events-none absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t",
+                "pointer-events-none absolute -bottom-px left-0 right-0 h-12 bg-gradient-to-t",
                 "from-background via-background/60 to-transparent transition-opacity duration-300 dark:from-background-night dark:via-background-night/60",
                 canScrollDown ? "opacity-100" : "opacity-0"
               )}

--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -182,7 +182,7 @@ export function DetectedSkillsList({
             <div
               className={cn(
                 "pointer-events-none absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t",
-                "from-background via-background/60 to-transparent transition-opacity dark:from-background-night dark:via-background-night/60",
+                "from-background via-background/60 to-transparent transition-opacity duration-300 dark:from-background-night dark:via-background-night/60",
                 canScrollDown ? "opacity-100" : "opacity-0"
               )}
             />

--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -58,8 +58,6 @@ export function DetectedSkillsList({
       scrollRef.current = node;
       if (node) {
         node.addEventListener("scroll", updateScrollIndicator);
-        // Check on mount (after layout).
-        requestAnimationFrame(updateScrollIndicator);
       }
     },
     [updateScrollIndicator]

--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -58,6 +58,8 @@ export function DetectedSkillsList({
       scrollRef.current = node;
       if (node) {
         node.addEventListener("scroll", updateScrollIndicator);
+        // Check on mount (after layout).
+        requestAnimationFrame(updateScrollIndicator);
       }
     },
     [updateScrollIndicator]

--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -177,7 +177,7 @@ export function DetectedSkillsList({
               ))}
             </ContextItem.List>
             {canScrollDown && (
-              <div className="pointer-events-none sticky bottom-0 left-0 right-0 -mt-12 h-12 bg-gradient-to-t from-background  to-transparent dark:from-background-night " />
+              <div className="pointer-events-none sticky bottom-0 left-0 right-0 -mt-12 h-12 bg-gradient-to-t from-background via-background/60 to-transparent dark:from-background-night dark:via-background-night/60" />
             )}
           </div>
         </div>

--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -7,9 +7,9 @@ import {
 import {
   Checkbox,
   Chip,
-  cn,
   ContentMessage,
   ContextItem,
+  cn,
   InformationCircleIcon,
   Label,
   PuzzleIcon,
@@ -142,10 +142,7 @@ export function DetectedSkillsList({
                 <ContextItem
                   key={skill.name}
                   title={
-                    <Label
-                      className="text-sm font-normal"
-                      htmlFor={skill.name}
-                    >
+                    <Label className="text-sm font-normal" htmlFor={skill.name}>
                       {skill.name}
                     </Label>
                   }

--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -133,53 +133,55 @@ export function DetectedSkillsList({
               />
             </ContextItem.List>
           )}
-          <div
-            ref={scrollCallbackRef}
-            className="relative max-h-64 overflow-y-auto"
-          >
-            <ContextItem.List>
-              {detectedSkills.map((skill) => (
-                <ContextItem
-                  key={skill.name}
-                  title={
-                    <Label
-                      className="text-sm font-normal"
-                      htmlFor={skill.name}
-                    >
-                      {skill.name}
-                    </Label>
-                  }
-                  visual={
-                    <div className="flex items-center gap-2">
-                      <Checkbox
-                        id={skill.name}
-                        size="xs"
-                        checked={selectedField.value.includes(skill.name)}
-                        disabled={!isImportableSkillStatus(skill.status)}
-                        onCheckedChange={() => toggleSkill(skill.name)}
-                      />
-                      <ContextItem.Visual visual={PuzzleIcon} />
-                    </div>
-                  }
-                  action={
-                    skill.status !== "ready" ? (
-                      <Chip
-                        label={STATUS_CHIP_LABEL[skill.status]}
-                        size="xs"
-                        color={
-                          skill.status === "skill_already_exists"
-                            ? "info"
-                            : "warning"
-                        }
-                      />
-                    ) : undefined
-                  }
-                />
-              ))}
-            </ContextItem.List>
+          <div className="relative max-h-64 overflow-hidden">
+            <div
+              ref={scrollCallbackRef}
+              className="max-h-64 overflow-y-auto"
+            >
+              <ContextItem.List>
+                {detectedSkills.map((skill) => (
+                  <ContextItem
+                    key={skill.name}
+                    title={
+                      <Label
+                        className="text-sm font-normal"
+                        htmlFor={skill.name}
+                      >
+                        {skill.name}
+                      </Label>
+                    }
+                    visual={
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          id={skill.name}
+                          size="xs"
+                          checked={selectedField.value.includes(skill.name)}
+                          disabled={!isImportableSkillStatus(skill.status)}
+                          onCheckedChange={() => toggleSkill(skill.name)}
+                        />
+                        <ContextItem.Visual visual={PuzzleIcon} />
+                      </div>
+                    }
+                    action={
+                      skill.status !== "ready" ? (
+                        <Chip
+                          label={STATUS_CHIP_LABEL[skill.status]}
+                          size="xs"
+                          color={
+                            skill.status === "skill_already_exists"
+                              ? "info"
+                              : "warning"
+                          }
+                        />
+                      ) : undefined
+                    }
+                  />
+                ))}
+              </ContextItem.List>
+            </div>
             <div
               className={cn(
-                "pointer-events-none sticky bottom-0 left-0 right-0 -mt-12 h-12 bg-gradient-to-t",
+                "pointer-events-none absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t",
                 "from-background via-background/60 to-transparent transition-opacity dark:from-background-night dark:via-background-night/60",
                 canScrollDown ? "opacity-100" : "opacity-0"
               )}

--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -7,9 +7,9 @@ import {
 import {
   Checkbox,
   Chip,
-  cn,
   ContentMessage,
   ContextItem,
+  cn,
   InformationCircleIcon,
   Label,
   PuzzleIcon,
@@ -134,10 +134,7 @@ export function DetectedSkillsList({
             </ContextItem.List>
           )}
           <div className="relative max-h-64 overflow-hidden">
-            <div
-              ref={scrollCallbackRef}
-              className="max-h-64 overflow-y-auto"
-            >
+            <div ref={scrollCallbackRef} className="max-h-64 overflow-y-auto">
               <ContextItem.List>
                 {detectedSkills.map((skill) => (
                   <ContextItem

--- a/front/components/skills/import/DetectedSkillsList.tsx
+++ b/front/components/skills/import/DetectedSkillsList.tsx
@@ -14,7 +14,7 @@ import {
   PuzzleIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 const STATUS_CHIP_LABEL: Record<
@@ -37,6 +37,33 @@ export function DetectedSkillsList({
   isDetecting,
   detectError,
 }: DetectedSkillsListProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [canScrollDown, setCanScrollDown] = useState(false);
+
+  const updateScrollIndicator = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) {
+      return;
+    }
+    setCanScrollDown(el.scrollHeight - el.scrollTop - el.clientHeight > 1);
+  }, []);
+
+  const scrollCallbackRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      const prev = scrollRef.current;
+      if (prev) {
+        prev.removeEventListener("scroll", updateScrollIndicator);
+      }
+      scrollRef.current = node;
+      if (node) {
+        node.addEventListener("scroll", updateScrollIndicator);
+        // Check on mount (after layout).
+        requestAnimationFrame(updateScrollIndicator);
+      }
+    },
+    [updateScrollIndicator]
+  );
+
   const { control } = useFormContext<ImportFormValues>();
   const { field: selectedField } = useController({
     name: "selectedSkillNames",
@@ -105,13 +132,19 @@ export function DetectedSkillsList({
               />
             </ContextItem.List>
           )}
-          <div className="max-h-64 overflow-y-auto">
+          <div
+            ref={scrollCallbackRef}
+            className="relative max-h-64 overflow-y-auto"
+          >
             <ContextItem.List>
               {detectedSkills.map((skill) => (
                 <ContextItem
                   key={skill.name}
                   title={
-                    <Label className="text-sm font-normal" htmlFor={skill.name}>
+                    <Label
+                      className="text-sm font-normal"
+                      htmlFor={skill.name}
+                    >
                       {skill.name}
                     </Label>
                   }
@@ -143,6 +176,9 @@ export function DetectedSkillsList({
                 />
               ))}
             </ContextItem.List>
+            {canScrollDown && (
+              <div className="pointer-events-none sticky bottom-0 left-0 right-0 -mt-12 h-12 bg-gradient-to-t from-background  to-transparent dark:from-background-night " />
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Description

### Problem tackled

- We can import skills from a github repository or a zip file.
- When doing this the detected skills are displayed in a list that can be scrollable.
- Currently hard to tell that this list is scrollable at all.

### Proposal

- This PR adds a gradient of opacity at the bottom of the list if there are more elements to discover underneath it.
- Colors: `from-background via-background/60 to-transparent`.
- Transition of 300ms.
- The gradient is always rendered, only its opacity changes (no gradient when we're at the bottom).

<img width="572" height="549" alt="Screenshot 2026-04-02 at 1 16 40 PM" src="https://github.com/user-attachments/assets/7d0c33a3-157a-4960-bede-0cdb46161cc2" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
