### PR TITLE
`enable_steering` feature flag, `steeringEnabled` invariants and code path in `postUserMessage`

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -565,7 +565,7 @@ export async function postUserMessage(
     agenticMessageData,
     skipToolsValidation,
     doNotAssociateUser,
-    enforceSteeringInvariants,
+    steeringEnabled,
   }: {
     conversation: ConversationType;
     content: string;
@@ -574,7 +574,7 @@ export async function postUserMessage(
     agenticMessageData?: AgenticMessageData;
     skipToolsValidation: boolean;
     doNotAssociateUser?: boolean;
-    enforceSteeringInvariants?: boolean;
+    steeringEnabled?: boolean;
   }
 ): Promise<
   Result<
@@ -632,8 +632,9 @@ export async function postUserMessage(
     return limitResult;
   }
 
-  // Steering invariants: enforce single agent loop per conversation.
-  if (enforceSteeringInvariants) {
+  // Steering invariants: enforce single agent loop per conversation when
+  // `steeringEnabled` is true.
+  if (steeringEnabled) {
     const agentMentions = mentions.filter(isAgentMention);
 
     // At most one agent mention per message.
@@ -664,7 +665,7 @@ export async function postUserMessage(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Cannot address a different agent while one is running.",
+            message: "Cannot run a different agent while one is running.",
           },
         });
       }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -565,6 +565,7 @@ export async function postUserMessage(
     agenticMessageData,
     skipToolsValidation,
     doNotAssociateUser,
+    enforceSteeringInvariants,
   }: {
     conversation: ConversationType;
     content: string;
@@ -573,6 +574,7 @@ export async function postUserMessage(
     agenticMessageData?: AgenticMessageData;
     skipToolsValidation: boolean;
     doNotAssociateUser?: boolean;
+    enforceSteeringInvariants?: boolean;
   }
 ): Promise<
   Result<
@@ -628,6 +630,45 @@ export async function postUserMessage(
   const limitResult = await checkMessagesLimit(auth, { mentions, context });
   if (limitResult.isErr()) {
     return limitResult;
+  }
+
+  // Steering invariants: enforce single agent loop per conversation.
+  if (enforceSteeringInvariants) {
+    const agentMentions = mentions.filter(isAgentMention);
+
+    // At most one agent mention per message.
+    if (agentMentions.length > 1) {
+      return new Err({
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Only one agent can be mentioned per message.",
+        },
+      });
+    }
+
+    // Cannot address a different agent than the running one.
+    const runningAgentMessage = conversation.content
+      .flat()
+      .find(
+        (m): m is AgentMessageType =>
+          isAgentMessageType(m) && m.status === "created"
+      );
+
+    if (runningAgentMessage && agentMentions.length > 0) {
+      if (
+        agentMentions[0].configurationId !==
+        runningAgentMessage.configuration.sId
+      ) {
+        return new Err({
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Cannot address a different agent while one is running.",
+          },
+        });
+      }
+    }
   }
 
   // `getAgentConfiguration` checks that we're only pulling a configuration from the

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -855,8 +855,12 @@ export async function postUserMessage(
       }
     }
 
+    // We set the visibility of the user message to "pending" if steering is enabled, we have a
+    // running agent message and there are agent mentions in the user messsage.
     const visibility: MessageVisibility =
-      steeringEnabled && runningAgentMessage ? "pending" : "visible";
+      steeringEnabled && runningAgentMessage && agentMentions.length > 0
+        ? "pending"
+        : "visible";
 
     // Return the user message without mentions.
     // This way typescript forces us to create the mentions after the user message is created.
@@ -891,9 +895,9 @@ export async function postUserMessage(
       });
     }
 
-    if (steeringEnabled && runningAgentMessage) {
-      // Pending path: agent is still running, create a pending user message without an agent
-      // message.
+    if (visibility === "pending") {
+      // Pending path: agent is still running, and we have agent mentions, create a pending user
+      // message without an agent message.
       const userMessage = {
         ...userMessageWithoutMentions,
         richMentions,
@@ -993,7 +997,11 @@ export async function postUserMessage(
       conversation,
       userMessage,
     });
-  } else if (steeringEnabled && runningAgentMessage) {
+  } else if (
+    steeringEnabled &&
+    runningAgentMessage &&
+    userMessage.visibility === "pending"
+  ) {
     // Pending path: signal the running agent loop to gracefully stop.
     await gracefullyStopAgentLoop(auth, {
       messageIds: [runningAgentMessage.sId],

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -634,7 +634,7 @@ export async function postUserMessage(
   }
 
   const agentMentions = mentions.filter(isAgentMention);
-  const runningAgentMessage = conversation.content
+  let runningAgentMessage = conversation.content
     .flat()
     .find(
       (m): m is AgentMessageType =>
@@ -758,63 +758,70 @@ export async function postUserMessage(
     // connection pool, resulting in a deadlock.
     await getConversationRankVersionLock(auth, conversation, t);
 
-    // Pending path: re-read agent message status under lock. If the agent is
-    // still running, create a pending user message without an agent message.
+    // Re-read the agent message status inside the critical section of the
+    // advisory lock. Between the initial check and acquiring the lock, the
+    // agent loop may have finalized — if so, clear runningAgentMessage so we
+    // fall through to the normal flow.
     if (steeringEnabled && runningAgentMessage) {
       const agentMessageRow = await AgentMessageModel.findByPk(
         runningAgentMessage.agentMessageId,
         { transaction: t }
       );
 
-      if (agentMessageRow?.status === "created") {
-        const nextMessageRank =
-          ((await MessageModel.max<number | null, MessageModel>("rank", {
-            where: {
-              workspaceId: owner.id,
-              conversationId: conversation.id,
-              branchId: conversation.branchId
-                ? getResourceIdFromSId(conversation.branchId)
-                : null,
-            },
-            transaction: t,
-          })) ?? -1) + 1;
+      if (agentMessageRow?.status !== "created") {
+        runningAgentMessage = undefined;
+      }
+    }
 
-        const enrichedContext: UserMessageContext = {
-          ...context,
-          apiKeyId: auth.key()?.id ?? null,
-          authMethod: auth.authMethod(),
-        };
-
-        const userMessageWithoutMentions = await createUserMessage(auth, {
-          conversation,
-          content,
-          metadata: {
-            type: "create",
-            user: doNotAssociateUser ? null : (user?.toJSON() ?? null),
-            rank: nextMessageRank,
-            context: enrichedContext,
-            agenticMessageData,
-            visibility: "pending",
+    // Pending path: agent is still running, create a pending user message
+    // without an agent message.
+    if (steeringEnabled && runningAgentMessage) {
+      const nextMessageRank =
+        ((await MessageModel.max<number | null, MessageModel>("rank", {
+          where: {
+            workspaceId: owner.id,
+            conversationId: conversation.id,
+            branchId: conversation.branchId
+              ? getResourceIdFromSId(conversation.branchId)
+              : null,
           },
           transaction: t,
-        });
+        })) ?? -1) + 1;
 
-        const richMentions = await createUserMentions(auth, {
-          mentions,
-          message: userMessageWithoutMentions,
-          conversation,
-          transaction: t,
-        });
+      const enrichedContext: UserMessageContext = {
+        ...context,
+        apiKeyId: auth.key()?.id ?? null,
+        authMethod: auth.authMethod(),
+      };
 
-        const userMessage = {
-          ...userMessageWithoutMentions,
-          richMentions,
-          mentions: richMentions.map(toMentionType),
-        };
+      const userMessageWithoutMentions = await createUserMessage(auth, {
+        conversation,
+        content,
+        metadata: {
+          type: "create",
+          user: doNotAssociateUser ? null : (user?.toJSON() ?? null),
+          rank: nextMessageRank,
+          context: enrichedContext,
+          agenticMessageData,
+          visibility: "pending",
+        },
+        transaction: t,
+      });
 
-        return { userMessage, agentMessages: [] };
-      }
-      // Agent is no longer running — fall through to normal flow.
+      const richMentions = await createUserMentions(auth, {
+        mentions,
+        message: userMessageWithoutMentions,
+        conversation,
+        transaction: t,
+      });
+
+      const userMessage = {
+        ...userMessageWithoutMentions,
+        richMentions,
+        mentions: richMentions.map(toMentionType),
+      };
+
+      return { userMessage, agentMessages: [] };
     }
 
     let nextMessageRank: number | undefined;

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -633,12 +633,16 @@ export async function postUserMessage(
     return limitResult;
   }
 
-  // Steering invariants: enforce single agent loop per conversation when
-  // `steeringEnabled` is true.
-  if (steeringEnabled) {
-    const agentMentions = mentions.filter(isAgentMention);
+  const agentMentions = mentions.filter(isAgentMention);
+  const runningAgentMessage = conversation.content
+    .flat()
+    .find(
+      (m): m is AgentMessageType =>
+        isAgentMessageType(m) && m.status === "created"
+    );
 
-    // At most one agent mention per message.
+  // Steering invariants: enforce single agent loop per conversation.
+  if (steeringEnabled) {
     if (agentMentions.length > 1) {
       return new Err({
         status_code: 400,
@@ -649,27 +653,18 @@ export async function postUserMessage(
       });
     }
 
-    // Cannot address a different agent than the running one.
-    const runningAgentMessage = conversation.content
-      .flat()
-      .find(
-        (m): m is AgentMessageType =>
-          isAgentMessageType(m) && m.status === "created"
-      );
-
-    if (runningAgentMessage && agentMentions.length > 0) {
-      if (
-        agentMentions[0].configurationId !==
-        runningAgentMessage.configuration.sId
-      ) {
-        return new Err({
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Cannot run a different agent while one is running.",
-          },
-        });
-      }
+    if (
+      runningAgentMessage &&
+      agentMentions.length > 0 &&
+      agentMentions[0].configurationId !== runningAgentMessage.configuration.sId
+    ) {
+      return new Err({
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Cannot run a different agent while one is running.",
+        },
+      });
     }
   }
 
@@ -756,27 +751,6 @@ export async function postUserMessage(
     }
   }
 
-  // When steering is enabled, detect the running agent message (if any) to
-  // determine whether to take the pending path inside the transaction.
-  const runningAgentMessage = steeringEnabled
-    ? conversation.content
-        .flat()
-        .find(
-          (m): m is AgentMessageType =>
-            isAgentMessageType(m) && m.status === "created"
-        )
-    : undefined;
-
-  const agentMentions = mentions.filter(isAgentMention);
-
-  // Determine if we should attempt the pending path: steering is enabled,
-  // there's a running agent, and the user mentioned that same agent.
-  const shouldAttemptPendingPath =
-    steeringEnabled &&
-    runningAgentMessage &&
-    agentMentions.length > 0 &&
-    agentMentions[0].configurationId === runningAgentMessage.configuration.sId;
-
   // In one big transaction create all Message, UserMessage, AgentMessage and Mention rows.
   const { userMessage, agentMessages } = await withTransaction(async (t) => {
     // Since we are getting a transaction level lock, we can't execute any other SQL query outside of
@@ -786,7 +760,7 @@ export async function postUserMessage(
 
     // Pending path: re-read agent message status under lock. If the agent is
     // still running, create a pending user message without an agent message.
-    if (shouldAttemptPendingPath) {
+    if (steeringEnabled && runningAgentMessage) {
       const agentMessageRow = await AgentMessageModel.findByPk(
         runningAgentMessage.agentMessageId,
         { transaction: t }
@@ -1042,7 +1016,7 @@ export async function postUserMessage(
       conversation,
       userMessage,
     });
-  } else if (shouldAttemptPendingPath && runningAgentMessage) {
+  } else if (steeringEnabled && runningAgentMessage) {
     // Pending path: signal the running agent loop to gracefully stop.
     await gracefullyStopAgentLoop(auth, {
       messageIds: [runningAgentMessage.sId],

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -842,10 +842,13 @@ export async function postUserMessage(
     // the initial check and acquiring the lock, the agent loop may have finalized — if so, clear
     // runningAgentMessage so we fall through to the normal flow.
     if (steeringEnabled && runningAgentMessage) {
-      const agentMessageRow = await AgentMessageModel.findByPk(
-        runningAgentMessage.agentMessageId,
-        { transaction: t }
-      );
+      const agentMessageRow = await AgentMessageModel.findOne({
+        where: {
+          id: runningAgentMessage.agentMessageId,
+          workspaceId: owner.id,
+        },
+        transaction: t,
+      });
 
       if (agentMessageRow?.status !== "created") {
         runningAgentMessage = undefined;

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -113,6 +113,7 @@ import type {
   ConversationType,
   ConversationVisibility,
   ConversationWithoutContentType,
+  MessageVisibility,
   RichMentionWithStatus,
   UserMessageContext,
   UserMessageType,
@@ -758,72 +759,6 @@ export async function postUserMessage(
     // connection pool, resulting in a deadlock.
     await getConversationRankVersionLock(auth, conversation, t);
 
-    // Re-read the agent message status inside the critical section of the
-    // advisory lock. Between the initial check and acquiring the lock, the
-    // agent loop may have finalized — if so, clear runningAgentMessage so we
-    // fall through to the normal flow.
-    if (steeringEnabled && runningAgentMessage) {
-      const agentMessageRow = await AgentMessageModel.findByPk(
-        runningAgentMessage.agentMessageId,
-        { transaction: t }
-      );
-
-      if (agentMessageRow?.status !== "created") {
-        runningAgentMessage = undefined;
-      }
-    }
-
-    // Pending path: agent is still running, create a pending user message
-    // without an agent message.
-    if (steeringEnabled && runningAgentMessage) {
-      const nextMessageRank =
-        ((await MessageModel.max<number | null, MessageModel>("rank", {
-          where: {
-            workspaceId: owner.id,
-            conversationId: conversation.id,
-            branchId: conversation.branchId
-              ? getResourceIdFromSId(conversation.branchId)
-              : null,
-          },
-          transaction: t,
-        })) ?? -1) + 1;
-
-      const enrichedContext: UserMessageContext = {
-        ...context,
-        apiKeyId: auth.key()?.id ?? null,
-        authMethod: auth.authMethod(),
-      };
-
-      const userMessageWithoutMentions = await createUserMessage(auth, {
-        conversation,
-        content,
-        metadata: {
-          type: "create",
-          user: doNotAssociateUser ? null : (user?.toJSON() ?? null),
-          rank: nextMessageRank,
-          context: enrichedContext,
-          agenticMessageData,
-          visibility: "pending",
-        },
-        transaction: t,
-      });
-
-      const richMentions = await createUserMentions(auth, {
-        mentions,
-        message: userMessageWithoutMentions,
-        conversation,
-        transaction: t,
-      });
-
-      const userMessage = {
-        ...userMessageWithoutMentions,
-        richMentions,
-        mentions: richMentions.map(toMentionType),
-      };
-
-      return { userMessage, agentMessages: [] };
-    }
-
     let nextMessageRank: number | undefined;
 
     // We will do best effort to create a branch, but there a several conditions that we will not create a branch.
@@ -903,6 +838,23 @@ export async function postUserMessage(
       authMethod: auth.authMethod(),
     };
 
+    // Re-read the agent message status inside the critical section of the advisory lock. Between
+    // the initial check and acquiring the lock, the agent loop may have finalized — if so, clear
+    // runningAgentMessage so we fall through to the normal flow.
+    if (steeringEnabled && runningAgentMessage) {
+      const agentMessageRow = await AgentMessageModel.findByPk(
+        runningAgentMessage.agentMessageId,
+        { transaction: t }
+      );
+
+      if (agentMessageRow?.status !== "created") {
+        runningAgentMessage = undefined;
+      }
+    }
+
+    const visibility: MessageVisibility =
+      steeringEnabled && runningAgentMessage ? "pending" : "visible";
+
     // Return the user message without mentions.
     // This way typescript forces us to create the mentions after the user message is created.
     const userMessageWithoutMentions = await createUserMessage(auth, {
@@ -914,6 +866,7 @@ export async function postUserMessage(
         rank: nextMessageRank++,
         context: enrichedContext,
         agenticMessageData,
+        visibility,
       },
       transaction: t,
     });
@@ -925,28 +878,6 @@ export async function postUserMessage(
       transaction: t,
     });
 
-    const { agentMessages, richMentions: agentRichMentions } =
-      await createAgentMessages(auth, {
-        conversation,
-        metadata: {
-          type: "create",
-          mentions,
-          agentConfigurations,
-          skipToolsValidation,
-          nextMessageRank,
-          userMessage: userMessageWithoutMentions,
-        },
-        transaction: t,
-      });
-
-    richMentions.push(...agentRichMentions);
-
-    const userMessage = {
-      ...userMessageWithoutMentions,
-      richMentions: richMentions,
-      mentions: richMentions.map(toMentionType),
-    };
-
     await ConversationResource.markAsUpdated(auth, { conversation, t });
 
     if (!doNotAssociateUser) {
@@ -957,10 +888,46 @@ export async function postUserMessage(
       });
     }
 
-    return {
-      userMessage,
-      agentMessages,
-    };
+    if (steeringEnabled && runningAgentMessage) {
+      // Pending path: agent is still running, create a pending user message without an agent
+      // message.
+      const userMessage = {
+        ...userMessageWithoutMentions,
+        richMentions,
+        mentions: richMentions.map(toMentionType),
+      };
+
+      return { userMessage, agentMessages: [] };
+    } else {
+      // Normal path: create agent messages for all mentioned agents, and associate them with the
+      // user message.
+      const { agentMessages, richMentions: agentRichMentions } =
+        await createAgentMessages(auth, {
+          conversation,
+          metadata: {
+            type: "create",
+            mentions,
+            agentConfigurations,
+            skipToolsValidation,
+            nextMessageRank,
+            userMessage: userMessageWithoutMentions,
+          },
+          transaction: t,
+        });
+
+      richMentions.push(...agentRichMentions);
+
+      const userMessage = {
+        ...userMessageWithoutMentions,
+        richMentions: richMentions,
+        mentions: richMentions.map(toMentionType),
+      };
+
+      return {
+        userMessage,
+        agentMessages,
+      };
+    }
   });
 
   // If a user is mentioned, we want to make sure the conversation has a title.

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -20,6 +20,7 @@ import {
 } from "@app/lib/api/assistant/conversation/permissions";
 import { ensureConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
+import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import {
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR,
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR_WINDOW_SECONDS,
@@ -755,12 +756,92 @@ export async function postUserMessage(
     }
   }
 
+  // When steering is enabled, detect the running agent message (if any) to
+  // determine whether to take the pending path inside the transaction.
+  const runningAgentMessage = steeringEnabled
+    ? conversation.content
+        .flat()
+        .find(
+          (m): m is AgentMessageType =>
+            isAgentMessageType(m) && m.status === "created"
+        )
+    : undefined;
+
+  const agentMentions = mentions.filter(isAgentMention);
+
+  // Determine if we should attempt the pending path: steering is enabled,
+  // there's a running agent, and the user mentioned that same agent.
+  const shouldAttemptPendingPath =
+    steeringEnabled &&
+    runningAgentMessage &&
+    agentMentions.length > 0 &&
+    agentMentions[0].configurationId === runningAgentMessage.configuration.sId;
+
   // In one big transaction create all Message, UserMessage, AgentMessage and Mention rows.
   const { userMessage, agentMessages } = await withTransaction(async (t) => {
     // Since we are getting a transaction level lock, we can't execute any other SQL query outside of
     // this transaction, otherwise this other query will be competing for a connection in the database
     // connection pool, resulting in a deadlock.
     await getConversationRankVersionLock(auth, conversation, t);
+
+    // Pending path: re-read agent message status under lock. If the agent is
+    // still running, create a pending user message without an agent message.
+    if (shouldAttemptPendingPath) {
+      const agentMessageRow = await AgentMessageModel.findByPk(
+        runningAgentMessage.agentMessageId,
+        { transaction: t }
+      );
+
+      if (agentMessageRow?.status === "created") {
+        const nextMessageRank =
+          ((await MessageModel.max<number | null, MessageModel>("rank", {
+            where: {
+              workspaceId: owner.id,
+              conversationId: conversation.id,
+              branchId: conversation.branchId
+                ? getResourceIdFromSId(conversation.branchId)
+                : null,
+            },
+            transaction: t,
+          })) ?? -1) + 1;
+
+        const enrichedContext: UserMessageContext = {
+          ...context,
+          apiKeyId: auth.key()?.id ?? null,
+          authMethod: auth.authMethod(),
+        };
+
+        const userMessageWithoutMentions = await createUserMessage(auth, {
+          conversation,
+          content,
+          metadata: {
+            type: "create",
+            user: doNotAssociateUser ? null : (user?.toJSON() ?? null),
+            rank: nextMessageRank,
+            context: enrichedContext,
+            agenticMessageData,
+            visibility: "pending",
+          },
+          transaction: t,
+        });
+
+        const richMentions = await createUserMentions(auth, {
+          mentions,
+          message: userMessageWithoutMentions,
+          conversation,
+          transaction: t,
+        });
+
+        const userMessage = {
+          ...userMessageWithoutMentions,
+          richMentions,
+          mentions: richMentions.map(toMentionType),
+        };
+
+        return { userMessage, agentMessages: [] };
+      }
+      // Agent is no longer running — fall through to normal flow.
+    }
 
     let nextMessageRank: number | undefined;
 
@@ -960,6 +1041,12 @@ export async function postUserMessage(
       agentMessages,
       conversation,
       userMessage,
+    });
+  } else if (shouldAttemptPendingPath && runningAgentMessage) {
+    // Pending path: signal the running agent loop to gracefully stop.
+    await gracefullyStopAgentLoop(auth, {
+      messageIds: [runningAgentMessage.sId],
+      conversationId: conversation.sId,
     });
   }
 

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -89,6 +89,7 @@ export async function createUserMessage(
           rank: number;
           context: UserMessageContext;
           agenticMessageData?: AgenticMessageData;
+          visibility?: MessageVisibility;
         };
     transaction: Transaction;
   }
@@ -139,6 +140,9 @@ export async function createUserMessage(
 
       context = metadata.context;
       agenticMessageData = metadata.agenticMessageData;
+      if (metadata.visibility) {
+        visibility = metadata.visibility;
+      }
       break;
     default:
       assertNever(metadata);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -127,6 +127,7 @@ import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 
@@ -328,6 +329,8 @@ async function handler(
           ? "agent_sidekick"
           : "web");
 
+      const featureFlags = await getFeatureFlags(auth);
+
       const messageRes = await postUserMessage(auth, {
         conversation,
         content,
@@ -342,6 +345,7 @@ async function handler(
           clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
         },
         skipToolsValidation: skipToolsValidation ?? false,
+        enforceSteeringInvariants: featureFlags.includes("enable_steering"),
       });
 
       if (messageRes.isErr()) {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -291,7 +291,10 @@ async function handler(
         }
       }
 
-      const conversationRes = await getConversation(auth, conversationId);
+      const [conversationRes, featureFlags] = await Promise.all([
+        getConversation(auth, conversationId),
+        getFeatureFlags(auth),
+      ]);
 
       if (conversationRes.isErr()) {
         return apiErrorForConversation(req, res, conversationRes.error);
@@ -328,8 +331,6 @@ async function handler(
         (isSidekickConversation(conversation.metadata)
           ? "agent_sidekick"
           : "web");
-
-      const featureFlags = await getFeatureFlags(auth);
 
       const messageRes = await postUserMessage(auth, {
         conversation,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -346,7 +346,7 @@ async function handler(
           clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
         },
         skipToolsValidation: skipToolsValidation ?? false,
-        enforceSteeringInvariants: featureFlags.includes("enable_steering"),
+        steeringEnabled: featureFlags.includes("enable_steering"),
       });
 
       if (messageRes.isErr()) {

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -135,6 +135,7 @@ import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/hel
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -403,6 +404,8 @@ async function handler(
 
         // If a message was provided we do await for the message to be created before returning the
         // conversation along with the message.
+        const featureFlags = await getFeatureFlags(auth);
+
         const messageRes = await postUserMessage(auth, {
           conversation,
           content: message.content,
@@ -418,6 +421,7 @@ async function handler(
               message.context.clientSideMCPServerIds ?? [],
           },
           skipToolsValidation: skipToolsValidation ?? false,
+          enforceSteeringInvariants: featureFlags.includes("enable_steering"),
         });
         if (messageRes.isErr()) {
           return apiError(req, res, messageRes.error);

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -402,10 +402,10 @@ async function handler(
           }
         }
 
-        // If a message was provided we do await for the message to be created before returning the
-        // conversation along with the message.
         const featureFlags = await getFeatureFlags(auth);
 
+        // If a message was provided we do await for the message to be created before returning the
+        // conversation along with the message.
         const messageRes = await postUserMessage(auth, {
           conversation,
           content: message.content,
@@ -421,7 +421,7 @@ async function handler(
               message.context.clientSideMCPServerIds ?? [],
           },
           skipToolsValidation: skipToolsValidation ?? false,
-          enforceSteeringInvariants: featureFlags.includes("enable_steering"),
+          steeringEnabled: featureFlags.includes("enable_steering"),
         });
         if (messageRes.isErr()) {
           return apiError(req, res, messageRes.error);

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -281,6 +281,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     // Not really on_demand but we want to be able to enable it for customers
     stage: "on_demand",
   },
+  enable_steering: {
+    description:
+      "Enable steering: pending user messages + graceful stop of running agent loops",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -743,6 +743,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "collapsible_messages"
   | "email_restricted_sharing"
   | "use_dust_keys"
+  | "enable_steering"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;

--- a/x/spolu/steering/plan.md
+++ b/x/spolu/steering/plan.md
@@ -76,11 +76,11 @@ Implement the graceful stop mechanism end-to-end.
 
 ---
 
-## Phase 3: Steering (behind `enable_steering_behavior` feature flag)
+## Phase 3: Steering (behind `enable_steering` feature flag)
 
 All steering behavior gated behind a feature flag. No UI work except pending message display.
 
-### - [ ] PR 3.1 — Add `"pending"` to `MessageVisibility` + `UserMessagePromotedEvent`
+### - [x] PR 3.1 — Add `"pending"` to `MessageVisibility` + `UserMessagePromotedEvent`
 
 Type + DB schema change, no runtime behavior.
 
@@ -94,7 +94,7 @@ Type + DB schema change, no runtime behavior.
 
 ### - [ ] PR 3.2 — Pending path in `postUserMessage`
 
-Behind `enable_steering_behavior` feature flag:
+Behind `enable_steering` feature flag:
 
 - Add constraints and routing logic in `postUserMessage`:
   - At most one agent mention per message (error if >1).

--- a/x/spolu/steering/plan.md
+++ b/x/spolu/steering/plan.md
@@ -92,7 +92,7 @@ Type + DB schema change, no runtime behavior.
 - Add `UserMessagePromotedEvent` type in `front/types/assistant/conversation.ts`.
 - Add to `ConversationEvents` union in `front/lib/api/assistant/streaming/types.ts`.
 
-### - [ ] PR 3.2 — Pending path in `postUserMessage`
+### - [x] PR 3.2 — Pending path in `postUserMessage`
 
 Behind `enable_steering` feature flag:
 


### PR DESCRIPTION
## Description

- Add feature flag `enable_steering`
- Add parameter `steeringEnabled` to `postUserMessage` which
  - Enforces steering invariants, basically only one agentic loop at a time
  - Create userMessage in pending if `steeringEnabled` and there is a `runningAgentMessage`
  - If message was created in pending signal `gracefullyStopAgentLoop`
  
Refer to the steering proposal for detail on concurrency.

Call sites for `postUserMessage` for reference:

```
  1. Private API (already done):                                                                                                                                                                                                                                                           
    - pages/api/w/.../conversations/index.ts ✓                                                                                                                                                                                                                                             
    - pages/api/w/.../messages/index.ts ✓                                                                                                                                                                                                                                                  
  2. Public v1 API (should NOT enforce — API callers keep current behavior per the plan):                                                                                                                                                                                                  
    - pages/api/v1/.../conversations/index.ts — no change needed                                                                                                                                                                                                                           
    - pages/api/v1/.../messages/index.ts — no change needed                                                                                                                                                                                                                                
  3. Internal/system callers (not user-initiated, should NOT enforce):                                                                                                                                                                                                                     
    - temporal/triggers/common/activities.ts — trigger-initiated                                                                                                                                                                                                                           
    - lib/api/assistant/onboarding.ts — system onboarding                                                                                                                                                                                                                                  
    - lib/api/assistant/email/email_trigger.ts — email-initiated                                                                                                                                                                                                                           
    - lib/reinforced_agent/aggregate_suggestions.ts — system                                                                                                                                                                                                                               
    - lib/api/actions/servers/run_agent/conversation.ts — agent handover                                                                                                                                                                                                                   
    - lib/api/actions/servers/project_conversation/tools/index.ts — project tool                                                                                                                                                                                                           
    - lib/api/assistant/conversation/branches.ts — branching
    - pages/api/w/.../onboarding-followup.ts — onboarding                                                                                                                                                                                                                                  
  4. Wrappers (delegates to postUserMessage):                                                                                                                                                                                                                                              
    - lib/api/assistant/streaming/blocking.ts — postUserMessageAndWaitForCompletion (used by v1 API)                                                                                                                                                                                       
  5. Tests:                                                                                                                                                                                                                                                                                
    - conversation.test.ts, validate_actions.test.ts                                  
```

## Tests

Local tests.

## Risk

Low, behind feature flag.

## Deploy Plan

- deploy `front`