### PR TITLE
Make sure run_usages is populated for reinforced runs

### DIFF
--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -160,7 +160,8 @@ export async function storeLlmResult(
   auth: Authenticator,
   conversation: ConversationResource,
   events: LLMEvent[],
-  agentConfigurationId: string
+  agentConfigurationId: string,
+  { runIds }: { runIds?: string[] } = {}
 ): Promise<StoreLlmResultInfo> {
   const workspace = auth.getNonNullableWorkspace();
 
@@ -212,6 +213,7 @@ export async function storeLlmResult(
           errorCode: firstError ? firstError.content.type : null,
           errorMessage: firstError ? firstError.content.message : null,
           completedAt: new Date(),
+          runIds: runIds ?? null,
         },
         { transaction: t }
       );
@@ -350,7 +352,7 @@ export async function downloadBatchResultFromLlm(
   conversationIds: string[],
   agentConfigurationId: string
 ): Promise<BatchDownloadResult> {
-  const events = await llm.getBatchResult(batchId);
+  const batchResults = await llm.getBatchResult(batchId);
 
   const conversationResources = await ConversationResource.fetchByIds(
     auth,
@@ -360,8 +362,13 @@ export async function downloadBatchResultFromLlm(
     conversationResources.map((c) => [c.sId, c])
   );
 
+  const events = new Map<string, LLMEvent[]>();
   const storedResultInfo = new Map<string, StoreLlmResultInfo>();
-  for (const [conversationId, convEvents] of events) {
+  for (const [
+    conversationId,
+    { events: convEvents, dustRunId },
+  ] of batchResults) {
+    events.set(conversationId, convEvents);
     const conversation = conversationById.get(conversationId);
     if (!conversation) {
       continue;
@@ -370,7 +377,8 @@ export async function downloadBatchResultFromLlm(
       auth,
       conversation,
       convEvents,
-      agentConfigurationId
+      agentConfigurationId,
+      { runIds: [dustRunId] }
     );
     storedResultInfo.set(conversationId, info);
   }

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -8,7 +8,11 @@ import type {
   LLMTraceContext,
   LLMTraceCustomization,
 } from "@app/lib/api/llm/traces/types";
-import type { BatchResult, BatchStatus } from "@app/lib/api/llm/types/batch";
+import type {
+  BatchResult,
+  BatchResultWithRunIds,
+  BatchStatus,
+} from "@app/lib/api/llm/types/batch";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
 import type {
@@ -455,12 +459,12 @@ export abstract class LLM<TPayload = unknown> {
    * Only call this when getBatchStatus returns "ready".
    * Results are automatically traced when a tracing context is set.
    */
-  async getBatchResult(batchId: string): Promise<BatchResult> {
+  async getBatchResult(batchId: string): Promise<BatchResultWithRunIds> {
     const results = await this.internalGetBatchResult(batchId);
-    if (!this.context) {
-      return results;
+    if (this.context) {
+      await this.traceBatchResults(results);
     }
-    return this.traceBatchResults(results);
+    return this.createRunsForBatchResults(results);
   }
 
   /**
@@ -477,7 +481,47 @@ export abstract class LLM<TPayload = unknown> {
   /**
    * Traces batch results by creating one Langfuse generation per batch entry.
    */
-  private async traceBatchResults(results: BatchResult): Promise<BatchResult> {
+  /**
+   * Creates RunResource entries and records token usage for each batch entry.
+   * This enables cost tracking by linking batch results to run_usages.
+   */
+  private async createRunsForBatchResults(
+    results: BatchResult
+  ): Promise<BatchResultWithRunIds> {
+    const workspaceId = this.authenticator.getNonNullableWorkspace().id;
+    const enrichedResults: BatchResultWithRunIds = new Map();
+
+    for (const [customId, events] of results) {
+      const traceId = createLLMTraceId(randomUUID());
+
+      const run = await RunResource.makeNew({
+        appId: null,
+        dustRunId: traceId,
+        runType: "deploy",
+        useWorkspaceCredentials: false,
+        workspaceId,
+      });
+
+      // Extract token usage from events and record it.
+      const tokenUsageEvent = events.find((e) => e.type === "token_usage");
+      if (tokenUsageEvent && tokenUsageEvent.type === "token_usage") {
+        await run.recordTokenUsage(
+          this.authenticator,
+          tokenUsageEvent.content,
+          this.modelId
+        );
+      }
+
+      enrichedResults.set(customId, { events, dustRunId: traceId });
+    }
+
+    return enrichedResults;
+  }
+
+  /**
+   * Traces batch results by creating one Langfuse generation per batch entry.
+   */
+  private async traceBatchResults(results: BatchResult): Promise<void> {
     const workspaceId = this.authenticator.getNonNullableWorkspace().sId;
 
     for (const [customId, events] of results) {
@@ -581,8 +625,6 @@ export abstract class LLM<TPayload = unknown> {
 
       generation.end();
     }
-
-    return results;
   }
 
   /**

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -488,7 +488,6 @@ export abstract class LLM<TPayload = unknown> {
   private async createRunsForBatchResults(
     results: BatchResult
   ): Promise<BatchResultWithRunIds> {
-    const workspaceId = this.authenticator.getNonNullableWorkspace().id;
     const enrichedResults: BatchResultWithRunIds = new Map();
 
     for (const [customId, events] of results) {
@@ -499,7 +498,7 @@ export abstract class LLM<TPayload = unknown> {
         dustRunId: traceId,
         runType: "deploy",
         useWorkspaceCredentials: false,
-        workspaceId,
+        workspaceId: this.authenticator.getNonNullableWorkspace().id,
       });
 
       // Extract token usage from events and record it.

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -479,9 +479,6 @@ export abstract class LLM<TPayload = unknown> {
   }
 
   /**
-   * Traces batch results by creating one Langfuse generation per batch entry.
-   */
-  /**
    * Creates RunResource entries and records token usage for each batch entry.
    * This enables cost tracking by linking batch results to run_usages.
    */

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -498,14 +498,15 @@ export abstract class LLM<TPayload = unknown> {
         workspaceId: this.authenticator.getNonNullableWorkspace().id,
       });
 
-      // Extract token usage from events and record it.
-      const tokenUsageEvent = events.find((e) => e.type === "token_usage");
-      if (tokenUsageEvent && tokenUsageEvent.type === "token_usage") {
-        await run.recordTokenUsage(
-          this.authenticator,
-          tokenUsageEvent.content,
-          this.modelId
-        );
+      // Record token usage from events.
+      for (const event of events) {
+        if (event.type === "token_usage") {
+          await run.recordTokenUsage(
+            this.authenticator,
+            event.content,
+            this.modelId
+          );
+        }
       }
 
       enrichedResults.set(customId, { events, dustRunId: traceId });

--- a/front/lib/api/llm/tests/llmBatch.test.ts
+++ b/front/lib/api/llm/tests/llmBatch.test.ts
@@ -299,13 +299,14 @@ describe.skipIf(!RUN_LLM_BATCH_TEST || modelsWithBatchSupport.length === 0)(
           expect(result.size).toBe(batchMap.size);
 
           for (const { id, expectedInResponse } of conversations) {
-            const events = result.get(id);
+            const entry = result.get(id);
             expect(
-              events,
+              entry,
               `Expected results for conversation ${id}`
             ).toBeDefined();
-            if (events) {
-              checkResponse(id, events, expectedInResponse);
+            if (entry) {
+              expect(entry.dustRunId).toBeDefined();
+              checkResponse(id, entry.events, expectedInResponse);
             }
           }
         },

--- a/front/lib/api/llm/types/batch.ts
+++ b/front/lib/api/llm/types/batch.ts
@@ -12,3 +12,12 @@ export type BatchStatus = "computing" | "ready" | "aborted";
  * Maps each conversation's custom_id to the sequence of LLM events produced for it.
  */
 export type BatchResult = Map<string, LLMEvent[]>;
+
+/**
+ * Enriched batch result that includes the dustRunId for each entry,
+ * enabling linkage between batch results and run_usages for cost tracking.
+ */
+export type BatchResultWithRunIds = Map<
+  string,
+  { events: LLMEvent[]; dustRunId: string }
+>;

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -164,7 +164,8 @@ async function runReinforcedStep({
     auth,
     reinforcementConv,
     events,
-    REINFORCEMENT_AGENT_ID
+    REINFORCEMENT_AGENT_ID,
+    { runIds: [llm.getTraceId()] }
   );
 
   const { exploratoryToolCalls, terminalToolCalls } = classifyToolCalls(events);

--- a/front/tests/reinforced-agent-evals/lib/reinforced-executor.ts
+++ b/front/tests/reinforced-agent-evals/lib/reinforced-executor.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/api/assistant/global_agents/sidekick_context";
 import { getLLM } from "@app/lib/api/llm";
 import type { LLM } from "@app/lib/api/llm/llm";
+import type { BatchResultWithRunIds } from "@app/lib/api/llm/types/batch";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
@@ -246,7 +247,7 @@ function sleep(ms: number): Promise<void> {
 async function submitAndWaitForBatch(
   llm: LLM,
   batchMap: Map<string, LLMStreamParameters>
-): Promise<Map<string, LLMEvent[]>> {
+): Promise<BatchResultWithRunIds> {
   const batchId = await llm.sendBatchProcessing(batchMap);
 
   let status = await llm.getBatchStatus(batchId);
@@ -290,7 +291,7 @@ export async function executeBatch(
 
     const nextPendingParams = new Map<string, LLMStreamParameters>();
 
-    for (const [scenarioId, events] of batchResult) {
+    for (const [scenarioId, { events }] of batchResult) {
       const stepResult = extractFromEvents(events);
       const prev = accumulatedToolCalls.get(scenarioId) ?? [];
       const allToolCalls = [...prev, ...stepResult.toolCalls];


### PR DESCRIPTION
## Description

- Fix batch LLM path: traceBatchResults() never created RunResource or called recordTokenUsage(), so batch calls had no entries in run_usages. Added createRunsForBatchResults() that creates a run and records token usage per batch entry.
- Fix non-batch (streaming) path: storeLlmResult() never set runIds on the AgentMessageModel, so agent messages couldn't be joined to their runs. Added optional runIds param and pass llm.getTraceId() from callers.
- Both fixes together enable the agent_messages.runIds → runs.dustRunId → run_usages.runId join for cost tracking.

## Tests

Tweaked existing

## Risk

Low

## Deploy Plan

Front