### PR TITLE
Ensure transactionId uniqueness

### DIFF
--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -36,7 +36,7 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import { isDevelopment } from "@app/types/shared/env";
-import { createHash } from "crypto";
+import { Context } from "@temporalio/activity";
 
 export async function recordUsageActivity(workspaceId: string) {
   const workspace = await WorkspaceResource.fetchById(workspaceId);
@@ -298,12 +298,10 @@ export async function emitMetronomeUsageEventsActivity(
   );
   const messageTier = classifyMessageTier({ modelIds, toolCategories });
 
-  // Deterministic short hash of runIds — ensures different runs of the same
-  // message produce different transaction_ids (e.g., error then success finalization).
-  const runKey = createHash("sha256")
-    .update([...agentMessage.runIds].sort().join("-"))
-    .digest("hex")
-    .slice(0, 12);
+  // Use the Temporal workflow run ID as the unique key — each workflow execution
+  // gets a unique runId, even when the workflow ID is reused across retries.
+  const { runId: workflowRunId } = Context.current().info.workflowExecution;
+  const runKey = workflowRunId.slice(0, 12);
 
   // Build and ingest events.
   const llmEvents = buildLlmUsageEvents({


### PR DESCRIPTION
## Description

Fixes duplicate Metronome events caused by multiple agent loop attempts producing the same `runIds` hash.

**Problem**: Different workflow executions for the same message could have identical `runIds`, making the SHA-256 hash (and thus the transaction_id) identical. Metronome treated these as duplicates even though they represented different billing events.

**Fix**: Replace the `runIds` hash with the Temporal workflow **run ID** (`Context.current().info.workflowExecution.runId`), which is guaranteed unique per workflow execution:
- Activity retries within the same execution → same `runId` → same transaction_id → correctly deduplicated by Metronome
- Different workflow executions → different `runId` → different transaction_ids → all events kept

## Risk

None — only changes the `runKey` portion of transaction_ids. No impact on billing logic.

## Deploy Plan

No special steps. New events will use the updated transaction_id format immediately.