### PR TITLE
[front] feat: wire `tool_ask_user_question` event through streaming pipeline

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -348,6 +348,7 @@ export function AgentMessage({
           case "tool_notification":
           case "tool_params":
           case "agent_context_pruned":
+          case "tool_ask_user_question":
             // Do nothing
             break;
           default:

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -238,6 +238,7 @@ export function useAgentMessageStream({
           // end of the stream to the client. So we just return.
           return;
 
+        case "tool_ask_user_question":
         case "tool_personal_auth_required":
         case "tool_file_auth_required":
         case "tool_approve_execution":

--- a/front/hooks/useChildAgentStream.ts
+++ b/front/hooks/useChildAgentStream.ts
@@ -75,6 +75,7 @@ function childAgentStreamReducer(
     case "tool_approve_execution":
     case "tool_personal_auth_required":
     case "tool_file_auth_required":
+    case "tool_ask_user_question":
       return state;
 
     default:

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -5,6 +5,7 @@ import type {
 import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   MCPApproveExecutionEvent,
+  ToolAskUserQuestionEvent,
   ToolExecution,
   ToolFileAuthRequiredEvent,
   ToolPersonalAuthRequiredEvent,
@@ -283,10 +284,22 @@ function isToolFileAuthRequiredEvent(
   );
 }
 
+export function isToolAskUserQuestionEvent(
+  event: unknown
+): event is ToolAskUserQuestionEvent {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "type" in event &&
+    event.type === "tool_ask_user_question"
+  );
+}
+
 export function isBlockedActionEvent(
   event: unknown
 ): event is
   | MCPApproveExecutionEvent
+  | ToolAskUserQuestionEvent
   | ToolPersonalAuthRequiredEvent
   | ToolFileAuthRequiredEvent {
   return (
@@ -296,6 +309,7 @@ export function isBlockedActionEvent(
     (isMCPApproveExecutionEvent(event) ||
       isToolPersonalAuthRequiredEvent(event) ||
       isToolFileAuthRequiredEvent(event) ||
+      isToolAskUserQuestionEvent(event) ||
       isLegacyToolPersonalAuthRequiredEvent(event))
   );
 }

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -1,4 +1,5 @@
 import type {
+  ToolAskUserQuestionEvent,
   ToolEarlyExitEvent,
   ToolFileAuthRequiredEvent,
   ToolPersonalAuthRequiredEvent,
@@ -37,6 +38,7 @@ export async function getExitOrPauseEvents(
 ): Promise<
   (
     | MCPApproveExecutionEvent
+    | ToolAskUserQuestionEvent
     | ToolPersonalAuthRequiredEvent
     | ToolFileAuthRequiredEvent
     | ToolEarlyExitEvent
@@ -174,9 +176,24 @@ export async function getExitOrPauseEvents(
           resumeState: { type: "user_question", question },
         });
 
-        // TODO(ask-user-question): Emit a ToolAskUserQuestionEvent here once
-        // the event streaming pipeline supports it.
-        return [];
+        return [
+          {
+            type: "tool_ask_user_question",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            userId: auth.user()?.sId,
+            messageId: agentMessage.sId,
+            conversationId: conversation.sId,
+            actionId: action.sId,
+            metadata: {
+              toolName: action.toolConfiguration.originalName,
+              mcpServerName: action.toolConfiguration.mcpServerName,
+              agentName: agentConfiguration.name,
+            },
+            inputs: action.augmentedInputs,
+            question,
+          },
+        ];
       }
       default: {
         assertNever(exitOutputItem);

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -121,6 +121,7 @@ function isMessageEventParams(
     case "tool_notification":
     case "tool_params":
     case "tool_personal_auth_required":
+    case "tool_ask_user_question":
       return true;
     case "butler_done":
     case "butler_suggestion_created":

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -1,5 +1,6 @@
 import type { AgentActionRunningEvents } from "@app/lib/actions/mcp";
 import type {
+  ToolAskUserQuestionEvent,
   ToolFileAuthRequiredEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
@@ -33,6 +34,7 @@ export type AgentMessageEvents =
   | AgentMessageSuccessEvent
   | GenerationTokensEvent
   | ToolErrorEvent
+  | ToolAskUserQuestionEvent
   | ToolFileAuthRequiredEvent
   | ToolPersonalAuthRequiredEvent;
 

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/lib/actions/mcp_execution";
 import type {
   MCPApproveExecutionEvent,
+  ToolAskUserQuestionEvent,
   ToolEarlyExitEvent,
   ToolFileAuthRequiredEvent,
   ToolPersonalAuthRequiredEvent,
@@ -60,7 +61,8 @@ export async function* runToolWithStreaming(
   | ToolNotificationEvent
   | ToolFileAuthRequiredEvent
   | ToolPersonalAuthRequiredEvent
-  | ToolEarlyExitEvent,
+  | ToolEarlyExitEvent
+  | ToolAskUserQuestionEvent,
   void
 > {
   const owner = auth.getNonNullableWorkspace();

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -118,6 +118,17 @@ export async function publishDeferredEventsActivity(
         };
         break;
 
+      case "tool_ask_user_question":
+        eventToPublish = {
+          ...event,
+          metadata: {
+            ...event.metadata,
+            // Override the message id to root the event to the right channel.
+            pubsubMessageId: deferredEvent.context.agentMessageId,
+          },
+        };
+        break;
+
       default:
         assertNever(event);
     }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -288,6 +288,7 @@ async function executeToolStreaming(
       case "tool_personal_auth_required":
       case "tool_file_auth_required":
       case "tool_approve_execution":
+      case "tool_ask_user_question":
         updateActiveObservation(
           {
             output: { status: event.type },

--- a/front/temporal/agent_loop/lib/deferred_events.ts
+++ b/front/temporal/agent_loop/lib/deferred_events.ts
@@ -1,5 +1,6 @@
 import type {
   MCPApproveExecutionEvent,
+  ToolAskUserQuestionEvent,
   ToolFileAuthRequiredEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
@@ -12,6 +13,7 @@ import type { ModelId } from "@app/types/shared/model_id";
  */
 type DeferrableEvent =
   | MCPApproveExecutionEvent
+  | ToolAskUserQuestionEvent
   | ToolFileAuthRequiredEvent
   | ToolPersonalAuthRequiredEvent;
 


### PR DESCRIPTION
## Description

- Wire `ToolAskUserQuestionEvent` through the event streaming pipeline so blocked ask-user-question actions emit events to the frontend
- Emit the event in `exit_events` with actual event emission.
- Add no-op handlers in client-side event consumers (UI handling in a follow-up).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
