### PR TITLE
[front] feat: add `ask_user_question` tool to dust and deep-dive

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -435,7 +435,10 @@ export function _getDeepDiveGlobalAgent(
     hasSandbox?: boolean;
   }
 ): AgentConfigurationType | null {
-  const { run_agent: runAgentMCPServerView } = mcpServerViews;
+  const {
+    run_agent: runAgentMCPServerView,
+    ask_user_question: askUserQuestionMCPServerView,
+  } = mcpServerViews;
   const pictureUrl = DUST_AVATAR_URL;
   const modelConfig = getModelConfig(auth, "anthropic");
 
@@ -557,6 +560,27 @@ export function _getDeepDiveGlobalAgent(
       dataSources: null,
       tables: null,
       childAgentId: GLOBAL_AGENTS_SID.DUST_PLANNING,
+      additionalConfiguration: {},
+      timeFrame: null,
+      dustAppConfiguration: null,
+      jsonSchema: null,
+      secretName: null,
+      dustProject: null,
+    });
+  }
+
+  if (askUserQuestionMCPServerView) {
+    actions.push({
+      id: -1,
+      sId: GLOBAL_AGENTS_SID.DEEP_DIVE + "-ask-user-question",
+      type: "mcp_server_configuration",
+      name: "ask_user_question",
+      description: "Ask the user a question with multiple-choice options.",
+      mcpServerViewId: askUserQuestionMCPServerView.sId,
+      internalMCPServerId: askUserQuestionMCPServerView.internalMCPServerId,
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
       additionalConfiguration: {},
       timeFrame: null,
       dustAppConfiguration: null,

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -335,7 +335,10 @@ function _getDustLikeGlobalAgent(
     omittedThinking?: boolean;
   }
 ): (AgentConfigurationType & { omittedThinking?: boolean }) | null {
-  const { agent_memory: agentMemoryMCPServerView } = mcpServerViews;
+  const {
+    agent_memory: agentMemoryMCPServerView,
+    ask_user_question: askUserQuestionMCPServerView,
+  } = mcpServerViews;
   const owner = auth.getNonNullableWorkspace();
 
   const description = `Dust is your general purpose agent. It has access to all of your company data and tools available in the Company space. Dust can help you:
@@ -500,6 +503,27 @@ function _getDustLikeGlobalAgent(
       description: "The agent memory tool",
       mcpServerViewId: agentMemoryMCPServerView.sId,
       internalMCPServerId: agentMemoryMCPServerView.internalMCPServerId,
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      additionalConfiguration: {},
+      timeFrame: null,
+      dustAppConfiguration: null,
+      jsonSchema: null,
+      secretName: null,
+      dustProject: null,
+    });
+  }
+
+  if (askUserQuestionMCPServerView) {
+    actions.push({
+      id: -1,
+      sId: agentId + "-ask-user-question",
+      type: "mcp_server_configuration",
+      name: "ask_user_question" satisfies InternalMCPServerNameType,
+      description: "Ask the user a question with multiple-choice options.",
+      mcpServerViewId: askUserQuestionMCPServerView.sId,
+      internalMCPServerId: askUserQuestionMCPServerView.internalMCPServerId,
       dataSources: null,
       tables: null,
       childAgentId: null,

--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -31,6 +31,7 @@ export const MCP_SERVERS_FOR_GLOBAL_AGENTS = [
   "data_warehouses",
   "slideshow",
   "agent_memory",
+  "ask_user_question",
 ] as const satisfies AutoInternalMCPServerNameType[];
 
 export type MCPServerViewsForGlobalAgentsMap = Record<


### PR DESCRIPTION
## Description

- This PR adds the `ask_user_question` tool to the `dust` and `deep-dive` global agents.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
