### PR TITLE
Make active action clickable on inline activity chip

### DIFF
--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -244,11 +244,21 @@ export function InlineActivitySteps({
 
             {/* Active action (tool in progress) */}
             {isActing && activeAction && (
-              <TimelineRow spinner isLast={false}>
-                <span className="text-muted-foreground dark:text-muted-foreground-night">
-                  {getActionOneLineLabel(activeAction, "running")}
-                </span>
-              </TimelineRow>
+              <div
+                className="cursor-pointer"
+                onClick={() => openBreakdownPanel(activeAction.sId)}
+              >
+                <TimelineRow spinner isLast={false}>
+                  <span className="text-muted-foreground dark:text-muted-foreground-night flex items-center gap-1">
+                    {getActionOneLineLabel(activeAction, "running")}
+                    <Icon
+                      size="xs"
+                      visual={ChevronRightIcon}
+                      className="shrink-0 opacity-50"
+                    />
+                  </span>
+                </TimelineRow>
+              </div>
             )}
 
             {/* Pending spinner — shown when between transitions (not done, nothing active) */}


### PR DESCRIPTION
## Description

The inline activity chip only allowed clicking on completed actions to open the breakdown panel. Actions that were still running were not clickable, which felt inconsistent. This makes the active action clickable too, with the same chevron indicator as completed actions.

<kbd>
<img width="496" height="288" alt="Screenshot 2026-04-02 at 23 23 31" src="https://github.com/user-attachments/assets/dd114e41-29af-44a9-8058-87bdc1bc6926" />
</kbd>

## Tests

Locally.

## Risk

Gated. 
Can be rolled back. 

## Deploy Plan

Deploy front. 