### PR TITLE
[sessions] improve single agent mode

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -109,7 +109,9 @@ function PreviewContent({
                 draftAgent: draftAgent ?? undefined,
                 isSubmitting: isSavingDraftAgent,
                 resetConversation,
-                actionsToShow: ["attachment"],
+                actionsToShow: isSingleAgentInputEnabled()
+                  ? ["attachment", "agents-list"]
+                  : ["attachment"],
               }}
               key={conversation.sId}
             />

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -11,6 +11,7 @@ import { useConversationSidePanelContext } from "@app/components/assistant/conve
 import { ConversationViewer } from "@app/components/assistant/conversation/ConversationViewer";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import type { InputBarAction } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { isSingleAgentInputEnabled } from "@app/lib/development";

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -11,7 +11,6 @@ import { useConversationSidePanelContext } from "@app/components/assistant/conve
 import { ConversationViewer } from "@app/components/assistant/conversation/ConversationViewer";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
-import type { InputBarAction } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { isSingleAgentInputEnabled } from "@app/lib/development";

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -204,10 +204,11 @@ export const InputBar = React.memo(function InputBar({
     const singleAgentInput = isSingleAgentInputEnabled();
     // When single-agent input is enabled, inject the selected agent into mentions
     // since it's no longer in the editor as a mention node.
+    const hasUserMention = rawMentions.some((m) => m.type === "user");
     const shouldInjectSelectedAgent =
       singleAgentInput &&
       selectedSingleAgent &&
-      rawMentions.length > 0 &&
+      !hasUserMention &&
       !rawMentions.some((m) => m.id === selectedSingleAgent.id);
 
     const allMentions = shouldInjectSelectedAgent

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -86,8 +86,7 @@ export const InputBar = React.memo(function InputBar({
   >([]);
 
   const {
-    selectedAgent,
-    setSelectedAgent,
+    getAndClearSelectedAgent,
     selectedSingleAgent,
     getAndClearPendingInputText,
     fileUploaderService,

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -58,6 +58,7 @@ interface InputBarProps {
   isFloatingWithoutMargin?: boolean;
   isSubmitting?: boolean;
   disable?: boolean;
+  isAgentBuilder?: boolean;
   shouldUseDraft?: boolean;
 }
 
@@ -72,6 +73,7 @@ export const InputBar = React.memo(function InputBar({
   actions = DEFAULT_INPUT_BAR_ACTIONS,
   disableAutoFocus = false,
   disableUserMentions,
+  isAgentBuilder = false,
   isFloating = true,
   isSubmitting = false,
   disable = false,
@@ -399,6 +401,7 @@ export const InputBar = React.memo(function InputBar({
             onSkillSelect={handleSkillSelect}
             onSkillDeselect={handleSkillDeselect}
             onResetSelections={handleResetSelections}
+            isAgentBuilder={isAgentBuilder}
             attachedNodes={attachedNodes}
             saveDraft={saveDraft}
             getDraft={getDraft}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -189,8 +189,11 @@ export const InputBar = React.memo(function InputBar({
     void deleteSkill(skill.sId);
   };
 
-  const activeAgents = agentConfigurations.filter((a) => a.status === "active");
-  activeAgents.sort(compareAgentsForSort);
+  const activeAgents = useMemo(() => {
+    const agents = agentConfigurations.filter((a) => a.status === "active");
+    agents.sort(compareAgentsForSort);
+    return agents;
+  }, [agentConfigurations]);
 
   const handleSubmit: InputBarContainerProps["onEnterKeyDown"] = async (
     isEmpty,

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -268,7 +268,6 @@ export const InputBar = React.memo(function InputBar({
           clearDraft();
           resetEditorText();
           fileUploaderService.resetUpload();
-          setSelectedAgent(null);
         }
       } finally {
         setLoading(false);
@@ -295,7 +294,6 @@ export const InputBar = React.memo(function InputBar({
         clearDraft();
         fileUploaderService.resetUpload();
         setAttachedNodes([]);
-        setSelectedAgent(null);
 
         await submitPromise;
       } finally {

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -84,7 +84,8 @@ export const InputBar = React.memo(function InputBar({
   >([]);
 
   const {
-    getAndClearSelectedAgent,
+    selectedAgent,
+    setSelectedAgent,
     selectedSingleAgent,
     getAndClearPendingInputText,
     fileUploaderService,
@@ -114,10 +115,6 @@ export const InputBar = React.memo(function InputBar({
     }
   }, [droppedFiles, setDroppedFiles, fileUploaderService]);
 
-  const selectedAgent = useMemo(
-    () => getAndClearSelectedAgent(),
-    [getAndClearSelectedAgent]
-  );
   const pendingInputText = useMemo(
     () => getAndClearPendingInputText(),
     [getAndClearPendingInputText]
@@ -271,6 +268,7 @@ export const InputBar = React.memo(function InputBar({
           clearDraft();
           resetEditorText();
           fileUploaderService.resetUpload();
+          setSelectedAgent(null);
         }
       } finally {
         setLoading(false);
@@ -297,6 +295,7 @@ export const InputBar = React.memo(function InputBar({
         clearDraft();
         fileUploaderService.resetUpload();
         setAttachedNodes([]);
+        setSelectedAgent(null);
 
         await submitPromise;
       } finally {

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -115,6 +115,10 @@ export const InputBar = React.memo(function InputBar({
     }
   }, [droppedFiles, setDroppedFiles, fileUploaderService]);
 
+  const selectedAgent = useMemo(
+    () => getAndClearSelectedAgent(),
+    [getAndClearSelectedAgent]
+  );
   const pendingInputText = useMemo(
     () => getAndClearPendingInputText(),
     [getAndClearPendingInputText]

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -321,6 +321,18 @@ export const InputBar = React.memo(function InputBar({
     setAttachedNodes((prev) => prev.filter((n) => !isEqualNode(n, node)));
   };
 
+  const handleResetSelections = () => {
+    setSelectedMCPServerViews((prev) => {
+      prev.forEach((sv) => void deleteTool(sv.sId));
+      return [];
+    });
+    setSelectedSkills((prev) => {
+      prev.forEach((s) => void deleteSkill(s.sId));
+      return [];
+    });
+    setAttachedNodes([]);
+  };
+
   useEffect(() => {
     setIsLocalSubmitting(isSubmitting);
   }, [isSubmitting]);
@@ -386,6 +398,7 @@ export const InputBar = React.memo(function InputBar({
             selectedSkills={selectedSkills}
             onSkillSelect={handleSkillSelect}
             onSkillDeselect={handleSkillDeselect}
+            onResetSelections={handleResetSelections}
             attachedNodes={attachedNodes}
             saveDraft={saveDraft}
             getDraft={getDraft}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -207,6 +207,7 @@ export const InputBar = React.memo(function InputBar({
     const shouldInjectSelectedAgent =
       singleAgentInput &&
       selectedSingleAgent &&
+      rawMentions.length > 0 &&
       !rawMentions.some((m) => m.id === selectedSingleAgent.id);
 
     const allMentions = shouldInjectSelectedAgent

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -20,13 +20,13 @@ import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
 import { isSingleAgentInputEnabled } from "@app/lib/development";
-import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { getSkillIcon } from "@app/lib/skill";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { classNames } from "@app/lib/utils";
 import { getManageSkillsRoute } from "@app/lib/utils/router";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type {
   RichAgentMention,
@@ -138,7 +138,10 @@ export interface InputBarContainerProps {
   disableInput: boolean;
   disableUserMentions?: boolean;
   fileUploaderService: FileUploaderService;
-  getDraft: () => { text: string } | null;
+  getDraft: () => {
+    text: string;
+    agentMention?: RichAgentMention | null;
+  } | null;
   isSubmitting: boolean;
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
   onMCPServerViewDeselect: (serverView: MCPServerViewType) => void;
@@ -148,7 +151,7 @@ export interface InputBarContainerProps {
   onSkillDeselect: (skill: SkillType) => void;
   onSkillSelect: (skill: SkillType) => void;
   owner: WorkspaceType;
-  saveDraft: (markdown: string) => void;
+  saveDraft: (markdown: string, agentMention?: RichAgentMention | null) => void;
   pendingInputText: string | null;
   selectedAgent: RichAgentMention | null;
   selectedMCPServerViews: MCPServerViewType[];
@@ -192,16 +195,42 @@ const InputBarContainer = ({
     useContext(InputBarContext);
   const [hasUserMention, setHasUserMention] = useState(false);
 
-  // Auto-select the "dust" agent by default in single-agent mode for new conversations.
-  // Skip when a human is mentioned or when sticky mentions are provided (e.g. agent builder).
-  if (singleAgentInput && !conversation && !selectedSingleAgent && !hasUserMention && !stickyMentions?.length) {
-    const dustAgent = allAgents.find(
-      (a) => a.sId === GLOBAL_AGENTS_SID.DUST
-    );
+  // Auto-select the agent in single-agent mode for new conversations on mount.
+  // Prefer the agent saved in the draft; fall back to "dust".
+  // Runs once on mount (empty deps) so it doesn't override manual agent changes later.
+  const hasInitializedAgentRef = useRef(false);
+
+  useEffect(() => {
+    if (
+      hasInitializedAgentRef.current ||
+      !singleAgentInput ||
+      conversation ||
+      hasUserMention ||
+      stickyMentions?.length
+    ) {
+      return;
+    }
+    hasInitializedAgentRef.current = true;
+
+    const draft = getDraft();
+    if (draft?.agentMention) {
+      setSelectedSingleAgent(draft.agentMention);
+      return;
+    }
+
+    const dustAgent = allAgents.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST);
     if (dustAgent) {
       setSelectedSingleAgent(toRichAgentMentionType(dustAgent));
     }
-  }
+  }, [
+    singleAgentInput,
+    conversation,
+    hasUserMention,
+    stickyMentions?.length,
+    allAgents,
+    setSelectedSingleAgent,
+    getDraft,
+  ]);
 
   // Callback for the editor's @ mention suggestion — sets the selected agent
   // without focusing (the editor already has focus when the user types @).
@@ -501,7 +530,7 @@ const InputBarContainer = ({
   // Uses a ref so the editor listener always calls the latest closure without needing
   // all the deselection callbacks/arrays as effect dependencies.
   const onEditorMentionsChangedRef = useRef((_userMentioned: boolean) => {});
-  
+
   onEditorMentionsChangedRef.current = (userMentioned: boolean) => {
     shouldSuggestAgentRef.current = !(singleAgentInput && userMentioned);
     if (singleAgentInput && userMentioned) {
@@ -512,6 +541,14 @@ const InputBarContainer = ({
       fileUploaderService.resetUpload();
     }
   };
+
+  // Persist the selected agent to the draft whenever it changes.
+  useEffect(() => {
+    if (singleAgentInput && selectedSingleAgent) {
+      const { markdown } = editorService.getMarkdownAndMentions();
+      saveDraft(markdown, selectedSingleAgent);
+    }
+  }, [singleAgentInput, selectedSingleAgent, editorService, saveDraft]);
 
   // Update the editor ref when the editor is created and listen for updates to the editor.
   useEffect(() => {
@@ -756,6 +793,10 @@ const InputBarContainer = ({
       draft &&
       (editorService.isEmpty() || editorContainsOnlyStickyMentions)
     ) {
+      // Restore the selected agent from the draft (single-agent mode).
+      if (singleAgentInput && draft.agentMention) {
+        setSelectedSingleAgent(draft.agentMention);
+      }
       // Schedule content restoration to avoid flushing during render lifecycle.
       queueMicrotask(() =>
         editorService.setContent(draft.text, { focus: !disableAutoFocus })

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -194,7 +194,7 @@ const InputBarContainer = ({
 
   // Auto-select the "dust" agent by default in single-agent mode for new conversations.
   // Skip when a human is mentioned or when sticky mentions are provided (e.g. agent builder).
-  if (singleAgentInput && !conversation && !selectedSingleAgent && !hasUserMention && !stickyMentions?.length && allAgents.length > 0) {
+  if (singleAgentInput && !conversation && !selectedSingleAgent && !hasUserMention && !stickyMentions?.length) {
     const dustAgent = allAgents.find(
       (a) => a.sId === GLOBAL_AGENTS_SID.DUST
     );

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -772,9 +772,15 @@ const InputBarContainer = ({
     };
   }, [clientType, editorService]);
 
+  // Tracks whether the draft restore effect set the selected agent,
+  // so the sticky-mentions sync in useHandleMentions can skip overwriting it.
+  const draftAgentRestoredRef = useRef(false);
+
   // Restore draft when switching conversations (including new conversations).
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   useEffect(() => {
+    draftAgentRestoredRef.current = false;
+
     if (
       !editor ||
       editor.isDestroyed ||
@@ -796,6 +802,7 @@ const InputBarContainer = ({
       // Restore the selected agent from the draft (single-agent mode).
       if (singleAgentInput && draft.agentMention) {
         setSelectedSingleAgent(draft.agentMention);
+        draftAgentRestoredRef.current = true;
       }
       // Schedule content restoration to avoid flushing during render lifecycle.
       queueMicrotask(() =>
@@ -816,7 +823,8 @@ const InputBarContainer = ({
     stickyMentions,
     selectedAgent,
     disableAutoFocus,
-    pendingInputText
+    pendingInputText,
+    draftAgentRestoredRef
   );
 
   const buttonSize = useMemo(() => {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -197,7 +197,7 @@ const InputBarContainer = ({
 
   // Auto-select the agent in single-agent mode for new conversations on mount.
   // Prefer the agent saved in the draft; fall back to "dust".
-  // Runs once on mount (empty deps) so it doesn't override manual agent changes later.
+  // The ref guard ensures this only runs once so it doesn't override manual agent changes.
   const hasInitializedAgentRef = useRef(false);
 
   useEffect(() => {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -210,16 +210,16 @@ const InputBarContainer = ({
     ) {
       return;
     }
-    hasInitializedAgentRef.current = true;
-
     const draft = getDraft();
     if (draft?.agentMention) {
+      hasInitializedAgentRef.current = true;
       setSelectedSingleAgent(draft.agentMention);
       return;
     }
 
     const dustAgent = allAgents.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST);
     if (dustAgent) {
+      hasInitializedAgentRef.current = true;
       setSelectedSingleAgent(toRichAgentMentionType(dustAgent));
     }
   }, [

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -20,6 +20,7 @@ import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
 import { isSingleAgentInputEnabled } from "@app/lib/development";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { getSkillIcon } from "@app/lib/skill";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -151,6 +152,16 @@ const InputBarContainer = ({
   const singleAgentInput = isSingleAgentInputEnabled();
   const { selectedSingleAgent, setSelectedSingleAgent } =
     useContext(InputBarContext);
+
+  // Auto-select the "dust" agent by default in single-agent mode for new conversations.
+  if (singleAgentInput && !conversation && !selectedSingleAgent && allAgents.length > 0) {
+    const dustAgent = allAgents.find(
+      (a) => a.sId === GLOBAL_AGENTS_SID.DUST
+    );
+    if (dustAgent) {
+      setSelectedSingleAgent(toRichAgentMentionType(dustAgent));
+    }
+  }
 
   // Callback for the editor's @ mention suggestion — sets the selected agent
   // without focusing (the editor already has focus when the user types @).

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -152,9 +152,11 @@ const InputBarContainer = ({
   const singleAgentInput = isSingleAgentInputEnabled();
   const { selectedSingleAgent, setSelectedSingleAgent } =
     useContext(InputBarContext);
+  const [hasUserMention, setHasUserMention] = useState(false);
 
   // Auto-select the "dust" agent by default in single-agent mode for new conversations.
-  if (singleAgentInput && !conversation && !selectedSingleAgent && allAgents.length > 0) {
+  // Skip when a human is mentioned — the user explicitly chose to talk to a person, not an agent.
+  if (singleAgentInput && !conversation && !selectedSingleAgent && !hasUserMention && allAgents.length > 0) {
     const dustAgent = allAgents.find(
       (a) => a.sId === GLOBAL_AGENTS_SID.DUST
     );
@@ -176,7 +178,6 @@ const InputBarContainer = ({
   >(null);
   const [pastedCount, setPastedCount] = useState(0);
   const [isEmpty, setIsEmpty] = useState(true);
-  const [hasUserMention, setHasUserMention] = useState(false);
   // In single-agent mode, set to false when a human is mentioned to hide agents from the @ dropdown.
   // A ref so the mention suggestion plugin (which lives outside React) can read it synchronously.
   const shouldSuggestAgentRef = useRef(true);

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1059,7 +1059,6 @@ const InputBarContainer = ({
             </div>
           </div>
         </div>
-        {/* Single voice + send group: absolutely positioned over editor when hideButtons, bottom-right otherwise */}
         <div
           className={cn(
             "absolute bottom-2 right-2 flex items-center gap-2 md:gap-1"

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -142,6 +142,7 @@ export interface InputBarContainerProps {
     text: string;
     agentMention?: RichAgentMention | null;
   } | null;
+  isAgentBuilder?: boolean;
   isSubmitting: boolean;
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
   onMCPServerViewDeselect: (serverView: MCPServerViewType) => void;
@@ -177,6 +178,7 @@ const InputBarContainer = ({
   disableInput,
   fileUploaderService,
   getDraft,
+  isAgentBuilder = false,
   onNodeSelect,
   onNodeUnselect,
   attachedNodes,
@@ -211,6 +213,7 @@ const InputBarContainer = ({
     if (
       hasInitializedAgentRef.current ||
       !singleAgentInput ||
+      isAgentBuilder ||
       conversation ||
       hasUserMention ||
       stickyMentions?.length
@@ -237,6 +240,7 @@ const InputBarContainer = ({
     agentsBySId,
     setSelectedSingleAgent,
     getDraft,
+    isAgentBuilder,
   ]);
 
   // Callback for the editor's @ mention suggestion — sets the selected agent

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -45,7 +45,6 @@ import { isBuilder } from "@app/types/user";
 import {
   ArrowUpIcon,
   AttachmentIcon,
-  Avatar,
   Button,
   CameraIcon,
   Chip,
@@ -57,7 +56,6 @@ import {
   DropdownMenuTrigger,
   GlobeAltIcon,
   PlusIcon,
-  RobotIcon,
   TextIcon,
   Toolbar,
   VoicePicker,

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -804,9 +804,17 @@ const InputBarContainer = ({
         setSelectedSingleAgent(draft.agentMention);
         draftAgentRestoredRef.current = true;
       }
+      // TODO: cleanup once we ship the single agent mode
+      // In single-agent mode, strip agent mentions from the draft text since
+      // the agent is handled by the picker button, not inline in the editor.
+      // This handles drafts saved before single-agent mode was enabled.
+      const draftText = singleAgentInput
+        ? draft.text.replace(/:mention\[[^\]]*\]\{sId=[^}]*\}\s*/g, "").trim()
+        : draft.text;
+
       // Schedule content restoration to avoid flushing during render lifecycle.
       queueMicrotask(() =>
-        editorService.setContent(draft.text, { focus: !disableAutoFocus })
+        editorService.setContent(draftText, { focus: !disableAutoFocus })
       );
     }
   }, [

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -78,6 +78,44 @@ const COLLAPSE_TRANSITION = "200ms cubic-bezier(0.34, 1.15, 0.64, 1)";
 const FADE_OUT_TRANSITION = "50ms ease-out";
 const FADE_IN_TRANSITION = "150ms ease-out";
 
+function getButtonsTransitionStyle(
+  singleAgentInput: boolean,
+  hideButtons: boolean
+): React.CSSProperties | undefined {
+  if (!singleAgentInput) {
+    return undefined;
+  }
+  const opacityTransition = hideButtons
+    ? FADE_OUT_TRANSITION
+    : FADE_IN_TRANSITION;
+  return {
+    maxWidth: hideButtons ? 0 : 500,
+    opacity: hideButtons ? 0 : 1,
+    overflow: "hidden",
+    transition: `max-width ${COLLAPSE_TRANSITION}, opacity ${opacityTransition}`,
+  };
+}
+
+function getToolbarRowTransitionStyle(
+  singleAgentInput: boolean,
+  hideButtons: boolean
+): React.CSSProperties | undefined {
+  if (!singleAgentInput) {
+    return undefined;
+  }
+  const opacityTransition = hideButtons
+    ? FADE_OUT_TRANSITION
+    : FADE_IN_TRANSITION;
+  return {
+    maxHeight: hideButtons ? 0 : 100,
+    opacity: hideButtons ? 0 : 1,
+    overflow: "hidden",
+    paddingTop: hideButtons ? 0 : undefined,
+    paddingBottom: hideButtons ? 0 : undefined,
+    transition: `max-height ${COLLAPSE_TRANSITION}, opacity ${opacityTransition}, padding ${COLLAPSE_TRANSITION}`,
+  };
+}
+
 export const INPUT_BAR_ACTIONS = [
   "capabilities",
   "attachment",
@@ -155,8 +193,8 @@ const InputBarContainer = ({
   const [hasUserMention, setHasUserMention] = useState(false);
 
   // Auto-select the "dust" agent by default in single-agent mode for new conversations.
-  // Skip when a human is mentioned — the user explicitly chose to talk to a person, not an agent.
-  if (singleAgentInput && !conversation && !selectedSingleAgent && !hasUserMention && allAgents.length > 0) {
+  // Skip when a human is mentioned or when sticky mentions are provided (e.g. agent builder).
+  if (singleAgentInput && !conversation && !selectedSingleAgent && !hasUserMention && !stickyMentions?.length && allAgents.length > 0) {
     const dustAgent = allAgents.find(
       (a) => a.sId === GLOBAL_AGENTS_SID.DUST
     );
@@ -178,7 +216,6 @@ const InputBarContainer = ({
   >(null);
   const [pastedCount, setPastedCount] = useState(0);
   const [isEmpty, setIsEmpty] = useState(true);
-  // In single-agent mode, set to false when a human is mentioned to hide agents from the @ dropdown.
   // A ref so the mention suggestion plugin (which lives outside React) can read it synchronously.
   const shouldSuggestAgentRef = useRef(true);
   const [isCaptureDropdownOpen, setIsCaptureDropdownOpen] = useState(false);
@@ -461,29 +498,20 @@ const InputBarContainer = ({
   });
 
   // When a user is mentioned in single-agent mode, deselect the agent and clear capabilities.
-  // TODO: Refactor to avoid cascading re-runs — each deselect call mutates a dependency array,
-  // re-triggering this effect until all arrays are empty.
-  useEffect(() => {
-    shouldSuggestAgentRef.current = !(singleAgentInput && hasUserMention);
-    if (singleAgentInput && hasUserMention) {
+  // Uses a ref so the editor listener always calls the latest closure without needing
+  // all the deselection callbacks/arrays as effect dependencies.
+  const onEditorMentionsChangedRef = useRef((_userMentioned: boolean) => {});
+  
+  onEditorMentionsChangedRef.current = (userMentioned: boolean) => {
+    shouldSuggestAgentRef.current = !(singleAgentInput && userMentioned);
+    if (singleAgentInput && userMentioned) {
       setSelectedSingleAgent(null);
       selectedMCPServerViews.forEach((sv) => onMCPServerViewDeselect(sv));
       selectedSkills.forEach((s) => onSkillDeselect(s));
       attachedNodes.forEach((n) => onNodeUnselect(n));
       fileUploaderService.resetUpload();
     }
-  }, [
-    singleAgentInput,
-    hasUserMention,
-    setSelectedSingleAgent,
-    selectedMCPServerViews,
-    onMCPServerViewDeselect,
-    selectedSkills,
-    onSkillDeselect,
-    attachedNodes,
-    onNodeUnselect,
-    fileUploaderService,
-  ]);
+  };
 
   // Update the editor ref when the editor is created and listen for updates to the editor.
   useEffect(() => {
@@ -493,7 +521,9 @@ const InputBarContainer = ({
       // Auto-save draft when content changes and track user mentions.
       const { markdown, mentions } = editorService.getMarkdownAndMentions();
       saveDraft(markdown);
-      setHasUserMention(mentions.some((m) => m.type === "user"));
+      const userMentioned = mentions.some((m) => m.type === "user");
+      setHasUserMention(userMentioned);
+      onEditorMentionsChangedRef.current(userMentioned);
     };
 
     if (editorRef.current) {
@@ -767,31 +797,14 @@ const InputBarContainer = ({
 
   const isRecording = voiceTranscriberService.status === "recording";
 
-  const opacityTransition = hideButtons
-    ? FADE_OUT_TRANSITION
-    : FADE_IN_TRANSITION;
-
-  const buttonsTransitionStyle: React.CSSProperties | undefined =
-    singleAgentInput
-      ? {
-          maxWidth: hideButtons ? 0 : 500,
-          opacity: hideButtons ? 0 : 1,
-          overflow: "hidden",
-          transition: `max-width ${COLLAPSE_TRANSITION}, opacity ${opacityTransition}`,
-        }
-      : undefined;
-
-  const toolbarRowTransitionStyle: React.CSSProperties | undefined =
-    singleAgentInput
-      ? {
-          maxHeight: hideButtons ? 0 : 100,
-          opacity: hideButtons ? 0 : 1,
-          overflow: "hidden",
-          paddingTop: hideButtons ? 0 : undefined,
-          paddingBottom: hideButtons ? 0 : undefined,
-          transition: `max-height ${COLLAPSE_TRANSITION}, opacity ${opacityTransition}, padding ${COLLAPSE_TRANSITION}`,
-        }
-      : undefined;
+  const buttonsTransitionStyle = getButtonsTransitionStyle(
+    singleAgentInput,
+    hideButtons
+  );
+  const toolbarRowTransitionStyle = getToolbarRowTransitionStyle(
+    singleAgentInput,
+    hideButtons
+  );
 
   return (
     <div

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -197,6 +197,11 @@ const InputBarContainer = ({
     useContext(InputBarContext);
   const [hasUserMention, setHasUserMention] = useState(false);
 
+  const agentsBySId = useMemo(
+    () => new Map(allAgents.map((a) => [a.sId, a])),
+    [allAgents]
+  );
+
   // Auto-select the agent in single-agent mode for new conversations on mount.
   // Prefer the agent saved in the draft; fall back to "dust".
   // The ref guard ensures this only runs once so it doesn't override manual agent changes.
@@ -219,7 +224,7 @@ const InputBarContainer = ({
       return;
     }
 
-    const dustAgent = allAgents.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST);
+    const dustAgent = agentsBySId.get(GLOBAL_AGENTS_SID.DUST);
     if (dustAgent) {
       hasInitializedAgentRef.current = true;
       setSelectedSingleAgent(toRichAgentMentionType(dustAgent));
@@ -229,7 +234,7 @@ const InputBarContainer = ({
     conversation,
     hasUserMention,
     stickyMentions?.length,
-    allAgents,
+    agentsBySId,
     setSelectedSingleAgent,
     getDraft,
   ]);
@@ -501,7 +506,7 @@ const InputBarContainer = ({
             break;
           case "mention": {
             if (singleAgentInput) {
-              const agent = allAgents.find((a) => a.sId === message.id);
+              const agent = agentsBySId.get(message.id);
               if (agent) {
                 handleSingleAgentSelect(toRichAgentMentionType(agent));
               }

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -45,6 +45,7 @@ import { isBuilder } from "@app/types/user";
 import {
   ArrowUpIcon,
   AttachmentIcon,
+  Avatar,
   Button,
   CameraIcon,
   Chip,
@@ -56,6 +57,7 @@ import {
   DropdownMenuTrigger,
   GlobeAltIcon,
   PlusIcon,
+  RobotIcon,
   TextIcon,
   Toolbar,
   VoicePicker,

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -73,6 +73,10 @@ import React, {
 } from "react";
 import { InputBarContext } from "./InputBarContext";
 
+const COLLAPSE_TRANSITION = "200ms cubic-bezier(0.34, 1.15, 0.64, 1)";
+const FADE_OUT_TRANSITION = "50ms ease-out";
+const FADE_IN_TRANSITION = "150ms ease-out";
+
 export const INPUT_BAR_ACTIONS = [
   "capabilities",
   "attachment",
@@ -161,6 +165,10 @@ const InputBarContainer = ({
   >(null);
   const [pastedCount, setPastedCount] = useState(0);
   const [isEmpty, setIsEmpty] = useState(true);
+  const [hasUserMention, setHasUserMention] = useState(false);
+  // In single-agent mode, set to false when a human is mentioned to hide agents from the @ dropdown.
+  // A ref so the mention suggestion plugin (which lives outside React) can read it synchronously.
+  const shouldSuggestAgentRef = useRef(true);
   const [isCaptureDropdownOpen, setIsCaptureDropdownOpen] = useState(false);
   const [showKnowledgePicker, setShowKnowledgePicker] = useState(false);
   const plusButtonRef = useRef<HTMLDivElement>(null);
@@ -336,6 +344,7 @@ const InputBarContainer = ({
     conversationId: conversation?.sId,
     spaceId: space?.sId,
     onInlineText: handleInlineText,
+    shouldSuggestAgentRef: singleAgentInput ? shouldSuggestAgentRef : undefined,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";
       let inserted = false;
@@ -439,14 +448,31 @@ const InputBarContainer = ({
     },
   });
 
+  // Keep a ref to the deselection logic so the editor listener doesn't need
+  // all the deselection callbacks/arrays as effect dependencies.
+  const onEditorMentionsChangedRef = useRef((_userMentioned: boolean) => {});
+  onEditorMentionsChangedRef.current = (userMentioned: boolean) => {
+    shouldSuggestAgentRef.current = !(singleAgentInput && userMentioned);
+    if (singleAgentInput && userMentioned) {
+      setSelectedSingleAgent(null);
+      selectedMCPServerViews.forEach((sv) => onMCPServerViewDeselect(sv));
+      selectedSkills.forEach((s) => onSkillDeselect(s));
+      attachedNodes.forEach((n) => onNodeUnselect(n));
+      fileUploaderService.resetUpload();
+    }
+  };
+
   // Update the editor ref when the editor is created and listen for updates to the editor.
   useEffect(() => {
     const handleUpdate = () => {
       setIsEmpty(editorService.isEmpty());
 
-      // Auto-save draft when content changes.
-      const { markdown } = editorService.getMarkdownAndMentions();
+      // Auto-save draft when content changes and track user mentions.
+      const { markdown, mentions } = editorService.getMarkdownAndMentions();
       saveDraft(markdown);
+      const userMentioned = mentions.some((m) => m.type === "user");
+      setHasUserMention(userMentioned);
+      onEditorMentionsChangedRef.current(userMentioned);
     };
 
     if (editorRef.current) {
@@ -707,15 +733,44 @@ const InputBarContainer = ({
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const [isToolbarOpen, setIsToolbarOpen] = useState(false);
+  const hideButtons = singleAgentInput && hasUserMention;
+
   const contentEditableClasses = classNames(
     "inline-block w-full",
     "border-0 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
     "whitespace-pre-wrap font-normal",
-    "px-3 sm:pl-4 sm:pt-3.5 pt-3"
+    "px-3 sm:pl-4 pt-3",
+    !hideButtons && "sm:pt-3.5"
   );
 
-  const [isToolbarOpen, setIsToolbarOpen] = useState(false);
   const isRecording = voiceTranscriberService.status === "recording";
+
+  const opacityTransition = hideButtons
+    ? FADE_OUT_TRANSITION
+    : FADE_IN_TRANSITION;
+
+  const buttonsTransitionStyle: React.CSSProperties | undefined =
+    singleAgentInput
+      ? {
+          maxWidth: hideButtons ? 0 : 500,
+          opacity: hideButtons ? 0 : 1,
+          overflow: "hidden",
+          transition: `max-width ${COLLAPSE_TRANSITION}, opacity ${opacityTransition}`,
+        }
+      : undefined;
+
+  const toolbarRowTransitionStyle: React.CSSProperties | undefined =
+    singleAgentInput
+      ? {
+          maxHeight: hideButtons ? 0 : 100,
+          opacity: hideButtons ? 0 : 1,
+          overflow: "hidden",
+          paddingTop: hideButtons ? 0 : undefined,
+          paddingBottom: hideButtons ? 0 : undefined,
+          transition: `max-height ${COLLAPSE_TRANSITION}, opacity ${opacityTransition}, padding ${COLLAPSE_TRANSITION}`,
+        }
+      : undefined;
 
   return (
     <div
@@ -729,17 +784,21 @@ const InputBarContainer = ({
       }}
     >
       <div className="flex w-0 flex-grow flex-col">
-        <EditorContent
-          disabled={disableInput}
-          editor={editor}
-          className={classNames(
-            contentEditableClasses,
-            "scrollbar-hide",
-            "overflow-y-auto",
-            disableInput && "cursor-not-allowed",
-            "max-h-[40vh] min-h-14 sm:min-h-16"
-          )}
-        />
+        <div className="relative">
+          <EditorContent
+            disabled={disableInput}
+            editor={editor}
+            className={classNames(
+              contentEditableClasses,
+              "scrollbar-hide",
+              "overflow-y-auto",
+              disableInput && "cursor-not-allowed",
+              hideButtons
+                ? "max-h-[40vh] pr-20"
+                : "max-h-[40vh] min-h-14 sm:min-h-16"
+            )}
+          />
+        </div>
         <BubbleMenu
           editor={editor ?? undefined}
           className={cn("flex", isMobile && "hidden")}
@@ -750,8 +809,23 @@ const InputBarContainer = ({
             </Toolbar>
           )}
         </BubbleMenu>
-        <div className="flex w-full flex-col py-1.5 sm:pb-2">
-          <div className="mb-1 flex flex-wrap items-center px-2">
+        <div
+          className={cn(
+            "flex w-full flex-col",
+            !hideButtons && "py-1.5 sm:pb-2"
+          )}
+          style={
+            singleAgentInput
+              ? {
+                  transition: `padding ${COLLAPSE_TRANSITION}`,
+                }
+              : undefined
+          }
+        >
+          <div
+            className="mb-1 flex flex-wrap items-center px-2"
+            style={toolbarRowTransitionStyle}
+          >
             {selectedSkills.map((skill) => (
               <React.Fragment key={skill.sId}>
                 {/* Two Chips: one for larger screens (desktop), one for smaller screens (mobile). */}
@@ -825,7 +899,10 @@ const InputBarContainer = ({
               </React.Fragment>
             ))}
           </div>
-          <div className="relative flex w-full items-center justify-between">
+          <div
+            className="relative flex w-full items-center justify-between"
+            style={toolbarRowTransitionStyle}
+          >
             {!isRecording && editor && (
               <Toolbar
                 variant="overlay"
@@ -850,7 +927,10 @@ const InputBarContainer = ({
               )}
             >
               {!isRecording && (
-                <div className="flex items-center">
+                <div
+                  className="flex items-center"
+                  style={buttonsTransitionStyle}
+                >
                   <Button
                     variant="ghost-secondary"
                     icon={TextIcon}
@@ -885,21 +965,10 @@ const InputBarContainer = ({
                 </div>
               )}
               <div className="grow" />
-              <div className="flex items-center gap-2 md:gap-1">
-                {!subscription.plan.isByok &&
-                  owner.metadata?.allowVoiceTranscription !== false &&
-                  actions.includes("voice") && (
-                    <VoicePicker
-                      status={voiceTranscriberService.status}
-                      level={voiceTranscriberService.level}
-                      elapsedSeconds={voiceTranscriberService.elapsedSeconds}
-                      onRecordStart={voiceTranscriberService.startRecording}
-                      onRecordStop={voiceTranscriberService.stopRecording}
-                      disabled={disableInput}
-                      size={buttonSize}
-                      showStopLabel={!isMobile}
-                    />
-                  )}
+              <div
+                className="flex items-center gap-2 md:gap-1"
+                style={buttonsTransitionStyle}
+              >
                 {clientType === "extension" && (
                   <>
                     <div ref={plusButtonRef}>
@@ -986,47 +1055,65 @@ const InputBarContainer = ({
                     )}
                   </>
                 )}
-                <Button
-                  size={buttonSize}
-                  isLoading={
-                    isSubmitting &&
-                    voiceTranscriberService.status !== "transcribing"
-                  }
-                  icon={ArrowUpIcon}
-                  variant="highlight"
-                  disabled={
-                    isEmpty ||
-                    isSubmitting ||
-                    disableInput ||
-                    voiceTranscriberService.status !== "idle"
-                  }
-                  onClick={async (e: React.MouseEvent<HTMLButtonElement>) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (disableAutoFocus) {
-                      editorService.blur();
-                      // wait a bit for the keyboard to be closed on mobile
-                      if (isMobile) {
-                        editorService.setLoading(true);
-                        await new Promise((resolve) =>
-                          setTimeout(resolve, 500)
-                        );
-                        editorService.setLoading(false);
-                      }
-                    }
-                    onEnterKeyDown(
-                      editorService.isEmpty(),
-                      editorService.getMarkdownAndMentions(),
-                      () => {
-                        editorService.clearEditor();
-                      },
-                      editorService.setLoading
-                    );
-                  }}
-                />
               </div>
             </div>
           </div>
+        </div>
+        {/* Single voice + send group: absolutely positioned over editor when hideButtons, bottom-right otherwise */}
+        <div
+          className={cn(
+            "absolute bottom-2 right-2 flex items-center gap-2 md:gap-1"
+          )}
+        >
+          {!subscription.plan.isByok &&
+            owner.metadata?.allowVoiceTranscription !== false &&
+            actions.includes("voice") && (
+              <VoicePicker
+                status={voiceTranscriberService.status}
+                level={voiceTranscriberService.level}
+                elapsedSeconds={voiceTranscriberService.elapsedSeconds}
+                onRecordStart={voiceTranscriberService.startRecording}
+                onRecordStop={voiceTranscriberService.stopRecording}
+                disabled={disableInput}
+                size={buttonSize}
+                showStopLabel={!isMobile}
+              />
+            )}
+          <Button
+            size={buttonSize}
+            isLoading={
+              isSubmitting && voiceTranscriberService.status !== "transcribing"
+            }
+            icon={ArrowUpIcon}
+            variant="highlight"
+            disabled={
+              isEmpty ||
+              isSubmitting ||
+              disableInput ||
+              voiceTranscriberService.status !== "idle"
+            }
+            onClick={async (e: React.MouseEvent<HTMLButtonElement>) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (disableAutoFocus) {
+                editorService.blur();
+                // wait a bit for the keyboard to be closed on mobile
+                if (isMobile) {
+                  editorService.setLoading(true);
+                  await new Promise((resolve) => setTimeout(resolve, 500));
+                  editorService.setLoading(false);
+                }
+              }
+              onEnterKeyDown(
+                editorService.isEmpty(),
+                editorService.getMarkdownAndMentions(),
+                () => {
+                  editorService.clearEditor();
+                },
+                editorService.setLoading
+              );
+            }}
+          />
         </div>
       </div>
     </div>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -148,6 +148,7 @@ export interface InputBarContainerProps {
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
+  onResetSelections: () => void;
   onSkillDeselect: (skill: SkillType) => void;
   onSkillSelect: (skill: SkillType) => void;
   owner: WorkspaceType;
@@ -182,6 +183,7 @@ const InputBarContainer = ({
   onMCPServerViewSelect,
   onMCPServerViewDeselect,
   selectedMCPServerViews,
+  onResetSelections,
   onSkillSelect,
   onSkillDeselect,
   selectedSkills,
@@ -527,17 +529,15 @@ const InputBarContainer = ({
   });
 
   // When a user is mentioned in single-agent mode, deselect the agent and clear capabilities.
-  // Uses a ref so the editor listener always calls the latest closure without needing
-  // all the deselection callbacks/arrays as effect dependencies.
+  // Uses a ref so the editor listener (registered once in the useEffect below) always calls
+  // the latest closure without re-registering the listener on every render.
   const onEditorMentionsChangedRef = useRef((_userMentioned: boolean) => {});
 
   onEditorMentionsChangedRef.current = (userMentioned: boolean) => {
     shouldSuggestAgentRef.current = !(singleAgentInput && userMentioned);
     if (singleAgentInput && userMentioned) {
       setSelectedSingleAgent(null);
-      selectedMCPServerViews.forEach((sv) => onMCPServerViewDeselect(sv));
-      selectedSkills.forEach((s) => onSkillDeselect(s));
-      attachedNodes.forEach((n) => onNodeUnselect(n));
+      onResetSelections();
       fileUploaderService.resetUpload();
     }
   };

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -459,19 +459,30 @@ const InputBarContainer = ({
     },
   });
 
-  // Keep a ref to the deselection logic so the editor listener doesn't need
-  // all the deselection callbacks/arrays as effect dependencies.
-  const onEditorMentionsChangedRef = useRef((_userMentioned: boolean) => {});
-  onEditorMentionsChangedRef.current = (userMentioned: boolean) => {
-    shouldSuggestAgentRef.current = !(singleAgentInput && userMentioned);
-    if (singleAgentInput && userMentioned) {
+  // When a user is mentioned in single-agent mode, deselect the agent and clear capabilities.
+  // TODO: Refactor to avoid cascading re-runs — each deselect call mutates a dependency array,
+  // re-triggering this effect until all arrays are empty.
+  useEffect(() => {
+    shouldSuggestAgentRef.current = !(singleAgentInput && hasUserMention);
+    if (singleAgentInput && hasUserMention) {
       setSelectedSingleAgent(null);
       selectedMCPServerViews.forEach((sv) => onMCPServerViewDeselect(sv));
       selectedSkills.forEach((s) => onSkillDeselect(s));
       attachedNodes.forEach((n) => onNodeUnselect(n));
       fileUploaderService.resetUpload();
     }
-  };
+  }, [
+    singleAgentInput,
+    hasUserMention,
+    setSelectedSingleAgent,
+    selectedMCPServerViews,
+    onMCPServerViewDeselect,
+    selectedSkills,
+    onSkillDeselect,
+    attachedNodes,
+    onNodeUnselect,
+    fileUploaderService,
+  ]);
 
   // Update the editor ref when the editor is created and listen for updates to the editor.
   useEffect(() => {
@@ -481,9 +492,7 @@ const InputBarContainer = ({
       // Auto-save draft when content changes and track user mentions.
       const { markdown, mentions } = editorService.getMarkdownAndMentions();
       saveDraft(markdown);
-      const userMentioned = mentions.some((m) => m.type === "user");
-      setHasUserMention(userMentioned);
-      onEditorMentionsChangedRef.current(userMentioned);
+      setHasUserMention(mentions.some((m) => m.type === "user"));
     };
 
     if (editorRef.current) {

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -51,7 +51,7 @@ export const InputBarContext = createContext<{
 
 interface InputBarContextProviderProps {
   children: ReactNode;
-  conversationId: string | null;
+  conversationId?: string | null;
   fileUploaderService: FileUploaderService;
   captureActions?: {
     onCapture: (type: "text" | "screenshot") => void;
@@ -61,7 +61,7 @@ interface InputBarContextProviderProps {
 
 export function InputBarContextProvider({
   children,
-  conversationId,
+  conversationId = null,
   fileUploaderService,
   captureActions,
 }: InputBarContextProviderProps) {

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -51,6 +51,7 @@ export const InputBarContext = createContext<{
 
 interface InputBarContextProviderProps {
   children: ReactNode;
+  conversationId: string | null;
   fileUploaderService: FileUploaderService;
   captureActions?: {
     onCapture: (type: "text" | "screenshot") => void;
@@ -60,6 +61,7 @@ interface InputBarContextProviderProps {
 
 export function InputBarContextProvider({
   children,
+  conversationId,
   fileUploaderService,
   captureActions,
 }: InputBarContextProviderProps) {
@@ -73,6 +75,14 @@ export function InputBarContextProvider({
   // Persistent agent selection for single-agent input mode (displayed in the agent picker button).
   const [selectedSingleAgent, setSelectedSingleAgent] =
     useState<RichAgentMention | null>(null);
+
+  // Reset the single-agent selection when conversation changes so the stale
+  // agent from a previous conversation doesn't leak into the new one.
+  const [prevConversationId, setPrevConversationId] = useState(conversationId);
+  if (conversationId !== prevConversationId) {
+    setPrevConversationId(conversationId);
+    setSelectedSingleAgent(null);
+  }
 
   // Useful when a component needs to pre-fill the input bar with text (e.g. butler suggestions).
   const [pendingInputText, setPendingInputTextState] = useState<string | null>(
@@ -176,7 +186,10 @@ export function InputBarProvider({ children }: InputBarProviderProps) {
   }
 
   return (
-    <InputBarContextProvider fileUploaderService={fileUploaderService}>
+    <InputBarContextProvider
+      conversationId={conversationId}
+      fileUploaderService={fileUploaderService}
+    >
       {children}
     </InputBarContextProvider>
   );

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -15,7 +15,7 @@ import {
 
 export const InputBarContext = createContext<{
   animate: boolean;
-  getAndClearSelectedAgent: () => RichAgentMention | null;
+  selectedAgent: RichAgentMention | null;
   setAnimate: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
   selectedSingleAgent: RichAgentMention | null;
@@ -29,7 +29,7 @@ export const InputBarContext = createContext<{
   };
 }>({
   animate: false,
-  getAndClearSelectedAgent: () => null,
+  selectedAgent: null,
   setAnimate: () => {},
   setSelectedAgent: () => {},
   selectedSingleAgent: null,
@@ -92,14 +92,6 @@ export function InputBarContextProvider({
     [setSelectedAgent]
   );
 
-  // Immediately clear the selected agent and return the previous selected agent to avoid sticky agent mentions.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
-  const getAndClearSelectedAgent = useCallback(() => {
-    const previousSelectedAgent = selectedAgent;
-    setSelectedAgent(null);
-    return previousSelectedAgent;
-  }, [selectedAgent, setSelectedAgent]);
-
   const getAndClearPendingInputText = useCallback(() => {
     const text = pendingInputText;
     setPendingInputTextState(null);
@@ -114,7 +106,7 @@ export function InputBarContextProvider({
     () => ({
       animate,
       setAnimate,
-      getAndClearSelectedAgent,
+      selectedAgent,
       setSelectedAgent: setSelectedAgentOuter,
       selectedSingleAgent,
       setSelectedSingleAgent,
@@ -125,7 +117,7 @@ export function InputBarContextProvider({
     }),
     [
       animate,
-      getAndClearSelectedAgent,
+      selectedAgent,
       setSelectedAgentOuter,
       selectedSingleAgent,
       getAndClearPendingInputText,

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -15,7 +15,7 @@ import {
 
 export const InputBarContext = createContext<{
   animate: boolean;
-  selectedAgent: RichAgentMention | null;
+  getAndClearSelectedAgent: () => RichAgentMention | null;
   setAnimate: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
   selectedSingleAgent: RichAgentMention | null;
@@ -29,7 +29,7 @@ export const InputBarContext = createContext<{
   };
 }>({
   animate: false,
-  selectedAgent: null,
+  getAndClearSelectedAgent: () => null,
   setAnimate: () => {},
   setSelectedAgent: () => {},
   selectedSingleAgent: null,
@@ -92,6 +92,14 @@ export function InputBarContextProvider({
     [setSelectedAgent]
   );
 
+  // Immediately clear the selected agent and return the previous selected agent to avoid sticky agent mentions.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
+  const getAndClearSelectedAgent = useCallback(() => {
+    const previousSelectedAgent = selectedAgent;
+    setSelectedAgent(null);
+    return previousSelectedAgent;
+  }, [selectedAgent, setSelectedAgent]);
+
   const getAndClearPendingInputText = useCallback(() => {
     const text = pendingInputText;
     setPendingInputTextState(null);
@@ -106,7 +114,7 @@ export function InputBarContextProvider({
     () => ({
       animate,
       setAnimate,
-      selectedAgent,
+      getAndClearSelectedAgent,
       setSelectedAgent: setSelectedAgentOuter,
       selectedSingleAgent,
       setSelectedSingleAgent,
@@ -117,7 +125,7 @@ export function InputBarContextProvider({
     }),
     [
       animate,
-      selectedAgent,
+      getAndClearSelectedAgent,
       setSelectedAgentOuter,
       selectedSingleAgent,
       getAndClearPendingInputText,

--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -1,10 +1,12 @@
 import logger from "@app/logger/logger";
+import type { RichAgentMention } from "@app/types/assistant/mentions";
 import debounce from "lodash/debounce";
 import { useCallback, useEffect, useRef } from "react";
 
 interface ConversationDraft {
   text: string;
   timestamp: number;
+  agentMention?: RichAgentMention | null;
 }
 
 type KeyId = string;
@@ -92,6 +94,7 @@ export function useConversationDrafts({
             draftKey: string;
             text: string;
             timestamp: number;
+            agentMention?: RichAgentMention | null;
           }) => void
         >
       >
@@ -110,12 +113,14 @@ export function useConversationDrafts({
         draftKey,
         text,
         timestamp,
+        agentMention,
       }: {
         workspaceId: string;
         userId: string;
         draftKey: string;
         text: string;
         timestamp: number;
+        agentMention?: RichAgentMention | null;
       }) => {
         if (!userId) {
           return;
@@ -125,6 +130,7 @@ export function useConversationDrafts({
         drafts[getKeyId(workspaceId, userId, draftKey)] = {
           text,
           timestamp,
+          agentMention,
         };
         saveDraftsToStorage(drafts);
       },
@@ -134,7 +140,7 @@ export function useConversationDrafts({
 
   // Save draft for current conversation (debounced).
   const saveDraft = useCallback(
-    (text: string) => {
+    (text: string, agentMention?: RichAgentMention | null) => {
       if (!shouldUseDraft || !userId) {
         return;
       }
@@ -145,6 +151,7 @@ export function useConversationDrafts({
         draftKey,
         text,
         timestamp: Date.now(),
+        agentMention,
       });
     },
     [workspaceId, userId, shouldUseDraft, draftKey]

--- a/front/components/editor/input_bar/mentionSuggestion.tsx
+++ b/front/components/editor/input_bar/mentionSuggestion.tsx
@@ -11,6 +11,7 @@ import type {
   SuggestionKeyDownProps,
   SuggestionProps,
 } from "@tiptap/suggestion";
+import type React from "react";
 import type { RefAttributes } from "react";
 
 export const mentionPluginKey = new PluginKey("mention-suggestion");
@@ -20,6 +21,7 @@ export function createMentionSuggestion({
   conversationId,
   spaceId,
   select,
+  shouldSuggestAgentRef,
   includeCurrentUser = false,
   onAgentSelect,
   singleAgentInputEnabled,
@@ -32,6 +34,8 @@ export function createMentionSuggestion({
     agents: boolean;
     users: boolean;
   };
+  // Optional ref that gates select.agents at render time (used to hide agents dynamically in single-agent mode).
+  shouldSuggestAgentRef?: React.RefObject<boolean>;
   onAgentSelect?: (mention: RichMention) => void;
   singleAgentInputEnabled?: boolean;
 }) {
@@ -90,7 +94,11 @@ export function createMentionSuggestion({
               spaceId,
               includeCurrentUser,
               onClose: closeDropdown,
-              select,
+              select: {
+                agents:
+                  select.agents && (shouldSuggestAgentRef?.current ?? true),
+                users: select.users,
+              },
             },
           });
 
@@ -104,6 +112,10 @@ export function createMentionSuggestion({
             owner,
             conversationId,
             spaceId,
+            select: {
+              agents: select.agents && (shouldSuggestAgentRef?.current ?? true),
+              users: select.users,
+            },
           });
         },
 

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -189,6 +189,8 @@ export interface CustomEditorProps {
   }) => void;
   longTextPasteCharsThreshold?: number;
   onInlineText?: (fileId: string, textContent: string) => void;
+  // Ref that dynamically controls whether agent suggestions are shown for single agent mode.
+  shouldSuggestAgentRef?: React.RefObject<boolean>;
 }
 
 export const buildEditorExtensions = ({
@@ -200,6 +202,7 @@ export const buildEditorExtensions = ({
   onUrlDetected,
   onAgentSelect,
   singleAgentInputEnabled,
+  shouldSuggestAgentRef,
 }: {
   owner: WorkspaceType;
   conversationId?: string | null;
@@ -209,6 +212,7 @@ export const buildEditorExtensions = ({
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
   onAgentSelect?: (mention: RichMention) => void;
   singleAgentInputEnabled?: boolean;
+  shouldSuggestAgentRef?: React.RefObject<boolean>;
 }) => {
   const extensions = [
     KeyboardShortcutsExtension,
@@ -282,6 +286,7 @@ export const buildEditorExtensions = ({
           agents: true,
           users: !disableUserMentions,
         },
+        shouldSuggestAgentRef,
         onAgentSelect,
         singleAgentInputEnabled,
       }),
@@ -326,6 +331,7 @@ const useCustomEditor = ({
   onLongTextPaste,
   longTextPasteCharsThreshold,
   onInlineText,
+  shouldSuggestAgentRef,
 }: CustomEditorProps) => {
   const editor = useEditor(
     {
@@ -339,6 +345,7 @@ const useCustomEditor = ({
         onUrlDetected,
         onAgentSelect,
         singleAgentInputEnabled,
+        shouldSuggestAgentRef,
       }),
       shouldRerenderOnTransaction: true, // necessary to update the editor state (and so the toolbar icons "activation") in real time
       editorProps: {

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -38,7 +38,12 @@ const useHandleMentions = (
     if (agentMention) {
       setSelectedSingleAgent(agentMention);
     }
-  }, [singleAgentInput, stickyMentions, setSelectedSingleAgent, draftAgentRestoredRef]);
+  }, [
+    singleAgentInput,
+    stickyMentions,
+    setSelectedSingleAgent,
+    draftAgentRestoredRef,
+  ]);
 
   useEffect(() => {
     if (!stickyMentions || stickyMentions.length === 0) {

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -6,6 +6,7 @@ import type {
   RichMention,
 } from "@app/types/assistant/mentions";
 import { isRichAgentMention } from "@app/types/assistant/mentions";
+import type { MutableRefObject } from "react";
 import { useContext, useEffect, useRef } from "react";
 
 const useHandleMentions = (
@@ -13,7 +14,8 @@ const useHandleMentions = (
   stickyMentions: RichMention[] | undefined,
   selectedAgent: RichAgentMention | null,
   disableAutoFocus: boolean,
-  pendingInputText?: string | null
+  pendingInputText?: string | null,
+  draftAgentRestoredRef?: MutableRefObject<boolean>
 ) => {
   const stickyMentionsTextContent = useRef<string | null>(null);
   const singleAgentInput = isSingleAgentInputEnabled();
@@ -23,15 +25,20 @@ const useHandleMentions = (
   // so the agent picker button shows the correct agent on existing conversations.
   // Only sync when sticky mentions are provided (existing conversations); skip for
   // new conversations (undefined stickyMentions) to avoid overriding the auto-selected default.
+  // Also skip when the draft restore already set the agent to avoid overwriting the user's draft.
   useEffect(() => {
     if (!singleAgentInput || !stickyMentions) {
+      return;
+    }
+    // Skip if the draft restore effect already set the selected agent.
+    if (draftAgentRestoredRef?.current) {
       return;
     }
     const agentMention = stickyMentions.find(isRichAgentMention) ?? null;
     if (agentMention) {
       setSelectedSingleAgent(agentMention);
     }
-  }, [singleAgentInput, stickyMentions, setSelectedSingleAgent]);
+  }, [singleAgentInput, stickyMentions, setSelectedSingleAgent, draftAgentRestoredRef]);
 
   useEffect(() => {
     if (!stickyMentions || stickyMentions.length === 0) {

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -67,23 +67,29 @@ const useHandleMentions = (
   }, [editorService, stickyMentions, disableAutoFocus, singleAgentInput]);
 
   useEffect(() => {
-    if (selectedAgent) {
-      if (!editorService.hasMention(selectedAgent)) {
-        // Schedule insertion to avoid synchronous editor updates during React render/effects.
-        queueMicrotask(() => {
-          editorService.insertMention(selectedAgent);
-          // If there's pending input text (e.g. from a butler suggestion), insert it after the mention.
-          if (pendingInputText) {
-            editorService.insertText(pendingInputText);
-          }
-        });
+    if (singleAgentInput) {
+      if (pendingInputText) {
+        queueMicrotask(() => editorService.insertText(pendingInputText));
+      }
+    } else {
+      if (selectedAgent) {
+        if (!editorService.hasMention(selectedAgent)) {
+          // Schedule insertion to avoid synchronous editor updates during React render/effects.
+          queueMicrotask(() => {
+            editorService.insertMention(selectedAgent);
+            // If there's pending input text (e.g. from a butler suggestion), insert it after the mention.
+            if (pendingInputText) {
+              editorService.insertText(pendingInputText);
+            }
+          });
+        } else if (pendingInputText) {
+          queueMicrotask(() => editorService.insertText(pendingInputText));
+        }
       } else if (pendingInputText) {
         queueMicrotask(() => editorService.insertText(pendingInputText));
       }
-    } else if (pendingInputText) {
-      queueMicrotask(() => editorService.insertText(pendingInputText));
     }
-  }, [selectedAgent, pendingInputText, editorService]);
+  }, [selectedAgent, pendingInputText, editorService, singleAgentInput]);
 
   return { stickyMentionsTextContent };
 };

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -66,29 +66,22 @@ const useHandleMentions = (
     }
   }, [editorService, stickyMentions, disableAutoFocus, singleAgentInput]);
 
+  // Insert the selected agent mention into the editor (non-single-agent mode only)
+  // and any pending input text (e.g. from butler suggestions).
+  // Scheduled via queueMicrotask to avoid synchronous editor updates during React render/effects.
   useEffect(() => {
-    if (singleAgentInput) {
+    queueMicrotask(() => {
+      if (
+        !singleAgentInput &&
+        selectedAgent &&
+        !editorService.hasMention(selectedAgent)
+      ) {
+        editorService.insertMention(selectedAgent);
+      }
       if (pendingInputText) {
-        queueMicrotask(() => editorService.insertText(pendingInputText));
+        editorService.insertText(pendingInputText);
       }
-    } else {
-      if (selectedAgent) {
-        if (!editorService.hasMention(selectedAgent)) {
-          // Schedule insertion to avoid synchronous editor updates during React render/effects.
-          queueMicrotask(() => {
-            editorService.insertMention(selectedAgent);
-            // If there's pending input text (e.g. from a butler suggestion), insert it after the mention.
-            if (pendingInputText) {
-              editorService.insertText(pendingInputText);
-            }
-          });
-        } else if (pendingInputText) {
-          queueMicrotask(() => editorService.insertText(pendingInputText));
-        }
-      } else if (pendingInputText) {
-        queueMicrotask(() => editorService.insertText(pendingInputText));
-      }
-    }
+    });
   }, [selectedAgent, pendingInputText, editorService, singleAgentInput]);
 
   return { stickyMentionsTextContent };

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -66,24 +66,24 @@ const useHandleMentions = (
     }
   }, [editorService, stickyMentions, disableAutoFocus, singleAgentInput]);
 
-  // Insert the selected agent mention into the editor (non-single-agent mode only)
-  // and any pending input text (e.g. from butler suggestions).
-  // Scheduled via queueMicrotask to avoid synchronous editor updates during React render/effects.
   useEffect(() => {
-    queueMicrotask(() => {
-      if (
-        !singleAgentInput &&
-        selectedAgent &&
-        !editorService.hasMention(selectedAgent)
-      ) {
-        editorService.insertMention(selectedAgent);
-        setSelectedAgent(null);
+    if (selectedAgent) {
+      if (!editorService.hasMention(selectedAgent)) {
+        // Schedule insertion to avoid synchronous editor updates during React render/effects.
+        queueMicrotask(() => {
+          editorService.insertMention(selectedAgent);
+          // If there's pending input text (e.g. from a butler suggestion), insert it after the mention.
+          if (pendingInputText) {
+            editorService.insertText(pendingInputText);
+          }
+        });
+      } else if (pendingInputText) {
+        queueMicrotask(() => editorService.insertText(pendingInputText));
       }
-      if (pendingInputText) {
-        editorService.insertText(pendingInputText);
-      }
-    });
-  }, [selectedAgent, pendingInputText, editorService, singleAgentInput]);
+    } else if (pendingInputText) {
+      queueMicrotask(() => editorService.insertText(pendingInputText));
+    }
+  }, [selectedAgent, pendingInputText, editorService]);
 
   return { stickyMentionsTextContent };
 };

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -77,6 +77,7 @@ const useHandleMentions = (
         !editorService.hasMention(selectedAgent)
       ) {
         editorService.insertMention(selectedAgent);
+        setSelectedAgent(null);
       }
       if (pendingInputText) {
         editorService.insertText(pendingInputText);

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -20,14 +20,17 @@ const useHandleMentions = (
   const { setSelectedSingleAgent } = useContext(InputBarContext);
 
   // In single agent mode, sync the selected agent from sticky mentions
-  // so the agent picker button shows the correct agent on existing conversations,
-  // and clears it when navigating to a new conversation.
+  // so the agent picker button shows the correct agent on existing conversations.
+  // Only sync when sticky mentions are provided (existing conversations); skip for
+  // new conversations (undefined stickyMentions) to avoid overriding the auto-selected default.
   useEffect(() => {
-    if (!singleAgentInput) {
+    if (!singleAgentInput || !stickyMentions) {
       return;
     }
-    const agentMention = stickyMentions?.find(isRichAgentMention) ?? null;
-    setSelectedSingleAgent(agentMention);
+    const agentMention = stickyMentions.find(isRichAgentMention) ?? null;
+    if (agentMention) {
+      setSelectedSingleAgent(agentMention);
+    }
   }, [singleAgentInput, stickyMentions, setSelectedSingleAgent]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description
This PR is a re-re-retry of [this PR](https://github.com/dust-tt/dust/pull/23668). I'm aware that sometimes draft restoration logic is not working well (race condition somewhere but my brain is no longer working) & sometimes we set @/dust as default agent in sidekick, I will fix that next week 🙃

The description from the previous PR:

This PR is to improve the single agent input behavior. 

- Select @/Dust by default for new conversations (only in conversation context)
- When you mention a human you cannot mention an agent, and you cannot add skills & attachements etc

This PR does NOT contain the following and I will create separate PRs for that :
- the logic to prevent you sending a new message when you switch to another agent, but the agent loop with previous agent hasn't been finished
- preventing you from mentioning multiple agents via copy paste, or mentioning an agent via copy paste when a human is mentioned 
- transition animation when you start a new conversation with a human mention only (the input bar gets back to the normal size during the page transition and it doesn't look nice, clément and I have an idea but this is low prio) 
- disable file drop when a human is mentioned
- mobile view doesn't look nice
<img width="718" height="268" alt="CleanShot 2026-04-03 at 10 20 06@2x" src="https://github.com/user-attachments/assets/9d421b2a-bba0-43b4-895f-8f0a33758c28" />
<img width="730" height="140" alt="CleanShot 2026-04-03 at 10 20 21@2x" src="https://github.com/user-attachments/assets/bda2cd79-355c-4b36-9262-28a124caf30b" />


I tested in both with and without the ff in the following: 

in Agent Builder
- Sidekick works as usual
- Preview works as usual

In conversation view:
- Draft correctly restores agent & text for new and existing conversations
- If there is a draft pick up an agent from draft. If not, take from the last one. If not, use @/dust for new conversation.
- skills & files are removed as soon as you mention a human (I need to disable drag & drop file feature, I will do it in another PR)


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
