### PR TITLE
fix: improve error message for failed text extraction on large Office files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,9 +48,12 @@ services:
       - 6379:6379
     command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lfu
   apache-tika:
-    image: apache/tika:2.9.2.1-full
+    image: apache/tika:3.2.3.0-full
     ports:
       - "9998:9998"
+    volumes:
+      - ./tika-config.xml:/tika-config.xml:ro
+    command: ["-c", "/tika-config.xml"]
   elasticsearch:
     build:
       context: .

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -705,17 +705,19 @@ export async function processAndStoreFile(
 
   if (processingRes.isErr()) {
     await file.markAsFailed();
-    // Unfortunately, there is no better way to catch this image format error.
-    const code = processingRes.error.message.includes(
-      "Input buffer contains unsupported image format"
-    )
-      ? "file_type_not_supported"
-      : "internal_server_error";
+    // Unfortunately, there is no better way to catch these errors.
+    const message = processingRes.error.message;
+    let code: ProcessAndStoreFileError["code"] = "internal_server_error";
+    if (message.includes("Input buffer contains unsupported image format")) {
+      code = "file_type_not_supported";
+    } else if (message.includes("could not be processed")) {
+      code = "file_too_large";
+    }
 
     return new Err({
       name: "dust_error",
       code,
-      message: `Failed to process the file : ${processingRes.error}`,
+      message: `Failed to process the file: ${message}`,
     });
   }
 

--- a/front/types/shared/text_extraction/index.ts
+++ b/front/types/shared/text_extraction/index.ts
@@ -110,6 +110,11 @@ export class TextExtraction {
     } as RequestInitWithDuplex);
 
     if (!response.ok) {
+      if (response.status === 422) {
+        throw new Error(
+          "Text extraction failed: the file could not be processed. It may contain elements that are too large or complex to extract text from (e.g. large embedded media)."
+        );
+      }
       throw new Error(
         `Text extraction failed with status ${response.status} ${response.statusText}`
       );

--- a/tika-config.xml
+++ b/tika-config.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<properties>
+  <server>
+    <!-- If set to 'true', this runs tika server "in process"
+    in the legacy 1.x mode.
+    This means that the server will be susceptible to infinite loops
+    and crashes.
+    If set to 'false', the server will spawn a forked
+    process and restart the forked process on catastrophic failures
+    (this was called -spawnChild mode in 1.x).
+    noFork=false is the default in 2.x
+    -->
+    <noFork>true</noFork>
+  </server>
+  <parsers>
+    <parser class="org.apache.tika.parser.DefaultParser">
+      <parser-exclude class="org.apache.tika.parser.microsoft.ooxml.OOXMLParser"/>
+      <parser-exclude class="org.apache.tika.parser.microsoft.OfficeParser"/>
+    </parser>
+    <!-- Raise POI's byte array limit from 100MB to 250MB to handle large
+         Office documents with big embedded media (e.g. 14MB PPTX).
+         This is a temporary per-parse allocation, not persistent memory. -->
+    <parser class="org.apache.tika.parser.microsoft.ooxml.OOXMLParser">
+      <params>
+        <param name="byteArrayMaxOverride" type="int">250000000</param>
+      </params>
+    </parser>
+    <parser class="org.apache.tika.parser.microsoft.OfficeParser">
+      <params>
+        <param name="byteArrayMaxOverride" type="int">250000000</param>
+      </params>
+    </parser>
+  </parsers>
+</properties>

--- a/x/henry/dust-hive/docker-compose.yml
+++ b/x/henry/dust-hive/docker-compose.yml
@@ -59,7 +59,10 @@ services:
       retries: 10
 
   apache-tika:
-    image: apache/tika:2.9.2.1-full
+    image: apache/tika:3.2.3.0-full
+    volumes:
+      - ./tika-config.xml:/tika-config.xml:ro
+    command: ["-c", "/tika-config.xml"]
     healthcheck:
       test: [ "CMD-SHELL", "wget -q --spider http://localhost:9998/tika || exit 1" ]
       interval: 5s

--- a/x/henry/dust-hive/tika-config.xml
+++ b/x/henry/dust-hive/tika-config.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<properties>
+  <server>
+    <!-- If set to 'true', this runs tika server "in process"
+    in the legacy 1.x mode.
+    This means that the server will be susceptible to infinite loops
+    and crashes.
+    If set to 'false', the server will spawn a forked
+    process and restart the forked process on catastrophic failures
+    (this was called -spawnChild mode in 1.x).
+    noFork=false is the default in 2.x
+    -->
+    <noFork>true</noFork>
+  </server>
+  <parsers>
+    <parser class="org.apache.tika.parser.DefaultParser">
+      <parser-exclude class="org.apache.tika.parser.microsoft.ooxml.OOXMLParser"/>
+      <parser-exclude class="org.apache.tika.parser.microsoft.OfficeParser"/>
+    </parser>
+    <!-- Raise POI's byte array limit from 100MB to 250MB to handle large
+         Office documents with big embedded media (e.g. 14MB PPTX).
+         This is a temporary per-parse allocation, not persistent memory. -->
+    <parser class="org.apache.tika.parser.microsoft.ooxml.OOXMLParser">
+      <params>
+        <param name="byteArrayMaxOverride" type="int">250000000</param>
+      </params>
+    </parser>
+    <parser class="org.apache.tika.parser.microsoft.OfficeParser">
+      <params>
+        <param name="byteArrayMaxOverride" type="int">250000000</param>
+      </params>
+    </parser>
+  </parsers>
+</properties>


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7280

When Tika returns a 422 (e.g. a PPTX with embedded media exceeding POI's byte array limit), users previously saw a generic 500 "internal_server_error". This PR:

- Returns a clear error message explaining the file could not be processed (too large/complex embedded content)
- Uses `file_too_large` error code (400) instead of `internal_server_error` (500)
- Upgrades local dev Tika from 2.9.2.1 to 3.2.3.0 (matching production)
- Adds `tika-config.xml` with `byteArrayMaxOverride=250MB` for local dev (matching production config in dust-tt/dust-infra#708)

## Tests

Tested manually by uploading the 14MB PPTX from the issue. Verified:
- Tika 3.2.3.0 with config returns 200 (text extracted successfully)
- Without config, the 422 now surfaces as a 400 with a clear message instead of 500

## Risk

Low — error handling change only affects the message and HTTP status code for already-failing requests. Local docker-compose changes don't affect production.

## Deploy Plan

1. Deploy dust-tt/dust-infra#708 first (Tika config fix — makes extraction succeed)
2. Deploy this PR (better error handling as fallback + local dev alignment)