### PR TITLE
Don't scrub enterprise workflow when payment failed

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -10,6 +10,7 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   FREE_BYOK_TRANSITIONING_PLAN_CODE,
   FREE_TRIAL_PHONE_PLAN_CODE,
+  isEntreprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
@@ -125,7 +126,7 @@ export const NavigationSidebar = React.forwardRef<
           />
           {appStatus && <AppStatusBanner appStatus={appStatus} />}
           {subscription.paymentFailingSince && isAdmin(owner) && (
-            <SubscriptionPastDueBanner />
+            <SubscriptionPastDueBanner subscription={subscription} />
           )}
         </div>
         {navs.length > 1 && (
@@ -340,7 +341,30 @@ function AppStatusBanner({ appStatus }: AppStatusBannerProps) {
   return null;
 }
 
-function SubscriptionPastDueBanner() {
+interface SubscriptionPastDueBannerProps {
+  subscription: SubscriptionType;
+}
+
+function SubscriptionPastDueBanner({
+  subscription,
+}: SubscriptionPastDueBannerProps) {
+  const isEnterprise = isEntreprisePlanPrefix(subscription.plan.code);
+
+  if (isEnterprise) {
+    return (
+      <StatusBanner
+        variant="warning"
+        title="A recent payment requires attention."
+        description={
+          <>
+            <br />
+            Please reach out to your account manager to resolve this.
+          </>
+        }
+      />
+    );
+  }
+
   return (
     <StatusBanner
       variant="warning"

--- a/front/components/navigation/TrialBanner.tsx
+++ b/front/components/navigation/TrialBanner.tsx
@@ -1,4 +1,7 @@
-import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
+import {
+  isEntreprisePlanPrefix,
+  isFreeTrialPhonePlan,
+} from "@app/lib/plans/plan_codes";
 import type { SubscriptionType } from "@app/types/plan";
 import { Button, cn, LinkWrapper } from "@dust-tt/sparkle";
 import { useMemo, useRef } from "react";
@@ -21,6 +24,7 @@ export function SubscriptionEndBanner({
 }: SubscriptionEndBannerProps) {
   const endDate = subscription.endDate;
   const isTrial = isFreeTrialPhonePlan(subscription.plan.code);
+  const isEnterprise = isEntreprisePlanPrefix(subscription.plan.code);
 
   // Capture initial timestamp in a ref to avoid re-computation on re-renders.
   // This is intentionally not reactive - the banner state is stable for the session.
@@ -51,14 +55,26 @@ export function SubscriptionEndBanner({
   const { hasEnded, daysRemaining } = bannerState;
 
   let title: string;
+  let description: string;
+
   if (isTrial) {
     title = hasEnded
       ? "Heads up, your trial has ended"
       : `Heads up, your trial ends in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}`;
+    description =
+      "When your trial wraps up, your connections and team member access will be removed. Subscribe now to keep everything.";
+  } else if (isEnterprise) {
+    title = hasEnded
+      ? "Your current subscription period has ended"
+      : `Your current subscription period ends in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}`;
+    description =
+      "Please reach out to your account manager to ensure continuity.";
   } else {
     title = hasEnded
       ? "Heads up, your subscription has ended"
       : `Heads up, your subscription ends in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}`;
+    description =
+      "When your subscription wraps up, your connections and team member access will be removed. Subscribe now to keep everything.";
   }
 
   return (
@@ -78,12 +94,10 @@ export function SubscriptionEndBanner({
           {title}
         </span>
         <span className="text-sky-800 dark:text-sky-800-night">
-          When your {isTrial ? "trial" : "subscription"} wraps up, your
-          connections and team member access will be removed. Subscribe now to
-          keep everything.
+          {description}
         </span>
       </div>
-      {isAdmin && (
+      {isAdmin && !isEnterprise && (
         <LinkWrapper
           href={`/w/${owner.sId}/subscription`}
           className="shrink-0 no-underline"

--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -5,6 +5,7 @@ import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import {
+  isEntreprisePlanPrefix,
   isProPlan,
   isUpgraded,
   isWhitelistedBusinessPlan,
@@ -450,17 +451,24 @@ export function SubscriptionPage() {
               title={`Your subscription ends on ${endDate}.`}
               variant="warning"
             >
-              <>
-                Connections will be deleted and members will be revoked. Details{" "}
-                <LinkWrapper
-                  href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
-                  target="_blank"
-                  className="underline"
-                >
-                  here
-                </LinkWrapper>
-                .
-              </>
+              {isEntreprisePlanPrefix(plan.code) ? (
+                <>
+                  Please reach out to your account manager to ensure continuity.
+                </>
+              ) : (
+                <>
+                  Connections will be deleted and members will be revoked.
+                  Details{" "}
+                  <LinkWrapper
+                    href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
+                    target="_blank"
+                    className="underline"
+                  >
+                    here
+                  </LinkWrapper>
+                  .
+                </>
+              )}
             </ContentMessage>
           )}
 

--- a/front/lib/api/email.ts
+++ b/front/lib/api/email.ts
@@ -103,19 +103,34 @@ export async function sendReactivateSubscriptionEmail(
 
 export async function sendAdminSubscriptionPaymentFailedEmail(
   email: string,
-  customerPortailUrl: string | null
+  customerPortailUrl: string | null,
+  isEnterprise: boolean
 ): Promise<void> {
-  await sendEmailWithTemplate({
-    to: email,
-    from: config.getSupportEmailAddress(),
-    subject: `[Dust] Your payment has failed`,
-    body: `
+  if (isEnterprise) {
+    await sendEmailWithTemplate({
+      to: email,
+      from: config.getSupportEmailAddress(),
+      subject: `[Dust] A recent payment requires attention`,
+      body: `
+      <p>A recent payment for your Dust workspace could not be processed.</p>
+      <p>
+        Please reach out to your account manager to resolve this.
+      </p>
+      <p>Please reply to this email if you have any questions.</p>`,
+    });
+  } else {
+    await sendEmailWithTemplate({
+      to: email,
+      from: config.getSupportEmailAddress(),
+      subject: `[Dust] Your payment has failed`,
+      body: `
       <p>Your payment has failed. Please visit ${customerPortailUrl} to edit your payment information.</p>
       <p>
         Please note: your workspace will be downgraded after 3 failed payment retries. This will trigger the removal of any feature attached to the paid plan you were on, and the permanent deletion of connections and the data associated with them. Any agent that are linked to connections will also be removed.
       </p>
       <p>Please reply to this email if you have any questions.</p>`,
-  });
+    });
+  }
 }
 
 export async function sendAdminDataDeletionEmail({

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -25,6 +25,7 @@ import {
 import { handleMetronomeSetupCheckout } from "@app/lib/metronome/checkout";
 import { createMetronomeCustomer } from "@app/lib/metronome/client";
 import { PlanModel } from "@app/lib/models/plan";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
   assertStripeSubscriptionIsValid,
@@ -687,10 +688,14 @@ async function handler(
               owner,
               subscription: subscriptionType,
             });
+            const isEnterprise = isEntreprisePlanPrefix(
+              subscriptionType.plan.code
+            );
             for (const adminEmail of adminEmails) {
               await sendAdminSubscriptionPaymentFailedEmail(
                 adminEmail,
-                portalUrl
+                portalUrl,
+                isEnterprise
               );
             }
           }
@@ -1342,13 +1347,7 @@ async function handler(
               );
               await matchingSubscription.markAsEnded("ended");
               break;
-            case "active":
-              logger.info(
-                { event },
-                "[Stripe Webhook] Received customer.subscription.deleted event with the subscription status = active. Ending the subscription and deleting some workspace data"
-              );
-              await matchingSubscription.markAsEnded("ended");
-
+            case "active": {
               const workspace = await WorkspaceResource.fetchByModelId(
                 matchingSubscription.workspaceId
               );
@@ -1356,6 +1355,30 @@ async function handler(
                 workspace,
                 "Workspace not found for trialing subscription."
               );
+
+              // Enterprise subscriptions should not be automatically scrubbed
+              // when Stripe cancels due to payment failure. Instead, we log
+              // a critical warning so the team can intervene manually.
+              if (isEntreprisePlanPrefix(matchingSubscription.getPlan().code)) {
+                logger.error(
+                  {
+                    event,
+                    panic: true,
+                    stripeError: true,
+                    workspaceId: workspace.sId,
+                    stripeSubscriptionId: stripeSubscription.id,
+                    planCode: matchingSubscription.getPlan().code,
+                  },
+                  "[Stripe Webhook] Enterprise subscription deleted by Stripe. Skipping automatic scrub — manual intervention required."
+                );
+                break;
+              }
+
+              logger.info(
+                { event },
+                "[Stripe Webhook] Received customer.subscription.deleted event with the subscription status = active. Ending the subscription and deleting some workspace data"
+              );
+              await matchingSubscription.markAsEnded("ended");
 
               const scheduleScrubRes =
                 await launchScheduleWorkspaceScrubWorkflow({
@@ -1380,6 +1403,7 @@ async function handler(
                 });
               }
               break;
+            }
             default:
               assertNever(matchingSubscription.status);
           }


### PR DESCRIPTION
## Description

Prevent automatic workspace scrubbing for Enterprise plans when Stripe cancels a subscription due to payment failure, and soften payment failure messaging.

Stacked on #23630.

Fixes https://github.com/dust-tt/tasks/issues/7275

### Prevent automatic scrub for Enterprise (`webhook.ts`)

When Stripe cancels a subscription after exhausted payment retries, the `customer.subscription.deleted` webhook previously treated all plans identically — ending the subscription and launching the scrub workflow (pause connectors, delete data after retention period).

For Enterprise plans, we now:
- **Skip** `markAsEnded()` and `launchScheduleWorkspaceScrubWorkflow()` — the workspace stays intact
- **Log a `panic: true` error** to trigger a Datadog alert for manual intervention

### Softer payment failure messaging for Enterprise

- **Payment failure banner** (`NavigationSidebar.tsx`): Enterprise plans see *"A recent payment requires attention"* / *"Please reach out to your account manager to resolve this — your workspace will not be affected in the meantime."* instead of the downgrade threat.
- **Payment failure email** (`email.ts`): Enterprise admins receive *"A recent payment requires attention"* without the *"your workspace will be downgraded after 3 failed payment retries"* language.

Non-enterprise plans keep all existing behavior unchanged.

## Tests

Type-checking passes. All changes are gated on `isEntreprisePlanPrefix(plan.code)`, no impact on non-enterprise plans.

## Risk

Medium — Enterprise workspaces will no longer be auto-scrubbed on Stripe cancellation. This is intentional but requires the team to handle Enterprise payment failures manually (alerted via `panic: true` log).

## Deploy Plan

Standard deploy. After deploy, verify that Datadog alerts are configured for the new `panic: true` log in the Stripe webhook (`"Enterprise subscription deleted by Stripe. Skipping automatic scrub"`).