### PR TITLE
Collapse long chain-of-thought in inline activity steps

### DIFF
--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -233,6 +233,7 @@ export function InlineActivitySteps({
                     variant="light"
                     buttonClassName="mt-1"
                     animated
+                    isStreaming={true}
                   >
                     <Markdown
                       content={chainOfThought}

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -227,17 +227,25 @@ export function InlineActivitySteps({
                 isLast={!activeAction && !isDone}
               >
                 {chainOfThought ? (
-                  <Markdown
-                    content={chainOfThought}
-                    isStreaming={false}
-                    streamingState="streaming"
-                    enableAnimation
-                    animationDurationSeconds={0.3}
-                    delimiter=" "
-                    forcedTextSize="text-sm"
-                    textColor="text-muted-foreground dark:text-muted-foreground-night"
-                    isLastMessage={false}
-                  />
+                  <TruncatedContent
+                    thresholdPx={80}
+                    collapsedHeightPx={60}
+                    variant="light"
+                    buttonClassName="mt-1"
+                    animated
+                  >
+                    <Markdown
+                      content={chainOfThought}
+                      isStreaming={false}
+                      streamingState="streaming"
+                      enableAnimation
+                      animationDurationSeconds={0.3}
+                      delimiter=" "
+                      forcedTextSize="text-sm"
+                      textColor="text-muted-foreground dark:text-muted-foreground-night"
+                      isLastMessage={false}
+                    />
+                  </TruncatedContent>
                 ) : null}
               </TimelineRow>
             )}

--- a/sparkle/src/components/TruncatedContent.tsx
+++ b/sparkle/src/components/TruncatedContent.tsx
@@ -47,6 +47,7 @@ export function TruncatedContent({
   const contentRef = useRef<HTMLDivElement>(null);
   const [exceedsThreshold, setExceedsThreshold] = useState(defaultCollapsed);
   const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
+  const [isAnimating, setIsAnimating] = useState(false);
 
   useEffect(() => {
     const el = contentRef.current;
@@ -58,7 +59,10 @@ export function TruncatedContent({
   const shouldShowToggle = exceedsThreshold;
   const isCurrentlyCollapsed = shouldShowToggle && isCollapsed;
 
-  const handleToggle = () => setIsCollapsed((prev) => !prev);
+  const handleToggle = () => {
+    setIsAnimating(animated);
+    setIsCollapsed((prev) => !prev);
+  };
 
   return (
     <div className={className}>
@@ -68,14 +72,14 @@ export function TruncatedContent({
         style={{
           maxHeight: isCurrentlyCollapsed
             ? `${collapsedHeightPx}px`
-            : animated && shouldShowToggle
+            : isAnimating
               ? `${contentRef.current?.scrollHeight}px`
               : undefined,
-          transition:
-            animated && shouldShowToggle
-              ? `max-height ${animationDurationMs}ms ease-out`
-              : undefined,
+          transition: isAnimating
+            ? `max-height ${animationDurationMs}ms ease-out`
+            : undefined,
         }}
+        onTransitionEnd={() => setIsAnimating(false)}
       >
         {children}
         <div

--- a/sparkle/src/components/TruncatedContent.tsx
+++ b/sparkle/src/components/TruncatedContent.tsx
@@ -24,6 +24,7 @@ export interface TruncatedContentProps {
   animationDurationMs?: number;
   expandLabel?: string;
   collapseLabel?: string;
+  isStreaming?: boolean;
   variant?: "default" | "light";
   footer?: React.ReactNode;
   className?: string;
@@ -39,13 +40,16 @@ export function TruncatedContent({
   animationDurationMs = 200,
   expandLabel = "Show more",
   collapseLabel = "Show less",
+  isStreaming = false,
   variant = "default",
   footer,
   className,
   buttonClassName,
 }: TruncatedContentProps) {
   const contentRef = useRef<HTMLDivElement>(null);
-  const [exceedsThreshold, setExceedsThreshold] = useState(defaultCollapsed);
+  const [exceedsThreshold, setExceedsThreshold] = useState(
+    defaultCollapsed && !isStreaming
+  );
   const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
   const [isAnimating, setIsAnimating] = useState(false);
 
@@ -83,11 +87,16 @@ export function TruncatedContent({
       >
         {children}
         <div
-          className={cn(
-            "s-pointer-events-none s-absolute s-bottom-0 s-left-0 s-right-0 s-h-24 s-bg-gradient-to-t s-from-background dark:s-from-background-night s-transition-opacity",
-            isCurrentlyCollapsed ? "s-opacity-100" : "s-opacity-0"
-          )}
-          style={{ transitionDuration: `${animationDurationMs}ms` }}
+          className="s-pointer-events-none s-absolute s-bottom-0 s-left-0 s-right-0 s-bg-gradient-to-t s-from-background dark:s-from-background-night s-transition-all s-overflow-hidden"
+          style={{
+            height:
+              isCurrentlyCollapsed || (isStreaming && isCollapsed)
+                ? "6rem"
+                : "0",
+            opacity:
+              isCurrentlyCollapsed || (isStreaming && isCollapsed) ? 1 : 0,
+            transitionDuration: `${animationDurationMs}ms`,
+          }}
         />
       </div>
       <div className="s-flex s-items-center s-gap-3">

--- a/sparkle/src/components/TruncatedContent.tsx
+++ b/sparkle/src/components/TruncatedContent.tsx
@@ -53,7 +53,7 @@ export function TruncatedContent({
     if (el) {
       setExceedsThreshold(el.scrollHeight > thresholdPx);
     }
-  }, [thresholdPx]);
+  }, [children, thresholdPx]);
 
   const shouldShowToggle = exceedsThreshold;
   const isCurrentlyCollapsed = shouldShowToggle && isCollapsed;
@@ -78,9 +78,13 @@ export function TruncatedContent({
         }}
       >
         {children}
-        {isCurrentlyCollapsed && (
-          <div className="s-pointer-events-none s-absolute s-bottom-0 s-left-0 s-right-0 s-h-24 s-bg-gradient-to-t s-from-background dark:s-from-background-night" />
-        )}
+        <div
+          className={cn(
+            "s-pointer-events-none s-absolute s-bottom-0 s-left-0 s-right-0 s-h-24 s-bg-gradient-to-t s-from-background dark:s-from-background-night s-transition-opacity",
+            isCurrentlyCollapsed ? "s-opacity-100" : "s-opacity-0"
+          )}
+          style={{ transitionDuration: `${animationDurationMs}ms` }}
+        />
       </div>
       <div className="s-flex s-items-center s-gap-3">
         {shouldShowToggle && (


### PR DESCRIPTION
## Description
Previously, long chain of thought blocks were expanded and then once the thinking was done they became auto-collapsed. This change wraps the chain-of-thought content in TruncatedContent and add makes a few small tweaks so these can auto-collapse as they stream in. Once the max height is reached (ie there will be more than three lines of text), fade the gradient overlay smoothly via opacity transition 

Also noticed that when expanded and actively streaming, the "show less" button would overlay the end of the content so I fixed that quickly

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manual visual test:
https://github.com/user-attachments/assets/fb46df5c-af22-4271-8400-7a9ba47f3745

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
Deploy front
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
