### PR TITLE
gracefullyStopAgentLoopSignal

### DIFF
--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -53,7 +53,7 @@ export async function updateAgentMessageDBAndMemory(
         update:
           | {
               type: "status";
-              status: "succeeded" | "cancelled";
+              status: "succeeded" | "cancelled" | "gracefully_stopped";
             }
           | {
               type: "error";
@@ -300,15 +300,19 @@ export async function processEventForDatabase(
       });
       break;
 
+    case "agent_message_gracefully_stopped":
     case "agent_message_success":
       await Promise.all([
-        // Store success in database behind advisory lock.
+        // Store terminal status in database behind advisory lock.
         updateAgentMessageDBAndMemory(auth, {
           agentMessage,
           conversation,
           update: {
             type: "status",
-            status: "succeeded",
+            status:
+              event.type === "agent_message_gracefully_stopped"
+                ? "gracefully_stopped"
+                : "succeeded",
           },
         }),
         // Mark the conversation as updated
@@ -596,5 +600,57 @@ export async function finalizeCancellation(
       conversationId: conversation.sId,
     },
     "Agent generation cancelled"
+  );
+}
+
+/**
+ * Activity executed after a graceful stop signal. The current step
+ * completed normally so all content is already flushed — we just
+ * need to emit the terminal event.
+ */
+export async function finalizeGracefulStop(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  const runAgentDataRes = await getAgentLoopData(authType, agentLoopArgs);
+  if (runAgentDataRes.isErr()) {
+    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+      logger.info(
+        {
+          conversationId: agentLoopArgs.conversationId,
+          agentMessageId: agentLoopArgs.agentMessageId,
+        },
+        "Message or conversation was deleted, exiting"
+      );
+      return;
+    }
+    throw new Error(
+      `Failed to get run agent data: ${runAgentDataRes.error.message}`
+    );
+  }
+  const { auth, agentConfiguration, agentMessage, conversation } =
+    runAgentDataRes.value;
+
+  const step = _.maxBy(agentMessage.contents, "step")?.step ?? 0;
+
+  await updateResourceAndPublishEvent(auth, {
+    event: {
+      type: "agent_message_gracefully_stopped",
+      created: Date.now(),
+      configurationId: agentConfiguration.sId,
+      messageId: agentMessage.sId,
+      message: agentMessage,
+      runIds: [],
+    },
+    agentMessage,
+    conversation,
+    step,
+  });
+  logger.info(
+    {
+      agentMessageId: agentMessage.sId,
+      conversationId: conversation.sId,
+    },
+    "Agent generation gracefully stopped"
   );
 }

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -604,9 +604,8 @@ export async function finalizeCancellation(
 }
 
 /**
- * Activity executed after a graceful stop signal. The current step
- * completed normally so all content is already flushed — we just
- * need to emit the terminal event.
+ * Activity executed after a graceful stop signal. The current step completed normally so all
+ * content is already flushed — we just need to emit the terminal event.
  */
 export async function finalizeGracefulStop(
   authType: AuthenticatorType,

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -141,19 +141,16 @@ export async function finalizeSuccessfulAgentLoopActivity(
 }
 
 /**
- * Graceful stop mirrors the successful path: content is valid,
- * all side-effects (analytics, notifications, etc.) should run.
+ * Graceful stop mirrors the successful path: content is valid, all side-effects (analytics,
+ * notifications, etc.) should run. We're not running email response nor project related signals
+ * since the work is not finished per se since it was gracefully stopped and the intent of the user
+ * is to steer or continue with something else.
  */
 export async function finalizeGracefullyStoppedAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
   await finalizeGracefulStop(authType, agentLoopArgs);
-
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    return;
-  }
 
   await Promise.all([
     snapshotAgentMessageSkills(authType, agentLoopArgs),

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -11,25 +11,25 @@ import {
   AgentMessageModel,
   MessageModel,
 } from "@app/lib/models/agent/conversation";
-import {ConversationButlerSuggestionResource} from "@app/lib/resources/conversation_butler_suggestion_resource";
-import {ConversationResource} from "@app/lib/resources/conversation_resource";
+import { ConversationButlerSuggestionResource } from "@app/lib/resources/conversation_butler_suggestion_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
-import {launchAgentMessageAnalytics} from "@app/temporal/agent_loop/activities/analytics";
+import { launchAgentMessageAnalytics } from "@app/temporal/agent_loop/activities/analytics";
 import {
   finalizeCancellation,
   finalizeGracefulStop,
   notifyWorkflowError,
 } from "@app/temporal/agent_loop/activities/common";
-import {handleMentions} from "@app/temporal/agent_loop/activities/mentions";
-import {conversationUnreadNotificationActivity} from "@app/temporal/agent_loop/activities/notification";
-import {snapshotAgentMessageSkills} from "@app/temporal/agent_loop/activities/snapshot_skills";
+import { handleMentions } from "@app/temporal/agent_loop/activities/mentions";
+import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
+import { snapshotAgentMessageSkills } from "@app/temporal/agent_loop/activities/snapshot_skills";
 import {
   launchEmitMetronomeUsageEvents,
   launchTrackProgrammaticUsage,
 } from "@app/temporal/agent_loop/activities/usage_tracking";
-import {signalButlerComplete} from "@app/temporal/butler/client";
-import {signalProjectTodoComplete} from "@app/temporal/project_todo/client";
-import type {AgentLoopArgs} from "@app/types/assistant/agent_run";
+import { signalButlerComplete } from "@app/temporal/butler/client";
+import { signalProjectTodoComplete } from "@app/temporal/project_todo/client";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
 /**
  * Link the completed agent message to an accepted butler suggestion if the
@@ -54,7 +54,7 @@ async function linkButlerSuggestionResult(
         sId: agentLoopArgs.agentMessageId,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
-      include: [{model: AgentMessageModel, as: "agentMessage"}],
+      include: [{ model: AgentMessageModel, as: "agentMessage" }],
     });
 
     if (!message?.agentMessage) {
@@ -122,20 +122,20 @@ export async function finalizeSuccessfulAgentLoopActivity(
     sendEmailReplyOnCompletion(authType, agentLoopArgs),
     shouldSignalButler
       ? signalButlerComplete({
-        authType,
-        conversationId: agentLoopArgs.conversationId,
-        messageId: agentLoopArgs.agentMessageId,
-      })
+          authType,
+          conversationId: agentLoopArgs.conversationId,
+          messageId: agentLoopArgs.agentMessageId,
+        })
       : Promise.resolve(),
     shouldSignalButler
       ? linkButlerSuggestionResult(auth, agentLoopArgs)
       : Promise.resolve(),
     shouldSignalTodo
       ? signalProjectTodoComplete({
-        authType,
-        conversationId: agentLoopArgs.conversationId,
-        messageId: agentLoopArgs.agentMessageId,
-      })
+          authType,
+          conversationId: agentLoopArgs.conversationId,
+          messageId: agentLoopArgs.agentMessageId,
+        })
       : Promise.resolve(),
   ]);
 }
@@ -188,7 +188,7 @@ export async function finalizeCancelledAgentLoopActivity(
 export async function finalizeErroredAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs,
-  error: {message: string; name: string}
+  error: { message: string; name: string }
 ): Promise<void> {
   await notifyWorkflowError(authType, agentLoopArgs, error);
 

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -17,6 +17,7 @@ import logger from "@app/logger/logger";
 import { launchAgentMessageAnalytics } from "@app/temporal/agent_loop/activities/analytics";
 import {
   finalizeCancellation,
+  finalizeGracefulStop,
   notifyWorkflowError,
 } from "@app/temporal/agent_loop/activities/common";
 import { handleMentions } from "@app/temporal/agent_loop/activities/mentions";
@@ -90,6 +91,65 @@ export async function finalizeSuccessfulAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    return;
+  }
+
+  const auth = authResult.value;
+  const featureFlags = await getFeatureFlags(auth);
+
+  let shouldSignalButler = false;
+  let shouldSignalTodo = false;
+  if (
+    featureFlags.includes("conversation_butler") ||
+    featureFlags.includes("project_todo")
+  ) {
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      agentLoopArgs.conversationId
+    );
+    shouldSignalButler = conversation?.spaceId !== null;
+  }
+
+  await Promise.all([
+    snapshotAgentMessageSkills(authType, agentLoopArgs),
+    launchAgentMessageAnalytics(authType, agentLoopArgs),
+    launchTrackProgrammaticUsage(authType, agentLoopArgs),
+    launchEmitMetronomeUsageEvents(authType, agentLoopArgs),
+    conversationUnreadNotificationActivity(authType, agentLoopArgs),
+    handleMentions(authType, agentLoopArgs),
+    sendEmailReplyOnCompletion(authType, agentLoopArgs),
+    shouldSignalButler
+      ? signalButlerComplete({
+          authType,
+          conversationId: agentLoopArgs.conversationId,
+          messageId: agentLoopArgs.agentMessageId,
+        })
+      : Promise.resolve(),
+    shouldSignalButler
+      ? linkButlerSuggestionResult(auth, agentLoopArgs)
+      : Promise.resolve(),
+    shouldSignalTodo
+      ? signalProjectTodoComplete({
+          authType,
+          conversationId: agentLoopArgs.conversationId,
+          messageId: agentLoopArgs.agentMessageId,
+        })
+      : Promise.resolve(),
+  ]);
+}
+
+/**
+ * Graceful stop mirrors the successful path: content is valid,
+ * all side-effects (analytics, notifications, etc.) should run.
+ */
+export async function finalizeGracefullyStoppedAgentLoopActivity(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  await finalizeGracefulStop(authType, agentLoopArgs);
+
   const authResult = await Authenticator.fromJSON(authType);
   if (authResult.isErr()) {
     return;

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -11,25 +11,25 @@ import {
   AgentMessageModel,
   MessageModel,
 } from "@app/lib/models/agent/conversation";
-import { ConversationButlerSuggestionResource } from "@app/lib/resources/conversation_butler_suggestion_resource";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import {ConversationButlerSuggestionResource} from "@app/lib/resources/conversation_butler_suggestion_resource";
+import {ConversationResource} from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
-import { launchAgentMessageAnalytics } from "@app/temporal/agent_loop/activities/analytics";
+import {launchAgentMessageAnalytics} from "@app/temporal/agent_loop/activities/analytics";
 import {
   finalizeCancellation,
   finalizeGracefulStop,
   notifyWorkflowError,
 } from "@app/temporal/agent_loop/activities/common";
-import { handleMentions } from "@app/temporal/agent_loop/activities/mentions";
-import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
-import { snapshotAgentMessageSkills } from "@app/temporal/agent_loop/activities/snapshot_skills";
+import {handleMentions} from "@app/temporal/agent_loop/activities/mentions";
+import {conversationUnreadNotificationActivity} from "@app/temporal/agent_loop/activities/notification";
+import {snapshotAgentMessageSkills} from "@app/temporal/agent_loop/activities/snapshot_skills";
 import {
   launchEmitMetronomeUsageEvents,
   launchTrackProgrammaticUsage,
 } from "@app/temporal/agent_loop/activities/usage_tracking";
-import { signalButlerComplete } from "@app/temporal/butler/client";
-import { signalProjectTodoComplete } from "@app/temporal/project_todo/client";
-import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import {signalButlerComplete} from "@app/temporal/butler/client";
+import {signalProjectTodoComplete} from "@app/temporal/project_todo/client";
+import type {AgentLoopArgs} from "@app/types/assistant/agent_run";
 
 /**
  * Link the completed agent message to an accepted butler suggestion if the
@@ -54,7 +54,7 @@ async function linkButlerSuggestionResult(
         sId: agentLoopArgs.agentMessageId,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
-      include: [{ model: AgentMessageModel, as: "agentMessage" }],
+      include: [{model: AgentMessageModel, as: "agentMessage"}],
     });
 
     if (!message?.agentMessage) {
@@ -122,20 +122,20 @@ export async function finalizeSuccessfulAgentLoopActivity(
     sendEmailReplyOnCompletion(authType, agentLoopArgs),
     shouldSignalButler
       ? signalButlerComplete({
-          authType,
-          conversationId: agentLoopArgs.conversationId,
-          messageId: agentLoopArgs.agentMessageId,
-        })
+        authType,
+        conversationId: agentLoopArgs.conversationId,
+        messageId: agentLoopArgs.agentMessageId,
+      })
       : Promise.resolve(),
     shouldSignalButler
       ? linkButlerSuggestionResult(auth, agentLoopArgs)
       : Promise.resolve(),
     shouldSignalTodo
       ? signalProjectTodoComplete({
-          authType,
-          conversationId: agentLoopArgs.conversationId,
-          messageId: agentLoopArgs.agentMessageId,
-        })
+        authType,
+        conversationId: agentLoopArgs.conversationId,
+        messageId: agentLoopArgs.agentMessageId,
+      })
       : Promise.resolve(),
   ]);
 }
@@ -155,47 +155,14 @@ export async function finalizeGracefullyStoppedAgentLoopActivity(
     return;
   }
 
-  const auth = authResult.value;
-  const featureFlags = await getFeatureFlags(auth);
-
-  let shouldSignalButler = false;
-  let shouldSignalTodo = false;
-  if (
-    featureFlags.includes("conversation_butler") ||
-    featureFlags.includes("project_todo")
-  ) {
-    const conversation = await ConversationResource.fetchById(
-      auth,
-      agentLoopArgs.conversationId
-    );
-    shouldSignalButler = conversation?.spaceId !== null;
-  }
-
   await Promise.all([
     snapshotAgentMessageSkills(authType, agentLoopArgs),
     launchAgentMessageAnalytics(authType, agentLoopArgs),
     launchTrackProgrammaticUsage(authType, agentLoopArgs),
     launchEmitMetronomeUsageEvents(authType, agentLoopArgs),
+
     conversationUnreadNotificationActivity(authType, agentLoopArgs),
     handleMentions(authType, agentLoopArgs),
-    sendEmailReplyOnCompletion(authType, agentLoopArgs),
-    shouldSignalButler
-      ? signalButlerComplete({
-          authType,
-          conversationId: agentLoopArgs.conversationId,
-          messageId: agentLoopArgs.agentMessageId,
-        })
-      : Promise.resolve(),
-    shouldSignalButler
-      ? linkButlerSuggestionResult(auth, agentLoopArgs)
-      : Promise.resolve(),
-    shouldSignalTodo
-      ? signalProjectTodoComplete({
-          authType,
-          conversationId: agentLoopArgs.conversationId,
-          messageId: agentLoopArgs.agentMessageId,
-        })
-      : Promise.resolve(),
   ]);
 }
 
@@ -221,7 +188,7 @@ export async function finalizeCancelledAgentLoopActivity(
 export async function finalizeErroredAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs,
-  error: { message: string; name: string }
+  error: {message: string; name: string}
 ): Promise<void> {
   await notifyWorkflowError(authType, agentLoopArgs, error);
 

--- a/front/temporal/agent_loop/signals.ts
+++ b/front/temporal/agent_loop/signals.ts
@@ -6,9 +6,8 @@ export const cancelAgentLoopSignal = defineSignal<[void]>(
   "cancel_agent_loop_signal"
 );
 
-// Signal to request a graceful stop of the agent loop workflow.
-// Unlike cancellation, in-flight activities continue to completion.
-// The loop exits cleanly at the next step boundary.
+// Signal to request a graceful stop of the agent loop workflow. Unlike cancellation, in-flight
+// activities continue to completion. The loop exits cleanly at the next step boundary.
 export const gracefullyStopAgentLoopSignal = defineSignal<[void]>(
   "gracefully_stop_agent_loop_signal"
 );

--- a/front/temporal/agent_loop/signals.ts
+++ b/front/temporal/agent_loop/signals.ts
@@ -5,3 +5,10 @@ import { defineSignal } from "@temporalio/workflow";
 export const cancelAgentLoopSignal = defineSignal<[void]>(
   "cancel_agent_loop_signal"
 );
+
+// Signal to request a graceful stop of the agent loop workflow.
+// Unlike cancellation, in-flight activities continue to completion.
+// The loop exits cleanly at the next step boundary.
+export const gracefullyStopAgentLoopSignal = defineSignal<[void]>(
+  "gracefully_stop_agent_loop_signal"
+);

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -145,9 +145,8 @@ export async function agentLoopWorkflow({
     executionScope.cancel();
   });
 
-  // Graceful stop: let the current step finish, then exit the loop at the
-  // next step boundary. Unlike cancellation, in-flight activities are not
-  // killed.
+  // Graceful stop: let the current step finish, then exit the loop at the next step boundary.
+  // Unlike cancellation, in-flight activities are not killed.
   let gracefulStopRequested = false;
 
   setHandler(gracefullyStopAgentLoopSignal, () => {
@@ -200,9 +199,9 @@ export async function agentLoopWorkflow({
           stepStartTime
         );
 
-        // After the first step completes, launch title generation in the background.
-        // We wait until the first step so the agent has at least one response in the database,
-        // otherwise the title model would only see the user's question without context.
+        // After the first step completes, launch title generation in the background. We wait until
+        // the first step so the agent has at least one response in the database, otherwise the
+        // title model would only see the user's question without context.
         if (i === startStep && !agentLoopArgs.conversationTitle) {
           try {
             childWorkflowHandle = await startChild(
@@ -256,9 +255,9 @@ export async function agentLoopWorkflow({
       if (cancelRequested) {
         return finalizeCancelledAgentLoopActivity(authType, agentLoopArgs);
       }
-      // Error objects don't survive JSON serialization across the workflow→activity
-      // boundary (Error.message is not enumerable), so we extract the relevant
-      // fields into a plain object before passing to the activity.
+      // Error objects don't survive JSON serialization across the workflow→activity boundary
+      // (Error.message is not enumerable), so we extract the relevant fields into a plain object
+      // before passing to the activity.
       await finalizeErroredAgentLoopActivity(authType, agentLoopArgs, {
         message: workflowError.message,
         name: workflowError.name,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -146,9 +146,8 @@ export async function agentLoopWorkflow({
     executionScope.cancel();
   });
 
-  // Graceful stop: let the current step finish, then exit the
-  // loop at the next step boundary. Unlike cancellation, in-flight
-  // activities are not killed.
+  // Graceful stop: let the current step finish, then exit the loop at the next step boundary.
+  // Unlike cancellation, in-flight activities are not killed.
   let gracefulStopRequested = false;
 
   setHandler(gracefullyStopAgentLoopSignal, () => {

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -3,25 +3,25 @@ import {
   RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
-import type { AuthenticatorType } from "@app/lib/auth";
+import type {AuthenticatorType} from "@app/lib/auth";
 import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import type * as finalizeActivities from "@app/temporal/agent_loop/activities/finalize";
 import type * as publishDeferredEventsActivities from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
-import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
-import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
+import {RUN_MODEL_MAX_RETRIES} from "@app/temporal/agent_loop/config";
+import {makeAgentLoopConversationTitleWorkflowId} from "@app/temporal/agent_loop/lib/workflow_ids";
 import {
   cancelAgentLoopSignal,
   gracefullyStopAgentLoopSignal,
 } from "@app/temporal/agent_loop/signals";
-import type { AgentLoopInstrumentationSinks } from "@app/temporal/agent_loop/sinks";
-import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
+import type {AgentLoopInstrumentationSinks} from "@app/temporal/agent_loop/sinks";
+import {MAX_STEPS_USE_PER_RUN_LIMIT} from "@app/types/assistant/agent";
 import type {
   AgentLoopArgs,
   AgentLoopArgsWithTiming,
 } from "@app/types/assistant/agent_run";
-import { WorkflowExecutionAlreadyStartedError } from "@temporalio/common";
+import {WorkflowExecutionAlreadyStartedError} from "@temporalio/common";
 import type {
   ChildWorkflowHandle,
   WorkflowInterceptorsFactory,
@@ -55,7 +55,7 @@ export const interceptors: WorkflowInterceptorsFactory = () => ({
   internals: [new OpenTelemetryInternalsInterceptor()],
 });
 
-const { runModelAndCreateActionsActivity } = proxyActivities<
+const {runModelAndCreateActionsActivity} = proxyActivities<
   typeof runModelAndCreateWrapperActivities
 >({
   startToCloseTimeout: "10 minutes",
@@ -66,7 +66,7 @@ const { runModelAndCreateActionsActivity } = proxyActivities<
   },
 });
 
-const { runToolActivity } = proxyActivities<typeof runToolActivities>({
+const {runToolActivity} = proxyActivities<typeof runToolActivities>({
   // Activity timeout keeps a short buffer above the tool timeout to detect worker restarts promptly.
   startToCloseTimeout: toolActivityStartToCloseTimeoutMs,
   heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
@@ -76,7 +76,7 @@ const { runToolActivity } = proxyActivities<typeof runToolActivities>({
   },
 });
 
-const { runToolActivity: runRetryableToolActivity } = proxyActivities<
+const {runToolActivity: runRetryableToolActivity} = proxyActivities<
   typeof runToolActivities
 >({
   startToCloseTimeout: toolActivityStartToCloseTimeoutMs,
@@ -86,15 +86,15 @@ const { runToolActivity: runRetryableToolActivity } = proxyActivities<
   },
 });
 
-const { publishDeferredEventsActivity } = proxyActivities<
+const {publishDeferredEventsActivity} = proxyActivities<
   typeof publishDeferredEventsActivities
 >({
   startToCloseTimeout: "2 minutes",
 });
 
-const { metrics } = proxySinks<AgentLoopInstrumentationSinks>();
+const {metrics} = proxySinks<AgentLoopInstrumentationSinks>();
 
-const { ensureConversationTitleActivity } = proxyActivities<
+const {ensureConversationTitleActivity} = proxyActivities<
   typeof ensureTitleActivities
 >({
   startToCloseTimeout: "5 minutes",
@@ -135,7 +135,7 @@ export async function agentLoopWorkflow({
   agentLoopArgs: AgentLoopArgs;
   startStep: number;
 }) {
-  const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
+  const {searchAttributes: parentSearchAttributes, memo} = workflowInfo();
 
   // Allow cancellation of in-flight activities via signal-triggered scope cancellation.
   let cancelRequested = false;
@@ -155,7 +155,7 @@ export async function agentLoopWorkflow({
   });
 
   try {
-    const { agentMessageId, conversationId } = agentLoopArgs;
+    const {agentMessageId, conversationId} = agentLoopArgs;
 
     await executionScope.run(async () => {
       const runIds: string[] = [];
@@ -177,7 +177,7 @@ export async function agentLoopWorkflow({
 
         const stepStartTime = Date.now();
 
-        const { runId, shouldContinue } = await executeStepIteration({
+        const {runId, shouldContinue} = await executeStepIteration({
           authType,
           agentLoopArgs: {
             ...agentLoopArgs,
@@ -213,7 +213,7 @@ export async function agentLoopWorkflow({
                   agentLoopArgs
                 ),
                 searchAttributes: parentSearchAttributes,
-                args: [{ authType, agentLoopArgs }],
+                args: [{authType, agentLoopArgs}],
                 memo,
               }
             );
@@ -310,7 +310,7 @@ async function executeStepIteration({
     };
   }
 
-  const { runId, actionBlobs } = result;
+  const {runId, actionBlobs} = result;
 
   // If at least one action needs approval, we break out of the loop and will resume once all
   // actions have been approved.
@@ -324,20 +324,20 @@ async function executeStepIteration({
 
   // Execute tools and collect any deferred events.
   const toolResults = await Promise.all(
-    actionBlobs.map(({ actionId, retryPolicy }) =>
+    actionBlobs.map(({actionId, retryPolicy}) =>
       retryPolicy === "no_retry"
         ? runToolActivity(authType, {
-            actionId,
-            runAgentArgs: agentLoopArgs,
-            step: currentStep,
-            runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
-          })
+          actionId,
+          runAgentArgs: agentLoopArgs,
+          step: currentStep,
+          runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
+        })
         : runRetryableToolActivity(authType, {
-            actionId,
-            runAgentArgs: agentLoopArgs,
-            step: currentStep,
-            runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
-          })
+          actionId,
+          runAgentArgs: agentLoopArgs,
+          step: currentStep,
+          runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
+        })
     )
   );
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -3,25 +3,25 @@ import {
   RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
-import type {AuthenticatorType} from "@app/lib/auth";
+import type { AuthenticatorType } from "@app/lib/auth";
 import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import type * as finalizeActivities from "@app/temporal/agent_loop/activities/finalize";
 import type * as publishDeferredEventsActivities from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
-import {RUN_MODEL_MAX_RETRIES} from "@app/temporal/agent_loop/config";
-import {makeAgentLoopConversationTitleWorkflowId} from "@app/temporal/agent_loop/lib/workflow_ids";
+import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
+import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 import {
   cancelAgentLoopSignal,
   gracefullyStopAgentLoopSignal,
 } from "@app/temporal/agent_loop/signals";
-import type {AgentLoopInstrumentationSinks} from "@app/temporal/agent_loop/sinks";
-import {MAX_STEPS_USE_PER_RUN_LIMIT} from "@app/types/assistant/agent";
+import type { AgentLoopInstrumentationSinks } from "@app/temporal/agent_loop/sinks";
+import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import type {
   AgentLoopArgs,
   AgentLoopArgsWithTiming,
 } from "@app/types/assistant/agent_run";
-import {WorkflowExecutionAlreadyStartedError} from "@temporalio/common";
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/common";
 import type {
   ChildWorkflowHandle,
   WorkflowInterceptorsFactory,
@@ -55,7 +55,7 @@ export const interceptors: WorkflowInterceptorsFactory = () => ({
   internals: [new OpenTelemetryInternalsInterceptor()],
 });
 
-const {runModelAndCreateActionsActivity} = proxyActivities<
+const { runModelAndCreateActionsActivity } = proxyActivities<
   typeof runModelAndCreateWrapperActivities
 >({
   startToCloseTimeout: "10 minutes",
@@ -66,7 +66,7 @@ const {runModelAndCreateActionsActivity} = proxyActivities<
   },
 });
 
-const {runToolActivity} = proxyActivities<typeof runToolActivities>({
+const { runToolActivity } = proxyActivities<typeof runToolActivities>({
   // Activity timeout keeps a short buffer above the tool timeout to detect worker restarts promptly.
   startToCloseTimeout: toolActivityStartToCloseTimeoutMs,
   heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
@@ -76,7 +76,7 @@ const {runToolActivity} = proxyActivities<typeof runToolActivities>({
   },
 });
 
-const {runToolActivity: runRetryableToolActivity} = proxyActivities<
+const { runToolActivity: runRetryableToolActivity } = proxyActivities<
   typeof runToolActivities
 >({
   startToCloseTimeout: toolActivityStartToCloseTimeoutMs,
@@ -86,15 +86,15 @@ const {runToolActivity: runRetryableToolActivity} = proxyActivities<
   },
 });
 
-const {publishDeferredEventsActivity} = proxyActivities<
+const { publishDeferredEventsActivity } = proxyActivities<
   typeof publishDeferredEventsActivities
 >({
   startToCloseTimeout: "2 minutes",
 });
 
-const {metrics} = proxySinks<AgentLoopInstrumentationSinks>();
+const { metrics } = proxySinks<AgentLoopInstrumentationSinks>();
 
-const {ensureConversationTitleActivity} = proxyActivities<
+const { ensureConversationTitleActivity } = proxyActivities<
   typeof ensureTitleActivities
 >({
   startToCloseTimeout: "5 minutes",
@@ -135,7 +135,7 @@ export async function agentLoopWorkflow({
   agentLoopArgs: AgentLoopArgs;
   startStep: number;
 }) {
-  const {searchAttributes: parentSearchAttributes, memo} = workflowInfo();
+  const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
 
   // Allow cancellation of in-flight activities via signal-triggered scope cancellation.
   let cancelRequested = false;
@@ -155,7 +155,7 @@ export async function agentLoopWorkflow({
   });
 
   try {
-    const {agentMessageId, conversationId} = agentLoopArgs;
+    const { agentMessageId, conversationId } = agentLoopArgs;
 
     await executionScope.run(async () => {
       const runIds: string[] = [];
@@ -177,7 +177,7 @@ export async function agentLoopWorkflow({
 
         const stepStartTime = Date.now();
 
-        const {runId, shouldContinue} = await executeStepIteration({
+        const { runId, shouldContinue } = await executeStepIteration({
           authType,
           agentLoopArgs: {
             ...agentLoopArgs,
@@ -213,7 +213,7 @@ export async function agentLoopWorkflow({
                   agentLoopArgs
                 ),
                 searchAttributes: parentSearchAttributes,
-                args: [{authType, agentLoopArgs}],
+                args: [{ authType, agentLoopArgs }],
                 memo,
               }
             );
@@ -247,10 +247,7 @@ export async function agentLoopWorkflow({
             agentLoopArgs
           );
         } else {
-          await finalizeSuccessfulAgentLoopActivity(
-            authType,
-            agentLoopArgs
-          );
+          await finalizeSuccessfulAgentLoopActivity(authType, agentLoopArgs);
         }
       });
 
@@ -310,7 +307,7 @@ async function executeStepIteration({
     };
   }
 
-  const {runId, actionBlobs} = result;
+  const { runId, actionBlobs } = result;
 
   // If at least one action needs approval, we break out of the loop and will resume once all
   // actions have been approved.
@@ -324,20 +321,20 @@ async function executeStepIteration({
 
   // Execute tools and collect any deferred events.
   const toolResults = await Promise.all(
-    actionBlobs.map(({actionId, retryPolicy}) =>
+    actionBlobs.map(({ actionId, retryPolicy }) =>
       retryPolicy === "no_retry"
         ? runToolActivity(authType, {
-          actionId,
-          runAgentArgs: agentLoopArgs,
-          step: currentStep,
-          runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
-        })
+            actionId,
+            runAgentArgs: agentLoopArgs,
+            step: currentStep,
+            runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
+          })
         : runRetryableToolActivity(authType, {
-          actionId,
-          runAgentArgs: agentLoopArgs,
-          step: currentStep,
-          runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
-        })
+            actionId,
+            runAgentArgs: agentLoopArgs,
+            step: currentStep,
+            runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
+          })
     )
   );
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -28,6 +28,7 @@ import type {
 } from "@temporalio/workflow";
 import {
   CancellationScope,
+  patched,
   proxyActivities,
   proxySinks,
   setHandler,
@@ -146,13 +147,17 @@ export async function agentLoopWorkflow({
     executionScope.cancel();
   });
 
-  // Graceful stop: let the current step finish, then exit the loop at the next step boundary.
-  // Unlike cancellation, in-flight activities are not killed.
+  // Graceful stop: let the current step finish, then exit the
+  // loop at the next step boundary. Unlike cancellation, in-flight
+  // activities are not killed.
+  const supportsGracefulStop = patched("graceful-stop-signal");
   let gracefulStopRequested = false;
 
-  setHandler(gracefullyStopAgentLoopSignal, () => {
-    gracefulStopRequested = true;
-  });
+  if (supportsGracefulStop) {
+    setHandler(gracefullyStopAgentLoopSignal, () => {
+      gracefulStopRequested = true;
+    });
+  }
 
   try {
     const { agentMessageId, conversationId } = agentLoopArgs;

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -11,7 +11,10 @@ import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_lo
 import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
 import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
 import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
-import { cancelAgentLoopSignal } from "@app/temporal/agent_loop/signals";
+import {
+  cancelAgentLoopSignal,
+  gracefullyStopAgentLoopSignal,
+} from "@app/temporal/agent_loop/signals";
 import type { AgentLoopInstrumentationSinks } from "@app/temporal/agent_loop/sinks";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import type {
@@ -142,6 +145,15 @@ export async function agentLoopWorkflow({
     executionScope.cancel();
   });
 
+  // Graceful stop: let the current step finish, then exit the loop at the
+  // next step boundary. Unlike cancellation, in-flight activities are not
+  // killed.
+  let gracefulStopRequested = false;
+
+  setHandler(gracefullyStopAgentLoopSignal, () => {
+    gracefulStopRequested = true;
+  });
+
   try {
     const { agentMessageId, conversationId } = agentLoopArgs;
 
@@ -212,7 +224,7 @@ export async function agentLoopWorkflow({
           }
         }
 
-        if (!shouldContinue) {
+        if (!shouldContinue || gracefulStopRequested) {
           break;
         }
       }

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -28,7 +28,6 @@ import type {
 } from "@temporalio/workflow";
 import {
   CancellationScope,
-  patched,
   proxyActivities,
   proxySinks,
   setHandler,
@@ -150,14 +149,11 @@ export async function agentLoopWorkflow({
   // Graceful stop: let the current step finish, then exit the
   // loop at the next step boundary. Unlike cancellation, in-flight
   // activities are not killed.
-  const supportsGracefulStop = patched("graceful-stop-signal");
   let gracefulStopRequested = false;
 
-  if (supportsGracefulStop) {
-    setHandler(gracefullyStopAgentLoopSignal, () => {
-      gracefulStopRequested = true;
-    });
-  }
+  setHandler(gracefullyStopAgentLoopSignal, () => {
+    gracefulStopRequested = true;
+  });
 
   try {
     const { agentMessageId, conversationId } = agentLoopArgs;

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -107,6 +107,7 @@ const { ensureConversationTitleActivity } = proxyActivities<
 
 const {
   finalizeSuccessfulAgentLoopActivity,
+  finalizeGracefullyStoppedAgentLoopActivity,
   finalizeCancelledAgentLoopActivity,
   finalizeErroredAgentLoopActivity,
 } = proxyActivities<typeof finalizeActivities>({
@@ -240,7 +241,17 @@ export async function agentLoopWorkflow({
       );
 
       await CancellationScope.nonCancellable(async () => {
-        await finalizeSuccessfulAgentLoopActivity(authType, agentLoopArgs);
+        if (gracefulStopRequested) {
+          await finalizeGracefullyStoppedAgentLoopActivity(
+            authType,
+            agentLoopArgs
+          );
+        } else {
+          await finalizeSuccessfulAgentLoopActivity(
+            authType,
+            agentLoopArgs
+          );
+        }
       });
 
       if (childWorkflowHandle) {

--- a/x/spolu/steering/plan.md
+++ b/x/spolu/steering/plan.md
@@ -37,24 +37,15 @@ Implement the graceful stop mechanism end-to-end.
 - Map to `"succeeded"` in public API backward compatibility layer.
 - Frontend: use message status from event (no hardcoded override).
 
-### - [ ] PR 2.2 — Add `gracefullyStopAgentLoopSignal` + workflow handler
+### - [x] PR 2.2+2.3 — Add `gracefullyStopAgentLoopSignal` + finalization
 
-- Add signal definition in `front/temporal/agent_loop/signals.ts`.
-- Add `gracefulStopRequested` flag + `setHandler` in `agentLoopWorkflow`
-  (`front/temporal/agent_loop/workflows.ts`).
-- Check `gracefulStopRequested` at step boundary (`if (!shouldContinue || gracefulStopRequested)`).
-- No finalization yet — just break the loop. The existing `finalizeSuccessfulAgentLoopActivity`
-  runs (status = `"succeeded"`). This is safe because no one sends the signal yet.
-
-### - [ ] PR 2.3 — Add `finalizeGracefulStop` + `finalizeGracefullyStoppedAgentLoopActivity`
-
-- Add `finalizeGracefulStop` in `front/temporal/agent_loop/activities/common.ts` (mirrors
-  `finalizeCancellation` but sets `"gracefully_stopped"` + emits
-  `agent_message_gracefully_stopped`).
-- Add `finalizeGracefullyStoppedAgentLoopActivity` in
-  `front/temporal/agent_loop/activities/finalize.ts` (mirrors
-  `finalizeSuccessfulAgentLoopActivity`).
-- Route `gracefulStopRequested` in the workflow to the new finalization path.
+- Add `gracefullyStopAgentLoopSignal` in `signals.ts`.
+- Add `gracefulStopRequested` flag + handler in `agentLoopWorkflow`, check at step boundary.
+- Add `finalizeGracefulStop` in `common.ts` (emits `agent_message_gracefully_stopped`,
+  no content parser flush needed since step completed normally).
+- Add `finalizeGracefullyStoppedAgentLoopActivity` in `finalize.ts` (mirrors successful path).
+- Route `gracefulStopRequested` in the workflow to the new finalization.
+- Handle `agent_message_gracefully_stopped` in `processEventForDatabase`.
 
 ### - [ ] PR 2.4 — Add `gracefullyStopAgentLoop` helper
 


### PR DESCRIPTION
## Description

- Add gracefullyStopAgentLoopSignal Temporal signal — sets a flag without cancelling the execution scope, so in-flight activities complete normally
- Add gracefulStopRequested handler + step boundary check in agentLoopWorkflow — loop exits cleanly after the current step finishes
- Add finalizeGracefulStop in common.ts — emits agent_message_gracefully_stopped event (no content parser flush needed since the step completed normally)
- Add finalizeGracefullyStoppedAgentLoopActivity in finalize.ts — mirrors the successful finalization path (analytics, notifications, butler, etc.)
- Handle agent_message_gracefully_stopped in processEventForDatabase (sets status + marks conversation updated)

## Tests

Type-checking, no functional change yet.

## Risk

Low as the code path is not activated yet.

## Deploy Plan

- deploy `front`