### PR TITLE
[Tool Calls] Emit tool_call_started for OpenAI chat

### DIFF
--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
@@ -97,6 +97,98 @@ const toolCallChunks = [
   },
 ] satisfies ChatCompletionChunk[];
 
+const chunkedToolNameChunks = [
+  {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_123",
+              function: {
+                name: "create_inter",
+              },
+            },
+          ],
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              function: {
+                name: "active_content_file",
+              },
+            },
+          ],
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              function: {
+                arguments: '{"prompt":"hi"}',
+              },
+            },
+          ],
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: "tool_calls",
+        logprobs: null,
+      },
+    ],
+    usage: {
+      prompt_tokens: 1,
+      completion_tokens: 2,
+      total_tokens: 3,
+    },
+  },
+] satisfies ChatCompletionChunk[];
+
 describe("streamLLMEvents", () => {
   it("should emit a tool call start before the first arguments chunk", async () => {
     const result = [];
@@ -121,6 +213,110 @@ describe("streamLLMEvents", () => {
         content: {
           index: 0,
           name: "create_interactive_content_file",
+        },
+        metadata,
+      },
+      {
+        type: "tool_call_delta",
+        metadata,
+      },
+      {
+        type: "tool_call_started",
+        content: {
+          id: "call_123",
+          index: 0,
+          name: "create_interactive_content_file",
+        },
+        metadata,
+      },
+      {
+        type: "tool_call_delta",
+        metadata,
+      },
+      {
+        type: "tool_call_delta",
+        metadata,
+      },
+      {
+        type: "token_usage",
+        content: {
+          inputTokens: 1,
+          outputTokens: 2,
+          totalTokens: 3,
+          cachedTokens: undefined,
+        },
+        metadata,
+      },
+      {
+        type: "tool_call",
+        content: {
+          id: "call_123",
+          name: "create_interactive_content_file",
+          arguments: {
+            prompt: "hi",
+          },
+        },
+        metadata,
+      },
+      {
+        type: "success",
+        aggregated: [
+          {
+            type: "tool_call",
+            content: {
+              id: "call_123",
+              name: "create_interactive_content_file",
+              arguments: {
+                prompt: "hi",
+              },
+            },
+            metadata,
+          },
+        ],
+        textGenerated: undefined,
+        reasoningGenerated: undefined,
+        toolCalls: [
+          {
+            type: "tool_call",
+            content: {
+              id: "call_123",
+              name: "create_interactive_content_file",
+              arguments: {
+                prompt: "hi",
+              },
+            },
+            metadata,
+          },
+        ],
+        metadata,
+      },
+    ]);
+  });
+
+  it("should re-emit tool call start when the streamed tool name grows", async () => {
+    const result = [];
+
+    for await (const event of streamLLMEvents(
+      createAsyncGenerator(chunkedToolNameChunks),
+      metadata
+    )) {
+      result.push(event);
+    }
+
+    expect(result).toEqual([
+      {
+        type: "interaction_id",
+        content: {
+          modelInteractionId: "chatcmpl_test",
+        },
+        metadata,
+      },
+      {
+        type: "tool_call_started",
+        content: {
+          id: "call_123",
+          index: 0,
+          name: "create_inter",
         },
         metadata,
       },

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
@@ -1,0 +1,203 @@
+import { createAsyncGenerator } from "@app/lib/api/llm/utils";
+import { streamLLMEvents } from "@app/lib/api/llm/utils/openai_like/chat/openai_to_events";
+import type { ChatCompletionChunk } from "openai/resources/chat/completions";
+import { describe, expect, it } from "vitest";
+
+const metadata = {
+  clientId: "openai",
+  modelId: "gpt-5",
+} as const;
+
+const toolCallChunks = [
+  {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              function: {
+                name: "create_interactive_content_file",
+              },
+            },
+          ],
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_123",
+            },
+          ],
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              function: {
+                arguments: '{"prompt":"hi"}',
+              },
+            },
+          ],
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  },
+  {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: "tool_calls",
+        logprobs: null,
+      },
+    ],
+    usage: {
+      prompt_tokens: 1,
+      completion_tokens: 2,
+      total_tokens: 3,
+    },
+  },
+] satisfies ChatCompletionChunk[];
+
+describe("streamLLMEvents", () => {
+  it("should emit a tool call start before the first arguments chunk", async () => {
+    const result = [];
+
+    for await (const event of streamLLMEvents(
+      createAsyncGenerator(toolCallChunks),
+      metadata
+    )) {
+      result.push(event);
+    }
+
+    expect(result).toEqual([
+      {
+        type: "interaction_id",
+        content: {
+          modelInteractionId: "chatcmpl_test",
+        },
+        metadata,
+      },
+      {
+        type: "tool_call_started",
+        content: {
+          index: 0,
+          name: "create_interactive_content_file",
+        },
+        metadata,
+      },
+      {
+        type: "tool_call_delta",
+        metadata,
+      },
+      {
+        type: "tool_call_started",
+        content: {
+          id: "call_123",
+          index: 0,
+          name: "create_interactive_content_file",
+        },
+        metadata,
+      },
+      {
+        type: "tool_call_delta",
+        metadata,
+      },
+      {
+        type: "tool_call_delta",
+        metadata,
+      },
+      {
+        type: "token_usage",
+        content: {
+          inputTokens: 1,
+          outputTokens: 2,
+          totalTokens: 3,
+          cachedTokens: undefined,
+        },
+        metadata,
+      },
+      {
+        type: "tool_call",
+        content: {
+          id: "call_123",
+          name: "create_interactive_content_file",
+          arguments: {
+            prompt: "hi",
+          },
+        },
+        metadata,
+      },
+      {
+        type: "success",
+        aggregated: [
+          {
+            type: "tool_call",
+            content: {
+              id: "call_123",
+              name: "create_interactive_content_file",
+              arguments: {
+                prompt: "hi",
+              },
+            },
+            metadata,
+          },
+        ],
+        textGenerated: undefined,
+        reasoningGenerated: undefined,
+        toolCalls: [
+          {
+            type: "tool_call",
+            content: {
+              id: "call_123",
+              name: "create_interactive_content_file",
+              arguments: {
+                prompt: "hi",
+              },
+            },
+            metadata,
+          },
+        ],
+        metadata,
+      },
+    ]);
+  });
+});

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
@@ -8,185 +8,130 @@ const metadata = {
   modelId: "gpt-5",
 } as const;
 
+type ChunkDelta = ChatCompletionChunk["choices"][number]["delta"];
+type ChunkFinishReason =
+  ChatCompletionChunk["choices"][number]["finish_reason"];
+type ChunkUsage = ChatCompletionChunk["usage"];
+
+function makeChunk({
+  delta,
+  finishReason = null,
+  usage,
+}: {
+  delta: ChunkDelta;
+  finishReason?: ChunkFinishReason;
+  usage?: ChunkUsage;
+}): ChatCompletionChunk {
+  return {
+    id: "chatcmpl_test",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "gpt-5",
+    choices: [
+      {
+        index: 0,
+        delta,
+        finish_reason: finishReason,
+        logprobs: null,
+      },
+    ],
+    ...(usage ? { usage } : {}),
+  };
+}
+
 const toolCallChunks = [
-  {
-    id: "chatcmpl_test",
-    object: "chat.completion.chunk",
-    created: 1,
-    model: "gpt-5",
-    choices: [
-      {
-        index: 0,
-        delta: {
-          tool_calls: [
-            {
-              index: 0,
-              function: {
-                name: "create_interactive_content_file",
-              },
-            },
-          ],
+  makeChunk({
+    delta: {
+      tool_calls: [
+        {
+          index: 0,
+          function: {
+            name: "create_interactive_content_file",
+          },
         },
-        finish_reason: null,
-        logprobs: null,
-      },
-    ],
-  },
-  {
-    id: "chatcmpl_test",
-    object: "chat.completion.chunk",
-    created: 1,
-    model: "gpt-5",
-    choices: [
-      {
-        index: 0,
-        delta: {
-          tool_calls: [
-            {
-              index: 0,
-              id: "call_123",
-            },
-          ],
+      ],
+    },
+  }),
+  makeChunk({
+    delta: {
+      tool_calls: [
+        {
+          index: 0,
+          id: "call_123",
         },
-        finish_reason: null,
-        logprobs: null,
-      },
-    ],
-  },
-  {
-    id: "chatcmpl_test",
-    object: "chat.completion.chunk",
-    created: 1,
-    model: "gpt-5",
-    choices: [
-      {
-        index: 0,
-        delta: {
-          tool_calls: [
-            {
-              index: 0,
-              function: {
-                arguments: '{"prompt":"hi"}',
-              },
-            },
-          ],
+      ],
+    },
+  }),
+  makeChunk({
+    delta: {
+      tool_calls: [
+        {
+          index: 0,
+          function: {
+            arguments: '{"prompt":"hi"}',
+          },
         },
-        finish_reason: null,
-        logprobs: null,
-      },
-    ],
-  },
-  {
-    id: "chatcmpl_test",
-    object: "chat.completion.chunk",
-    created: 1,
-    model: "gpt-5",
-    choices: [
-      {
-        index: 0,
-        delta: {},
-        finish_reason: "tool_calls",
-        logprobs: null,
-      },
-    ],
+      ],
+    },
+  }),
+  makeChunk({
+    delta: {},
+    finishReason: "tool_calls",
     usage: {
       prompt_tokens: 1,
       completion_tokens: 2,
       total_tokens: 3,
     },
-  },
+  }),
 ] satisfies ChatCompletionChunk[];
 
 const chunkedToolNameChunks = [
-  {
-    id: "chatcmpl_test",
-    object: "chat.completion.chunk",
-    created: 1,
-    model: "gpt-5",
-    choices: [
-      {
-        index: 0,
-        delta: {
-          tool_calls: [
-            {
-              index: 0,
-              id: "call_123",
-              function: {
-                name: "create_inter",
-              },
-            },
-          ],
+  makeChunk({
+    delta: {
+      tool_calls: [
+        {
+          index: 0,
+          id: "call_123",
+          function: {
+            name: "create_inter",
+          },
         },
-        finish_reason: null,
-        logprobs: null,
-      },
-    ],
-  },
-  {
-    id: "chatcmpl_test",
-    object: "chat.completion.chunk",
-    created: 1,
-    model: "gpt-5",
-    choices: [
-      {
-        index: 0,
-        delta: {
-          tool_calls: [
-            {
-              index: 0,
-              function: {
-                name: "active_content_file",
-              },
-            },
-          ],
+      ],
+    },
+  }),
+  makeChunk({
+    delta: {
+      tool_calls: [
+        {
+          index: 0,
+          function: {
+            name: "active_content_file",
+          },
         },
-        finish_reason: null,
-        logprobs: null,
-      },
-    ],
-  },
-  {
-    id: "chatcmpl_test",
-    object: "chat.completion.chunk",
-    created: 1,
-    model: "gpt-5",
-    choices: [
-      {
-        index: 0,
-        delta: {
-          tool_calls: [
-            {
-              index: 0,
-              function: {
-                arguments: '{"prompt":"hi"}',
-              },
-            },
-          ],
+      ],
+    },
+  }),
+  makeChunk({
+    delta: {
+      tool_calls: [
+        {
+          index: 0,
+          function: {
+            arguments: '{"prompt":"hi"}',
+          },
         },
-        finish_reason: null,
-        logprobs: null,
-      },
-    ],
-  },
-  {
-    id: "chatcmpl_test",
-    object: "chat.completion.chunk",
-    created: 1,
-    model: "gpt-5",
-    choices: [
-      {
-        index: 0,
-        delta: {},
-        finish_reason: "tool_calls",
-        logprobs: null,
-      },
-    ],
+      ],
+    },
+  }),
+  makeChunk({
+    delta: {},
+    finishReason: "tool_calls",
     usage: {
       prompt_tokens: 1,
       completion_tokens: 2,
       total_tokens: 3,
     },
-  },
+  }),
 ] satisfies ChatCompletionChunk[];
 
 describe("streamLLMEvents", () => {

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
@@ -20,7 +20,8 @@ export async function* streamLLMEvents(
       id: string;
       name: string;
       arguments: string;
-      startEmissionState: "none" | "without_id" | "with_id";
+      lastEmittedStartedName: string;
+      hasEmittedStartedWithId: boolean;
     }
   > = new Map();
   let hasYieldedResponseId = false;
@@ -86,7 +87,8 @@ export async function* streamLLMEvents(
             id: "",
             name: "",
             arguments: "",
-            startEmissionState: "none",
+            lastEmittedStartedName: "",
+            hasEmittedStartedWithId: false,
           });
         }
 
@@ -103,17 +105,14 @@ export async function* streamLLMEvents(
           toolCall.arguments += toolCallDelta.function.arguments;
         }
 
-        const shouldEmitStartWithoutId =
-          toolCall.startEmissionState === "none" &&
+        const shouldEmitStart =
           toolCall.name.length > 0 &&
-          !toolCall.id;
-        const shouldEmitStartWithId =
-          toolCall.startEmissionState !== "with_id" &&
-          toolCall.name.length > 0 &&
-          toolCall.id.length > 0;
+          (toolCall.name !== toolCall.lastEmittedStartedName ||
+            (toolCall.id.length > 0 && !toolCall.hasEmittedStartedWithId));
 
-        if (shouldEmitStartWithoutId || shouldEmitStartWithId) {
-          toolCall.startEmissionState = toolCall.id ? "with_id" : "without_id";
+        if (shouldEmitStart) {
+          toolCall.lastEmittedStartedName = toolCall.name;
+          toolCall.hasEmittedStartedWithId ||= toolCall.id.length > 0;
           yield {
             type: "tool_call_started",
             content: {

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
@@ -16,7 +16,12 @@ export async function* streamLLMEvents(
   let reasoningDelta = "";
   const toolCalls: Map<
     number,
-    { id: string; name: string; arguments: string }
+    {
+      id: string;
+      name: string;
+      arguments: string;
+      startEmissionState: "none" | "without_id" | "with_id";
+    }
   > = new Map();
   let hasYieldedResponseId = false;
   let hasError = false;
@@ -81,6 +86,7 @@ export async function* streamLLMEvents(
             id: "",
             name: "",
             arguments: "",
+            startEmissionState: "none",
           });
         }
 
@@ -95,6 +101,28 @@ export async function* streamLLMEvents(
         }
         if (toolCallDelta.function?.arguments) {
           toolCall.arguments += toolCallDelta.function.arguments;
+        }
+
+        const shouldEmitStartWithoutId =
+          toolCall.startEmissionState === "none" &&
+          toolCall.name.length > 0 &&
+          !toolCall.id;
+        const shouldEmitStartWithId =
+          toolCall.startEmissionState !== "with_id" &&
+          toolCall.name.length > 0 &&
+          toolCall.id.length > 0;
+
+        if (shouldEmitStartWithoutId || shouldEmitStartWithId) {
+          toolCall.startEmissionState = toolCall.id ? "with_id" : "without_id";
+          yield {
+            type: "tool_call_started",
+            content: {
+              ...(toolCall.id ? { id: toolCall.id } : {}),
+              index,
+              name: toolCall.name,
+            },
+            metadata,
+          };
         }
       }
       yield { type: "tool_call_delta", metadata };


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/23634.

Emit `tool_call_started` from the OpenAI chat-completions adapter as soon as a tool name is known, then re-emit it once the call id arrives later in the stream.

Add a focused adapter test covering the name-first, id-later case.

## Risks
Blast radius: OpenAI chat-completions event normalization, including providers that use the same adapter such as Fireworks.
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Tests
- [x] `npm test lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts`