### PR TITLE
fix: skip slack channel linking call for non-builder users

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -158,6 +158,10 @@ export default function AgentBuilder({
     });
 
   const slackProvider = useMemo(() => {
+    if (!isBuilder(owner)) {
+      return null;
+    }
+
     const slackBotProvider = supportedDataSourceViews.find(
       (dsv) => dsv.dataSource.connectorProvider === "slack_bot"
     );
@@ -169,7 +173,7 @@ export default function AgentBuilder({
       (dsv) => dsv.dataSource.connectorProvider === "slack"
     );
     return slackProvider ? "slack" : null;
-  }, [supportedDataSourceViews]);
+  }, [supportedDataSourceViews, owner]);
 
   const processedActions = useMemo(() => {
     return processActionsFromStorage(actions ?? emptyArray());

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -36,7 +36,6 @@ import type { DataSourceViewSelectionConfigurations } from "@app/types/data_sour
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { isBuilder } from "@app/types/user";
 import type { UserType, WorkspaceType } from "@app/types/user";
 
 function processDataSourceConfigurations(
@@ -557,7 +556,7 @@ export async function submitAgentBuilderForm({
     // unlink them from the previous agent and link them to this one.
     // Make the call even if slackChannels is empty, since if the user deselects all channels,
     // the call need to be made to unlink them.
-    if (slackProvider && areSlackChannelsChanged && isBuilder(owner)) {
+    if (slackProvider && areSlackChannelsChanged) {
       const autoRespondWithoutMention =
         slackChannels.length > 0
           ? slackChannels[0].autoRespondWithoutMention

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -36,6 +36,7 @@ import type { DataSourceViewSelectionConfigurations } from "@app/types/data_sour
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isBuilder } from "@app/types/user";
 import type { UserType, WorkspaceType } from "@app/types/user";
 
 function processDataSourceConfigurations(
@@ -556,7 +557,7 @@ export async function submitAgentBuilderForm({
     // unlink them from the previous agent and link them to this one.
     // Make the call even if slackChannels is empty, since if the user deselects all channels,
     // the call need to be made to unlink them.
-    if (slackProvider && areSlackChannelsChanged) {
+    if (slackProvider && areSlackChannelsChanged && isBuilder(owner)) {
       const autoRespondWithoutMention =
         slackChannels.length > 0
           ? slackChannels[0].autoRespondWithoutMention


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7317

The `linked_slack_channels` PATCH endpoint requires `builder` or `admin` role, but agent creation is open to all authenticated users. When non-builder users save an agent, the form always calls the slack linking endpoint (even with 0 channels), which returns 403 — causing a spurious "An error occurred while linking Slack channels" error despite the agent being created successfully.

This was hitting ~50 users over the past 2 days across 12 workspaces.

Fix: skip the `linked_slack_channels` call when the user isn't a builder, since they can't manage Slack channel linking anyway.

## Tests


## Risk

Low. Non-builder users were already unable to link Slack channels (server returns 403). This just avoids making the call in the first place.

## Deploy Plan

Standard deploy, no special steps needed.