### PR TITLE
[Tool Calls] Add normalized tool_call_started event

### DIFF
--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -433,6 +433,7 @@ function eventToStoredStepContent(
     case "success":
     case "text_delta":
     case "token_usage":
+    case "tool_call_started":
     case "tool_call_delta":
       return null;
     default:

--- a/front/lib/api/llm/types/events.ts
+++ b/front/lib/api/llm/types/events.ts
@@ -30,6 +30,16 @@ export interface ReasoningDeltaEvent {
   metadata: LLMClientMetadata & { encrypted_content?: string };
 }
 
+export interface ToolCallStartedEvent {
+  type: "tool_call_started";
+  content: {
+    id?: string;
+    index?: number;
+    name: string;
+  };
+  metadata: LLMClientMetadata;
+}
+
 // Tool call deltas are not streamed to the UI but they are used internally
 // as heartbeat to know the LLM is still active.
 export interface ToolCallDeltaEvent {
@@ -113,6 +123,7 @@ export type LLMEvent =
   | ResponseIdEvent
   | TextDeltaEvent
   | ReasoningDeltaEvent
+  | ToolCallStartedEvent
   | ToolCallDeltaEvent
   | ToolCallEvent
   | TextGeneratedEvent


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/23626
- Add `tool_call_started` to the normalized LLM event union.
- Treat it as a non-persisted batch event so later provider PRs can emit it without changing stored step content.

## Risks
Blast radius: normalized LLM event typing and batch step-content conversion in `front`
Risk: low

## Deploy Plan
- pmrr
- deploy front