### PR TITLE
Fix inline activity chip labels for dynamic MCP server tools

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -61,6 +61,7 @@ export type ServerSideMCPToolType = Omit<
   // For "medium" stake tools: defines which arguments require per-agent approval.
   // When present, the user must approve the specific (agent, tool, argument values) combination.
   argumentsRequiringApproval?: string[];
+  displayLabels?: ToolDisplayLabels;
 };
 
 export type ClientSideMCPToolType = Omit<

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -226,6 +226,7 @@ function makeServerSideMCPToolConfigurations(
     secretName: config.secretName,
     dustProject: config.dustProject,
     ...(tool.timeoutMs && { timeoutMs: tool.timeoutMs }),
+    ...(tool.displayLabels && { displayLabels: tool.displayLabels }),
     argumentsRequiringApproval: toolsArgumentsRequiringApproval?.[tool.name],
   }));
 }

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -26,11 +26,18 @@ export function registerTool(
   tool: ToolDefinition,
   { monitoringName }: { monitoringName: string }
 ): void {
-  server.tool(
+  server.registerTool(
     tool.name,
-    tool.description,
-    tool.schema,
-
+    {
+      description: tool.description,
+      inputSchema: tool.schema,
+      _meta: {
+        dust: {
+          stake: tool.stake,
+          displayLabels: tool.displayLabels,
+        },
+      },
+    },
     withToolLogging(
       auth,
       {

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -796,8 +796,8 @@ async function createServer(
     schema: schema,
     stake: "never_ask",
     displayLabels: {
-      running: "Running child agent",
-      done: "Run child agent",
+      running: `Running @${childAgentBlob.name}`,
+      done: `Run @${childAgentBlob.name}`,
     },
     enableAlerting: true,
     handler: (params: SchemaType, extra: ToolHandlerExtra) =>

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -15,10 +15,7 @@ import {
 } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import { isFileAuthorizationInfo } from "@app/lib/actions/types";
-import {
-  isLightClientSideMCPToolConfiguration,
-  isLightServerSideMCPToolConfiguration,
-} from "@app/lib/actions/types/guards";
+import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { getCitationsFromToolOutput } from "@app/lib/api/assistant/citations";
 import { getAgentConfigurationsWithVersion } from "@app/lib/api/assistant/configuration/agent";
 import type { ToolDisplayLabels } from "@app/lib/api/mcp";
@@ -983,17 +980,10 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       this.functionCallName;
     const mcpServerId = this.metadata.mcpServerId ?? null;
 
-    const displayLabels = internalMCPServerName
-      ? (getInternalMCPServerToolDisplayLabels(internalMCPServerName)?.[
-          toolName
-        ] ?? null)
-      : isLightClientSideMCPToolConfiguration(this.toolConfiguration) &&
-          this.toolConfiguration.displayLabels
-        ? this.toolConfiguration.displayLabels
-        : getDefaultRemoteDisplayLabels(
-            this.toolConfiguration.mcpServerName,
-            toolName
-          );
+    const displayLabels = this.resolveDisplayLabels(
+      internalMCPServerName,
+      toolName
+    );
 
     return {
       id: this.id,
@@ -1013,6 +1003,33 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       executionDurationMs: this.executionDurationMs,
       displayLabels,
     };
+  }
+
+  /**
+   * Resolve displayLabels for this action. Checks the persisted toolConfiguration
+   * first (handles dynamic tool names), then falls back to static metadata for
+   * older DB records or remote server defaults.
+   */
+  private resolveDisplayLabels(
+    internalMCPServerName: InternalMCPServerNameType | null,
+    toolName: string
+  ): ToolDisplayLabels | null {
+    if (this.toolConfiguration.displayLabels) {
+      return this.toolConfiguration.displayLabels;
+    }
+
+    if (internalMCPServerName) {
+      return (
+        getInternalMCPServerToolDisplayLabels(internalMCPServerName)?.[
+          toolName
+        ] ?? null
+      );
+    }
+
+    return getDefaultRemoteDisplayLabels(
+      this.toolConfiguration.mcpServerName,
+      toolName
+    );
   }
 
   async updateStatus(


### PR DESCRIPTION
## Description

Internal MCP servers with dynamic tool names (like run_agent and run_dust_app) were showing raw function call names on
the inline activity chip, e.g. "Sub Agent Run Dust Task" instead of "Run @dust-task".

The root cause was that displayLabels set on ToolDefinition objects never reached the persisted action. 

If I understand correctly, the registerTool wrapper used the deprecated server.tool() which discards _meta, the ServerSideMCPToolType didn't have a displayLabels field, and makeServerSideMCPToolConfigurations didn't include it in the config. So for servers with dynamic tool names that don't match static metadata, the label resolution fell back to asDisplayName(functionCallName).

This change makes displayLabels flow end-to-end for server-side tools, the same way they already do for client-side tools. The registerTool wrapper now uses server.registerTool() which passes displayLabels via _meta.dust. The ServerSideMCPToolType gains a displayLabels field. makeServerSideMCPToolConfigurations includes it in the tool config. The resolution logic in the resource checks toolConfiguration.displayLabels first, then falls back to static metadata
for old DB records that don't have it yet.

The run_agent server now sets "Running @{agentName}" / "Run @{agentName}" directly in its tool definition, matching the
 format already used in the detail panel.

## Tests

Locally. 

## Risk

I'm not sure about the blast radius of the change in `registerTool`, but it look like both server.tool()  is deprecated and we should call `registerTool`, iiuc: https://github.com/modelcontextprotocol/typescript-sdk/blob/v1.x/src/server/mcp.ts#L943

Can be rolled back. 

## Deploy Plan

Deploy front. 
