### PR TITLE
Use HTTP 307 redirects for cross-region share token resolution

### DIFF
--- a/front/lib/api/regions/lookup.ts
+++ b/front/lib/api/regions/lookup.ts
@@ -1,6 +1,7 @@
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import type { RegionType } from "@app/lib/api/regions/config";
 import { config } from "@app/lib/api/regions/config";
+import logger from "@app/logger/logger";
 import { isWorkspaceRelocationDone } from "@app/lib/api/workspace";
 import { findWorkspaceWithVerifiedDomain } from "@app/lib/iam/workspaces";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
@@ -303,6 +304,30 @@ export async function lookupShareToken(
   } catch (error) {
     return new Err(normalizeError(error));
   }
+}
+
+/**
+ * Returns the full URL in the other region for this share token, or null if the token should be
+ * handled locally.
+ */
+export async function getShareTokenRegionRedirectUrl(
+  { requestUrl, token }: { requestUrl: string; token: string }
+): Promise<string | null> {
+  const lookupResult = await lookupShareToken(token);
+  if (lookupResult.isErr()) {
+    logger.error(
+      { err: lookupResult.error },
+      "Failed to lookup share token in other region"
+    );
+    return null;
+  }
+
+  const otherRegion = lookupResult.value;
+  if (!otherRegion) {
+    return null;
+  }
+
+  return `${config.getRegionUrl(otherRegion)}${requestUrl}`;
 }
 
 /**

--- a/front/lib/swr/share.ts
+++ b/front/lib/swr/share.ts
@@ -1,13 +1,11 @@
-import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   getErrorFromResponse,
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import { isRegionRedirect } from "@app/lib/swr/workspaces";
 import type { GetShareFrameMetadataResponseBody } from "@app/pages/api/share/frame/[token]";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 export function useShareFrameMetadata({
@@ -18,11 +16,10 @@ export function useShareFrameMetadata({
   const { fetcher } = useFetcher();
   const shareMetadataFetcher: Fetcher<GetShareFrameMetadataResponseBody> =
     fetcher;
-  const regionContext = useRegionContext();
 
   const swrKey = shareToken ? `/api/share/frame/${shareToken}` : null;
 
-  const { data, error, isLoading, mutate } = useSWRWithDefaults(
+  const { data, error, isLoading } = useSWRWithDefaults(
     swrKey,
     shareMetadataFetcher,
     {
@@ -31,26 +28,10 @@ export function useShareFrameMetadata({
     }
   );
 
-  const isRegionRedirectResponse = error && isRegionRedirect(error.error);
-  const regionRedirect = isRegionRedirectResponse
-    ? error.error.redirect
-    : undefined;
-
-  // Handle region redirect.
-  useEffect(() => {
-    if (regionRedirect) {
-      regionContext.setRegionInfo({
-        name: regionRedirect.region,
-        url: regionRedirect.url,
-      });
-      void mutate();
-    }
-  }, [regionRedirect, mutate, regionContext]);
-
   return {
-    shareMetadata: isRegionRedirectResponse ? undefined : data,
-    isShareMetadataLoading: isLoading || !!isRegionRedirectResponse,
-    shareMetadataError: isRegionRedirectResponse ? undefined : error,
+    shareMetadata: data,
+    isShareMetadataLoading: isLoading,
+    shareMetadataError: error,
   };
 }
 

--- a/front/pages/api/share/frame/[token].ts
+++ b/front/pages/api/share/frame/[token].ts
@@ -1,10 +1,8 @@
 /** @ignoreswagger */
 import config from "@app/lib/api/config";
-import { config as regionConfig } from "@app/lib/api/regions/config";
-import { lookupShareToken } from "@app/lib/api/regions/lookup";
+import { getShareTokenRegionRedirectUrl } from "@app/lib/api/regions/lookup";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isInteractiveContentType } from "@app/types/files";
@@ -47,26 +45,10 @@ async function handler(
   const result = await FileResource.fetchByShareToken(token);
   if (result.isErr()) {
     if (result.error.code === "file_not_found") {
-      // Not found locally — check other region.
-      const lookupResult = await lookupShareToken(token);
-      if (lookupResult.isErr()) {
-        logger.error(
-          { err: lookupResult.error },
-          "Failed to lookup share token in other region"
-        );
-      }
-      if (lookupResult.isOk() && lookupResult.value) {
-        const region = lookupResult.value;
-        return res.status(400).json({
-          error: {
-            type: "workspace_in_different_region",
-            message: "File is located in a different region",
-            redirect: {
-              region,
-              url: regionConfig.getRegionUrl(region),
-            },
-          },
-        });
+      const redirectUrl = await getShareTokenRegionRedirectUrl({ requestUrl: req.url ?? "", token });
+      if (redirectUrl) {
+        res.redirect(307, redirectUrl);
+        return;
       }
     }
 

--- a/front/pages/api/v1/public/frames/[token]/index.test.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.test.ts
@@ -23,6 +23,13 @@ vi.mock("@app/lib/api/auth_wrappers", () => ({
   getAuthForSharedEndpointWorkspaceMembersOnly: vi.fn(),
 }));
 
+// Mock region redirect — returns null by default (no redirect).
+vi.mock("@app/lib/api/regions/lookup", () => ({
+  getShareTokenRegionRedirectUrl: vi.fn().mockResolvedValue(null),
+}));
+
+import { getShareTokenRegionRedirectUrl } from "@app/lib/api/regions/lookup";
+
 describe("GET /api/v1/public/frames/[token]", () => {
   let auth: Authenticator;
   let user: UserResource;
@@ -444,6 +451,40 @@ describe("GET /api/v1/public/frames/[token]", () => {
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);
+    });
+  });
+
+  describe("cross-region redirect", () => {
+    it("returns 307 when token belongs to another region", async () => {
+      const otherRegionUrl = "https://eu.dust.tt/api/v1/public/frames/unknown-token";
+      vi.mocked(getShareTokenRegionRedirectUrl).mockResolvedValueOnce(
+        otherRegionUrl
+      );
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { token: "unknown-token" },
+        url: "/api/v1/public/frames/unknown-token",
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(307);
+      expect(res._getRedirectUrl()).toBe(otherRegionUrl);
+    });
+
+    it("returns 404 when token is not found in any region", async () => {
+      vi.mocked(getShareTokenRegionRedirectUrl).mockResolvedValueOnce(null);
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { token: "nonexistent-token" },
+        url: "/api/v1/public/frames/nonexistent-token",
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
     });
   });
 });

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -1,5 +1,6 @@
 import { getAuthForSharedEndpointWorkspaceMembersOnly } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { getShareTokenRegionRedirectUrl } from "@app/lib/api/regions/lookup";
 import {
   FRAME_SESSION_COOKIE_NAME,
   getFrameSessionEmail,
@@ -10,7 +11,6 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getConversationRoute, getProjectRoute } from "@app/lib/utils/router";
-import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isInteractiveContentType } from "@app/types/files";
@@ -49,14 +49,11 @@ async function handler(
 
   const result = await FileResource.fetchByShareToken(token);
   if (result.isErr()) {
-    logger.info(
-      {
-        token,
-        errorCode: result.error.code,
-        errorMessage: result.error.message,
-      },
-      "Public frame fetch failed"
-    );
+    const redirectUrl = await getShareTokenRegionRedirectUrl({ requestUrl: req.url ?? "", token });
+    if (redirectUrl) {
+      res.redirect(307, redirectUrl);
+      return;
+    }
 
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/v1/public/frames/[token]/verify-code.ts
+++ b/front/pages/api/v1/public/frames/[token]/verify-code.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+import { getShareTokenRegionRedirectUrl } from "@app/lib/api/regions/lookup";
 import { createFrameSession } from "@app/lib/api/share/frame_session";
 import { validateFrameOtpChallenge } from "@app/lib/api/share/frame_sharing";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -62,6 +63,12 @@ async function handler(
 
   const result = await FileResource.fetchByShareToken(token);
   if (result.isErr()) {
+    const redirectUrl = await getShareTokenRegionRedirectUrl({ requestUrl: req.url ?? "", token });
+    if (redirectUrl) {
+      res.redirect(307, redirectUrl);
+      return;
+    }
+
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/pages/api/v1/public/frames/[token]/verify-email.ts
+++ b/front/pages/api/v1/public/frames/[token]/verify-email.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+import { getShareTokenRegionRedirectUrl } from "@app/lib/api/regions/lookup";
 import {
   generateFrameOtpChallenge,
   sendFrameOtpEmail,
@@ -60,6 +61,12 @@ async function handler(
 
   const result = await FileResource.fetchByShareToken(token);
   if (result.isErr()) {
+    const redirectUrl = await getShareTokenRegionRedirectUrl({ requestUrl: req.url ?? "", token });
+    if (redirectUrl) {
+      res.redirect(307, redirectUrl);
+      return;
+    }
+
     // Return 200 to prevent enumeration.
     return res.status(200).json({ success: true });
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When a shared frame lives in a different region than the one the user's request lands on, we need to route API calls to the correct backend. Until now, only the metadata endpoint (`/api/share/frame/[token]`) handled this, by returning a JSON error with `workspace_in_different_region` that the client had to parse. The SPA then called `regionContext.setRegionInfo()`, which mutated a global React context, invalidated the entire SWR cache, and re-triggered all fetches against the new region. This had several problems:
- First, the three v1 endpoints (`/api/v1/public/frames/[token]`, `/verify-email`, `/verify-code`) didn't have any cross-region lookup at all. They just returned 404 if the file wasn't local. So the flow only worked because the metadata endpoint happened to fire first and switch the region context before the content endpoint retried.
- Second, mutating `RegionContext` from a share page is conceptually wrong. It's a global singleton that affects all SWR fetches, meaning a share link to a file in region B could pollute API routing for a user whose workspace is in region A.

The fix is straightforward: use standard HTTP 307 Temporary Redirect. All four share endpoints now do a cross-region lookup when `fetchByShareToken` fails, and if the token exists in the other region, respond with a 307 pointing to the correct regional URL. The browser's fetch follows the redirect transparently. The client never knows it happened. This removes the `RegionContext` and `isRegionRedirect` handling from the share SWR hooks entirely. 307 (not 302) because it preserves the HTTP method, which matters for the POST verification endpoints.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
