### PR TITLE
Make `stop` button do graceful stop instead of cancel

### DIFF
--- a/front/hooks/conversations/useCancelMessage.ts
+++ b/front/hooks/conversations/useCancelMessage.ts
@@ -25,9 +25,7 @@ export function useCancelMessage({
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              action: isInlineActivityEnabled()
-                ? "gracefully_stop"
-                : "cancel",
+              action: isInlineActivityEnabled() ? "gracefully_stop" : "cancel",
               messageIds,
             }),
           }

--- a/front/hooks/conversations/useCancelMessage.ts
+++ b/front/hooks/conversations/useCancelMessage.ts
@@ -1,4 +1,5 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import { isInlineActivityEnabled } from "@app/lib/development";
 import { clientFetch } from "@app/lib/egress/client";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback } from "react";
@@ -23,7 +24,12 @@ export function useCancelMessage({
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ action: "cancel", messageIds }),
+            body: JSON.stringify({
+              action: isInlineActivityEnabled()
+                ? "gracefully_stop"
+                : "cancel",
+              messageIds,
+            }),
           }
         );
         // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## Description

Use `gracefully_stop` as replacement for `cancel` when `isInlineActivityEnabled()`.

- Change `useCancelMessage` to send `action: "gracefully_stop"` instead of `"cancel"`

The stop button now triggers a graceful stop: the agent loop completes its current step before exiting, preserving all content through the last step

## Test

Tested locally

## Risk

Low

## Deploy

- deploy `front`