### PR TITLE
Add commits to Metronome once paid

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -521,6 +521,11 @@ const config = {
   getMetronomeApiKey: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("METRONOME_API_KEY");
   },
+  getMetronomeCommitProductId: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "METRONOME_COMMIT_PRODUCT_ID"
+    );
+  },
 };
 
 export default config;

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -115,13 +115,10 @@ export async function startCreditFromProOneOffInvoice({
     "customer:pro",
   ]);
 
-  const amountMicroUsd = creditAmountCents
-    ? Math.round(creditAmountCents * 10_000)
-    : null;
-  if (amountMicroUsd) {
+  if (creditAmountCents) {
     const metronomeResult = await addMetronomeCommitsForWorkspace({
       auth,
-      amountMicroUsd,
+      amountCents: creditAmountCents,
     });
     if (metronomeResult.isErr()) {
       return new Err(metronomeResult.error);
@@ -318,7 +315,7 @@ export async function createEnterpriseCreditPurchase({
 
   const metronomeResult = await addMetronomeCommitsForWorkspace({
     auth,
-    amountMicroUsd,
+    amountCents: amountMicroUsd / 10_000,
     startDate,
     expirationDate,
   });
@@ -493,12 +490,12 @@ export async function deleteCreditFromVoidedInvoice({
 
 async function addMetronomeCommitsForWorkspace({
   auth,
-  amountMicroUsd,
+  amountCents,
   startDate,
   expirationDate,
 }: {
   auth: Authenticator;
-  amountMicroUsd: number;
+  amountCents: number;
   startDate?: Date;
   expirationDate?: Date;
 }): Promise<Result<void, Error>> {
@@ -545,7 +542,7 @@ async function addMetronomeCommitsForWorkspace({
     metronomeCustomerId,
     contractId: metronomeContractId,
     productId: creditProduct.id,
-    amountMicroUsd,
+    amountCents,
     startingAt: effectiveStartDate,
     endingBefore: effectiveExpirationDate,
     name: `${PREPAID_COMMIT_PRODUCT_NAME} (${effectiveStartDate.toISOString()})`,
@@ -557,7 +554,7 @@ async function addMetronomeCommitsForWorkspace({
         workspaceId: workspace.sId,
         metronomeCustomerId,
         metronomeContractId,
-        amountMicroUsd,
+        amountCents,
         error: result.error.message,
       },
       "[Commit Purchase] Failed to add commits to Metronome"

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -1,5 +1,9 @@
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import type { Authenticator } from "@app/lib/auth";
+import {
+  createMetronomeCommit,
+  listMetronomeProducts,
+} from "@app/lib/metronome/client";
 import type { CustomerFacingInvoiceInfo } from "@app/lib/plans/stripe";
 import {
   ENTERPRISE_N30_PAYMENTS_DAYS,
@@ -17,10 +21,13 @@ import { CreditResource } from "@app/lib/resources/credit_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
+import { CREDIT_EXPIRATION_DAYS } from "@app/types/credits";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
 import type Stripe from "stripe";
+
+const PREPAID_COMMIT_PRODUCT_NAME = "Prepaid Commit";
 
 export async function startCreditFromProOneOffInvoice({
   auth,
@@ -107,6 +114,20 @@ export async function startCreditFromProOneOffInvoice({
     "type:committed",
     "customer:pro",
   ]);
+
+  const amountMicroUsd = creditAmountCents
+    ? Math.round(creditAmountCents * 10_000)
+    : null;
+  if (amountMicroUsd) {
+    const metronomeResult = await addMetronomeCommitsForWorkspace({
+      auth,
+      amountMicroUsd,
+    });
+    if (metronomeResult.isErr()) {
+      return new Err(metronomeResult.error);
+    }
+  }
+
   logger.info(
     {
       workspaceId: workspace.sId,
@@ -294,6 +315,17 @@ export async function createEnterpriseCreditPurchase({
     "type:committed",
     "customer:enterprise",
   ]);
+
+  const metronomeResult = await addMetronomeCommitsForWorkspace({
+    auth,
+    amountMicroUsd,
+    startDate,
+    expirationDate,
+  });
+  if (metronomeResult.isErr()) {
+    return new Err(metronomeResult.error);
+  }
+
   logger.info(
     {
       workspaceId: workspace.sId,
@@ -457,4 +489,79 @@ export async function deleteCreditFromVoidedInvoice({
   await credit.delete(auth);
 
   return new Ok(undefined);
+}
+
+async function addMetronomeCommitsForWorkspace({
+  auth,
+  amountMicroUsd,
+  startDate,
+  expirationDate,
+}: {
+  auth: Authenticator;
+  amountMicroUsd: number;
+  startDate?: Date;
+  expirationDate?: Date;
+}): Promise<Result<void, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription();
+
+  const metronomeCustomerId = workspace.metronomeCustomerId;
+  const metronomeContractId = subscription?.metronomeContractId;
+
+  if (!metronomeCustomerId || !metronomeContractId) {
+    logger.info(
+      { subscription },
+      "[Credit Purchase] Subscription missing Metronome contract ID, skipping credit addition"
+    );
+    logger.info(
+      { workspaceId: workspace.sId, metronomeCustomerId, metronomeContractId },
+      "[Credit Purchase] Workspace not provisioned in Metronome, skipping credit addition"
+    );
+    return new Ok(undefined);
+  }
+
+  const effectiveStartDate = startDate ?? new Date();
+  const effectiveExpirationDate =
+    expirationDate ??
+    new Date(
+      effectiveStartDate.getTime() +
+        CREDIT_EXPIRATION_DAYS * 24 * 60 * 60 * 1000
+    );
+
+  const productsResult = await listMetronomeProducts();
+  if (productsResult.isErr()) {
+    return new Err(productsResult.error);
+  }
+  const creditProduct = productsResult.value.find(
+    (p) => p.name === PREPAID_COMMIT_PRODUCT_NAME
+  );
+  if (!creditProduct) {
+    return new Err(
+      new Error(`Metronome product "${PREPAID_COMMIT_PRODUCT_NAME}" not found`)
+    );
+  }
+
+  const result = await createMetronomeCommit({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+    productId: creditProduct.id,
+    amountMicroUsd,
+    startingAt: effectiveStartDate,
+    endingBefore: effectiveExpirationDate,
+    name: `${PREPAID_COMMIT_PRODUCT_NAME} (${effectiveStartDate.toISOString()})`,
+  });
+
+  if (result.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId,
+        metronomeContractId,
+        amountMicroUsd,
+        error: result.error.message,
+      },
+      "[Commit Purchase] Failed to add commits to Metronome"
+    );
+  }
+  return result;
 }

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -546,6 +546,7 @@ async function addMetronomeCommitsForWorkspace({
     startingAt: effectiveStartDate,
     endingBefore: effectiveExpirationDate,
     name: `${PREPAID_COMMIT_PRODUCT_NAME} (${effectiveStartDate.toISOString()})`,
+    idempotencyKey: `commit-${workspace.sId}-${effectiveStartDate.getTime()}-${amountCents}`,
   });
 
   if (result.isErr()) {

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -1,9 +1,7 @@
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
+import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  createMetronomeCommit,
-  listMetronomeProducts,
-} from "@app/lib/metronome/client";
+import { createMetronomeCommit } from "@app/lib/metronome/client";
 import type { CustomerFacingInvoiceInfo } from "@app/lib/plans/stripe";
 import {
   ENTERPRISE_N30_PAYMENTS_DAYS,
@@ -26,8 +24,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
 import type Stripe from "stripe";
-
-const PREPAID_COMMIT_PRODUCT_NAME = "Prepaid Commit";
 
 export async function startCreditFromProOneOffInvoice({
   auth,
@@ -508,11 +504,11 @@ async function addMetronomeCommitsForWorkspace({
   if (!metronomeCustomerId || !metronomeContractId) {
     logger.info(
       { subscription },
-      "[Credit Purchase] Subscription missing Metronome contract ID, skipping credit addition"
+      "[Commit Purchase] Subscription missing Metronome contract ID, skipping credit addition"
     );
     logger.info(
       { workspaceId: workspace.sId, metronomeCustomerId, metronomeContractId },
-      "[Credit Purchase] Workspace not provisioned in Metronome, skipping credit addition"
+      "[Commit Purchase] Workspace not provisioned in Metronome, skipping credit addition"
     );
     return new Ok(undefined);
   }
@@ -525,27 +521,23 @@ async function addMetronomeCommitsForWorkspace({
         CREDIT_EXPIRATION_DAYS * 24 * 60 * 60 * 1000
     );
 
-  const productsResult = await listMetronomeProducts();
-  if (productsResult.isErr()) {
-    return new Err(productsResult.error);
-  }
-  const creditProduct = productsResult.value.find(
-    (p) => p.name === PREPAID_COMMIT_PRODUCT_NAME
-  );
-  if (!creditProduct) {
+  const productId = config.getMetronomeCommitProductId();
+  if (!productId) {
     return new Err(
-      new Error(`Metronome product "${PREPAID_COMMIT_PRODUCT_NAME}" not found`)
+      new Error(
+        "[Commit Purchase] Metronome commit product ID not configured; cannot add commits for credit purchase"
+      )
     );
   }
 
   const result = await createMetronomeCommit({
     metronomeCustomerId,
     contractId: metronomeContractId,
-    productId: creditProduct.id,
+    productId,
     amountCents,
     startingAt: effectiveStartDate,
     endingBefore: effectiveExpirationDate,
-    name: `${PREPAID_COMMIT_PRODUCT_NAME} (${effectiveStartDate.toISOString()})`,
+    name: `Prepaid commit (${effectiveStartDate.toISOString()})`,
     idempotencyKey: `commit-${workspace.sId}-${effectiveStartDate.getTime()}-${amountCents}`,
   });
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -451,7 +451,7 @@ export async function createMetronomeCommit({
   metronomeCustomerId,
   contractId,
   productId,
-  amountMicroUsd,
+  amountCents,
   startingAt,
   endingBefore,
   name,
@@ -459,14 +459,11 @@ export async function createMetronomeCommit({
   metronomeCustomerId: string;
   contractId: string;
   productId: string;
-  amountMicroUsd: number;
+  amountCents: number;
   startingAt: Date;
   endingBefore: Date;
   name?: string;
 }): Promise<Result<void, Error>> {
-  // Metronome commits are expressed in cents.
-  const amountCents = amountMicroUsd / 10_000;
-
   // Metronome requires dates on hour boundaries — round down start, round up end.
   const roundedStartingAt = new Date(
     Math.floor(startingAt.getTime() / 3_600_000) * 3_600_000
@@ -480,7 +477,6 @@ export async function createMetronomeCommit({
         metronomeCustomerId,
         contractId,
         productId,
-        amountMicroUsd,
         amountCents,
         roundedStartingAt,
         roundedEndingBefore,
@@ -514,7 +510,6 @@ export async function createMetronomeCommit({
         metronomeCustomerId,
         contractId,
         productId,
-        amountMicroUsd,
         amountCents,
         roundedStartingAt,
         roundedEndingBefore,
@@ -530,7 +525,6 @@ export async function createMetronomeCommit({
         metronomeCustomerId,
         contractId,
         productId,
-        amountMicroUsd,
         amountCents,
         roundedStartingAt,
         roundedEndingBefore,

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -455,6 +455,7 @@ export async function createMetronomeCommit({
   startingAt,
   endingBefore,
   name,
+  idempotencyKey,
 }: {
   metronomeCustomerId: string;
   contractId: string;
@@ -462,6 +463,7 @@ export async function createMetronomeCommit({
   amountCents: number;
   startingAt: Date;
   endingBefore: Date;
+  idempotencyKey: string;
   name?: string;
 }): Promise<Result<void, Error>> {
   // Metronome requires dates on hour boundaries — round down start, round up end.
@@ -484,27 +486,30 @@ export async function createMetronomeCommit({
       "[Metronome] Adding commits to contract"
     );
 
-    await getClient().v2.contracts.edit({
-      customer_id: metronomeCustomerId,
-      contract_id: contractId,
-      add_commits: [
-        {
-          type: "PREPAID",
-          product_id: productId,
-          name: name ?? "Commit purchase",
-          applicable_product_tags: ["usage"],
-          access_schedule: {
-            schedule_items: [
-              {
-                amount: amountCents,
-                starting_at: roundedStartingAt.toISOString(),
-                ending_before: roundedEndingBefore.toISOString(),
-              },
-            ],
+    await getClient().v2.contracts.edit(
+      {
+        customer_id: metronomeCustomerId,
+        contract_id: contractId,
+        add_commits: [
+          {
+            type: "PREPAID",
+            product_id: productId,
+            name: name ?? "Commit purchase",
+            applicable_product_tags: ["usage"],
+            access_schedule: {
+              schedule_items: [
+                {
+                  amount: amountCents,
+                  starting_at: roundedStartingAt.toISOString(),
+                  ending_before: roundedEndingBefore.toISOString(),
+                },
+              ],
+            },
           },
-        },
-      ],
-    });
+        ],
+      },
+      { idempotencyKey }
+    );
 
     logger.info(
       {

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -441,6 +441,107 @@ export async function editMetronomeContractSeats({
 }
 
 // ---------------------------------------------------------------------------
+// Commits
+// ---------------------------------------------------------------------------
+
+/**
+ * Add paid credits (=commits) to a Metronome contract via a contract edit.
+ */
+export async function createMetronomeCommit({
+  metronomeCustomerId,
+  contractId,
+  productId,
+  amountMicroUsd,
+  startingAt,
+  endingBefore,
+  name,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  productId: string;
+  amountMicroUsd: number;
+  startingAt: Date;
+  endingBefore: Date;
+  name?: string;
+}): Promise<Result<void, Error>> {
+  // Metronome commits are expressed in cents.
+  const amountCents = amountMicroUsd / 10_000;
+
+  // Metronome requires dates on hour boundaries — round down start, round up end.
+  const roundedStartingAt = new Date(
+    Math.floor(startingAt.getTime() / 3_600_000) * 3_600_000
+  );
+  const roundedEndingBefore = new Date(
+    Math.ceil(endingBefore.getTime() / 3_600_000) * 3_600_000
+  );
+  try {
+    logger.info(
+      {
+        metronomeCustomerId,
+        contractId,
+        productId,
+        amountMicroUsd,
+        amountCents,
+        roundedStartingAt,
+        roundedEndingBefore,
+      },
+      "[Metronome] Adding commits to contract"
+    );
+
+    await getClient().v2.contracts.edit({
+      customer_id: metronomeCustomerId,
+      contract_id: contractId,
+      add_commits: [
+        {
+          type: "PREPAID",
+          product_id: productId,
+          name: name ?? "Commit purchase",
+          access_schedule: {
+            schedule_items: [
+              {
+                amount: amountCents,
+                starting_at: roundedStartingAt.toISOString(),
+                ending_before: roundedEndingBefore.toISOString(),
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    logger.info(
+      {
+        metronomeCustomerId,
+        contractId,
+        productId,
+        amountMicroUsd,
+        amountCents,
+        roundedStartingAt,
+        roundedEndingBefore,
+      },
+      "[Metronome] Commits added to contract"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      {
+        error,
+        metronomeCustomerId,
+        contractId,
+        productId,
+        amountMicroUsd,
+        amountCents,
+        roundedStartingAt,
+        roundedEndingBefore,
+      },
+      "[Metronome] Failed to add commits to contract"
+    );
+    return new Err(error);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Products
 // ---------------------------------------------------------------------------
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -492,6 +492,7 @@ export async function createMetronomeCommit({
           type: "PREPAID",
           product_id: productId,
           name: name ?? "Commit purchase",
+          applicable_product_tags: ["usage"],
           access_schedule: {
             schedule_items: [
               {

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -360,6 +360,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         attributes: [
           "endDate",
           "id",
+          "metronomeContractId",
           "paymentFailingSince",
           "sId",
           "startDate",


### PR DESCRIPTION
## Description

Add Metronome commit creation when purchasing credits (both Pro one-off invoices and Enterprise credit purchases). After credit creation succeeds, the code now calls `addMetronomeCommitsForWorkspace` which creates a prepaid commit in Metronome via the contract edit API (`v2.contracts.edit` with `add_commits`). This ensures that purchased credits are reflected in Metronome for Metronome-billed workspaces, creating a single source of truth for credit balances.

Add `applicable_product_tags: ["usage"]` so the commit only draws down against AI usage charges, not seats or other products.

The implementation gracefully skips commit creation if the workspace doesn't have `metronomeCustomerId` or the subscription doesn't have `metronomeContractId` (i.e., Stripe-billed workspaces), so this doesn't affect existing credit purchases.

## Tests

Manually purchased credits in Dust and verified commits were added in Metronome (example [here](https://app.metronome.com/sandbox/customers/2af83a97-ac28-49af-8d20-90f3978a3327/contracts/7f5927b8-e303-47e4-8db8-58b44a8aaf66/commits-and-credits/41a70025-a706-4d48-9584-1009d5b84222))

## Risk

Low. However, this PR doesn't include the retry process in case commits creation in Metronome fails. Since it will change a lot shortly, that will be part of another PR.

## Deploy Plan

Deploy front