### PR TITLE
Change permissions to access all conversations to analyse

### DIFF
--- a/front/lib/reinforced_agent/utils.test.ts
+++ b/front/lib/reinforced_agent/utils.test.ts
@@ -1,0 +1,60 @@
+import { Authenticator } from "@app/lib/auth";
+import { listRecentConversationsForAgent } from "@app/lib/reinforced_agent/utils";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(import("../api/redis"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    runOnRedis: vi.fn().mockImplementation((_, fn) =>
+      fn({
+        zAdd: vi.fn().mockResolvedValue(undefined),
+        expire: vi.fn().mockResolvedValue(undefined),
+      })
+    ),
+  };
+});
+
+describe("listRecentConversationsForAgent", () => {
+  it("should return conversations from a personal project", async () => {
+    const { workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+
+    // Create a project
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+
+    // Refresh user auth after space membership change.
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    // Create a test agent.
+    const agent = await AgentConfigurationFactory.createTestAgent(userAuth, {
+      name: "Test Agent",
+      scope: "hidden",
+    });
+
+    // Create a conversation inside the project space.
+    await ConversationFactory.create(userAuth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+      spaceId: projectSpace.id,
+    });
+
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - 1);
+
+    const results = await listRecentConversationsForAgent(workspace.sId, {
+      agentConfigurationId: agent.sId,
+      cutoffDate,
+    });
+
+    expect(results).toHaveLength(1);
+  });
+});

--- a/front/lib/reinforced_agent/utils.ts
+++ b/front/lib/reinforced_agent/utils.ts
@@ -1,5 +1,9 @@
+import { Authenticator } from "@app/lib/auth";
 import type { ExploratoryToolCallInfo } from "@app/lib/reinforced_agent/types";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
+import { ApplicationFailure } from "@temporalio/common";
 
 /**
  * Build continuation messages from exploratory tool calls and their results.
@@ -40,4 +44,50 @@ export function buildContinuationMessages(
   }
 
   return messages;
+}
+
+export async function getAuthForWorkspace(
+  workspaceId: string
+): Promise<Authenticator> {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    throw ApplicationFailure.nonRetryable(
+      `Workspace not found: ${workspaceId}`
+    );
+  }
+  // The auth need access to all groups to access conversations in projects
+  return Authenticator.internalAdminForWorkspace(workspaceId, {
+    dangerouslyRequestAllGroups: true,
+  });
+}
+
+/**
+ * List recent conversation sIds that involved a specific agent.
+ *
+ * Uses `getAuthForWorkspace` internally so that conversations in personal
+ * projects are included (the auth has access to all groups).
+ */
+export async function listRecentConversationsForAgent(
+  workspaceId: string,
+  {
+    agentConfigurationId,
+    cutoffDate,
+    excludeHumanOutOfTheLoop = true,
+  }: {
+    agentConfigurationId: string;
+    cutoffDate: Date;
+    excludeHumanOutOfTheLoop?: boolean;
+  }
+): Promise<string[]> {
+  const auth = await getAuthForWorkspace(workspaceId);
+
+  const convSIdsByAgent = await ConversationResource.getConversationSIdsByAgent(
+    auth,
+    {
+      agentSIds: [agentConfigurationId],
+      cutoffDate,
+      excludeHumanOutOfTheLoop,
+    }
+  );
+  return convSIdsByAgent.get(agentConfigurationId) ?? [];
 }

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -15,7 +15,7 @@ import {
 import type { BatchStatus } from "@app/lib/api/llm/types/batch";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { notifyAgentSuggestionsReady } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import {
   buildAggregationBatchMap,
@@ -49,11 +49,14 @@ import {
   storeTerminalToolCallResults,
 } from "@app/lib/reinforced_agent/tool_execution";
 import type { ReinforcedOperationType } from "@app/lib/reinforced_agent/types";
+import {
+  getAuthForWorkspace,
+  listRecentConversationsForAgent,
+} from "@app/lib/reinforced_agent/utils";
 import { hasReinforcementEnabled } from "@app/lib/reinforced_agent/workspace_check";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { updateActiveTrace } from "@langfuse/tracing";
@@ -62,18 +65,6 @@ import { ApplicationFailure } from "@temporalio/common";
 // Re-export runToolActivity so the reinforced agent worker registers it,
 // allowing the workflow to call it via proxyActivities.
 export { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
-
-async function getAuthForWorkspace(
-  workspaceId: string
-): Promise<Authenticator> {
-  const workspace = await WorkspaceResource.fetchById(workspaceId);
-  if (!workspace) {
-    throw ApplicationFailure.nonRetryable(
-      `Workspace not found: ${workspaceId}`
-    );
-  }
-  return Authenticator.internalAdminForWorkspace(workspaceId);
-}
 
 /**
  * Common logic for a single reinforced step (analysis or aggregation).
@@ -302,20 +293,13 @@ export async function getRecentConversationsForAgentActivity({
     metadata: { agentConfigurationId },
   });
 
-  const auth = await getAuthForWorkspace(workspaceId);
-
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - conversationLookbackDays);
 
-  const convSIdsByAgent = await ConversationResource.getConversationSIdsByAgent(
-    auth,
-    {
-      agentSIds: [agentConfigurationId],
-      cutoffDate,
-      excludeHumanOutOfTheLoop: true,
-    }
-  );
-  const conversationSIds = convSIdsByAgent.get(agentConfigurationId) ?? [];
+  const conversationSIds = await listRecentConversationsForAgent(workspaceId, {
+    agentConfigurationId,
+    cutoffDate,
+  });
   // TODO(https://github.com/dust-tt/tasks/issues/7313): This is a placeholder for the actual sampling logic
   return conversationSIds.slice(0, maxConversations);
 }


### PR DESCRIPTION
## Description

We need to have access to spaces to be able to list all the conversations even the one inside projects, so I have added `dangerouslyRequestAllGroups: true` to the auth.

Extract the function to list the conversations to a util so I can unit test it.

## Tests

Tested locally + unit tests

## Risk

low: it adds all group access but I think it is justified here as we need read access to all group to read all conversations

## Deploy Plan

deploy front
