### PR TITLE
List project's files using content fragment. Fix cleanup of datasource on file deletion.

### DIFF
--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -348,7 +348,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
 
           {!hasFiles ? (
             <EmptyCTA
-              message="No knowledge files in this room yet."
+              message="No knowledge added to this project yet."
               action={
                 <EmptyCTAButton
                   icon={ArrowUpOnSquareIcon}

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -16,7 +16,10 @@ import { PROJECT_MANAGER_TOOLS_METADATA } from "@app/lib/api/actions/servers/pro
 import { formatConversationsForDisplay } from "@app/lib/api/actions/servers/project_manager/tools/conversation_formatting";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import config from "@app/lib/api/config";
-import { addFileToProject } from "@app/lib/api/projects";
+import {
+  addFileToProject,
+  listProjectContextFiles,
+} from "@app/lib/api/projects";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -357,10 +360,7 @@ export function createProjectManagerTools(
           space
         );
 
-        // Fetch files
-        const files = await FileResource.listByProject(auth, {
-          projectId: space.sId,
-        });
+        const files = await listProjectContextFiles(auth, space);
 
         const fileList = files
           .filter((file) => isSupportedFileContentType(file.contentType))

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -162,7 +162,11 @@ export function createProjectManagerTools(
           );
         }
 
-        const upsertRes = await addFileToProject(auth, file);
+        const upsertRes = await addFileToProject(auth, {
+          file,
+          space,
+          sourceConversationId: agentLoopContext?.runContext?.conversation?.sId,
+        });
 
         if (upsertRes.isErr()) {
           logger.warn(
@@ -272,7 +276,11 @@ export function createProjectManagerTools(
         await file.uploadContent(auth, fileContent);
 
         // Re-upsert to datasource to update search index.
-        const upsertRes = await addFileToProject(auth, file);
+        const upsertRes = await addFileToProject(auth, {
+          file,
+          space,
+          sourceConversationId: agentLoopContext?.runContext?.conversation?.sId,
+        });
 
         if (upsertRes.isErr()) {
           logger.error(

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -8,8 +8,8 @@ import {
   getAttachmentFromContentFragment,
   makeFileAttachment,
 } from "@app/lib/api/assistant/conversation/attachments";
+import { listProjectContextFiles } from "@app/lib/api/projects";
 import type { Authenticator } from "@app/lib/auth";
-import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
@@ -81,9 +81,7 @@ export async function listAttachments(
         "Space not found for conversation"
       );
     } else {
-      const files = await FileResource.listByProject(auth, {
-        projectId: space.sId,
-      });
+      const files = await listProjectContextFiles(auth, space);
 
       for (const f of files) {
         attachments.set(

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -8,64 +8,14 @@ import { fetchProjectDataSource } from "@app/lib/api/projects/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
-import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { isSupportedDelimitedTextContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { slugify } from "@app/types/shared/utils/string_utils";
-
-function validateFileMetadataForProjectContext(
-  file: FileResource
-): Result<string, Error> {
-  const spaceId = file.useCaseMetadata?.spaceId;
-  if (!spaceId) {
-    return new Err(new Error("Field spaceId is missing from metadata"));
-  }
-
-  return new Ok(spaceId);
-}
-
-export async function getProjectDataSourceFromFile(
-  auth: Authenticator,
-  file: FileResource
-): Promise<
-  Result<
-    DataSourceResource,
-    DustError<
-      "space_not_found" | "invalid_request_error" | "data_source_not_found"
-    >
-  >
-> {
-  // Note: this assume that if we don't have useCaseMetadata, the file is fine.
-  const metadataResult = validateFileMetadataForProjectContext(file);
-  if (metadataResult.isErr()) {
-    return new Err({
-      name: "dust_error",
-      code: "invalid_request_error",
-      message: metadataResult.error.message,
-    });
-  }
-
-  const space = await SpaceResource.fetchById(auth, metadataResult.value);
-  if (!space) {
-    return new Err({
-      name: "dust_error",
-      code: "space_not_found",
-      message: `Failed to fetch space.`,
-    });
-  }
-
-  const r = await fetchProjectDataSource(auth, space);
-  if (r.isErr()) {
-    return new Err(r.error);
-  }
-
-  return new Ok(r.value);
-}
 
 export async function listProjectContentFragments(
   auth: Authenticator,
@@ -123,25 +73,29 @@ export async function listProjectContextFiles(
  */
 export async function addFileToProject(
   auth: Authenticator,
-  file: FileResource
+  {
+    file,
+    space,
+    sourceConversationId,
+  }: {
+    file: FileResource;
+    space: SpaceResource;
+    sourceConversationId?: string;
+  }
 ): Promise<Result<ContentFragmentResource, DustError>> {
-  const metadataResult = validateFileMetadataForProjectContext(file);
-  if (metadataResult.isErr()) {
+  if (space.kind !== "project") {
     return new Err({
       name: "dust_error",
       code: "invalid_request_error",
-      message: metadataResult.error.message,
+      message: "Space is not a project.",
     });
   }
 
-  const space = await SpaceResource.fetchById(auth, metadataResult.value);
-  if (!space) {
-    return new Err({
-      name: "dust_error",
-      code: "space_not_found",
-      message: `Failed to fetch space.`,
-    });
-  }
+  await file.updateUseCase(auth, "project_context", {
+    spaceId: space.sId,
+    conversationId: undefined,
+    sourceConversationId,
+  });
 
   const projectContextDatasource = await fetchProjectDataSource(auth, space);
   if (projectContextDatasource.isErr()) {

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -9,12 +9,13 @@ import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { isSupportedDelimitedTextContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
 import { slugify } from "@app/types/shared/utils/string_utils";
 
 function validateFileMetadataForProjectContext(
@@ -71,6 +72,46 @@ export async function listProjectContentFragments(
   space: SpaceResource
 ): Promise<ContentFragmentResource[]> {
   return ContentFragmentResource.listBySpace(auth, space);
+}
+
+/**
+ * Project context files for a space from latest file-backed `content_fragments`
+ * rows (`spaceId`), in fragment order (`createdAt` DESC).
+ */
+export async function listProjectContextFiles(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<FileResource[]> {
+  const fragments = await ContentFragmentResource.listBySpace(auth, space);
+  const fileModelIds = removeNulls(fragments.map((fr) => fr.fileId));
+
+  const filesByModelId = new Map<number, FileResource>();
+  if (fileModelIds.length > 0) {
+    const fetched = await FileResource.fetchByModelIdsWithAuth(
+      auth,
+      fileModelIds
+    );
+    for (const f of fetched) {
+      filesByModelId.set(f.id, f);
+    }
+  }
+
+  const files: FileResource[] = [];
+  const seenSIds = new Set<string>();
+
+  for (const fr of fragments) {
+    if (fr.fileId == null) {
+      continue;
+    }
+    const file = filesByModelId.get(fr.fileId);
+    if (!file || seenSIds.has(file.sId)) {
+      continue;
+    }
+    seenSIds.add(file.sId);
+    files.push(file);
+  }
+
+  return files;
 }
 
 /**

--- a/front/lib/api/projects/index.ts
+++ b/front/lib/api/projects/index.ts
@@ -4,6 +4,7 @@ export {
   addFileToProject,
   getProjectDataSourceFromFile,
   listProjectContentFragments,
+  listProjectContextFiles,
 } from "./context";
 export {
   fetchProjectDataSource,

--- a/front/lib/api/projects/index.ts
+++ b/front/lib/api/projects/index.ts
@@ -2,7 +2,6 @@ export type { ProjectType } from "@app/types/space";
 export { createDataSourceAndConnectorForProject } from "./connector";
 export {
   addFileToProject,
-  getProjectDataSourceFromFile,
   listProjectContentFragments,
   listProjectContextFiles,
 } from "./context";

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -11,6 +11,7 @@ import {
   getProcessedContentType,
   hasProcessedVersion,
 } from "@app/lib/api/files/processing";
+import { fetchProjectDataSource } from "@app/lib/api/projects/data_sources";
 import {
   getDefaultFrameShareScope,
   sendFrameSharedEmail,
@@ -24,6 +25,8 @@ import {
 } from "@app/lib/file_storage";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   ExternalViewerSessionModel,
   FileModel,
@@ -37,6 +40,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { copyContent } from "@app/lib/utils/files";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import { CoreAPI } from "@app/types/core/core_api";
 import type {
   FileShareScope,
   FileType,
@@ -430,6 +434,8 @@ export class FileResource extends BaseResource<FileModel> {
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
     try {
       if (this.isReady) {
+        await maybeDeleteCoreArtifactsForIndexedFile(auth, this);
+
         // Delete mount file copies if set.
         await this.deleteMountFileCopies();
 
@@ -1500,6 +1506,145 @@ export class FileResource extends BaseResource<FileModel> {
     } catch (error) {
       return new Err(normalizeError(error));
     }
+  }
+}
+
+function isBenignCoreIndexedFileDeleteError(code: string): boolean {
+  return (
+    code === "data_source_document_not_found" || code === "table_not_found"
+  );
+}
+
+/**
+ * Best-effort: remove Core tables (including `generatedTables` and `file.sId`) and the
+ * document `file.sId` from the given data source. Wrong-type deletes return benign errors.
+ */
+async function deleteCoreFileArtifactsFromDataSource(
+  auth: Authenticator,
+  dataSource: DataSourceResource,
+  file: FileResource
+): Promise<void> {
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+  const projectId = dataSource.dustAPIProjectId;
+  const dataSourceId = dataSource.dustAPIDataSourceId;
+  const logCtx = {
+    workspaceId: auth.workspace()?.sId,
+    fileId: file.sId,
+    dataSourceSId: dataSource.sId,
+  };
+
+  const tableIds = new Set<string>([
+    ...(file.useCaseMetadata?.generatedTables ?? []),
+    file.sId,
+  ]);
+
+  for (const tableId of tableIds) {
+    const delTableRes = await coreAPI.deleteTable({
+      projectId,
+      dataSourceId,
+      tableId,
+    });
+    if (
+      delTableRes.isErr() &&
+      !isBenignCoreIndexedFileDeleteError(delTableRes.error.code)
+    ) {
+      logger.warn(
+        { ...logCtx, tableId, error: delTableRes.error },
+        "File delete: failed to remove table from Core data source."
+      );
+    }
+  }
+
+  const delDocRes = await coreAPI.deleteDataSourceDocument({
+    projectId,
+    dataSourceId,
+    documentId: file.sId,
+  });
+  if (
+    delDocRes.isErr() &&
+    !isBenignCoreIndexedFileDeleteError(delDocRes.error.code)
+  ) {
+    logger.warn(
+      { ...logCtx, error: delDocRes.error },
+      "File delete: failed to remove document from Core data source."
+    );
+  }
+}
+
+async function maybeDeleteCoreArtifactsForIndexedFile(
+  auth: Authenticator,
+  file: FileResource
+): Promise<void> {
+  if (file.useCase === "project_context") {
+    const spaceSId = file.useCaseMetadata?.spaceId;
+    if (!spaceSId) {
+      return;
+    }
+    const space = await SpaceResource.fetchById(auth, spaceSId);
+    if (!space) {
+      logger.warn(
+        {
+          workspaceId: auth.workspace()?.sId,
+          fileId: file.sId,
+          spaceSId,
+        },
+        "File delete: project space not found; skipping Core cleanup."
+      );
+      return;
+    }
+    const dsRes = await fetchProjectDataSource(auth, space);
+    if (dsRes.isErr()) {
+      logger.warn(
+        {
+          workspaceId: auth.workspace()?.sId,
+          fileId: file.sId,
+          spaceSId,
+          error: dsRes.error,
+        },
+        "File delete: project dust_project data source not found; skipping Core cleanup."
+      );
+      return;
+    }
+    await deleteCoreFileArtifactsFromDataSource(auth, dsRes.value, file);
+    return;
+  }
+
+  if (file.useCase === "conversation") {
+    const conversationSId = file.useCaseMetadata?.conversationId;
+    if (!conversationSId) {
+      return;
+    }
+    const cRes = await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationSId
+    );
+    if (cRes.isErr()) {
+      logger.warn(
+        {
+          workspaceId: auth.workspace()?.sId,
+          fileId: file.sId,
+          conversationSId,
+        },
+        "File delete: conversation not found; skipping Core cleanup."
+      );
+      return;
+    }
+    const dataSource = await DataSourceResource.fetchByConversation(
+      auth,
+      cRes.value
+    );
+    if (!dataSource) {
+      logger.warn(
+        {
+          workspaceId: auth.workspace()?.sId,
+          fileId: file.sId,
+          conversationSId,
+        },
+        "File delete: conversation data source not found; skipping Core cleanup."
+      );
+      return;
+    }
+    await deleteCoreFileArtifactsFromDataSource(auth, dataSource, file);
   }
 }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1057,28 +1057,26 @@ export class FileResource extends BaseResource<FileModel> {
     );
   }
 
-  /**
-   * Move a conversation frame file to a project (change use case to project_context).
-   * Preserves existing metadata and sets spaceId and sourceConversationId.
-   */
-  async moveFrameToSpace(
+  async updateUseCase(
     auth: Authenticator,
-    { projectId }: { projectId: string }
-  ): Promise<void> {
-    const existingMetadata = this.useCaseMetadata ?? {};
-    if (!this.isInteractiveContent || !existingMetadata.conversationId) {
-      throw new Error("File is not a conversation frame");
+    useCase: FileUseCase,
+    metadata: FileUseCaseMetadata
+  ) {
+    if (this.useCase === useCase) {
+      return;
     }
 
+    // Eg: for a conversation file, we need to cleanup the core artifacts.
+    await maybeDeleteCoreArtifactsForIndexedFile(auth, this);
+
+    const mergedMetadata: FileUseCaseMetadata = {
+      ...(this.useCaseMetadata ?? {}),
+      ...metadata,
+    };
+
     await this.update({
-      useCase: "project_context",
-      useCaseMetadata: {
-        ...existingMetadata,
-        spaceId: projectId,
-        // Remove conversationId to prevent confusion when accessing the file.
-        conversationId: undefined,
-        sourceConversationId: existingMetadata.conversationId,
-      },
+      useCase,
+      useCaseMetadata: mergedMetadata,
       userId: auth.getNonNullableUser().id ?? null,
     });
   }

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -177,7 +177,7 @@ export function useFileMetadata({
       : `/api/w/${owner.sId}/files/${fileId}/metadata`
     : null;
 
-  const { data, error, mutate } = useSWRWithDefaults(
+  const { data, error, mutateRegardlessOfQueryParams } = useSWRWithDefaults(
     swrKey,
     fileMetadataFetcher
   );
@@ -186,7 +186,7 @@ export function useFileMetadata({
     fileMetadata: data,
     isFileMetadataLoading: !error && !data,
     isFileMetadataError: error,
-    mutateFileMetadata: mutate,
+    mutateFileMetadata: mutateRegardlessOfQueryParams,
   };
 }
 

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -453,28 +453,27 @@ async function handler(
             });
           }
         }
-      } else if (
-        file.useCase === "project_context" &&
-        space &&
-        isFileTypeUpsertableForUseCase(file)
-      ) {
-        const upsertRes = await addFileToProject(auth, file);
+      } else if (file.useCase === "project_context" && space) {
+        const addFileToProjectRes = await addFileToProject(auth, {
+          file,
+          space,
+        });
 
-        if (upsertRes.isErr()) {
+        if (addFileToProjectRes.isErr()) {
           logger.error({
             fileModelId: file.id,
             workspaceId: auth.workspace()?.sId,
             contentType: file.contentType,
             useCase: file.useCase,
             useCaseMetadata: file.useCaseMetadata,
-            message: "Failed to upsert the file.",
-            error: upsertRes.error,
+            message: "Failed to add the file to the project.",
+            error: addFileToProjectRes.error,
           });
           return apiError(req, res, {
             status_code: 500,
             api_error: {
               type: "internal_server_error",
-              message: "Failed to upsert the file.",
+              message: "Failed to add the file to the project.",
             },
           });
         }

--- a/front/pages/api/w/[wId]/files/[fileId]/save-in-project.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/save-in-project.test.ts
@@ -365,7 +365,7 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
     expect(data.file.useCaseMetadata.sourceConversationId).toBe(
       conversation.sId
     );
-    // moveFrameToSpace clears conversationId to avoid confusion when accessing the file in project context.
+    // updateUseCase clears conversationId to avoid confusion when accessing the file in project context.
     expect(data.file.useCaseMetadata.conversationId).toBeUndefined();
   });
 

--- a/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
@@ -1,5 +1,6 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { addFileToProject } from "@app/lib/api/projects";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -145,7 +146,11 @@ async function handler(
 
   switch (req.method) {
     case "POST": {
-      await file.moveFrameToSpace(auth, { projectId });
+      await addFileToProject(auth, {
+        file,
+        space,
+        sourceConversationId: file.useCaseMetadata?.conversationId,
+      });
 
       return res.status(200).json({
         file: file.toJSONWithMetadata(auth),

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
@@ -1,6 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
-import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { describe, expect, it } from "vitest";
@@ -24,22 +24,18 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_files", () => {
     const space = globalSpace;
 
     // Create some project files
-    await FileFactory.create(auth, user, {
+    await ProjectFileFactory.create(auth, user, space, {
       contentType: "text/plain",
       fileName: "test1.txt",
       fileSize: 100,
       status: "ready",
-      useCase: "project_context",
-      useCaseMetadata: { spaceId: space.sId },
     });
 
-    await FileFactory.create(auth, user, {
+    await ProjectFileFactory.create(auth, user, space, {
       contentType: "image/png",
       fileName: "test2.png",
       fileSize: 200,
       status: "ready",
-      useCase: "project_context",
-      useCaseMetadata: { spaceId: space.sId },
     });
 
     req.query.spaceId = space.sId;
@@ -121,23 +117,19 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_files", () => {
     const space = globalSpace;
 
     // Create file with user
-    await FileFactory.create(auth, user, {
+    await ProjectFileFactory.create(auth, user, space, {
       contentType: "text/csv",
       fileName: "data.csv",
       fileSize: 500,
       status: "ready",
-      useCase: "project_context",
-      useCaseMetadata: { spaceId: space.sId },
     });
 
     // Create file without user
-    await FileFactory.create(auth, null, {
+    await ProjectFileFactory.create(auth, null, space, {
       contentType: "application/json",
       fileName: "data.json",
       fileSize: 300,
       status: "ready",
-      useCase: "project_context",
-      useCaseMetadata: { spaceId: space.sId },
     });
 
     req.query.spaceId = space.sId;
@@ -210,13 +202,11 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_files", () => {
 
     const space = globalSpace;
 
-    await FileFactory.create(auth, user, {
+    await ProjectFileFactory.create(auth, user, space, {
       contentType: "text/markdown",
       fileName: "readme.md",
       fileSize: 1024,
       status: "ready",
-      useCase: "project_context",
-      useCaseMetadata: { spaceId: space.sId },
     });
 
     req.query.spaceId = space.sId;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -1,7 +1,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { listProjectContextFiles } from "@app/lib/api/projects";
 import type { Authenticator } from "@app/lib/auth";
-import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -53,9 +53,7 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const files = await FileResource.listByProject(auth, {
-        projectId: spaceId,
-      });
+      const files = await listProjectContextFiles(auth, space);
 
       // Fetch user information for all files
       const userIds = files

--- a/front/tests/utils/ProjectFileFactory.ts
+++ b/front/tests/utils/ProjectFileFactory.ts
@@ -1,0 +1,63 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type { AllSupportedFileContentType, FileStatus } from "@app/types/files";
+
+import { FileFactory } from "./FileFactory";
+
+type ProjectFileCreateOptions = {
+  contentType: AllSupportedFileContentType;
+  fileName: string;
+  fileSize: number;
+  status: FileStatus;
+  snippet?: string | null;
+};
+
+export class ProjectFileFactory {
+  /**
+   * Creates a project-context file and ensures the corresponding latest
+   * `content_fragments` row exists so project endpoints can list it.
+   */
+  static async create(
+    auth: Authenticator,
+    user: UserResource | null,
+    space: SpaceResource,
+    {
+      contentType,
+      fileName,
+      fileSize,
+      status,
+      snippet = null,
+    }: ProjectFileCreateOptions
+  ): Promise<FileResource> {
+    const file = await FileFactory.create(auth, user, {
+      contentType,
+      fileName,
+      fileSize,
+      status,
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+      snippet,
+    });
+
+    // Project content fragments are only created for ready project-context files.
+    if (file.isReady) {
+      const fragmentRes =
+        await ContentFragmentResource.upsertLatestProjectFileFragment(
+          auth,
+          space,
+          file
+        );
+
+      if (fragmentRes.isErr()) {
+        throw new Error(
+          `Failed to upsert latest project content fragment: ${fragmentRes.error.message}`
+        );
+      }
+    }
+
+    return file;
+  }
+}


### PR DESCRIPTION
## Description

Sorry, it's a bit of a bundle of fix for bugs I discovered while testing (my initial intent was just to switch the source of truth)
- Use content fragment as the source of truth for listing files in project.
- Deletion of previous datasource entry when deleting or moving a file.
- Streamline adding a file to project (the whole logic is now in addFileToProject).
- Fix frame "saved to project" state not updating immediately.

## Tests

Local + green

## Risk

Low

## Deploy Plan

Deploy front