### PR TITLE
Reinforced agent: skip analysis and aggregation if no conversation to analyse

### DIFF
--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -204,6 +204,11 @@ export async function reinforcedAgentForAgentWorkflow({
     conversationLookbackDays,
   });
 
+  // No conversations to analyze: skip both analysis and aggregation.
+  if (conversationIds.length === 0) {
+    return;
+  }
+
   if (useBatchMode) {
     // Phase 1: Batch-analyze all conversations with multi-step loop.
     // Each iteration: submit batch → wait → process results → execute tools.


### PR DESCRIPTION
## Description

Avoid useless activities when there is no conversations to analyse.

Here is what it looked like before:

<img width="1800" height="372" alt="image" src="https://github.com/user-attachments/assets/1d362ddb-764d-41aa-bfd7-ad550dca7b11" />

## Tests



## Risk

low

## Deploy Plan

deploy front
