### PR TITLE
Take into account 50% batch model discount

### DIFF
--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -1,4 +1,3 @@
-import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type {
   ImageModelIdType,
   StaticModelIdType,
@@ -513,18 +512,22 @@ const DEFAULT_PRICING = MODEL_PRICING[DEFAULT_PRICING_MODEL_ID];
  * Note: promptTokens currently includes cached read and cache write tokens for some providers.
  * To avoid double counting, price all promptTokens at base input rate, then adjust with deltas.
  */
+const BATCH_DISCOUNT_FACTOR = 0.5;
+
 export function computeTokensCostForUsageInMicroUsd({
   modelId,
   promptTokens,
   completionTokens,
   cachedTokens,
   cacheCreationTokens,
+  isBatch = false,
 }: {
   modelId: ModelIdType | ImageModelIdType;
   promptTokens: number;
   completionTokens: number;
   cachedTokens: number | null;
   cacheCreationTokens?: number | null;
+  isBatch?: boolean;
 }): number {
   const pricing = MODEL_PRICING[modelId] ?? DEFAULT_PRICING;
 
@@ -539,14 +542,7 @@ export function computeTokensCostForUsageInMicroUsd({
   const cacheWriteDelta = cacheWriteTokens * (cacheWriteRate - pricing.input);
   const outputCost = completionTokens * pricing.output;
 
-  return basePromptCost + cachedReadDelta + cacheWriteDelta + outputCost;
-}
+  const cost = basePromptCost + cachedReadDelta + cacheWriteDelta + outputCost;
 
-export function calculateTokenUsageCostInMicroUsd(
-  usages: RunUsageType[]
-): number {
-  return usages.reduce(
-    (acc, usage) => acc + computeTokensCostForUsageInMicroUsd(usage),
-    0
-  );
+  return isBatch ? Math.round(cost * BATCH_DISCOUNT_FACTOR) : cost;
 }

--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -507,13 +507,14 @@ const DEFAULT_PRICING_MODEL_ID: StaticModelIdType = "gpt-4o";
 
 const DEFAULT_PRICING = MODEL_PRICING[DEFAULT_PRICING_MODEL_ID];
 
+// This discount factor applies to OpenAi, Anthropic, Google and Mistral
+const BATCH_DISCOUNT_FACTOR = 0.5;
+
 /**
  * Calculate the cost in micro USD for token usage.
  * Note: promptTokens currently includes cached read and cache write tokens for some providers.
  * To avoid double counting, price all promptTokens at base input rate, then adjust with deltas.
  */
-const BATCH_DISCOUNT_FACTOR = 0.5;
-
 export function computeTokensCostForUsageInMicroUsd({
   modelId,
   promptTokens,

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -504,7 +504,8 @@ export abstract class LLM<TPayload = unknown> {
           await run.recordTokenUsage(
             this.authenticator,
             event.content,
-            this.modelId
+            this.modelId,
+            { isBatch: true }
           );
         }
       }

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -270,6 +270,7 @@ export class RunResource extends BaseResource<RunModel> {
           cachedTokens,
           cacheCreationTokens,
           costMicroUsd,
+          isBatch,
         }) => ({
           runId: this.id,
           workspaceId: this.workspaceId,
@@ -280,6 +281,7 @@ export class RunResource extends BaseResource<RunModel> {
           cachedTokens,
           cacheCreationTokens: cacheCreationTokens ?? null,
           costMicroUsd,
+          isBatch,
         })
       )
     );
@@ -327,7 +329,8 @@ export class RunResource extends BaseResource<RunModel> {
   async recordTokenUsage(
     auth: Authenticator,
     usage: TokenUsage,
-    modelId: ModelIdType
+    modelId: ModelIdType,
+    { isBatch = false }: { isBatch?: boolean } = {}
   ) {
     const modelConfig = getModelConfigByModelId(modelId);
 
@@ -336,13 +339,19 @@ export class RunResource extends BaseResource<RunModel> {
       return;
     }
 
-    const usageCostMicroUsd = computeTokensCostForUsageInMicroUsd({
+    const BATCH_DISCOUNT_FACTOR = 0.5;
+
+    let usageCostMicroUsd = computeTokensCostForUsageInMicroUsd({
       modelId: modelConfig.modelId,
       promptTokens: usage.inputTokens,
       completionTokens: usage.outputTokens,
       cachedTokens: usage.cachedTokens ?? null,
       cacheCreationTokens: usage.cacheCreationTokens ?? null,
     });
+
+    if (isBatch) {
+      usageCostMicroUsd = Math.round(usageCostMicroUsd * BATCH_DISCOUNT_FACTOR);
+    }
 
     return this.recordRunUsage(auth, [
       {
@@ -353,6 +362,7 @@ export class RunResource extends BaseResource<RunModel> {
         promptTokens: usage.inputTokens,
         providerId: modelConfig.providerId,
         costMicroUsd: usageCostMicroUsd,
+        isBatch,
       },
     ]);
   }
@@ -373,6 +383,7 @@ export class RunResource extends BaseResource<RunModel> {
       cachedTokens: usage.cachedTokens,
       cacheCreationTokens: usage.cacheCreationTokens,
       costMicroUsd: usage.costMicroUsd,
+      isBatch: usage.isBatch,
     }));
   }
 }
@@ -395,4 +406,5 @@ export interface RunUsageType {
   // Optional: tokens spent writing to cache (e.g., Anthropic cache creation)
   cacheCreationTokens?: number | null;
   costMicroUsd: number;
+  isBatch: boolean;
 }

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -339,19 +339,14 @@ export class RunResource extends BaseResource<RunModel> {
       return;
     }
 
-    const BATCH_DISCOUNT_FACTOR = 0.5;
-
-    let usageCostMicroUsd = computeTokensCostForUsageInMicroUsd({
+    const usageCostMicroUsd = computeTokensCostForUsageInMicroUsd({
       modelId: modelConfig.modelId,
       promptTokens: usage.inputTokens,
       completionTokens: usage.outputTokens,
       cachedTokens: usage.cachedTokens ?? null,
       cacheCreationTokens: usage.cacheCreationTokens ?? null,
+      isBatch,
     });
-
-    if (isBatch) {
-      usageCostMicroUsd = Math.round(usageCostMicroUsd * BATCH_DISCOUNT_FACTOR);
-    }
 
     return this.recordRunUsage(auth, [
       {

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -73,6 +73,7 @@ export class RunUsageModel extends WorkspaceAwareModel<RunUsageModel> {
   declare cacheCreationTokens: number | null;
 
   declare costMicroUsd: number;
+  declare isBatch: boolean;
 }
 
 RunUsageModel.init(
@@ -106,6 +107,11 @@ RunUsageModel.init(
     costMicroUsd: {
       type: DataTypes.BIGINT,
       defaultValue: 0,
+      allowNull: false,
+    },
+    isBatch: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
       allowNull: false,
     },
   },

--- a/front/migrations/db/migration_563.sql
+++ b/front/migrations/db/migration_563.sql
@@ -1,0 +1,2 @@
+-- Migration created on Apr 03, 2026
+ALTER TABLE "public"."run_usages" ADD COLUMN "isBatch" BOOLEAN NOT NULL DEFAULT false;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -90,6 +90,7 @@ function extractUsageFromExecutions(
             cachedTokens: cachedTokens ?? null,
             cacheCreationTokens: cacheCreationTokens ?? null,
             costMicroUsd: usageCostMicroUsd,
+            isBatch: false,
           });
         }
       }


### PR DESCRIPTION
## Description

Main goal is to have the costMicroUsd in the run_usages table be correct when using batching.

- Add isBatch boolean column to run_usages table to distinguish batch from streaming LLM calls
- Apply 50% discount to batch call costs in computeTokensCostForUsageInMicroUsd(), centralizing the pricing logic
- Pass isBatch: true when recording token usage for batch LLM results in createRunsForBatchResults()
- Remove unused calculateTokenUsageCostInMicroUsd function

Known issue: the discounted price is not reflected in langfuse, which has its own cost calculation logic. We can try to tackle that separately (but may not be a big deal if we don't).
 
## Tests

Manually tested both batch and non-batch Reinforcement scenarios, and validated cost in DB.

## Risk

Low

## Deploy Plan

Run migration, and then deploy front.