### PR TITLE
Move agent message final status updates behind advisory lock

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2239,7 +2239,10 @@ export async function finalizeAgentMessage(
     status: "succeeded" | "cancelled" | "failed";
     error?: ToolErrorEvent["error"];
   }
-): Promise<{ completedTs: number; status: "succeeded" | "cancelled" | "failed" }> {
+): Promise<{
+  completedTs: number;
+  status: "succeeded" | "cancelled" | "failed";
+}> {
   const completedAt = new Date();
 
   await withTransaction(async (t) => {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2223,8 +2223,8 @@ export async function isConversationEventAllowedForAuth(
 /**
  * Finalize an agent message terminal status behind the conversation advisory lock.
  *
- * This ensures the status transition is serialized against other conversation
- * operations (e.g. postUserMessage's pending path in the future).
+ * This ensures the status transition is serialized against other conversation operations (e.g.
+ * postUserMessage's pending path in the future).
  */
 export async function finalizeAgentMessage(
   auth: Authenticator,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2267,6 +2267,8 @@ export async function finalizeAgentMessage(
     );
   });
 
+  // Update the in-memory object to reflect the DB state. Callers hold a reference to this object
+  // and rely on it being up-to-date for subsequent event publishing and finalization logic.
   agentMessage.status = status;
   agentMessage.completedTs = completedAt.getTime();
   if (error) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -90,7 +90,10 @@ import type {
   ContentFragmentInputWithFileIdType,
 } from "@app/types/api/internal/assistant";
 import { isContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  LightAgentConfigurationType,
+  ToolErrorEvent,
+} from "@app/types/assistant/agent";
 import type {
   AgenticMessageData,
   AgentMessageType,
@@ -2218,19 +2221,23 @@ export async function isConversationEventAllowedForAuth(
 }
 
 /**
- * Finalize a succeeded agent message behind the conversation advisory lock.
+ * Finalize an agent message terminal status behind the conversation advisory lock.
  *
  * This ensures the status transition is serialized against other conversation
  * operations (e.g. postUserMessage's pending path in the future).
  */
-export async function finalizeSucceededAgentMessage(
+export async function finalizeAgentMessage(
   auth: Authenticator,
   {
     conversation,
     agentMessage,
+    status,
+    error,
   }: {
     conversation: ConversationWithoutContentType;
     agentMessage: AgentMessageType;
+    status: "succeeded" | "cancelled" | "failed";
+    error?: ToolErrorEvent["error"];
   }
 ): Promise<void> {
   const completedAt = new Date();
@@ -2239,7 +2246,17 @@ export async function finalizeSucceededAgentMessage(
     await getConversationRankVersionLock(auth, conversation, t);
 
     await AgentMessageModel.update(
-      { status: "succeeded", completedAt },
+      {
+        status,
+        completedAt,
+        ...(error
+          ? {
+              errorCode: error.code,
+              errorMessage: error.message,
+              errorMetadata: error.metadata,
+            }
+          : {}),
+      },
       {
         where: {
           id: agentMessage.agentMessageId,
@@ -2250,6 +2267,9 @@ export async function finalizeSucceededAgentMessage(
     );
   });
 
-  agentMessage.status = "succeeded";
+  agentMessage.status = status;
   agentMessage.completedTs = completedAt.getTime();
+  if (error) {
+    agentMessage.error = error;
+  }
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2239,7 +2239,7 @@ export async function finalizeAgentMessage(
     status: "succeeded" | "cancelled" | "failed";
     error?: ToolErrorEvent["error"];
   }
-): Promise<Date> {
+): Promise<{ completedTs: number; status: "succeeded" | "cancelled" | "failed" }> {
   const completedAt = new Date();
 
   await withTransaction(async (t) => {
@@ -2267,5 +2267,5 @@ export async function finalizeAgentMessage(
     );
   });
 
-  return completedAt;
+  return { completedTs: completedAt.getTime(), status };
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2216,3 +2216,40 @@ export async function isConversationEventAllowedForAuth(
       assertNever(type);
   }
 }
+
+/**
+ * Finalize a succeeded agent message behind the conversation advisory lock.
+ *
+ * This ensures the status transition is serialized against other conversation
+ * operations (e.g. postUserMessage's pending path in the future).
+ */
+export async function finalizeSucceededAgentMessage(
+  auth: Authenticator,
+  {
+    conversation,
+    agentMessage,
+  }: {
+    conversation: ConversationWithoutContentType;
+    agentMessage: AgentMessageType;
+  }
+): Promise<void> {
+  const completedAt = new Date();
+
+  await withTransaction(async (t) => {
+    await getConversationRankVersionLock(auth, conversation, t);
+
+    await AgentMessageModel.update(
+      { status: "succeeded", completedAt },
+      {
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        transaction: t,
+      }
+    );
+  });
+
+  agentMessage.status = "succeeded";
+  agentMessage.completedTs = completedAt.getTime();
+}

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2239,7 +2239,7 @@ export async function finalizeAgentMessage(
     status: "succeeded" | "cancelled" | "failed";
     error?: ToolErrorEvent["error"];
   }
-): Promise<void> {
+): Promise<Date> {
   const completedAt = new Date();
 
   await withTransaction(async (t) => {
@@ -2267,11 +2267,5 @@ export async function finalizeAgentMessage(
     );
   });
 
-  // Update the in-memory object to reflect the DB state. Callers hold a reference to this object
-  // and rely on it being up-to-date for subsequent event publishing and finalization logic.
-  agentMessage.status = status;
-  agentMessage.completedTs = completedAt.getTime();
-  if (error) {
-    agentMessage.error = error;
-  }
+  return completedAt;
 }

--- a/front/temporal/agent_loop/activities/common.test.ts
+++ b/front/temporal/agent_loop/activities/common.test.ts
@@ -1,4 +1,3 @@
-import { finalizeSucceededAgentMessage } from "@app/lib/api/assistant/conversation";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -577,6 +576,7 @@ describe("updateAgentMessageDBAndMemory", () => {
       // Act: Update with error
       await updateAgentMessageDBAndMemory(auth, {
         agentMessage,
+        conversation,
         update: {
           type: "error",
           error,
@@ -629,10 +629,14 @@ describe("updateAgentMessageDBAndMemory", () => {
       expect(agentMessage.status).toBe("created");
       expect(agentMessage.completedTs).toBeNull();
 
-      // Act: Update status to succeeded via locked finalization
-      await finalizeSucceededAgentMessage(auth, {
-        conversation,
+      // Act: Update status to succeeded
+      await updateAgentMessageDBAndMemory(auth, {
         agentMessage,
+        conversation,
+        update: {
+          type: "status",
+          status: "succeeded",
+        },
       });
 
       // Assert: Database should be updated
@@ -674,6 +678,7 @@ describe("updateAgentMessageDBAndMemory", () => {
       // Act: Update status to cancelled
       await updateAgentMessageDBAndMemory(auth, {
         agentMessage,
+        conversation,
         update: {
           type: "status",
           status: "cancelled",

--- a/front/temporal/agent_loop/activities/common.test.ts
+++ b/front/temporal/agent_loop/activities/common.test.ts
@@ -1,3 +1,4 @@
+import { finalizeSucceededAgentMessage } from "@app/lib/api/assistant/conversation";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -628,13 +629,10 @@ describe("updateAgentMessageDBAndMemory", () => {
       expect(agentMessage.status).toBe("created");
       expect(agentMessage.completedTs).toBeNull();
 
-      // Act: Update status to succeeded
-      await updateAgentMessageDBAndMemory(auth, {
+      // Act: Update status to succeeded via locked finalization
+      await finalizeSucceededAgentMessage(auth, {
+        conversation,
         agentMessage,
-        update: {
-          type: "status",
-          status: "succeeded",
-        },
       });
 
       // Assert: Database should be updated

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -90,14 +90,14 @@ export async function updateAgentMessageDBAndMemory(
             "conversation is required for terminal status updates"
           );
         }
-        const completedAt = await finalizeAgentMessage(auth, {
+        const result = await finalizeAgentMessage(auth, {
           conversation,
           agentMessage,
           status: "failed",
           error: update.error,
         });
-        agentMessage.status = "failed";
-        agentMessage.completedTs = completedAt.getTime();
+        agentMessage.status = result.status;
+        agentMessage.completedTs = result.completedTs;
         agentMessage.error = update.error;
       }
       break;
@@ -109,13 +109,13 @@ export async function updateAgentMessageDBAndMemory(
             "conversation is required for terminal status updates"
           );
         }
-        const completedAt = await finalizeAgentMessage(auth, {
+        const result = await finalizeAgentMessage(auth, {
           conversation,
           agentMessage,
           status: update.status,
         });
-        agentMessage.status = update.status;
-        agentMessage.completedTs = completedAt.getTime();
+        agentMessage.status = result.status;
+        agentMessage.completedTs = result.completedTs;
       }
       break;
 

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -77,46 +77,51 @@ export async function updateAgentMessageDBAndMemory(
             };
       }
 ): Promise<void> {
-  const { agentMessage, update } = args;
-  const updateType = update.type;
+  const { agentMessage } = args;
   const where: WhereOptions<InferAttributes<AgentMessageModel>> = {
     id: agentMessage.agentMessageId,
     workspaceId: auth.getNonNullableWorkspace().id,
   };
 
-  switch (updateType) {
-    case "error":
-      {
-        const { conversation } = args as {
-          conversation: ConversationWithoutContentType;
-        };
-        const result = await finalizeAgentMessage(auth, {
-          conversation,
-          agentMessage,
-          status: "failed",
-          error: update.error,
-        });
-        agentMessage.status = result.status;
-        agentMessage.completedTs = result.completedTs;
-        agentMessage.error = update.error;
-      }
-      break;
+  // Terminal status updates go through the advisory-locked finalizeAgentMessage.
+  if ("conversation" in args) {
+    const { conversation, update } = args;
+    switch (update.type) {
+      case "error":
+        {
+          const result = await finalizeAgentMessage(auth, {
+            conversation,
+            agentMessage,
+            status: "failed",
+            error: update.error,
+          });
+          agentMessage.status = result.status;
+          agentMessage.completedTs = result.completedTs;
+          agentMessage.error = update.error;
+        }
+        break;
 
-    case "status":
-      {
-        const { conversation } = args as {
-          conversation: ConversationWithoutContentType;
-        };
-        const result = await finalizeAgentMessage(auth, {
-          conversation,
-          agentMessage,
-          status: update.status,
-        });
-        agentMessage.status = result.status;
-        agentMessage.completedTs = result.completedTs;
-      }
-      break;
+      case "status":
+        {
+          const result = await finalizeAgentMessage(auth, {
+            conversation,
+            agentMessage,
+            status: update.status,
+          });
+          agentMessage.status = result.status;
+          agentMessage.completedTs = result.completedTs;
+        }
+        break;
 
+      default:
+        assertNever(update);
+    }
+    return;
+  }
+
+  // Non-terminal metadata updates — no lock needed.
+  const { update } = args;
+  switch (update.type) {
     case "modelInteractionDurationMs":
       {
         const roundedModelInteractionDurationMs = Math.round(
@@ -170,7 +175,7 @@ export async function updateAgentMessageDBAndMemory(
       break;
 
     default:
-      assertNever(updateType);
+      assertNever(update);
   }
 }
 

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -1,3 +1,4 @@
+import { finalizeSucceededAgentMessage } from "@app/lib/api/assistant/conversation";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
@@ -53,7 +54,7 @@ export async function updateAgentMessageDBAndMemory(
     update:
       | {
           type: "status";
-          status: "succeeded" | "cancelled";
+          status: "cancelled";
         }
       | {
           type: "error";
@@ -288,13 +289,10 @@ export async function processEventForDatabase(
 
     case "agent_message_success":
       await Promise.all([
-        // Store success in database. runIds are already merged above.
-        updateAgentMessageDBAndMemory(auth, {
+        // Store success in database behind advisory lock.
+        finalizeSucceededAgentMessage(auth, {
+          conversation,
           agentMessage,
-          update: {
-            type: "status",
-            status: "succeeded",
-          },
         }),
         // Mark the conversation as updated
         ConversationResource.markAsUpdated(auth, { conversation }),

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -1,4 +1,4 @@
-import { finalizeSucceededAgentMessage } from "@app/lib/api/assistant/conversation";
+import { finalizeAgentMessage } from "@app/lib/api/assistant/conversation";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
@@ -48,13 +48,15 @@ export async function updateAgentMessageDBAndMemory(
   auth: Authenticator,
   {
     agentMessage,
+    conversation,
     update,
   }: {
     agentMessage: AgentMessageType;
+    conversation?: ConversationWithoutContentType;
     update:
       | {
           type: "status";
-          status: "cancelled";
+          status: "succeeded" | "cancelled";
         }
       | {
           type: "error";
@@ -83,35 +85,32 @@ export async function updateAgentMessageDBAndMemory(
   switch (updateType) {
     case "error":
       {
-        const completedAt = new Date();
-        await AgentMessageModel.update(
-          {
-            status: "failed",
-            completedAt,
-            errorCode: update.error.code,
-            errorMessage: update.error.message,
-            errorMetadata: update.error.metadata,
-          },
-          { where }
-        );
-        agentMessage.status = "failed";
-        agentMessage.completedTs = completedAt.getTime();
-        agentMessage.error = update.error;
+        if (!conversation) {
+          throw new Error(
+            "conversation is required for terminal status updates"
+          );
+        }
+        await finalizeAgentMessage(auth, {
+          conversation,
+          agentMessage,
+          status: "failed",
+          error: update.error,
+        });
       }
       break;
 
     case "status":
       {
-        const completedAt = new Date();
-        await AgentMessageModel.update(
-          {
-            status: update.status,
-            completedAt,
-          },
-          { where }
-        );
-        agentMessage.status = update.status;
-        agentMessage.completedTs = completedAt.getTime();
+        if (!conversation) {
+          throw new Error(
+            "conversation is required for terminal status updates"
+          );
+        }
+        await finalizeAgentMessage(auth, {
+          conversation,
+          agentMessage,
+          status: update.status,
+        });
       }
       break;
 
@@ -176,14 +175,17 @@ export async function markAgentMessageAsFailed(
   auth: Authenticator,
   {
     agentMessage,
+    conversation,
     error,
   }: {
     agentMessage: AgentMessageType;
+    conversation: ConversationWithoutContentType;
     error: ToolErrorEvent["error"];
   }
 ): Promise<void> {
   await updateAgentMessageDBAndMemory(auth, {
     agentMessage,
+    conversation,
     update: {
       type: "error",
       error,
@@ -236,6 +238,7 @@ export async function processEventForDatabase(
       // Store error in database.
       await markAgentMessageAsFailed(auth, {
         agentMessage,
+        conversation,
         error: event.error,
       });
 
@@ -267,6 +270,7 @@ export async function processEventForDatabase(
     case "tool_error":
       await markAgentMessageAsFailed(auth, {
         agentMessage,
+        conversation,
         error: event.error,
       });
 
@@ -280,6 +284,7 @@ export async function processEventForDatabase(
       // Store cancellation in database.
       await updateAgentMessageDBAndMemory(auth, {
         agentMessage,
+        conversation,
         update: {
           type: "status",
           status: "cancelled",
@@ -290,9 +295,13 @@ export async function processEventForDatabase(
     case "agent_message_success":
       await Promise.all([
         // Store success in database behind advisory lock.
-        finalizeSucceededAgentMessage(auth, {
-          conversation,
+        updateAgentMessageDBAndMemory(auth, {
           agentMessage,
+          conversation,
+          update: {
+            type: "status",
+            status: "succeeded",
+          },
         }),
         // Mark the conversation as updated
         ConversationResource.markAsUpdated(auth, { conversation }),

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -90,12 +90,15 @@ export async function updateAgentMessageDBAndMemory(
             "conversation is required for terminal status updates"
           );
         }
-        await finalizeAgentMessage(auth, {
+        const completedAt = await finalizeAgentMessage(auth, {
           conversation,
           agentMessage,
           status: "failed",
           error: update.error,
         });
+        agentMessage.status = "failed";
+        agentMessage.completedTs = completedAt.getTime();
+        agentMessage.error = update.error;
       }
       break;
 
@@ -106,11 +109,13 @@ export async function updateAgentMessageDBAndMemory(
             "conversation is required for terminal status updates"
           );
         }
-        await finalizeAgentMessage(auth, {
+        const completedAt = await finalizeAgentMessage(auth, {
           conversation,
           agentMessage,
           status: update.status,
         });
+        agentMessage.status = update.status;
+        agentMessage.completedTs = completedAt.getTime();
       }
       break;
 

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -46,36 +46,38 @@ const DEEP_CONVERSATION_FLUSH_INTERVAL_MS = 1000;
  */
 export async function updateAgentMessageDBAndMemory(
   auth: Authenticator,
-  {
-    agentMessage,
-    conversation,
-    update,
-  }: {
-    agentMessage: AgentMessageType;
-    conversation?: ConversationWithoutContentType;
-    update:
-      | {
-          type: "status";
-          status: "succeeded" | "cancelled";
-        }
-      | {
-          type: "error";
-          error: ToolErrorEvent["error"];
-        }
-      | {
-          type: "runIds";
-          runIds: string[];
-        }
-      | {
-          type: "modelInteractionDurationMs";
-          modelInteractionDurationMs: number;
-        }
-      | {
-          type: "prunedContext";
-          prunedContext: true;
-        };
-  }
+  args:
+    | {
+        agentMessage: AgentMessageType;
+        conversation: ConversationWithoutContentType;
+        update:
+          | {
+              type: "status";
+              status: "succeeded" | "cancelled";
+            }
+          | {
+              type: "error";
+              error: ToolErrorEvent["error"];
+            };
+      }
+    | {
+        agentMessage: AgentMessageType;
+        update:
+          | {
+              type: "runIds";
+              runIds: string[];
+            }
+          | {
+              type: "modelInteractionDurationMs";
+              modelInteractionDurationMs: number;
+            }
+          | {
+              type: "prunedContext";
+              prunedContext: true;
+            };
+      }
 ): Promise<void> {
+  const { agentMessage, update } = args;
   const updateType = update.type;
   const where: WhereOptions<InferAttributes<AgentMessageModel>> = {
     id: agentMessage.agentMessageId,
@@ -85,11 +87,9 @@ export async function updateAgentMessageDBAndMemory(
   switch (updateType) {
     case "error":
       {
-        if (!conversation) {
-          throw new Error(
-            "conversation is required for terminal status updates"
-          );
-        }
+        const { conversation } = args as {
+          conversation: ConversationWithoutContentType;
+        };
         const result = await finalizeAgentMessage(auth, {
           conversation,
           agentMessage,
@@ -104,11 +104,9 @@ export async function updateAgentMessageDBAndMemory(
 
     case "status":
       {
-        if (!conversation) {
-          throw new Error(
-            "conversation is required for terminal status updates"
-          );
-        }
+        const { conversation } = args as {
+          conversation: ConversationWithoutContentType;
+        };
         const result = await finalizeAgentMessage(auth, {
           conversation,
           agentMessage,

--- a/x/spolu/steering/plan.md
+++ b/x/spolu/steering/plan.md
@@ -6,19 +6,19 @@ Three phases of bitesize PRs. Each PR should be small, reviewable, and independe
 
 Foundational refactors that don't change any user-facing behavior.
 
-### - [ ] PR 1.1 — Add `finalizeSucceededAgentMessage` in `conversation.ts`
+### - [x] PR 1.1 — Add `finalizeAgentMessage` in `conversation.ts`
 
-Move the agent message success status update behind the conversation advisory lock. Today,
-`updateAgentMessageDBAndMemory` does a bare `UPDATE` on `AgentMessageModel.status`. Extract
-the `"succeeded"` transition into a new locked function:
+Move all agent message terminal status updates behind the conversation advisory lock.
 
-- Add `finalizeSucceededAgentMessage()` to `front/lib/api/assistant/conversation.ts` that:
+- Add `finalizeAgentMessage()` to `front/lib/api/assistant/conversation.ts` that:
+  - Takes `status: "succeeded" | "cancelled" | "failed"` and optional `error`
   - Acquires `getConversationRankVersionLock`
-  - Updates `AgentMessageModel.status` to `"succeeded"` + `completedAt`
-  - (For now, the "promote" part is a no-op — no pending messages exist yet)
-- Update `updateResourceAndPublishEvent` in `common.ts` to call this new function for the
-  `agent_message_success` event instead of `updateAgentMessageDBAndMemory` for the status update.
-- Verify no behavior change via existing tests.
+  - Updates `AgentMessageModel.status` + `completedAt` (+ error fields if applicable)
+  - Returns `{ completedTs, status }`
+- Update `updateAgentMessageDBAndMemory` in `common.ts` to delegate to `finalizeAgentMessage`
+  for `"status"` and `"error"` update types via discriminated union (conversation required at
+  compile time for terminal updates only).
+- In-memory `agentMessage` mutation stays in `common.ts` (caller side).
 
 ---
 
@@ -131,10 +131,10 @@ Behind `enable_steering_behavior` feature flag:
 - Update `finalizeGracefullyStoppedAgentLoopActivity` to call this function, publish
   `UserMessagePromotedEvent` events, publish `AgentMessageNewEvent`, launch new agent loop.
 
-### - [ ] PR 3.4 — Safety net in `finalizeSucceededAgentMessage`
+### - [ ] PR 3.4 — Safety net in `finalizeAgentMessage` for succeeded path
 
-- Update `finalizeSucceededAgentMessage()` to check for orphaned pending messages and promote
-  them (same logic as `finalizeGracefulStopAgentMessage`).
+- Update `finalizeAgentMessage()` to check for orphaned pending messages when `status` is
+  `"succeeded"` and promote them (same logic as `finalizeGracefulStopAgentMessage`).
 - This handles the edge case where the graceful stop signal was lost or arrived after the loop
   already decided to exit naturally.
 

--- a/x/spolu/steering/steering.md
+++ b/x/spolu/steering/steering.md
@@ -269,13 +269,13 @@ message), the Temporal activity sees it and promotes it.
 **Note:** Today, `updateAgentMessageDBAndMemory` updates `AgentMessageModel.status` with a bare
 `UPDATE` — no transaction, no advisory lock. The `finalizeGracefulStopAgentMessage` function
 replaces this for the graceful stop path. For the `"succeeded"` path, a similar
-`finalizeSucceededAgentMessage` function should be added to `conversation.ts` that acquires the lock,
+`finalizeAgentMessage` function should be added to `conversation.ts` that acquires the lock,
 so that all terminal status transitions are serialized. This ensures the safety net works:
 
 ```typescript
 // front/lib/api/assistant/conversation.ts
 
-export async function finalizeSucceededAgentMessage(
+export async function finalizeAgentMessage(
   auth: Authenticator,
   {
     conversation,
@@ -312,7 +312,7 @@ export async function finalizeSucceededAgentMessage(
 
 - **All locked conversation operations live in `conversation.ts`** — both the API side
   (`postUserMessage`) and the Temporal side (`finalizeGracefulStopAgentMessage`,
-  `finalizeSucceededAgentMessage`) use the same advisory lock via `getConversationRankVersionLock`.
+  `finalizeAgentMessage`) use the same advisory lock via `getConversationRankVersionLock`.
 - **One agent message** regardless of how many pending messages were sent. The model sees all
   pending messages as conversation context and generates a single response.
 - **`parentMessageId`** points to the last pending message (highest rank), establishing the
@@ -358,7 +358,7 @@ Agent loop gracefully stops
 | 1 | `front/types/assistant/conversation.ts` | Add `"pending"` to `MessageVisibility`, add `wasPending` to `UserMessageType`, add `UserMessagePromotedEvent` |
 | 2 | `front/lib/models/agent/conversation.ts` | Add `"pending"` to `MessageModel.visibility` validation, add `wasPending` boolean to `MessageModel` |
 | 3 | New migration SQL | Update CHECK constraint on `visibility` column, add `wasPending` column to `messages` table |
-| 4 | `front/lib/api/assistant/conversation.ts` | Constraints + pending path in `postUserMessage`; add `finalizeGracefulStopAgentMessage()` and `finalizeSucceededAgentMessage()` (all locked operations in one file) |
+| 4 | `front/lib/api/assistant/conversation.ts` | Constraints + pending path in `postUserMessage`; add `finalizeGracefulStopAgentMessage()` and `finalizeAgentMessage()` (all locked operations in one file) |
 | 5 | `front/lib/api/assistant/conversation_rendering/helpers.ts` | Add steering instruction to `renderUserMessage()` when `wasPending` is true |
 | 6 | `front/temporal/agent_loop/activities/finalize.ts` | `finalizeGracefullyStoppedAgentLoopActivity` calls `finalizeGracefulStopAgentMessage()`, publishes events, launches new agent loop |
 | 7 | `front/lib/api/assistant/streaming/types.ts` | Add `UserMessagePromotedEvent` to `ConversationEvents` union |
@@ -374,7 +374,7 @@ Dependencies:
 2. **Agent loop ends naturally before graceful stop takes effect** — The advisory lock in
    `postUserMessage` catches this: if status is no longer `"created"`, falls through to normal
    flow. If the race is narrower (pending message created, but loop ends before the signal is
-   processed), `finalizeSucceededAgentMessage` acts as safety net — it acquires the same advisory
+   processed), `finalizeAgentMessage` acts as safety net — it acquires the same advisory
    lock and promotes any orphaned pending messages.
 
 3. **User sends message, then sends another before graceful stop completes** — Both are created


### PR DESCRIPTION
## Description

Add `finalizeSucceededAgentMessage` in conversation.ts that acquires the conversation advisory lock before updating AgentMessageModel status to "succeeded". This serializes the status transition against other conversation operations (preparation for graceful stop and steering).

Update processEventForDatabase to call the new function for agent_message_success events instead of the unlocked updateAgentMessageDBAndMemory.

## Tests

Covered by existing tests. Also tested locally.

## Risk

High touches conversation lifecycle.

## Deploy Plan

- deploy `front`