### PR TITLE
Add audit logs for accessing audit logs, viewing conversation

### DIFF
--- a/front/admin/audit_log_schemas/audit_log.export_configured.json
+++ b/front/admin/audit_log_schemas/audit_log.export_configured.json
@@ -1,0 +1,8 @@
+{
+  "action": "audit_log.export_configured",
+  "targets": [
+    {
+      "type": "workspace"
+    }
+  ]
+}

--- a/front/admin/audit_log_schemas/audit_log.viewed.json
+++ b/front/admin/audit_log_schemas/audit_log.viewed.json
@@ -1,0 +1,8 @@
+{
+  "action": "audit_log.viewed",
+  "targets": [
+    {
+      "type": "workspace"
+    }
+  ]
+}

--- a/front/admin/audit_log_schemas/conversation.accessed.json
+++ b/front/admin/audit_log_schemas/conversation.accessed.json
@@ -1,0 +1,14 @@
+{
+  "action": "conversation.accessed",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "conversation"
+    }
+  ],
+  "metadata": {
+    "conversationId": "string"
+  }
+}

--- a/front/components/workspace/AuditLogsSection.tsx
+++ b/front/components/workspace/AuditLogsSection.tsx
@@ -1,6 +1,8 @@
-import { useAuditLogsStatus } from "@app/lib/swr/workos";
+import { useOpenAuditLogsPortal } from "@app/lib/swr/workos";
+import type { AuditLogsPortal } from "@app/pages/api/w/[wId]/audit-logs";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, DocumentTextIcon, LoadingBlock, Page } from "@dust-tt/sparkle";
+import { Button, DocumentTextIcon, Page } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 import { WorkspaceSection } from "./WorkspaceSection";
 
@@ -9,65 +11,44 @@ interface AuditLogsSectionProps {
 }
 
 export function AuditLogsSection({ owner }: AuditLogsSectionProps) {
-  const { viewLogsLink, configureExportLink, isLoading, error } =
-    useAuditLogsStatus({ owner });
+  const { openPortal } = useOpenAuditLogsPortal({ owner });
+  const [loadingPortal, setLoadingPortal] = useState<AuditLogsPortal | null>(
+    null
+  );
+
+  const handleClick = async (portal: AuditLogsPortal) => {
+    setLoadingPortal(portal);
+    try {
+      await openPortal(portal);
+    } finally {
+      setLoadingPortal(null);
+    }
+  };
 
   return (
     <WorkspaceSection title="Audit Logs" icon={DocumentTextIcon}>
       <div className="flex w-full flex-row items-center gap-2">
         <div className="flex-1">
           <Page.P variant="secondary">
-            {error
-              ? "Failed to load audit logs configuration. Please try again later."
-              : "View workspace activity logs or configure export to your security information and event management (SIEM) system."}
+            View workspace activity logs or configure export to your security
+            information and event management (SIEM) system.
           </Page.P>
         </div>
         <div className="flex justify-end gap-2">
-          {isLoading ? (
-            <LoadingBlock className="h-8 w-32 rounded-xl" />
-          ) : (
-            <>
-              <Button
-                label="View Logs"
-                size="sm"
-                variant="outline"
-                disabled={!viewLogsLink}
-                onClick={() => {
-                  if (viewLogsLink) {
-                    // Fire-and-forget audit event — not awaited to avoid popup blocker.
-                    void fetch(`/api/w/${owner.sId}/audit-logs`, {
-                      method: "POST",
-                      headers: { "Content-Type": "application/json" },
-                      body: JSON.stringify({ action: "audit_log.viewed" }),
-                    });
-                    window.open(viewLogsLink, "_blank", "noopener,noreferrer");
-                  }
-                }}
-              />
-              <Button
-                label="Configure Export"
-                size="sm"
-                variant="outline"
-                disabled={!configureExportLink}
-                onClick={() => {
-                  if (configureExportLink) {
-                    void fetch(`/api/w/${owner.sId}/audit-logs`, {
-                      method: "POST",
-                      headers: { "Content-Type": "application/json" },
-                      body: JSON.stringify({
-                        action: "audit_log.export_configured",
-                      }),
-                    });
-                    window.open(
-                      configureExportLink,
-                      "_blank",
-                      "noopener,noreferrer"
-                    );
-                  }
-                }}
-              />
-            </>
-          )}
+          <Button
+            label="View Logs"
+            size="sm"
+            variant="outline"
+            disabled={loadingPortal !== null}
+            onClick={() => void handleClick("view_logs")}
+          />
+          <Button
+            label="Configure Export"
+            size="sm"
+            variant="outline"
+            disabled={loadingPortal !== null}
+            onClick={() => void handleClick("configure_export")}
+          />
         </div>
       </div>
     </WorkspaceSection>

--- a/front/components/workspace/AuditLogsSection.tsx
+++ b/front/components/workspace/AuditLogsSection.tsx
@@ -34,6 +34,12 @@ export function AuditLogsSection({ owner }: AuditLogsSectionProps) {
                 disabled={!viewLogsLink}
                 onClick={() => {
                   if (viewLogsLink) {
+                    // Fire-and-forget audit event — not awaited to avoid popup blocker.
+                    void fetch(`/api/w/${owner.sId}/audit-logs`, {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ action: "audit_log.viewed" }),
+                    });
                     window.open(viewLogsLink, "_blank", "noopener,noreferrer");
                   }
                 }}
@@ -45,6 +51,13 @@ export function AuditLogsSection({ owner }: AuditLogsSectionProps) {
                 disabled={!configureExportLink}
                 onClick={() => {
                   if (configureExportLink) {
+                    void fetch(`/api/w/${owner.sId}/audit-logs`, {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({
+                        action: "audit_log.export_configured",
+                      }),
+                    });
                     window.open(
                       configureExportLink,
                       "_blank",

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -73,11 +73,15 @@ type AuditAction =
   | "space.created"
   | "space.deleted"
   | "space.permissions_updated"
+  // Conversations.
+  | "conversation.accessed"
   // Data Sources.
   | "datasource.created"
   | "datasource.updated"
   | "datasource.deleted"
-  | "datasource.deleted_admin";
+  | "datasource.deleted_admin"
+  // Audit Logs.
+  | "audit_log.viewed";
 
 export type EmitAuditLogEventParams = {
   auth: Authenticator;

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -244,6 +244,7 @@ type AuditTargetType =
   | "workspace"
   | "user"
   | "agent"
+  | "conversation"
   | "space"
   | "data_source"
   | "tool"

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -81,7 +81,8 @@ type AuditAction =
   | "datasource.deleted"
   | "datasource.deleted_admin"
   // Audit Logs.
-  | "audit_log.viewed";
+  | "audit_log.viewed"
+  | "audit_log.export_configured";
 
 export type EmitAuditLogEventParams = {
   auth: Authenticator;

--- a/front/lib/swr/workos.ts
+++ b/front/lib/swr/workos.ts
@@ -7,7 +7,10 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
-import type { AuditLogsSetupResponse } from "@app/pages/api/w/[wId]/audit-logs";
+import type {
+  AuditLogsPortal,
+  AuditLogsPortalResponse,
+} from "@app/pages/api/w/[wId]/audit-logs";
 import type { GetWorkspaceDomainsResponseBody } from "@app/pages/api/w/[wId]/domains";
 import type { GetProvisioningStatusResponseBody } from "@app/pages/api/w/[wId]/provisioning-status";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -257,23 +260,39 @@ export function useProvisioningStatus({
  * Audit Logs
  */
 
-export function useAuditLogsStatus({
-  disabled,
+export function useOpenAuditLogsPortal({
   owner,
 }: {
-  disabled?: boolean;
   owner: LightWorkspaceType;
 }) {
-  const { fetcher } = useFetcher();
-  const { data, error, isLoading } = useSWRWithDefaults<
-    string,
-    AuditLogsSetupResponse
-  >(`/api/w/${owner.sId}/audit-logs`, fetcher, { disabled });
+  const sendNotification = useSendNotification();
 
-  return {
-    viewLogsLink: data?.viewLogsLink,
-    configureExportLink: data?.configureExportLink,
-    isLoading: !disabled && isLoading,
-    error,
+  const openPortal = async (portal: AuditLogsPortal) => {
+    // Open a blank window synchronously to avoid popup blockers.
+    const newWindow = window.open("", "_blank");
+
+    const response = await clientFetch(`/api/w/${owner.sId}/audit-logs`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ portal }),
+    });
+
+    if (!response.ok) {
+      newWindow?.close();
+      const errorData = await getErrorFromResponse(response);
+      sendNotification({
+        type: "error",
+        title: "Failed to open audit logs portal",
+        description: errorData.message,
+      });
+      return;
+    }
+
+    const data: AuditLogsPortalResponse = await response.json();
+    if (newWindow) {
+      newWindow.location.href = data.portalUrl;
+    }
   };
+
+  return { openPortal };
 }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -120,7 +120,7 @@ import { deleteOrLeaveConversation } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
@@ -206,12 +206,11 @@ async function handler(
         auth,
         action: "conversation.accessed",
         targets: [
-          buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-          {
-            type: "conversation",
-            id: conversation.sId,
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("conversation", {
+            sId: conversation.sId,
             name: conversation.title ?? "",
-          },
+          }),
         ],
         context: getAuditLogContext(auth, req),
         metadata: {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -119,6 +119,11 @@
 import { deleteOrLeaveConversation } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";
+import {
+  buildWorkspaceTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { moveConversationToProject } from "@app/lib/api/projects/conversations";
 import type { Authenticator } from "@app/lib/auth";
@@ -196,6 +201,24 @@ async function handler(
       }
 
       const conversation = conversationRes.value;
+
+      void emitAuditLogEvent({
+        auth,
+        action: "conversation.accessed",
+        targets: [
+          buildWorkspaceTarget(auth.getNonNullableWorkspace()),
+          {
+            type: "conversation",
+            id: conversation.sId,
+            name: conversation.title ?? "",
+          },
+        ],
+        context: getAuditLogContext(auth, req),
+        metadata: {
+          conversationId: conversation.sId,
+        },
+      });
+
       res.status(200).json({ conversation });
       return;
     }

--- a/front/pages/api/w/[wId]/audit-logs.ts
+++ b/front/pages/api/w/[wId]/audit-logs.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import {
-  buildWorkspaceTarget,
+  buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
   isAuditLogsEnabled,
@@ -14,14 +14,15 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type AuditLogsSetupResponse = {
-  viewLogsLink: string;
-  configureExportLink: string;
+export type AuditLogsPortal = "view_logs" | "configure_export";
+
+export type AuditLogsPortalResponse = {
+  portalUrl: string;
 };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<AuditLogsSetupResponse>>,
+  res: NextApiResponse<WithAPIErrorResponse<AuditLogsPortalResponse>>,
   auth: Authenticator
 ) {
   if (!auth.isAdmin()) {
@@ -56,57 +57,50 @@ async function handler(
   }
 
   switch (req.method) {
-    case "GET": {
-      const returnUrl = `${config.getAppUrl()}/w/${owner.sId}/members`;
-
-      const [viewLogsResult, configureExportResult] = await Promise.all([
-        generateWorkOSAdminPortalUrl({
-          organization: owner.workOSOrganizationId,
-          workOSIntent: WorkOSPortalIntent.AuditLogs,
-          returnUrl,
-        }),
-        generateWorkOSAdminPortalUrl({
-          organization: owner.workOSOrganizationId,
-          workOSIntent: WorkOSPortalIntent.LogStreams,
-          returnUrl,
-        }),
-      ]);
-
-      return res.status(200).json({
-        viewLogsLink: viewLogsResult.link,
-        configureExportLink: configureExportResult.link,
-      });
-    }
-
-    // Emit audit events on button click. WorkOS portal links are org-scoped
-    // (not user-scoped), so this is the only place we can attribute portal
-    // access to a specific admin.
+    // Generates a WorkOS portal URL on click and emits an audit event.
+    // WorkOS portal links are org-scoped (not user-scoped), so this is the
+    // only place we can attribute portal access to a specific admin.
     case "POST": {
-      const { action } = req.body;
-      const allowedActions = [
-        "audit_log.viewed",
-        "audit_log.export_configured",
-      ] as const;
+      const { portal } = req.body;
 
-      if (!allowedActions.includes(action)) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Invalid action. Must be one of: ${allowedActions.join(", ")}`,
-          },
-        });
+      let workOSIntent: WorkOSPortalIntent;
+      let action: "audit_log.viewed" | "audit_log.export_configured";
+
+      switch (portal) {
+        case "view_logs":
+          workOSIntent = WorkOSPortalIntent.AuditLogs;
+          action = "audit_log.viewed";
+          break;
+        case "configure_export":
+          workOSIntent = WorkOSPortalIntent.LogStreams;
+          action = "audit_log.export_configured";
+          break;
+        default:
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Invalid portal. Must be 'view_logs' or 'configure_export'.",
+            },
+          });
       }
+
+      const returnUrl = `${config.getAppUrl()}/w/${owner.sId}/members`;
+      const result = await generateWorkOSAdminPortalUrl({
+        organization: owner.workOSOrganizationId,
+        workOSIntent,
+        returnUrl,
+      });
 
       void emitAuditLogEvent({
         auth,
         action,
-        targets: [buildWorkspaceTarget(owner)],
+        targets: [buildAuditLogTarget("workspace", owner)],
         context: getAuditLogContext(auth, req),
       });
 
-      res.status(200).end();
-      return;
+      return res.status(200).json({ portalUrl: result.link });
     }
 
     default:

--- a/front/pages/api/w/[wId]/audit-logs.ts
+++ b/front/pages/api/w/[wId]/audit-logs.ts
@@ -63,6 +63,16 @@ async function handler(
     case "POST": {
       const { portal } = req.body;
 
+      if (!portal || typeof portal !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Missing or invalid portal parameter.",
+          },
+        });
+      }
+
       let workOSIntent: WorkOSPortalIntent;
       let action: "audit_log.viewed" | "audit_log.export_configured";
 

--- a/front/pages/api/w/[wId]/audit-logs.ts
+++ b/front/pages/api/w/[wId]/audit-logs.ts
@@ -72,17 +72,41 @@ async function handler(
         }),
       ]);
 
-      void emitAuditLogEvent({
-        auth,
-        action: "audit_log.viewed",
-        targets: [buildWorkspaceTarget(owner)],
-        context: getAuditLogContext(auth, req),
-      });
-
       return res.status(200).json({
         viewLogsLink: viewLogsResult.link,
         configureExportLink: configureExportResult.link,
       });
+    }
+
+    // Emit audit events on button click. WorkOS portal links are org-scoped
+    // (not user-scoped), so this is the only place we can attribute portal
+    // access to a specific admin.
+    case "POST": {
+      const { action } = req.body;
+      const allowedActions = [
+        "audit_log.viewed",
+        "audit_log.export_configured",
+      ] as const;
+
+      if (!allowedActions.includes(action)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid action. Must be one of: ${allowedActions.join(", ")}`,
+          },
+        });
+      }
+
+      void emitAuditLogEvent({
+        auth,
+        action,
+        targets: [buildWorkspaceTarget(owner)],
+        context: getAuditLogContext(auth, req),
+      });
+
+      res.status(200).end();
+      return;
     }
 
     default:

--- a/front/pages/api/w/[wId]/audit-logs.ts
+++ b/front/pages/api/w/[wId]/audit-logs.ts
@@ -1,5 +1,10 @@
 /** @ignoreswagger */
-import { isAuditLogsEnabled } from "@app/lib/api/audit/workos_audit";
+import {
+  buildWorkspaceTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+  isAuditLogsEnabled,
+} from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { generateWorkOSAdminPortalUrl } from "@app/lib/api/workos/organization";
@@ -66,6 +71,13 @@ async function handler(
           returnUrl,
         }),
       ]);
+
+      void emitAuditLogEvent({
+        auth,
+        action: "audit_log.viewed",
+        targets: [buildWorkspaceTarget(owner)],
+        context: getAuditLogContext(auth, req),
+      });
 
       return res.status(200).json({
         viewLogsLink: viewLogsResult.link,


### PR DESCRIPTION
## Description
Adds 2 new audit logs
Refactors the way we load audit log urls so they are constructed on click instead of on page load. This allows us to emit a log when they are actually accessed and prevents stale urls (they have a shelf life of 5min per workos docs)
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Test opening audit logs from admin panel, see there is now a slight load delay but I think this is worth the tradeoff
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
register new scemas
deploy front
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
