### PR TITLE
[front] feat: add blocked action support for `ask_user_question` tool

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -12,7 +12,10 @@ import type {
 import { hideInternalConfiguration } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
-import type { FileAuthorizationInfo } from "@app/lib/actions/types";
+import type {
+  FileAuthorizationInfo,
+  UserQuestion,
+} from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import type {
   MCPToolRetryPolicyType,
@@ -143,6 +146,11 @@ export type BlockedToolExecution = ToolExecution &
           mcpServerDisplayName: string;
         };
         fileAuthorizationInfo: FileAuthorizationInfo;
+      }
+    | {
+        status: "blocked_user_answer_required";
+        question: UserQuestion;
+        authorizationInfo: null;
       }
   );
 

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -164,6 +164,20 @@ export async function getExitOrPauseEvents(
           },
         ];
       }
+      case "tool_user_answer_required": {
+        const { question } = exitOutputItem;
+
+        await action.updateStatus("blocked_user_answer_required");
+
+        await action.updateStepContext({
+          ...action.stepContext,
+          resumeState: { type: "user_question", question },
+        });
+
+        // TODO(ask-user-question): Emit a ToolAskUserQuestionEvent here once
+        // the event streaming pipeline supports it.
+        return [];
+      }
       default: {
         assertNever(exitOutputItem);
       }

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -3,6 +3,7 @@ import {
   INTERNAL_ALLOWED_ICONS,
 } from "@app/components/resources/resources_icon_names";
 import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
+import { UserQuestionSchema } from "@app/lib/actions/types";
 import { CONNECTOR_PROVIDERS } from "@app/types/data_source";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { ALL_FILE_FORMATS } from "@app/types/files";
@@ -1069,11 +1070,24 @@ export type EarlyExitOutputResourceType = z.infer<
   typeof EarlyExitOutputResourceSchema
 >;
 
+export const UserAnswerRequiredOutputResourceSchema = z.object({
+  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT),
+  type: z.literal("tool_user_answer_required"),
+  question: UserQuestionSchema,
+  text: z.string(),
+  uri: z.string(),
+});
+
+export type UserAnswerRequiredOutputResourceType = z.infer<
+  typeof UserAnswerRequiredOutputResourceSchema
+>;
+
 export const AgentPauseOutputResourceSchema = z.union([
   AuthRequiredOutputResourceSchema,
   BlockedAwaitingInputOutputResourceSchema,
   EarlyExitOutputResourceSchema,
   FileAuthRequiredOutputResourceSchema,
+  UserAnswerRequiredOutputResourceSchema,
 ]);
 
 export type AgentPauseOutputResourceType = z.infer<

--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -11,6 +11,7 @@ export const TOOL_EXECUTION_BLOCKED_STATUSES = [
   "blocked_file_authorization_required",
   "blocked_validation_required",
   "blocked_child_action_input_required",
+  "blocked_user_answer_required",
 ] as const;
 
 export type ToolExecutionBlockedStatus =

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -59,6 +59,22 @@ export const UserQuestionAnswerSchema = z.object({
 
 export type UserQuestionAnswer = z.infer<typeof UserQuestionAnswerSchema>;
 
+const UserQuestionResumeStateSchema = z.object({
+  type: z.literal("user_question"),
+  question: UserQuestionSchema,
+  answer: UserQuestionAnswerSchema.optional(),
+});
+
+export type UserQuestionResumeState = z.infer<
+  typeof UserQuestionResumeStateSchema
+>;
+
+export function isUserQuestionResumeState(
+  value: unknown
+): value is UserQuestionResumeState {
+  return UserQuestionResumeStateSchema.safeParse(value).success;
+}
+
 export type StepContext = {
   citationsCount: number;
   citationsOffset: number;

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -1,7 +1,7 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { UserQuestion } from "@app/lib/actions/types";
-import { UserQuestionAnswerSchema } from "@app/lib/actions/types";
+import { isUserQuestionResumeState } from "@app/lib/actions/types";
 import { ASK_USER_QUESTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/ask_user_question/metadata";
 import { Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -18,12 +18,8 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
     };
 
     const resumeState = agentLoopContext?.runContext?.stepContext?.resumeState;
-    const parsed = UserQuestionAnswerSchema.safeParse(
-      resumeState && "answer" in resumeState ? resumeState.answer : undefined
-    );
-
-    if (parsed.success) {
-      const answer = parsed.data;
+    if (isUserQuestionResumeState(resumeState) && resumeState.answer) {
+      const { answer } = resumeState;
       const selections: string[] = [];
       for (const idx of answer.selectedOptions) {
         if (idx >= 0 && idx < typedQuestion.options.length) {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -14,7 +14,10 @@ import {
   TOOL_EXECUTION_BLOCKED_STATUSES,
 } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
-import { isFileAuthorizationInfo } from "@app/lib/actions/types";
+import {
+  isFileAuthorizationInfo,
+  isUserQuestionResumeState,
+} from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { getCitationsFromToolOutput } from "@app/lib/api/assistant/citations";
 import { getAgentConfigurationsWithVersion } from "@app/lib/api/assistant/configuration/agent";
@@ -482,6 +485,27 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
             mcpServerId,
             mcpServerDisplayName,
           },
+        });
+      } else if (action.status === "blocked_user_answer_required") {
+        const { resumeState } = action.stepContext;
+        if (!isUserQuestionResumeState(resumeState)) {
+          logger.warn(
+            {
+              actionId: action.id,
+              conversationId: conversation.sId,
+              messageId: agentMessage.message.sId,
+              workspaceId: owner.id,
+            },
+            `User question resume state not found for blocked action ${action.id}`
+          );
+          continue;
+        }
+
+        blockedActionsList.push({
+          ...baseActionParams,
+          status: action.status,
+          question: resumeState.question,
+          authorizationInfo: null,
         });
       } else if (action.status === "blocked_child_action_input_required") {
         const conversationId = action.stepContext.resumeState?.conversationId;

--- a/sdks/js/src/output_schemas.ts
+++ b/sdks/js/src/output_schemas.ts
@@ -649,11 +649,24 @@ export const UserQuestionItemSchema = z.object({
   multiSelect: z.boolean(),
 });
 
+export const UserAnswerRequiredOutputResourceSchema = z.object({
+  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT),
+  type: z.literal("tool_user_answer_required"),
+  question: UserQuestionItemSchema,
+  text: z.string(),
+  uri: z.string(),
+});
+
+export type UserAnswerRequiredOutputResourceType = z.infer<
+  typeof UserAnswerRequiredOutputResourceSchema
+>;
+
 export const AgentPauseOutputResourceSchema = z.union([
   AuthRequiredOutputResourceSchema,
   BlockedAwaitingInputOutputResourceSchema,
   EarlyExitOutputResourceSchema,
   FileAuthRequiredOutputResourceSchema,
+  UserAnswerRequiredOutputResourceSchema,
 ]);
 
 export type AgentPauseOutputResourceType = z.infer<

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1332,6 +1332,7 @@ const ToolExecutionBlockedStatusSchema = z.enum([
   "blocked_file_authorization_required",
   "blocked_validation_required",
   "blocked_child_action_input_required",
+  "blocked_user_answer_required",
 ]);
 
 export type ToolExecutionBlockedStatusType = z.infer<
@@ -1352,7 +1353,7 @@ const BlockedActionExecutionSchema = ToolExecutionMetadataSchema.extend({
   messageId: z.string(),
   conversationId: z.string(),
   status: ToolExecutionBlockedStatusSchema,
-  // Present only when status is "blocked_user_question_required".
+  // Present only when status is "blocked_user_answer_required".
   question: UserQuestionItemSchema.optional(),
 });
 


### PR DESCRIPTION
## Description

- Add `blocked_user_answer_required` status and `UserAnswerRequiredOutputResourceSchema` for the `ask_user_question` tool's pause mechanism
- When the tool fires, the action is blocked and the question is persisted in stepContext (no event streamed yet, will be in the next PR).
- Consolidate resume state parsing: `UserQuestionResumeState` schema (with optional answer) is now shared between exit_events, the tool handler, and the blocked action resource.
- SDK mirrors for blocked status and output schema (we'll need it for Slack at least).

## Tests

- Tested locally.

## Risk

- Low. Unreachable code paths as the events are never emitted.

## Deploy Plan

- Deploy front.
