### PR TITLE
[front] chore: rename sId -> ID in seed script

### DIFF
--- a/front/lib/dev/dust_hive_seed.sql
+++ b/front/lib/dev/dust_hive_seed.sql
@@ -11,7 +11,7 @@
 -- 3. The test outputs a prompt for Claude Code to fix the drift
 --
 -- PARAMETERS (using Sequelize replacements :paramName syntax):
---   :userSid, :workspaceSid, :subscriptionSid
+--   :userId, :workspaceId, :subscriptionId
 --   :email, :username, :name, :firstName, :lastName
 --   :workspaceName
 --   :workOSUserId, :provider, :providerId, :imageUrl
@@ -30,7 +30,7 @@ inserted_user AS (
     "isDustSuperUser", "lastLoginAt", "createdAt", "updatedAt"
   )
   VALUES (
-    :userSid,
+    :userId,
     :username,
     lower(:email),
     :name,
@@ -60,7 +60,7 @@ inserted_workspace AS (
     "workOSOrganizationId", metadata, "createdAt", "updatedAt"
   )
   VALUES (
-    :workspaceSid,
+    :workspaceId,
     :workspaceName,
     NULL,
     NULL,
@@ -157,7 +157,7 @@ inserted_subscription AS (
   )
   SELECT
     w.id,
-    :subscriptionSid,
+    :subscriptionId,
     'active',
     false,
     NULL,

--- a/front/lib/dev/dust_hive_seed_schema.test.ts
+++ b/front/lib/dev/dust_hive_seed_schema.test.ts
@@ -57,9 +57,9 @@ Error details:
 
 describe("dust-hive seed SQL schema compatibility", () => {
   // Test data - these will be cleaned up after the test
-  const testUserSId = generateRandomModelSId();
-  const testWorkspaceSId = generateRandomModelSId();
-  const testSubscriptionSId = generateRandomModelSId();
+  const testUserId = generateRandomModelSId();
+  const testWorkspaceId = generateRandomModelSId();
+  const testSubscriptionId = generateRandomModelSId();
 
   // Track created IDs for cleanup
   let createdUserId: number | null = null;
@@ -126,7 +126,7 @@ describe("dust-hive seed SQL schema compatibility", () => {
     try {
       const result = await frontSequelize.query(seedSql, {
         replacements: {
-          userSid: testUserSId,
+          userId: testUserId,
           username: "test_dust_hive_seed",
           email: `test_dust_hive_${Date.now()}@example.com`,
           name: "Test Dust Hive Seed",
@@ -136,9 +136,9 @@ describe("dust-hive seed SQL schema compatibility", () => {
           provider: null,
           providerId: null,
           imageUrl: null,
-          workspaceSid: testWorkspaceSId,
+          workspaceId: testWorkspaceId,
           workspaceName: "Test Dust Hive Workspace",
-          subscriptionSid: testSubscriptionSId,
+          subscriptionId: testSubscriptionId,
         },
         type: QueryTypes.SELECT,
       });

--- a/front/scripts/seed/queue_user_search_indexation.ts
+++ b/front/scripts/seed/queue_user_search_indexation.ts
@@ -3,32 +3,32 @@ import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/clien
 
 makeScript(
   {
-    userSids: {
+    userIds: {
       type: "array",
       demandOption: true,
       description: "User sIds to queue for user search indexation",
     },
   },
-  async ({ userSids, execute }, logger) => {
-    const uniqueUserSids = [...new Set(userSids)];
+  async ({ userIds, execute }, logger) => {
+    const uniqueUserIds = [...new Set(userIds)];
 
     if (!execute) {
       logger.info(
         {
-          userCount: uniqueUserSids.length,
+          userCount: uniqueUserIds.length,
         },
         "Would queue user search indexation workflows"
       );
       return;
     }
 
-    for (const userSid of uniqueUserSids) {
-      if (typeof userSid !== "string" || userSid.length === 0) {
-        throw new Error("All --userSids values must be non-empty strings");
+    for (const userId of uniqueUserIds) {
+      if (typeof userId !== "string" || userId.length === 0) {
+        throw new Error("All --userIds values must be non-empty strings");
       }
 
       const workflowResult = await launchIndexUserSearchWorkflow({
-        userId: userSid,
+        userId,
       });
       if (workflowResult.isErr()) {
         throw workflowResult.error;
@@ -36,7 +36,7 @@ makeScript(
 
       logger.info(
         {
-          userSid,
+          userId,
         },
         "Queued user search indexation workflow"
       );

--- a/x/henry/dust-hive/src/commands/flag.ts
+++ b/x/henry/dust-hive/src/commands/flag.ts
@@ -5,7 +5,7 @@ import { logger } from "../lib/logger";
 import { getWorktreeDir } from "../lib/paths";
 import { restoreTerminal } from "../lib/prompt";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
-import { WORKSPACE_SID } from "../lib/seed";
+import { WORKSPACE_ID } from "../lib/seed";
 import { getStateInfo } from "../lib/state";
 
 interface FlagInfo {
@@ -92,7 +92,7 @@ export async function flagCommand(
   const disable = Boolean(options?.disable);
   const action = disable ? "Disabling" : "Enabling";
 
-  logger.info(`${action} feature flag '${flagName}' on workspace ${WORKSPACE_SID}...`);
+  logger.info(`${action} feature flag '${flagName}' on workspace ${WORKSPACE_ID}...`);
   console.log();
 
   const args = [
@@ -102,7 +102,7 @@ export async function flagCommand(
     "--featureFlag",
     flagName,
     "--workspaceIds",
-    WORKSPACE_SID,
+    WORKSPACE_ID,
     "--execute",
   ];
 

--- a/x/henry/dust-hive/src/commands/seed-config.ts
+++ b/x/henry/dust-hive/src/commands/seed-config.ts
@@ -16,7 +16,7 @@ export interface SeedUserConfig {
   provider: string | null;
   providerId: string | null;
   imageUrl: string | null;
-  workspaceSId: string;
+  workspaceId: string;
   workspaceName: string;
   extractedAt: string;
   sourceUri: string;
@@ -213,7 +213,7 @@ export async function seedConfigCommand(postgresUri?: string): Promise<Result<vo
     provider: nullableField(f[7]),
     providerId: nullableField(f[8]),
     imageUrl: nullableField(f[9]),
-    workspaceSId: workspace.sId,
+    workspaceId: workspace.sId,
     workspaceName: workspace.name,
     extractedAt: new Date().toISOString(),
     sourceUri: postgresUri.replace(/:[^:@]+@/, ":***@"),

--- a/x/henry/dust-hive/src/lib/seed.ts
+++ b/x/henry/dust-hive/src/lib/seed.ts
@@ -54,7 +54,7 @@ function buildDatabaseUri(envVars: Record<string, string>): string {
   return buildPostgresUri(envVars, "dust_front");
 }
 
-async function listActiveSeededuserIds({
+async function listActiveSeededUserIds({
   databaseUri,
   workspaceId,
 }: {
@@ -142,22 +142,22 @@ async function queueSeededUsersForUserSearchIndexation({
   envShPath: string;
   worktreePath: string;
 }): Promise<void> {
-  const seededuserIds = await listActiveSeededuserIds({
+  const seededUserIds = await listActiveSeededUserIds({
     databaseUri,
     workspaceId,
   });
 
-  if (seededuserIds.length === 0) {
+  if (seededUserIds.length === 0) {
     logger.warn("No active seeded users found for user search indexing.");
     return;
   }
 
-  logger.step(`Queueing user search indexing workflows (${seededuserIds.length} user(s))...`);
+  logger.step(`Queueing user search indexing workflows (${seededUserIds.length} user(s))...`);
 
   const queueResult = await queueUserSearchIndexationWorkflows({
     envShPath,
     worktreePath,
-    userIds: seededuserIds,
+    userIds: seededUserIds,
   });
 
   if (!queueResult.success) {
@@ -171,7 +171,7 @@ async function queueSeededUsersForUserSearchIndexation({
     return;
   }
 
-  logger.success(`Queued user search indexing workflows for ${seededuserIds.length} user(s)`);
+  logger.success(`Queued user search indexing workflows for ${seededUserIds.length} user(s)`);
 }
 
 export async function runSqlSeed(env: Environment): Promise<boolean> {

--- a/x/henry/dust-hive/src/lib/seed.ts
+++ b/x/henry/dust-hive/src/lib/seed.ts
@@ -14,7 +14,7 @@ import { SEED_USER_PATH, getEnvFilePath, getWorktreeDir } from "./paths";
 import { buildShell, shellQuote } from "./shell";
 
 // Keep in sync with front/scripts/seed/* (workspace created by dust-hive seed SQL).
-export const WORKSPACE_SID = "DevWkSpace";
+export const WORKSPACE_ID = "DevWkSpace";
 
 // Generate a random 10-character alphanumeric ID
 // This is compatible with front's generateRandomModelSId() output format
@@ -54,21 +54,21 @@ function buildDatabaseUri(envVars: Record<string, string>): string {
   return buildPostgresUri(envVars, "dust_front");
 }
 
-async function listActiveSeededUserSids({
+async function listActiveSeededuserIds({
   databaseUri,
-  workspaceSid,
+  workspaceId,
 }: {
   databaseUri: string;
-  workspaceSid: string;
+  workspaceId: string;
 }): Promise<string[]> {
-  const escapedWorkspaceSid = workspaceSid.replace(/'/g, "''");
+  const escapedWorkspaceId = workspaceId.replace(/'/g, "''");
 
   const query = `
 SELECT DISTINCT u."sId"
 FROM users u
 JOIN memberships m ON m."userId" = u.id
 JOIN workspaces w ON w.id = m."workspaceId"
-WHERE w."sId" = '${escapedWorkspaceSid}'
+WHERE w."sId" = '${escapedWorkspaceId}'
   AND m."startAt" <= NOW()
   AND (m."endAt" IS NULL OR m."endAt" > NOW());
   `;
@@ -88,29 +88,29 @@ WHERE w."sId" = '${escapedWorkspaceSid}'
     );
   }
 
-  const userSids = stdout
+  const userIds = stdout
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
 
-  return [...new Set(userSids)];
+  return [...new Set(userIds)];
 }
 
 async function queueUserSearchIndexationWorkflows({
   envShPath,
   worktreePath,
-  userSids,
+  userIds,
 }: {
   envShPath: string;
   worktreePath: string;
-  userSids: string[];
+  userIds: string[];
 }): Promise<{ success: boolean; stdout: string; stderr: string }> {
-  const userSidArgs = userSids.map((userSid) => `--userSids ${shellQuote(userSid)}`).join(" ");
+  const userIdArgs = userIds.map((userId) => `--userIds ${shellQuote(userId)}`).join(" ");
 
   const command = buildShell({
     sourceEnv: envShPath,
     sourceNvm: true,
-    run: `npx tsx ./scripts/seed/queue_user_search_indexation.ts --execute ${userSidArgs}`,
+    run: `npx tsx ./scripts/seed/queue_user_search_indexation.ts --execute ${userIdArgs}`,
   });
 
   const proc = Bun.spawn(["bash", "-c", command], {
@@ -133,31 +133,31 @@ async function queueUserSearchIndexationWorkflows({
 
 async function queueSeededUsersForUserSearchIndexation({
   databaseUri,
-  workspaceSid,
+  workspaceId,
   envShPath,
   worktreePath,
 }: {
   databaseUri: string;
-  workspaceSid: string;
+  workspaceId: string;
   envShPath: string;
   worktreePath: string;
 }): Promise<void> {
-  const seededUserSids = await listActiveSeededUserSids({
+  const seededuserIds = await listActiveSeededuserIds({
     databaseUri,
-    workspaceSid,
+    workspaceId,
   });
 
-  if (seededUserSids.length === 0) {
+  if (seededuserIds.length === 0) {
     logger.warn("No active seeded users found for user search indexing.");
     return;
   }
 
-  logger.step(`Queueing user search indexing workflows (${seededUserSids.length} user(s))...`);
+  logger.step(`Queueing user search indexing workflows (${seededuserIds.length} user(s))...`);
 
   const queueResult = await queueUserSearchIndexationWorkflows({
     envShPath,
     worktreePath,
-    userSids: seededUserSids,
+    userIds: seededuserIds,
   });
 
   if (!queueResult.success) {
@@ -171,7 +171,7 @@ async function queueSeededUsersForUserSearchIndexation({
     return;
   }
 
-  logger.success(`Queued user search indexing workflows for ${seededUserSids.length} user(s)`);
+  logger.success(`Queued user search indexing workflows for ${seededuserIds.length} user(s)`);
 }
 
 export async function runSqlSeed(env: Environment): Promise<boolean> {
@@ -184,12 +184,12 @@ export async function runSqlSeed(env: Environment): Promise<boolean> {
 
   const envShPath = getEnvFilePath(env.name);
   const envVars = await loadEnvVars(envShPath);
-  const dbUri = buildDatabaseUri(envVars);
+  const databaseUri = buildDatabaseUri(envVars);
 
   // Generate sIds - workspace uses static ID for consistency across environments
-  const userSid = config.sId ?? generateRandomModelSId();
-  const workspaceSid = WORKSPACE_SID;
-  const subscriptionSid = generateRandomModelSId();
+  const userId = config.sId ?? generateRandomModelSId();
+  const workspaceId = WORKSPACE_ID;
+  const subscriptionId = generateRandomModelSId();
   const username = config.username ?? config.email.split("@")[0];
 
   // Read the SQL file from front (single source of truth)
@@ -211,9 +211,9 @@ export async function runSqlSeed(env: Environment): Promise<boolean> {
   // Replace Sequelize-style :paramName placeholders with actual values
   // Use word boundaries to avoid partial matches (e.g., :provider matching :providerId)
   const finalSql = sql
-    .replace(/:userSid\b/g, escapeSql(userSid))
-    .replace(/:workspaceSid\b/g, escapeSql(workspaceSid))
-    .replace(/:subscriptionSid\b/g, escapeSql(subscriptionSid))
+    .replace(/:userId\b/g, escapeSql(userId))
+    .replace(/:workspaceId\b/g, escapeSql(workspaceId))
+    .replace(/:subscriptionId\b/g, escapeSql(subscriptionId))
     .replace(/:email\b/g, escapeSql(config.email))
     .replace(/:username\b/g, escapeSql(username))
     .replace(/:firstName\b/g, escapeSql(config.firstName))
@@ -226,7 +226,7 @@ export async function runSqlSeed(env: Environment): Promise<boolean> {
     .replace(/:name\b/g, escapeSql(config.name));
 
   // Execute via psql
-  const proc = Bun.spawn(["psql", dbUri, "-c", finalSql], {
+  const proc = Bun.spawn(["psql", databaseUri, "-c", finalSql], {
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -260,8 +260,8 @@ export async function runSqlSeed(env: Environment): Promise<boolean> {
   logger.info("Created subscription");
 
   await queueSeededUsersForUserSearchIndexation({
-    databaseUri: dbUri,
-    workspaceSid,
+    databaseUri,
+    workspaceId,
     envShPath,
     worktreePath,
   }).catch((error) => {


### PR DESCRIPTION
## Description

- This PR renames variables for sqids in the dust-hive `seed` command `xxxSid` -> `xxxId`.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- No deploy.
