### PR TITLE
feat: add CRUD todos endpoints + UI

### DIFF
--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -1,0 +1,429 @@
+import {
+  useCreateProjectTodo,
+  useProjectTodos,
+  useUpdateProjectTodo,
+} from "@app/lib/swr/projects";
+import type {
+  ProjectTodoCategory,
+  ProjectTodoType,
+} from "@app/types/project_todo";
+import { PROJECT_TODO_CATEGORIES } from "@app/types/project_todo";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Checkbox,
+  CircleIcon,
+  cn,
+  Icon,
+  Input,
+  PlusIcon,
+  Spinner,
+  SquareIcon,
+  TriangleIcon,
+  WindIcon,
+} from "@dust-tt/sparkle";
+import type React from "react";
+import { useCallback, useState } from "react";
+
+// ── Category display configuration ────────────────────────────────────────────
+
+type CategoryConfig = {
+  label: string;
+  icon: React.ComponentType;
+  iconClassName: string;
+};
+
+const CATEGORY_CONFIG: Record<ProjectTodoCategory, CategoryConfig> = {
+  need_attention: {
+    label: "Need attention",
+    icon: TriangleIcon,
+    iconClassName: "text-warning-300 dark:text-warning-300-night",
+  },
+  key_decisions: {
+    label: "Key decisions",
+    icon: SquareIcon,
+    iconClassName: "text-golden-300 dark:text-golden-300-night",
+  },
+  follow_ups: {
+    label: "Follow-ups",
+    icon: CircleIcon,
+    iconClassName: "text-blue-300 dark:text-blue-300-night",
+  },
+  notable_updates: {
+    label: "Notable updates",
+    icon: CircleIcon,
+    iconClassName: "text-green-300 dark:text-green-300-night",
+  },
+};
+
+// Stable display order for categories.
+const ORDERED_CATEGORIES: ProjectTodoCategory[] = [...PROJECT_TODO_CATEGORIES];
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+interface AddTodoFormProps {
+  defaultCategory?: ProjectTodoCategory;
+  onSubmit: (category: ProjectTodoCategory, text: string) => Promise<void>;
+  onCancel: () => void;
+  isBusy: boolean;
+}
+
+function AddTodoForm({
+  defaultCategory = "follow_ups",
+  onSubmit,
+  onCancel,
+  isBusy,
+}: AddTodoFormProps) {
+  const [text, setText] = useState("");
+  const [category, setCategory] =
+    useState<ProjectTodoCategory>(defaultCategory);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter" && text.trim()) {
+        void onSubmit(category, text.trim());
+      } else if (e.key === "Escape") {
+        onCancel();
+      }
+    },
+    [category, onCancel, onSubmit, text]
+  );
+
+  return (
+    <div className="flex flex-col gap-2 pt-1">
+      <Input
+        autoFocus
+        placeholder="What needs to be done?"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={isBusy}
+        className="text-sm"
+      />
+      {/* Category selector chips */}
+      <div className="flex flex-wrap gap-1">
+        {ORDERED_CATEGORIES.map((cat) => {
+          const config = CATEGORY_CONFIG[cat];
+          const isSelected = category === cat;
+          return (
+            <button
+              key={cat}
+              type="button"
+              onClick={() => setCategory(cat)}
+              className={cn(
+                "flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors",
+                isSelected
+                  ? "bg-primary-100 dark:bg-primary-100-night text-primary dark:text-primary-night font-medium"
+                  : "bg-muted dark:bg-muted-night text-muted-foreground dark:text-muted-foreground-night hover:bg-primary-50 dark:hover:bg-primary-50-night"
+              )}
+            >
+              <Icon
+                visual={config.icon}
+                size="xs"
+                className={config.iconClassName}
+              />
+              {config.label}
+            </button>
+          );
+        })}
+      </div>
+      {/* Submit / cancel */}
+      <div className="flex gap-2">
+        <Button
+          size="xs"
+          variant="primary"
+          label="Add"
+          disabled={!text.trim() || isBusy}
+          isLoading={isBusy}
+          onClick={() => {
+            if (text.trim()) {
+              void onSubmit(category, text.trim());
+            }
+          }}
+        />
+        <Button
+          size="xs"
+          variant="ghost"
+          label="Cancel"
+          onClick={onCancel}
+          disabled={isBusy}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface TodoItemProps {
+  todo: ProjectTodoType;
+  isPendingDone: boolean;
+  onMarkDone: (todo: ProjectTodoType) => void;
+}
+
+function TodoItem({ todo, isPendingDone, onMarkDone }: TodoItemProps) {
+  const isDone = isPendingDone || todo.status === "done";
+
+  return (
+    <li className="flex items-start gap-2 py-0.5">
+      <div className="mt-0.5 shrink-0">
+        <Checkbox
+          size="xs"
+          checked={isDone}
+          isMutedAfterCheck
+          onCheckedChange={(checked) => {
+            if (checked === true && !isDone) {
+              onMarkDone(todo);
+            }
+          }}
+        />
+      </div>
+      <span
+        className={cn(
+          "text-sm leading-5 transition-all duration-300",
+          isDone
+            ? "text-faint dark:text-faint-night line-through"
+            : "text-foreground dark:text-foreground-night"
+        )}
+      >
+        {todo.text}
+      </span>
+    </li>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────────────
+
+interface ProjectTodosPanelProps {
+  owner: LightWorkspaceType;
+  spaceId: string;
+  hasFeatureFlagProjectTodo: boolean;
+}
+
+export function ProjectTodosPanel({
+  owner,
+  spaceId,
+  hasFeatureFlagProjectTodo,
+}: ProjectTodosPanelProps) {
+  const { todos, isTodosLoading, mutateTodos } = useProjectTodos({
+    owner,
+    spaceId,
+    disabled: !hasFeatureFlagProjectTodo,
+  });
+  const doCreate = useCreateProjectTodo({ owner, spaceId });
+  const doUpdate = useUpdateProjectTodo({ owner, spaceId });
+
+  // Tracks todos being optimistically marked as done (shown with strikethrough).
+  const [pendingDoneIds, setPendingDoneIds] = useState<Set<string>>(new Set());
+  // Which section's inline add form is open, or "global" for the bottom-level form.
+  const [addingTo, setAddingTo] = useState<
+    ProjectTodoCategory | "global" | null
+  >(null);
+  const [isCreating, setIsCreating] = useState(false);
+
+  // Group todos by category.
+  const todosByCategory = todos.reduce<
+    Partial<Record<ProjectTodoCategory, ProjectTodoType[]>>
+  >((acc, todo) => {
+    const cat = todo.category;
+    const existing = acc[cat] ?? [];
+    return { ...acc, [cat]: [...existing, todo] };
+  }, {});
+
+  const activeSections = ORDERED_CATEGORIES.filter(
+    (cat) => (todosByCategory[cat]?.length ?? 0) > 0
+  );
+  const isEmpty = activeSections.length === 0 && !isCreating;
+
+  const handleMarkDone = useCallback(
+    async (todo: ProjectTodoType) => {
+      setPendingDoneIds((prev) => new Set([...prev, todo.sId]));
+
+      const result = await doUpdate(todo.sId, { status: "done" });
+
+      if (result.isErr()) {
+        setPendingDoneIds((prev) => {
+          const next = new Set(prev);
+          next.delete(todo.sId);
+          return next;
+        });
+        return;
+      }
+
+      // After a brief visual pause, refresh the list.
+      setTimeout(() => {
+        void mutateTodos();
+        setPendingDoneIds((prev) => {
+          const next = new Set(prev);
+          next.delete(todo.sId);
+          return next;
+        });
+      }, 600);
+    },
+    [doUpdate, mutateTodos]
+  );
+
+  const handleMarkSectionDone = useCallback(
+    async (category: ProjectTodoCategory) => {
+      const undone = (todosByCategory[category] ?? []).filter(
+        (t) => t.status !== "done" && !pendingDoneIds.has(t.sId)
+      );
+      for (const todo of undone) {
+        void handleMarkDone(todo);
+      }
+    },
+    [handleMarkDone, pendingDoneIds, todosByCategory]
+  );
+
+  const handleClean = useCallback(() => {
+    void mutateTodos();
+    setPendingDoneIds(new Set());
+  }, [mutateTodos]);
+
+  const handleCreate = useCallback(
+    async (category: ProjectTodoCategory, text: string) => {
+      setIsCreating(true);
+      const result = await doCreate(category, text);
+      setIsCreating(false);
+
+      if (result.isOk()) {
+        setAddingTo(null);
+        void mutateTodos();
+      }
+    },
+    [doCreate, mutateTodos]
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Header */}
+      <div className="inline-flex items-center gap-2">
+        <h3 className="heading-2xl text-foreground dark:text-foreground-night">
+          Todos
+        </h3>
+        <div className="flex-1" />
+        {pendingDoneIds.size > 0 && (
+          <Button
+            size="xs"
+            variant="outline"
+            icon={WindIcon}
+            label="Clean"
+            tooltip="Remove checked items"
+            onClick={handleClean}
+          />
+        )}
+      </div>
+
+      {/* Body */}
+      {isTodosLoading ? (
+        <div className="flex justify-center py-4">
+          <Spinner size="sm" />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {/* Per-category sections */}
+          {activeSections.map((cat) => {
+            const config = CATEGORY_CONFIG[cat];
+            const items = todosByCategory[cat] ?? [];
+            const allPendingDone =
+              items.length > 0 &&
+              items.every(
+                (t) => t.status === "done" || pendingDoneIds.has(t.sId)
+              );
+
+            return (
+              <div key={cat} className="flex flex-col gap-1">
+                {/* Section header: icon by default, checkbox on hover */}
+                <div className="group/section-title flex items-center gap-3 pt-2">
+                  <div className="flex h-4 w-4 items-center">
+                    <Icon
+                      visual={config.icon}
+                      size="xs"
+                      className={cn(
+                        "group-hover/section-title:hidden",
+                        config.iconClassName
+                      )}
+                    />
+                    <Checkbox
+                      size="xs"
+                      className="hidden group-hover/section-title:flex"
+                      checked={allPendingDone}
+                      isMutedAfterCheck
+                      onCheckedChange={(checked) => {
+                        if (checked === true) {
+                          void handleMarkSectionDone(cat);
+                        }
+                      }}
+                    />
+                  </div>
+                  <h4 className="heading-lg text-foreground dark:text-foreground-night">
+                    {config.label}
+                  </h4>
+                </div>
+
+                {/* Todo items */}
+                <ul className="flex flex-col pl-7">
+                  {items.map((todo) => (
+                    <TodoItem
+                      key={todo.sId}
+                      todo={todo}
+                      isPendingDone={pendingDoneIds.has(todo.sId)}
+                      onMarkDone={handleMarkDone}
+                    />
+                  ))}
+                </ul>
+
+                {/* Inline add form / button for this section */}
+                <div className="pl-7">
+                  {addingTo === cat ? (
+                    <AddTodoForm
+                      defaultCategory={cat}
+                      onSubmit={handleCreate}
+                      onCancel={() => setAddingTo(null)}
+                      isBusy={isCreating}
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setAddingTo(cat)}
+                      className="flex items-center gap-1 text-xs text-muted-foreground dark:text-muted-foreground-night hover:text-foreground dark:hover:text-foreground-night transition-colors"
+                    >
+                      <Icon visual={PlusIcon} size="xs" />
+                      Add
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+
+          {/* Empty state */}
+          {isEmpty && (
+            <p className="text-sm italic text-faint dark:text-faint-night">
+              All caught up!
+            </p>
+          )}
+
+          {/* Global add todo */}
+          {addingTo === "global" ? (
+            <AddTodoForm
+              onSubmit={handleCreate}
+              onCancel={() => setAddingTo(null)}
+              isBusy={isCreating}
+            />
+          ) : (
+            addingTo === null && (
+              <div>
+                <Button
+                  size="xs"
+                  variant="outline"
+                  icon={PlusIcon}
+                  label="Add todo"
+                  onClick={() => setAddingTo("global")}
+                />
+              </div>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -1,5 +1,6 @@
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { ProjectKickoffButton } from "@app/components/assistant/conversation/space/conversations/ProjectKickoffButton";
+import { ProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/ProjectTodosPanel";
 import { SpaceConversationListItem } from "@app/components/assistant/conversation/space/conversations/SpaceConversationListItem";
 import { SpaceConversationsActions } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsActions";
 import { SpaceLoadingConversationListItem } from "@app/components/assistant/conversation/space/conversations/SpaceLoadingConversationListItem";
@@ -169,6 +170,14 @@ export function SpaceConversationsTab({
               space={spaceInfo}
               hasConversations={hasHistory}
               unreadCount={unreadConversationIds.length}
+            />
+          )}
+
+          {hasFeature("project_todo") && (
+            <ProjectTodosPanel
+              owner={owner}
+              spaceId={spaceInfo.sId}
+              hasFeatureFlagProjectTodo={hasFeature("project_todo")}
             />
           )}
 

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -9,7 +9,10 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
-import type { ProjectTodoSourceType } from "@app/types/project_todo";
+import type {
+  ProjectTodoSourceType,
+  ProjectTodoType,
+} from "@app/types/project_todo";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Ok, type Result } from "@app/types/shared/result";
 import type {
@@ -145,6 +148,32 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
   }
 
+  // Returns only the latest version of each logical todo for the given space.
+  // Fetches all version rows ordered by (sId ASC, version DESC) then keeps
+  // only the first occurrence per sId, which has the highest version number.
+  static async fetchLatestBySpace(
+    auth: Authenticator,
+    { spaceId }: { spaceId: ModelId }
+  ): Promise<ProjectTodoResource[]> {
+    const all = await this.baseFetch(auth, {
+      where: { spaceId, userId: auth.getNonNullableUser().id },
+      order: [
+        ["sId", "ASC"],
+        ["version", "DESC"],
+      ],
+    });
+
+    // O(n) deduplication — keep the first occurrence per sId (highest version).
+    const latestBySId = new Map<string, ProjectTodoResource>();
+    for (const todo of all) {
+      if (!latestBySId.has(todo.sId)) {
+        latestBySId.set(todo.sId, todo);
+      }
+    }
+
+    return Array.from(latestBySId.values());
+  }
+
   // Returns every version row for (spaceId, userId), across all sIds. Used by the
   // diff algorithm to reconstruct snapshots at arbitrary cutoff dates.
   static async fetchAllVersionsBySpace(
@@ -236,6 +265,28 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       },
       transaction,
     });
+  }
+
+  // ── Serialization ──────────────────────────────────────────────────────────
+
+  toJSON(): ProjectTodoType {
+    return {
+      id: this.id,
+      sId: this.sId,
+      category: this.category,
+      text: this.text,
+      status: this.status,
+      version: this.version,
+      doneAt: this.doneAt,
+      actorRationale: this.actorRationale,
+      createdByType: this.createdByType,
+      createdByAgentConfigurationId: this.createdByAgentConfigurationId,
+      markedAsDoneByType: this.markedAsDoneByType,
+      markedAsDoneByAgentConfigurationId:
+        this.markedAsDoneByAgentConfigurationId,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
   }
 
   // ── Lifecycle ──────────────────────────────────────────────────────────────

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -10,7 +10,17 @@ import type {
   FileWithCreatorType,
   GetProjectFilesResponseBody,
 } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_files";
+import type { PatchProjectTodoResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index";
+import type {
+  GetProjectTodosResponseBody,
+  PostProjectTodoResponseBody,
+} from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index";
 import type { CheckNameResponseBody } from "@app/pages/api/w/[wId]/spaces/check-name";
+import type {
+  ProjectTodoCategory,
+  ProjectTodoStatus,
+  ProjectTodoType,
+} from "@app/types/project_todo";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -162,5 +172,124 @@ export function useCheckProjectName({
     isNameAvailable: data?.available ?? true,
     isChecking: isLoading || isDebouncing,
     setValue,
+  };
+}
+
+export function useProjectTodos({
+  owner,
+  spaceId,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const todosFetcher: Fetcher<GetProjectTodosResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    disabled ? null : `/api/w/${owner.sId}/spaces/${spaceId}/project_todos`,
+    todosFetcher
+  );
+
+  return {
+    todos: data?.todos ?? [],
+    isTodosLoading: !disabled && !error && !data,
+    isTodosError: !!error,
+    mutateTodos: mutate,
+  };
+}
+
+export function useCreateProjectTodo({
+  owner,
+  spaceId,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  return async (
+    category: ProjectTodoCategory,
+    text: string
+  ): Promise<Result<ProjectTodoType, Error>> => {
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/spaces/${spaceId}/project_todos`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ category, text }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to create todo",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      const responseData: PostProjectTodoResponseBody = await res.json();
+      return new Ok(responseData.todo);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to create todo",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
+export function useUpdateProjectTodo({
+  owner,
+  spaceId,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  return async (
+    todoId: string,
+    updates: { text?: string; status?: ProjectTodoStatus }
+  ): Promise<Result<ProjectTodoType, Error>> => {
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/spaces/${spaceId}/project_todos/${todoId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(updates),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to update todo",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      const responseData: PatchProjectTodoResponseBody = await res.json();
+      return new Ok(responseData.todo);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to update todo",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
   };
 }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.test.ts
@@ -1,0 +1,163 @@
+import { Authenticator } from "@app/lib/auth";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { ProjectTodoFactory } from "@app/tests/utils/ProjectTodoFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { WorkspaceType } from "@app/types/user";
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { MockRequest, MockResponse } from "node-mocks-http";
+import { describe, expect, it } from "vitest";
+
+import handler from ".";
+
+describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]", () => {
+  let req: MockRequest<NextApiRequest>;
+  let res: MockResponse<NextApiResponse>;
+  let workspace: WorkspaceType;
+
+  async function setup() {
+    const result = await createPrivateApiMockRequest({ method: "PATCH" });
+    req = result.req;
+    res = result.res;
+    workspace = result.workspace;
+    return result;
+  }
+
+  it("should edit the text of a todo", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+      text: "Original text",
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.todoId = todo.sId;
+    req.body = { text: "Updated text" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { todo: updated } = res._getJSONData();
+    expect(updated.text).toBe("Updated text");
+    expect(updated.sId).toBe(todo.sId);
+    expect(updated.version).toBe(2);
+  });
+
+  it("should mark a todo as done", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.todoId = todo.sId;
+    req.body = { status: "done" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { todo: updated } = res._getJSONData();
+    expect(updated.status).toBe("done");
+    expect(updated.markedAsDoneByType).toBe("user");
+    expect(updated.doneAt).not.toBeNull();
+    expect(updated.version).toBe(2);
+  });
+
+  it("should allow un-marking a done todo", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+    });
+    const doneTodo = await todo.createVersion(auth, {
+      status: "done",
+      markedAsDoneByType: "user",
+      markedAsDoneByUserId: user.id,
+      markedAsDoneByAgentConfigurationId: null,
+      doneAt: new Date(),
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.todoId = doneTodo.sId;
+    req.body = { status: "todo" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { todo: updated } = res._getJSONData();
+    expect(updated.status).toBe("todo");
+    expect(updated.markedAsDoneByType).toBeNull();
+    expect(updated.doneAt).toBeNull();
+  });
+
+  it("should return 404 for a non-existent todo", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+
+    req.query.spaceId = project.sId;
+    req.query.todoId = "nonexistent_todo_sid";
+    req.body = { text: "Update" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("project_todo_not_found");
+  });
+
+  it("should return 404 for a todo that belongs to a different space", async () => {
+    const { user } = await setup();
+    const project1 = await SpaceFactory.project(workspace, user.id);
+    const project2 = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTodoFactory.create(workspace, project1, {
+      userId: user.id,
+    });
+
+    req.query.spaceId = project2.sId;
+    req.query.todoId = todo.sId;
+    req.body = { text: "Update" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("project_todo_not_found");
+  });
+
+  it("should return 400 when no update fields are provided", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.todoId = todo.sId;
+    req.body = {};
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("should return 405 for unsupported methods", async () => {
+    const result = await createPrivateApiMockRequest({ method: "DELETE" });
+    req = result.req;
+    res = result.res;
+    workspace = result.workspace;
+
+    const { user } = result;
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.todoId = todo.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.ts
@@ -1,0 +1,126 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import {
+  PROJECT_TODO_STATUSES,
+  type ProjectTodoType,
+} from "@app/types/project_todo";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const PatchProjectTodoBodySchema = z
+  .object({
+    text: z.string().min(1, "Text cannot be empty.").optional(),
+    status: z.enum(PROJECT_TODO_STATUSES).optional(),
+  })
+  .refine((data) => data.text !== undefined || data.status !== undefined, {
+    message: "At least one of text or status must be provided.",
+  });
+
+export interface PatchProjectTodoResponseBody {
+  todo: ProjectTodoType;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PatchProjectTodoResponseBody>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  if (!space.isProject()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Todos are only available for project spaces.",
+      },
+    });
+  }
+
+  const { todoId } = req.query;
+  if (!isString(todoId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid todo id.",
+      },
+    });
+  }
+
+  const todo = await ProjectTodoResource.fetchBySId(auth, todoId);
+  if (!todo || todo.spaceId !== space.id) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "project_todo_not_found",
+        message: "Todo not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "PATCH": {
+      const parseResult = PatchProjectTodoBodySchema.safeParse(req.body);
+      if (!parseResult.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: parseResult.error.message,
+          },
+        });
+      }
+
+      const { text, status } = parseResult.data;
+      const user = auth.getNonNullableUser();
+
+      const updates: Parameters<typeof todo.createVersion>[1] = {};
+
+      if (text !== undefined) {
+        updates.text = text;
+      }
+
+      if (status !== undefined) {
+        updates.status = status;
+        if (status === "done") {
+          updates.markedAsDoneByType = "user";
+          updates.markedAsDoneByUserId = user.id;
+          updates.markedAsDoneByAgentConfigurationId = null;
+          updates.doneAt = new Date();
+        } else {
+          // Clearing done status — reset all done-by fields.
+          updates.markedAsDoneByType = null;
+          updates.markedAsDoneByUserId = null;
+          updates.markedAsDoneByAgentConfigurationId = null;
+          updates.doneAt = null;
+        }
+      }
+
+      const updatedTodo = await todo.createVersion(auth, updates);
+
+      return res.status(200).json({ todo: updatedTodo.toJSON() });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, PATCH is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanRead: true },
+  })
+);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.test.ts
@@ -1,0 +1,170 @@
+import { Authenticator } from "@app/lib/auth";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { ProjectTodoFactory } from "@app/tests/utils/ProjectTodoFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { WorkspaceType } from "@app/types/user";
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { MockRequest, MockResponse } from "node-mocks-http";
+import { describe, expect, it } from "vitest";
+
+import handler from "./index";
+
+describe("GET /api/w/[wId]/spaces/[spaceId]/project_todos", () => {
+  let req: MockRequest<NextApiRequest>;
+  let res: MockResponse<NextApiResponse>;
+  let workspace: WorkspaceType;
+
+  async function setup(method = "GET") {
+    const result = await createPrivateApiMockRequest({ method: method as any });
+    req = result.req;
+    res = result.res;
+    workspace = result.workspace;
+    return result;
+  }
+
+  it("should return 200 with an empty list when no todos exist", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    req.query.spaceId = project.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().todos).toEqual([]);
+  });
+
+  it("should return latest versions of todos for the space", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+      text: "First todo",
+    });
+    // Create a new version of the same todo.
+    await todo.createVersion(auth, { text: "Updated todo" });
+
+    req.query.spaceId = project.sId;
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { todos } = res._getJSONData();
+    // Only the latest version should appear.
+    expect(todos).toHaveLength(1);
+    expect(todos[0].text).toBe("Updated todo");
+    expect(todos[0].sId).toBe(todo.sId);
+  });
+
+  it("should return 400 for non-project spaces", async () => {
+    const { user } = await setup();
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const regularSpace = await SpaceFactory.regular(workspace);
+
+    // Add the user to the space so auth passes and we reach the handler logic.
+    const memberGroup = regularSpace.groups.find((g) => g.kind === "regular");
+    if (memberGroup) {
+      await memberGroup.dangerouslyAddMembers(adminAuth, {
+        users: [user.toJSON()],
+      });
+    }
+
+    req.query.spaceId = regularSpace.sId;
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("should return 405 for unsupported methods", async () => {
+    const { user } = await setup("DELETE");
+    const project = await SpaceFactory.project(workspace, user.id);
+    req.query.spaceId = project.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+});
+
+describe("POST /api/w/[wId]/spaces/[spaceId]/project_todos", () => {
+  let req: MockRequest<NextApiRequest>;
+  let res: MockResponse<NextApiResponse>;
+  let workspace: WorkspaceType;
+
+  async function setup() {
+    const result = await createPrivateApiMockRequest({ method: "POST" });
+    req = result.req;
+    res = result.res;
+    workspace = result.workspace;
+    return result;
+  }
+
+  it("should create a todo and return 201", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    req.query.spaceId = project.sId;
+    req.body = { category: "follow_ups", text: "New todo item" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(201);
+    const { todo } = res._getJSONData();
+    expect(todo.text).toBe("New todo item");
+    expect(todo.category).toBe("follow_ups");
+    expect(todo.status).toBe("todo");
+    expect(todo.version).toBe(1);
+    expect(typeof todo.sId).toBe("string");
+  });
+
+  it("should create todos for different members in the same project", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+
+    // Add a second user to the project.
+    const user2 = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user2, { role: "user" });
+    const memberGroup = project.groups.find((g) => g.kind === "regular");
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    if (memberGroup) {
+      await memberGroup.dangerouslyAddMembers(adminAuth, {
+        users: [user2.toJSON()],
+      });
+    }
+
+    req.query.spaceId = project.sId;
+    req.body = { category: "key_decisions", text: "User1 todo" };
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(201);
+  });
+
+  it("should return 400 for missing required fields", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    req.query.spaceId = project.sId;
+    req.body = { text: "Missing category" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("should return 400 for an invalid category", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    req.query.spaceId = project.sId;
+    req.body = { category: "invalid_category", text: "Some todo" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
@@ -1,0 +1,109 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import {
+  PROJECT_TODO_CATEGORIES,
+  type ProjectTodoType,
+} from "@app/types/project_todo";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const PostProjectTodoBodySchema = z.object({
+  category: z.enum(PROJECT_TODO_CATEGORIES),
+  text: z.string().min(1, "Text cannot be empty."),
+});
+
+export interface GetProjectTodosResponseBody {
+  todos: ProjectTodoType[];
+}
+
+export interface PostProjectTodoResponseBody {
+  todo: ProjectTodoType;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      GetProjectTodosResponseBody | PostProjectTodoResponseBody
+    >
+  >,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  if (!space.isProject()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Todos are only available for project spaces.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const todos = await ProjectTodoResource.fetchLatestBySpace(auth, {
+        spaceId: space.id,
+      });
+
+      return res.status(200).json({ todos: todos.map((t) => t.toJSON()) });
+    }
+
+    case "POST": {
+      const parseResult = PostProjectTodoBodySchema.safeParse(req.body);
+      if (!parseResult.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: parseResult.error.message,
+          },
+        });
+      }
+
+      const { category, text } = parseResult.data;
+      const user = auth.getNonNullableUser();
+
+      const todo = await ProjectTodoResource.makeNew(auth, {
+        spaceId: space.id,
+        userId: user.id,
+        createdByType: "user",
+        createdByUserId: user.id,
+        createdByAgentConfigurationId: null,
+        markedAsDoneByType: null,
+        markedAsDoneByUserId: null,
+        markedAsDoneByAgentConfigurationId: null,
+        category,
+        text,
+        status: "todo",
+        version: 1,
+        doneAt: null,
+        actorRationale: null,
+      });
+
+      return res.status(201).json({ todo: todo.toJSON() });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanRead: true },
+  })
+);

--- a/front/tests/utils/ProjectTodoFactory.ts
+++ b/front/tests/utils/ProjectTodoFactory.ts
@@ -1,0 +1,36 @@
+import { Authenticator } from "@app/lib/auth";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { ProjectTodoCategory } from "@app/types/project_todo";
+import type { WorkspaceType } from "@app/types/user";
+
+export class ProjectTodoFactory {
+  static async create(
+    workspace: WorkspaceType,
+    space: SpaceResource,
+    params: {
+      userId: number;
+      category?: ProjectTodoCategory;
+      text?: string;
+    }
+  ): Promise<ProjectTodoResource> {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    return ProjectTodoResource.makeNew(auth, {
+      spaceId: space.id,
+      userId: params.userId,
+      createdByType: "user",
+      createdByUserId: params.userId,
+      createdByAgentConfigurationId: null,
+      markedAsDoneByType: null,
+      markedAsDoneByUserId: null,
+      markedAsDoneByAgentConfigurationId: null,
+      category: params.category ?? "follow_ups",
+      text: params.text ?? "A test todo item.",
+      status: "todo",
+      version: 1,
+      doneAt: null,
+      actorRationale: null,
+    });
+  }
+}

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -114,6 +114,8 @@ const API_ERROR_TYPES = [
   // Spaces:
   "space_already_exists",
   "space_not_found",
+  // Project todos:
+  "project_todo_not_found",
   // Groups:
   "group_not_found",
   // Plugins:

--- a/front/types/project_todo.ts
+++ b/front/types/project_todo.ts
@@ -1,3 +1,5 @@
+import type { ModelId } from "@app/types/shared/model_id";
+
 export const PROJECT_TODO_CATEGORIES = [
   "need_attention",
   "key_decisions",
@@ -18,3 +20,21 @@ export type ProjectTodoActorType = (typeof PROJECT_TODO_ACTOR_TYPES)[number];
 export const PROJECT_TODO_SOURCE_TYPES = ["conversation"] as const;
 
 export type ProjectTodoSourceType = (typeof PROJECT_TODO_SOURCE_TYPES)[number];
+
+// Safe public representation of a ProjectTodo — no internal ModelIds exposed.
+export type ProjectTodoType = {
+  id: ModelId;
+  sId: string;
+  category: ProjectTodoCategory;
+  text: string;
+  status: ProjectTodoStatus;
+  version: number;
+  doneAt: Date | null;
+  actorRationale: string | null;
+  createdByType: ProjectTodoActorType;
+  createdByAgentConfigurationId: string | null;
+  markedAsDoneByType: ProjectTodoActorType | null;
+  markedAsDoneByAgentConfigurationId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};


### PR DESCRIPTION
## Description

Add CRUD for TODO in the project, this PRs adds:
* the endpoint to handle a TODO
* the UI based on Ed's design. The UI for adding is done by me, we can iterate on this later on

It's behind a feature flag so hidden in production

https://github.com/user-attachments/assets/5f52a670-82db-4bbb-bc50-ce0660e3d982


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
