### PR TITLE
[BYOK] Add use_dust_keys feature flag to override BYOK with Dust-managed keys

### DIFF
--- a/front/lib/api/provider_credentials.ts
+++ b/front/lib/api/provider_credentials.ts
@@ -1,6 +1,6 @@
 import config from "@app/lib/api/config";
 
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
@@ -81,6 +81,15 @@ export async function getLlmCredentials(
     return {
       ...BASE_VARIABLES,
       ...DUST_MANAGED_OTHER_PROVIDERS_API_KEYS,
+      ...DUST_MANAGED_BYOK_PROVIDERS_API_KEYS,
+    };
+  }
+
+  const featureFlags = await getFeatureFlags(auth);
+
+  if (featureFlags.includes("use_dust_keys")) {
+    return {
+      ...BASE_VARIABLES,
       ...DUST_MANAGED_BYOK_PROVIDERS_API_KEYS,
     };
   }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -274,6 +274,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Gong MCP tool for sales conversation analytics",
     stage: "dust_only",
   },
+  use_dust_keys: {
+    description:
+      "Force BYOK workspaces to use Dust-managed keys instead of customer-provided keys",
+    // Not really on_demand but we want to be able to enable it for customers
+    stage: "on_demand",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -739,6 +739,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "anthropic_reasoning_token_count"
   | "collapsible_messages"
   | "email_restricted_sharing"
+  | "use_dust_keys"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Adds a `use_dust_keys` feature flag that, when enabled on a BYOK workspace, forces the credential resolution to use Dust-managed API keys instead of the customer-provided ones. This allows Dust to temporarily take over key usage for specific workspaces without removing their BYOK configuration.

## Tests

Tested manually by enabling the flag on a BYOK workspace and verifying that Dust-managed keys are returned by `getLlmCredentials`.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`