### PR TITLE
[Front] feat(metronome): shadow-provision Metronome customer and contract on Stripe checkout

### DIFF
--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -9,6 +9,8 @@
 // These map to packages configured in the Metronome dashboard.
 export const LEGACY_PRO_29_PACKAGE_ALIAS = "legacy-pro-29";
 export const LEGACY_BUSINESS_39_PACKAGE_ALIAS = "legacy-business-39";
+export const SHADOW_PRO_29_PACKAGE_ALIAS = "shadow-pro-29";
+export const SHADOW_BUSINESS_39_PACKAGE_ALIAS = "shadow-business-39";
 
 export const PRO_OR_BUSINESS_PACKAGE_ALIASES: ReadonlySet<string> = new Set([
   LEGACY_PRO_29_PACKAGE_ALIAS,

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -160,12 +160,14 @@ export type SupportedPaymentMethod = (typeof SUPPORTED_PAYMENT_METHODS)[number];
 export const createStripeSubscriptionCheckoutSession = async ({
   allowedPaymentMethods = ["card"],
   billingPeriod,
+  metronomePackageAlias,
   owner,
   planCode,
   user,
 }: {
   allowedPaymentMethods?: SupportedPaymentMethod[];
   billingPeriod: BillingPeriod;
+  metronomePackageAlias?: string;
   owner: WorkspaceType;
   planCode: string;
   user: UserType;
@@ -232,6 +234,7 @@ export const createStripeSubscriptionCheckoutSession = async ({
     metadata: {
       planCode: planCode,
       userId: `${user.id}`,
+      ...(metronomePackageAlias ? { metronomePackageAlias } : {}),
     },
     line_items: [
       {

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -12,6 +12,8 @@ import {
   LEGACY_BUSINESS_39_PACKAGE_ALIAS,
   LEGACY_PRO_29_PACKAGE_ALIAS,
   PRO_OR_BUSINESS_PACKAGE_ALIASES,
+  SHADOW_BUSINESS_39_PACKAGE_ALIAS,
+  SHADOW_PRO_29_PACKAGE_ALIAS,
 } from "@app/lib/metronome/types";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
@@ -884,21 +886,27 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     { useMetronomeBilling }: { useMetronomeBilling: boolean }
   ): Promise<CheckoutUrlResult> {
     const isBusiness = !!owner.metadata?.isBusiness;
-    const { planCode, allowedPaymentMethods, metronomePackageAlias } =
-      isBusiness
-        ? {
-            planCode: PRO_PLAN_SEAT_39_CODE,
-            allowedPaymentMethods: [
-              "card",
-              "sepa_debit",
-            ] satisfies SupportedPaymentMethod[],
-            metronomePackageAlias: LEGACY_BUSINESS_39_PACKAGE_ALIAS,
-          }
-        : {
-            planCode: PRO_PLAN_SEAT_29_CODE,
-            allowedPaymentMethods: ["card"] satisfies SupportedPaymentMethod[],
-            metronomePackageAlias: LEGACY_PRO_29_PACKAGE_ALIAS,
-          };
+    const {
+      planCode,
+      allowedPaymentMethods,
+      legacyPackageAlias,
+      shadowPackageAlias,
+    } = isBusiness
+      ? {
+          planCode: PRO_PLAN_SEAT_39_CODE,
+          allowedPaymentMethods: [
+            "card",
+            "sepa_debit",
+          ] satisfies SupportedPaymentMethod[],
+          legacyPackageAlias: LEGACY_BUSINESS_39_PACKAGE_ALIAS,
+          shadowPackageAlias: SHADOW_BUSINESS_39_PACKAGE_ALIAS,
+        }
+      : {
+          planCode: PRO_PLAN_SEAT_29_CODE,
+          allowedPaymentMethods: ["card"] satisfies SupportedPaymentMethod[],
+          legacyPackageAlias: LEGACY_PRO_29_PACKAGE_ALIAS,
+          shadowPackageAlias: SHADOW_PRO_29_PACKAGE_ALIAS,
+        };
 
     const proPlan = await SubscriptionResource.findPlanOrThrow(planCode);
 
@@ -916,7 +924,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         owner,
         user,
         planCode,
-        metronomePackageAlias,
+        metronomePackageAlias: legacyPackageAlias,
         allowedPaymentMethods,
       });
     } else {
@@ -925,6 +933,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         user,
         billingPeriod,
         planCode,
+        metronomePackageAlias: shadowPackageAlias,
         allowedPaymentMethods,
       });
     }
@@ -951,6 +960,16 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       transaction,
     });
     return new Ok(undefined);
+  }
+
+  static async updateMetronomeContractId(
+    subscriptionModelId: ModelId,
+    metronomeContractId: string
+  ): Promise<void> {
+    await SubscriptionModel.update(
+      { metronomeContractId },
+      { where: { id: subscriptionModelId } }
+    );
   }
 
   async getPerSeatPricing(): Promise<SubscriptionPerSeatPricing | null> {
@@ -1229,6 +1248,21 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   private async isSubscriptionOnProOrBusinessPlan(
     owner: WorkspaceType
   ): Promise<boolean> {
+    // Check Stripe-billed subscription first (covers shadow mode where both IDs are set).
+    if (this.stripeSubscriptionId) {
+      const stripeSubscription = await getStripeSubscription(
+        this.stripeSubscriptionId
+      );
+      if (!stripeSubscription) {
+        return false;
+      }
+
+      return SubscriptionResource.isStripeSubscriptionOnProOrBusinessPlan(
+        owner,
+        stripeSubscription
+      );
+    }
+
     // Check Metronome-billed subscription.
     if (this.metronomeContractId && owner.metronomeCustomerId) {
       const aliasesResult = await getMetronomeContractPackageAliases({
@@ -1244,21 +1278,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       );
     }
 
-    // Check Stripe-billed subscription.
-    if (!this.stripeSubscriptionId) {
-      return false;
-    }
-    const stripeSubscription = await getStripeSubscription(
-      this.stripeSubscriptionId
-    );
-    if (!stripeSubscription) {
-      return false;
-    }
-
-    return SubscriptionResource.isStripeSubscriptionOnProOrBusinessPlan(
-      owner,
-      stripeSubscription
-    );
+    return false;
   }
 }
 

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -23,7 +23,7 @@ import {
   isPAYGEnabled,
 } from "@app/lib/credits/payg";
 import { handleMetronomeSetupCheckout } from "@app/lib/metronome/checkout";
-import { createMetronomeCustomer } from "@app/lib/metronome/client";
+import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/client";
 import { PlanModel } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
@@ -48,6 +48,7 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { launchWorkOSWorkspaceSubscriptionCreatedWorkflow } from "@app/temporal/workos_events_queue/client";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
@@ -101,45 +102,63 @@ async function grantFreeCreditsForSubscription({
 }
 
 /**
- * Provision a Metronome customer for a workspace, linked to the Stripe customer.
- * Fire-and-forget: logs errors but does not throw.
+ * Shadow-provision Metronome customer + contract for a workspace.
+ * Uses shadow packages (no billing provider) so Metronome generates invoices
+ * but does NOT deliver them to Stripe. Fire-and-forget: logs errors but does not throw.
  */
-async function provisionMetronomeCustomer({
+async function shadowProvisionMetronome({
   workspace,
   stripeCustomerId,
+  metronomePackageAlias,
+  sessionId,
+  subscriptionModelId,
 }: {
   workspace: WorkspaceResource;
   stripeCustomerId: string;
+  metronomePackageAlias: string;
+  sessionId: string;
+  subscriptionModelId: ModelId;
 }): Promise<void> {
   try {
-    const result = await createMetronomeCustomer({
+    const result = await provisionMetronomeCustomerAndContract({
       workspaceId: workspace.sId,
       workspaceName: workspace.name,
       stripeCustomerId,
+      packageAlias: metronomePackageAlias,
+      uniquenessKey: sessionId,
     });
 
-    if (result.isOk()) {
-      await WorkspaceResource.updateMetronomeCustomerId(
-        workspace.id,
-        result.value.metronomeCustomerId
-      );
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          metronomeCustomerId: result.value.metronomeCustomerId,
-        },
-        "[Stripe Webhook] Metronome customer provisioned"
-      );
-    } else {
+    if (result.isErr()) {
       logger.error(
         { workspaceId: workspace.sId, error: result.error.message },
-        "[Stripe Webhook] Failed to provision Metronome customer"
+        "[Stripe Webhook] Failed to shadow-provision Metronome"
       );
+      return;
     }
+
+    const { metronomeCustomerId, metronomeContractId } = result.value;
+
+    await WorkspaceResource.updateMetronomeCustomerId(
+      workspace.id,
+      metronomeCustomerId
+    );
+    await SubscriptionResource.updateMetronomeContractId(
+      subscriptionModelId,
+      metronomeContractId
+    );
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId,
+        metronomeContractId,
+      },
+      "[Stripe Webhook] Metronome shadow provisioned"
+    );
   } catch (err) {
     logger.error(
       { workspaceId: workspace.sId, error: normalizeError(err) },
-      "[Stripe Webhook] Failed to provision Metronome customer"
+      "[Stripe Webhook] Failed to shadow-provision Metronome"
     );
   }
 }
@@ -206,9 +225,9 @@ async function handler(
           const session = event.data.object as Stripe.Checkout.Session;
           const workspaceId = session.client_reference_id;
           const stripeSubscriptionId = session.subscription;
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           const planCode = session?.metadata?.planCode || null;
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          const metronomePackageAlias =
+            session?.metadata?.metronomePackageAlias || null;
           const userId = session?.metadata?.userId || null;
 
           if (session.status === "open" || session.status === "expired") {
@@ -309,7 +328,7 @@ async function handler(
             const checkoutStripeSubscription =
               await stripe.subscriptions.retrieve(stripeSubscriptionId);
 
-            await withTransaction(async (t) => {
+            const newSubscription = await withTransaction(async (t) => {
               const activeSubscription =
                 await SubscriptionResource.fetchActiveByWorkspaceModelId(
                   workspace.id,
@@ -361,7 +380,7 @@ async function handler(
                 await activeSubscription.markAsEnded("ended", t);
               }
 
-              await SubscriptionResource.makeNew(
+              return SubscriptionResource.makeNew(
                 {
                   sId: generateRandomModelSId(),
                   workspaceId: workspace.id,
@@ -415,19 +434,18 @@ async function handler(
             }
             await restoreWorkspaceAfterSubscription(auth);
 
-            // Provision Metronome customer if not already set.
-            if (!workspace.metronomeCustomerId) {
-              const stripeCustomerId = isString(
-                checkoutStripeSubscription.customer
-              )
-                ? checkoutStripeSubscription.customer
-                : null;
-              if (stripeCustomerId) {
-                void provisionMetronomeCustomer({
-                  workspace,
-                  stripeCustomerId,
-                });
-              }
+            if (
+              metronomePackageAlias &&
+              newSubscription &&
+              isString(checkoutStripeSubscription.customer)
+            ) {
+              void shadowProvisionMetronome({
+                workspace,
+                stripeCustomerId: checkoutStripeSubscription.customer,
+                metronomePackageAlias,
+                sessionId: session.id,
+                subscriptionModelId: newSubscription.id,
+              });
             }
 
             await launchWorkOSWorkspaceSubscriptionCreatedWorkflow({


### PR DESCRIPTION
## Description

When a workspace subscribes via the normal Stripe checkout flow, we now also provision a Metronome customer + shadow contract (fire-and-forget). Shadow packages (`shadow-pro-29` / `shadow-business-39`) have no billing provider configured, so Metronome generates invoices viewable via API but does NOT deliver them to Stripe. This enables shadow mode validation (Phase 1) — comparing Metronome invoices vs Stripe for all subscribing workspaces while Stripe billing remains unchanged.

The shadow package alias is passed through Stripe checkout session metadata and read in the webhook handler. After provisioning, both `workspace.metronomeCustomerId` and `subscription.metronomeContractId` are updated.

Also reorders `isSubscriptionOnProOrBusinessPlan` to check Stripe first — shadow mode sets both `stripeSubscriptionId` and `metronomeContractId` on a subscription, and the previous order would incorrectly check shadow package aliases against `PRO_OR_BUSINESS_PACKAGE_ALIASES` (which doesn't include shadow aliases), bypassing the Stripe check entirely.

## Risk

Fire-and-forget — failure to provision shadow contract does not affect the Stripe subscription flow. Idempotent via Metronome 409 handling.