### PR TITLE
Remove language from extension url

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -193,7 +193,7 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
         <DropdownMenuItem
           label="Dust Chrome Extension"
           icon={ChromeLogo}
-          href="https://chromewebstore.google.com/detail/dust/fnkfcndbgingjcbdhaofkcnhcjpljhdn?authuser=0&hl=fr"
+          href="https://chromewebstore.google.com/detail/dust/fnkfcndbgingjcbdhaofkcnhcjpljhdn"
           target="_blank"
         />
 


### PR DESCRIPTION
## Description

The link to the Chrome extension was redirecting to the French translation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Deploy front
