### PR TITLE
Create customer on checkout

### DIFF
--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -22,6 +22,7 @@ import {
   invoiceEnterprisePAYGCredits,
   isPAYGEnabled,
 } from "@app/lib/credits/payg";
+import { createMetronomeCustomer } from "@app/lib/metronome/client";
 import { PlanModel } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
@@ -96,6 +97,50 @@ async function grantFreeCreditsForSubscription({
     auth,
     stripeSubscription,
   });
+}
+
+/**
+ * Provision a Metronome customer for a workspace, linked to the Stripe customer.
+ * Fire-and-forget: logs errors but does not throw.
+ */
+async function provisionMetronomeCustomer({
+  workspace,
+  stripeCustomerId,
+}: {
+  workspace: WorkspaceResource;
+  stripeCustomerId: string;
+}): Promise<void> {
+  try {
+    const result = await createMetronomeCustomer({
+      workspaceId: workspace.sId,
+      workspaceName: workspace.name,
+      stripeCustomerId,
+    });
+
+    if (result.isOk()) {
+      await WorkspaceResource.updateMetronomeCustomerId(
+        workspace.id,
+        result.value.metronomeCustomerId
+      );
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          metronomeCustomerId: result.value.metronomeCustomerId,
+        },
+        "[Stripe Webhook] Metronome customer provisioned"
+      );
+    } else {
+      logger.error(
+        { workspaceId: workspace.sId, error: result.error.message },
+        "[Stripe Webhook] Failed to provision Metronome customer"
+      );
+    }
+  } catch (err) {
+    logger.error(
+      { workspaceId: workspace.sId, error: err },
+      "[Stripe Webhook] Failed to provision Metronome customer"
+    );
+  }
 }
 
 async function handler(
@@ -330,6 +375,18 @@ async function handler(
               });
             }
             await restoreWorkspaceAfterSubscription(auth);
+
+            // Provision Metronome customer if not already set.
+            if (!workspace.metronomeCustomerId) {
+              const stripeCustomerId =
+                typeof checkoutStripeSubscription.customer === "string"
+                  ? checkoutStripeSubscription.customer
+                  : "";
+              void provisionMetronomeCustomer({
+                workspace,
+                stripeCustomerId,
+              });
+            }
 
             await launchWorkOSWorkspaceSubscriptionCreatedWorkflow({
               workspaceId,

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -49,6 +49,7 @@ import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_worksp
 import { launchWorkOSWorkspaceSubscriptionCreatedWorkflow } from "@app/temporal/workos_events_queue/client";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import assert from "assert";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -137,7 +138,7 @@ async function provisionMetronomeCustomer({
     }
   } catch (err) {
     logger.error(
-      { workspaceId: workspace.sId, error: err },
+      { workspaceId: workspace.sId, error: normalizeError(err) },
       "[Stripe Webhook] Failed to provision Metronome customer"
     );
   }
@@ -378,14 +379,17 @@ async function handler(
 
             // Provision Metronome customer if not already set.
             if (!workspace.metronomeCustomerId) {
-              const stripeCustomerId =
-                typeof checkoutStripeSubscription.customer === "string"
-                  ? checkoutStripeSubscription.customer
-                  : "";
-              void provisionMetronomeCustomer({
-                workspace,
-                stripeCustomerId,
-              });
+              const stripeCustomerId = isString(
+                checkoutStripeSubscription.customer
+              )
+                ? checkoutStripeSubscription.customer
+                : null;
+              if (stripeCustomerId) {
+                void provisionMetronomeCustomer({
+                  workspace,
+                  stripeCustomerId,
+                });
+              }
             }
 
             await launchWorkOSWorkspaceSubscriptionCreatedWorkflow({

--- a/front/scripts/provision_metronome_customers.ts
+++ b/front/scripts/provision_metronome_customers.ts
@@ -14,7 +14,8 @@ async function provisionCustomer(
   execute: boolean,
   logger: Logger
 ) {
-  // Try to get Stripe customer ID from the active subscription.
+  // Get Stripe customer ID from the active subscription.
+  // Skip workspaces without a Stripe customer — only paying workspaces get a Metronome customer.
   let stripeCustomerId = "";
   const subscription = await SubscriptionModel.findOne({
     where: { workspaceId: workspace.id, status: "active" },
@@ -31,11 +32,19 @@ async function provisionCustomer(
     }
   }
 
+  if (!stripeCustomerId) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "Skipping — no Stripe customer"
+    );
+    return;
+  }
+
   logger.info(
     {
       workspaceId: workspace.sId,
       workspaceName: workspace.name,
-      stripeCustomerId: stripeCustomerId || "(none)",
+      stripeCustomerId,
     },
     `${execute ? "" : "[DRYRUN] "}Provisioning Metronome customer`
   );


### PR DESCRIPTION
## Description

Automatically provisions a Metronome customer when a workspace completes Stripe checkout.

In the `checkout.session.completed` webhook handler, after the subscription is created:
- Checks if workspace already has a `metronomeCustomerId` (skips if already provisioned)
- Creates Metronome customer linked to the Stripe customer ID via `createMetronomeCustomer`
- Persists `metronomeCustomerId` on the workspace

Fire-and-forget (`void`) — Metronome provisioning failure does not block checkout completion.

Replaces the need to run the `provision_metronome_customers.ts` script manually for new workspaces.

## Tests

Type-checked.

## Risk

Low — fire-and-forget, no impact on checkout flow if Metronome is unavailable or API key is not set.

## Deploy Plan

No special steps. Requires `METRONOME_API_KEY` to be set for provisioning to happen.