### PR TITLE
[front] enh: Add poke button to go to dd logs for sbx

### DIFF
--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -305,6 +305,17 @@ const ContentFragmentView = ({ message }: ContentFragmentViewProps) => {
   );
 };
 
+function getDatadogSandboxLogsUrl(
+  conversationId: string,
+  conversationCreatedMs: number
+): string {
+  const nowMs = Date.now();
+  const fromMs = conversationCreatedMs;
+  const query = `service:sandbox-runner @conversation_id:${conversationId}`;
+
+  return `https://app.datadoghq.eu/logs?query=${encodeURIComponent(query)}&from_ts=${fromMs}&to_ts=${nowMs}&live=true`;
+}
+
 export function ConversationPage() {
   const owner = useWorkspace();
   useDocumentTitle(`Poke - ${owner.name} - Conversation`);
@@ -456,6 +467,16 @@ export function ConversationPage() {
             <Button
               href={`https://cloud.temporal.io/namespaces/${temporalWorkspace}/workflows?query=%60conversationId%60%3D"${conversationId}"`}
               label="Temporal Workflows"
+              variant="primary"
+              size="xs"
+              target="_blank"
+            />
+            <Button
+              href={getDatadogSandboxLogsUrl(
+                conversationId,
+                conversation.created
+              )}
+              label="Sandbox Logs"
               variant="primary"
               size="xs"
               target="_blank"

--- a/front/lib/api/sandbox/image/telemetry/enrich.lua
+++ b/front/lib/api/sandbox/image/telemetry/enrich.lua
@@ -42,6 +42,7 @@ function enrich_message(tag, timestamp, record)
         record["gcsfuse_mount_id"] = mount_id
     end
 
+    record["sandbox_id"] = os.getenv("E2B_SANDBOX_ID")
     record["conversation_id"] = os.getenv("CONVERSATION_ID")
     record["workspace_id"] = os.getenv("WORKSPACE_ID")
 

--- a/front/lib/api/sandbox/image/telemetry/fluent-bit.conf
+++ b/front/lib/api/sandbox/image/telemetry/fluent-bit.conf
@@ -77,4 +77,4 @@
     apikey      ${DD_API_KEY}
     dd_service  sandbox-runner
     dd_source   e2b-sandbox
-    dd_tags     env:prod,sandbox_id:${E2B_SANDBOX_ID},conversation_id:${CONVERSATION_ID},workspace_id:${WORKSPACE_ID}
+    dd_tags     env:prod


### PR DESCRIPTION
## Description


<img width="1806" height="232" alt="CleanShot 2026-04-02 at 11 06 18@2x" src="https://github.com/user-attachments/assets/9201a676-5b9d-48fd-b8f3-141eacaa7d47" />

Does what it says.


Also removed workspace id/convo id/sbx id from DD logs tags, because Datadog will lowercase them 😐 
They can still be accessed as record attributes.

## Tests

Tested locally


## Risk

Low


## Deploy Plan

- Deploy front