### PR TITLE
[front] feat: add answer-question endpoint for `ask_user_question` tool

### DIFF
--- a/front/lib/api/assistant/conversation/answer_user_question.ts
+++ b/front/lib/api/assistant/conversation/answer_user_question.ts
@@ -1,0 +1,152 @@
+import { isToolAskUserQuestionEvent } from "@app/lib/actions/mcp";
+import type { UserQuestionAnswer } from "@app/lib/actions/types";
+import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
+import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export async function registerUserAnswer(
+  auth: Authenticator,
+  conversation: ConversationResource,
+  {
+    actionId,
+    messageId,
+    answer,
+  }: {
+    actionId: string;
+    messageId: string;
+    answer: UserQuestionAnswer;
+  }
+): Promise<Result<void, DustError>> {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.user();
+  const { sId: conversationId, title: conversationTitle } = conversation;
+
+  logger.info(
+    {
+      actionId,
+      messageId,
+      conversationId,
+      workspaceId: owner.sId,
+      userId: user?.sId,
+    },
+    "User question answer request"
+  );
+
+  const {
+    agentMessageId,
+    agentMessageVersion,
+    userMessageId,
+    userMessageVersion,
+    userMessageUserId,
+    userMessageOrigin,
+    branchId,
+  } = await getUserMessageIdFromMessageId(auth, {
+    messageId,
+  });
+
+  if (userMessageUserId !== user?.id) {
+    return new Err(
+      new DustError(
+        "unauthorized",
+        "User is not authorized to answer this question"
+      )
+    );
+  }
+
+  const action = await AgentMCPActionResource.fetchById(auth, actionId);
+  if (!action) {
+    return new Err(
+      new DustError("action_not_found", `Action not found: ${actionId}`)
+    );
+  }
+
+  if (action.status !== "blocked_user_answer_required") {
+    return new Err(
+      new DustError(
+        "action_not_blocked",
+        `Action is not blocked for user question: ${action.status}`
+      )
+    );
+  }
+
+  await action.updateStepContext({
+    ...action.stepContext,
+    resumeState: {
+      ...action.stepContext.resumeState,
+      answer,
+    },
+  });
+
+  // Change status to ready so the tool re-runs.
+  const [updatedCount] = await action.updateStatus("ready_allowed_explicitly");
+
+  if (updatedCount === 0) {
+    logger.info(
+      {
+        actionId,
+        messageId,
+        workspaceId: owner.sId,
+        userId: user?.sId,
+      },
+      "Action already answered"
+    );
+
+    return new Ok(undefined);
+  }
+
+  await getRedisHybridManager().removeEvent((event) => {
+    const payload = JSON.parse(event.message["payload"]);
+    return isToolAskUserQuestionEvent(payload) && payload.actionId === actionId;
+  }, getMessageChannelId(messageId));
+
+  // Only launch the agent loop if there are no remaining blocked actions.
+  const blockedActions =
+    await AgentMCPActionResource.listBlockedActionsForConversation(
+      auth,
+      conversation
+    );
+
+  if (blockedActions.some((a) => a.messageId === messageId)) {
+    logger.info(
+      { blockedActions },
+      "Skipping agent loop launch because there are remaining blocked actions"
+    );
+    return new Ok(undefined);
+  }
+
+  await launchAgentLoopWorkflow({
+    auth,
+    agentLoopArgs: {
+      agentMessageId,
+      agentMessageVersion,
+      conversationId,
+      conversationTitle,
+      conversationBranchId: branchId,
+      userMessageId,
+      userMessageVersion,
+      userMessageOrigin,
+    },
+    startStep: action.stepContent.step,
+    waitForCompletion: true,
+  });
+
+  logger.info(
+    {
+      workspaceId: owner.sId,
+      conversationId,
+      messageId,
+      actionId,
+    },
+    "User question answered, agent loop resumed"
+  );
+
+  return new Ok(undefined);
+}

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
@@ -1,0 +1,124 @@
+/** @ignoreswagger */
+import { UserQuestionAnswerSchema } from "@app/lib/actions/types";
+import { registerUserAnswer } from "@app/lib/api/assistant/conversation/answer_user_question";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const AnswerQuestionRequestSchema = z.object({
+  actionId: z.string(),
+  answer: UserQuestionAnswerSchema,
+});
+
+interface AnswerQuestionResponse {
+  success: boolean;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<AnswerQuestionResponse>>,
+  auth: Authenticator
+): Promise<void> {
+  const { cId, mId } = req.query;
+  if (!isString(cId) || !isString(mId)) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation, message, or workspace not found.",
+      },
+    });
+  }
+
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const parseResult = AnswerQuestionRequestSchema.safeParse(req.body);
+  if (!parseResult.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${parseResult.error.message}`,
+      },
+    });
+  }
+
+  const conversation = await ConversationResource.fetchById(auth, cId);
+
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  const { actionId, answer } = parseResult.data;
+
+  const result = await registerUserAnswer(auth, conversation, {
+    actionId,
+    messageId: mId,
+    answer,
+  });
+
+  if (result.isErr()) {
+    switch (result.error.code) {
+      case "unauthorized":
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: result.error.message,
+          },
+        });
+      case "action_not_blocked":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "action_not_blocked",
+            message: result.error.message,
+          },
+        });
+      case "action_not_found":
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "action_not_found",
+            message: result.error.message,
+          },
+        });
+      default:
+        return apiError(
+          req,
+          res,
+          {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to answer question",
+            },
+          },
+          result.error
+        );
+    }
+  }
+
+  res.status(200).json({ success: true });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

- Adds an `/answer-question` endpoint to submit user answers to blocked `ask_user_question` tool calls.
- registerUserAnswer validates the caller is the original user, persists the answer in the action's resume state, clears the blocked event from Redis, and resumes the agent loop
- Follows the same pattern as `/validate-action`

## Tests

- Checked locally.

## Risk

- Low. Purely additive.

## Deploy Plan

- Deploy front.
