### PR TITLE
Hide completion UI for gracefully_stopped agent messages

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -370,6 +370,7 @@ export function AgentMessage({
 
   const isDeleted = agentMessage.visibility === "deleted";
   const isCancelled = agentMessage.status === "cancelled";
+  const isGracefullyStopped = agentMessage.status === "gracefully_stopped";
   const isCancelledOrDeleted = isDeleted || isCancelled;
   const cancelMessage = useCancelMessage({ owner, conversationId });
 
@@ -902,7 +903,7 @@ export function AgentMessage({
     </ConversationMessageContent>
   );
 
-  const footerButtons = !isCancelledOrDeleted &&
+  const footerButtons = !isCancelledOrDeleted && !isGracefullyStopped &&
     (alwaysVisibleButtons.length > 0 || hoverButtons.length > 0) && (
       <div className="flex items-center gap-2">
         {alwaysVisibleButtons}
@@ -938,7 +939,8 @@ export function AgentMessage({
     );
   };
 
-  const hideCompletionStatus = isDeleted || isInlineActivityEnabled;
+  const hideCompletionStatus =
+    isDeleted || isInlineActivityEnabled || isGracefullyStopped;
 
   return (
     <ConversationMessageContainer messageType="agent" type="agent">

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -939,8 +939,7 @@ export function AgentMessage({
     );
   };
 
-  const hideCompletionStatus =
-    isDeleted || isInlineActivityEnabled || isGracefullyStopped;
+  const hideCompletionStatus = isDeleted || isInlineActivityEnabled;
 
   return (
     <ConversationMessageContainer messageType="agent" type="agent">

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -903,7 +903,8 @@ export function AgentMessage({
     </ConversationMessageContent>
   );
 
-  const footerButtons = !isCancelledOrDeleted && !isGracefullyStopped &&
+  const footerButtons = !isCancelledOrDeleted &&
+    !isGracefullyStopped &&
     (alwaysVisibleButtons.length > 0 || hoverButtons.length > 0) && (
       <div className="flex items-center gap-2">
         {alwaysVisibleButtons}

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -114,7 +114,8 @@ export function InlineActivitySteps({
   const toggleCollapse = () => setIsCollapsed((c) => !c);
 
   // Done with no steps: show a static line — no toggle, not clickable.
-  if (isDone && completedSteps.length === 0) {
+  // For gracefully stopped, skip this entirely (no completion UI needed).
+  if (isDone && completedSteps.length === 0 && agentMessage.status !== "gracefully_stopped") {
     return (
       <div className="mt-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
         {headerLabel ? `${headerLabel}, without tools.` : "No tools used."}
@@ -265,13 +266,15 @@ export function InlineActivitySteps({
             {!isDone && !showActiveThinking && !activeAction && (
               <TimelineRow spinner isLast />
             )}
-            {isDone && completedSteps.length > 0 && (
-              <TimelineRow icon={CheckIcon} isLast>
-                <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                  Done
-                </span>
-              </TimelineRow>
-            )}
+            {isDone &&
+              completedSteps.length > 0 &&
+              agentMessage.status !== "gracefully_stopped" && (
+                <TimelineRow icon={CheckIcon} isLast>
+                  <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    Done
+                  </span>
+                </TimelineRow>
+              )}
           </div>
         </div>
       </div>

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -114,8 +114,7 @@ export function InlineActivitySteps({
   const toggleCollapse = () => setIsCollapsed((c) => !c);
 
   // Done with no steps: show a static line — no toggle, not clickable.
-  // For gracefully stopped, skip this entirely (no completion UI needed).
-  if (isDone && completedSteps.length === 0 && agentMessage.status !== "gracefully_stopped") {
+  if (isDone && completedSteps.length === 0) {
     return (
       <div className="mt-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
         {headerLabel ? `${headerLabel}, without tools.` : "No tools used."}


### PR DESCRIPTION
## Summary

- Hide footer buttons (provide feedback, copy, more) for gracefully_stopped messages
- Hide "Done" marker in inline activity timeline

Result is iteratively better, may require a bit of fine-tuning:

<img width="751" height="969" alt="Screenshot 2026-04-03 at 14 39 16" src="https://github.com/user-attachments/assets/15444f5f-97fb-4dd9-b7e8-54e2137b7c38" />

## Test

N/A

## Risk

None

## Deploy

- deploy `front`