### PR TITLE
Temporarily keep reinforced consideration to only on agent

### DIFF
--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -256,7 +256,16 @@ export async function getAgentConfigurationsActivity({
     variant: "extra_light",
   });
 
-  const eligible = await filterEligibleAgents(auth, agents, lookbackWindowDays);
+  const explicitOnAgents = agents.filter(
+    (a) => a.id > 0 && a.reinforcement === "on"
+  );
+
+  const eligible = await filterEligibleAgents(
+    auth,
+    explicitOnAgents,
+    lookbackWindowDays
+  );
+  
   return eligible.map((a) => a.sId);
 }
 

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -265,7 +265,7 @@ export async function getAgentConfigurationsActivity({
     explicitOnAgents,
     lookbackWindowDays
   );
-  
+
   return eligible.map((a) => a.sId);
 }
 


### PR DESCRIPTION

## Description

* Adding temporary check to only include on mode agents in reinforced, just to avoid any unexpected costs
* Will push PR to add limits separately

## Tests

* Local

## Risk

* None (fixes potential risk of high volume)

## Deploy Plan

* Deploy front