### PR TITLE
Add a toggle to disable reinforced agent

### DIFF
--- a/front/components/workspace/settings/AgentReinforcementToggle.tsx
+++ b/front/components/workspace/settings/AgentReinforcementToggle.tsx
@@ -1,0 +1,30 @@
+import { useAgentReinforcementToggle } from "@app/lib/swr/useAgentReinforcementToggle";
+import type { WorkspaceType } from "@app/types/user";
+import { ContextItem, SliderToggle, SparklesIcon } from "@dust-tt/sparkle";
+
+interface AgentReinforcementToggleProps {
+  owner: WorkspaceType;
+}
+
+export function AgentReinforcementToggle({
+  owner,
+}: AgentReinforcementToggleProps) {
+  const { isEnabled, isChanging, doToggleAgentReinforcement } =
+    useAgentReinforcementToggle({ owner });
+
+  return (
+    <ContextItem
+      title="Allow agent reinforcement"
+      subElement="Allow Dust to analyse conversations to suggest improvement to your agents"
+      visual={<SparklesIcon className="h-6 w-6" />}
+      hasSeparatorIfLast={true}
+      action={
+        <SliderToggle
+          selected={isEnabled}
+          disabled={isChanging}
+          onClick={doToggleAgentReinforcement}
+        />
+      }
+    />
+  );
+}

--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -1,8 +1,9 @@
+import { AgentReinforcementToggle } from "@app/components/workspace/settings/AgentReinforcementToggle";
 import { EmailAgentsToggle } from "@app/components/workspace/settings/EmailAgentsToggle";
 import { InteractiveContentSharingToggle } from "@app/components/workspace/settings/InteractiveContentSharingToggle";
 import { RestrictAgentsPublishingCapability } from "@app/components/workspace/settings/RestrictAgentsPublishingCapability";
 import { VoiceTranscriptionToggle } from "@app/components/workspace/settings/VoiceTranscriptionToggle";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
 import { ContextItem, Page } from "@dust-tt/sparkle";
 
@@ -16,6 +17,7 @@ export function CapabilitiesSection({
   publishingRestrictionMessage,
 }: CapabilitiesSectionProps) {
   const { subscription } = useAuth();
+  const { hasFeature } = useFeatureFlags();
 
   return (
     <Page.Vertical align="stretch" gap="md">
@@ -27,6 +29,9 @@ export function CapabilitiesSection({
           <VoiceTranscriptionToggle owner={owner} />
         )}
         <EmailAgentsToggle owner={owner} />
+        {hasFeature("reinforced_agents") && (
+          <AgentReinforcementToggle owner={owner} />
+        )}
         {publishingRestrictionMessage && (
           <RestrictAgentsPublishingCapability
             subElement={publishingRestrictionMessage}

--- a/front/lib/reinforced_agent/workspace_check.ts
+++ b/front/lib/reinforced_agent/workspace_check.ts
@@ -1,0 +1,18 @@
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+
+/**
+ * Check whether reinforcement is enabled for the workspace:
+ * - the `reinforced_agents` feature flag must be active, AND
+ * - the workspace must not have opted out via `allowAgentReinforcement` metadata.
+ */
+export async function hasReinforcementEnabled(
+  auth: Authenticator
+): Promise<boolean> {
+  if (!(await hasFeatureFlag(auth, "reinforced_agents"))) {
+    return false;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  return workspace.metadata?.allowAgentReinforcement !== false;
+}

--- a/front/lib/swr/useAgentReinforcementToggle.ts
+++ b/front/lib/swr/useAgentReinforcementToggle.ts
@@ -1,0 +1,55 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useState } from "react";
+
+interface UseAgentReinforcementToggleProps {
+  owner: LightWorkspaceType;
+}
+
+export function useAgentReinforcementToggle({
+  owner,
+}: UseAgentReinforcementToggleProps) {
+  const [isChanging, setIsChanging] = useState(false);
+  const sendNotification = useSendNotification();
+  const [isEnabled, setIsEnabled] = useState(
+    owner.metadata?.allowAgentReinforcement !== false
+  );
+
+  const doToggleAgentReinforcement = async () => {
+    setIsChanging(true);
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          allowAgentReinforcement: !isEnabled,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to update agent reinforcement setting");
+      }
+      setIsEnabled(!isEnabled);
+      return true;
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to update agent reinforcement setting",
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsChanging(false);
+    }
+  };
+
+  return {
+    isEnabled,
+    isChanging,
+    doToggleAgentReinforcement,
+  };
+}

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
@@ -2,7 +2,7 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { hasFeatureFlag } from "@app/lib/auth";
+import { hasReinforcementEnabled } from "@app/lib/reinforced_agent/workspace_check";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -123,9 +123,8 @@ async function handler(
         });
       }
 
-      const sources: AgentSuggestionSource[] = (await hasFeatureFlag(
-        auth,
-        "reinforced_agents"
+      const sources: AgentSuggestionSource[] = (await hasReinforcementEnabled(
+        auth
       ))
         ? ["sidekick", "reinforcement"]
         : ["sidekick"];

--- a/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/existing.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/existing.ts
@@ -6,7 +6,7 @@ import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overvie
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { hasFeatureFlag } from "@app/lib/auth";
+import { hasReinforcementEnabled } from "@app/lib/reinforced_agent/workspace_check";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -240,13 +240,13 @@ async function handler(
         await Promise.all([
           fetchFeedbackMarkdown(auth, agentConfigurationId),
           fetchInsightsMarkdown(auth, agentConfigurationId),
-          hasFeatureFlag(auth, "reinforced_agents").then((hasFlag) =>
+          hasReinforcementEnabled(auth).then((enabled) =>
             AgentSuggestionResource.listByAgentConfigurationId(
               auth,
               agentConfigurationId,
               {
                 states: ["pending"],
-                sources: hasFlag ? undefined : ["sidekick"],
+                sources: enabled ? undefined : ["sidekick"],
                 limit: MAX_PENDING_SUGGESTIONS_IN_FIRST_MESSAGE,
               }
             )

--- a/front/pages/api/w/[wId]/index.test.ts
+++ b/front/pages/api/w/[wId]/index.test.ts
@@ -239,6 +239,52 @@ describe("POST /api/w/[wId]", () => {
     expect(res._getJSONData().error.type).toBe("invalid_request_error");
   });
 
+  it("enables agent reinforcement", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.body = {
+      allowAgentReinforcement: true,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      workspace: expect.objectContaining({
+        id: workspace.id,
+        metadata: expect.objectContaining({
+          allowAgentReinforcement: true,
+        }),
+      }),
+    });
+  });
+
+  it("disables agent reinforcement", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.body = {
+      allowAgentReinforcement: false,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      workspace: expect.objectContaining({
+        id: workspace.id,
+        metadata: expect.objectContaining({
+          allowAgentReinforcement: false,
+        }),
+      }),
+    });
+  });
+
   it("returns 405 for non-POST methods", async () => {
     for (const method of ["PUT", "DELETE"] as const) {
       const { req, res } = await createPrivateApiMockRequest({

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -66,6 +66,10 @@ const WorkspaceEmailAgentsUpdateBodySchema = t.type({
   allowEmailAgents: t.boolean,
 });
 
+const WorkspaceAgentReinforcementUpdateBodySchema = t.type({
+  allowAgentReinforcement: t.boolean,
+});
+
 const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceAllowedDomainUpdateBodySchema,
   WorkspaceBatchDomainUpdateBodySchema,
@@ -76,6 +80,7 @@ const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceInteractiveContentSharingUpdateBodySchema,
   WorkspaceVoiceTranscriptionUpdateBodySchema,
   WorkspaceEmailAgentsUpdateBodySchema,
+  WorkspaceAgentReinforcementUpdateBodySchema,
 ]);
 
 async function handler(
@@ -193,6 +198,14 @@ async function handler(
         const newMetadata = {
           ...previousMetadata,
           allowEmailAgents: body.allowEmailAgents,
+        };
+        await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+        owner.metadata = newMetadata;
+      } else if ("allowAgentReinforcement" in body) {
+        const previousMetadata = owner.metadata ?? {};
+        const newMetadata = {
+          ...previousMetadata,
+          allowAgentReinforcement: body.allowAgentReinforcement,
         };
         await workspace.updateWorkspaceSettings({ metadata: newMetadata });
         owner.metadata = newMetadata;

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -42,6 +42,7 @@ import {
   storeTerminalToolCallResults,
 } from "@app/lib/reinforced_agent/tool_execution";
 import type { ReinforcedOperationType } from "@app/lib/reinforced_agent/types";
+import { hasReinforcementEnabled } from "@app/lib/reinforced_agent/workspace_check";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -236,6 +237,18 @@ async function runReinforcedStep({
     reinforcementConversationId,
     toolActionInfo,
   };
+}
+
+/**
+ * Check whether the workspace has opted out of agent reinforcement.
+ */
+export async function isAgentReinforcementAllowedActivity({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<boolean> {
+  const auth = await getAuthForWorkspace(workspaceId);
+  return hasReinforcementEnabled(auth);
 }
 
 /**

--- a/front/temporal/reinforced_agent/client.ts
+++ b/front/temporal/reinforced_agent/client.ts
@@ -1,5 +1,6 @@
 import { config, REGION_TIMEZONES } from "@app/lib/api/regions/config";
-import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import { hasReinforcementEnabled } from "@app/lib/reinforced_agent/workspace_check";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -40,8 +41,7 @@ async function getFlaggedWorkspaceIds(): Promise<string[]> {
   for (const workspace of allWorkspaces) {
     try {
       const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-      const featureFlags = await getFeatureFlags(auth);
-      if (featureFlags.includes("reinforced_agents")) {
+      if (await hasReinforcementEnabled(auth)) {
         flaggedIds.push(workspace.sId);
       }
     } catch (e) {

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -24,6 +24,12 @@ export const interceptors: WorkflowInterceptorsFactory = () => ({
   internals: [new OpenTelemetryInternalsInterceptor()],
 });
 
+const { isAgentReinforcementAllowedActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "5 minutes",
+});
+
 const { getAgentConfigurationsActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
 });
@@ -124,6 +130,11 @@ export async function reinforcedAgentWorkspaceWorkflow({
   useBatchMode: boolean;
   skipDelay?: boolean;
 }): Promise<void> {
+  const isAllowed = await isAgentReinforcementAllowedActivity({ workspaceId });
+  if (!isAllowed) {
+    return;
+  }
+
   if (!skipDelay) {
     const delayMs = computeWorkspaceDelayMs(workspaceId);
     if (delayMs > 0) {


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/7354

Toggle to disable the whole feature, might be useful for security in some workspaces.
Simialr structure to other workspace settings

<img width="2352" height="916" alt="image" src="https://github.com/user-attachments/assets/f3afa7f6-596e-4d4f-a15b-2cd3e5d67ff8" />

## Tests

Unit test + manual tests

## Risk

low

## Deploy Plan

deploy front
