### PR TITLE
Add gracefullyStopAgentLoop helper + expose on internal cancel endpoint

### DIFF
--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -164,7 +164,7 @@ export async function gracefullyStopAgentLoop(
       } catch (err) {
         const signalError = normalizeError(err);
         // Swallow errors from signaling (workflow might not exist anymore)
-        logger.info(
+        logger.warn(
           { error: signalError, messageId },
           "Failed to signal agent loop workflow for graceful stop"
         );

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -160,7 +160,7 @@ export async function gracefullyStopAgentLoop(
         const handle = client.workflow.getHandle(workflowId);
         await handle.signal(gracefullyStopAgentLoopSignal);
       } catch (signalError) {
-        // Workflow may have already completed — safe to ignore.
+        // Swallow errors from signaling (workflow might not exist anymore)
         logger.info(
           { error: signalError, messageId },
           "Failed to signal agent loop workflow for graceful stop"

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -9,7 +9,10 @@ import { createCallbackReader } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { makeAgentLoopWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
-import { cancelAgentLoopSignal } from "@app/temporal/agent_loop/signals";
+import {
+  cancelAgentLoopSignal,
+  gracefullyStopAgentLoopSignal,
+} from "@app/temporal/agent_loop/signals";
 import type {
   AgentActionSuccessEvent,
   AgentErrorEvent,
@@ -127,6 +130,40 @@ export async function cancelMessageGenerationEvent(
         logger.warn(
           { error: signalError, messageId },
           "Failed to signal agent loop workflow for cancellation"
+        );
+      }
+    },
+    { concurrency: 8 }
+  );
+}
+
+export async function gracefullyStopAgentLoop(
+  auth: Authenticator,
+  {
+    messageIds,
+    conversationId,
+  }: { messageIds: string[]; conversationId: string }
+): Promise<void> {
+  const client = await getTemporalClientForAgentNamespace();
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+
+  await concurrentExecutor(
+    messageIds,
+    async (messageId) => {
+      const agentMessageId = messageId;
+      const workflowId = makeAgentLoopWorkflowId({
+        workspaceId,
+        conversationId,
+        agentMessageId,
+      });
+      try {
+        const handle = client.workflow.getHandle(workflowId);
+        await handle.signal(gracefullyStopAgentLoopSignal);
+      } catch (signalError) {
+        // Workflow may have already completed — safe to ignore.
+        logger.info(
+          { error: signalError, messageId },
+          "Failed to signal agent loop workflow for graceful stop"
         );
       }
     },

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -19,6 +19,7 @@ import type {
   AgentGenerationCancelledEvent,
 } from "@app/types/assistant/agent";
 import type { GenerationTokensEvent } from "@app/types/assistant/generation";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export async function* getConversationEvents({
   conversationId,
@@ -125,7 +126,8 @@ export async function cancelMessageGenerationEvent(
       try {
         const handle = client.workflow.getHandle(workflowId);
         await handle.signal(cancelAgentLoopSignal);
-      } catch (signalError) {
+      } catch (err) {
+        const signalError = normalizeError(err);
         // Swallow errors from signaling (workflow might not exist anymore)
         logger.warn(
           { error: signalError, messageId },
@@ -159,7 +161,8 @@ export async function gracefullyStopAgentLoop(
       try {
         const handle = client.workflow.getHandle(workflowId);
         await handle.signal(gracefullyStopAgentLoopSignal);
-      } catch (signalError) {
+      } catch (err) {
+        const signalError = normalizeError(err);
         // Swallow errors from signaling (workflow might not exist anymore)
         logger.info(
           { error: signalError, messageId },

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -33,7 +33,7 @@
  *             properties:
  *               action:
  *                 type: string
- *                 enum: [cancel]
+ *                 enum: [cancel, gracefully_stop]
  *               messageIds:
  *                 type: array
  *                 items:
@@ -52,12 +52,16 @@
  *         description: Unauthorized
  */
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
-import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
+import {
+  cancelMessageGenerationEvent,
+  gracefullyStopAgentLoop,
+} from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -67,7 +71,7 @@ export type PostMessageEventResponseBody = {
   success: true;
 };
 const PostMessageEventBodySchema = t.type({
-  action: t.literal("cancel"),
+  action: t.union([t.literal("cancel"), t.literal("gracefully_stop")]),
   messageIds: t.array(t.string),
 });
 
@@ -110,10 +114,25 @@ async function handler(
           },
         });
       }
-      await cancelMessageGenerationEvent(auth, {
-        messageIds: bodyValidation.right.messageIds,
-        conversationId,
-      });
+      const { action, messageIds } = bodyValidation.right;
+
+      switch (action) {
+        case "cancel":
+          await cancelMessageGenerationEvent(auth, {
+            messageIds,
+            conversationId,
+          });
+          break;
+        case "gracefully_stop":
+          await gracefullyStopAgentLoop(auth, {
+            messageIds,
+            conversationId,
+          });
+          break;
+        default:
+          assertNever(action);
+      }
+
       return res.status(200).json({ success: true });
 
     default:

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -5870,7 +5870,8 @@
                   "action": {
                     "type": "string",
                     "enum": [
-                      "cancel"
+                      "cancel",
+                      "gracefully_stop"
                     ]
                   },
                   "messageIds": {

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -49,6 +49,7 @@ export async function runAgentLoopWorker() {
     activities: {
       ensureConversationTitleActivity,
       finalizeSuccessfulAgentLoopActivity,
+      finalizeGracefullyStoppedAgentLoopActivity,
       finalizeCancelledAgentLoopActivity,
       finalizeGracefullyStoppedAgentLoopActivity,
       finalizeErroredAgentLoopActivity,

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -51,7 +51,6 @@ export async function runAgentLoopWorker() {
       finalizeSuccessfulAgentLoopActivity,
       finalizeGracefullyStoppedAgentLoopActivity,
       finalizeCancelledAgentLoopActivity,
-      finalizeGracefullyStoppedAgentLoopActivity,
       finalizeErroredAgentLoopActivity,
       publishDeferredEventsActivity,
       runModelAndCreateActionsActivity,

--- a/x/spolu/steering/plan.md
+++ b/x/spolu/steering/plan.md
@@ -47,21 +47,13 @@ Implement the graceful stop mechanism end-to-end.
 - Route `gracefulStopRequested` in the workflow to the new finalization.
 - Handle `agent_message_gracefully_stopped` in `processEventForDatabase`.
 
-### - [ ] PR 2.4 — Add `gracefullyStopAgentLoop` helper
+### - [x] PR 2.4+2.5 — Add `gracefullyStopAgentLoop` helper + expose on cancel endpoint
 
-- Add `gracefullyStopAgentLoop()` in `front/lib/api/assistant/pubsub.ts`.
-- Sends the `gracefullyStopAgentLoopSignal` Temporal signal.
-
-### - [ ] PR 2.5 — Rename `/cancel` endpoint to `/stop` with `reason`
-
-- Rename `front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts` to `stop.ts`.
-- Change body schema from `{ action: "cancel", messageIds }` to
-  `{ reason: "cancel" | "gracefully_stop", messageIds }`.
-- When `reason === "cancel"`, call `cancelMessageGenerationEvent()` (existing behavior).
-- When `reason === "gracefully_stop"`, call `gracefullyStopAgentLoop()` with
-  `reason: "user_requested"`.
-- Keep the old `/cancel` endpoint as a redirect or alias for backward compatibility until
-  all clients are updated.
+- Add `gracefullyStopAgentLoop()` in `front/lib/api/assistant/pubsub.ts` (mirrors
+  `cancelMessageGenerationEvent` but sends `gracefullyStopAgentLoopSignal`).
+- Extend private `/cancel` endpoint to accept `action: "cancel" | "gracefully_stop"`.
+- When `action === "gracefully_stop"`, call `gracefullyStopAgentLoop()`.
+- Public v1 API endpoint unchanged (no breaking change).
 
 ### - [ ] PR 2.6 — Context pruning: preserve gracefully stopped chains as single interaction
 


### PR DESCRIPTION
## Description

- Add `gracefullyStopAgentLoop()` in `pubsub.ts` — mirrors `cancelMessageGenerationEvent` but sends `gracefullyStopAgentLoopSignal`
- Extend private `/cancel` endpoint to accept `action: "cancel" | "gracefully_stop"` with exhaustive switch
- Public v1 API endpoint unchanged for now

## Testing

Tested locally. Not much testing to be done here due to signal/workflow boundary.

## Risk

Low

## Deploy

- deploy `front`