### PR TITLE
PREVIOUS_INTERACTIONS_TO_PRESERVE to 3

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -29,8 +29,11 @@ import {
   prunePreviousInteractions,
 } from "./pruning";
 
-// When previous interactions pruning is enabled, we'll attempt to fully preserve this number of interactions.
-export const PREVIOUS_INTERACTIONS_TO_PRESERVE = 1;
+// When previous interactions pruning is enabled, we'll attempt to fully preserve this number of
+// interactions. This value was originally at 1 and bumped at 3 with the introduction of
+// gracefully_stopped agent message and user message steering to don't prune tool outputs too
+// agressively.
+export const PREVIOUS_INTERACTIONS_TO_PRESERVE = 3;
 
 // Fixed number of tokens assumed for image contents
 const IMAGE_CONTENT_TOKEN_COUNT = 3100;

--- a/x/spolu/steering/plan.md
+++ b/x/spolu/steering/plan.md
@@ -55,13 +55,15 @@ Implement the graceful stop mechanism end-to-end.
 - When `action === "gracefully_stop"`, call `gracefullyStopAgentLoop()`.
 - Public v1 API endpoint unchanged (no breaking change).
 
-### - [ ] PR 2.6 — Context pruning: preserve gracefully stopped chains as single interaction
+### - [x] PR 2.6 — Context pruning: preserve gracefully stopped chains as single interaction
 
 - Update `groupMessagesIntoInteractions` in
   `front/lib/api/assistant/conversation/interactions.ts`:
   - Don't close interaction at agent→user boundary when the agent turn ended with
     `status === "gracefully_stopped"`.
 - Add/update tests in `interactions.test.ts`.
+
+==> We went with simply increasing PREVIOUS_INTERACTIONS_TO_PRESERVE to 3 for now
 
 ### - [ ] PR 2.7 — Add `GracefulStopRequestedEvent` (when needed for UI)
 


### PR DESCRIPTION
## Description

Bumps `PREVIOUS_INTERACTIONS_TO_PRESERVE` from `1` to `3` to ensure we don't prune tool outputs too agressively in the context of user steering and gracefully stopped agent messages.

Full context: https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775219292657619

## Tests

N/A

## Risk

OOM of front-workers. Will keep an eye for them.

## Deploy Plan

- deploy `front`