### PR TITLE
Fix gauge schedule, add plugin to trigger immediatly

### DIFF
--- a/front/lib/api/poke/plugins/global/emit_metronome_gauges.ts
+++ b/front/lib/api/poke/plugins/global/emit_metronome_gauges.ts
@@ -1,0 +1,31 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import { QUEUE_NAME } from "@app/temporal/usage_queue/config";
+import { emitMetronomeGaugeEventsWorkflow } from "@app/temporal/usage_queue/workflows";
+import { Ok } from "@app/types/shared/result";
+
+export const emitMetronomeGaugesPlugin = createPlugin({
+  manifest: {
+    id: "emit-metronome-gauges",
+    name: "Emit Metronome Gauge Events",
+    description:
+      "Runs the Metronome gauge events workflow immediately for all workspaces (workspace_gauge: member_count, MAU, etc.).",
+    resourceTypes: ["global"],
+    args: {},
+  },
+  execute: async () => {
+    const client = await getTemporalClientForFrontNamespace();
+
+    const workflowId = `metronome-gauge-manual-${Date.now()}`;
+    await client.workflow.start(emitMetronomeGaugeEventsWorkflow, {
+      args: [],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+    });
+
+    return new Ok({
+      display: "text",
+      value: `Metronome gauge events workflow started (${workflowId}).`,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/global/index.ts
+++ b/front/lib/api/poke/plugins/global/index.ts
@@ -1,5 +1,6 @@
 export * from "./batch_downgrade";
 export * from "./create_workspace";
+export * from "./emit_metronome_gauges";
 export * from "./force_client_reload";
 export * from "./get_admins_for_workspaces";
 export * from "./relocate_user";

--- a/front/temporal/usage_queue/client.ts
+++ b/front/temporal/usage_queue/client.ts
@@ -210,7 +210,9 @@ export async function launchMetronomeGaugeEventsSchedule(): Promise<
       spec: isDevelopment()
         ? { intervals: [{ every: "1h" }] }
         : {
-            calendars: [{ hour: { start: 2 }, comment: "Daily at 02:00 UTC" }],
+            calendars: [
+              { hour: [{ start: 2, end: 2 }], comment: "Daily at 02:00 UTC" },
+            ],
           },
     });
 


### PR DESCRIPTION
## Description

Two changes for Metronome gauge events:

1. **Fix Temporal schedule calendar spec** (`temporal/usage_queue/client.ts`): The production schedule used `{ hour: { start: 2 } }` which is invalid — Temporal's `CalendarSpec.hour` expects an array of `Range` objects with both `start` and `end`. Fixed to `{ hour: [{ start: 2, end: 2 }] }` (daily at 02:00 UTC).

2. **Add Poke plugin to trigger gauge events immediately** (`poke/plugins/global/emit_metronome_gauges.ts`): "Emit Metronome Gauge Events" global plugin starts the `emitMetronomeGaugeEventsWorkflow` on demand for all workspaces. Useful for testing and shadow mode validation without waiting for the daily cron.

Part of Metronome billing integration (Pricing Push).

## Tests

- Manual: run the plugin from Poke, verify workflow starts in Temporal UI
- Schedule fix verified by type-check (Temporal SDK validates CalendarSpec at compile time)

## Risk

Low. Schedule fix corrects a broken config that prevented the cron from starting. Plugin is admin-only via Poke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)