### PR TITLE
Add "pending" to MessageVisibility + UserMessagePromotedEvent

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -542,6 +542,11 @@ export const ConversationViewer = ({
               }
             }
             break;
+
+          case "user_message_promoted":
+            // TODO(steering): implement promotion of user message.
+            break;
+
           case "agent_message_new":
             if (ref.current) {
               const agentMessage = makeInitialMessageStreamState(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2458,6 +2458,7 @@ export async function isConversationEventAllowedForAuth(
     case "butler_done":
     case "butler_thinking":
     case "conversation_title":
+    case "user_message_promoted":
       return true;
     default:
       assertNever(type);

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -127,6 +127,7 @@ function isMessageEventParams(
     case "butler_suggestion_created":
     case "butler_thinking":
     case "user_message_new":
+    case "user_message_promoted":
     case "agent_message_new":
     case "agent_message_done":
     case "conversation_title":

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -21,6 +21,7 @@ import type {
   ButlerThinkingEvent,
   ConversationTitleEvent,
   UserMessageNewEvent,
+  UserMessagePromotedEvent,
 } from "@app/types/assistant/conversation";
 import type { GenerationTokensEvent } from "@app/types/assistant/generation";
 
@@ -45,6 +46,7 @@ export type ConversationEvents =
   | ConversationTitleEvent
   | AgentMessageNewEvent
   | UserMessageNewEvent
+  | UserMessagePromotedEvent
   | AgentMessageDoneEvent;
 
 export const TERMINAL_AGENT_MESSAGE_EVENT_TYPES: AgentMessageEvents["type"][] =

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -122,11 +122,12 @@ async function handler(
       let backpressureCount = 0;
 
       for await (const event of eventStream) {
-        // Butler suggestions are internal events, not exposed via the public API.
+        // Butler suggestions and internal events are not exposed via the public API.
         if (
           event.data.type === "butler_suggestion_created" ||
           event.data.type === "butler_done" ||
-          event.data.type === "butler_thinking"
+          event.data.type === "butler_thinking" ||
+          event.data.type === "user_message_promoted"
         ) {
           continue;
         }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -469,6 +469,13 @@ export type UserMessageNewEvent = {
   message: UserMessageTypeWithContentFragments;
 };
 
+// Event sent when a pending user message is promoted to visible from pending.
+export type UserMessagePromotedEvent = {
+  type: "user_message_promoted";
+  created: number;
+  messageId: string;
+};
+
 // Event sent when the user message is created.
 export type UserMessageErrorEvent = {
   type: "user_message_error";
@@ -500,13 +507,6 @@ export type ButlerSuggestionCreatedEvent = {
   type: "butler_suggestion_created";
   created: number;
   suggestion: ButlerSuggestionPublicType;
-};
-
-// Event sent when a pending user message is promoted to visible after graceful stop.
-export type UserMessagePromotedEvent = {
-  type: "user_message_promoted";
-  created: number;
-  messageSId: string;
 };
 
 // Event sent when the butler starts analyzing a conversation.

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -16,7 +16,7 @@ import type {
 } from "./agent";
 import type { MentionType, RichMention } from "./mentions";
 
-export type MessageVisibility = "visible" | "deleted";
+export type MessageVisibility = "visible" | "deleted" | "pending";
 
 export type ConversationMessageReactions = {
   messageId: string;
@@ -500,6 +500,13 @@ export type ButlerSuggestionCreatedEvent = {
   type: "butler_suggestion_created";
   created: number;
   suggestion: ButlerSuggestionPublicType;
+};
+
+// Event sent when a pending user message is promoted to visible after graceful stop.
+export type UserMessagePromotedEvent = {
+  type: "user_message_promoted";
+  created: number;
+  messageSId: string;
 };
 
 // Event sent when the butler starts analyzing a conversation.

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -357,7 +357,9 @@ const UserMessageOriginSchema = UserMessageOriginEnumSchema.catch("api")
   .or(z.null())
   .or(z.undefined());
 
-const VisibilitySchema = FlexibleEnumSchema<"visible" | "deleted" | "pending">();
+const VisibilitySchema = FlexibleEnumSchema<
+  "visible" | "deleted" | "pending"
+>();
 
 const RankSchema = z.object({
   rank: z.number(),

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -357,7 +357,7 @@ const UserMessageOriginSchema = UserMessageOriginEnumSchema.catch("api")
   .or(z.null())
   .or(z.undefined());
 
-const VisibilitySchema = FlexibleEnumSchema<"visible" | "deleted">();
+const VisibilitySchema = FlexibleEnumSchema<"visible" | "deleted" | "pending">();
 
 const RankSchema = z.object({
   rank: z.number(),

--- a/x/spolu/steering/plan.md
+++ b/x/spolu/steering/plan.md
@@ -72,6 +72,8 @@ Implement the graceful stop mechanism end-to-end.
 - Publish from `gracefullyStopAgentLoop()` before sending the Temporal signal.
 - Handle in frontend to show "stopping..." state.
 
+==> P1 compared to phase3
+
 ---
 
 ## Phase 3: Steering (behind `enable_steering_behavior` feature flag)

--- a/x/spolu/steering/steering.md
+++ b/x/spolu/steering/steering.md
@@ -331,7 +331,7 @@ export async function updateAgentMessageWithFinalStatus(
 export interface UserMessagePromotedEvent {
   type: "user_message_promoted";
   created: number;
-  messageSId: string;
+  messageId: string;
 }
 ```
 


### PR DESCRIPTION
## Description

Add `"pending"` as a new `MessageVisibility` value and `UserMessagePromotedEvent` as a new conversation event type, as groundwork for steering support.

- Add `"pending"` to `MessageVisibility` type
- Add `UserMessagePromotedEvent` type (`{ type: "user_message_promoted", created, messageId }`)
- Add to `ConversationEvents` union
- Handle in all exhaustive switches (no-op / filtered from v1 API)

No runtime behavior change — no code creates pending messages or emits the event yet.

`sdk-ack` and `documentation-ack`: pure additive.

## Tests

- `npx tsgo --noEmit` passes
- `npx biome check` passes on all changed files
- Tested locally

## Risk

None — type-only changes, no runtime behavior affected.

## Deploy Plan

- deploy `front-sse`