### PR TITLE
Make upload retryable

### DIFF
--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -817,7 +817,7 @@ export class FileResource extends BaseResource<FileModel> {
     return this.getBucketForVersion(version)
       .file(this.getCloudStoragePath(auth, version))
       .createWriteStream({
-        resumable: false,
+        resumable: true,
         contentType: overrideContentType ?? this.contentType,
       });
   }


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#7286

Large xlsx file uploads fail in the EU region with a "socket hang up" error when uploading processed files to GCS. The root cause is that `getWriteStream()` in `FileResource` uses `resumable: false`, forcing a single-shot multipart upload with no retry capability. For large files (e.g. 15.1 MB multi-sheet xlsx), the connection can drop mid-upload, especially in the EU region.

This PR switches to `resumable: true`, which enables GCS resumable uploads. These handle large files more reliably — they can resume after socket errors and are GCS's recommended approach for files that may be large.

## Tests

Manual testing with large xlsx file upload.

## Risk

Low — resumable uploads add a small overhead (one extra HTTP request to initiate the upload session) but are strictly more reliable. This is GCS's default and recommended behavior for any file that might be large.

## Deploy Plan

Standard deploy, no special steps needed. Safe to rollback.