### PR TITLE
Hide from user, files generated to offload large action output.

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -459,37 +459,39 @@ export function GenericActionDetails({
             </Collapsible>
           )}
 
-          {action.generatedFiles.length > 0 && (
+          {action.generatedFiles.filter((f) => !f.hidden).length > 0 && (
             <>
               <span className="heading-base">Generated Files</span>
               <div className="flex flex-wrap gap-2">
-                {action.generatedFiles.map((file) => {
-                  if (isSupportedImageContentType(file.contentType)) {
+                {action.generatedFiles
+                  .filter((f) => !f.hidden)
+                  .map((file) => {
+                    if (isSupportedImageContentType(file.contentType)) {
+                      return (
+                        <div
+                          key={file.fileId}
+                          className="h-24 w-24 flex-shrink-0"
+                        >
+                          <img
+                            className="h-full w-full rounded-xl object-cover"
+                            src={`${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`}
+                            alt={`${file.title}`}
+                          />
+                        </div>
+                      );
+                    }
                     return (
-                      <div
-                        key={file.fileId}
-                        className="h-24 w-24 flex-shrink-0"
-                      >
-                        <img
-                          className="h-full w-full rounded-xl object-cover"
-                          src={`${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`}
-                          alt={`${file.title}`}
-                        />
+                      <div key={file.fileId}>
+                        <a
+                          href={`${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {file.title}
+                        </a>
                       </div>
                     );
-                  }
-                  return (
-                    <div key={file.fileId}>
-                      <a
-                        href={`${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {file.title}
-                      </a>
-                    </div>
-                  );
-                })}
+                  })}
               </div>
             </>
           )}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -333,7 +333,7 @@ export function AgentMessage({
             break;
           case "agent_action_success": {
             const action = eventPayload.data.action;
-            if (action.generatedFiles.length > 0) {
+            if (action.generatedFiles.filter((f) => !f.hidden).length > 0) {
               void mutateConversationAttachments();
             }
             if (action.internalMCPServerName === "sandbox") {
@@ -1237,10 +1237,10 @@ function AgentMessageContent({
 
   // Get completed images that are not already referenced in the Markdown content.
   // Combine from actions (updated during streaming) and generatedFiles (available on reload).
-  const filesFromActions = agentMessage.actions.flatMap(
-    (action) => action.generatedFiles
+  const filesFromActions = agentMessage.actions.flatMap((action) =>
+    action.generatedFiles.filter((f) => !f.hidden)
   );
-  const filesFromMessage = agentMessage.generatedFiles;
+  const filesFromMessage = agentMessage.generatedFiles.filter((f) => !f.hidden);
 
   // Combine both sources, preferring actions (more up-to-date during streaming).
   // Dedupe by fileId.
@@ -1259,7 +1259,7 @@ function AgentMessageContent({
     .filter((file) => isSupportedImageContentType(file.contentType))
     .filter((file) => !referencedFileIds.has(file.fileId));
 
-  const generatedFiles = agentMessage.generatedFiles.filter(
+  const generatedFiles = filesFromMessage.filter(
     (file) =>
       !isSupportedImageContentType(file.contentType) &&
       !isInteractiveContentType(file.contentType)

--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -138,9 +138,9 @@ export function ConversationFilesPanel({
 
   const fileRows = useMemo(
     () =>
-      attachments.map((a) =>
-        conversationAttachmentToRow(a, handleAttachmentClick)
-      ),
+      attachments
+        .filter((a) => !a.hidden)
+        .map((a) => conversationAttachmentToRow(a, handleAttachmentClick)),
     [attachments, handleAttachmentClick]
   );
 

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -87,6 +87,7 @@ export function createPlaceholderUserMessage({
             sourceProvider: null,
             sourceIcon: null,
             isInProjectContext: false,
+            hidden: false,
           }) satisfies FileContentFragmentType
       ),
       ...(contentFragments?.contentNodes ?? []).map(

--- a/front/lib/actions/action_file_helpers.ts
+++ b/front/lib/actions/action_file_helpers.ts
@@ -19,13 +19,13 @@ export async function generatePlainTextFile(
     conversationId,
     content,
     snippet,
-    hideFromGeneratedFiles,
+    hideFromUser,
   }: {
     title: string;
     conversationId: string;
     content: string;
     snippet?: string;
-    hideFromGeneratedFiles?: boolean;
+    hideFromUser?: boolean;
   }
 ): Promise<FileResource> {
   const workspace = auth.getNonNullableWorkspace();
@@ -40,7 +40,7 @@ export async function generatePlainTextFile(
     useCase: "tool_output",
     useCaseMetadata: {
       conversationId,
-      ...(hideFromGeneratedFiles ? { hideFromGeneratedFiles: true } : {}),
+      ...(hideFromUser ? { hideFromUser: true } : {}),
     },
     snippet,
   });

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -183,6 +183,7 @@ export async function processToolResults(
               conversationId: conversation.sId,
               content: block.text,
               snippet,
+              hideFromUser: true,
             });
             return {
               content: {
@@ -341,6 +342,7 @@ export async function processToolResults(
                 conversationId: conversation.sId,
                 content: text,
                 snippet,
+                hideFromUser: true,
               });
               return {
                 content: {
@@ -390,7 +392,7 @@ export async function processToolResults(
 
   const generatedFiles: ActionGeneratedFileType[] = removeNulls(
     cleanContent.map((c) => {
-      if (!c.file || c.file.useCaseMetadata?.hideFromGeneratedFiles) {
+      if (!c.file) {
         return null;
       }
 
@@ -402,6 +404,7 @@ export async function processToolResults(
         createdAt: c.file.createdAt.getTime(),
         updatedAt: c.file.updatedAt.getTime(),
         isInProjectContext: c.file.useCase === "project_context",
+        hidden: c.file.useCaseMetadata?.hideFromUser ?? false,
       } satisfies ActionGeneratedFileType;
     })
   );

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -3,8 +3,8 @@ import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversa
 import {
   conversationAttachmentId,
   getAttachmentFromContentFragment,
-  getAttachmentFromFile,
   isFileAttachmentType,
+  makeFileAttachment,
 } from "@app/lib/api/assistant/conversation/attachments";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -68,7 +68,7 @@ export async function getFileFromConversationAttachment(
 
       for (const f of generatedFiles) {
         if (f.fileId === fileId) {
-          attachment = getAttachmentFromFile({
+          attachment = makeFileAttachment({
             fileId: f.fileId,
             source: "agent",
             createdAt: f.createdAt,
@@ -77,6 +77,7 @@ export async function getFileFromConversationAttachment(
             title: f.title,
             snippet: f.snippet,
             isInProjectContext: f.isInProjectContext ?? false,
+            hideFromUser: f.hidden ?? false,
           });
           break;
         }

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -8,7 +8,7 @@ import {
   isToolMarkerResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
-  getAttachmentFromFile,
+  makeFileAttachment,
   renderAttachmentXml,
 } from "@app/lib/api/assistant/conversation/attachments";
 import type { ProcessAndStoreFileError } from "@app/lib/api/files/processing";
@@ -99,13 +99,14 @@ export function rewriteContentForModel(
     isToolGeneratedFile(content) &&
     isSupportedFileContentType(content.resource.contentType)
   ) {
-    const attachment = getAttachmentFromFile({
+    const attachment = makeFileAttachment({
       fileId: content.resource.fileId,
       source: "agent",
       contentType: content.resource.contentType,
       title: content.resource.title,
       snippet: content.resource.snippet,
       isInProjectContext: content.resource.isInProjectContext ?? false,
+      hideFromUser: false, // Model do not care.
     });
     const xml = renderAttachmentXml({ attachment });
     let text = content.resource.text;

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -51,6 +51,7 @@ export type ActionGeneratedFileType = {
   createdAt?: number;
   updatedAt?: number;
   isInProjectContext?: boolean;
+  hidden?: boolean;
 };
 
 export type AgentLoopRunContextType = {

--- a/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
@@ -17,6 +17,7 @@ function makeFileAttachment(
     isQueryable: false,
     creator: null,
     source: null,
+    hidden: false,
     ...partial,
   };
 }

--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -173,6 +173,7 @@ export async function generateProcessToolOutput({
     isInProjectContext: jsonFile.useCase === "project_context",
     createdAt: jsonFile.createdAt.getTime(),
     updatedAt: jsonFile.updatedAt.getTime(),
+    hidden: jsonFile.useCaseMetadata?.hideFromUser ?? false,
   };
   const timeFrameAsString = timeFrame
     ? "the last " +

--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -199,7 +199,7 @@ async function handleWebbrowser(
           conversationId,
           content: fileContent,
           snippet,
-          hideFromGeneratedFiles: true,
+          hideFromUser: true,
         });
 
         await uploadFileToConversationDataSource({ auth, file });

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -190,6 +190,7 @@ export function getLightAgentMessageFromAgentMessage(
         isInProjectContext: f.isInProjectContext,
         createdAt: f.createdAt,
         updatedAt: f.updatedAt,
+        hidden: f.hidden,
       })),
     richMentions: agentMessage.richMentions,
     completionDurationMs: agentMessage.completionDurationMs,

--- a/front/lib/api/assistant/content_fragments.test.ts
+++ b/front/lib/api/assistant/content_fragments.test.ts
@@ -42,6 +42,7 @@ function createMockContentFragment(
     sourceProvider: null,
     sourceIcon: null,
     isInProjectContext: false,
+    hidden: false,
   };
 }
 

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -43,6 +43,7 @@ export type BaseConversationAttachmentType = {
   isQueryable: boolean;
   isInProjectContext: boolean;
   creator: AttachmentCreator | null;
+  hidden: boolean; // Do not show this attachment to the user.
 };
 
 export type FileAttachmentType = BaseConversationAttachmentType & {
@@ -155,6 +156,7 @@ export function getAttachmentFromContentNodeContentFragment(
     isQueryable,
     isSearchable,
     isInProjectContext: false, // For now, content nodes can only be from the conversation, not the project. To be revisited if/when we allow connected data in the projects.
+    hidden: false, // For now, content nodes are not hidden from the user.
     creator,
   };
 
@@ -215,6 +217,7 @@ export function getAttachmentFromFileContentFragment(
     isQueryable,
     isSearchable,
     isInProjectContext: cf.isInProjectContext,
+    hidden: cf.hidden,
     creator,
   };
 
@@ -226,7 +229,7 @@ export function getAttachmentFromFileContentFragment(
   };
 }
 
-export function getAttachmentFromFile({
+export function makeFileAttachment({
   fileId,
   source,
   createdAt,
@@ -235,6 +238,7 @@ export function getAttachmentFromFile({
   title,
   snippet,
   isInProjectContext,
+  hideFromUser,
   creator = null,
 }: {
   fileId: string;
@@ -245,6 +249,7 @@ export function getAttachmentFromFile({
   title: string;
   snippet: string | null;
   isInProjectContext: boolean;
+  hideFromUser: boolean;
   creator?: AttachmentCreator | null;
 }): FileAttachmentType {
   const canDoJIT = snippet !== null;
@@ -267,6 +272,7 @@ export function getAttachmentFromFile({
     isQueryable,
     isSearchable,
     isInProjectContext,
+    hidden: hideFromUser,
     creator,
   };
 }

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -90,6 +90,7 @@ describe("getJITServers", () => {
           isSearchable: true,
           isQueryable: true,
           isInProjectContext: false,
+          hidden: false,
           creator: null,
         },
       ];
@@ -347,6 +348,7 @@ describe("getJITServers", () => {
           isSearchable: true,
           isQueryable: true,
           isInProjectContext: false,
+          hidden: false,
           creator: null,
         },
       ];
@@ -401,6 +403,7 @@ describe("getJITServers", () => {
           isSearchable: true,
           isQueryable: false,
           isInProjectContext: false,
+          hidden: false,
           creator: null,
         },
       ];
@@ -451,6 +454,7 @@ describe("getJITServers", () => {
           isSearchable: true,
           isQueryable: false,
           isInProjectContext: false,
+          hidden: false,
           creator: null,
         },
       ];
@@ -492,6 +496,7 @@ describe("getJITServers", () => {
           isSearchable: false,
           isQueryable: true,
           isInProjectContext: false,
+          hidden: false,
           creator: null,
         },
       ];
@@ -536,6 +541,7 @@ describe("getJITServers", () => {
           isSearchable: false,
           isQueryable: true,
           isInProjectContext: false,
+          hidden: false,
           creator: null,
         },
       ];
@@ -588,6 +594,7 @@ describe("getJITServers", () => {
           isSearchable: true,
           isQueryable: true,
           isInProjectContext: false,
+          hidden: false,
           creator: null,
         },
       ];
@@ -668,6 +675,7 @@ describe("getJITServers", () => {
           isSearchable: true,
           isQueryable: true,
           isInProjectContext: false,
+          hidden: false,
           creator: null,
         },
       ];

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -6,7 +6,7 @@ import type {
 } from "@app/lib/api/assistant/conversation/attachments";
 import {
   getAttachmentFromContentFragment,
-  getAttachmentFromFile,
+  makeFileAttachment,
 } from "@app/lib/api/assistant/conversation/attachments";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -56,7 +56,7 @@ export async function listAttachments(
       for (const f of generatedFiles) {
         attachments.set(
           f.fileId,
-          getAttachmentFromFile({
+          makeFileAttachment({
             fileId: f.fileId,
             source: "agent",
             createdAt: f.createdAt ?? 0,
@@ -65,6 +65,7 @@ export async function listAttachments(
             title: f.title,
             snippet: f.snippet,
             isInProjectContext: f.isInProjectContext ?? false,
+            hideFromUser: f.hidden ?? false,
             creator: agentCreator,
           })
         );
@@ -87,7 +88,7 @@ export async function listAttachments(
       for (const f of files) {
         attachments.set(
           f.sId,
-          getAttachmentFromFile({
+          makeFileAttachment({
             fileId: f.sId,
             source: null,
             createdAt: f.createdAt.getTime(),
@@ -96,6 +97,7 @@ export async function listAttachments(
             title: f.fileName,
             snippet: f.snippet,
             isInProjectContext: true,
+            hideFromUser: f.useCaseMetadata?.hideFromUser ?? false,
           })
         );
       }

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -943,7 +943,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
               outputItems.map((o) => {
                 const file = o.file;
 
-                if (!file || file.useCaseMetadata?.hideFromGeneratedFiles) {
+                if (!file) {
                   return null;
                 }
 
@@ -958,6 +958,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
                   createdAt: file.createdAt.getTime(),
                   updatedAt: file.updatedAt.getTime(),
                   isInProjectContext: file.useCase === "project_context",
+                  hidden: file.useCaseMetadata?.hideFromUser ?? false,
                 };
               })
             ),

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -363,6 +363,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
           sourceProvider: null,
           sourceIcon: null,
           isInProjectContext: null,
+          hidden: true,
         };
       } else if (contentFragmentType === "content_node") {
         return {
@@ -392,6 +393,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       let sourceProvider: string | null = null;
       let sourceIcon: string | null = null;
       let isInProjectContext: boolean = false;
+      let hidden: boolean = true;
 
       // Use pre-fetched file if provided, otherwise fetch it (for backward compatibility)
       const fileResource =
@@ -407,6 +409,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         sourceProvider = fileResource.useCaseMetadata?.sourceProvider ?? null;
         sourceIcon = fileResource.useCaseMetadata?.sourceIcon ?? null;
         isInProjectContext = !!fileResource.useCaseMetadata?.spaceId;
+        hidden = !!fileResource.useCaseMetadata?.hideFromUser;
       }
 
       return {
@@ -421,6 +424,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         sourceProvider,
         sourceIcon,
         isInProjectContext,
+        hidden,
       } satisfies FileContentFragmentType;
     } else if (contentFragmentType === "content_node") {
       assert(

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -88,6 +88,7 @@ export type FileContentFragmentType = BaseContentFragmentType & {
         sourceProvider: string | null;
         sourceIcon: string | null;
         isInProjectContext: boolean;
+        hidden: boolean;
       }
     | {
         expiredReason: ContentFragmentExpiredReason;
@@ -99,6 +100,7 @@ export type FileContentFragmentType = BaseContentFragmentType & {
         sourceProvider: null;
         sourceIcon: null;
         isInProjectContext: null;
+        hidden: boolean;
       }
   );
 

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -40,7 +40,7 @@ export type FileUseCaseMetadata = {
   lastEditedByAgentConfigurationId?: string;
   sourceProvider?: string;
   sourceIcon?: string;
-  hideFromGeneratedFiles?: boolean;
+  hideFromUser?: boolean;
 };
 
 export function isConversationFileUseCase(

--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -23,7 +23,7 @@ procs:
 
   oauth:
     cwd: "<CONFIG_DIR>/../core"
-    shell: "bacon oauth"
+    shell: "RUST_BACKTRACE=1 bacon oauth"
 
   sparkle:
     cwd: "<CONFIG_DIR>/../sparkle"


### PR DESCRIPTION
## Description

Hide from UI (but not from model) files generated to offload large content.
I think my PR 2 weeks ago created a bug where the webbrowse content file was not easily usable by the model.

## Tests

Local, thorough

## Risk

Medium, but confident.

## Deploy Plan

Deploy front