### PR TITLE
Delete old synthetic suggestions

### DIFF
--- a/front/lib/resources/agent_suggestion_resource.ts
+++ b/front/lib/resources/agent_suggestion_resource.ts
@@ -446,6 +446,33 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
   }
 
   /**
+   * Deletes all synthetic suggestions older than the given cutoff date.
+   * Requires admin permissions. Returns the number of deleted rows.
+   */
+  static async deleteExpiredSynthetic(
+    auth: Authenticator,
+    cutoffDate: Date,
+    { limit }: { limit?: number } = {}
+  ): Promise<number> {
+    if (!auth.isAdmin()) {
+      throw new Error(
+        "Only workspace admins can delete expired synthetic suggestions"
+      );
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+
+    return AgentSuggestionModel.destroy({
+      where: {
+        workspaceId: owner.id,
+        source: "synthetic",
+        createdAt: { [Op.lt]: cutoffDate },
+      },
+      limit,
+    });
+  }
+
+  /**
    * Lists all suggestions for the workspace.
    */
   static async listAll(

--- a/front/temporal/hard_delete/activities.test.ts
+++ b/front/temporal/hard_delete/activities.test.ts
@@ -1,7 +1,7 @@
 import { createPendingAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import {
   purgeExpiredPendingAgentsActivity,
@@ -232,7 +232,7 @@ const PAST_SYNTHETIC_THRESHOLD_MS =
 
 describe("purgeExpiredSyntheticSuggestionsActivity", () => {
   it("deletes synthetic suggestions older than threshold", async () => {
-    const { authenticator, workspace } = await createResourceTest({
+    const { authenticator } = await createResourceTest({
       role: "admin",
     });
 
@@ -252,14 +252,15 @@ describe("purgeExpiredSyntheticSuggestionsActivity", () => {
 
     await purgeExpiredSyntheticSuggestionsActivity();
 
-    const remaining = await AgentSuggestionModel.findOne({
-      where: { id: suggestion.id, workspaceId: workspace.id },
-    });
+    const remaining = await AgentSuggestionResource.fetchById(
+      authenticator,
+      suggestion.sId
+    );
     expect(remaining).toBeNull();
   });
 
   it("does not delete synthetic suggestions younger than threshold", async () => {
-    const { authenticator, workspace } = await createResourceTest({
+    const { authenticator } = await createResourceTest({
       role: "admin",
     });
 
@@ -276,14 +277,15 @@ describe("purgeExpiredSyntheticSuggestionsActivity", () => {
 
     await purgeExpiredSyntheticSuggestionsActivity();
 
-    const remaining = await AgentSuggestionModel.findOne({
-      where: { id: suggestion.id, workspaceId: workspace.id },
-    });
+    const remaining = await AgentSuggestionResource.fetchById(
+      authenticator,
+      suggestion.sId
+    );
     expect(remaining).not.toBeNull();
   });
 
   it("does not delete non-synthetic suggestions older than threshold", async () => {
-    const { authenticator, workspace } = await createResourceTest({
+    const { authenticator } = await createResourceTest({
       role: "admin",
     });
 
@@ -303,9 +305,10 @@ describe("purgeExpiredSyntheticSuggestionsActivity", () => {
 
     await purgeExpiredSyntheticSuggestionsActivity();
 
-    const remaining = await AgentSuggestionModel.findOne({
-      where: { id: suggestion.id, workspaceId: workspace.id },
-    });
+    const remaining = await AgentSuggestionResource.fetchById(
+      authenticator,
+      suggestion.sId
+    );
     expect(remaining).not.toBeNull();
   });
 });

--- a/front/temporal/hard_delete/activities.test.ts
+++ b/front/temporal/hard_delete/activities.test.ts
@@ -1,10 +1,18 @@
 import { createPendingAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { purgeExpiredPendingAgentsActivity } from "@app/temporal/hard_delete/activities";
-import { PENDING_AGENTS_RETENTION_HOURS } from "@app/temporal/hard_delete/utils";
+import {
+  purgeExpiredPendingAgentsActivity,
+  purgeExpiredSyntheticSuggestionsActivity,
+} from "@app/temporal/hard_delete/activities";
+import {
+  PENDING_AGENTS_RETENTION_HOURS,
+  SYNTHETIC_SUGGESTIONS_RETENTION_DAYS,
+} from "@app/temporal/hard_delete/utils";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -216,5 +224,88 @@ describe("purgeExpiredPendingAgentsActivity", () => {
     expect(
       await GroupResource.fetchByModelIds(authenticator, [activeGroupId])
     ).toHaveLength(1);
+  });
+});
+
+const PAST_SYNTHETIC_THRESHOLD_MS =
+  (SYNTHETIC_SUGGESTIONS_RETENTION_DAYS + 1) * 24 * 3600 * 1000;
+
+describe("purgeExpiredSyntheticSuggestionsActivity", () => {
+  it("deletes synthetic suggestions older than threshold", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Agent with suggestions" }
+    );
+
+    const suggestion = await AgentSuggestionFactory.createInstructions(
+      authenticator,
+      agentConfig,
+      { source: "synthetic" }
+    );
+
+    // Advance time past the synthetic retention threshold.
+    vi.advanceTimersByTime(PAST_SYNTHETIC_THRESHOLD_MS);
+
+    await purgeExpiredSyntheticSuggestionsActivity();
+
+    const remaining = await AgentSuggestionModel.findOne({
+      where: { id: suggestion.id, workspaceId: workspace.id },
+    });
+    expect(remaining).toBeNull();
+  });
+
+  it("does not delete synthetic suggestions younger than threshold", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Agent with fresh suggestions" }
+    );
+
+    const suggestion = await AgentSuggestionFactory.createInstructions(
+      authenticator,
+      agentConfig,
+      { source: "synthetic" }
+    );
+
+    await purgeExpiredSyntheticSuggestionsActivity();
+
+    const remaining = await AgentSuggestionModel.findOne({
+      where: { id: suggestion.id, workspaceId: workspace.id },
+    });
+    expect(remaining).not.toBeNull();
+  });
+
+  it("does not delete non-synthetic suggestions older than threshold", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Agent with sidekick suggestions" }
+    );
+
+    const suggestion = await AgentSuggestionFactory.createInstructions(
+      authenticator,
+      agentConfig,
+      { source: "sidekick" }
+    );
+
+    // Advance time past the synthetic retention threshold.
+    vi.advanceTimersByTime(PAST_SYNTHETIC_THRESHOLD_MS);
+
+    await purgeExpiredSyntheticSuggestionsActivity();
+
+    const remaining = await AgentSuggestionModel.findOne({
+      where: { id: suggestion.id, workspaceId: workspace.id },
+    });
+    expect(remaining).not.toBeNull();
   });
 });

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -188,10 +188,13 @@ export async function purgeExpiredSyntheticSuggestionsActivity(
     let hasMore = true;
 
     do {
-      const deletedCount =
-        await AgentSuggestionResource.deleteExpiredSynthetic(auth, cutoffDate, {
+      const deletedCount = await AgentSuggestionResource.deleteExpiredSynthetic(
+        auth,
+        cutoffDate,
+        {
           limit: batchSize,
-        });
+        }
+      );
 
       totalDeleted += deletedCount;
       hasMore = deletedCount === batchSize;

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -1,6 +1,7 @@
 // biome-ignore-all lint/plugin/noRawSql: hard delete activities require raw SQL for cascade deletions
 import { batchHardDeletePendingAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
@@ -11,6 +12,7 @@ import type {
 import {
   getPendingAgentsDeletionCutoffDate,
   getRunExecutionsDeletionCutoffDate,
+  getSyntheticSuggestionsDeletionCutoffDate,
   isSequelizeForeignKeyConstraintError,
 } from "@app/temporal/hard_delete/utils";
 import { Context } from "@temporalio/activity";
@@ -163,5 +165,45 @@ export async function purgeExpiredPendingAgentsActivity(
   logger.info(
     { totalDeleted },
     "Done purging expired pending agent configurations."
+  );
+}
+
+export async function purgeExpiredSyntheticSuggestionsActivity(
+  batchSize: number = BATCH_SIZE
+) {
+  const cutoffDate = getSyntheticSuggestionsDeletionCutoffDate();
+
+  logger.info(
+    {},
+    `About to purge synthetic agent suggestions created before ${cutoffDate.toISOString()}.`
+  );
+
+  const workspaces = await WorkspaceResource.listAll();
+
+  let totalDeleted = 0;
+
+  for (const workspace of workspaces) {
+    let hasMore = true;
+
+    do {
+      const deletedCount = await AgentSuggestionModel.destroy({
+        where: {
+          workspaceId: workspace.id,
+          source: "synthetic",
+          createdAt: { [Op.lt]: cutoffDate },
+        },
+        limit: batchSize,
+      });
+
+      totalDeleted += deletedCount;
+      hasMore = deletedCount === batchSize;
+
+      Context.current().heartbeat();
+    } while (hasMore);
+  }
+
+  logger.info(
+    { totalDeleted },
+    "Done purging expired synthetic agent suggestions."
   );
 }

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -1,8 +1,9 @@
 // biome-ignore-all lint/plugin/noRawSql: hard delete activities require raw SQL for cascade deletions
 import { batchHardDeletePendingAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type {
@@ -183,17 +184,14 @@ export async function purgeExpiredSyntheticSuggestionsActivity(
   let totalDeleted = 0;
 
   for (const workspace of workspaces) {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     let hasMore = true;
 
     do {
-      const deletedCount = await AgentSuggestionModel.destroy({
-        where: {
-          workspaceId: workspace.id,
-          source: "synthetic",
-          createdAt: { [Op.lt]: cutoffDate },
-        },
-        limit: batchSize,
-      });
+      const deletedCount =
+        await AgentSuggestionResource.deleteExpiredSynthetic(auth, cutoffDate, {
+          limit: batchSize,
+        });
 
       totalDeleted += deletedCount;
       hasMore = deletedCount === batchSize;

--- a/front/temporal/hard_delete/utils.ts
+++ b/front/temporal/hard_delete/utils.ts
@@ -35,3 +35,18 @@ export function getPendingAgentsDeletionCutoffDate(): Date {
 
   return cutoffDate;
 }
+
+/**
+ * Purge synthetic agent suggestions logic.
+ */
+
+export const SYNTHETIC_SUGGESTIONS_RETENTION_DAYS = 14;
+
+export function getSyntheticSuggestionsDeletionCutoffDate(): Date {
+  const cutoffDate = new Date();
+  cutoffDate.setDate(
+    cutoffDate.getDate() - SYNTHETIC_SUGGESTIONS_RETENTION_DAYS
+  );
+
+  return cutoffDate;
+}

--- a/front/temporal/hard_delete/workflows.ts
+++ b/front/temporal/hard_delete/workflows.ts
@@ -2,12 +2,16 @@ import type * as activities from "@app/temporal/hard_delete/activities";
 import { proxyActivities } from "@temporalio/workflow";
 
 // TODO(2024-06-13 flav) Lower `startToCloseTimeout` to 10 minutes.
-const { purgeExpiredRunExecutionsActivity, purgeExpiredPendingAgentsActivity } =
-  proxyActivities<typeof activities>({
-    startToCloseTimeout: "60 minutes",
-  });
+const {
+  purgeExpiredRunExecutionsActivity,
+  purgeExpiredPendingAgentsActivity,
+  purgeExpiredSyntheticSuggestionsActivity,
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "60 minutes",
+});
 
 export async function hardDeleteCronWorkflow(): Promise<void> {
   await purgeExpiredRunExecutionsActivity();
   await purgeExpiredPendingAgentsActivity();
+  await purgeExpiredSyntheticSuggestionsActivity();
 }


### PR DESCRIPTION
## Description

Do a nightly cleanup that deletes all synthetic suggestions that are older than 2 weeks.

Fixes https://github.com/dust-tt/tasks/issues/7279

## Tests

Added

## Risk

Low

## Deploy Plan

Front