### PR TITLE
[Front] feat(metronome): gated Metronome subscribe flow via Stripe setup checkout

### DIFF
--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -59,7 +59,12 @@ export type DustErrorCode =
   | "no_unread_messages_found"
   | "no_whitelisted_model_found"
   | "generation_failed"
-  | "invalid_conversation";
+  | "invalid_conversation"
+  // Subscription / billing errors
+  | "subscription_already_exists"
+  | "workspace_not_found"
+  | "plan_not_found"
+  | "metronome_error";
 
 export class DustError<T extends DustErrorCode = DustErrorCode> extends Error {
   constructor(

--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -1,0 +1,123 @@
+import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
+import { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/client";
+import { PlanModel } from "@app/lib/models/plan";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { ServerSideTracking } from "@app/lib/tracking/server";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { launchWorkOSWorkspaceSubscriptionCreatedWorkflow } from "@app/temporal/workos_events_queue/client";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type Stripe from "stripe";
+import { z } from "zod";
+
+const MetronomeSetupSessionSchema = z.object({
+  id: z.string(),
+  client_reference_id: z.string(),
+  metadata: z.object({
+    planCode: z.string(),
+    userId: z.string().optional(),
+    metronomePackageAlias: z.string(),
+  }),
+  customer: z.string(),
+});
+
+export async function handleMetronomeSetupCheckout({
+  session,
+  now,
+}: {
+  session: Stripe.Checkout.Session;
+  now: Date;
+}): Promise<Result<void, DustError>> {
+  const parsed = MetronomeSetupSessionSchema.safeParse(session);
+  if (!parsed.success) {
+    return new Err(
+      new DustError(
+        "invalid_request_error",
+        `Invalid Metronome setup session: ${parsed.error.message}`
+      )
+    );
+  }
+
+  const {
+    id: sessionId,
+    client_reference_id: workspaceId,
+    metadata: { planCode, userId, metronomePackageAlias },
+    customer: stripeCustomerId,
+  } = parsed.data;
+
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    return new Err(
+      new DustError(
+        "workspace_not_found",
+        `Workspace ${workspaceId} not found for Metronome setup session.`
+      )
+    );
+  }
+
+  const plan = await PlanModel.findOne({ where: { code: planCode } });
+  if (!plan) {
+    return new Err(
+      new DustError("plan_not_found", `Plan ${planCode} not found.`)
+    );
+  }
+
+  const provisionResult = await provisionMetronomeCustomerAndContract({
+    workspaceId: workspace.sId,
+    workspaceName: workspace.name,
+    stripeCustomerId,
+    packageAlias: metronomePackageAlias,
+    uniquenessKey: sessionId,
+  });
+  if (provisionResult.isErr()) {
+    return new Err(
+      new DustError("metronome_error", provisionResult.error.message)
+    );
+  }
+
+  const { metronomeCustomerId, metronomeContractId } = provisionResult.value;
+
+  const updateResult = await WorkspaceResource.updateMetronomeCustomerId(
+    workspace.id,
+    metronomeCustomerId
+  );
+  if (updateResult.isErr()) {
+    return new Err(new DustError("internal_error", updateResult.error.message));
+  }
+
+  const subscriptionResult =
+    await SubscriptionResource.createSubscriptionFromCheckout({
+      workspaceModelId: workspace.id,
+      plan,
+      metronomeContractId,
+      now,
+    });
+  if (subscriptionResult.isErr()) {
+    return subscriptionResult;
+  }
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  if (userId) {
+    const workspaceSeats = await MembershipResource.countActiveSeatsInWorkspace(
+      workspace.sId
+    );
+    await ServerSideTracking.trackSubscriptionCreated({
+      userId,
+      workspace: renderLightWorkspaceType({ workspace }),
+      planCode,
+      workspaceSeats,
+      subscriptionStartAt: now,
+    });
+  }
+
+  await restoreWorkspaceAfterSubscription(auth);
+
+  await launchWorkOSWorkspaceSubscriptionCreatedWorkflow({ workspaceId });
+
+  return new Ok(undefined);
+}

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -327,11 +327,11 @@ export async function endMetronomeContract({
 }
 
 /**
- * Get the rate card aliases for a contract.
- * Retrieves the contract to get its rate_card_id, then retrieves the rate card
+ * Get the package aliases for a contract.
+ * Retrieves the contract to get its package_id, then retrieves the package
  * to get its aliases.
  */
-export async function getMetronomeContractRateCardAliases({
+export async function getMetronomeContractPackageAliases({
   metronomeCustomerId,
   metronomeContractId,
 }: {
@@ -344,23 +344,23 @@ export async function getMetronomeContractRateCardAliases({
       contract_id: metronomeContractId,
     });
 
-    const rateCardId = contractResponse.data.current.rate_card_id;
-    if (!rateCardId) {
+    const packageId = contractResponse.data.package_id;
+    if (!packageId) {
       return new Ok([]);
     }
 
-    const rateCardResponse = await getClient().v1.contracts.rateCards.retrieve({
-      id: rateCardId,
+    const packageResponse = await getClient().v1.packages.retrieve({
+      package_id: packageId,
     });
 
-    const aliases = rateCardResponse.data.aliases?.map((a) => a.name) ?? [];
+    const aliases = packageResponse.data.aliases?.map((a) => a.name) ?? [];
 
     return new Ok(aliases);
   } catch (err) {
     const error = normalizeError(err);
     logger.error(
       { error, metronomeCustomerId, metronomeContractId },
-      "[Metronome] Failed to get contract rate card aliases"
+      "[Metronome] Failed to get contract package aliases"
     );
     return new Err(error);
   }

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -91,16 +91,10 @@ export async function createMetronomeCustomer({
     );
     return new Ok({ metronomeCustomerId: response.data.id });
   } catch (err) {
-    // 409 means a customer with this ingest alias already exists — extract
-    // the conflicting ID and return it rather than failing.
     if (err instanceof ConflictError) {
-      const body = err.error as { conflicting_id?: string } | undefined;
-      if (body?.conflicting_id) {
-        logger.info(
-          { workspaceId, metronomeCustomerId: body.conflicting_id },
-          "[Metronome] Customer already exists, reusing conflicting ID"
-        );
-        return new Ok({ metronomeCustomerId: body.conflicting_id });
+      const findResult = await findMetronomeCustomerByAlias(workspaceId);
+      if (findResult.isOk() && findResult.value) {
+        return new Ok({ metronomeCustomerId: findResult.value });
       }
     }
 
@@ -143,13 +137,17 @@ export async function findMetronomeCustomerByAlias(
 /**
  * Create a contract for a Metronome customer using a package alias.
  * The package defines the rate card, seat subscriptions, and credit allocations.
+ *
+ * Handles 409 conflict by extracting the existing contract's ID.
  */
 export async function createMetronomeContract({
   metronomeCustomerId,
   packageAlias,
+  uniquenessKey,
 }: {
   metronomeCustomerId: string;
   packageAlias: string;
+  uniquenessKey: string;
 }): Promise<Result<{ contractId: string }, Error>> {
   try {
     const response = await getClient().v1.contracts.create({
@@ -159,6 +157,7 @@ export async function createMetronomeContract({
       starting_at: new Date(
         Math.floor(Date.now() / 3_600_000) * 3_600_000
       ).toISOString(),
+      uniqueness_key: uniquenessKey,
     });
 
     logger.info(
@@ -171,6 +170,14 @@ export async function createMetronomeContract({
     );
     return new Ok({ contractId: response.data.id });
   } catch (err) {
+    if (err instanceof ConflictError) {
+      const existingContract =
+        await getMetronomeActiveContract(metronomeCustomerId);
+      if (existingContract.isOk() && existingContract.value) {
+        return new Ok({ contractId: existingContract.value.contractId });
+      }
+    }
+
     const error = normalizeError(err);
     logger.error(
       { error, metronomeCustomerId, packageAlias },
@@ -190,13 +197,15 @@ export async function provisionMetronomeCustomerAndContract({
   workspaceName,
   stripeCustomerId,
   packageAlias,
+  uniquenessKey,
 }: {
   workspaceId: string;
   workspaceName: string;
-  stripeCustomerId: string | null;
+  stripeCustomerId: string;
   packageAlias: string;
+  uniquenessKey: string;
 }): Promise<
-  Result<{ metronomeCustomerId: string; contractId: string }, Error>
+  Result<{ metronomeCustomerId: string; metronomeContractId: string }, Error>
 > {
   // Find or create customer.
   let metronomeCustomerId: string | null = null;
@@ -210,7 +219,7 @@ export async function provisionMetronomeCustomerAndContract({
     const createResult = await createMetronomeCustomer({
       workspaceId,
       workspaceName,
-      stripeCustomerId: stripeCustomerId ?? "",
+      stripeCustomerId,
     });
     if (createResult.isErr()) {
       return new Err(createResult.error);
@@ -218,10 +227,10 @@ export async function provisionMetronomeCustomerAndContract({
     metronomeCustomerId = createResult.value.metronomeCustomerId;
   }
 
-  // Create contract.
   const contractResult = await createMetronomeContract({
     metronomeCustomerId,
     packageAlias,
+    uniquenessKey,
   });
   if (contractResult.isErr()) {
     return new Err(contractResult.error);
@@ -229,7 +238,7 @@ export async function provisionMetronomeCustomerAndContract({
 
   return new Ok({
     metronomeCustomerId,
-    contractId: contractResult.value.contractId,
+    metronomeContractId: contractResult.value.contractId,
   });
 }
 
@@ -312,6 +321,46 @@ export async function endMetronomeContract({
     logger.error(
       { error, metronomeCustomerId, contractId },
       "[Metronome] Failed to end contract"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Get the rate card aliases for a contract.
+ * Retrieves the contract to get its rate_card_id, then retrieves the rate card
+ * to get its aliases.
+ */
+export async function getMetronomeContractRateCardAliases({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<Result<string[], Error>> {
+  try {
+    const contractResponse = await getClient().v1.contracts.retrieve({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+    });
+
+    const rateCardId = contractResponse.data.current.rate_card_id;
+    if (!rateCardId) {
+      return new Ok([]);
+    }
+
+    const rateCardResponse = await getClient().v1.contracts.rateCards.retrieve({
+      id: rateCardId,
+    });
+
+    const aliases = rateCardResponse.data.aliases?.map((a) => a.name) ?? [];
+
+    return new Ok(aliases);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, metronomeContractId },
+      "[Metronome] Failed to get contract rate card aliases"
     );
     return new Err(error);
   }

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -5,6 +5,16 @@
  * MetronomeEvent is our own type — stricter than the SDK's UsageIngestParams
  * because we enforce `properties: Record<string, string | number>` (no unknown).
  */
+// Metronome package aliases for contract provisioning.
+// These map to packages configured in the Metronome dashboard.
+export const LEGACY_PRO_29_PACKAGE_ALIAS = "legacy-pro-29";
+export const LEGACY_BUSINESS_39_PACKAGE_ALIAS = "legacy-business-39";
+
+export const PRO_OR_BUSINESS_PACKAGE_ALIASES: ReadonlySet<string> = new Set([
+  LEGACY_PRO_29_PACKAGE_ALIAS,
+  LEGACY_BUSINESS_39_PACKAGE_ALIAS,
+]);
+
 export interface MetronomeEvent {
   transaction_id: string;
   customer_id: string;

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -148,7 +148,7 @@ export const ENTERPRISE_N30_PAYMENTS_DAYS = 30;
 // At the time of writing, this is only used for Credit Purchase self-serve flow
 export const MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED = 3;
 
-type SupportedPaymentMethod = (typeof SUPPORTED_PAYMENT_METHODS)[number];
+export type SupportedPaymentMethod = (typeof SUPPORTED_PAYMENT_METHODS)[number];
 
 /**
  * Calls the Stripe API to create a pro plan checkout session for a given workspace.
@@ -157,7 +157,7 @@ type SupportedPaymentMethod = (typeof SUPPORTED_PAYMENT_METHODS)[number];
  * The `auth` role is not checked, because we allow anyone (even if not logged in or not part of the WS)
  * to go through the checkout process.
  */
-export const createProPlanCheckoutSession = async ({
+export const createStripeSubscriptionCheckoutSession = async ({
   allowedPaymentMethods = ["card"],
   billingPeriod,
   owner,
@@ -246,6 +246,57 @@ export const createProPlanCheckoutSession = async ({
     automatic_tax: {
       enabled: true,
     },
+    tax_id_collection: {
+      enabled: true,
+    },
+    success_url: `${config.getAppUrl()}/w/${owner.sId}/subscription/payment_processing?type=succeeded&session_id={CHECKOUT_SESSION_ID}&plan_code=${planCode}`,
+    cancel_url: `${config.getAppUrl()}/w/${owner.sId}/subscription?type=cancelled`,
+    consent_collection: {
+      terms_of_service: "required",
+    },
+    custom_text: {
+      terms_of_service_acceptance: {
+        message:
+          "I have read and accept the [Master Services Agreement](https://dust-tt.notion.site/Master-Services-Agreement-2bdcf30156db4a40bcb20d27b0b1bd4e?pvs=4) and [Data Processing Addendum](https://www.notion.so/dust-tt/Data-Processing-Addendum-466528e861e34f08949428e06eecd5f4?pvs=4).",
+      },
+    },
+  });
+
+  return session.url;
+};
+
+/**
+ * Creates a Stripe Checkout session in "setup" mode for Metronome-billed workspaces.
+ * This captures the payment method without creating a Stripe subscription.
+ * After checkout, the webhook provisions a Metronome customer + contract.
+ */
+export const createMetronomeSetupCheckoutSession = async ({
+  allowedPaymentMethods = ["card"],
+  metronomePackageAlias,
+  owner,
+  planCode,
+  user,
+}: {
+  allowedPaymentMethods?: SupportedPaymentMethod[];
+  metronomePackageAlias: string;
+  owner: WorkspaceType;
+  planCode: string;
+  user: UserType;
+}): Promise<string | null> => {
+  const stripe = getStripeClient();
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "setup",
+    client_reference_id: owner.sId,
+    customer_email: user.email,
+    customer_creation: "always",
+    payment_method_types: allowedPaymentMethods,
+    metadata: {
+      planCode,
+      userId: `${user.id}`,
+      metronomePackageAlias,
+    },
+    billing_address_collection: "auto",
     tax_id_collection: {
       enabled: true,
     },

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { sendProactiveTrialCancelledEmail } from "@app/lib/api/email";
 import {
   disableWorkOSSSOAndSCIM,
@@ -5,6 +6,13 @@ import {
 } from "@app/lib/api/workos/organization";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { getMetronomeContractRateCardAliases } from "@app/lib/metronome/client";
+import {
+  LEGACY_BUSINESS_39_PACKAGE_ALIAS,
+  LEGACY_PRO_29_PACKAGE_ALIAS,
+  PRO_OR_BUSINESS_PACKAGE_ALIASES,
+} from "@app/lib/metronome/types";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
@@ -23,10 +31,12 @@ import {
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
   cancelSubscriptionImmediately,
-  createProPlanCheckoutSession,
+  createMetronomeSetupCheckoutSession,
+  createStripeSubscriptionCheckoutSession,
   getBusinessProPlanProductId,
   getProPlanProductId,
   getStripeSubscription,
+  type SupportedPaymentMethod,
   upgradeProSubscriptionToBusiness,
 } from "@app/lib/plans/stripe";
 import { getTrialVersionForPlan, isTrial } from "@app/lib/plans/trial/limits";
@@ -112,6 +122,12 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     this.plan = plan;
   }
 
+  get isBilled(): boolean {
+    return (
+      this.stripeSubscriptionId !== null || this.metronomeContractId !== null
+    );
+  }
+
   static async makeNew(
     blob: CreationAttributes<SubscriptionModel>,
     plan: PlanType,
@@ -130,6 +146,61 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       subscription.get(),
       plan
     );
+  }
+
+  static async createSubscriptionFromCheckout({
+    workspaceModelId,
+    plan,
+    metronomeContractId,
+    now,
+  }: {
+    workspaceModelId: ModelId;
+    plan: PlanModel;
+    metronomeContractId: string;
+    now: Date;
+  }): Promise<Result<void, DustError>> {
+    return withTransaction(async (t) => {
+      const activeSubscription =
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(
+          workspaceModelId,
+          t
+        );
+
+      if (activeSubscription?.planId === plan.id) {
+        return new Err(
+          new DustError(
+            "subscription_already_exists",
+            `Active subscription already exists for plan ${plan.code}.`
+          )
+        );
+      }
+
+      if (activeSubscription?.isBilled) {
+        return new Err(
+          new DustError(
+            "subscription_already_exists",
+            "Active paid subscription already exists."
+          )
+        );
+      }
+
+      await activeSubscription?.markAsEnded("ended", t);
+      await SubscriptionResource.makeNew(
+        {
+          sId: generateRandomModelSId(),
+          workspaceId: workspaceModelId,
+          planId: plan.id,
+          status: "active",
+          trialing: false,
+          startDate: now,
+          metronomeContractId,
+        },
+        renderPlanFromModel({ plan }),
+        t
+      );
+
+      return new Ok(undefined);
+    });
   }
 
   private static readonly subscriptionCacheKeyResolver = (
@@ -809,40 +880,59 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   async getCheckoutUrlForUpgrade(
     owner: WorkspaceType,
     user: UserType,
-    billingPeriod: BillingPeriod
+    billingPeriod: BillingPeriod,
+    { useMetronomeBilling }: { useMetronomeBilling: boolean }
   ): Promise<CheckoutUrlResult> {
-    const planCode = owner.metadata?.isBusiness
-      ? PRO_PLAN_SEAT_39_CODE
-      : PRO_PLAN_SEAT_29_CODE;
+    const isBusiness = !!owner.metadata?.isBusiness;
+    const { planCode, allowedPaymentMethods, metronomePackageAlias } =
+      isBusiness
+        ? {
+            planCode: PRO_PLAN_SEAT_39_CODE,
+            allowedPaymentMethods: [
+              "card",
+              "sepa_debit",
+            ] satisfies SupportedPaymentMethod[],
+            metronomePackageAlias: LEGACY_BUSINESS_39_PACKAGE_ALIAS,
+          }
+        : {
+            planCode: PRO_PLAN_SEAT_29_CODE,
+            allowedPaymentMethods: ["card"] satisfies SupportedPaymentMethod[],
+            metronomePackageAlias: LEGACY_PRO_29_PACKAGE_ALIAS,
+          };
 
     const proPlan = await SubscriptionResource.findPlanOrThrow(planCode);
 
     // We verify that the workspace is not already subscribed to the Pro plan product.
     const isAlreadyOnProPlan =
       await this.isSubscriptionOnProOrBusinessPlan(owner);
-    if (isAlreadyOnProPlan) {
-      throw new Error(
-        `Cannot subscribe to plan ${planCode}: already subscribed to a Pro plan.`
-      );
+    assert(
+      !isAlreadyOnProPlan,
+      `Cannot subscribe to plan ${planCode}: already subscribed to a Pro plan.`
+    );
+
+    let checkoutUrl: string | null;
+    if (useMetronomeBilling) {
+      checkoutUrl = await createMetronomeSetupCheckoutSession({
+        owner,
+        user,
+        planCode,
+        metronomePackageAlias,
+        allowedPaymentMethods,
+      });
+    } else {
+      checkoutUrl = await createStripeSubscriptionCheckoutSession({
+        owner,
+        user,
+        billingPeriod,
+        planCode,
+        allowedPaymentMethods,
+      });
     }
 
-    // We enter Stripe Checkout flow.
-    const checkoutUrl = await createProPlanCheckoutSession({
-      owner,
-      user,
-      billingPeriod,
-      planCode,
-      allowedPaymentMethods:
-        owner.metadata?.isBusiness && planCode === PRO_PLAN_SEAT_39_CODE
-          ? ["card", "sepa_debit"]
-          : ["card"],
-    });
-
-    if (!checkoutUrl) {
-      throw new Error(
-        `Cannot subscribe to plan ${planCode}: error while creating Stripe Checkout session (URL is null).`
-      );
-    }
+    assert(
+      checkoutUrl,
+      `Cannot subscribe to plan ${planCode}: error while creating checkout session (URL is null).`
+    );
 
     return {
       checkoutUrl,
@@ -1139,6 +1229,22 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   private async isSubscriptionOnProOrBusinessPlan(
     owner: WorkspaceType
   ): Promise<boolean> {
+    // Check Metronome-billed subscription.
+    if (this.metronomeContractId && owner.metronomeCustomerId) {
+      const aliasesResult = await getMetronomeContractRateCardAliases({
+        metronomeCustomerId: owner.metronomeCustomerId,
+        metronomeContractId: this.metronomeContractId,
+      });
+      if (aliasesResult.isErr()) {
+        throw aliasesResult.error;
+      }
+
+      return aliasesResult.value.some((alias) =>
+        PRO_OR_BUSINESS_PACKAGE_ALIASES.has(alias)
+      );
+    }
+
+    // Check Stripe-billed subscription.
     if (!this.stripeSubscriptionId) {
       return false;
     }

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -7,7 +7,7 @@ import {
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import { getMetronomeContractRateCardAliases } from "@app/lib/metronome/client";
+import { getMetronomeContractPackageAliases } from "@app/lib/metronome/client";
 import {
   LEGACY_BUSINESS_39_PACKAGE_ALIAS,
   LEGACY_PRO_29_PACKAGE_ALIAS,
@@ -1231,7 +1231,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   ): Promise<boolean> {
     // Check Metronome-billed subscription.
     if (this.metronomeContractId && owner.metronomeCustomerId) {
-      const aliasesResult = await getMetronomeContractRateCardAliases({
+      const aliasesResult = await getMetronomeContractPackageAliases({
         metronomeCustomerId: owner.metronomeCustomerId,
         metronomeContractId: this.metronomeContractId,
       });

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -22,6 +22,7 @@ import {
   invoiceEnterprisePAYGCredits,
   isPAYGEnabled,
 } from "@app/lib/credits/payg";
+import { handleMetronomeSetupCheckout } from "@app/lib/metronome/checkout";
 import { createMetronomeCustomer } from "@app/lib/metronome/client";
 import { PlanModel } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
@@ -43,7 +44,6 @@ import { withTransaction } from "@app/lib/utils/sql_utils";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { launchWorkOSWorkspaceSubscriptionCreatedWorkflow } from "@app/temporal/workos_events_queue/client";
@@ -235,6 +235,44 @@ async function handler(
               `[Stripe Webhook] Received checkout.session.completed with unkown status "${session.status}". Ignoring event.`
             );
             return res.status(200).json({ success: true });
+          }
+
+          // Branch on session mode: "setup" for Metronome, "subscription" for Stripe.
+          if (session.mode === "setup") {
+            const result = await handleMetronomeSetupCheckout({
+              session,
+              now,
+            });
+
+            if (result.isOk()) {
+              return res.status(200).json({ success: true });
+            }
+
+            switch (result.error.code) {
+              case "subscription_already_exists":
+              case "workspace_not_found":
+                logger.warn(
+                  { error: result.error, workspaceId, planCode },
+                  `[Stripe Webhook] Metronome setup: ${result.error.message}`
+                );
+                return res
+                  .status(200)
+                  .json({ success: false, message: result.error.message });
+
+              default:
+                logger.error(
+                  { error: result.error, workspaceId, planCode },
+                  `[Stripe Webhook] Metronome setup: ${result.error.message}`
+                );
+                return apiError(req, res, {
+                  status_code: 500,
+                  api_error: {
+                    type: "internal_server_error",
+                    message:
+                      "Stripe Webhook: error handling Metronome setup checkout.session.completed.",
+                  },
+                });
+            }
           }
 
           try {

--- a/front/pages/api/w/[wId]/subscriptions/index.test.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.test.ts
@@ -1,3 +1,4 @@
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import type { Stripe } from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -5,12 +6,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import handler from "./index";
 
 const TEST_CHECKOUT_URL = "https://checkout.stripe.com/test-session";
+const TEST_METRONOME_CHECKOUT_URL =
+  "https://checkout.stripe.com/test-setup-session";
 
 vi.mock("@app/lib/plans/stripe", async () => {
   return {
-    createProPlanCheckoutSession: vi
+    createStripeSubscriptionCheckoutSession: vi
       .fn()
       .mockResolvedValue("https://checkout.stripe.com/test-session"),
+    createMetronomeSetupCheckoutSession: vi
+      .fn()
+      .mockResolvedValue("https://checkout.stripe.com/test-setup-session"),
     getProPlanStripeProductId: vi.fn().mockResolvedValue("testProductID"),
     getStripeSubscription: vi.fn().mockResolvedValue({
       id: "sub_test123",
@@ -86,6 +92,31 @@ describe("POST /api/w/[wId]/subscriptions", () => {
     const data = res._getJSONData();
     expect(data.checkoutUrl).toEqual(TEST_CHECKOUT_URL);
     expect(data.plan).toBeDefined();
+  });
+
+  it("returns Metronome setup checkout URL when metronome_billing flag is enabled", async () => {
+    const { req, res, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    await FeatureFlagFactory.basic(auth, "metronome_billing");
+
+    req.body = {
+      billingPeriod: "monthly",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.checkoutUrl).toEqual(TEST_METRONOME_CHECKOUT_URL);
+    expect(data.plan).toEqual(
+      expect.objectContaining({
+        code: expect.any(String),
+        name: expect.any(String),
+      })
+    );
   });
 
   it("returns 403 when user is not admin", async () => {

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import {
   cancelSubscriptionAtPeriodEnd,
   skipSubscriptionFreeTrial,
@@ -9,17 +10,14 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { PlanType, SubscriptionType } from "@app/types/plan";
+import type { CheckoutUrlResult, SubscriptionType } from "@app/types/plan";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type PostSubscriptionResponseBody = {
-  plan: PlanType;
-  checkoutUrl?: string;
-};
+export type PostSubscriptionResponseBody = CheckoutUrlResult;
 
 type PatchSubscriptionResponseBody = {
   success: boolean;
@@ -95,14 +93,22 @@ async function handler(
       }
 
       try {
-        const { checkoutUrl, plan: newPlan } = await auth
-          .getNonNullableSubscriptionResource()
-          .getCheckoutUrlForUpgrade(
-            auth.getNonNullableWorkspace(),
-            auth.getNonNullableUser().toJSON(),
-            bodyValidation.right.billingPeriod
-          );
-        return res.status(200).json({ checkoutUrl, plan: newPlan });
+        const useMetronomeBilling = await hasFeatureFlag(
+          auth,
+          "metronome_billing"
+        );
+        const owner = auth.getNonNullableWorkspace();
+        const user = auth.getNonNullableUser().toJSON();
+        const subscription = auth.getNonNullableSubscriptionResource();
+
+        const checkoutUrlResult = await subscription.getCheckoutUrlForUpgrade(
+          owner,
+          user,
+          bodyValidation.right.billingPeriod,
+          { useMetronomeBilling }
+        );
+
+        return res.status(200).json(checkoutUrlResult);
       } catch (error) {
         logger.error({ error }, "Error while subscribing workspace to plan");
         return apiError(req, res, {


### PR DESCRIPTION
## Description

Adds a gated Metronome subscribe flow for dev/testing (C1). When a workspace has the `metronome_billing` feature flag enabled, the subscribe endpoint creates a Stripe Checkout session in `setup` mode (payment method capture only, no Stripe subscription). The webhook then provisions a Metronome customer + contract and creates a subscription with `metronomeContractId`.

The existing Stripe subscription flow is untouched — the feature flag transparently routes to the new path.

### Design notes

**Why setup mode?** Metronome owns billing, so we don't need a Stripe subscription. Setup mode captures the payment method, Stripe auto-creates a customer (`customer_creation: "always"`), and Metronome links to that Stripe customer for invoice collection.

**Idempotency on webhook retry:** Customer creation handles 409 by re-fetching via alias. Contract creation uses `uniqueness_key` (Stripe session ID) and handles 409 by re-fetching the active contract. Subscription creation guards against conflicts via `isBilled` check.

**Error handling:** `handleMetronomeSetupCheckout` returns `Result<void, DustError>` with specific error codes. The webhook switches on `error.code` to decide warn+200 (expected conflicts) vs error+500 (failures).

**Double subscription guard:** `isSubscriptionOnProOrBusinessPlan` now checks Metronome rate card aliases (2 API calls: retrieve contract → retrieve rate card → match against known aliases) in addition to the existing Stripe product check.

Closes dust-tt/tasks#7498