### PR TITLE
[front] feat: add event types for `ask_user_question`

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -647,6 +647,9 @@ async function streamAgentAnswerToSlack(
 
       case "agent_context_pruned":
       case "agent_message_done":
+      // TODO(2026-04-02 ask-user-question): add support for the AskUserQuestion tool on Slack.
+      // Temporarily we will not add the tool for messages coming from Slack to avoid receiving this event at all here.
+      case "tool_ask_user_question":
         // No-op.
         break;
 

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -75,7 +75,7 @@ export interface MCPApproveExecutionEvent extends ToolExecution {
 
 export interface ToolAskUserQuestionEvent extends ToolExecution {
   type: "tool_ask_user_question";
-  questions: UserQuestion[];
+  question: UserQuestion;
   questionMetadata: Record<string, unknown> | null;
 }
 

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -2,6 +2,7 @@ import type {
   MCPToolStakeLevelType,
   MCPValidationMetadataType,
 } from "@app/lib/actions/constants";
+import type { UserQuestion } from "@app/lib/actions/types";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 
 export interface ToolExecution<
@@ -70,6 +71,12 @@ export interface ToolFileAuthRequiredEvent
 
 export interface MCPApproveExecutionEvent extends ToolExecution {
   type: "tool_approve_execution";
+}
+
+export interface ToolAskUserQuestionEvent extends ToolExecution {
+  type: "tool_ask_user_question";
+  questions: UserQuestion[];
+  questionMetadata: Record<string, unknown> | null;
 }
 
 export type ToolEarlyExitEvent = {

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -3,7 +3,6 @@ import {
   INTERNAL_ALLOWED_ICONS,
 } from "@app/components/resources/resources_icon_names";
 import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
-import { UserQuestionSchema } from "@app/lib/actions/types";
 import { CONNECTOR_PROVIDERS } from "@app/types/data_source";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { ALL_FILE_FORMATS } from "@app/types/files";
@@ -1069,15 +1068,6 @@ export const EarlyExitOutputResourceSchema = z.object({
 export type EarlyExitOutputResourceType = z.infer<
   typeof EarlyExitOutputResourceSchema
 >;
-
-export const UserAnswerRequiredOutputResourceSchema = z.object({
-  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT),
-  type: z.literal("tool_user_answer_required"),
-  questions: z.array(UserQuestionSchema),
-  metadata: z.record(z.unknown()).nullable(),
-  text: z.string(),
-  uri: z.string(),
-});
 
 export const AgentPauseOutputResourceSchema = z.union([
   AuthRequiredOutputResourceSchema,

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -3,6 +3,7 @@ import {
   INTERNAL_ALLOWED_ICONS,
 } from "@app/components/resources/resources_icon_names";
 import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
+import { UserQuestionSchema } from "@app/lib/actions/types";
 import { CONNECTOR_PROVIDERS } from "@app/types/data_source";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { ALL_FILE_FORMATS } from "@app/types/files";
@@ -1068,6 +1069,15 @@ export const EarlyExitOutputResourceSchema = z.object({
 export type EarlyExitOutputResourceType = z.infer<
   typeof EarlyExitOutputResourceSchema
 >;
+
+export const UserAnswerRequiredOutputResourceSchema = z.object({
+  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT),
+  type: z.literal("tool_user_answer_required"),
+  questions: z.array(UserQuestionSchema),
+  metadata: z.record(z.unknown()).nullable(),
+  text: z.string(),
+  uri: z.string(),
+});
 
 export const AgentPauseOutputResourceSchema = z.union([
   AuthRequiredOutputResourceSchema,

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -39,42 +39,6 @@ export const UserQuestionSchema = z.object({
 
 export type UserQuestion = z.infer<typeof UserQuestionSchema>;
 
-const UserQuestionResumeStateSchema = z.object({
-  type: z.literal("user_question"),
-  questions: z.array(UserQuestionSchema),
-  metadata: z.record(z.unknown()).optional(),
-});
-
-export type UserQuestionResumeState = z.infer<
-  typeof UserQuestionResumeStateSchema
->;
-
-export function isUserQuestionResumeState(
-  value: Record<string, unknown> | null
-): value is UserQuestionResumeState {
-  return UserQuestionResumeStateSchema.safeParse(value).success;
-}
-
-export const UserQuestionAnswerItemSchema = z.object({
-  selectedOptions: z.array(z.number()),
-  customResponse: z.string().optional(),
-});
-
-export type UserQuestionAnswerItem = z.infer<
-  typeof UserQuestionAnswerItemSchema
->;
-
-const UserQuestionAnswersSchema = z.object({
-  answers: z.array(UserQuestionAnswerItemSchema),
-});
-
-export type UserQuestionAnswers = z.infer<typeof UserQuestionAnswersSchema>;
-
-export function isUserQuestionAnswers(
-  value: unknown
-): value is UserQuestionAnswers {
-  return UserQuestionAnswersSchema.safeParse(value).success;
-}
 
 export type StepContext = {
   citationsCount: number;

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -39,7 +39,6 @@ export const UserQuestionSchema = z.object({
 
 export type UserQuestion = z.infer<typeof UserQuestionSchema>;
 
-
 export type StepContext = {
   citationsCount: number;
   citationsOffset: number;

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -28,7 +28,7 @@ export function isFileAuthorizationInfo(
 
 const UserQuestionOptionSchema = z.object({
   label: z.string(),
-  description: z.string(),
+  description: z.string().nullable(),
 });
 
 export const UserQuestionSchema = z.object({

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -9,29 +9,71 @@ import type {
   ConversationType,
 } from "@app/types/assistant/conversation";
 import type { AllSupportedFileContentType } from "@app/types/files";
+import { z } from "zod";
 
-export type FileAuthorizationInfo = {
-  fileId: string;
-  fileName: string;
-  connectionId: string;
-  mimeType: string;
-};
+const FileAuthorizationInfoSchema = z.object({
+  fileId: z.string(),
+  fileName: z.string(),
+  connectionId: z.string(),
+  mimeType: z.string(),
+});
+
+export type FileAuthorizationInfo = z.infer<typeof FileAuthorizationInfoSchema>;
 
 export function isFileAuthorizationInfo(
   value: unknown
 ): value is FileAuthorizationInfo {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "fileId" in value &&
-    typeof (value as Record<string, unknown>).fileId === "string" &&
-    "fileName" in value &&
-    typeof (value as Record<string, unknown>).fileName === "string" &&
-    "connectionId" in value &&
-    typeof (value as Record<string, unknown>).connectionId === "string" &&
-    "mimeType" in value &&
-    typeof (value as Record<string, unknown>).mimeType === "string"
-  );
+  return FileAuthorizationInfoSchema.safeParse(value).success;
+}
+
+const UserQuestionOptionSchema = z.object({
+  label: z.string(),
+  description: z.string(),
+});
+
+export const UserQuestionSchema = z.object({
+  question: z.string(),
+  options: z.array(UserQuestionOptionSchema),
+  multiSelect: z.boolean(),
+});
+
+export type UserQuestion = z.infer<typeof UserQuestionSchema>;
+
+const UserQuestionResumeStateSchema = z.object({
+  type: z.literal("user_question"),
+  questions: z.array(UserQuestionSchema),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type UserQuestionResumeState = z.infer<
+  typeof UserQuestionResumeStateSchema
+>;
+
+export function isUserQuestionResumeState(
+  value: Record<string, unknown> | null
+): value is UserQuestionResumeState {
+  return UserQuestionResumeStateSchema.safeParse(value).success;
+}
+
+export const UserQuestionAnswerItemSchema = z.object({
+  selectedOptions: z.array(z.number()),
+  customResponse: z.string().optional(),
+});
+
+export type UserQuestionAnswerItem = z.infer<
+  typeof UserQuestionAnswerItemSchema
+>;
+
+const UserQuestionAnswersSchema = z.object({
+  answers: z.array(UserQuestionAnswerItemSchema),
+});
+
+export type UserQuestionAnswers = z.infer<typeof UserQuestionAnswersSchema>;
+
+export function isUserQuestionAnswers(
+  value: unknown
+): value is UserQuestionAnswers {
+  return UserQuestionAnswersSchema.safeParse(value).success;
 }
 
 export type StepContext = {

--- a/sdks/js/src/output_schemas.ts
+++ b/sdks/js/src/output_schemas.ts
@@ -649,15 +649,6 @@ export const UserQuestionItemSchema = z.object({
   multiSelect: z.boolean(),
 });
 
-export const UserAnswerRequiredOutputResourceSchema = z.object({
-  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT),
-  type: z.literal("tool_user_answer_required"),
-  questions: z.array(UserQuestionItemSchema),
-  metadata: z.record(z.unknown()).nullable(),
-  text: z.string(),
-  uri: z.string(),
-});
-
 export const AgentPauseOutputResourceSchema = z.union([
   AuthRequiredOutputResourceSchema,
   BlockedAwaitingInputOutputResourceSchema,

--- a/sdks/js/src/output_schemas.ts
+++ b/sdks/js/src/output_schemas.ts
@@ -643,7 +643,7 @@ export const UserQuestionItemSchema = z.object({
   options: z.array(
     z.object({
       label: z.string(),
-      description: z.string(),
+      description: z.string().nullable(),
     })
   ),
   multiSelect: z.boolean(),

--- a/sdks/js/src/output_schemas.ts
+++ b/sdks/js/src/output_schemas.ts
@@ -638,6 +638,26 @@ export const FileAuthRequiredOutputResourceSchema = z.object({
   uri: z.string(),
 });
 
+export const UserQuestionItemSchema = z.object({
+  question: z.string(),
+  options: z.array(
+    z.object({
+      label: z.string(),
+      description: z.string(),
+    })
+  ),
+  multiSelect: z.boolean(),
+});
+
+export const UserAnswerRequiredOutputResourceSchema = z.object({
+  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT),
+  type: z.literal("tool_user_answer_required"),
+  questions: z.array(UserQuestionItemSchema),
+  metadata: z.record(z.unknown()).nullable(),
+  text: z.string(),
+  uri: z.string(),
+});
+
 export const AgentPauseOutputResourceSchema = z.union([
   AuthRequiredOutputResourceSchema,
   BlockedAwaitingInputOutputResourceSchema,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1352,7 +1352,7 @@ const BlockedActionExecutionSchema = ToolExecutionMetadataSchema.extend({
   conversationId: z.string(),
   status: ToolExecutionBlockedStatusSchema,
   // Present only when status is "blocked_user_question_required".
-  questions: z.array(UserQuestionItemSchema).optional(),
+  question: UserQuestionItemSchema.optional(),
   questionMetadata: z.record(z.unknown()).nullish(),
 });
 
@@ -1445,7 +1445,7 @@ const ToolAskUserQuestionEventSchema = ToolExecutionMetadataSchema.extend({
   conversationId: z.string(),
   created: z.number(),
   messageId: z.string(),
-  questions: z.array(UserQuestionItemSchema),
+  question: UserQuestionItemSchema,
   questionMetadata: z.record(z.unknown()).nullable(),
 });
 

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -9,6 +9,7 @@ import {
 import {
   NotificationInteractiveContentFileContentSchema,
   OAuthProviderSchema,
+  UserQuestionItemSchema,
 } from "./output_schemas";
 import { CallToolResultSchema, ContentBlockSchema } from "./raw_mcp_types";
 import { TIMEZONE_NAMES } from "./timezone_names";
@@ -1350,6 +1351,9 @@ const BlockedActionExecutionSchema = ToolExecutionMetadataSchema.extend({
   messageId: z.string(),
   conversationId: z.string(),
   status: ToolExecutionBlockedStatusSchema,
+  // Present only when status is "blocked_user_question_required".
+  questions: z.array(UserQuestionItemSchema).optional(),
+  questionMetadata: z.record(z.unknown()).nullish(),
 });
 
 export type BlockedActionExecutionType = z.infer<
@@ -1434,11 +1438,27 @@ const AgentErrorEventSchema = z.object({
 });
 export type AgentErrorEvent = z.infer<typeof AgentErrorEventSchema>;
 
+const ToolAskUserQuestionEventSchema = ToolExecutionMetadataSchema.extend({
+  type: z.literal("tool_ask_user_question"),
+  userId: z.string().optional(),
+  configurationId: z.string(),
+  conversationId: z.string(),
+  created: z.number(),
+  messageId: z.string(),
+  questions: z.array(UserQuestionItemSchema),
+  questionMetadata: z.record(z.unknown()).nullable(),
+});
+
+export type ToolAskUserQuestionEvent = z.infer<
+  typeof ToolAskUserQuestionEventSchema
+>;
+
 const AgentActionSpecificEventSchema = z.union([
   MCPParamsEventSchema,
   ToolNotificationEventSchema,
   MCPApproveExecutionEventSchema,
   ToolPersonalAuthRequiredEventSchema,
+  ToolAskUserQuestionEventSchema,
 ]);
 export type AgentActionSpecificEvent = z.infer<
   typeof AgentActionSpecificEventSchema


### PR DESCRIPTION
## Description

- This PR adds types and zod schemas for a new type of event `tool_ask_user_question`.
- Defines what will be surfaced to the front-end: we need the question ("what authentication system are you using?"), a few options ("OAuth", "JWT") with some optional descriptions, and whether it's multi choice.
- This event will be emitted by a new `ask_user_question` tool that will allow the agent to pause its execution mid-loop and present the user with one or more structured multiple-choice questions before continuing.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
