### PR TITLE
Reinforce agent prompt: do not generate overly specific suggestions

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared.ts
@@ -59,9 +59,6 @@ NEVER hardcode overly specific values (exact error messages, specific line numbe
 
 Ask yourself: "Would this instruction still be useful if the exact error message, variable name, or line number changed?"
 
-DO: Suggest category-level handling rules (e.g., "When encountering null reference errors, check the data pipeline upstream")
-DON'T: Hardcode specific error text (e.g., "When you see 'Cannot read property subresult of undefined at line 453', check the parser module")
-
 DO: Suggest general diagnostic approaches (e.g., "For performance issues, start by checking slow database queries and high memory usage")
 DON'T: Suggest handling for one-off incidents (e.g., "If latency spikes to 2847ms on endpoint /api/v2/reports/quarterly, restart pod west-2a")
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/agent_suggestions_shared.ts
@@ -52,6 +52,22 @@ Example:
 The goal is flexible agents that handle real-world variation, not brittle agents that only match training examples.
 </generalization_over_examples>
 
+<no_overly_specific_suggestions>
+NEVER hardcode overly specific values (exact error messages, specific line numbers, particular variable names, individual ticket IDs, etc.) into instruction suggestions. If an observation from a conversation is too specific to be useful as a general instruction, either:
+1. Generalize it into a broader rule that covers the category of issue, OR
+2. Do not suggest it at all.
+
+Ask yourself: "Would this instruction still be useful if the exact error message, variable name, or line number changed?"
+
+DO: Suggest category-level handling rules (e.g., "When encountering null reference errors, check the data pipeline upstream")
+DON'T: Hardcode specific error text (e.g., "When you see 'Cannot read property subresult of undefined at line 453', check the parser module")
+
+DO: Suggest general diagnostic approaches (e.g., "For performance issues, start by checking slow database queries and high memory usage")
+DON'T: Suggest handling for one-off incidents (e.g., "If latency spikes to 2847ms on endpoint /api/v2/reports/quarterly, restart pod west-2a")
+
+Some issues can be generalized into useful rules — do so. Others are too specific and one-off — skip them entirely.
+</no_overly_specific_suggestions>
+
 Instructions SHOULD reference how to use skills, tools, and knowledge that are configured in the agent.
 
 Suggestions ALWAYS need to be using the same language as the existing instructions OR, for new agents, the language of the user conversation.

--- a/front/lib/reinforced_agent/aggregate_suggestions.ts
+++ b/front/lib/reinforced_agent/aggregate_suggestions.ts
@@ -63,7 +63,9 @@ Use your discretion on what suggestions will most improve the agent's ability to
 
 You SHOULD drop suggestions that only have minor impact and are only supported by a single conversation.
 
-There may be situations where suggestions are co-dependent. For example, there may be an instruction suggestion that requires a tool suggestion to be effective. In this case, NEVER create one suggestion without the other.`,
+There may be situations where suggestions are co-dependent. For example, there may be an instruction suggestion that requires a tool suggestion to be effective. In this case, NEVER create one suggestion without the other.
+
+You MUST drop or generalize suggestions that hardcode overly specific values (exact error messages, specific line numbers, particular variable names, individual ticket IDs, etc.). If the suggestion can be generalized into a broader, reusable rule, rewrite it. If not, drop it entirely.`,
 
   suggestion_tool_calls: `
 You are provided all of the attributes associated with a conversation suggestion. You MUST use these EXACT attributes to create the final suggestion.

--- a/front/lib/reinforced_agent/analyze_conversation.ts
+++ b/front/lib/reinforced_agent/analyze_conversation.ts
@@ -52,6 +52,7 @@ Subsequently, an aggregation workflow will use this analysis to determine which 
 
 Step 5: Make suggestions. You MUST refer to <instruction_suggestion_formatting> for instruction suggestions.
 ONLY make suggestions that will effect the agent behavior. NEVER suggest cosmetic-only fixes.
+Ensure suggestions are generic and reusable, not tied to specific values from this conversation. See <no_overly_specific_suggestions> and <generalization_over_examples> in <instructions_guidance>.
 `,
 
   conversation_analysis: `ALWAYS inspect the full conversation, which is a chronological timeline of messages. Each message has an index, sId, sender (user or

--- a/front/tests/reinforced-agent-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforced-agent-evals/test-suites/aggregate-suggestions.ts
@@ -417,5 +417,45 @@ Score 0 if it creates a suggestion similar to the rejected one (empathy/acknowle
 Score 1 if it creates an unrelated suggestion.
 Score 3 if no suggestion is created.`,
     },
+    {
+      scenarioId: "dismiss-or-generalize-overly-specific-suggestion",
+      type: "aggregation",
+      agentConfig: {
+        name: "Incident Analysis Bot",
+        description:
+          "Helps the on-call team investigate production incidents using Datadog, Jira, and GitHub",
+      },
+      syntheticSuggestions: [
+        makeInstructionSuggestion({
+          id: 1,
+          sId: "sug-1",
+          analysis:
+            "The agent had difficulty finding a specific error in Datadog. Adding an instruction about this error pattern would help the agent handle it in the future.",
+          suggestion: {
+            content:
+              '<p>When a user reports the error "TypeError: Cannot read properties of undefined (reading subresult) at ProcessingPipeline.transform (pipeline.js:453:22)", search Datadog with the query \'service:data-processor "Cannot read properties of undefined (reading subresult)"\' and check the GitHub repo for recent commits to pipeline.js.</p>',
+            targetBlockId: "instructions-root",
+            type: "replace",
+          },
+        }),
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [],
+      judgeCriteria: `The synthetic suggestion hardcodes a specific error message ("TypeError: Cannot read properties
+of undefined (reading subresult) at ProcessingPipeline.transform (pipeline.js:453:22)") and specific
+file references. The aggregation agent must either:
+1. Dismiss the suggestion entirely (no suggestion created) — this is acceptable, OR
+2. Generalize it into a broader, useful instruction about how to investigate errors in Datadog
+   (e.g., general guidance on searching for error patterns, correlating across tools, etc.)
+
+What is NOT acceptable:
+- Reproducing the suggestion as-is with the specific error message hardcoded
+- Keeping any reference to "subresult", "pipeline.js:453", or the exact TypeError text
+
+Score 0 if the suggestion is reproduced with the specific error message, file name, or line number.
+Score 1 if the suggestion is partially generalized but still contains overly specific references.
+Score 2 if the suggestion is dismissed entirely (acceptable but not ideal if a generic version would be useful).
+Score 3 if the suggestion is generalized into clear, actionable guidance about investigating errors using Datadog/Jira/GitHub without hardcoding specifics.`,
+    },
   ],
 };

--- a/front/tests/reinforced-agent-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforced-agent-evals/test-suites/analyze-conversation.ts
@@ -302,5 +302,109 @@ Score 1 if the suggestion targets the correct block but is too vague or generic.
 Score 2 if the suggestion correctly targets the tools block and addresses the tool usage order but lacks specificity.
 Score 3 if the suggestion targets the tools block with clear, specific instructions about using search-company first to get the ID, then get-owner with the ID.`,
     },
+    {
+      scenarioId: "no-overly-specific-error-message-in-suggestion",
+      type: "analysis",
+      agentConfig: {
+        name: "Incident Analysis Bot",
+        description:
+          "Helps the on-call team investigate production incidents using Datadog, Jira, and GitHub",
+        instructionsHtml: `<div data-type="instructions-root" data-block-id="instructions-root">
+        <div data-block-id="role-block" data-instruction-type="role" data-collapsed="false" data-type="instruction-block">
+          <p data-block-id="role-p">You are an incident analysis assistant. Help engineers investigate production incidents by correlating logs from Datadog, tickets from Jira, and code changes from GitHub.</p>
+        </div>
+        <div data-block-id="workflow-block" data-instruction-type="guidelines" data-collapsed="false" data-type="instruction-block">
+          <p data-block-id="workflow-p">When investigating an incident: 1) Search Datadog for relevant logs and metrics, 2) Check Jira for related tickets, 3) Look at recent GitHub commits that may have caused the issue.</p>
+        </div>
+        </div>`,
+        tools: [
+          { name: "Datadog", sId: "mcp_datadog" },
+          { name: "JIRA", sId: "mcp_jira" },
+          { name: "GitHub", sId: "mcp_github" },
+        ],
+      },
+      conversation: [
+        {
+          role: "user",
+          content:
+            "We're getting a lot of errors in production. Can you check Datadog for the error 'TypeError: Cannot read properties of undefined (reading subresult) at ProcessingPipeline.transform (pipeline.js:453:22)'?",
+        },
+        {
+          role: "agent",
+          content: "I'll search Datadog for that error message.",
+          actions: [
+            {
+              functionCallName: "datadog-search-logs",
+              status: "succeeded",
+              params: {
+                query:
+                  "TypeError: Cannot read properties of undefined (reading subresult) at ProcessingPipeline.transform",
+              },
+              output:
+                '{"logs": [{"timestamp": "2025-01-15T10:23:00Z", "message": "TypeError: Cannot read properties of undefined (reading \'subresult\') at ProcessingPipeline.transform (pipeline.js:453:22)", "service": "data-processor", "count": 847}]}',
+            },
+          ],
+        },
+        {
+          role: "agent",
+          content:
+            "I found the error in Datadog. It's occurring in the data-processor service with 847 occurrences. The error is a TypeError where it tries to read 'subresult' from an undefined object in the ProcessingPipeline at line 453. Let me check Jira for related tickets.",
+          actions: [
+            {
+              functionCallName: "jira-search",
+              status: "succeeded",
+              params: { query: "subresult undefined pipeline" },
+              output: '{"issues": []}',
+            },
+          ],
+        },
+        {
+          role: "agent",
+          content:
+            "No related Jira tickets found. Let me check recent GitHub commits to the pipeline module.",
+          actions: [
+            {
+              functionCallName: "github-search-commits",
+              status: "succeeded",
+              params: { query: "pipeline.js ProcessingPipeline" },
+              output:
+                '{"commits": [{"sha": "abc123", "message": "refactor: restructure pipeline output format", "date": "2025-01-14T18:00:00Z", "author": "dev@company.com"}]}',
+            },
+          ],
+        },
+        {
+          role: "agent",
+          content:
+            "I found a recent commit from yesterday that restructured the pipeline output format. This likely changed the shape of the result object, causing 'subresult' to be undefined. The commit 'refactor: restructure pipeline output format' by dev@company.com is the probable cause.",
+          feedback: {
+            direction: "down",
+            comment:
+              "The agent had trouble finding this specific error. It should know how to search for this kind of error in Datadog.",
+          },
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [promptSuggestion()],
+      judgeCriteria: `The reinforced agent MUST call suggest_prompt_edits, but the suggestion MUST NOT hardcode
+the specific error message "Cannot read properties of undefined (reading subresult)" or the specific
+file/line "pipeline.js:453". Instead, the suggestion should provide generic guidance about how to
+search for and investigate error messages in Datadog effectively.
+
+Acceptable suggestions include:
+- General guidance on how to search Datadog logs for error patterns
+- Tips for correlating errors across Datadog, Jira, and GitHub
+- A systematic approach for investigating TypeError/null reference errors in general
+
+Unacceptable suggestions include:
+- Hardcoding the specific error message "Cannot read properties of undefined (reading subresult)"
+- Referencing the specific file "pipeline.js" or line number "453"
+- Instructions that only work for this one specific error
+
+Score 0 if no suggest_prompt_edits call is made.
+Score 0 if the suggestion hardcodes the specific error message, file name, or line number from this conversation.
+Score 1 if the suggestion is made but is too vague to be useful.
+Score 2 if the suggestion provides reasonable generic guidance but could be more actionable.
+Score 3 if the suggestion provides clear, generic, actionable guidance for investigating errors using Datadog without hardcoding specifics from this conversation.`,
+    },
   ],
 };


### PR DESCRIPTION
## Description

Improve prompt to encourage only suggesdtion which can be reuse and are not overly fitting one conversation.


## Tests

Add corresponding eval test

## Risk

low

## Deploy Plan

deploy front