### PR TITLE
[front] chore: refactor error handling of conversation destroy

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -27,10 +27,7 @@ import {
   ProjectTodoSourceModel,
 } from "@app/lib/resources/storage/models/project_todo";
 import { UserProjectDigestModel } from "@app/lib/resources/storage/models/user_project_digest";
-import type {
-  ConversationError,
-  ConversationWithoutContentType,
-} from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -186,7 +183,7 @@ export async function destroyConversation(
   }: {
     conversation: ConversationResource;
   }
-): Promise<Result<void, ConversationError>> {
+): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
   // Clean up all branches attached to this conversation before deleting messages.
@@ -333,7 +330,7 @@ export async function destroyConversation(
   // );
   const result = await conversation.delete(auth);
   if (result.isErr()) {
-    throw result.error;
+    return result;
   }
 
   return new Ok(undefined);

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -254,7 +254,7 @@ async function deleteSpaceConversations(
     conversations,
     async (conversation) => {
       const result = await destroyConversation(auth, { conversation });
-      if (result.isErr() && result.error.type !== "conversation_not_found") {
+      if (result.isErr()) {
         throw result.error;
       }
     },

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -86,17 +86,6 @@ export async function purgeConversationsBatchActivity({
       async (conversation) => {
         const result = await destroyConversation(auth, { conversation });
         if (result.isErr()) {
-          if (result.error.type === "conversation_not_found") {
-            logger.warn(
-              {
-                workspaceId,
-                conversationId: conversation.sId,
-                error: result.error,
-              },
-              "Attempting to delete a non-existing conversation."
-            );
-            return;
-          }
           throw result.error;
         }
         deletedCount++;
@@ -203,17 +192,6 @@ export async function purgeAgentConversationsBatchActivity({
       }
       const result = await destroyConversation(auth, { conversation });
       if (result.isErr()) {
-        if (result.error.type === "conversation_not_found") {
-          logger.warn(
-            {
-              workspaceId,
-              conversationId,
-              error: result.error,
-            },
-            "Attempting to delete a non-existing conversation."
-          );
-          return;
-        }
         throw result.error;
       }
     },

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -193,17 +193,6 @@ export async function deleteAllConversations(auth: Authenticator) {
     async (conversation) => {
       const result = await destroyConversation(auth, { conversation });
       if (result.isErr()) {
-        if (result.error.type === "conversation_not_found") {
-          logger.warn(
-            {
-              workspaceId: workspace.sId,
-              conversationId: conversation.sId,
-              error: result.error,
-            },
-            "Attempting to delete a non-existing conversation."
-          );
-          return;
-        }
         throw result.error;
       }
     },


### PR DESCRIPTION
## Description

- This PR cleans up the error handling of `destroyConversation`.
- Relies on a Result instead of throwing.
- Simplifies the type and call sites as it never returns a `ConversationError`.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
