### PR TITLE
[front] perf: remove N+1 queries on conversations in deletion path

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -509,7 +509,7 @@ describe("listConversationWithAgentCreatedBeforeDate", () => {
           cutoffDate: dateFromDaysAgo(1),
         }
       );
-    
+
     const conversationsAgent1Ids = conversationsAgent1.map((c) => c.sId);
     expect(conversationsAgent1.length).toBe(1);
     expect(conversationsAgent1Ids).toContain(convo4Id);

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -479,9 +479,11 @@ describe("listConversationWithAgentCreatedBeforeDate", () => {
           cutoffDate: dateFromDaysAgo(7),
         }
       );
+
+    const conversationIds = conversations.map((c) => c.sId);
     expect(conversations.length).toBe(2);
-    expect(conversations).toContain(convo1Id);
-    expect(conversations).toContain(convo2Id);
+    expect(conversationIds).toContain(convo1Id);
+    expect(conversationIds).toContain(convo2Id);
   });
   it("should return only conversations created before cutoff date and with the valid agent: 1 day ago", async () => {
     const conversationsAgent0 =
@@ -492,10 +494,12 @@ describe("listConversationWithAgentCreatedBeforeDate", () => {
           cutoffDate: dateFromDaysAgo(1),
         }
       );
+
+    const conversationsAgent0Ids = conversationsAgent0.map((c) => c.sId);
     expect(conversationsAgent0.length).toBe(3);
-    expect(conversationsAgent0).toContain(convo1Id);
-    expect(conversationsAgent0).toContain(convo2Id);
-    expect(conversationsAgent0).toContain(convo3Id);
+    expect(conversationsAgent0Ids).toContain(convo1Id);
+    expect(conversationsAgent0Ids).toContain(convo2Id);
+    expect(conversationsAgent0Ids).toContain(convo3Id);
 
     const conversationsAgent1 =
       await ConversationResource.listConversationWithAgentCreatedBeforeDate(
@@ -505,8 +509,10 @@ describe("listConversationWithAgentCreatedBeforeDate", () => {
           cutoffDate: dateFromDaysAgo(1),
         }
       );
+    
+    const conversationsAgent1Ids = conversationsAgent1.map((c) => c.sId);
     expect(conversationsAgent1.length).toBe(1);
-    expect(conversationsAgent1).toContain(convo4Id);
+    expect(conversationsAgent1Ids).toContain(convo4Id);
   });
 });
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -612,7 +612,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       cutoffDate: Date;
     },
     options?: FetchConversationOptions
-  ): Promise<string[]> {
+  ): Promise<ConversationResource[]> {
     // Find all conversations that:
     // 1. Were created before the cutoff date.
     // 2. Have at least one message from the specified agent.
@@ -651,7 +651,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     // Step 2: Filter conversations by creation date.
     const conversationIds = messageWithAgent.map((m) => m.conversationId);
-    const conversations = await this.baseFetchWithAuthorization(auth, options, {
+    return this.baseFetchWithAuthorization(auth, options, {
       where: {
         id: {
           [Op.in]: conversationIds,
@@ -661,8 +661,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         },
       },
     });
-
-    return conversations.map((c) => c.sId);
   }
 
   /**

--- a/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
@@ -53,7 +53,7 @@ async function handler(
           );
       } else if (isString(agentId)) {
         // Get conversation IDs for this agent
-        const conversationIds =
+        const conversationResources =
           await ConversationResource.listConversationWithAgentCreatedBeforeDate(
             auth,
             {
@@ -61,12 +61,6 @@ async function handler(
               cutoffDate: new Date(), // Current time to get all conversations.
             }
           );
-
-        // Fetch full conversation objects
-        const conversationResources = await ConversationResource.fetchByIds(
-          auth,
-          conversationIds
-        );
 
         conversations = conversationResources.map((c) => {
           return {

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -155,7 +155,7 @@ export async function purgeAgentConversationsBatchActivity({
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
 
-  const conversationIds =
+  const conversations =
     await ConversationResource.listConversationWithAgentCreatedBeforeDate(
       auth,
       {
@@ -170,26 +170,8 @@ export async function purgeAgentConversationsBatchActivity({
     );
 
   await concurrentExecutor(
-    conversationIds,
-    async (conversationId) => {
-      const conversation = await ConversationResource.fetchById(
-        auth,
-        conversationId,
-        {
-          dangerouslySkipPermissionFiltering: true,
-          includeDeleted: true,
-        }
-      );
-      if (!conversation) {
-        logger.warn(
-          {
-            workspaceId,
-            conversationId,
-          },
-          "Conversation not found."
-        );
-        return;
-      }
+    conversations,
+    async (conversation) => {
       const result = await destroyConversation(auth, { conversation });
       if (result.isErr()) {
         throw result.error;
@@ -205,6 +187,6 @@ export async function purgeAgentConversationsBatchActivity({
     workspaceModelId: workspace.id,
     workspaceId: workspace.sId,
     retentionDays,
-    nbConversationsDeleted: conversationIds.length,
+    nbConversationsDeleted: conversations.length,
   };
 }


### PR DESCRIPTION
## Description

- This PR removes two N + 1 queries on conversations, one in the data retention and one in the endpoint `/api/poke/workspaces/[wId]/conversations`.
- In both code paths we re-fetch in a loop conversations we had already fetched.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
