### PR TITLE
Fix local oauth failing on finalize

### DIFF
--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -311,14 +311,13 @@ export async function finalizeConnection(
     }
   }
 
-  if (auth) {
+  const workspace = auth?.workspace();
+  if (auth && workspace) {
     // No req available in this library function — context defaults to auth.clientIp().
     void emitAuditLogEvent({
       auth,
       action: "oauth.authorized",
-      targets: [
-        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-      ],
+      targets: [buildAuditLogTarget("workspace", workspace)],
       metadata: {
         provider: String(provider),
         connectionId,


### PR DESCRIPTION
## Description

For some reason, locally on the hive, I don't have a workspace when hitting `/api/oauth/google_drive/finalize`.
Do we need this? On prod it's not broken, but locally I could not activate the Gmail tool for example. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
