### PR TITLE
feat: simplify butler/todo in one tab

### DIFF
--- a/front/components/assistant/conversation/space/SpaceTodoTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceTodoTab.tsx
@@ -1,0 +1,36 @@
+import { ProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/ProjectTodosPanel";
+import { SpaceUserProjectDigest } from "@app/components/assistant/conversation/space/conversations/SpaceUserProjectDigest";
+import { useSpaceUnreadConversationIds } from "@app/hooks/conversations";
+import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
+import type { LightWorkspaceType } from "@app/types/user";
+
+interface SpaceTodoTabProps {
+  owner: LightWorkspaceType;
+  spaceInfo: GetSpaceResponseBody["space"];
+  hasConversations: boolean;
+}
+
+export function SpaceTodoTab({
+  owner,
+  spaceInfo,
+  hasConversations,
+}: SpaceTodoTabProps) {
+  const { unreadConversationIds } = useSpaceUnreadConversationIds({
+    workspaceId: owner.sId,
+    spaceId: spaceInfo.sId,
+  });
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-y-auto px-6">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 py-8">
+        <SpaceUserProjectDigest
+          owner={owner}
+          space={spaceInfo}
+          hasConversations={hasConversations}
+          unreadCount={unreadConversationIds.length}
+        />
+        <ProjectTodosPanel owner={owner} spaceId={spaceInfo.sId} />
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -195,18 +195,12 @@ function TodoItem({ todo, isPendingDone, onMarkDone }: TodoItemProps) {
 interface ProjectTodosPanelProps {
   owner: LightWorkspaceType;
   spaceId: string;
-  hasFeatureFlagProjectTodo: boolean;
 }
 
-export function ProjectTodosPanel({
-  owner,
-  spaceId,
-  hasFeatureFlagProjectTodo,
-}: ProjectTodosPanelProps) {
+export function ProjectTodosPanel({ owner, spaceId }: ProjectTodosPanelProps) {
   const { todos, isTodosLoading, mutateTodos } = useProjectTodos({
     owner,
     spaceId,
-    disabled: !hasFeatureFlagProjectTodo,
   });
   const doCreate = useCreateProjectTodo({ owner, spaceId });
   const doUpdate = useUpdateProjectTodo({ owner, spaceId });

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -1,10 +1,8 @@
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { ProjectKickoffButton } from "@app/components/assistant/conversation/space/conversations/ProjectKickoffButton";
-import { ProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/ProjectTodosPanel";
 import { SpaceConversationListItem } from "@app/components/assistant/conversation/space/conversations/SpaceConversationListItem";
 import { SpaceConversationsActions } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsActions";
 import { SpaceLoadingConversationListItem } from "@app/components/assistant/conversation/space/conversations/SpaceLoadingConversationListItem";
-import { SpaceUserProjectDigest } from "@app/components/assistant/conversation/space/conversations/SpaceUserProjectDigest";
 import { getGroupConversationsByDate } from "@app/components/assistant/conversation/utils";
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
@@ -12,7 +10,6 @@ import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
 import { useSpaceUnreadConversationIds } from "@app/hooks/conversations";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useSearchConversations } from "@app/hooks/useSearchConversations";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
@@ -76,7 +73,6 @@ export function SpaceConversationsTab({
   onOpenMembersPanel,
 }: SpaceConversationsTabProps) {
   const { isEditor: isProjectEditor } = spaceInfo;
-  const { hasFeature } = useFeatureFlags();
   const router = useAppRouter();
   const hasHistory = useMemo(() => conversations.length > 0, [conversations]);
 
@@ -163,23 +159,6 @@ export function SpaceConversationsTab({
               />
             )}
           </div>
-
-          {hasFeature("project_butler") && (
-            <SpaceUserProjectDigest
-              owner={owner}
-              space={spaceInfo}
-              hasConversations={hasHistory}
-              unreadCount={unreadConversationIds.length}
-            />
-          )}
-
-          {hasFeature("project_todo") && (
-            <ProjectTodosPanel
-              owner={owner}
-              spaceId={spaceInfo.sId}
-              hasFeatureFlagProjectTodo={hasFeature("project_todo")}
-            />
-          )}
 
           {/* Suggestions for empty rooms */}
           {!hasHistory && !isConversationsLoading && (

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -4,12 +4,17 @@ import { ManageUsersPanel } from "@app/components/assistant/conversation/space/M
 import { ProjectHeaderActions } from "@app/components/assistant/conversation/space/ProjectHeaderActions";
 import { SpaceAlphaTab } from "@app/components/assistant/conversation/space/SpaceAlphaTab";
 import { SpaceKnowledgeTab } from "@app/components/assistant/conversation/space/SpaceKnowledgeTab";
+import { SpaceTodoTab } from "@app/components/assistant/conversation/space/SpaceTodoTab";
 import { useSpaceConversations } from "@app/hooks/conversations";
 import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
@@ -30,6 +35,7 @@ import {
   BookOpenIcon,
   ChatBubbleLeftRightIcon,
   Cog6ToothIcon,
+  ListCheckIcon,
   Spinner,
   Tabs,
   TabsContent,
@@ -39,11 +45,12 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useCallback, useRef, useState } from "react";
 
-type SpaceTab = "conversations" | "knowledge" | "settings";
+type SpaceTab = "conversations" | "knowledge" | "settings" | "todo";
 
 export function SpaceConversationsPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
+  const { hasFeature } = useFeatureFlags();
   const clientType = useClientType();
   const router = useAppRouter();
   const spaceId = useActiveSpaceId();
@@ -94,7 +101,8 @@ export function SpaceConversationsPage() {
     if (
       hash === "knowledge" ||
       hash === "settings" ||
-      hash === "conversations"
+      hash === "conversations" ||
+      hash === "todo"
     ) {
       return hash;
     }
@@ -333,6 +341,9 @@ export function SpaceConversationsPage() {
                 />
               </>
             )}
+            {hasFeature("project_todo") && (
+              <TabsTrigger value="todo" label="Todo" icon={ListCheckIcon} />
+            )}
             <TabsTrigger
               value="settings"
               icon={Cog6ToothIcon}
@@ -387,6 +398,17 @@ export function SpaceConversationsPage() {
             onOpenMembersPanel={() => setIsInvitePanelOpen(true)}
           />
         </TabsContent>
+
+        {hasFeature("project_todo") && (
+          <TabsContent value="todo">
+            <SpaceTodoTab
+              key={spaceId}
+              owner={owner}
+              spaceInfo={spaceInfo}
+              hasConversations={conversations.length > 0}
+            />
+          </TabsContent>
+        )}
 
         <TabsContent value="alpha">
           <SpaceAlphaTab key={spaceId} />

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests.ts
@@ -24,13 +24,12 @@ async function handler(
   { space }: { space: SpaceResource }
 ): Promise<void> {
   const featureFlags = await getFeatureFlags(auth);
-  if (!featureFlags.includes("project_butler")) {
+  if (!featureFlags.includes("project_todo")) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
         type: "feature_flag_not_found",
-        message:
-          "The project butler feature is not enabled for this workspace.",
+        message: "The project todo feature is not enabled for this workspace.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests/generate.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests/generate.test.ts
@@ -27,7 +27,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/user_project_digests/generate", () 
     const resourceTest = await createResourceTest({});
     workspace = resourceTest.workspace;
     auth = resourceTest.authenticator;
-    await FeatureFlagFactory.basic(auth, "project_butler");
+    await FeatureFlagFactory.basic(auth, "project_todo");
   });
 
   it("should successfully trigger digest generation for a project space", async () => {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests/generate/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests/generate/index.ts
@@ -26,13 +26,12 @@ export async function handler(
   { space }: { space: SpaceResource }
 ): Promise<void> {
   const featureFlags = await getFeatureFlags(auth);
-  if (!featureFlags.includes("project_butler")) {
+  if (!featureFlags.includes("project_todo")) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
         type: "feature_flag_not_found",
-        message:
-          "The project butler feature is not enabled for this workspace.",
+        message: "The project todo feature is not enabled for this workspace.",
       },
     });
   }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -203,10 +203,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Discord bot integration for workspace-level Discord integration",
     stage: "dust_only",
   },
-  project_butler: {
-    description: "Enable user project digest generation in project spaces",
-    stage: "dust_only",
-  },
   projects: {
     description: "Enable use Spaces as Projects",
     stage: "dust_only",
@@ -230,7 +226,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
   },
   project_todo: {
-    description: "Enable project todo feature",
+    description: "Enable project todo tab (todos and what's new digest)",
     stage: "dust_only",
   },
   conversations_slack_notifications: {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -683,7 +683,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "confluence_tool"
   | "conversation_butler"
   | "conversation_branches"
-  | "project_butler"
   | "project_todo"
   | "projects"
   | "databricks_tool"


### PR DESCRIPTION
## Description

Following @Duncid's idea, putting the summary and the todo in one tab in projects. 

I took the liberty to keep only 1 feature flag for both features, as we'll merge them eventually

<img width="913" height="546" alt="image" src="https://github.com/user-attachments/assets/b2b3dcca-347c-480c-8387-3a75f25e6281" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
