### PR TITLE
feat: add next occurences in schedules

### DIFF
--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
@@ -2,6 +2,7 @@ import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useTextAsCronRule } from "@app/lib/swr/agent_triggers";
 import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
+import { getNextOccurrences } from "@app/lib/utils/schedule_next_occurrences";
 import type { ScheduleConfig } from "@app/types/assistant/triggers";
 import { isCronScheduleConfig } from "@app/types/assistant/triggers";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -12,13 +13,18 @@ import {
   ContentMessage,
   ContentMessageInline,
   DotIcon,
+  Icon,
+  InformationCircleIcon,
   Label,
   TextArea,
+  Tooltip,
 } from "@dust-tt/sparkle";
 import type React from "react";
 import { useMemo, useState } from "react";
+
 import { useController, useFormContext } from "react-hook-form";
 
+const NEXT_OCCURRENCES_COUNT = 5;
 const MIN_DESCRIPTION_LENGTH = 10;
 
 function formatTimezone(timezone: string): string {
@@ -136,6 +142,23 @@ export function ScheduleEditionScheduler({
     { delayMs: 500 }
   );
 
+  const {
+    field: { value: timezone },
+  } = useController({ control, name: "schedule.timezone" });
+
+  // Resolved schedule config, shared between description and next occurrences.
+  const resolvedConfig = useMemo((): ScheduleConfig | null => {
+    if (generationStatus !== "idle") {
+      return null;
+    }
+    const hasSchedule =
+      scheduleType === "interval" ? !!generatedConfig : !!cron;
+    if (!hasSchedule) {
+      return null;
+    }
+    return generatedConfig ?? { cron, timezone };
+  }, [generationStatus, scheduleType, generatedConfig, cron, timezone]);
+
   const cronDescription = useMemo(() => {
     switch (generationStatus) {
       case "loading":
@@ -143,16 +166,10 @@ export function ScheduleEditionScheduler({
       case "error":
         return cronErrorMessage;
       case "idle": {
-        const hasSchedule =
-          scheduleType === "interval" ? !!generatedConfig : !!cron;
-        if (!hasSchedule) {
+        if (!resolvedConfig) {
           return undefined;
         }
-        const config = generatedConfig ?? {
-          cron,
-          timezone: "",
-        };
-        const desc = describeScheduleConfig(config);
+        const desc = describeScheduleConfig(resolvedConfig);
         if (generatedTimezone) {
           return `${desc}, in ${formatTimezone(generatedTimezone)} timezone.`;
         }
@@ -161,14 +178,14 @@ export function ScheduleEditionScheduler({
       default:
         assertNever(generationStatus);
     }
-  }, [
-    generationStatus,
-    cron,
-    scheduleType,
-    generatedConfig,
-    generatedTimezone,
-    cronErrorMessage,
-  ]);
+  }, [generationStatus, resolvedConfig, generatedTimezone, cronErrorMessage]);
+
+  const nextOccurrences = useMemo(() => {
+    if (!resolvedConfig) {
+      return [];
+    }
+    return getNextOccurrences(resolvedConfig, NEXT_OCCURRENCES_COUNT);
+  }, [resolvedConfig]);
 
   const handleNaturalDescriptionChange = (
     e: React.ChangeEvent<HTMLTextAreaElement>
@@ -209,7 +226,38 @@ export function ScheduleEditionScheduler({
               ) : (
                 <>
                   <ArrowRightIcon className="mt-0.5 h-4 w-4 shrink-0 self-start" />
-                  <p>{cronDescription}</p>
+                  <div className="flex flex-1 items-center justify-between">
+                    <p>{cronDescription}</p>
+                    {nextOccurrences.length > 0 && (
+                      <Tooltip
+                        label={
+                          <div className="flex flex-col gap-0.5 text-xs">
+                            <span className="font-semibold">
+                              Next 5 occurrences
+                            </span>
+                            {nextOccurrences.map((date, index) => (
+                              <span key={index}>
+                                {date.toLocaleDateString("en-US", {
+                                  weekday: "long",
+                                  month: "long",
+                                  day: "numeric",
+                                  hour: "2-digit",
+                                  minute: "2-digit",
+                                })}
+                              </span>
+                            ))}
+                          </div>
+                        }
+                        trigger={
+                          <Icon
+                            visual={InformationCircleIcon}
+                            size="xs"
+                            className="shrink-0 text-faint dark:text-faint-night"
+                          />
+                        }
+                      />
+                    )}
+                  </div>
                 </>
               )}
             </div>

--- a/front/lib/utils/schedule_next_occurrences.ts
+++ b/front/lib/utils/schedule_next_occurrences.ts
@@ -1,0 +1,74 @@
+import type {
+  IntervalScheduleConfig,
+  ScheduleConfig,
+} from "@app/types/assistant/triggers";
+import { isCronScheduleConfig } from "@app/types/assistant/triggers";
+import { CronExpressionParser } from "cron-parser";
+import { DateTime } from "luxon";
+
+const DAYS_PER_WEEK = 7;
+
+export function getNextOccurrences(
+  config: ScheduleConfig,
+  count: number
+): Date[] {
+  if (isCronScheduleConfig(config)) {
+    return getNextCronOccurrences(config.cron, config.timezone, count);
+  }
+  return getNextIntervalOccurrences(config, count);
+}
+
+function getNextCronOccurrences(
+  cron: string,
+  timezone: string,
+  count: number
+): Date[] {
+  try {
+    const expression = CronExpressionParser.parse(cron, { tz: timezone });
+    const dates: Date[] = [];
+    for (let i = 0; i < count; i++) {
+      dates.push(expression.next().toDate());
+    }
+    return dates;
+  } catch {
+    return [];
+  }
+}
+
+function getNextIntervalOccurrences(
+  config: IntervalScheduleConfig,
+  count: number
+): Date[] {
+  const now = DateTime.now().setZone(config.timezone);
+  let candidate = now.set({
+    hour: config.hour,
+    minute: config.minute,
+    second: 0,
+    millisecond: 0,
+  });
+
+  if (config.dayOfWeek !== null) {
+    // Luxon weekdays: 1=Monday..7=Sunday; config uses 0=Sunday..6=Saturday.
+    const luxonWeekday =
+      config.dayOfWeek === 0 ? DAYS_PER_WEEK : config.dayOfWeek;
+    const daysUntil =
+      (luxonWeekday - candidate.weekday + DAYS_PER_WEEK) % DAYS_PER_WEEK;
+    candidate = candidate.plus({ days: daysUntil });
+
+    if (candidate <= now) {
+      candidate = candidate.plus({ days: config.intervalDays });
+    }
+  } else {
+    if (candidate <= now) {
+      candidate = candidate.plus({ days: 1 });
+    }
+  }
+
+  const dates: Date[] = [];
+  for (let i = 0; i < count; i++) {
+    dates.push(candidate.toJSDate());
+    candidate = candidate.plus({ days: config.intervalDays });
+  }
+
+  return dates;
+}

--- a/front/package.json
+++ b/front/package.json
@@ -123,6 +123,7 @@
     "cmdk": "^1.0.0",
     "contentful": "^11.9.0",
     "convertapi": "^1.15.0",
+    "cron-parser": "^5.5.0",
     "cronstrue": "^3.2.0",
     "csv-parse": "^6.1.0",
     "csv-stringify": "^6.4.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -400,6 +400,7 @@
         "cmdk": "^1.0.0",
         "contentful": "^11.9.0",
         "convertapi": "^1.15.0",
+        "cron-parser": "^5.5.0",
         "cronstrue": "^3.2.0",
         "csv-parse": "^6.1.0",
         "csv-stringify": "^6.4.5",
@@ -28010,6 +28011,18 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
+    },
+    "node_modules/cron-parser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.5.0.tgz",
+      "integrity": "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cronstrue": {
       "version": "3.13.0",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

<img width="611" height="330" alt="Capture d’écran 2026-04-03 à 14 42 05" src="https://github.com/user-attachments/assets/aa403c29-2de8-4fe1-af06-1597c8a4f1f3" />

Add a popover to display the next 5 occurence of a schedule, to allow a bit more debugging and more deterministic understanding of the behavior for the users.

Adds a new npm dependency to "cron-parser"

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front