### PR TITLE
Add poke filter for source in suggestions

### DIFF
--- a/front/components/poke/suggestions/columns.tsx
+++ b/front/components/poke/suggestions/columns.tsx
@@ -134,6 +134,9 @@ export function makeColumnsForSuggestions(
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Source" />
       ),
+      filterFn: (row, id, value) => {
+        return value.includes(row.getValue(id));
+      },
     },
     {
       accessorKey: "conversationId",

--- a/front/components/poke/suggestions/table.tsx
+++ b/front/components/poke/suggestions/table.tsx
@@ -7,6 +7,7 @@ import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import {
   AGENT_SUGGESTION_KINDS,
+  AGENT_SUGGESTION_SOURCES,
   AGENT_SUGGESTION_STATES,
 } from "@app/types/suggestions/agent_suggestion";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -89,6 +90,14 @@ export function SuggestionDataTable({
       options: AGENT_SUGGESTION_STATES.map((state) => ({
         label: asDisplayName(state),
         value: state,
+      })),
+    },
+    {
+      columnId: "source",
+      title: "Source",
+      options: AGENT_SUGGESTION_SOURCES.map((source) => ({
+        label: asDisplayName(source),
+        value: source,
       })),
     },
   ];


### PR DESCRIPTION
## Description

Make it easier to select the reinforcement or sidekick suggestions

<img width="3332" height="1118" alt="image" src="https://github.com/user-attachments/assets/8c56be7b-9ee1-4da2-9431-a867a59648dd" />

## Tests

tested locally

## Risk

low, it's poke

## Deploy Plan

deploy front