### PR TITLE
[front] fix: add graceful stop finalization to agent loop activities

### DIFF
--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -10,6 +10,7 @@ import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activi
 import {
   finalizeCancelledAgentLoopActivity,
   finalizeErroredAgentLoopActivity,
+  finalizeGracefullyStoppedAgentLoopActivity,
   finalizeSuccessfulAgentLoopActivity,
 } from "@app/temporal/agent_loop/activities/finalize";
 import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activities/publish_deferred_events";
@@ -49,6 +50,7 @@ export async function runAgentLoopWorker() {
       ensureConversationTitleActivity,
       finalizeSuccessfulAgentLoopActivity,
       finalizeCancelledAgentLoopActivity,
+      finalizeGracefullyStoppedAgentLoopActivity,
       finalizeErroredAgentLoopActivity,
       publishDeferredEventsActivity,
       runModelAndCreateActionsActivity,


### PR DESCRIPTION
## Description

- This PR register `finalizeGracefullyStoppedAgentLoopActivity` on the worker.
- See https://dust4ai.slack.com/archives/C050SM8NSPK/p1775212503624059

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
