### PR TITLE
Check for workspace

### DIFF
--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -311,7 +311,7 @@ export async function finalizeConnection(
     }
   }
 
-  if (auth) {
+  if (auth && auth.workspace()) {
     // No req available in this library function — context defaults to auth.clientIp().
     void emitAuditLogEvent({
       auth,


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#7276

Google Calendar connection fails with an unhandled internal server error ("Unexpected unauthenticated call to `getNonNullableWorkspace`") when `auth` is non-null but has no workspace populated.

The `finalizeConnection` function in `oauth.ts` only checked `if (auth)` before calling `emitAuditLogEvent`, which internally calls `auth.getNonNullableWorkspace()`. In some OAuth callback flows, the `Authenticator` object exists but doesn't have a workspace set, causing the crash (endpoint does not contain a workspace) 

This adds a `auth.workspace()` check to guard the audit log emission path.

## Tests

Manual — reproduce by attempting to connect Google Calendar with an account that hasn't previously authenticated.

## Risk

Low — this is a defensive guard on an audit logging path. The else branch already handles the null-auth case with a logger.warn.

## Deploy Plan

Standard deploy, no special considerations.