### PR TITLE
Invalidate cache from script

### DIFF
--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -216,6 +216,14 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     WorkspaceResource.workspaceCacheKeyResolver
   );
 
+  /**
+   * Public cache invalidation — for use in scripts where the fire-and-forget
+   * invalidation in update() may not complete before process.exit().
+   */
+  static async invalidateCache(sId: string): Promise<void> {
+    await this.invalidateWorkspaceCache(sId);
+  }
+
   private static fromCachedData(data: CachedWorkspaceData): WorkspaceResource {
     const blob: Attributes<WorkspaceModel> = {
       id: data.id,

--- a/front/scripts/provision_metronome_customers.ts
+++ b/front/scripts/provision_metronome_customers.ts
@@ -69,6 +69,10 @@ async function provisionCustomer(
       return;
     }
 
+    // Explicitly await cache invalidation — the fire-and-forget invalidation
+    // in update() may not complete before the script calls process.exit().
+    await WorkspaceResource.invalidateCache(workspace.sId);
+
     logger.info(
       { workspaceId: workspace.sId, metronomeCustomerId },
       "Metronome customer provisioned and workspace updated"


### PR DESCRIPTION
## Description

Fixes workspace cache not being invalidated when running the Metronome provisioning script from prodbox.

The `WorkspaceResource.update()` method invalidates the Redis cache via a fire-and-forget promise (`invalidateCacheAfterCommit`). In long-running workers this is fine, but in scripts `makeScript` calls `process.exit(0)` immediately after the worker returns — killing the process before the async Redis `DEL` completes.

**Fix:**
- Added public `WorkspaceResource.invalidateCache(sId)` method (wraps the private `invalidateWorkspaceCache`)
- `provision_metronome_customers.ts` now explicitly awaits cache invalidation after updating `metronomeCustomerId`

## Risk

None — adds an explicit await for an operation that was already happening (just not completing in time).

## Deploy Plan

No special steps.