### PR TITLE
fix: terminate connector workflows by known ID before visibility sweep

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -15,6 +15,10 @@ import {
   launchGoogleGarbageCollector,
 } from "@connectors/connectors/google_drive/temporal/client";
 import {
+  googleDriveFullSyncWorkflowId,
+  googleDriveGarbageCollectorWorkflowId,
+} from "@connectors/connectors/google_drive/temporal/workflows";
+import {
   isGoogleDriveFolder,
   isGoogleDriveSpreadSheetFile,
 } from "@connectors/connectors/google_drive/temporal/mime_types";
@@ -45,7 +49,10 @@ import {
   GoogleDriveSheetModel,
 } from "@connectors/lib/models/google_drive";
 import { syncSucceeded } from "@connectors/lib/sync_status";
-import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
+import {
+  terminateAllWorkflowsForConnectorId,
+  terminateWorkflow,
+} from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type {
@@ -58,6 +65,7 @@ import type {
 import {
   FILE_ATTRIBUTES_TO_FETCH,
   getGoogleSheetContentNodeInternalId,
+  googleDriveIncrementalSyncWorkflowId,
   INTERNAL_MIME_TYPES,
   normalizeError,
 } from "@connectors/types";
@@ -793,6 +801,17 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
   }: {
     reason: string;
   }): Promise<Result<undefined, Error>> {
+    // Terminate known long-lived workflows by deterministic ID first to avoid
+    // relying solely on Temporal's eventually-consistent visibility query,
+    // which can miss workflows during a continueAsNew transition.
+    await terminateWorkflow(
+      googleDriveIncrementalSyncWorkflowId(this.connectorId)
+    );
+    await terminateWorkflow(googleDriveFullSyncWorkflowId(this.connectorId));
+    await terminateWorkflow(
+      googleDriveGarbageCollectorWorkflowId(this.connectorId)
+    );
+    // Sweep for any remaining child/transient workflows via visibility query.
     await terminateAllWorkflowsForConnectorId({
       connectorId: this.connectorId,
       stopReason: reason,

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -15,10 +15,6 @@ import {
   launchGoogleGarbageCollector,
 } from "@connectors/connectors/google_drive/temporal/client";
 import {
-  googleDriveFullSyncWorkflowId,
-  googleDriveGarbageCollectorWorkflowId,
-} from "@connectors/connectors/google_drive/temporal/workflows";
-import {
   isGoogleDriveFolder,
   isGoogleDriveSpreadSheetFile,
 } from "@connectors/connectors/google_drive/temporal/mime_types";
@@ -31,6 +27,10 @@ import {
   getDriveFileId,
   getInternalId,
 } from "@connectors/connectors/google_drive/temporal/utils";
+import {
+  googleDriveFullSyncWorkflowId,
+  googleDriveGarbageCollectorWorkflowId,
+} from "@connectors/connectors/google_drive/temporal/workflows";
 import type {
   CreateConnectorErrorCode,
   RetrievePermissionsErrorCode,

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -38,11 +38,19 @@ import {
   launchMicrosoftIncrementalSyncWorkflow,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/microsoft/temporal/client";
+import {
+  microsoftFullSyncWorkflowId,
+  microsoftGarbageCollectionWorkflowId,
+  microsoftIncrementalSyncWorkflowId,
+} from "@connectors/connectors/microsoft/temporal/workflows";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import type { SelectedSiteMetadata } from "@connectors/lib/models/microsoft";
 import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import { syncSucceeded } from "@connectors/lib/sync_status";
-import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
+import {
+  terminateAllWorkflowsForConnectorId,
+  terminateWorkflow,
+} from "@connectors/lib/temporal";
 import logger, { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import {
@@ -566,6 +574,17 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
   }: {
     reason: string;
   }): Promise<Result<undefined, Error>> {
+    // Terminate known long-lived workflows by deterministic ID first to avoid
+    // relying solely on Temporal's eventually-consistent visibility query,
+    // which can miss workflows during a continueAsNew transition.
+    await terminateWorkflow(
+      microsoftIncrementalSyncWorkflowId(this.connectorId)
+    );
+    await terminateWorkflow(microsoftFullSyncWorkflowId(this.connectorId));
+    await terminateWorkflow(
+      microsoftGarbageCollectionWorkflowId(this.connectorId)
+    );
+    // Sweep for any remaining child/transient workflows via visibility query.
     await terminateAllWorkflowsForConnectorId({
       connectorId: this.connectorId,
       stopReason: reason,


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#7348

When a workspace transitions from phone trial to free plan, connectors are paused via `pauseAndStop()`. Google Drive and Microsoft connectors relied solely on `terminateAllWorkflowsForConnectorId()`, which queries Temporal's eventually-consistent visibility store (`ExecutionStatus = 'Running' AND connectorId = X`). This can miss workflows during a `continueAsNew` transition — the old execution is already `ContinuedAsNew` (not `Running`) and the new execution isn't yet indexed.

The incremental sync workflows for both connectors loop forever via `sleep(5 min) → continueAsNew`, so a missed termination means the workflow keeps running indefinitely while the connector is marked as paused.

The fix: terminate known long-lived workflows (incremental sync, full sync, garbage collection) by their deterministic workflow ID first — this goes directly to Temporal's core and is not subject to visibility lag — then sweep for remaining child/transient workflows via the visibility query.

This matches the pattern already used by Confluence, Snowflake, and Notion connectors.

## Tests

- Verified the `terminateWorkflow()` function already handles `WorkflowNotFoundError` gracefully (returns `false`), so these calls are safe when the workflow isn't running.
- Typecheck passes (all errors are pre-existing and unrelated).
- The change is additive — the existing visibility-based sweep is still performed as a fallback.

## Risk

**Low.** The change only adds extra termination calls before the existing sweep. `terminateWorkflow` is already used extensively throughout the codebase (e.g., in `launchGoogleDriveIncrementalSyncWorkflow`). Worst case if a workflow ID doesn't exist, the call is a no-op.

## Deploy Plan

Standard deploy. No migration needed. The fix takes effect immediately for any future connector pause operations.