### PR TITLE
Fix: do not auto mention dust when there is only one other human in the convo

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -678,15 +678,15 @@ export async function postUserMessage(
       mentions.length === 0 &&
       (context.origin === "web" || context.origin === "extension")
     ) {
-      const areHumansInteracting =
+      const hasOtherHumans =
         uniq(
           conversation.content
             .map((versions) => versions[versions.length - 1])
             .filter(isUserMessageType)
-            .map((m) => m.user?.sId)
-        ).length >= 2;
+            .map((m) => m.user?.sId && m.user.sId !== auth.user()?.sId)
+        ).length >= 1;
 
-      if (!areHumansInteracting) {
+      if (!hasOtherHumans) {
         // Check if the global @dust agent is active for this workspace.
         const dustAgent = agentConfigurations.find(
           (agent) =>


### PR DESCRIPTION
## Description

When moved to the backend, didn't realilze that the new user's message wouldn't be accounted for like in the front end.

## Tests

Green

## Risk

Low

## Deploy Plan

Deploy front