### PR TITLE
 Improve inline activity steps

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContent.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContent.tsx
@@ -1,10 +1,12 @@
 import { AgentActionsPanel } from "@app/components/assistant/conversation/actions/AgentActionsPanel";
+import { ThinkingPanel } from "@app/components/assistant/conversation/actions/ThinkingPanel";
 import { ConversationFilesPanel } from "@app/components/assistant/conversation/files_panel/ConversationFilesPanel";
 import { InteractiveContentContainer } from "@app/components/assistant/conversation/interactive_content/InteractiveContentContainer";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import {
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
+  AGENT_THINKING_SIDE_PANEL_TYPE,
   FILES_SIDE_PANEL_TYPE,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
 } from "@app/types/conversation_side_panel";
@@ -37,6 +39,9 @@ export default function ConversationSidePanelContent({
       return (
         <ConversationFilesPanel conversation={conversation} owner={owner} />
       );
+
+    case AGENT_THINKING_SIDE_PANEL_TYPE:
+      return <ThinkingPanel />;
 
     default:
       return null;

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -3,6 +3,7 @@ import { useHashParam } from "@app/hooks/useHashParams";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import {
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
+  AGENT_THINKING_SIDE_PANEL_TYPE,
   FILES_SIDE_PANEL_TYPE,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
   SIDE_PANEL_HASH_PARAM,
@@ -25,12 +26,20 @@ type OpenPanelParams =
     }
   | {
       type: "files";
+    }
+  | {
+      type: "thinking";
+      stepId: string;
+      content: string;
     };
 
 const isSupportedPanelType = (
   type: string | undefined
 ): type is ConversationSidePanelType =>
-  type === "actions" || type === "interactive_content" || type === "files";
+  type === "actions" ||
+  type === "interactive_content" ||
+  type === "files" ||
+  type === "thinking";
 
 interface ConversationSidePanelContextType {
   currentPanel: ConversationSidePanelType;
@@ -42,6 +51,7 @@ interface ConversationSidePanelContextType {
   setVirtuosoMsg: (msg: MessageTemporaryState) => void;
   virtuosoMsg: MessageTemporaryState | null;
   data: string | undefined;
+  thinkingContent: string | null;
 }
 
 const ConversationSidePanelContext = React.createContext<
@@ -88,6 +98,9 @@ export function ConversationSidePanelProvider({
   const panelRef = React.useRef<ImperativePanelHandle | null>(null);
   const [virtuosoMsg, setVirtuosoMsg] =
     React.useState<MessageTemporaryState | null>(null);
+  const [thinkingContent, setThinkingContent] = React.useState<string | null>(
+    null
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const setPanelRef = useCallback(
@@ -153,6 +166,15 @@ export function ConversationSidePanelProvider({
           setData("files");
           break;
 
+        case AGENT_THINKING_SIDE_PANEL_TYPE:
+          if (params.stepId === data) {
+            closePanel();
+            return;
+          }
+          setThinkingContent(params.content);
+          setData(params.stepId);
+          break;
+
         default:
           assertNever(params);
       }
@@ -182,6 +204,7 @@ export function ConversationSidePanelProvider({
       setVirtuosoMsg,
       virtuosoMsg,
       data,
+      thinkingContent,
     }),
     [
       currentPanel,
@@ -191,6 +214,7 @@ export function ConversationSidePanelProvider({
       setPanelRef,
       virtuosoMsg,
       data,
+      thinkingContent,
     ]
   );
 

--- a/front/components/assistant/conversation/actions/ThinkingPanel.tsx
+++ b/front/components/assistant/conversation/actions/ThinkingPanel.tsx
@@ -1,0 +1,33 @@
+import { AgentActionsPanelHeader } from "@app/components/assistant/conversation/actions/AgentActionsPanelHeader";
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { ContentMessage, Markdown, XMarkIcon } from "@dust-tt/sparkle";
+
+export function ThinkingPanel() {
+  const { onPanelClosed, thinkingContent: content } =
+    useConversationSidePanelContext();
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <div className="flex h-full flex-col bg-background dark:bg-background-night">
+      <AgentActionsPanelHeader
+        title="Thinking"
+        closeIcon={XMarkIcon}
+        onClose={onPanelClosed}
+      />
+      <div className="flex-1 overflow-y-auto p-4 pb-12">
+        <ContentMessage variant="primary" size="lg">
+          <Markdown
+            content={content}
+            isStreaming={false}
+            forcedTextSize="text-sm"
+            textColor="text-muted-foreground dark:text-muted-foreground-night"
+            isLastMessage={false}
+          />
+        </ContentMessage>
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -14,15 +14,15 @@ import { isLightAgentMessageWithActionsType } from "@app/types/assistant/convers
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import {
   AnimatedText,
+  ChatBubbleThoughtIcon,
   CheckIcon,
   ChevronRightIcon,
   cn,
   Icon,
   Markdown,
   ToolsIcon,
-  TruncatedContent,
 } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 interface InlineActivityStepsProps {
   agentMessage: LightAgentMessageType | LightAgentMessageWithActionsType;
@@ -78,13 +78,7 @@ export function InlineActivitySteps({
   const isDone =
     lastAgentStateClassification === "done" || agentMessage.status === "failed";
 
-  const [isCollapsed, setIsCollapsed] = useState(isDone);
-
-  useEffect(() => {
-    if (isDone) {
-      setIsCollapsed(true);
-    }
-  }, [isDone]);
+  const [isCollapsed, setIsCollapsed] = useState(false);
 
   const openBreakdownPanel = (actionId?: string) => {
     if (onOpenDetails) {
@@ -167,23 +161,44 @@ export function InlineActivitySteps({
 
               switch (step.type) {
                 case "thinking":
+                  if (isDone) {
+                    return (
+                      <div
+                        key={step.id}
+                        className="cursor-pointer"
+                        onClick={() =>
+                          openPanel({
+                            type: "thinking",
+                            stepId: step.id,
+                            content: step.content,
+                          })
+                        }
+                      >
+                        <TimelineRow
+                          icon={ChatBubbleThoughtIcon}
+                          isLast={isLast}
+                        >
+                          <span className="text-muted-foreground dark:text-muted-foreground-night flex items-center gap-1">
+                            Thinking
+                            <Icon
+                              size="xs"
+                              visual={ChevronRightIcon}
+                              className="shrink-0 opacity-50"
+                            />
+                          </span>
+                        </TimelineRow>
+                      </div>
+                    );
+                  }
                   return (
                     <TimelineRow key={step.id} icon="circle" isLast={isLast}>
-                      <TruncatedContent
-                        thresholdPx={80}
-                        collapsedHeightPx={60}
-                        variant="light"
-                        buttonClassName="mt-1"
-                        animated
-                      >
-                        <Markdown
-                          content={step.content}
-                          isStreaming={false}
-                          forcedTextSize="text-sm"
-                          textColor="text-muted-foreground dark:text-muted-foreground-night"
-                          isLastMessage={false}
-                        />
-                      </TruncatedContent>
+                      <Markdown
+                        content={step.content}
+                        isStreaming={false}
+                        forcedTextSize="text-sm"
+                        textColor="text-muted-foreground dark:text-muted-foreground-night"
+                        isLastMessage={false}
+                      />
                     </TimelineRow>
                   );
                 case "action": {

--- a/front/types/conversation_side_panel.ts
+++ b/front/types/conversation_side_panel.ts
@@ -5,12 +5,14 @@ export const FULL_SCREEN_HASH_PARAM = "fullScreen";
 export const AGENT_ACTIONS_SIDE_PANEL_TYPE = "actions";
 export const INTERACTIVE_CONTENT_SIDE_PANEL_TYPE = "interactive_content";
 export const FILES_SIDE_PANEL_TYPE = "files";
+export const AGENT_THINKING_SIDE_PANEL_TYPE = "thinking";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SIDE_PANEL_TYPES = [
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
   FILES_SIDE_PANEL_TYPE,
+  AGENT_THINKING_SIDE_PANEL_TYPE,
 ] as const;
 
 export type ConversationSidePanelType =


### PR DESCRIPTION
## Description

This changes how thinking steps and actions appear on the inline activity timeline.
Completed thinking steps no longer render their full markdown content inline with a truncated view. Instead they show a compact "Thinking" label, consistent with how tool actions are displayed. Clicking it opens a new dedicated thinking side panel that shows the full reasoning content. While the agent is still streaming, thinking steps continue to render their markdown inline as before.

Active actions (tools currently running) are now clickable, matching the behavior of completed actions. Previously only completed actions could be clicked to open the breakdown panel.

The inline activity toggle is now always open by default instead of auto-collapsing when the agent finishes.
I could have completely removed the toggle, but I figured out it was ok to keep if the user wants to hide? 


Screenshot using deep dive so there's tons of steps: 

<kbd>
<img width="1013" height="1388" alt="Screenshot 2026-04-03 at 15 22 26" src="https://github.com/user-attachments/assets/c9b45427-e966-4eff-951d-278a1aa0c203" />
</kbd>

## Tests


Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
