### PR TITLE
[Tool Calls] Emit tool_call_started for Anthropic

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -117,7 +117,11 @@ function* handleMessageStreamEvent(
      * content_block_stop (marks the end of the content block)
      */
     case "content_block_start":
-      handleContentBlockStart(messageStreamEvent, stateContainer);
+      yield* handleContentBlockStart(
+        messageStreamEvent,
+        stateContainer,
+        metadata
+      );
       break;
     case "content_block_delta":
       yield* handleContentBlockDelta(
@@ -145,10 +149,11 @@ function* handleMessageStreamEvent(
   }
 }
 
-function handleContentBlockStart(
+function* handleContentBlockStart(
   event: Extract<BetaRawMessageStreamEvent, { type: "content_block_start" }>,
-  stateContainer: { state: StreamState }
-): void {
+  stateContainer: { state: StreamState },
+  metadata: LLMClientMetadata
+): Generator<LLMEvent> {
   assert(
     stateContainer.state === null,
     `A content block is already being processed, cannot start a new one at index ${event.index}`
@@ -162,8 +167,8 @@ function handleContentBlockStart(
         accumulator: "",
         accumulatorType: blockType === "text" ? "text" : "reasoning",
       };
-      break;
-    case "tool_use":
+      return;
+    case "tool_use": {
       stateContainer.state = {
         currentBlockIndex: event.index,
         accumulator: "",
@@ -173,10 +178,20 @@ function handleContentBlockStart(
           name: event.content_block.name,
         },
       };
-      break;
+      yield {
+        type: "tool_call_started",
+        content: {
+          id: event.content_block.id,
+          index: event.index,
+          name: event.content_block.name,
+        },
+        metadata,
+      };
+      return;
+    }
     case "redacted_thinking":
       // "Redacted thinking" provides no actionable information, as everything is encrypted
-      break;
+      return;
     case "server_tool_use":
     case "web_search_tool_result":
     case "web_fetch_tool_result":
@@ -189,7 +204,7 @@ function handleContentBlockStart(
     case "container_upload":
     case "compaction":
       // We don't use these Anthropic tools
-      break;
+      return;
     default:
       assertNever(blockType);
   }

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
@@ -11,6 +11,18 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     },
   },
   {
+    type: "tool_call_started",
+    content: {
+      id: "EmptyToolCall1",
+      index: 0,
+      name: "test_tool",
+    },
+    metadata: {
+      clientId: "anthropic" as const,
+      modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+    },
+  },
+  {
     type: "tool_call_delta",
     metadata: {
       clientId: "anthropic" as const,

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
@@ -41,6 +41,18 @@ export const toolUseLLMEvents: LLMEvent[] = [
     },
   },
   {
+    type: "tool_call_started",
+    content: {
+      id: "DdHr7L197",
+      index: 1,
+      name: "web_search_browse__websearch",
+    },
+    metadata: {
+      clientId: "anthropic" as const,
+      modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+    },
+  },
+  {
     type: "tool_call_delta",
     metadata: {
       clientId: "anthropic" as const,


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/23634
- Emit `tool_call_started` when Anthropic starts a `tool_use` content block.
- Update the streamed-event fixtures so the tool name and id are exposed before the input JSON delta arrives.

## Risks
Blast radius: Anthropic streaming normalization in `front`
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test TEST_FRONT_DATABASE_URI=postgres://test:test@localhost:5433/dust_front_test_stream_tool_calls TEST_REDIS_URI=redis://localhost:6479 npm test lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts`
- [x] Local logging of tool call