### PR TITLE
feat(project-todo): add per-project merge workflow with hourly throttle

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -943,6 +943,7 @@ export async function postUserMessage(
   if (isPartOfProject) {
     const projectTodoAndConversationButlerParams = {
       authType: auth.toJSON(),
+      spaceId: conversation.spaceId,
       conversationId: conversation.sId,
       messageId: userMessage.sId,
     };
@@ -1287,6 +1288,7 @@ export async function editUserMessage(
   if (isProjectConversation(conversation)) {
     const projectTodoAndConversationButlerParams = {
       authType: auth.toJSON(),
+      spaceId: conversation.spaceId,
       conversationId: conversation.sId,
       messageId: userMessage.sId,
     };
@@ -1795,6 +1797,7 @@ export async function retryAgentMessage(
   if (isProjectConversation(conversation)) {
     const projectTodoAndConversationButlerParams = {
       authType: auth.toJSON(),
+      spaceId: conversation.spaceId,
       conversationId: conversation.sId,
       messageId: agentMessage.sId,
     };
@@ -1962,6 +1965,7 @@ export async function postNewContentFragment(
   if (isProjectConversation(conversation)) {
     const projectTodoAndConversationButlerParams = {
       authType: auth.toJSON(),
+      spaceId: conversation.spaceId,
       conversationId: conversation.sId,
       messageId,
     };

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -1,0 +1,38 @@
+// TODO: implement "merge".
+//
+// This module will merge the latest conversation_todo_versioned snapshots for all
+// conversations in a project into project_todo rows. It is called by
+// mergeTodosForProjectActivity, which itself is invoked by the per-project
+// projectMergeWorkflow at most once per MERGE_THROTTLE_MS (1 hour by default).
+//
+// High-level algorithm (to be implemented):
+//
+//   1. Fetch all ConversationTodoVersioned snapshots (latest per conversation) for
+//      conversations that belong to the given spaceId.
+//   2. For each item (actionItem / keyDecision / notableFact):
+//        - Resolve target users (assigneeUserId, relevantUserIds, or conversation participants).
+//        - For each target user, look up existing agent-created ProjectTodo via
+//          ProjectTodoResource.fetchByConversationSource(auth, {
+//            sourceConversationModelId, conversationTodoItemSId, userId
+//          }).
+//        - not found  → ProjectTodoResource.makeNew() + addSource({ conversationTodoItemSId })
+//        - found, changed  → existing.createVersion()
+//        - found, unchanged → skip
+//   3. For each agent-created ProjectTodo whose conversationTodoItemSId is absent from
+//      the latest snapshot → createVersion({ status: "done", markedAsDoneByType: "agent" }).
+//
+// Category mapping:
+//   actionItems  (open)    → "follow_ups",      status: "todo"
+//   actionItems  (done)    → "follow_ups",      status: "done"
+//   keyDecisions (open)    → "key_decisions",   status: "todo"
+//   keyDecisions (decided) → "key_decisions",   status: "done"
+//   notableFacts           → "notable_updates", status: "todo"
+
+import type { Authenticator } from "@app/lib/auth";
+
+export async function mergeConversationTodosIntoProject(
+  _auth: Authenticator,
+  { spaceId }: { spaceId: string }
+): Promise<void> {
+  void spaceId;
+}

--- a/front/temporal/project_todo/activities.ts
+++ b/front/temporal/project_todo/activities.ts
@@ -1,7 +1,9 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
 import { analyzeConversationTodos } from "@app/lib/project_todo/analyze_conversation";
+import { mergeConversationTodosIntoProject } from "@app/lib/project_todo/merge_into_project";
 import logger from "@app/logger/logger";
+import { signalOrStartProjectMergeWorkflow } from "@app/temporal/project_todo/client";
 import { Context } from "@temporalio/activity";
 
 export async function analyzeProjectTodosActivity({
@@ -41,4 +43,44 @@ export async function analyzeProjectTodosActivity({
 
   const { runId } = Context.current().info.workflowExecution;
   await analyzeConversationTodos(auth, { conversation, messageId, runId });
+}
+
+// Called by projectTodoWorkflow after a successful analysis run. Uses signalWithStart
+// so the merge workflow is automatically created if not already running.
+export async function signalOrStartMergeWorkflowActivity({
+  authType,
+  spaceId,
+}: {
+  authType: AuthenticatorType;
+  spaceId: string;
+}): Promise<void> {
+  await signalOrStartProjectMergeWorkflow({ authType, spaceId });
+}
+
+// Called by projectMergeWorkflow. Merges the latest conversation_todo_versioned snapshots
+// for all conversations in the project into project_todo rows.
+export async function mergeTodosForProjectActivity({
+  authType,
+  spaceId,
+}: {
+  authType: AuthenticatorType;
+  spaceId: string;
+}): Promise<void> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    logger.error(
+      { spaceId, error: authResult.error },
+      "Project todo merge: failed to deserialize authenticator"
+    );
+    return;
+  }
+
+  const auth = authResult.value;
+
+  logger.info(
+    { spaceId, workspaceId: auth.getNonNullableWorkspace().sId },
+    "Project todo merge: activity invoked (not yet implemented)"
+  );
+
+  await mergeConversationTodosIntoProject(auth, { spaceId });
 }

--- a/front/temporal/project_todo/client.ts
+++ b/front/temporal/project_todo/client.ts
@@ -3,10 +3,14 @@ import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/project_todo/config";
 import {
+  mergeRequestSignal,
   todoCompleteSignal,
   todoRefreshSignal,
 } from "@app/temporal/project_todo/signals";
-import { projectTodoWorkflow } from "@app/temporal/project_todo/workflows";
+import {
+  projectMergeWorkflow,
+  projectTodoWorkflow,
+} from "@app/temporal/project_todo/workflows";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 function makeProjectTodoWorkflowId(
@@ -16,12 +20,21 @@ function makeProjectTodoWorkflowId(
   return `conversation-todo-${workspaceId}-${conversationId}`;
 }
 
+function makeProjectMergeWorkflowId(
+  workspaceId: string,
+  spaceId: string
+): string {
+  return `project-merge-todo-${workspaceId}-${spaceId}`;
+}
+
 export async function launchOrSignalProjectTodoWorkflow({
   authType,
+  spaceId,
   conversationId,
   messageId,
 }: {
   authType: AuthenticatorType;
+  spaceId: string;
   conversationId: string;
   messageId: string;
 }): Promise<void> {
@@ -33,7 +46,7 @@ export async function launchOrSignalProjectTodoWorkflow({
 
   try {
     await client.workflow.signalWithStart(projectTodoWorkflow, {
-      args: [{ authType, conversationId, messageId }],
+      args: [{ authType, conversationId, messageId, spaceId }],
       taskQueue: QUEUE_NAME,
       workflowId,
       signal: todoRefreshSignal,
@@ -43,6 +56,7 @@ export async function launchOrSignalProjectTodoWorkflow({
         workspaceId: authType.workspaceId,
         conversationId,
         messageId,
+        spaceId,
       },
     });
   } catch (e) {
@@ -53,6 +67,7 @@ export async function launchOrSignalProjectTodoWorkflow({
         workspaceId: authType.workspaceId,
         conversationId,
         messageId,
+        spaceId,
         error: normalizeError(e),
       },
       "Failed starting conversation todo workflow"
@@ -86,6 +101,46 @@ export async function signalProjectTodoComplete({
         error: normalizeError(e),
       },
       "Failed signaling conversation todo complete (workflow may have already finished)"
+    );
+  }
+}
+
+// Called from signalOrStartMergeWorkflowActivity to fan-in signals from per-conversation
+// workflows into the single per-project merge workflow. Uses signalWithStart so the merge
+// workflow is automatically created if not already running.
+export async function signalOrStartProjectMergeWorkflow({
+  authType,
+  spaceId,
+}: {
+  authType: AuthenticatorType;
+  spaceId: string;
+}): Promise<void> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = makeProjectMergeWorkflowId(authType.workspaceId, spaceId);
+
+  try {
+    await client.workflow.signalWithStart(projectMergeWorkflow, {
+      args: [{ authType, spaceId }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      signal: mergeRequestSignal,
+      signalArgs: [],
+      workflowExecutionTimeout: "7 days",
+      memo: {
+        workspaceId: authType.workspaceId,
+        spaceId,
+      },
+    });
+  } catch (e) {
+    // Swallow errors — merge workflow failures must not block the analysis workflow.
+    logger.error(
+      {
+        workflowId,
+        workspaceId: authType.workspaceId,
+        spaceId,
+        error: normalizeError(e),
+      },
+      "Failed signaling project merge workflow"
     );
   }
 }

--- a/front/temporal/project_todo/config.ts
+++ b/front/temporal/project_todo/config.ts
@@ -1,7 +1,12 @@
 const QUEUE_VERSION = 1;
 
+// TODO: rename this queue
 export const QUEUE_NAME = `conversation-todo-queue-v${QUEUE_VERSION}`;
 
 // Much longer than the butler debounce (3 s) — we want to wait for a quiet
 // window in the conversation before running the heavier todo analysis.
 export const TODO_DEBOUNCE_DELAY_MS = 5 * 60 * 1_000;
+
+// The merge workflow (projectMergeWorkflow) calls an LLM to update project todos.
+// This throttle prevents more than one LLM merge per project per hour.
+export const MERGE_THROTTLE_MS = 60 * 60 * 1_000; // 1 hour

--- a/front/temporal/project_todo/signals.ts
+++ b/front/temporal/project_todo/signals.ts
@@ -6,3 +6,9 @@ export const todoRefreshSignal = defineSignal<[string]>(
 export const todoCompleteSignal = defineSignal<[string]>(
   "project_todo_complete_signal"
 );
+
+// Sent by projectTodoWorkflow to projectMergeWorkflow after a successful analysis run.
+// Carries no payload — the merge workflow only needs to know "there is work to do".
+export const mergeRequestSignal = defineSignal<[]>(
+  "project_todo_merge_request_signal"
+);

--- a/front/temporal/project_todo/workflows.ts
+++ b/front/temporal/project_todo/workflows.ts
@@ -1,7 +1,11 @@
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/project_todo/activities";
-import { TODO_DEBOUNCE_DELAY_MS } from "@app/temporal/project_todo/config";
 import {
+  MERGE_THROTTLE_MS,
+  TODO_DEBOUNCE_DELAY_MS,
+} from "@app/temporal/project_todo/config";
+import {
+  mergeRequestSignal,
   todoCompleteSignal,
   todoRefreshSignal,
 } from "@app/temporal/project_todo/signals";
@@ -12,18 +16,27 @@ import {
   sleep,
 } from "@temporalio/workflow";
 
-const { analyzeProjectTodosActivity } = proxyActivities<typeof activities>({
+const {
+  analyzeProjectTodosActivity,
+  signalOrStartMergeWorkflowActivity,
+  mergeTodosForProjectActivity,
+} = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
 });
 
+// Per-conversation workflow. Debounces analysis and signals the per-project merge
+// workflow after each successful run. spaceId identifies the project the conversation
+// belongs to and is forwarded to the merge workflow.
 export async function projectTodoWorkflow({
   authType,
   conversationId,
   messageId,
+  spaceId,
 }: {
   authType: AuthenticatorType;
   conversationId: string;
   messageId: string;
+  spaceId: string;
 }): Promise<void> {
   let needsAnalysis = true;
   let complete = false;
@@ -56,15 +69,50 @@ export async function projectTodoWorkflow({
         conversationId,
         messageId: msgId,
       });
+      // Signal the per-project merge workflow that fresh analysis data is available.
+      // Uses signalWithStart so the merge workflow is started if not already running.
+      await signalOrStartMergeWorkflowActivity({ authType, spaceId });
     }
   }
 
-  // Final analysis after completion signal.
+  // Final analysis + merge signal after completion.
   if (latestMessageId) {
     await analyzeProjectTodosActivity({
       authType,
       conversationId,
       messageId: latestMessageId,
     });
+    await signalOrStartMergeWorkflowActivity({ authType, spaceId });
+  }
+}
+
+// One long-running workflow per (workspace, project/space). Receives merge-request signals
+// from per-conversation projectTodoWorkflows and runs the LLM merge at most once per
+// MERGE_THROTTLE_MS, batching all dirty conversations into a single call.
+export async function projectMergeWorkflow({
+  authType,
+  spaceId,
+}: {
+  authType: AuthenticatorType;
+  spaceId: string;
+}): Promise<void> {
+  let hasPendingWork = false;
+  let isCoolingDown = false;
+
+  setHandler(mergeRequestSignal, () => {
+    hasPendingWork = true;
+  });
+
+  // Process merge requests, throttled to at most once per MERGE_THROTTLE_MS.
+  // Signals that arrive during the cool-down are coalesced into the next run.
+  while (true) {
+    await condition(() => hasPendingWork && !isCoolingDown);
+    hasPendingWork = false;
+    isCoolingDown = true;
+
+    await mergeTodosForProjectActivity({ authType, spaceId });
+
+    await sleep(MERGE_THROTTLE_MS);
+    isCoolingDown = false;
   }
 }


### PR DESCRIPTION
## Description

Adds the skeleton of the temporal workflow to "merge" the conversation todos to project level.

It runs per space, each hour (if there are changes). 

For now this does nothing

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
