### PR TITLE
[Front+SDK] fix(usage-api): return 400 for unknown table names and fix assistant_messages key

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -15,12 +15,24 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { ModelId } from "@app/types/shared/model_id";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import { stringify } from "csv-stringify/sync";
 import { format } from "date-fns/format";
 import { Op, QueryTypes, Sequelize } from "sequelize";
 
-export interface WorkspaceUsageQueryResult {
+export const USAGE_TABLES = [
+  "users",
+  "assistant_messages",
+  "builders",
+  "assistants",
+  "feedback",
+  "all",
+] as const;
+
+export type UsageTableType = (typeof USAGE_TABLES)[number];
+
+interface WorkspaceUsageQueryResult {
   createdAt: string;
   conversationModelId: string;
   messageId: string;
@@ -195,7 +207,7 @@ export async function unsafeGetUsageData(
   return generateCsvFromQueryResult(results);
 }
 
-export async function getMessageUsageData(
+async function getMessageUsageData(
   startDate: Date,
   endDate: Date,
   workspace: WorkspaceType
@@ -250,27 +262,6 @@ export async function getMessageUsageData(
   return generateCsvFromQueryResult(results);
 }
 
-export async function getGroupMembershipsData(
-  startDate: Date,
-  endDate: Date,
-  workspace: WorkspaceType
-): Promise<string> {
-  const wId = workspace.id;
-  const userGroupsMap = await getUserGroupMemberships(wId, startDate, endDate);
-
-  const groupMembershipsData: GroupMembershipQueryResult[] = Object.entries(
-    userGroupsMap
-  ).map(([userId, groups]) => ({
-    userId,
-    groups,
-  }));
-
-  if (!groupMembershipsData.length) {
-    return "No group memberships data available.";
-  }
-  return generateCsvFromQueryResult(groupMembershipsData);
-}
-
 export async function getUserGroupMemberships(
   workspaceId: number,
   startDate: Date,
@@ -320,7 +311,7 @@ export async function getUserGroupMemberships(
   return result;
 }
 
-export async function getUserUsageData(
+async function getUserUsageData(
   startDate: Date,
   endDate: Date,
   workspace: WorkspaceType,
@@ -536,7 +527,7 @@ export async function getUserUsageData(
   return generateCsvFromQueryResult(userUsage);
 }
 
-export async function getBuildersUsageData(
+async function getBuildersUsageData(
   startDate: Date,
   endDate: Date,
   workspace: WorkspaceType
@@ -658,7 +649,7 @@ export async function getAssistantUsageData(
   return mentions[0].messages;
 }
 
-export async function getAssistantsUsageData(
+async function getAssistantsUsageData(
   startDate: Date,
   endDate: Date,
   workspace: WorkspaceType,
@@ -726,7 +717,7 @@ export async function getAssistantsUsageData(
   return generateCsvFromQueryResult(filteredAgents);
 }
 
-export async function getFeedbackUsageData(
+async function getFeedbackUsageData(
   startDate: Date,
   endDate: Date,
   workspace: WorkspaceType
@@ -777,6 +768,57 @@ function reconstructConversationUrl(
     undefined,
     config.getAppUrl()
   );
+}
+
+export async function fetchUsageData({
+  table,
+  start,
+  end,
+  workspace,
+  includeInactive = false,
+}: {
+  table: UsageTableType;
+  start: Date;
+  end: Date;
+  workspace: WorkspaceType;
+  includeInactive?: boolean;
+}): Promise<Partial<Record<UsageTableType, string>>> {
+  switch (table) {
+    case "users":
+      return {
+        users: await getUserUsageData(start, end, workspace, {
+          includeInactive,
+        }),
+      };
+    case "assistant_messages":
+      return {
+        assistant_messages: await getMessageUsageData(start, end, workspace),
+      };
+    case "builders":
+      return { builders: await getBuildersUsageData(start, end, workspace) };
+    case "assistants":
+      return {
+        assistants: await getAssistantsUsageData(start, end, workspace, {
+          includeInactive,
+        }),
+      };
+    case "feedback":
+      return {
+        feedback: await getFeedbackUsageData(start, end, workspace),
+      };
+    case "all":
+      const [users, assistant_messages, builders, assistants, feedback] =
+        await Promise.all([
+          getUserUsageData(start, end, workspace, { includeInactive }),
+          getMessageUsageData(start, end, workspace),
+          getBuildersUsageData(start, end, workspace),
+          getAssistantsUsageData(start, end, workspace, { includeInactive }),
+          getFeedbackUsageData(start, end, workspace),
+        ]);
+      return { users, assistant_messages, builders, assistants, feedback };
+    default:
+      assertNever(table);
+  }
 }
 
 function generateCsvFromQueryResult(

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -2,22 +2,14 @@ import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { getConversationsDataRetention } from "@app/lib/data_retention";
-import {
-  getAssistantsUsageData,
-  getBuildersUsageData,
-  getFeedbackUsageData,
-  getMessageUsageData,
-  getUserUsageData,
-} from "@app/lib/workspace_usage";
+import { fetchUsageData } from "@app/lib/workspace_usage";
 import { getWorkspaceUsageRetentionErrorMessage } from "@app/lib/workspace_usage_retention";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { WorkspaceType } from "@app/types/user";
 import type {
   GetWorkspaceUsageRequestType,
   GetWorkspaceUsageResponseType,
-  UsageTableType,
 } from "@dust-tt/client";
 import { GetWorkspaceUsageRequestSchema } from "@dust-tt/client";
 import { parse as parseCSV } from "csv-parse/sync";
@@ -270,63 +262,6 @@ function resolveDates(query: GetWorkspaceUsageRequestType) {
       };
     default:
       assertNever(query);
-  }
-}
-
-async function fetchUsageData({
-  table,
-  start,
-  end,
-  workspace,
-  includeInactive = false,
-}: {
-  table: UsageTableType;
-  start: Date;
-  end: Date;
-  workspace: WorkspaceType;
-  includeInactive?: boolean;
-}): Promise<Partial<Record<UsageTableType, string>>> {
-  switch (table) {
-    case "users":
-      return {
-        users: await getUserUsageData(start, end, workspace, {
-          includeInactive,
-        }),
-      };
-    case "assistant_messages":
-      return {
-        assistant_messages: await getMessageUsageData(start, end, workspace),
-      };
-    case "builders":
-      return { builders: await getBuildersUsageData(start, end, workspace) };
-    case "assistants":
-      return {
-        assistants: await getAssistantsUsageData(start, end, workspace, {
-          includeInactive,
-        }),
-      };
-    case "feedback":
-      return {
-        feedback: await getFeedbackUsageData(start, end, workspace),
-      };
-    case "all":
-      const [users, assistant_messages, builders, assistants, feedback] =
-        await Promise.all([
-          getUserUsageData(start, end, workspace, { includeInactive }),
-          getMessageUsageData(start, end, workspace),
-          getBuildersUsageData(start, end, workspace),
-          getAssistantsUsageData(start, end, workspace, { includeInactive }),
-          getFeedbackUsageData(start, end, workspace),
-        ]);
-      return {
-        users,
-        assistant_messages,
-        builders,
-        assistants,
-        feedback,
-      };
-    default:
-      return {};
   }
 }
 

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -3,16 +3,13 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { getConversationsDataRetention } from "@app/lib/data_retention";
 import {
-  getAssistantsUsageData,
-  getBuildersUsageData,
-  getFeedbackUsageData,
-  getMessageUsageData,
-  getUserUsageData,
+  fetchUsageData,
+  USAGE_TABLES,
+  type UsageTableType,
 } from "@app/lib/workspace_usage";
 import { getWorkspaceUsageRetentionErrorMessage } from "@app/lib/workspace_usage_retention";
 import { apiError } from "@app/logger/withlogging";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { WorkspaceType } from "@app/types/user";
 import { endOfMonth } from "date-fns/endOfMonth";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -26,19 +23,8 @@ const MonthSchema = t.refinement(
   "YYYY-MM"
 );
 
-const usageTables = [
-  "users",
-  "assistant_messages",
-  "builders",
-  "assistants",
-  "feedback",
-  "all",
-];
-
-type usageTableType = (typeof usageTables)[number];
-
-function getSupportedUsageTablesCodec(): t.Mixed {
-  const [first, second, ...rest] = usageTables;
+function getSupportedUsageTablesCodec(): t.Type<UsageTableType> {
+  const [first, second, ...rest] = USAGE_TABLES;
   return t.union([
     t.literal(first),
     t.literal(second),
@@ -190,54 +176,5 @@ function resolveDates(query: t.TypeOf<typeof GetUsageQueryParamsSchema>) {
       };
     default:
       assertNever(query);
-  }
-}
-
-async function fetchUsageData({
-  table,
-  start,
-  end,
-  workspace,
-  includeInactive = false,
-}: {
-  table: usageTableType;
-  start: Date;
-  end: Date;
-  workspace: WorkspaceType;
-  includeInactive?: boolean;
-}): Promise<Partial<Record<usageTableType, string>>> {
-  switch (table) {
-    case "users":
-      return {
-        users: await getUserUsageData(start, end, workspace, {
-          includeInactive,
-        }),
-      };
-    case "assistant_messages":
-      return { mentions: await getMessageUsageData(start, end, workspace) };
-    case "builders":
-      return { builders: await getBuildersUsageData(start, end, workspace) };
-    case "feedback":
-      return {
-        feedback: await getFeedbackUsageData(start, end, workspace),
-      };
-    case "assistants":
-      return {
-        assistants: await getAssistantsUsageData(start, end, workspace, {
-          includeInactive,
-        }),
-      };
-    case "all":
-      const [users, assistant_messages, builders, assistants, feedback] =
-        await Promise.all([
-          getUserUsageData(start, end, workspace, { includeInactive }),
-          getMessageUsageData(start, end, workspace),
-          getBuildersUsageData(start, end, workspace),
-          getAssistantsUsageData(start, end, workspace, { includeInactive }),
-          getFeedbackUsageData(start, end, workspace),
-        ]);
-      return { users, assistant_messages, builders, assistants, feedback };
-    default:
-      return {};
   }
 }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2663,14 +2663,14 @@ const UpsertTableResponseSchema = z.object({
 });
 export type UpsertTableResponseType = z.infer<typeof UpsertTableResponseSchema>;
 
-const SupportedUsageTablesSchema = FlexibleEnumSchema<
-  | "users"
-  | "assistant_messages"
-  | "builders"
-  | "assistants"
-  | "feedback"
-  | "all"
->();
+const SupportedUsageTablesSchema = z.enum([
+  "users",
+  "assistant_messages",
+  "builders",
+  "assistants",
+  "feedback",
+  "all",
+]);
 
 export type UsageTableType = z.infer<typeof SupportedUsageTablesSchema>;
 


### PR DESCRIPTION
## Description

The workspace-usage API returned HTTP 200 with empty data for unknown table names (e.g. `table=messages` instead of `table=assistant_messages`). 

**Root cause**:
Sdk: `FlexibleEnumSchema` accepts any string at runtime — replaced with `z.enum()` for strict validation on the `table` param.

Fix internal endpoint: the `assistant_messages` case returned data under a `mentions` key instead of `assistant_messages`, so the consumer never found it. "Bug" introduced in #5980 (was never actually called in internal endpoint).

Also deduplicated `fetchUsageData` (was copy-pasted in both endpoints with diverging bugs) into `lib/workspace_usage.ts`.

Closes https://github.com/dust-tt/tasks/issues/7265

## Tests

Tested locally with both internal and public endpoint

## Risks

SDK enum stays the same, should not impact any customers negatively 