### PR TITLE
refactor: use withResourceFetchingFromRoute for space endpoints

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversation_ids.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversation_ids.ts
@@ -1,11 +1,11 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isString } from "@app/types/shared/utils/general";
 import type { GetSpaceConversationIdsResponseType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -21,28 +21,9 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<GetSpaceConversationIdsResponseType>
   >,
-  auth: Authenticator
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
 ): Promise<void> {
-  const { wId, spaceId } = req.query;
-  if (!isString(wId)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Missing or invalid workspace id.",
-      },
-    });
-  }
-  if (!isString(spaceId)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Missing or invalid space id.",
-      },
-    });
-  }
-
   // Only allow system keys (connectors) to access this endpoint
   if (!auth.isSystemKey()) {
     return apiError(req, res, {
@@ -56,24 +37,12 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      // Fetch and verify space exists
-      const space = await SpaceResource.fetchById(auth, spaceId);
-      if (!space) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "space_not_found",
-            message: "Space not found.",
-          },
-        });
-      }
-
       // Get all conversation IDs for the space (only visible/non-deleted conversations)
       // This endpoint is used for garbage collection to identify conversations that
       // were hard-deleted and no longer exist in the database
       const spaceConversations =
         await ConversationResource.listConversationsInSpace(auth, {
-          spaceId,
+          spaceId: space.sId,
           options: {
             dangerouslySkipPermissionFiltering: true, // System key has access
             // Don't include deleted - we only want conversations that still exist
@@ -87,8 +56,8 @@ async function handler(
 
       logger.info(
         {
-          workspaceId: wId,
-          spaceId,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          spaceId: space.sId,
           conversationCount: conversationIds.length,
         },
         "[GetSpaceConversationIds] Successfully fetched conversation IDs"
@@ -110,4 +79,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(
+  withResourceFetchingFromRoute(handler, { space: {} })
+);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversations/index.ts
@@ -1,10 +1,11 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import { addBackwardCompatibleConversationFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
@@ -25,28 +26,9 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<GetSpaceConversationsForDataSourceResponseType>
   >,
-  auth: Authenticator
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
 ): Promise<void> {
-  const { wId, spaceId } = req.query;
-  if (!isString(wId)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Missing or invalid workspace id.",
-      },
-    });
-  }
-  if (!isString(spaceId)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Missing or invalid space id.",
-      },
-    });
-  }
-
   // Only allow system keys (connectors) to access this endpoint
   if (!auth.isSystemKey()) {
     return apiError(req, res, {
@@ -65,23 +47,11 @@ async function handler(
         ? parseInt(updatedSince, 10)
         : null;
 
-      // Fetch and verify space exists
-      const space = await SpaceResource.fetchById(auth, spaceId);
-      if (!space) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "space_not_found",
-            message: "Space not found.",
-          },
-        });
-      }
-
       // Get all conversations for the space (including deleted ones)
       // Filter by updatedSince at the database level if provided
       const spaceConversations =
         await ConversationResource.listConversationsInSpace(auth, {
-          spaceId,
+          spaceId: space.sId,
           options: {
             dangerouslySkipPermissionFiltering: true, // System key has access
             includeDeleted: true, // Include deleted conversations so sync can detect and remove them
@@ -101,6 +71,8 @@ async function handler(
         conversationsFull.map((c) => (c.isOk() ? c.value : null))
       );
 
+      const wId = auth.getNonNullableWorkspace().sId;
+
       // Return raw conversations directly (ConversationSchema) - formatting happens in sync_conversation.ts
       const responseConversations = conversations.map((c: ConversationType) => {
         // Return the full conversation object as-is (matches ConversationSchema)
@@ -112,8 +84,8 @@ async function handler(
 
       logger.info(
         {
-          workspaceId: wId,
-          spaceId,
+          wId,
+          spaceId: space.sId,
           conversationCount: responseConversations.length,
           updatedSince,
         },
@@ -138,4 +110,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(
+  withResourceFetchingFromRoute(handler, { space: {} })
+);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -2,8 +2,9 @@
 // This endpoint only returns void as it is used only for deletion, so no need to use @dust-tt/client types.
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -17,7 +18,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<void>>,
-  auth: Authenticator
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
 ): Promise<void> {
   if (!auth.isAdmin()) {
     return apiError(req, res, {
@@ -29,34 +31,13 @@ async function handler(
     });
   }
 
-  const { spaceId, userId } = req.query;
-  if (!spaceId || !isString(spaceId)) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "The space was not found.",
-      },
-    });
-  }
-
+  const { userId } = req.query;
   if (!userId || !isString(userId)) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
         type: "user_not_found",
         message: "The user in the space was not found.",
-      },
-    });
-  }
-
-  const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "The space was not found.",
       },
     });
   }
@@ -143,4 +124,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(
+  withResourceFetchingFromRoute(handler, { space: {} })
+);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -1,12 +1,12 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { notifyProjectMembersAdded } from "@app/lib/notifications/workflows/project-added-as-member";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { isString } from "@app/types/shared/utils/general";
 import type {
   GetSpaceMembersResponseBody,
   PostSpaceMembersResponseBody,
@@ -27,7 +27,8 @@ async function handler(
       PostSpaceMembersResponseBody | GetSpaceMembersResponseBody
     >
   >,
-  auth: Authenticator
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
 ): Promise<void> {
   if (!auth.isAdmin()) {
     return apiError(req, res, {
@@ -35,28 +36,6 @@ async function handler(
       api_error: {
         type: "workspace_auth_error",
         message: "Only users that are `admins` can access this endpoint.",
-      },
-    });
-  }
-
-  const { spaceId } = req.query;
-  if (!spaceId || !isString(spaceId)) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "The space was not found.",
-      },
-    });
-  }
-
-  const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "The space was not found.",
       },
     });
   }
@@ -205,4 +184,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(
+  withResourceFetchingFromRoute(handler, { space: {} })
+);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,12 +1,12 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isString } from "@app/types/shared/utils/general";
 import type { GetSpaceMetadataResponseType } from "@dust-tt/client";
 import uniqBy from "lodash/uniqBy";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -20,28 +20,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetSpaceMetadataResponseType>>,
-  auth: Authenticator
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
 ): Promise<void> {
-  const { wId, spaceId } = req.query;
-  if (!isString(wId)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Missing or invalid workspace id.",
-      },
-    });
-  }
-  if (!isString(spaceId)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Missing or invalid space id.",
-      },
-    });
-  }
-
   // Only allow system keys (connectors) to access this endpoint
   if (!auth.isSystemKey()) {
     return apiError(req, res, {
@@ -55,18 +36,6 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      // Fetch and verify space exists
-      const space = await SpaceResource.fetchById(auth, spaceId);
-      if (!space) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "space_not_found",
-            message: "Space not found.",
-          },
-        });
-      }
-
       // Only project spaces can have metadata
       if (!space.isProject()) {
         return apiError(req, res, {
@@ -128,4 +97,6 @@ async function handler(
   }
 }
 
-export default withPublicAPIAuthentication(handler);
+export default withPublicAPIAuthentication(
+  withResourceFetchingFromRoute(handler, { space: {} })
+);


### PR DESCRIPTION
## Description

Refactoring of spaces API endpoints to use the `withResourceFetchingFromRoute` middleware, which automatically resolves route parameters (`space`, `dataSource`, `dataSourceView`) into typed resource objects before the handler runs.


## Tests

Covered by existing endpoint tests; no new test surface introduced.

## Risk
withResourceFetchingFromRoute