### PR TITLE
[Tool Calls] Emit tool_call_started for OpenAI responses

### DIFF
--- a/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
@@ -239,6 +239,22 @@ function toEvents({
 
       return [reasoningDelta("\n\n", metadata)];
     }
+    case "response.output_item.added":
+      if (event.item.type !== "function_call") {
+        return [];
+      }
+
+      return [
+        {
+          type: "tool_call_started",
+          content: {
+            id: event.item.call_id,
+            index: event.output_index,
+            name: event.item.name,
+          },
+          metadata,
+        },
+      ];
     case "response.function_call_arguments.delta":
       return [{ type: "tool_call_delta", metadata }];
     default:

--- a/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/function_call.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/function_call.ts
@@ -2,6 +2,18 @@ import type { LLMEvent } from "@app/lib/api/llm/types/events";
 
 export const functionCallLLMEvents: LLMEvent[] = [
   {
+    type: "tool_call_started",
+    content: {
+      id: "call_TNG5uqSoWvdMD4MFV6wKCwZT",
+      index: 0,
+      name: "common_utilities__math_operation",
+    },
+    metadata: {
+      clientId: "openai",
+      modelId: "gpt-5",
+    },
+  },
+  {
     type: "tool_call_delta",
     metadata: {
       clientId: "openai",
@@ -10,6 +22,18 @@ export const functionCallLLMEvents: LLMEvent[] = [
   },
   {
     type: "tool_call_delta",
+    metadata: {
+      clientId: "openai",
+      modelId: "gpt-5",
+    },
+  },
+  {
+    type: "tool_call_started",
+    content: {
+      id: "call_XoBlcEPygqXN28I2McKpLSfF",
+      index: 1,
+      name: "web_search_browse__websearch",
+    },
     metadata: {
       clientId: "openai",
       modelId: "gpt-5",


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/23634
- Emit `tool_call_started` from `response.output_item.added` for OpenAI Responses function calls.
- Update the streamed-event fixture so the adapter exposes the tool name and call id before argument deltas.

## Risks
Blast radius: OpenAI Responses-family streaming normalization in `front`
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test TEST_FRONT_DATABASE_URI=postgres://test:test@localhost:5433/dust_front_test_stream_tool_calls TEST_REDIS_URI=redis://localhost:6479 npm test lib/api/llm/utils/openai_like/responses/test/openai_to_events.test.ts`