### PR TITLE
Grant free credits (legacy plans) 

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -521,6 +521,11 @@ const config = {
   getMetronomeApiKey: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("METRONOME_API_KEY");
   },
+  getMetronomeFreeCreditProductId: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "METRONOME_FREE_CREDIT_PRODUCT_ID"
+    );
+  },
   getMetronomeCommitProductId: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable(
       "METRONOME_COMMIT_PRODUCT_ID"

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -539,6 +539,7 @@ async function addMetronomeCommitsForWorkspace({
     endingBefore: effectiveExpirationDate,
     name: `Prepaid commit (${effectiveStartDate.toISOString()})`,
     idempotencyKey: `commit-${workspace.sId}-${effectiveStartDate.getTime()}-${amountCents}`,
+    priority: 2, // Committed credits should be applied after any free credits (priority 1) but before any PAYG commits (priority 3)
   });
 
   if (result.isErr()) {

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -26,6 +26,22 @@ function getClient(): Metronome {
 }
 
 // ---------------------------------------------------------------------------
+// Metronome requires dates on hour boundaries.
+// ---------------------------------------------------------------------------
+
+function floorToHourISO(date: Date): string {
+  return new Date(
+    Math.floor(date.getTime() / 3_600_000) * 3_600_000
+  ).toISOString();
+}
+
+function ceilToHourISO(date: Date): string {
+  return new Date(
+    Math.ceil(date.getTime() / 3_600_000) * 3_600_000
+  ).toISOString();
+}
+
+// ---------------------------------------------------------------------------
 // Event ingestion
 // ---------------------------------------------------------------------------
 
@@ -159,9 +175,7 @@ export async function createMetronomeContract({
       customer_id: metronomeCustomerId,
       package_alias: packageAlias,
       // Metronome requires starting_at on an hour boundary — round down to current hour.
-      starting_at: new Date(
-        Math.floor(Date.now() / 3_600_000) * 3_600_000
-      ).toISOString(),
+      starting_at: floorToHourISO(new Date()),
       uniqueness_key: uniquenessKey,
     });
 
@@ -264,7 +278,7 @@ export async function getMetronomeActiveContract(
   >
 > {
   try {
-    const response = await getClient().v1.contracts.list({
+    const response = await getClient().v2.contracts.list({
       customer_id: metronomeCustomerId,
     });
 
@@ -472,12 +486,8 @@ export async function createMetronomeCommit({
   name?: string;
 }): Promise<Result<void, Error>> {
   // Metronome requires dates on hour boundaries — round down start, round up end.
-  const roundedStartingAt = new Date(
-    Math.floor(startingAt.getTime() / 3_600_000) * 3_600_000
-  );
-  const roundedEndingBefore = new Date(
-    Math.ceil(endingBefore.getTime() / 3_600_000) * 3_600_000
-  );
+  const roundedStartingAt = floorToHourISO(startingAt);
+  const roundedEndingBefore = ceilToHourISO(endingBefore);
   try {
     logger.info(
       {
@@ -505,8 +515,8 @@ export async function createMetronomeCommit({
               schedule_items: [
                 {
                   amount: amountCents,
-                  starting_at: roundedStartingAt.toISOString(),
-                  ending_before: roundedEndingBefore.toISOString(),
+                  starting_at: roundedStartingAt,
+                  ending_before: roundedEndingBefore,
                 },
               ],
             },
@@ -731,6 +741,10 @@ export async function createMetronomeCredit({
   name: string;
   idempotencyKey: string;
 }): Promise<Result<{ creditId: string }, Error>> {
+  // Metronome requires dates on hour boundaries — round down start, round up end.
+  const roundedStartingAt = floorToHourISO(new Date(startingAt));
+  const roundedEndingBefore = ceilToHourISO(new Date(endingBefore));
+
   try {
     const response = await getClient().v2.contracts.edit(
       {
@@ -746,8 +760,8 @@ export async function createMetronomeCredit({
               schedule_items: [
                 {
                   amount: amountCents,
-                  starting_at: startingAt,
-                  ending_before: endingBefore,
+                  starting_at: roundedStartingAt,
+                  ending_before: roundedEndingBefore,
                 },
               ],
             },

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -703,3 +703,66 @@ export async function listMetronomeUsageWithGroups({
     return new Err(error);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Credits
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a credit grant on a Metronome customer.
+ * Used for monthly free programmatic credits on legacy plans.
+ */
+export async function createMetronomeCredit({
+  metronomeCustomerId,
+  productId,
+  amountCents,
+  startingAt,
+  endingBefore,
+  name,
+  idempotencyKey,
+}: {
+  metronomeCustomerId: string;
+  productId: string;
+  amountCents: number;
+  startingAt: string;
+  endingBefore: string;
+  name: string;
+  idempotencyKey: string;
+}): Promise<Result<{ creditId: string }, Error>> {
+  try {
+    const response = await getClient().v1.customers.credits.create({
+      customer_id: metronomeCustomerId,
+      product_id: productId,
+      priority: 100,
+      access_schedule: {
+        schedule_items: [
+          {
+            amount: amountCents,
+            starting_at: startingAt,
+            ending_before: endingBefore,
+          },
+        ],
+      },
+      name,
+      uniqueness_key: idempotencyKey,
+    });
+
+    return new Ok({ creditId: response.data.id });
+  } catch (err) {
+    if (err instanceof ConflictError) {
+      // Idempotency key conflict — credit already granted, safe to ignore.
+      logger.info(
+        { metronomeCustomerId, idempotencyKey },
+        "[Metronome] Credit grant already exists (idempotent)"
+      );
+      return new Ok({ creditId: "already-exists" });
+    }
+
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, name },
+      "[Metronome] Failed to create credit grant"
+    );
+    return new Err(error);
+  }
+}

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -714,6 +714,7 @@ export async function listMetronomeUsageWithGroups({
  */
 export async function createMetronomeCredit({
   metronomeCustomerId,
+  contractId,
   productId,
   amountCents,
   startingAt,
@@ -722,6 +723,7 @@ export async function createMetronomeCredit({
   idempotencyKey,
 }: {
   metronomeCustomerId: string;
+  contractId: string;
   productId: string;
   amountCents: number;
   startingAt: string;
@@ -730,22 +732,30 @@ export async function createMetronomeCredit({
   idempotencyKey: string;
 }): Promise<Result<{ creditId: string }, Error>> {
   try {
-    const response = await getClient().v1.customers.credits.create({
-      customer_id: metronomeCustomerId,
-      product_id: productId,
-      priority: 100,
-      access_schedule: {
-        schedule_items: [
+    const response = await getClient().v2.contracts.edit(
+      {
+        customer_id: metronomeCustomerId,
+        contract_id: contractId,
+        add_credits: [
           {
-            amount: amountCents,
-            starting_at: startingAt,
-            ending_before: endingBefore,
+            product_id: productId,
+            name,
+            priority: 100,
+            applicable_product_tags: ["usage"],
+            access_schedule: {
+              schedule_items: [
+                {
+                  amount: amountCents,
+                  starting_at: startingAt,
+                  ending_before: endingBefore,
+                },
+              ],
+            },
           },
         ],
       },
-      name,
-      uniqueness_key: idempotencyKey,
-    });
+      { idempotencyKey }
+    );
 
     return new Ok({ creditId: response.data.id });
   } catch (err) {
@@ -760,7 +770,7 @@ export async function createMetronomeCredit({
 
     const error = normalizeError(err);
     logger.error(
-      { error, metronomeCustomerId, name },
+      { error, metronomeCustomerId, name, idempotencyKey },
       "[Metronome] Failed to create credit grant"
     );
     return new Err(error);

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -475,6 +475,7 @@ export async function createMetronomeCommit({
   endingBefore,
   name,
   idempotencyKey,
+  priority,
 }: {
   metronomeCustomerId: string;
   contractId: string;
@@ -484,6 +485,7 @@ export async function createMetronomeCommit({
   endingBefore: Date;
   idempotencyKey: string;
   name?: string;
+  priority?: number;
 }): Promise<Result<void, Error>> {
   // Metronome requires dates on hour boundaries — round down start, round up end.
   const roundedStartingAt = floorToHourISO(startingAt);
@@ -511,6 +513,7 @@ export async function createMetronomeCommit({
             product_id: productId,
             name: name ?? "Commit purchase",
             applicable_product_tags: ["usage"],
+            priority,
             access_schedule: {
               schedule_items: [
                 {
@@ -754,7 +757,7 @@ export async function createMetronomeCredit({
           {
             product_id: productId,
             name,
-            priority: 100,
+            priority: 1, // Apply credits before any prepaid commits
             applicable_product_tags: ["usage"],
             access_schedule: {
               schedule_items: [

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -28,16 +28,16 @@ function getClient(): Metronome {
 // ---------------------------------------------------------------------------
 // Metronome requires dates on hour boundaries.
 // ---------------------------------------------------------------------------
-
+const HOUR_IN_MS = 3_600_000;
 function floorToHourISO(date: Date): string {
   return new Date(
-    Math.floor(date.getTime() / 3_600_000) * 3_600_000
+    Math.floor(date.getTime() / HOUR_IN_MS) * HOUR_IN_MS
   ).toISOString();
 }
 
 function ceilToHourISO(date: Date): string {
   return new Date(
-    Math.ceil(date.getTime() / 3_600_000) * 3_600_000
+    Math.ceil(date.getTime() / HOUR_IN_MS) * HOUR_IN_MS
   ).toISOString();
 }
 

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -26,6 +26,7 @@ import {
 import { handleMetronomeSetupCheckout } from "@app/lib/metronome/checkout";
 import {
   createMetronomeCredit,
+  getMetronomeActiveContract,
   listMetronomeProducts,
   provisionMetronomeCustomerAndContract,
 } from "@app/lib/metronome/client";
@@ -187,6 +188,18 @@ async function grantMetronomeFreeCredits({
   }
 
   try {
+    // Resolve the active contract.
+    const contractResult = await getMetronomeActiveContract(
+      workspace.metronomeCustomerId
+    );
+    if (contractResult.isErr() || !contractResult.value) {
+      logger.error(
+        { workspaceId: workspace.sId },
+        "[Stripe Webhook] No active Metronome contract found for free credit grant"
+      );
+      return;
+    }
+
     // Resolve the "Free Monthly Credits" product ID.
     const productsResult = await listMetronomeProducts();
     if (productsResult.isErr()) {
@@ -227,6 +240,7 @@ async function grantMetronomeFreeCredits({
 
     const result = await createMetronomeCredit({
       metronomeCustomerId: workspace.metronomeCustomerId,
+      contractId: contractResult.value.contractId,
       productId: creditProduct.id,
       amountCents,
       startingAt: periodStart.toISOString(),

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -27,7 +27,6 @@ import { handleMetronomeSetupCheckout } from "@app/lib/metronome/checkout";
 import {
   createMetronomeCredit,
   getMetronomeActiveContract,
-  listMetronomeProducts,
   provisionMetronomeCustomerAndContract,
 } from "@app/lib/metronome/client";
 import { PlanModel } from "@app/lib/models/plan";
@@ -198,15 +197,6 @@ async function grantMetronomeFreeCredits({
       return;
     }
 
-    // Resolve the "Free Monthly Credits" product ID.
-    const productsResult = await listMetronomeProducts();
-    if (productsResult.isErr()) {
-      logger.error(
-        { workspaceId: workspace.sId, error: productsResult.error.message },
-        "[Stripe Webhook] Failed to list Metronome products for free credit grant"
-      );
-      return;
-    }
     const productId = apiConfig.getMetronomeFreeCreditProductId();
     if (!productId) {
       logger.error(

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -248,7 +248,7 @@ async function grantMetronomeFreeCredits({
     }
   } catch (err) {
     logger.error(
-      { workspaceId: workspace.sId, error: err },
+      { workspaceId: workspace.sId, error: normalizeError(err) },
       "[Stripe Webhook] Failed to grant Metronome free credits"
     );
   }

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -169,8 +169,6 @@ async function shadowProvisionMetronome({
   }
 }
 
-const FREE_MONTHLY_CREDITS_PRODUCT_NAME = "Free Monthly Credits";
-
 /**
  * Grant monthly free programmatic credits to a Metronome-billed workspace.
  * Uses the same bracket formula as the Stripe credit system.
@@ -209,13 +207,11 @@ async function grantMetronomeFreeCredits({
       );
       return;
     }
-    const creditProduct = productsResult.value.find(
-      (p) => p.name === FREE_MONTHLY_CREDITS_PRODUCT_NAME
-    );
-    if (!creditProduct) {
+    const productId = apiConfig.getMetronomeFreeCreditProductId();
+    if (!productId) {
       logger.error(
         { workspaceId: workspace.sId },
-        `[Stripe Webhook] Metronome product "${FREE_MONTHLY_CREDITS_PRODUCT_NAME}" not found`
+        `[Stripe Webhook] Metronome product "Free Monthly Credits" not found`
       );
       return;
     }
@@ -241,7 +237,7 @@ async function grantMetronomeFreeCredits({
     const result = await createMetronomeCredit({
       metronomeCustomerId: workspace.metronomeCustomerId,
       contractId: contractResult.value.contractId,
-      productId: creditProduct.id,
+      productId,
       amountCents,
       startingAt: periodStart.toISOString(),
       endingBefore: periodEnd.toISOString(),

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -14,6 +14,7 @@ import {
   voidFailedProCreditPurchaseInvoice,
 } from "@app/lib/credits/committed";
 import {
+  calculateFreeCreditAmountMicroUsd,
   grantFreeCreditFromSubscriptionStateChangeYearly,
   grantFreeCreditsFromSubscriptionStateChange,
 } from "@app/lib/credits/free";
@@ -23,7 +24,11 @@ import {
   isPAYGEnabled,
 } from "@app/lib/credits/payg";
 import { handleMetronomeSetupCheckout } from "@app/lib/metronome/checkout";
-import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/client";
+import {
+  createMetronomeCredit,
+  listMetronomeProducts,
+  provisionMetronomeCustomerAndContract,
+} from "@app/lib/metronome/client";
 import { PlanModel } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
@@ -159,6 +164,92 @@ async function shadowProvisionMetronome({
     logger.error(
       { workspaceId: workspace.sId, error: normalizeError(err) },
       "[Stripe Webhook] Failed to shadow-provision Metronome"
+    );
+  }
+}
+
+const FREE_MONTHLY_CREDITS_PRODUCT_NAME = "Free Monthly Credits";
+
+/**
+ * Grant monthly free programmatic credits to a Metronome-billed workspace.
+ * Uses the same bracket formula as the Stripe credit system.
+ * Idempotent via uniqueness_key: free-legacy-{workspaceSId}-{YYYY-MM}.
+ */
+async function grantMetronomeFreeCredits({
+  workspace,
+  stripeSubscription,
+}: {
+  workspace: WorkspaceResource;
+  stripeSubscription: Stripe.Subscription;
+}): Promise<void> {
+  if (!workspace.metronomeCustomerId) {
+    return;
+  }
+
+  try {
+    // Resolve the "Free Monthly Credits" product ID.
+    const productsResult = await listMetronomeProducts();
+    if (productsResult.isErr()) {
+      logger.error(
+        { workspaceId: workspace.sId, error: productsResult.error.message },
+        "[Stripe Webhook] Failed to list Metronome products for free credit grant"
+      );
+      return;
+    }
+    const creditProduct = productsResult.value.find(
+      (p) => p.name === FREE_MONTHLY_CREDITS_PRODUCT_NAME
+    );
+    if (!creditProduct) {
+      logger.error(
+        { workspaceId: workspace.sId },
+        `[Stripe Webhook] Metronome product "${FREE_MONTHLY_CREDITS_PRODUCT_NAME}" not found`
+      );
+      return;
+    }
+
+    // Count active members and compute bracket amount.
+    const memberCount = await MembershipResource.countActiveSeatsInWorkspace(
+      workspace.sId
+    );
+    const amountMicroUsd = calculateFreeCreditAmountMicroUsd(memberCount);
+    if (amountMicroUsd <= 0) {
+      return;
+    }
+
+    // Convert micro-USD to cents (Metronome credits are in cents).
+    const amountCents = Math.ceil(amountMicroUsd / 10_000);
+
+    const periodStart = new Date(
+      stripeSubscription.current_period_start * 1000
+    );
+    const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
+    const monthKey = `${periodStart.getUTCFullYear()}-${String(periodStart.getUTCMonth() + 1).padStart(2, "0")}`;
+
+    const result = await createMetronomeCredit({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      productId: creditProduct.id,
+      amountCents,
+      startingAt: periodStart.toISOString(),
+      endingBefore: periodEnd.toISOString(),
+      name: `Free Monthly Credits (${memberCount} users, ${monthKey})`,
+      idempotencyKey: `free-legacy-${workspace.sId}-${monthKey}`,
+    });
+
+    if (result.isOk()) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          memberCount,
+          amountCents,
+          monthKey,
+        },
+        "[Stripe Webhook] Metronome free credits granted"
+      );
+    }
+  } catch (err) {
+    logger.error(
+      { workspaceId: workspace.sId, error: err },
+      "[Stripe Webhook] Failed to grant Metronome free credits"
     );
   }
 }
@@ -1079,6 +1170,13 @@ async function handler(
                 "[Stripe Webhook] Error granting free credits"
               );
             }
+
+            // Grant free credits in Metronome for legacy workspaces.
+            // Fire-and-forget: Metronome failure should not block the webhook.
+            void grantMetronomeFreeCredits({
+              workspace,
+              stripeSubscription,
+            });
 
             if (subscriptionCycleChanged) {
               const paygEnabled = await isPAYGEnabled(auth);


### PR DESCRIPTION
## Description

Implements dust-tt/tasks#7510 (L6) — Monthly free credit grant for legacy Metronome workspaces.

At each Stripe billing cycle renewal (`customer.subscription.updated`), for workspaces with a `metronomeCustomerId`, grants free programmatic credits in Metronome using the same bracket formula as the existing Stripe credit system:
- 1–10 users → $5/user
- 11–50 users → $2/user
- 51–100 users → $1/user

**New in `lib/metronome/client.ts`** — `createMetronomeCredit()`:
- Creates a credit grant via `v1.customers.credits.create`
- Handles 409 conflict gracefully (idempotency key already used)

**New in `pages/api/stripe/webhook.ts`** — `grantMetronomeFreeCredits()`:
- Resolves "Free Monthly Credits" product by name from Metronome
- Counts active members, applies bracket formula (`calculateFreeCreditAmountMicroUsd`)
- Credit valid for the Stripe billing period (`current_period_start` → `current_period_end`)
- Idempotency key: `free-legacy-{workspaceSId}-{YYYY-MM}` — safe to retry
- Fire-and-forget: Metronome failure does not block the Stripe webhook

## Tests

Update the subscription in Stripe and click on "Reset billing cycle". New credits are added on the right contract in Metronome.

## Risk

Low — fire-and-forget, only runs for workspaces with `metronomeCustomerId`. Idempotent via uniqueness key.

## Deploy Plan

1. Ensure "Free Monthly Credits" product exists in Metronome (via `metronome_setup.ts` script)
2. Deploy — credits start flowing on next billing cycle renewal for provisioned workspaces