### PR TITLE
Change subscription warning for enterprise

### DIFF
--- a/front/components/navigation/TrialBanner.tsx
+++ b/front/components/navigation/TrialBanner.tsx
@@ -1,4 +1,7 @@
-import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
+import {
+  isEntreprisePlanPrefix,
+  isFreeTrialPhonePlan,
+} from "@app/lib/plans/plan_codes";
 import type { SubscriptionType } from "@app/types/plan";
 import { Button, cn, LinkWrapper } from "@dust-tt/sparkle";
 import { useMemo, useRef } from "react";
@@ -21,6 +24,7 @@ export function SubscriptionEndBanner({
 }: SubscriptionEndBannerProps) {
   const endDate = subscription.endDate;
   const isTrial = isFreeTrialPhonePlan(subscription.plan.code);
+  const isEnterprise = isEntreprisePlanPrefix(subscription.plan.code);
 
   // Capture initial timestamp in a ref to avoid re-computation on re-renders.
   // This is intentionally not reactive - the banner state is stable for the session.
@@ -51,14 +55,26 @@ export function SubscriptionEndBanner({
   const { hasEnded, daysRemaining } = bannerState;
 
   let title: string;
+  let description: string;
+
   if (isTrial) {
     title = hasEnded
       ? "Heads up, your trial has ended"
       : `Heads up, your trial ends in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}`;
+    description =
+      "When your trial wraps up, your connections and team member access will be removed. Subscribe now to keep everything.";
+  } else if (isEnterprise) {
+    title = hasEnded
+      ? "Your current subscription period has ended"
+      : `Your current subscription period ends in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}`;
+    description =
+      "Please reach out to your account manager to ensure continuity.";
   } else {
     title = hasEnded
       ? "Heads up, your subscription has ended"
       : `Heads up, your subscription ends in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}`;
+    description =
+      "When your subscription wraps up, your connections and team member access will be removed. Subscribe now to keep everything.";
   }
 
   return (
@@ -78,12 +94,10 @@ export function SubscriptionEndBanner({
           {title}
         </span>
         <span className="text-sky-800 dark:text-sky-800-night">
-          When your {isTrial ? "trial" : "subscription"} wraps up, your
-          connections and team member access will be removed. Subscribe now to
-          keep everything.
+          {description}
         </span>
       </div>
-      {isAdmin && (
+      {isAdmin && !isEnterprise && (
         <LinkWrapper
           href={`/w/${owner.sId}/subscription`}
           className="shrink-0 no-underline"

--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -5,6 +5,7 @@ import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import {
+  isEntreprisePlanPrefix,
   isProPlan,
   isUpgraded,
   isWhitelistedBusinessPlan,
@@ -450,17 +451,24 @@ export function SubscriptionPage() {
               title={`Your subscription ends on ${endDate}.`}
               variant="warning"
             >
-              <>
-                Connections will be deleted and members will be revoked. Details{" "}
-                <LinkWrapper
-                  href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
-                  target="_blank"
-                  className="underline"
-                >
-                  here
-                </LinkWrapper>
-                .
-              </>
+              {isEntreprisePlanPrefix(plan.code) ? (
+                <>
+                  Please reach out to your account manager to ensure continuity.
+                </>
+              ) : (
+                <>
+                  Connections will be deleted and members will be revoked.
+                  Details{" "}
+                  <LinkWrapper
+                    href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
+                    target="_blank"
+                    className="underline"
+                  >
+                    here
+                  </LinkWrapper>
+                  .
+                </>
+              )}
             </ContentMessage>
           )}
 


### PR DESCRIPTION
## Description

Soften end-of-subscription warning messages for Enterprise plans.

Fixes https://github.com/dust-tt/tasks/issues/7290

The current wording ("Connections will be deleted and members will be revoked") is too alarming for Enterprise customers in the process of renewing or upgrading.

- **Subscription page** (`SubscriptionPage.tsx`): Enterprise plans show *"Please reach out to your account manager to ensure continuity."* instead of the destructive warning.
- **Navigation banner** (`TrialBanner.tsx`): Enterprise plans get *"Your current subscription period ends in X days"* with *"Please reach out to your account manager to ensure continuity."* The "Subscribe to Dust" button is hidden (not relevant for enterprise).
- Pro plans: description updated to *"When your subscription wraps up, your connections and team member access will be removed. Subscribe now to keep everything."* (unchanged behavior, just refactored alongside enterprise branching).

Non-enterprise plans keep existing behavior unchanged.

## Tests

Type-checking passes. UI-only change, gated on `isEntreprisePlanPrefix(plan.code)`.

## Risk

Low — display-only change scoped to enterprise plan banners. No impact on non-enterprise plans.

## Deploy Plan

Standard deploy, no special steps needed.