### PR TITLE
[front] feat: scaffold `ask_user_question` tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -54,6 +54,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "search_candidates": "never_ask",
     "update_job_posting": "high",
   },
+  "ask_user_question": {
+    "ask_user_question": "never_ask",
+  },
   "common_utilities": {
     "generate_random_float": "never_ask",
     "generate_random_number": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -65,6 +65,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "sandbox", id: 1024 },
       { name: "project_conversation", id: 1025 },
       { name: "user_mentions", id: 1026 },
+      { name: "ask_user_question", id: 1028 },
     ];
     expect(
       autoInternalTools,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -12,8 +12,8 @@ import {
 } from "@app/lib/api/actions/servers/agent_router/metadata";
 import { AGENT_SIDEKICK_AGENT_STATE_SERVER } from "@app/lib/api/actions/servers/agent_sidekick_agent_state/metadata";
 import { AGENT_SIDEKICK_CONTEXT_SERVER } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
-import { ASK_USER_QUESTION_SERVER } from "@app/lib/api/actions/servers/ask_user_question/metadata";
 import { ASHBY_SERVER } from "@app/lib/api/actions/servers/ashby/metadata";
+import { ASK_USER_QUESTION_SERVER } from "@app/lib/api/actions/servers/ask_user_question/metadata";
 import { COMMON_UTILITIES_SERVER } from "@app/lib/api/actions/servers/common_utilities/metadata";
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
 import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversation_files/metadata";

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -12,6 +12,7 @@ import {
 } from "@app/lib/api/actions/servers/agent_router/metadata";
 import { AGENT_SIDEKICK_AGENT_STATE_SERVER } from "@app/lib/api/actions/servers/agent_sidekick_agent_state/metadata";
 import { AGENT_SIDEKICK_CONTEXT_SERVER } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
+import { ASK_USER_QUESTION_SERVER } from "@app/lib/api/actions/servers/ask_user_question/metadata";
 import { ASHBY_SERVER } from "@app/lib/api/actions/servers/ashby/metadata";
 import { COMMON_UTILITIES_SERVER } from "@app/lib/api/actions/servers/common_utilities/metadata";
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
@@ -205,6 +206,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "poke",
   "project_conversation",
   "sandbox",
+  "ask_user_question",
 ] as const;
 
 export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
@@ -1086,6 +1088,19 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: POKE_SERVER,
+  },
+  ask_user_question: {
+    id: 1028,
+    availability: "auto",
+    allowMultipleInstances: false,
+    isPreview: true,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("ask_user_question_tool");
+    },
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: ASK_USER_QUESTION_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -76,7 +76,6 @@ export interface MCPApproveExecutionEvent extends ToolExecution {
 export interface ToolAskUserQuestionEvent extends ToolExecution {
   type: "tool_ask_user_question";
   question: UserQuestion;
-  questionMetadata: Record<string, unknown> | null;
 }
 
 export type ToolEarlyExitEvent = {

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -10,6 +10,7 @@ import { default as agentMemoryServer } from "@app/lib/api/actions/servers/agent
 import { default as agentRouterServer } from "@app/lib/api/actions/servers/agent_router";
 import { default as agentSidekickAgentStateServer } from "@app/lib/api/actions/servers/agent_sidekick_agent_state";
 import { default as agentSidekickContextServer } from "@app/lib/api/actions/servers/agent_sidekick_context";
+import { default as askUserQuestionServer } from "@app/lib/api/actions/servers/ask_user_question";
 import { default as ashbyServer } from "@app/lib/api/actions/servers/ashby";
 import { default as commonUtilitiesServer } from "@app/lib/api/actions/servers/common_utilities";
 import { default as confluenceServer } from "@app/lib/api/actions/servers/confluence";
@@ -247,6 +248,8 @@ export async function getInternalMCPServer(
       return pokeServer(auth, agentLoopContext);
     case "project_conversation":
       return projectConversationServer(auth, agentLoopContext);
+    case "ask_user_question":
+      return askUserQuestionServer(auth, agentLoopContext);
     case "ukg_ready":
       return ukgReadyServer(auth, agentLoopContext);
     case "user_mentions":

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -10,8 +10,8 @@ import { default as agentMemoryServer } from "@app/lib/api/actions/servers/agent
 import { default as agentRouterServer } from "@app/lib/api/actions/servers/agent_router";
 import { default as agentSidekickAgentStateServer } from "@app/lib/api/actions/servers/agent_sidekick_agent_state";
 import { default as agentSidekickContextServer } from "@app/lib/api/actions/servers/agent_sidekick_context";
-import { default as askUserQuestionServer } from "@app/lib/api/actions/servers/ask_user_question";
 import { default as ashbyServer } from "@app/lib/api/actions/servers/ashby";
+import { default as askUserQuestionServer } from "@app/lib/api/actions/servers/ask_user_question";
 import { default as commonUtilitiesServer } from "@app/lib/api/actions/servers/common_utilities";
 import { default as confluenceServer } from "@app/lib/api/actions/servers/confluence";
 import { default as conversationFilesServer } from "@app/lib/api/actions/servers/conversation_files";

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -27,14 +27,27 @@ export function isFileAuthorizationInfo(
 }
 
 const UserQuestionOptionSchema = z.object({
-  label: z.string(),
-  description: z.string().nullable(),
+  label: z
+    .string()
+    .describe(
+      "Concise choice text, 1-5 words. " +
+        "Recommended option should include '(Recommended)'."
+    ),
+  description: z.string().nullable().describe("Explanation of this option."),
 });
 
 export const UserQuestionSchema = z.object({
-  question: z.string(),
-  options: z.array(UserQuestionOptionSchema),
-  multiSelect: z.boolean(),
+  question: z
+    .string()
+    .describe("The question text. Should be clear and specific."),
+  options: z
+    .array(UserQuestionOptionSchema)
+    .describe("The available choices (2 to 4 options)."),
+  multiSelect: z
+    .boolean()
+    .describe(
+      "Whether the user can select multiple options for this question."
+    ),
 });
 
 export type UserQuestion = z.infer<typeof UserQuestionSchema>;

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -52,6 +52,13 @@ export const UserQuestionSchema = z.object({
 
 export type UserQuestion = z.infer<typeof UserQuestionSchema>;
 
+export const UserQuestionAnswerSchema = z.object({
+  selectedOptions: z.array(z.number()),
+  customResponse: z.string().optional(),
+});
+
+export type UserQuestionAnswer = z.infer<typeof UserQuestionAnswerSchema>;
+
 export type StepContext = {
   citationsCount: number;
   citationsOffset: number;

--- a/front/lib/api/actions/servers/ask_user_question/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/index.ts
@@ -1,0 +1,23 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { TOOLS } from "@app/lib/api/actions/servers/ask_user_question/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("ask_user_question");
+
+  for (const tool of TOOLS) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: "ask_user_question",
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -1,0 +1,87 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const ASK_USER_QUESTION_TOOLS_METADATA = createToolsRecord({
+  ask_user_question: {
+    description:
+      "Ask the user a question with multiple-choice options.\n\n" +
+      "Use this tool when:\n" +
+      "- The user's request could apply to several known entities and asking " +
+      "narrows the work significantly. For example: 'What's the weather at " +
+      "the office?' when the company has offices in Paris, SF, and NY: ask " +
+      "which office instead of looking up all three.\n" +
+      "- A piece of information is missing and you can enumerate the likely " +
+      "options (e.g. which project, which account, which time range).\n" +
+      "- You need a decision that determines what you do next " +
+      "(e.g. deploy target, auth method, output format).\n" +
+      "- Doing the work for every possibility would be noticeably slower or " +
+      "noisier than asking one quick question first.\n\n" +
+      "Formatting:\n" +
+      "- List the recommended option first with '(Recommended)' in its label.\n" +
+      "- The user always gets an automatic 'Other' option for free-text input.",
+    schema: {
+      question: z
+        .string()
+        .describe("The question text. Should be clear and specific."),
+      options: z
+        .array(
+          z.object({
+            label: z
+              .string()
+              .describe(
+                "Concise choice text, 1-5 words. " +
+                  "Recommended option should include '(Recommended)'."
+              ),
+            description: z
+              .string()
+              .nullable()
+              .describe("Explanation of this option."),
+          })
+        )
+        .min(2)
+        .max(4)
+        .describe("The available choices (2 to 4 options)."),
+      multi_select: z
+        .boolean()
+        .describe(
+          "Whether the user can select multiple options for this question."
+        ),
+      metadata: z
+        .record(z.unknown())
+        .optional()
+        .describe("Optional analytics/tracking metadata."),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Asking user...",
+      done: "User answered",
+    },
+  },
+});
+
+export const ASK_USER_QUESTION_SERVER = {
+  serverInfo: {
+    name: "ask_user_question",
+    version: "1.0.0",
+    description: "Ask the user a question with multiple-choice options.",
+    icon: "ActionAtomIcon",
+    authorization: null,
+    documentationUrl: null,
+    instructions: null,
+  },
+  tools: Object.values(ASK_USER_QUESTION_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(ASK_USER_QUESTION_TOOLS_METADATA).map((t) => [
+      t.name,
+      t.stake,
+    ])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -1,5 +1,6 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { UserQuestionSchema } from "@app/lib/actions/types";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
@@ -23,36 +24,7 @@ export const ASK_USER_QUESTION_TOOLS_METADATA = createToolsRecord({
       "- List the recommended option first with '(Recommended)' in its label.\n" +
       "- The user always gets an automatic 'Other' option for free-text input.",
     schema: {
-      question: z
-        .string()
-        .describe("The question text. Should be clear and specific."),
-      options: z
-        .array(
-          z.object({
-            label: z
-              .string()
-              .describe(
-                "Concise choice text, 1-5 words. " +
-                  "Recommended option should include '(Recommended)'."
-              ),
-            description: z
-              .string()
-              .nullable()
-              .describe("Explanation of this option."),
-          })
-        )
-        .min(2)
-        .max(4)
-        .describe("The available choices (2 to 4 options)."),
-      multi_select: z
-        .boolean()
-        .describe(
-          "Whether the user can select multiple options for this question."
-        ),
-      metadata: z
-        .record(z.unknown())
-        .optional()
-        .describe("Optional analytics/tracking metadata."),
+      ...UserQuestionSchema.shape,
     },
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -1,13 +1,14 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { UserQuestion } from "@app/lib/actions/types";
+import { UserQuestionAnswerSchema } from "@app/lib/actions/types";
 import { ASK_USER_QUESTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/ask_user_question/metadata";
 import { Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
   ask_user_question: async (
-    { question, options, multiSelect, metadata },
+    { question, options, multiSelect },
     { agentLoopContext }
   ) => {
     const typedQuestion: UserQuestion = {
@@ -17,18 +18,16 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
     };
 
     const resumeState = agentLoopContext?.runContext?.stepContext?.resumeState;
-    const userAnswer =
+    const parsed = UserQuestionAnswerSchema.safeParse(
       resumeState && "answer" in resumeState
         ? resumeState.answer
-        : undefined;
+        : undefined
+    );
 
-    if (userAnswer && typeof userAnswer === "object") {
+    if (parsed.success) {
+      const answer = parsed.data;
       const selections: string[] = [];
-      const answer = userAnswer as {
-        selectedOptions?: number[];
-        customResponse?: string;
-      };
-      for (const idx of answer.selectedOptions ?? []) {
+      for (const idx of answer.selectedOptions) {
         if (idx >= 0 && idx < typedQuestion.options.length) {
           selections.push(typedQuestion.options[idx].label);
         }
@@ -36,13 +35,11 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
       if (answer.customResponse) {
         selections.push(`Other: ${answer.customResponse}`);
       }
-      const answerText =
-        selections.length > 0 ? selections.join(", ") : "No option selected";
 
       return new Ok([
         {
           type: "text",
-          text: `User answered: ${typedQuestion.question}: ${answerText}`,
+          text: `User answered: ${typedQuestion.question}: ${selections.join(", ")}`,
         },
       ]);
     }
@@ -54,7 +51,6 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
           mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
           type: "tool_user_answer_required",
           question: typedQuestion,
-          metadata: metadata ?? null,
           text: `Asking user: ${typedQuestion.question}`,
           uri: "",
         },

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -1,0 +1,66 @@
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { UserQuestion } from "@app/lib/actions/types";
+import { ASK_USER_QUESTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/ask_user_question/metadata";
+import { Ok } from "@app/types/shared/result";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+
+const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
+  ask_user_question: async (
+    { question, options, multiSelect, metadata },
+    { agentLoopContext }
+  ) => {
+    const typedQuestion: UserQuestion = {
+      question,
+      options,
+      multiSelect,
+    };
+
+    const resumeState = agentLoopContext?.runContext?.stepContext?.resumeState;
+    const userAnswer =
+      resumeState && "answer" in resumeState
+        ? resumeState.answer
+        : undefined;
+
+    if (userAnswer && typeof userAnswer === "object") {
+      const selections: string[] = [];
+      const answer = userAnswer as {
+        selectedOptions?: number[];
+        customResponse?: string;
+      };
+      for (const idx of answer.selectedOptions ?? []) {
+        if (idx >= 0 && idx < typedQuestion.options.length) {
+          selections.push(typedQuestion.options[idx].label);
+        }
+      }
+      if (answer.customResponse) {
+        selections.push(`Other: ${answer.customResponse}`);
+      }
+      const answerText =
+        selections.length > 0 ? selections.join(", ") : "No option selected";
+
+      return new Ok([
+        {
+          type: "text",
+          text: `User answered: ${typedQuestion.question}: ${answerText}`,
+        },
+      ]);
+    }
+
+    return new Ok([
+      {
+        type: "resource",
+        resource: {
+          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
+          type: "tool_user_answer_required",
+          question: typedQuestion,
+          metadata: metadata ?? null,
+          text: `Asking user: ${typedQuestion.question}`,
+          uri: "",
+        },
+      },
+    ]);
+  },
+};
+
+export const TOOLS = buildTools(ASK_USER_QUESTION_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -19,9 +19,7 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
 
     const resumeState = agentLoopContext?.runContext?.stepContext?.resumeState;
     const parsed = UserQuestionAnswerSchema.safeParse(
-      resumeState && "answer" in resumeState
-        ? resumeState.answer
-        : undefined
+      resumeState && "answer" in resumeState ? resumeState.answer : undefined
     );
 
     if (parsed.success) {

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -179,6 +179,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
   poke: "platform",
   project_conversation: "platform",
   sandbox: "platform",
+  ask_user_question: "platform",
 };
 
 export function getToolCategory(

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -13,6 +13,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Fallback to Vertex Anthropic for some Anthropic models",
     stage: "dust_only",
   },
+  ask_user_question_tool: {
+    description:
+      "Enable ask_user_question tool for agents to ask users questions",
+    stage: "dust_only",
+  },
   audit_logs: {
     description: "Enable audit log emission via WorkOS",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -678,6 +678,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "analytics_csv_export"
   | "custom_model_feature"
   | "anthropic_vertex_fallback"
+  | "ask_user_question_tool"
   | "audit_logs"
   | "claude_4_5_opus_feature"
   | "claude_4_opus_feature"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1354,7 +1354,6 @@ const BlockedActionExecutionSchema = ToolExecutionMetadataSchema.extend({
   status: ToolExecutionBlockedStatusSchema,
   // Present only when status is "blocked_user_question_required".
   question: UserQuestionItemSchema.optional(),
-  questionMetadata: z.record(z.unknown()).nullish(),
 });
 
 export type BlockedActionExecutionType = z.infer<
@@ -1447,7 +1446,6 @@ const ToolAskUserQuestionEventSchema = ToolExecutionMetadataSchema.extend({
   created: z.number(),
   messageId: z.string(),
   question: UserQuestionItemSchema,
-  questionMetadata: z.record(z.unknown()).nullable(),
 });
 
 export type ToolAskUserQuestionEvent = z.infer<


### PR DESCRIPTION
## Description

- This PR adds an MCP server `ask_user_question` behind feature flag.
- Follow up on https://github.com/dust-tt/dust/pull/23649.
- This MCP server contains a single tool that takes in input questions (generated by the model) and returns what can be used to emit an event surfaced to the frontend.

## Tests

- Tested locally.

## Risk

- Low, purely additive, behind FF.

## Deploy Plan

- Deploy front.
