### PR TITLE
accept comment non strictly equal to PMRR in label check

### DIFF
--- a/.github/workflows/label-pmrr.yml
+++ b/.github/workflows/label-pmrr.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   add_label:
-    if: github.event.issue.pull_request && github.event.comment.body == 'PMRR'
+    if: github.event.issue.pull_request && contains(github.event.comment.body, 'PMRR')
     runs-on: ubuntu-latest
     steps:
       - name: Add PMRR label


### PR DESCRIPTION
## Description

- This PR extends the existing GitHub action that adds the PMRR label on pull requests to trigger on comment that only contain the PMRR string instead of being strictly equal.

## Tests

- Yes.

## Risk

- N/A.

## Deploy Plan

- No deploy.
