### PR TITLE
[front] - refactor(agent-yaml): change YAML editors from objects to string

### DIFF
--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -8,7 +8,6 @@ import type {
   AgentYAMLAction,
   AgentYAMLConfig,
   AgentYAMLDataSourceConfiguration,
-  AgentYAMLEditor,
   AgentYAMLSkill,
   AgentYAMLSlackIntegration,
   AgentYAMLSpace,
@@ -84,14 +83,10 @@ export class AgentYAMLConverter {
 
   private static convertEditors(
     editors: AgentBuilderFormData["agentSettings"]["editors"]
-  ): AgentYAMLEditor[] {
+  ): string[] {
     return editors
-      .filter((editor) => editor.sId && editor.email)
-      .map((editor) => ({
-        user_id: editor.sId,
-        email: editor.email,
-        full_name: editor.fullName,
-      }));
+      .filter((editor) => editor.email)
+      .map((editor) => editor.email);
   }
 
   private static convertSkills(

--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -56,7 +56,7 @@ export class AgentYAMLConverter {
           response_format: formData.generationSettings.responseFormat,
         },
         tags: this.convertTags(formData.agentSettings.tags),
-        editors: this.convertEditors(formData.agentSettings.editors),
+        editors: this.convertEditorEmails(formData.agentSettings.editors),
         toolset: actionsResult.value,
         spaces,
         skills: skills.length > 0 ? skills : undefined,
@@ -81,7 +81,7 @@ export class AgentYAMLConverter {
       }));
   }
 
-  private static convertEditors(
+  private static convertEditorEmails(
     editors: AgentBuilderFormData["agentSettings"]["editors"]
   ): string[] {
     return editors

--- a/front/lib/agent_yaml_converter/schemas.ts
+++ b/front/lib/agent_yaml_converter/schemas.ts
@@ -26,11 +26,7 @@ export const agentYAMLTagSchema = z.object({
   kind: z.enum(["standard", "protected"]),
 });
 
-export const agentYAMLEditorSchema = z.object({
-  user_id: z.string().min(1, "User ID is required"),
-  email: z.string().email("Invalid email address"),
-  full_name: z.string().min(1, "Full name is required"),
-});
+export const agentYAMLEditorSchema = z.string().email("Invalid email address");
 
 export const agentYAMLTimeFrameSchema = z
   .object({

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -9,6 +9,7 @@ import { getAgentConfigurationAsYAMLConfig } from "@app/lib/api/assistant/config
 import type { Authenticator } from "@app/lib/auth";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { APIErrorWithStatusCode } from "@app/types/error";
@@ -49,8 +50,8 @@ async function importAgentConfiguration(
     });
   }
 
-  const editorIds = yamlConfig.editors.map((e) => e.user_id);
-  if (editorIds.length === 0) {
+  const editorEmails = yamlConfig.editors;
+  if (editorEmails.length === 0) {
     return new Err({
       status_code: 400,
       api_error: {
@@ -60,7 +61,14 @@ async function importAgentConfiguration(
     });
   }
 
-  const editorUsers = await UserResource.fetchByIds(editorIds);
+  const editorUsers = (
+    await concurrentExecutor(
+      editorEmails,
+      (email) => UserResource.fetchByEmail(email),
+      { concurrency: 5 }
+    )
+  ).filter((u) => u !== null);
+
   if (editorUsers.length === 0) {
     return new Err({
       status_code: 400,
@@ -114,8 +122,8 @@ async function importAgentConfiguration(
       name: tag.name,
       kind: tag.kind,
     })),
-    editors: yamlConfig.editors.map((editor) => ({
-      sId: editor.user_id,
+    editors: editorUsers.map((user) => ({
+      sId: user.sId,
     })),
     skills: (yamlConfig.skills ?? []).map((skill) => ({
       sId: skill.sId,

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -9,7 +9,6 @@ import { getAgentConfigurationAsYAMLConfig } from "@app/lib/api/assistant/config
 import type { Authenticator } from "@app/lib/auth";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { APIErrorWithStatusCode } from "@app/types/error";
@@ -61,13 +60,7 @@ async function importAgentConfiguration(
     });
   }
 
-  const editorUsers = (
-    await concurrentExecutor(
-      editorEmails,
-      (email) => UserResource.fetchByEmail(email),
-      { concurrency: 5 }
-    )
-  ).filter((u) => u !== null);
+  const editorUsers = await UserResource.fetchByEmails(editorEmails);
 
   if (editorUsers.length === 0) {
     return new Err({

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -285,6 +285,20 @@ export class UserResource extends BaseResource<UserModel> {
     return sortedUsers[0] ?? null;
   }
 
+  static async fetchByEmails(emails: string[]): Promise<UserResource[]> {
+    if (emails.length === 0) {
+      return [];
+    }
+
+    const users = await UserModel.findAll({
+      where: {
+        email: emails.map((e) => e.toLowerCase()),
+      },
+    });
+
+    return users.map((user) => new UserResource(UserModel, user.get()));
+  }
+
   static async getWorkspaceFirstAdmin(
     workspaceId: number
   ): Promise<UserResource | null> {


### PR DESCRIPTION
## Description

Simplifies the agent YAML editors representation by changing them from objects (`{user_id, email, full_name}`) to plain email strings. Updates the schema, converter logic, and import flow to use emails directly. During import, users are now fetched by email with concurrent execution (concurrency: 5) instead of by user IDs.

## Tests

Manually tested YAML import flow.

## Risk

Low

## Deploy Plan

Deploy front