### PR TITLE
Choose agents for auto-mode reinforced agent based on scoring system

### DIFF
--- a/front/lib/api/poke/plugins/agents/run_reinforced_agent.ts
+++ b/front/lib/api/poke/plugins/agents/run_reinforced_agent.ts
@@ -1,4 +1,5 @@
 import { createPlugin } from "@app/lib/api/poke/types";
+import { DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS } from "@app/lib/reinforced_agent/constants";
 import { startReinforcedAgentForAgentWorkflow } from "@app/temporal/reinforced_agent/client";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -21,7 +22,7 @@ export const runReinforcedAgentPlugin = createPlugin({
         variant: "text",
         label: "Days of conversations to analyze",
         description: "Number of past days of conversations to analyze.",
-        default: 1,
+        default: DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS,
       },
       disableNotifications: {
         type: "boolean",

--- a/front/lib/reinforced_agent/constants.ts
+++ b/front/lib/reinforced_agent/constants.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared defaults for reinforced agent workflow.
+ * These are semi-arbitrary defaults that can be tuned to optimize the workflow for a given use case.
+ */
+
+// Max conversations sampled per agent
+export const DEFAULT_MAX_CONVERSATIONS_PER_AGENT = 50;
+// Minimum number of conversations to include an agent in the selection
+export const DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE = 5;
+// Agents are only considered for reinforcement selection if they have a pending suggestion that is older than this
+export const DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS = 30;
+// Total number of conversations to analyze across all auto-mode agents in one run
+export const DEFAULT_TOTAL_CONVERSATIONS_TO_ANALYZE = 300;
+// Max number of auto-mode agents selected in one run
+export const DEFAULT_MAX_AUTO_AGENTS_PER_RUN = 10;
+
+/**
+ * Lookback window (days) for agent activity
+ *
+ * TODO(https://github.com/dust-tt/tasks/issues/7313): This will be replace with a more dynamic window using last reinforcement analysis time
+ */
+export const DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS = 1;

--- a/front/lib/reinforced_agent/eligibility.test.ts
+++ b/front/lib/reinforced_agent/eligibility.test.ts
@@ -5,8 +5,12 @@ vi.mock("@app/lib/utils/statsd", () => ({
 }));
 
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS } from "@app/lib/reinforced_agent/constants";
 import { filterEligibleAgents } from "@app/lib/reinforced_agent/eligibility";
+import {
+  fetchReinforcementAutoTrackSignals,
+  type ReinforcementAutoTrackSignals,
+} from "@app/lib/reinforced_agent/signals";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
@@ -18,26 +22,25 @@ import type { LightWorkspaceType } from "@app/types/user";
 const daysAgo = (days: number) =>
   new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 
-async function createRecentAgentMessage(
+function emptySignals(): ReinforcementAutoTrackSignals {
+  return {
+    feedbackCountByAgentSId: new Map(),
+    humanConversationSIdsByAgent: new Map(),
+    agentSIdsWithRecentPendingSuggestions: new Set(),
+  };
+}
+
+async function createHumanInLoopConversation(
   auth: Authenticator,
-  workspace: LightWorkspaceType,
   agent: LightAgentConfigurationType,
-  agentMessageCreatedAt: Date
+  messageDate: Date
 ) {
   const conv = await ConversationFactory.create(auth, {
     agentConfigurationId: agent.sId,
-    messagesCreatedAt: [],
+    messagesCreatedAt: [messageDate],
     visibility: "unlisted",
   });
-  const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {
-    workspace,
-    conversation: conv,
-    agentConfig: agent,
-  });
-  await AgentMessageModel.update(
-    { createdAt: agentMessageCreatedAt },
-    { where: { workspaceId: workspace.id, id: agentMessage.agentMessageId } }
-  );
+  await ConversationFactory.setUpdatedAtForTest(auth, conv.id, messageDate);
   return conv;
 }
 
@@ -51,34 +54,40 @@ describe("filterEligibleAgents", () => {
     workspace = setup.workspace;
   });
 
-  it("returns empty array when agents list is empty", async () => {
-    expect(await filterEligibleAgents(auth, [], 30)).toEqual([]);
+  it("returns empty array when agents list is empty", () => {
+    expect(filterEligibleAgents(auth, [], emptySignals())).toEqual([]);
   });
 
-  it("excludes agents with reinforcement off before any DB queries", async () => {
+  it("excludes agents with reinforcement off before using signals payload", async () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const withOff: LightAgentConfigurationType = {
       ...agent,
       reinforcement: "off",
     };
-    expect(await filterEligibleAgents(auth, [withOff], 30)).toEqual([]);
+    expect(filterEligibleAgents(auth, [withOff], emptySignals())).toEqual([]);
   });
 
-  it("excludes agents with non-positive id before any DB queries", async () => {
+  it("excludes agents with non-positive id before using signals payload", async () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const withBadId: LightAgentConfigurationType = { ...agent, id: 0 };
-    expect(await filterEligibleAgents(auth, [withBadId], 30)).toEqual([]);
+    expect(filterEligibleAgents(auth, [withBadId], emptySignals())).toEqual([]);
   });
 
-  it("includes agents with a recent agent message", async () => {
+  it("includes agents with a recent human-in-the-loop conversation", async () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
-    await createRecentAgentMessage(auth, workspace, agent, daysAgo(2));
+    await createHumanInLoopConversation(auth, agent, daysAgo(2));
 
-    const result = await filterEligibleAgents(auth, [agent], 30);
+    const signals = await fetchReinforcementAutoTrackSignals(auth, {
+      agentSIds: [agent.sId],
+      lookbackWindowDays: 30,
+      pendingSuggestionMaxAgeDays: DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
+    });
+
+    const result = filterEligibleAgents(auth, [agent], signals);
     expect(result.map((a) => a.sId)).toEqual([agent.sId]);
   });
 
-  it("includes agents with feedback even without a recent agent message", async () => {
+  it("includes agents with feedback even without a human-in-the-loop conversation", async () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const conv = await ConversationFactory.create(auth, {
       agentConfigurationId: agent.sId,
@@ -87,7 +96,11 @@ describe("filterEligibleAgents", () => {
     });
     const { agentMessage } = await ConversationFactory.createAgentMessage(
       auth,
-      { workspace, conversation: conv, agentConfig: agent }
+      {
+        workspace,
+        conversation: conv,
+        agentConfig: agent,
+      }
     );
     await AgentMessageFeedbackResource.makeNew({
       workspaceId: auth.getNonNullableWorkspace().id,
@@ -102,24 +115,44 @@ describe("filterEligibleAgents", () => {
       dismissed: false,
     });
 
-    const result = await filterEligibleAgents(auth, [agent], 30);
+    const signals = await fetchReinforcementAutoTrackSignals(auth, {
+      agentSIds: [agent.sId],
+      lookbackWindowDays: 30,
+      pendingSuggestionMaxAgeDays: DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
+    });
+
+    const result = filterEligibleAgents(auth, [agent], signals);
     expect(result.map((a) => a.sId)).toEqual([agent.sId]);
   });
 
   it("excludes agents blocked by a recent pending suggestion", async () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
-    await createRecentAgentMessage(auth, workspace, agent, daysAgo(2));
-    await AgentSuggestionFactory.createInstructions(auth, agent);
+    await createHumanInLoopConversation(auth, agent, daysAgo(2));
+    await AgentSuggestionFactory.createInstructions(auth, agent, {
+      source: "reinforcement",
+    });
 
-    const result = await filterEligibleAgents(auth, [agent], 30);
+    const signals = await fetchReinforcementAutoTrackSignals(auth, {
+      agentSIds: [agent.sId],
+      lookbackWindowDays: 30,
+      pendingSuggestionMaxAgeDays: DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
+    });
+
+    const result = filterEligibleAgents(auth, [agent], signals);
     expect(result).toEqual([]);
   });
 
-  it("excludes agents whose agent messages fall outside the lookback window", async () => {
+  it("excludes agents whose human-in-the-loop activity falls outside the lookback window", async () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
-    await createRecentAgentMessage(auth, workspace, agent, daysAgo(60));
+    await createHumanInLoopConversation(auth, agent, daysAgo(60));
 
-    const result = await filterEligibleAgents(auth, [agent], 30);
+    const signals = await fetchReinforcementAutoTrackSignals(auth, {
+      agentSIds: [agent.sId],
+      lookbackWindowDays: 30,
+      pendingSuggestionMaxAgeDays: DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
+    });
+
+    const result = filterEligibleAgents(auth, [agent], signals);
     expect(result).toEqual([]);
   });
 });

--- a/front/lib/reinforced_agent/eligibility.ts
+++ b/front/lib/reinforced_agent/eligibility.ts
@@ -1,12 +1,8 @@
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
-import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { ReinforcementAutoTrackSignals } from "@app/lib/reinforced_agent/signals";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-
-const PENDING_SUGGESTION_MAX_AGE_DAYS = 30;
 
 function recordReinforcedAgentEligibilityMetrics({
   workspaceId,
@@ -51,11 +47,11 @@ function recordReinforcedAgentEligibilityMetrics({
 // has no recent pending suggestions, and either:
 //   (a) has explicit human feedback in the lookback window, or
 //   (b) has recent qualifying conversations in the lookback window.
-export async function filterEligibleAgents(
+export function filterEligibleAgents(
   auth: Authenticator,
   agents: LightAgentConfigurationType[],
-  lookbackWindowDays: number
-): Promise<LightAgentConfigurationType[]> {
+  signals: ReinforcementAutoTrackSignals
+): LightAgentConfigurationType[] {
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const candidates = agents.filter(
     (a) => a.reinforcement !== "off" && a.id > 0
@@ -69,49 +65,14 @@ export async function filterEligibleAgents(
     return [];
   }
 
-  const candidateSIds = candidates.map((a) => a.sId);
-  const cutoffDate = new Date();
-  cutoffDate.setDate(cutoffDate.getDate() - lookbackWindowDays);
-  const pendingSuggestionCutoff = new Date();
-  pendingSuggestionCutoff.setDate(
-    pendingSuggestionCutoff.getDate() - PENDING_SUGGESTION_MAX_AGE_DAYS
-  );
-
-  const [agentsWithRecentConversations, feedbackCounts, pendingSuggestions] =
-    await Promise.all([
-      ConversationResource.listIdsOfAgentsWithRecentConversations(auth, {
-        agentSIds: candidateSIds,
-        cutoffDate,
-      }),
-      AgentMessageFeedbackResource.getFeedbackCountForAssistants(
-        auth,
-        candidateSIds,
-        lookbackWindowDays
-      ),
-      AgentSuggestionResource.listByAgentConfigurationIds(auth, candidateSIds, {
-        states: ["pending"],
-        createdAfter: pendingSuggestionCutoff,
-      }),
-    ]);
-
-  const agentsWithFeedback = new Set(
-    feedbackCounts.map((f) => f.agentConfigurationId)
-  );
-  const agentsWithRecentConversationsSet = new Set(
-    agentsWithRecentConversations
-  );
-  const agentsWithRecentPendingSuggestions = new Set(
-    pendingSuggestions.map((s) => s.agentConfigurationSId)
-  );
-
-  const eligible = candidates.filter((a) => {
-    if (agentsWithRecentPendingSuggestions.has(a.sId)) {
+  const eligible = candidates.filter((agent) => {
+    if (signals.agentSIdsWithRecentPendingSuggestions.has(agent.sId)) {
       return false;
     }
-    if (agentsWithFeedback.has(a.sId)) {
-      return true;
-    }
-    return agentsWithRecentConversationsSet.has(a.sId);
+    const feedback = signals.feedbackCountByAgentSId.get(agent.sId) ?? 0;
+    const humanConvCount =
+      signals.humanConversationSIdsByAgent.get(agent.sId)?.length ?? 0;
+    return feedback > 0 || humanConvCount > 0;
   });
 
   recordReinforcedAgentEligibilityMetrics({

--- a/front/lib/reinforced_agent/selection.test.ts
+++ b/front/lib/reinforced_agent/selection.test.ts
@@ -20,14 +20,11 @@ import {
   DEFAULT_MAX_AUTO_AGENTS_PER_RUN,
   DEFAULT_MAX_CONVERSATIONS_PER_AGENT,
   DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE,
-  DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
 } from "@app/lib/reinforced_agent/constants";
-import { filterEligibleAgents } from "@app/lib/reinforced_agent/eligibility";
 import {
   type SelectionOptions,
-  selectAgentsForReinforcement,
+  selectAgentsForReinforcementPipeline,
 } from "@app/lib/reinforced_agent/selection";
-import { fetchReinforcementAutoTrackSignals } from "@app/lib/reinforced_agent/signals";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
@@ -42,59 +39,11 @@ import type { LightWorkspaceType } from "@app/types/user";
 const daysAgo = (days: number) =>
   new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 
-type ReinforcementSelectionPipelineOptions = SelectionOptions & {
-  lookbackWindowDays?: number;
-  pendingSuggestionMaxAgeDays?: number;
-};
-
-const DEFAULT_PIPELINE_OPTIONS: ReinforcementSelectionPipelineOptions = {
-  lookbackWindowDays: 30,
-  pendingSuggestionMaxAgeDays: DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
+const DEFAULT_PIPELINE_OPTIONS: SelectionOptions = {
   maxConversationsPerAgent: DEFAULT_MAX_CONVERSATIONS_PER_AGENT,
   maxAutoAgentsPerRun: DEFAULT_MAX_AUTO_AGENTS_PER_RUN,
   minConversationsToInclude: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE,
 };
-
-function pickSelectionOptions(
-  pipeline: ReinforcementSelectionPipelineOptions
-): SelectionOptions {
-  const {
-    lookbackWindowDays: _l,
-    pendingSuggestionMaxAgeDays: _p,
-    ...selection
-  } = pipeline;
-  return selection;
-}
-
-async function runReinforcementSelectionLikeActivity(
-  auth: Authenticator,
-  agents: LightAgentConfigurationType[],
-  pipelineOptions: ReinforcementSelectionPipelineOptions = DEFAULT_PIPELINE_OPTIONS
-) {
-  const inScope = agents.filter((a) => a.id > 0 && a.reinforcement !== "off");
-  const explicitOnAgents = inScope.filter((a) => a.reinforcement === "on");
-  const autoAgents = inScope.filter((a) => a.reinforcement === "auto");
-
-  const lookbackWindowDays = pipelineOptions.lookbackWindowDays ?? 30;
-  const pendingSuggestionMaxAgeDays =
-    pipelineOptions.pendingSuggestionMaxAgeDays ??
-    DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS;
-
-  const signals = await fetchReinforcementAutoTrackSignals(auth, {
-    agentSIds: autoAgents.map((a) => a.sId),
-    lookbackWindowDays,
-    pendingSuggestionMaxAgeDays,
-  });
-
-  const eligibleAutoAgents = filterEligibleAgents(auth, autoAgents, signals);
-
-  return selectAgentsForReinforcement(auth, {
-    explicitOnAgents,
-    eligibleAutoAgents,
-    signals,
-    options: pickSelectionOptions(pipelineOptions),
-  });
-}
 
 async function createConversationWithUpdatedAt(
   auth: Authenticator,
@@ -114,7 +63,7 @@ async function createAgentOnlyConversation(
   workspace: LightWorkspaceType,
   agent: AgentConfigurationType,
   {
-    updatedAt = daysAgo(2),
+    updatedAt = new Date(),
     withFunctionCallStep = false,
   }: { updatedAt?: Date; withFunctionCallStep?: boolean } = {}
 ) {
@@ -162,7 +111,7 @@ async function addFeedback(
   });
 }
 
-describe("selectAgentsForReinforcement", () => {
+describe("selectAgentsForReinforcementPipeline", () => {
   let auth: Authenticator;
   let workspace: LightWorkspaceType;
   let userId: number;
@@ -176,7 +125,7 @@ describe("selectAgentsForReinforcement", () => {
 
   it("returns empty array when agents list is empty", async () => {
     expect(
-      await runReinforcementSelectionLikeActivity(
+      await selectAgentsForReinforcementPipeline(
         auth,
         [],
         DEFAULT_PIPELINE_OPTIONS
@@ -191,7 +140,7 @@ describe("selectAgentsForReinforcement", () => {
       reinforcement: "off",
     };
     expect(
-      await runReinforcementSelectionLikeActivity(
+      await selectAgentsForReinforcementPipeline(
         auth,
         [offAgent],
         DEFAULT_PIPELINE_OPTIONS
@@ -203,7 +152,7 @@ describe("selectAgentsForReinforcement", () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const globalAgent: LightAgentConfigurationType = { ...agent, id: 0 };
     expect(
-      await runReinforcementSelectionLikeActivity(
+      await selectAgentsForReinforcementPipeline(
         auth,
         [globalAgent],
         DEFAULT_PIPELINE_OPTIONS
@@ -217,7 +166,7 @@ describe("selectAgentsForReinforcement", () => {
       ...agent,
       reinforcement: "on",
     };
-    const results = await runReinforcementSelectionLikeActivity(
+    const results = await selectAgentsForReinforcementPipeline(
       auth,
       [onAgent],
       DEFAULT_PIPELINE_OPTIONS
@@ -244,7 +193,7 @@ describe("selectAgentsForReinforcement", () => {
 
     await Promise.all(
       Array.from({ length: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE }, () =>
-        createConversationWithUpdatedAt(auth, autoAgent.sId, daysAgo(2))
+        createConversationWithUpdatedAt(auth, autoAgent.sId, new Date())
       )
     );
 
@@ -261,7 +210,7 @@ describe("selectAgentsForReinforcement", () => {
       agentMessage.agentMessageId
     );
 
-    const results = await runReinforcementSelectionLikeActivity(
+    const results = await selectAgentsForReinforcementPipeline(
       auth,
       [autoAgent, onAgent],
       DEFAULT_PIPELINE_OPTIONS
@@ -286,7 +235,7 @@ describe("selectAgentsForReinforcement", () => {
 
     await Promise.all(
       Array.from({ length: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE }, () =>
-        createConversationWithUpdatedAt(auth, autoAgent.sId, daysAgo(2))
+        createConversationWithUpdatedAt(auth, autoAgent.sId, new Date())
       )
     );
 
@@ -303,7 +252,7 @@ describe("selectAgentsForReinforcement", () => {
       agentMessage.agentMessageId
     );
 
-    const results = await runReinforcementSelectionLikeActivity(
+    const results = await selectAgentsForReinforcementPipeline(
       auth,
       [onAgent, autoAgent],
       {
@@ -319,9 +268,9 @@ describe("selectAgentsForReinforcement", () => {
 
   it("excludes auto agent with only one human conversation and no feedback (insufficient signal)", async () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
-    await createConversationWithUpdatedAt(auth, agent.sId, daysAgo(2));
+    await createConversationWithUpdatedAt(auth, agent.sId, new Date());
 
-    const results = await runReinforcementSelectionLikeActivity(
+    const results = await selectAgentsForReinforcementPipeline(
       auth,
       [agent],
       DEFAULT_PIPELINE_OPTIONS
@@ -335,7 +284,7 @@ describe("selectAgentsForReinforcement", () => {
       withFunctionCallStep: true,
     });
 
-    const results = await runReinforcementSelectionLikeActivity(
+    const results = await selectAgentsForReinforcementPipeline(
       auth,
       [agent],
       DEFAULT_PIPELINE_OPTIONS
@@ -347,7 +296,7 @@ describe("selectAgentsForReinforcement", () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     await Promise.all(
       Array.from({ length: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE }, () =>
-        createConversationWithUpdatedAt(auth, agent.sId, daysAgo(2))
+        createConversationWithUpdatedAt(auth, agent.sId, new Date())
       )
     );
 
@@ -361,7 +310,7 @@ describe("selectAgentsForReinforcement", () => {
       agentMessage.agentMessageId
     );
 
-    const results = await runReinforcementSelectionLikeActivity(
+    const results = await selectAgentsForReinforcementPipeline(
       auth,
       [agent],
       DEFAULT_PIPELINE_OPTIONS
@@ -388,7 +337,7 @@ describe("selectAgentsForReinforcement", () => {
       source: "reinforcement",
     });
 
-    const results = await runReinforcementSelectionLikeActivity(
+    const results = await selectAgentsForReinforcementPipeline(
       auth,
       [agent],
       DEFAULT_PIPELINE_OPTIONS
@@ -401,7 +350,7 @@ describe("selectAgentsForReinforcement", () => {
 
     await Promise.all(
       Array.from({ length: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE }, () =>
-        createConversationWithUpdatedAt(auth, agent.sId, daysAgo(2))
+        createConversationWithUpdatedAt(auth, agent.sId, new Date())
       )
     );
 
@@ -424,10 +373,11 @@ describe("selectAgentsForReinforcement", () => {
     );
     await AgentSuggestionFactory.setCreatedAt(suggestion, daysAgo(31));
 
-    const results = await runReinforcementSelectionLikeActivity(auth, [agent], {
-      ...DEFAULT_PIPELINE_OPTIONS,
-      pendingSuggestionMaxAgeDays: 30,
-    });
+    const results = await selectAgentsForReinforcementPipeline(
+      auth,
+      [agent],
+      DEFAULT_PIPELINE_OPTIONS
+    );
     expect(results).toHaveLength(1);
     expect(results[0].agentConfigurationId).toBe(agent.sId);
   });
@@ -442,10 +392,10 @@ describe("selectAgentsForReinforcement", () => {
 
     await Promise.all([
       ...Array.from({ length: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE }, () =>
-        createConversationWithUpdatedAt(auth, agentA.sId, daysAgo(2))
+        createConversationWithUpdatedAt(auth, agentA.sId, new Date())
       ),
       ...Array.from({ length: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE }, () =>
-        createConversationWithUpdatedAt(auth, agentB.sId, daysAgo(2))
+        createConversationWithUpdatedAt(auth, agentB.sId, new Date())
       ),
     ]);
 
@@ -468,7 +418,7 @@ describe("selectAgentsForReinforcement", () => {
       await createAgentOnlyConversation(auth, workspace, agentB);
     await addFeedback(workspace, userId, agentB, convB.id, amB.agentMessageId);
 
-    const results = await runReinforcementSelectionLikeActivity(
+    const results = await selectAgentsForReinforcementPipeline(
       auth,
       [agentA, agentB],
       DEFAULT_PIPELINE_OPTIONS
@@ -487,7 +437,7 @@ describe("selectAgentsForReinforcement", () => {
 
     await Promise.all(
       Array.from({ length: 15 }, () =>
-        createConversationWithUpdatedAt(auth, agent.sId, daysAgo(2))
+        createConversationWithUpdatedAt(auth, agent.sId, new Date())
       )
     );
 
@@ -504,7 +454,7 @@ describe("selectAgentsForReinforcement", () => {
       agentMessage.agentMessageId
     );
 
-    const results = await runReinforcementSelectionLikeActivity(auth, [agent], {
+    const results = await selectAgentsForReinforcementPipeline(auth, [agent], {
       ...DEFAULT_PIPELINE_OPTIONS,
       maxConversationsPerAgent: 10,
     });
@@ -523,7 +473,7 @@ describe("selectAgentsForReinforcement", () => {
 
     await Promise.all(
       Array.from({ length: 4 }, () =>
-        createConversationWithUpdatedAt(auth, agentA.sId, daysAgo(2))
+        createConversationWithUpdatedAt(auth, agentA.sId, new Date())
       )
     );
 
@@ -546,11 +496,10 @@ describe("selectAgentsForReinforcement", () => {
       await createAgentOnlyConversation(auth, workspace, agentB);
     await addFeedback(workspace, userId, agentB, convB.id, amB.agentMessageId);
 
-    const results = await runReinforcementSelectionLikeActivity(
+    const results = await selectAgentsForReinforcementPipeline(
       auth,
       [agentA, agentB],
       {
-        lookbackWindowDays: 30,
         maxConversationsPerAgent: 4,
         maxAutoAgentsPerRun: 2,
         totalAutoConversationPool: 8,

--- a/front/lib/reinforced_agent/selection.test.ts
+++ b/front/lib/reinforced_agent/selection.test.ts
@@ -1,0 +1,523 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/utils/statsd", () => ({
+  getStatsDClient: () => ({ increment: vi.fn(), distribution: vi.fn() }),
+}));
+
+vi.mock("@app/lib/api/elasticsearch", async () => {
+  const { Ok } = await import("@app/types/shared/result");
+  return {
+    searchAnalytics: vi.fn().mockResolvedValue(
+      new Ok({
+        aggregations: { by_agent: { buckets: [] } },
+      })
+    ),
+  };
+});
+
+import type { Authenticator } from "@app/lib/auth";
+import {
+  DEFAULT_MAX_AUTO_AGENTS_PER_RUN,
+  DEFAULT_MAX_CONVERSATIONS_PER_AGENT,
+  DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE,
+  DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
+} from "@app/lib/reinforced_agent/constants";
+import { filterEligibleAgents } from "@app/lib/reinforced_agent/eligibility";
+import {
+  type SelectionOptions,
+  selectAgentsForReinforcement,
+} from "@app/lib/reinforced_agent/selection";
+import { fetchReinforcementAutoTrackSignals } from "@app/lib/reinforced_agent/signals";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type {
+  AgentConfigurationType,
+  LightAgentConfigurationType,
+} from "@app/types/assistant/agent";
+import type { LightWorkspaceType } from "@app/types/user";
+
+const daysAgo = (days: number) =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+type ReinforcementSelectionPipelineOptions = SelectionOptions & {
+  lookbackWindowDays?: number;
+  pendingSuggestionMaxAgeDays?: number;
+};
+
+const DEFAULT_PIPELINE_OPTIONS: ReinforcementSelectionPipelineOptions = {
+  lookbackWindowDays: 30,
+  pendingSuggestionMaxAgeDays: DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
+  maxConversationsPerAgent: DEFAULT_MAX_CONVERSATIONS_PER_AGENT,
+  maxAutoAgentsPerRun: DEFAULT_MAX_AUTO_AGENTS_PER_RUN,
+  minConversationsToInclude: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE,
+};
+
+function pickSelectionOptions(
+  pipeline: ReinforcementSelectionPipelineOptions
+): SelectionOptions {
+  const {
+    lookbackWindowDays: _l,
+    pendingSuggestionMaxAgeDays: _p,
+    ...selection
+  } = pipeline;
+  return selection;
+}
+
+async function runReinforcementSelectionLikeActivity(
+  auth: Authenticator,
+  agents: LightAgentConfigurationType[],
+  pipelineOptions: ReinforcementSelectionPipelineOptions = DEFAULT_PIPELINE_OPTIONS
+) {
+  const inScope = agents.filter((a) => a.id > 0 && a.reinforcement !== "off");
+  const explicitOnAgents = inScope.filter((a) => a.reinforcement === "on");
+  const autoAgents = inScope.filter((a) => a.reinforcement === "auto");
+
+  const lookbackWindowDays = pipelineOptions.lookbackWindowDays ?? 30;
+  const pendingSuggestionMaxAgeDays =
+    pipelineOptions.pendingSuggestionMaxAgeDays ??
+    DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS;
+
+  const signals = await fetchReinforcementAutoTrackSignals(auth, {
+    agentSIds: autoAgents.map((a) => a.sId),
+    lookbackWindowDays,
+    pendingSuggestionMaxAgeDays,
+  });
+
+  const eligibleAutoAgents = filterEligibleAgents(auth, autoAgents, signals);
+
+  return selectAgentsForReinforcement(auth, {
+    explicitOnAgents,
+    eligibleAutoAgents,
+    signals,
+    options: pickSelectionOptions(pipelineOptions),
+  });
+}
+
+async function createConversationWithUpdatedAt(
+  auth: Authenticator,
+  agentSId: string,
+  updatedAt: Date
+) {
+  const conv = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentSId,
+    messagesCreatedAt: [updatedAt],
+  });
+  await ConversationFactory.setUpdatedAtForTest(auth, conv.id, updatedAt);
+  return conv;
+}
+
+async function createAgentOnlyConversation(
+  auth: Authenticator,
+  workspace: LightWorkspaceType,
+  agent: AgentConfigurationType,
+  {
+    updatedAt = daysAgo(2),
+    withFunctionCallStep = false,
+  }: { updatedAt?: Date; withFunctionCallStep?: boolean } = {}
+) {
+  const conv = await ConversationFactory.create(auth, {
+    agentConfigurationId: agent.sId,
+    messagesCreatedAt: [],
+  });
+  await ConversationFactory.setUpdatedAtForTest(auth, conv.id, updatedAt);
+
+  const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {
+    workspace,
+    conversation: conv,
+    agentConfig: agent,
+  });
+
+  if (withFunctionCallStep) {
+    await ConversationFactory.createFunctionCallStepForTest(
+      auth,
+      agentMessage.agentMessageId,
+      { createdAt: updatedAt }
+    );
+  }
+
+  return { conv, agentMessage };
+}
+
+async function addFeedback(
+  workspace: LightWorkspaceType,
+  userId: number,
+  agent: AgentConfigurationType,
+  conversationId: number,
+  agentMessageId: number
+) {
+  return AgentMessageFeedbackResource.makeNew({
+    workspaceId: workspace.id,
+    agentConfigurationId: agent.sId,
+    agentConfigurationVersion: agent.version,
+    conversationId,
+    agentMessageId,
+    userId,
+    thumbDirection: "up",
+    content: "good",
+    isConversationShared: false,
+    dismissed: false,
+  });
+}
+
+describe("selectAgentsForReinforcement", () => {
+  let auth: Authenticator;
+  let workspace: LightWorkspaceType;
+  let userId: number;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({ role: "builder" });
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+    userId = setup.user.id;
+  });
+
+  it("returns empty array when agents list is empty", async () => {
+    expect(
+      await runReinforcementSelectionLikeActivity(
+        auth,
+        [],
+        DEFAULT_PIPELINE_OPTIONS
+      )
+    ).toEqual([]);
+  });
+
+  it("excludes agents with reinforcement off", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const offAgent: LightAgentConfigurationType = {
+      ...agent,
+      reinforcement: "off",
+    };
+    expect(
+      await runReinforcementSelectionLikeActivity(
+        auth,
+        [offAgent],
+        DEFAULT_PIPELINE_OPTIONS
+      )
+    ).toEqual([]);
+  });
+
+  it("excludes global/system agents (id <= 0)", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const globalAgent: LightAgentConfigurationType = { ...agent, id: 0 };
+    expect(
+      await runReinforcementSelectionLikeActivity(
+        auth,
+        [globalAgent],
+        DEFAULT_PIPELINE_OPTIONS
+      )
+    ).toEqual([]);
+  });
+
+  it("includes explicit-on agents at maxConversationsPerAgent without eligibility or scoring", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const onAgent: LightAgentConfigurationType = {
+      ...agent,
+      reinforcement: "on",
+    };
+    const results = await runReinforcementSelectionLikeActivity(
+      auth,
+      [onAgent],
+      DEFAULT_PIPELINE_OPTIONS
+    );
+    expect(results).toEqual([
+      {
+        agentConfigurationId: onAgent.sId,
+        conversationsToSample: DEFAULT_MAX_CONVERSATIONS_PER_AGENT,
+      },
+    ]);
+  });
+
+  it("explicit-on agents appear before auto agents in the output", async () => {
+    const autoAgent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Auto Agent",
+    });
+    const onAgentBase = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "On Agent",
+    });
+    const onAgent: LightAgentConfigurationType = {
+      ...onAgentBase,
+      reinforcement: "on",
+    };
+
+    const { conv, agentMessage } = await createAgentOnlyConversation(
+      auth,
+      workspace,
+      autoAgent
+    );
+    await addFeedback(
+      workspace,
+      userId,
+      autoAgent,
+      conv.id,
+      agentMessage.agentMessageId
+    );
+
+    const results = await runReinforcementSelectionLikeActivity(
+      auth,
+      [autoAgent, onAgent],
+      DEFAULT_PIPELINE_OPTIONS
+    );
+
+    expect(results.length).toBeGreaterThanOrEqual(2);
+    expect(results[0].agentConfigurationId).toBe(onAgent.sId);
+  });
+
+  it("maxAutoAgentsPerRun limits auto agents only, not explicit-on agents", async () => {
+    const onAgentBase = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "On Agent Budget",
+    });
+    const onAgent: LightAgentConfigurationType = {
+      ...onAgentBase,
+      reinforcement: "on",
+    };
+
+    const autoAgent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Auto Agent Budget",
+    });
+    const { conv, agentMessage } = await createAgentOnlyConversation(
+      auth,
+      workspace,
+      autoAgent
+    );
+    await addFeedback(
+      workspace,
+      userId,
+      autoAgent,
+      conv.id,
+      agentMessage.agentMessageId
+    );
+
+    const results = await runReinforcementSelectionLikeActivity(
+      auth,
+      [onAgent, autoAgent],
+      {
+        ...DEFAULT_PIPELINE_OPTIONS,
+        maxAutoAgentsPerRun: 1,
+      }
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0].agentConfigurationId).toBe(onAgent.sId);
+    expect(results[1].agentConfigurationId).toBe(autoAgent.sId);
+  });
+
+  it("excludes auto agent with only one human conversation and no feedback (insufficient signal)", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    await createConversationWithUpdatedAt(auth, agent.sId, daysAgo(2));
+
+    const results = await runReinforcementSelectionLikeActivity(
+      auth,
+      [agent],
+      DEFAULT_PIPELINE_OPTIONS
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("excludes auto agent with tool calls but no human messages and no feedback", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    await createAgentOnlyConversation(auth, workspace, agent, {
+      withFunctionCallStep: true,
+    });
+
+    const results = await runReinforcementSelectionLikeActivity(
+      auth,
+      [agent],
+      DEFAULT_PIPELINE_OPTIONS
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("includes auto agent that has feedback and sufficient human conversations", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    await Promise.all(
+      Array.from({ length: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE }, () =>
+        createConversationWithUpdatedAt(auth, agent.sId, daysAgo(2))
+      )
+    );
+
+    const { conv: feedbackConv, agentMessage } =
+      await createAgentOnlyConversation(auth, workspace, agent);
+    await addFeedback(
+      workspace,
+      userId,
+      agent,
+      feedbackConv.id,
+      agentMessage.agentMessageId
+    );
+
+    const results = await runReinforcementSelectionLikeActivity(
+      auth,
+      [agent],
+      DEFAULT_PIPELINE_OPTIONS
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].agentConfigurationId).toBe(agent.sId);
+  });
+
+  it("excludes auto agent with a recent pending reinforcement suggestion", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const { conv, agentMessage } = await createAgentOnlyConversation(
+      auth,
+      workspace,
+      agent
+    );
+    await addFeedback(
+      workspace,
+      userId,
+      agent,
+      conv.id,
+      agentMessage.agentMessageId
+    );
+    await AgentSuggestionFactory.createInstructions(auth, agent, {
+      source: "reinforcement",
+    });
+
+    const results = await runReinforcementSelectionLikeActivity(
+      auth,
+      [agent],
+      DEFAULT_PIPELINE_OPTIONS
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("includes auto agent whose pending suggestion is older than the threshold", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const { conv, agentMessage } = await createAgentOnlyConversation(
+      auth,
+      workspace,
+      agent
+    );
+    await addFeedback(
+      workspace,
+      userId,
+      agent,
+      conv.id,
+      agentMessage.agentMessageId
+    );
+    const suggestion = await AgentSuggestionFactory.createInstructions(
+      auth,
+      agent,
+      { source: "reinforcement" }
+    );
+    await AgentSuggestionFactory.setCreatedAt(suggestion, daysAgo(31));
+
+    const results = await runReinforcementSelectionLikeActivity(auth, [agent], {
+      ...DEFAULT_PIPELINE_OPTIONS,
+      pendingSuggestionMaxAgeDays: 30,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].agentConfigurationId).toBe(agent.sId);
+  });
+
+  it("agent with more feedback receives a higher score and appears first", async () => {
+    const agentA = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "High Feedback Agent",
+    });
+    const agentB = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Low Feedback Agent",
+    });
+
+    for (let i = 0; i < 3; i++) {
+      const { conv, agentMessage } = await createAgentOnlyConversation(
+        auth,
+        workspace,
+        agentA
+      );
+      await addFeedback(
+        workspace,
+        userId,
+        agentA,
+        conv.id,
+        agentMessage.agentMessageId
+      );
+    }
+
+    const { conv: convB, agentMessage: amB } =
+      await createAgentOnlyConversation(auth, workspace, agentB);
+    await addFeedback(workspace, userId, agentB, convB.id, amB.agentMessageId);
+
+    const results = await runReinforcementSelectionLikeActivity(
+      auth,
+      [agentA, agentB],
+      DEFAULT_PIPELINE_OPTIONS
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0].agentConfigurationId).toBe(agentA.sId);
+    expect(results[1].agentConfigurationId).toBe(agentB.sId);
+    expect(results[0].conversationsToSample).toBeGreaterThanOrEqual(
+      results[1].conversationsToSample
+    );
+  });
+
+  it("conversationsToSample does not exceed maxConversationsPerAgent", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const { conv, agentMessage } = await createAgentOnlyConversation(
+      auth,
+      workspace,
+      agent
+    );
+    await addFeedback(
+      workspace,
+      userId,
+      agent,
+      conv.id,
+      agentMessage.agentMessageId
+    );
+
+    const results = await runReinforcementSelectionLikeActivity(auth, [agent], {
+      ...DEFAULT_PIPELINE_OPTIONS,
+      maxConversationsPerAgent: 10,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].conversationsToSample).toBeLessThanOrEqual(10);
+  });
+
+  it("drops agents whose unclamped allocation falls below minConversationsToInclude", async () => {
+    const agentA = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Strong Signal Agent",
+    });
+    const agentB = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Weak Signal Agent",
+    });
+
+    for (let i = 0; i < 3; i++) {
+      const { conv, agentMessage } = await createAgentOnlyConversation(
+        auth,
+        workspace,
+        agentA
+      );
+      await addFeedback(
+        workspace,
+        userId,
+        agentA,
+        conv.id,
+        agentMessage.agentMessageId
+      );
+    }
+
+    const { conv: convB, agentMessage: amB } =
+      await createAgentOnlyConversation(auth, workspace, agentB);
+    await addFeedback(workspace, userId, agentB, convB.id, amB.agentMessageId);
+
+    const results = await runReinforcementSelectionLikeActivity(
+      auth,
+      [agentA, agentB],
+      {
+        lookbackWindowDays: 30,
+        maxConversationsPerAgent: 4,
+        maxAutoAgentsPerRun: 2,
+        totalAutoConversationPool: 8,
+        minConversationsToInclude: 4,
+      }
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].agentConfigurationId).toBe(agentA.sId);
+    expect(results[0].conversationsToSample).toBe(4);
+  });
+});

--- a/front/lib/reinforced_agent/selection.test.ts
+++ b/front/lib/reinforced_agent/selection.test.ts
@@ -242,6 +242,12 @@ describe("selectAgentsForReinforcement", () => {
       reinforcement: "on",
     };
 
+    await Promise.all(
+      Array.from({ length: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE }, () =>
+        createConversationWithUpdatedAt(auth, autoAgent.sId, daysAgo(2))
+      )
+    );
+
     const { conv, agentMessage } = await createAgentOnlyConversation(
       auth,
       workspace,
@@ -277,6 +283,13 @@ describe("selectAgentsForReinforcement", () => {
     const autoAgent = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Auto Agent Budget",
     });
+
+    await Promise.all(
+      Array.from({ length: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE }, () =>
+        createConversationWithUpdatedAt(auth, autoAgent.sId, daysAgo(2))
+      )
+    );
+
     const { conv, agentMessage } = await createAgentOnlyConversation(
       auth,
       workspace,
@@ -385,6 +398,13 @@ describe("selectAgentsForReinforcement", () => {
 
   it("includes auto agent whose pending suggestion is older than the threshold", async () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    await Promise.all(
+      Array.from({ length: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE }, () =>
+        createConversationWithUpdatedAt(auth, agent.sId, daysAgo(2))
+      )
+    );
+
     const { conv, agentMessage } = await createAgentOnlyConversation(
       auth,
       workspace,
@@ -419,6 +439,15 @@ describe("selectAgentsForReinforcement", () => {
     const agentB = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Low Feedback Agent",
     });
+
+    await Promise.all([
+      ...Array.from({ length: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE }, () =>
+        createConversationWithUpdatedAt(auth, agentA.sId, daysAgo(2))
+      ),
+      ...Array.from({ length: DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE }, () =>
+        createConversationWithUpdatedAt(auth, agentB.sId, daysAgo(2))
+      ),
+    ]);
 
     for (let i = 0; i < 3; i++) {
       const { conv, agentMessage } = await createAgentOnlyConversation(
@@ -455,6 +484,13 @@ describe("selectAgentsForReinforcement", () => {
 
   it("conversationsToSample does not exceed maxConversationsPerAgent", async () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    await Promise.all(
+      Array.from({ length: 15 }, () =>
+        createConversationWithUpdatedAt(auth, agent.sId, daysAgo(2))
+      )
+    );
+
     const { conv, agentMessage } = await createAgentOnlyConversation(
       auth,
       workspace,
@@ -484,6 +520,12 @@ describe("selectAgentsForReinforcement", () => {
     const agentB = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Weak Signal Agent",
     });
+
+    await Promise.all(
+      Array.from({ length: 4 }, () =>
+        createConversationWithUpdatedAt(auth, agentA.sId, daysAgo(2))
+      )
+    );
 
     for (let i = 0; i < 3; i++) {
       const { conv, agentMessage } = await createAgentOnlyConversation(

--- a/front/lib/reinforced_agent/selection.ts
+++ b/front/lib/reinforced_agent/selection.ts
@@ -277,7 +277,13 @@ function scoreAutoAgent(
     toolError: number;
     multiUser: number;
   },
-  maxes: {
+  {
+    maxFeedback,
+    maxHumanConversations,
+    maxToolError,
+    maxMultiUser,
+    now,
+  }: {
     maxFeedback: number;
     maxHumanConversations: number;
     maxToolError: number;
@@ -285,14 +291,6 @@ function scoreAutoAgent(
     now: number;
   }
 ): ScoredAgent {
-  const {
-    maxFeedback,
-    maxHumanConversations,
-    maxToolError,
-    maxMultiUser,
-    now,
-  } = maxes;
-
   const versionCreatedAt = agent.versionCreatedAt
     ? new Date(agent.versionCreatedAt).getTime()
     : null;
@@ -369,7 +367,7 @@ function recordAgentScoringMetrics(
         row.logKey,
         row.weight * row.value(normalized),
       ])
-    ) as Record<ContributionLogKey, number>;
+    );
 
     logger.info(
       {

--- a/front/lib/reinforced_agent/selection.ts
+++ b/front/lib/reinforced_agent/selection.ts
@@ -6,24 +6,19 @@ import {
   DEFAULT_MAX_AUTO_AGENTS_PER_RUN,
   DEFAULT_MAX_CONVERSATIONS_PER_AGENT,
   DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE,
+  DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
   DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS,
   DEFAULT_TOTAL_CONVERSATIONS_TO_ANALYZE,
 } from "./constants";
+import { filterEligibleAgents } from "./eligibility";
 import {
   fetchDistinctUsersAndToolErrorCounts,
+  fetchReinforcementAutoTrackSignals,
   type ReinforcementAutoTrackSignals,
 } from "./signals";
 
 // Maximum days since agent configuration update to consider it "stale".
 const AGENT_UPDATE_STALENESS_WINDOW_CLAMP = 90;
-
-// Weighted sum of normalized signals for auto-track ranking (each factor is 0–1 within the cohort; sum = 1).
-const REINFORCEMENT_RANK_WEIGHT_FEEDBACK = 0.3;
-const REINFORCEMENT_RANK_WEIGHT_REINFORCEMENT_STALENESS = 0.2; // Favors agents that have not been reinforced recently
-const REINFORCEMENT_RANK_WEIGHT_HUMAN_CONVERSATIONS = 0.2;
-const REINFORCEMENT_RANK_WEIGHT_TOOL_ERROR = 0.1;
-const REINFORCEMENT_RANK_WEIGHT_MULTI_USER = 0.1;
-const REINFORCEMENT_RANK_WEIGHT_AGENT_VERSION_FRESHNESS = 0.1; // Favors agents with recently updated configs
 
 export interface AgentSelectionResult {
   agentConfigurationId: string;
@@ -37,7 +32,7 @@ export interface SelectionOptions {
   minConversationsToInclude?: number;
 }
 
-export interface ReinforcementSelectionInput {
+interface ReinforcementSelectionInput {
   explicitOnAgents: LightAgentConfigurationType[];
   eligibleAutoAgents: LightAgentConfigurationType[];
   signals: ReinforcementAutoTrackSignals;
@@ -57,6 +52,62 @@ interface ScoredAgent {
   };
 }
 
+type NormalizedSignals = ScoredAgent["normalized"];
+
+type ContributionLogKey =
+  | "feedback"
+  | "recency"
+  | "humanConversations"
+  | "toolError"
+  | "multiUser"
+  | "staleness";
+
+const SCORING_SIGNAL_ROWS: {
+  logKey: ContributionLogKey;
+  weight: number;
+  prefix: string;
+  normalizedSuffix?: string;
+  value: (n: NormalizedSignals) => number;
+}[] = [
+  {
+    logKey: "feedback",
+    weight: 0.3,
+    prefix: "feedback",
+    value: (n) => n.feedback,
+  },
+  {
+    logKey: "recency",
+    weight: 0.2, // Favors agents not recently reinforced
+    prefix: "recency",
+    value: (n) => n.reinforcementStaleness,
+  },
+  {
+    logKey: "humanConversations",
+    weight: 0.2,
+    prefix: "human_conversations",
+    value: (n) => n.humanConversations,
+  },
+  {
+    logKey: "toolError",
+    weight: 0.1,
+    prefix: "tool_error",
+    value: (n) => n.toolError,
+  },
+  {
+    logKey: "multiUser",
+    weight: 0.1,
+    prefix: "multi_user",
+    value: (n) => n.multiUser,
+  },
+  {
+    logKey: "staleness",
+    weight: 0.1, // Favors recently updated configs
+    prefix: "staleness",
+    normalizedSuffix: "staleness_score",
+    value: (n) => n.staleness,
+  },
+];
+
 /**
  * Determines which agents will be run and how many conversations to sample for each.
  *
@@ -65,7 +116,33 @@ interface ScoredAgent {
  *
  * Each agent is assigned a score, then conversation counts are split in proportion to those scores among the agents that are selected.
  */
-export async function selectAgentsForReinforcement(
+export async function selectAgentsForReinforcementPipeline(
+  auth: Authenticator,
+  agents: LightAgentConfigurationType[],
+  options: SelectionOptions = {}
+): Promise<AgentSelectionResult[]> {
+  const inScope = agents.filter((a) => a.id > 0 && a.reinforcement !== "off");
+  const explicitOnAgents = inScope.filter((a) => a.reinforcement === "on");
+  const autoAgents = inScope.filter((a) => a.reinforcement === "auto");
+
+  const signals = await fetchReinforcementAutoTrackSignals(auth, {
+    agentSIds: autoAgents.map((a) => a.sId),
+    lookbackWindowDays: DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS,
+    pendingSuggestionMaxAgeDays: DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
+  });
+
+  const eligibleAutoAgents = filterEligibleAgents(auth, autoAgents, signals);
+
+  return computeReinforcementSelections(auth, {
+    explicitOnAgents,
+    eligibleAutoAgents,
+    signals,
+    options,
+  });
+}
+
+/** Scores eligible auto agents and splits the conversation pool; `on` agents are passed through unchanged. */
+async function computeReinforcementSelections(
   auth: Authenticator,
   {
     explicitOnAgents,
@@ -113,89 +190,32 @@ export async function selectAgentsForReinforcement(
   const feedbackCountMap = signals.feedbackCountByAgentSId;
   const humanConvsByAgent = signals.humanConversationSIdsByAgent;
 
-  // Collect raw metric values across all eligible agents for cross-agent normalization.
-  const agentFeedbackCounts: number[] = [];
-  const agentHumanConversationsCount: number[] = [];
-  const agentToolErrorCount: number[] = [];
-  const agentUserCount: number[] = [];
+  const rawByAgent = eligibleAutoAgents.map((agent) => ({
+    agent,
+    feedback: feedbackCountMap.get(agent.sId) ?? 0,
+    humanConversations: humanConvsByAgent.get(agent.sId)?.length ?? 0,
+    toolError: toolErrorCountByAgentSId.get(agent.sId) ?? 0,
+    multiUser: distinctUserCountByAgentSId.get(agent.sId) ?? 0,
+  }));
 
-  for (const agent of eligibleAutoAgents) {
-    agentFeedbackCounts.push(feedbackCountMap.get(agent.sId) ?? 0);
-    agentHumanConversationsCount.push(
-      humanConvsByAgent.get(agent.sId)?.length ?? 0
-    );
-    agentToolErrorCount.push(toolErrorCountByAgentSId.get(agent.sId) ?? 0);
-    agentUserCount.push(distinctUserCountByAgentSId.get(agent.sId) ?? 0);
-  }
+  const maxFeedback = Math.max(0, ...rawByAgent.map((r) => r.feedback));
+  const maxHumanConversations = Math.max(
+    0,
+    ...rawByAgent.map((r) => r.humanConversations)
+  );
+  const maxToolError = Math.max(0, ...rawByAgent.map((r) => r.toolError));
+  const maxMultiUser = Math.max(0, ...rawByAgent.map((r) => r.multiUser));
 
-  const maxFeedback = Math.max(...agentFeedbackCounts, 0);
-  const maxHumanConversations = Math.max(...agentHumanConversationsCount, 0);
-  const maxToolError = Math.max(...agentToolErrorCount, 0);
-  const maxMultiUser = Math.max(...agentUserCount, 0);
-
-  const normalize = (value: number, max: number): number =>
-    max === 0 ? 0 : value / max;
-
-  const scored: ScoredAgent[] = eligibleAutoAgents.map((agent) => {
-    const feedback = normalize(
-      feedbackCountMap.get(agent.sId) ?? 0,
-      maxFeedback
-    );
-    // TODO(dust-tt/tasks#7313): We do not yet persist last reinforcement analysis time per agent.
-    // Once we do, we can use that time to calculate the staleness of the agent.
-    // For now, we use a static factor of 1.
-    const reinforcementStaleness = 1;
-    const humanConversations = normalize(
-      humanConvsByAgent.get(agent.sId)?.length ?? 0,
-      maxHumanConversations
-    );
-    const toolError = normalize(
-      toolErrorCountByAgentSId.get(agent.sId) ?? 0,
-      maxToolError
-    );
-    const multiUser = normalize(
-      distinctUserCountByAgentSId.get(agent.sId) ?? 0,
-      maxMultiUser
-    );
-
-    const now = Date.now();
-    const versionCreatedAt = agent.versionCreatedAt
-      ? new Date(agent.versionCreatedAt).getTime()
-      : null;
-    const daysSinceConfigUpdate = versionCreatedAt
-      ? (now - versionCreatedAt) / (1000 * 60 * 60 * 24)
-      : AGENT_UPDATE_STALENESS_WINDOW_CLAMP;
-    // Despite the name `staleness`, this is a recency score: 1 right after a version bump, decays to 0 over the clamp window.
-    const staleness = Math.max(
-      0,
-      Math.min(
-        1,
-        1 - daysSinceConfigUpdate / AGENT_UPDATE_STALENESS_WINDOW_CLAMP
-      )
-    );
-
-    const score =
-      REINFORCEMENT_RANK_WEIGHT_FEEDBACK * feedback +
-      REINFORCEMENT_RANK_WEIGHT_REINFORCEMENT_STALENESS *
-        reinforcementStaleness +
-      REINFORCEMENT_RANK_WEIGHT_HUMAN_CONVERSATIONS * humanConversations +
-      REINFORCEMENT_RANK_WEIGHT_TOOL_ERROR * toolError +
-      REINFORCEMENT_RANK_WEIGHT_MULTI_USER * multiUser +
-      REINFORCEMENT_RANK_WEIGHT_AGENT_VERSION_FRESHNESS * staleness;
-
-    return {
-      agent,
-      score,
-      normalized: {
-        feedback,
-        reinforcementStaleness,
-        humanConversations,
-        toolError,
-        multiUser,
-        staleness,
-      },
-    };
-  });
+  const now = Date.now();
+  const scored: ScoredAgent[] = rawByAgent.map(({ agent, ...raw }) =>
+    scoreAutoAgent(agent, raw, {
+      maxFeedback,
+      maxHumanConversations,
+      maxToolError,
+      maxMultiUser,
+      now,
+    })
+  );
 
   // Sort agents by score descending
   scored.sort((a, b) => b.score - a.score);
@@ -245,6 +265,69 @@ export async function selectAgentsForReinforcement(
   return [...explicitOnResults, ...autoResults];
 }
 
+function normalize(value: number, max: number): number {
+  return max === 0 ? 0 : value / max;
+}
+
+function scoreAutoAgent(
+  agent: LightAgentConfigurationType,
+  raw: {
+    feedback: number;
+    humanConversations: number;
+    toolError: number;
+    multiUser: number;
+  },
+  maxes: {
+    maxFeedback: number;
+    maxHumanConversations: number;
+    maxToolError: number;
+    maxMultiUser: number;
+    now: number;
+  }
+): ScoredAgent {
+  const {
+    maxFeedback,
+    maxHumanConversations,
+    maxToolError,
+    maxMultiUser,
+    now,
+  } = maxes;
+
+  const versionCreatedAt = agent.versionCreatedAt
+    ? new Date(agent.versionCreatedAt).getTime()
+    : null;
+  const daysSinceConfigUpdate = versionCreatedAt
+    ? (now - versionCreatedAt) / (1000 * 60 * 60 * 24)
+    : AGENT_UPDATE_STALENESS_WINDOW_CLAMP;
+
+  const normalized: NormalizedSignals = {
+    feedback: normalize(raw.feedback, maxFeedback),
+    // TODO(dust-tt/tasks#7313): static placeholder until we persist last reinforcement time per agent.
+    reinforcementStaleness: 1,
+    humanConversations: normalize(
+      raw.humanConversations,
+      maxHumanConversations
+    ),
+    toolError: normalize(raw.toolError, maxToolError),
+    multiUser: normalize(raw.multiUser, maxMultiUser),
+    // Recency score: 1 right after a version bump, decays to 0 over the clamp window.
+    staleness: Math.max(
+      0,
+      Math.min(
+        1,
+        1 - daysSinceConfigUpdate / AGENT_UPDATE_STALENESS_WINDOW_CLAMP
+      )
+    ),
+  };
+
+  const score = SCORING_SIGNAL_ROWS.reduce(
+    (sum, row) => sum + row.weight * row.value(normalized),
+    0
+  );
+
+  return { agent, score, normalized };
+}
+
 function recordAgentScoringMetrics(
   workspaceId: string,
   scored: ScoredAgent[],
@@ -254,79 +337,22 @@ function recordAgentScoringMetrics(
   const statsd = getStatsDClient();
 
   for (const { agent, score, normalized } of scored) {
-    const {
-      feedback,
-      reinforcementStaleness: recency,
-      humanConversations,
-      toolError,
-      multiUser,
-      staleness,
-    } = normalized;
     const conversationsToSample = selectedAllocations.get(agent.sId) ?? null;
     const wasSelected = conversationsToSample !== null;
 
-    statsd.distribution(
-      "reinforced_agent.scoring.feedback_normalized",
-      feedback,
-      tags
-    );
-    statsd.distribution(
-      "reinforced_agent.scoring.recency_normalized",
-      recency,
-      tags
-    );
-    statsd.distribution(
-      "reinforced_agent.scoring.human_conversations_normalized",
-      humanConversations,
-      tags
-    );
-    statsd.distribution(
-      "reinforced_agent.scoring.tool_error_normalized",
-      toolError,
-      tags
-    );
-    statsd.distribution(
-      "reinforced_agent.scoring.multi_user_normalized",
-      multiUser,
-      tags
-    );
-    statsd.distribution(
-      "reinforced_agent.scoring.staleness_score",
-      staleness,
-      tags
-    );
-
-    // Weighted contributions (component × weight).
-    statsd.distribution(
-      "reinforced_agent.scoring.feedback_contribution",
-      REINFORCEMENT_RANK_WEIGHT_FEEDBACK * feedback,
-      tags
-    );
-    statsd.distribution(
-      "reinforced_agent.scoring.recency_contribution",
-      REINFORCEMENT_RANK_WEIGHT_REINFORCEMENT_STALENESS * recency,
-      tags
-    );
-    statsd.distribution(
-      "reinforced_agent.scoring.human_conversations_contribution",
-      REINFORCEMENT_RANK_WEIGHT_HUMAN_CONVERSATIONS * humanConversations,
-      tags
-    );
-    statsd.distribution(
-      "reinforced_agent.scoring.tool_error_contribution",
-      REINFORCEMENT_RANK_WEIGHT_TOOL_ERROR * toolError,
-      tags
-    );
-    statsd.distribution(
-      "reinforced_agent.scoring.multi_user_contribution",
-      REINFORCEMENT_RANK_WEIGHT_MULTI_USER * multiUser,
-      tags
-    );
-    statsd.distribution(
-      "reinforced_agent.scoring.staleness_contribution",
-      REINFORCEMENT_RANK_WEIGHT_AGENT_VERSION_FRESHNESS * staleness,
-      tags
-    );
+    for (const row of SCORING_SIGNAL_ROWS) {
+      const v = row.value(normalized);
+      statsd.distribution(
+        `reinforced_agent.scoring.${row.normalizedSuffix ?? `${row.prefix}_normalized`}`,
+        v,
+        tags
+      );
+      statsd.distribution(
+        `reinforced_agent.scoring.${row.prefix}_contribution`,
+        row.weight * v,
+        tags
+      );
+    }
 
     statsd.distribution("reinforced_agent.scoring.total_score", score, tags);
 
@@ -338,6 +364,13 @@ function recordAgentScoringMetrics(
       );
     }
 
+    const contributions = Object.fromEntries(
+      SCORING_SIGNAL_ROWS.map((row) => [
+        row.logKey,
+        row.weight * row.value(normalized),
+      ])
+    ) as Record<ContributionLogKey, number>;
+
     logger.info(
       {
         workspaceId,
@@ -346,23 +379,14 @@ function recordAgentScoringMetrics(
         wasSelected,
         conversationsToSample,
         normalized: {
-          feedback,
-          recency,
-          humanConversations,
-          toolError,
-          multiUser,
-          staleness,
+          feedback: normalized.feedback,
+          recency: normalized.reinforcementStaleness,
+          humanConversations: normalized.humanConversations,
+          toolError: normalized.toolError,
+          multiUser: normalized.multiUser,
+          staleness: normalized.staleness,
         },
-        contributions: {
-          feedback: REINFORCEMENT_RANK_WEIGHT_FEEDBACK * feedback,
-          recency: REINFORCEMENT_RANK_WEIGHT_REINFORCEMENT_STALENESS * recency,
-          humanConversations:
-            REINFORCEMENT_RANK_WEIGHT_HUMAN_CONVERSATIONS * humanConversations,
-          toolError: REINFORCEMENT_RANK_WEIGHT_TOOL_ERROR * toolError,
-          multiUser: REINFORCEMENT_RANK_WEIGHT_MULTI_USER * multiUser,
-          staleness:
-            REINFORCEMENT_RANK_WEIGHT_AGENT_VERSION_FRESHNESS * staleness,
-        },
+        contributions,
       },
       "ReinforcedAgent: agent score breakdown"
     );

--- a/front/lib/reinforced_agent/selection.ts
+++ b/front/lib/reinforced_agent/selection.ts
@@ -1,0 +1,402 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getStatsDClient } from "@app/lib/utils/statsd";
+import logger from "@app/logger/logger";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import {
+  DEFAULT_MAX_AUTO_AGENTS_PER_RUN,
+  DEFAULT_MAX_CONVERSATIONS_PER_AGENT,
+  DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE,
+  DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS,
+  DEFAULT_TOTAL_CONVERSATIONS_TO_ANALYZE,
+} from "./constants";
+import {
+  fetchDistinctUsersAndToolErrorCounts,
+  type ReinforcementAutoTrackSignals,
+} from "./signals";
+
+// Maximum days since agent configuration update to consider it "stale".
+const AGENT_UPDATE_STALENESS_WINDOW_CLAMP = 90;
+
+// Weighted sum of normalized signals for auto-track ranking (each factor is 0–1 within the cohort; sum = 1).
+const REINFORCEMENT_RANK_WEIGHT_FEEDBACK = 0.3;
+const REINFORCEMENT_RANK_WEIGHT_REINFORCEMENT_STALENESS = 0.2; // Favors agents that have not been reinforced recently
+const REINFORCEMENT_RANK_WEIGHT_HUMAN_CONVERSATIONS = 0.2;
+const REINFORCEMENT_RANK_WEIGHT_TOOL_ERROR = 0.1;
+const REINFORCEMENT_RANK_WEIGHT_MULTI_USER = 0.1;
+const REINFORCEMENT_RANK_WEIGHT_AGENT_VERSION_FRESHNESS = 0.1; // Favors agents with recently updated configs
+
+export interface AgentSelectionResult {
+  agentConfigurationId: string;
+  conversationsToSample: number;
+}
+
+export interface SelectionOptions {
+  maxConversationsPerAgent?: number;
+  maxAutoAgentsPerRun?: number;
+  totalAutoConversationPool?: number;
+  minConversationsToInclude?: number;
+}
+
+export interface ReinforcementSelectionInput {
+  explicitOnAgents: LightAgentConfigurationType[];
+  eligibleAutoAgents: LightAgentConfigurationType[];
+  signals: ReinforcementAutoTrackSignals;
+  options: SelectionOptions;
+}
+
+interface ScoredAgent {
+  agent: LightAgentConfigurationType;
+  score: number;
+  normalized: {
+    feedback: number;
+    reinforcementStaleness: number;
+    humanConversations: number;
+    toolError: number;
+    multiUser: number;
+    staleness: number;
+  };
+}
+
+/**
+ * Determines which agents will be run and how many conversations to sample for each.
+ *
+ * - Agents in `on` mode — Each gets `maxConversationsPerAgent`. Does not consume `maxAutoAgentsPerRun`.
+ * - Agents in `auto` mode — Prioritized based on a scoring system up to `maxAutoAgentsPerRun`.
+ *
+ * Each agent is assigned a score, then conversation counts are split in proportion to those scores among the agents that are selected.
+ */
+export async function selectAgentsForReinforcement(
+  auth: Authenticator,
+  {
+    explicitOnAgents,
+    eligibleAutoAgents,
+    signals,
+    options,
+  }: ReinforcementSelectionInput
+): Promise<AgentSelectionResult[]> {
+  const maxConversationsPerAgent =
+    options.maxConversationsPerAgent ?? DEFAULT_MAX_CONVERSATIONS_PER_AGENT;
+  const maxAutoAgentsPerRun =
+    options.maxAutoAgentsPerRun ?? DEFAULT_MAX_AUTO_AGENTS_PER_RUN;
+  const totalAutoConversationPool =
+    options.totalAutoConversationPool ?? DEFAULT_TOTAL_CONVERSATIONS_TO_ANALYZE;
+  const minConversationsToInclude =
+    options.minConversationsToInclude ?? DEFAULT_MIN_CONVERSATIONS_TO_INCLUDE;
+
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+
+  const explicitOnResults: AgentSelectionResult[] = explicitOnAgents.map(
+    (a) => ({
+      agentConfigurationId: a.sId,
+      conversationsToSample: maxConversationsPerAgent,
+    })
+  );
+
+  recordSelectionMetrics({
+    workspaceId,
+    explicitOnAgentsCount: explicitOnResults.length,
+    autoEligibleCount: eligibleAutoAgents.length,
+    autoSelectedCount: Math.min(eligibleAutoAgents.length, maxAutoAgentsPerRun),
+  });
+
+  if (eligibleAutoAgents.length === 0) {
+    return explicitOnResults;
+  }
+
+  const { distinctUserCountByAgentSId, toolErrorCountByAgentSId } =
+    await fetchDistinctUsersAndToolErrorCounts(
+      workspaceId,
+      eligibleAutoAgents.map((a) => a.sId),
+      DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS
+    );
+
+  const feedbackCountMap = signals.feedbackCountByAgentSId;
+  const humanConvsByAgent = signals.humanConversationSIdsByAgent;
+
+  // Collect raw metric values across all eligible agents for cross-agent normalization.
+  const agentFeedbackCounts: number[] = [];
+  const agentHumanConversationsCount: number[] = [];
+  const agentToolErrorCount: number[] = [];
+  const agentUserCount: number[] = [];
+
+  for (const agent of eligibleAutoAgents) {
+    agentFeedbackCounts.push(feedbackCountMap.get(agent.sId) ?? 0);
+    agentHumanConversationsCount.push(
+      humanConvsByAgent.get(agent.sId)?.length ?? 0
+    );
+    agentToolErrorCount.push(toolErrorCountByAgentSId.get(agent.sId) ?? 0);
+    agentUserCount.push(distinctUserCountByAgentSId.get(agent.sId) ?? 0);
+  }
+
+  const maxFeedback = Math.max(...agentFeedbackCounts, 0);
+  const maxHumanConversations = Math.max(...agentHumanConversationsCount, 0);
+  const maxToolError = Math.max(...agentToolErrorCount, 0);
+  const maxMultiUser = Math.max(...agentUserCount, 0);
+
+  const normalize = (value: number, max: number): number =>
+    max === 0 ? 0 : value / max;
+
+  const scored: ScoredAgent[] = eligibleAutoAgents.map((agent) => {
+    const feedback = normalize(
+      feedbackCountMap.get(agent.sId) ?? 0,
+      maxFeedback
+    );
+    // TODO(dust-tt/tasks#7313): We do not yet persist last reinforcement analysis time per agent.
+    // Once we do, we can use that time to calculate the staleness of the agent.
+    // For now, we use a static factor of 1.
+    const reinforcementStaleness = 1;
+    const humanConversations = normalize(
+      humanConvsByAgent.get(agent.sId)?.length ?? 0,
+      maxHumanConversations
+    );
+    const toolError = normalize(
+      toolErrorCountByAgentSId.get(agent.sId) ?? 0,
+      maxToolError
+    );
+    const multiUser = normalize(
+      distinctUserCountByAgentSId.get(agent.sId) ?? 0,
+      maxMultiUser
+    );
+
+    const now = Date.now();
+    const versionCreatedAt = agent.versionCreatedAt
+      ? new Date(agent.versionCreatedAt).getTime()
+      : null;
+    const daysSinceConfigUpdate = versionCreatedAt
+      ? (now - versionCreatedAt) / (1000 * 60 * 60 * 24)
+      : AGENT_UPDATE_STALENESS_WINDOW_CLAMP;
+    // Despite the name `staleness`, this is a recency score: 1 right after a version bump, decays to 0 over the clamp window.
+    const staleness = Math.max(
+      0,
+      Math.min(
+        1,
+        1 - daysSinceConfigUpdate / AGENT_UPDATE_STALENESS_WINDOW_CLAMP
+      )
+    );
+
+    const score =
+      REINFORCEMENT_RANK_WEIGHT_FEEDBACK * feedback +
+      REINFORCEMENT_RANK_WEIGHT_REINFORCEMENT_STALENESS *
+        reinforcementStaleness +
+      REINFORCEMENT_RANK_WEIGHT_HUMAN_CONVERSATIONS * humanConversations +
+      REINFORCEMENT_RANK_WEIGHT_TOOL_ERROR * toolError +
+      REINFORCEMENT_RANK_WEIGHT_MULTI_USER * multiUser +
+      REINFORCEMENT_RANK_WEIGHT_AGENT_VERSION_FRESHNESS * staleness;
+
+    return {
+      agent,
+      score,
+      normalized: {
+        feedback,
+        reinforcementStaleness,
+        humanConversations,
+        toolError,
+        multiUser,
+        staleness,
+      },
+    };
+  });
+
+  // Sort agents by score descending
+  scored.sort((a, b) => b.score - a.score);
+
+  const topK = Math.min(maxAutoAgentsPerRun, scored.length);
+  const totalScore = scored.slice(0, topK).reduce((sum, s) => sum + s.score, 0);
+
+  // Determining how many conversations to sample for each agent
+  const autoResults: AgentSelectionResult[] = [];
+  const selectedAllocations = new Map<string, number>();
+
+  for (let i = 0; i < scored.length; i++) {
+    const { agent, score } = scored[i]!;
+    if (autoResults.length >= maxAutoAgentsPerRun) {
+      break;
+    }
+    const raw = (score / totalScore) * totalAutoConversationPool;
+    if (raw < minConversationsToInclude) {
+      // Drop agents whose unclamped allocation is below the minimum — insufficient signal.
+      continue;
+    }
+
+    let conversationsToSample = Math.min(
+      maxConversationsPerAgent,
+      Math.max(minConversationsToInclude, Math.round(raw))
+    );
+
+    // Drop agents who do not have enough human-in-the-loop conversations to sample
+    const availableHumanConvs = humanConvsByAgent.get(agent.sId)?.length ?? 0;
+    conversationsToSample = Math.min(
+      conversationsToSample,
+      availableHumanConvs
+    );
+    if (conversationsToSample < minConversationsToInclude) {
+      continue;
+    }
+
+    autoResults.push({
+      agentConfigurationId: agent.sId,
+      conversationsToSample,
+    });
+    selectedAllocations.set(agent.sId, conversationsToSample);
+  }
+
+  recordAgentScoringMetrics(workspaceId, scored, selectedAllocations);
+
+  return [...explicitOnResults, ...autoResults];
+}
+
+function recordAgentScoringMetrics(
+  workspaceId: string,
+  scored: ScoredAgent[],
+  selectedAllocations: Map<string, number>
+) {
+  const tags = [`workspace_id:${workspaceId}`];
+  const statsd = getStatsDClient();
+
+  for (const { agent, score, normalized } of scored) {
+    const {
+      feedback,
+      reinforcementStaleness: recency,
+      humanConversations,
+      toolError,
+      multiUser,
+      staleness,
+    } = normalized;
+    const conversationsToSample = selectedAllocations.get(agent.sId) ?? null;
+    const wasSelected = conversationsToSample !== null;
+
+    statsd.distribution(
+      "reinforced_agent.scoring.feedback_normalized",
+      feedback,
+      tags
+    );
+    statsd.distribution(
+      "reinforced_agent.scoring.recency_normalized",
+      recency,
+      tags
+    );
+    statsd.distribution(
+      "reinforced_agent.scoring.human_conversations_normalized",
+      humanConversations,
+      tags
+    );
+    statsd.distribution(
+      "reinforced_agent.scoring.tool_error_normalized",
+      toolError,
+      tags
+    );
+    statsd.distribution(
+      "reinforced_agent.scoring.multi_user_normalized",
+      multiUser,
+      tags
+    );
+    statsd.distribution(
+      "reinforced_agent.scoring.staleness_score",
+      staleness,
+      tags
+    );
+
+    // Weighted contributions (component × weight).
+    statsd.distribution(
+      "reinforced_agent.scoring.feedback_contribution",
+      REINFORCEMENT_RANK_WEIGHT_FEEDBACK * feedback,
+      tags
+    );
+    statsd.distribution(
+      "reinforced_agent.scoring.recency_contribution",
+      REINFORCEMENT_RANK_WEIGHT_REINFORCEMENT_STALENESS * recency,
+      tags
+    );
+    statsd.distribution(
+      "reinforced_agent.scoring.human_conversations_contribution",
+      REINFORCEMENT_RANK_WEIGHT_HUMAN_CONVERSATIONS * humanConversations,
+      tags
+    );
+    statsd.distribution(
+      "reinforced_agent.scoring.tool_error_contribution",
+      REINFORCEMENT_RANK_WEIGHT_TOOL_ERROR * toolError,
+      tags
+    );
+    statsd.distribution(
+      "reinforced_agent.scoring.multi_user_contribution",
+      REINFORCEMENT_RANK_WEIGHT_MULTI_USER * multiUser,
+      tags
+    );
+    statsd.distribution(
+      "reinforced_agent.scoring.staleness_contribution",
+      REINFORCEMENT_RANK_WEIGHT_AGENT_VERSION_FRESHNESS * staleness,
+      tags
+    );
+
+    statsd.distribution("reinforced_agent.scoring.total_score", score, tags);
+
+    if (wasSelected && conversationsToSample !== null) {
+      statsd.distribution(
+        "reinforced_agent.scoring.conversations_to_sample",
+        conversationsToSample,
+        tags
+      );
+    }
+
+    logger.info(
+      {
+        workspaceId,
+        agentConfigurationId: agent.sId,
+        score,
+        wasSelected,
+        conversationsToSample,
+        normalized: {
+          feedback,
+          recency,
+          humanConversations,
+          toolError,
+          multiUser,
+          staleness,
+        },
+        contributions: {
+          feedback: REINFORCEMENT_RANK_WEIGHT_FEEDBACK * feedback,
+          recency: REINFORCEMENT_RANK_WEIGHT_REINFORCEMENT_STALENESS * recency,
+          humanConversations:
+            REINFORCEMENT_RANK_WEIGHT_HUMAN_CONVERSATIONS * humanConversations,
+          toolError: REINFORCEMENT_RANK_WEIGHT_TOOL_ERROR * toolError,
+          multiUser: REINFORCEMENT_RANK_WEIGHT_MULTI_USER * multiUser,
+          staleness:
+            REINFORCEMENT_RANK_WEIGHT_AGENT_VERSION_FRESHNESS * staleness,
+        },
+      },
+      "ReinforcedAgent: agent score breakdown"
+    );
+  }
+}
+
+function recordSelectionMetrics({
+  workspaceId,
+  explicitOnAgentsCount,
+  autoEligibleCount,
+  autoSelectedCount,
+}: {
+  workspaceId: string;
+  explicitOnAgentsCount: number;
+  autoEligibleCount: number;
+  autoSelectedCount: number;
+}) {
+  const tags = [`workspace_id:${workspaceId}`];
+  const statsd = getStatsDClient();
+
+  statsd.increment("reinforced_agent.selection.runs.count", 1, tags);
+  statsd.distribution(
+    "reinforced_agent.selection.on_agents.distribution",
+    explicitOnAgentsCount,
+    tags
+  );
+  statsd.distribution(
+    "reinforced_agent.selection.auto_eligible.distribution",
+    autoEligibleCount,
+    tags
+  );
+  statsd.distribution(
+    "reinforced_agent.selection.auto_selected.distribution",
+    autoSelectedCount,
+    tags
+  );
+}

--- a/front/lib/reinforced_agent/signals.ts
+++ b/front/lib/reinforced_agent/signals.ts
@@ -1,0 +1,179 @@
+import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { estypes } from "@elastic/elasticsearch";
+
+export interface ReinforcementAutoTrackSignals {
+  feedbackCountByAgentSId: Map<string, number>;
+  humanConversationSIdsByAgent: Map<string, string[]>;
+  agentSIdsWithRecentPendingSuggestions: Set<string>;
+}
+
+type ReinforcementSignalAggs = {
+  by_agent: estypes.AggregationsTermsAggregateBase<{
+    key: string;
+    doc_count: number;
+    user_count: estypes.AggregationsCardinalityAggregate;
+    tool_errors: {
+      errored: {
+        doc_count: number;
+        back_to_root: {
+          distinct_conversations: estypes.AggregationsCardinalityAggregate;
+        };
+      };
+    };
+  }>;
+};
+
+/**
+ * Fetches distinct user counts and tool-error conversation counts per agent
+ * from the analytics index. Call this after eligibility filtering so the query
+ * is scoped to only the agents that will actually be scored.
+ */
+export async function fetchDistinctUsersAndToolErrorCounts(
+  workspaceId: string,
+  agentSIds: string[],
+  lookbackWindowDays: number
+): Promise<{
+  distinctUserCountByAgentSId: Map<string, number>;
+  toolErrorCountByAgentSId: Map<string, number>;
+}> {
+  const query: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [
+        { term: { workspace_id: workspaceId } },
+        { terms: { agent_id: agentSIds } },
+        {
+          range: {
+            timestamp: { gte: `now-${lookbackWindowDays}d/d` },
+          },
+        },
+      ],
+    },
+  };
+
+  const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
+    {
+      by_agent: {
+        terms: { field: "agent_id", size: agentSIds.length + 1 },
+        aggs: {
+          user_count: { cardinality: { field: "user_id" } },
+          tool_errors: {
+            nested: { path: "tools_used" },
+            aggs: {
+              errored: {
+                filter: {
+                  bool: {
+                    must_not: { term: { "tools_used.status": "succeeded" } },
+                  },
+                },
+                aggs: {
+                  back_to_root: {
+                    reverse_nested: {},
+                    aggs: {
+                      distinct_conversations: {
+                        cardinality: { field: "conversation_id" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+  const result = await searchAnalytics<never, ReinforcementSignalAggs>(query, {
+    aggregations,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    throw new Error(`Analytics signals query failed: ${result.error.message}`);
+  }
+
+  const distinctUserCountByAgentSId = new Map<string, number>();
+  const toolErrorCountByAgentSId = new Map<string, number>();
+
+  const buckets = result.value.aggregations?.by_agent?.buckets;
+  if (buckets && Array.isArray(buckets)) {
+    for (const bucket of buckets) {
+      distinctUserCountByAgentSId.set(
+        bucket.key,
+        bucket.user_count?.value ?? 0
+      );
+      toolErrorCountByAgentSId.set(
+        bucket.key,
+        bucket.tool_errors?.errored?.back_to_root?.distinct_conversations
+          ?.value ?? 0
+      );
+    }
+  }
+
+  return { distinctUserCountByAgentSId, toolErrorCountByAgentSId };
+}
+
+export async function fetchReinforcementAutoTrackSignals(
+  auth: Authenticator,
+  {
+    agentSIds,
+    lookbackWindowDays,
+    pendingSuggestionMaxAgeDays,
+  }: {
+    agentSIds: string[];
+    lookbackWindowDays: number;
+    pendingSuggestionMaxAgeDays: number;
+  }
+): Promise<ReinforcementAutoTrackSignals> {
+  if (agentSIds.length === 0) {
+    return {
+      feedbackCountByAgentSId: new Map(),
+      humanConversationSIdsByAgent: new Map(),
+      agentSIdsWithRecentPendingSuggestions: new Set(),
+    };
+  }
+
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - lookbackWindowDays);
+
+  const pendingSuggestionCutoff = new Date();
+  pendingSuggestionCutoff.setDate(
+    pendingSuggestionCutoff.getDate() - pendingSuggestionMaxAgeDays
+  );
+
+  const [feedbackCounts, humanConvSIdsByAgent, pendingSuggestions] =
+    await Promise.all([
+      AgentMessageFeedbackResource.getFeedbackCountForAssistants(
+        auth,
+        agentSIds,
+        lookbackWindowDays
+      ),
+      ConversationResource.getConversationSIdsByAgent(auth, {
+        agentSIds,
+        cutoffDate,
+        excludeHumanOutOfTheLoop: true,
+      }),
+      AgentSuggestionResource.listByAgentConfigurationIds(auth, agentSIds, {
+        states: ["pending"],
+        sources: ["reinforcement"],
+        createdAfter: pendingSuggestionCutoff,
+      }),
+    ]);
+
+  const feedbackCountByAgentSId = new Map<string, number>();
+  for (const row of feedbackCounts) {
+    const prev = feedbackCountByAgentSId.get(row.agentConfigurationId) ?? 0;
+    feedbackCountByAgentSId.set(row.agentConfigurationId, prev + row.count);
+  }
+
+  return {
+    feedbackCountByAgentSId,
+    humanConversationSIdsByAgent: humanConvSIdsByAgent,
+    agentSIdsWithRecentPendingSuggestions: new Set(
+      pendingSuggestions.map((s) => s.agentConfigurationSId)
+    ),
+  };
+}

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -721,11 +721,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   }
 
   /**
-   * Returns the agent sIds that have at least one agent message with
+   * For each agent, returns the sIds of qualifying conversations in the window
    * createdAt >= cutoffDate. With excludeHumanOutOfTheLoop, removes conversations where
    * triggerId IS NOT NULL and no user messages are present.
    */
-  static async listIdsOfAgentsWithRecentConversations(
+  static async getConversationSIdsByAgent(
     auth: Authenticator,
     {
       agentSIds,
@@ -736,14 +736,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       cutoffDate: Date;
       excludeHumanOutOfTheLoop?: boolean;
     }
-  ): Promise<string[]> {
+  ): Promise<Map<string, string[]>> {
+    const result = new Map<string, string[]>(agentSIds.map((sId) => [sId, []]));
+
     if (agentSIds.length === 0) {
-      return [];
+      return result;
     }
 
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    // Step 1: start from agent_messages with the time window filter.
     const participations = await AgentMessageModel.findAll({
       attributes: ["agentConfigurationId"],
       where: {
@@ -762,52 +763,61 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
 
     if (participations.length === 0) {
-      return [];
+      return result;
     }
 
-    let qualifyingConvIds: Set<number>;
+    const allConvIds: ModelId[] = [
+      ...new Set(participations.map((p) => p.message!.conversationId)),
+    ];
+
+    const conversations = await ConversationModel.findAll({
+      attributes: ["id", "sId", "triggerId"],
+      where: { workspaceId, id: { [Op.in]: allConvIds } },
+    });
+
+    if (conversations.length === 0) {
+      return result;
+    }
+
+    const sIdById = new Map<ModelId, string>(
+      conversations.map((c) => [c.id, c.sId])
+    );
+
+    const agentToConvSIds = new Map<string, Set<string>>();
+    for (const p of participations) {
+      const convSId = sIdById.get(p.message!.conversationId);
+      if (!convSId) {
+        continue;
+      }
+      const agentSId = p.agentConfigurationId;
+      if (!agentToConvSIds.has(agentSId)) {
+        agentToConvSIds.set(agentSId, new Set());
+      }
+      agentToConvSIds.get(agentSId)!.add(convSId);
+    }
+
+    let qualifyingConvSIds: Set<string>;
 
     if (!excludeHumanOutOfTheLoop) {
-      qualifyingConvIds = new Set(
-        participations.map((p) => p.message!.conversationId)
-      );
+      qualifyingConvSIds = new Set(conversations.map((c) => c.sId));
     } else {
-      const conversationIds = [
-        ...new Set(participations.map((p) => p.message!.conversationId)),
-      ];
-      const candidateConversations = await ConversationModel.findAll({
-        attributes: ["id", "triggerId"],
-        where: {
-          workspaceId,
-          id: { [Op.in]: conversationIds },
-        },
-        raw: true,
-      });
+      const nonTriggered = conversations.filter((c) => c.triggerId === null);
+      const triggered = conversations.filter((c) => c.triggerId !== null);
 
-      if (candidateConversations.length === 0) {
-        return [];
-      }
-
-      // Non-triggered conversations are always human-initiated; triggered ones
-      // only qualify if a human has also replied.
-      const nonTriggeredIds = candidateConversations
-        .filter((c) => c.triggerId === null)
-        .map((c) => c.id);
-      const triggeredIds = candidateConversations
-        .filter((c) => c.triggerId !== null)
-        .map((c) => c.id);
-
-      if (triggeredIds.length === 0) {
-        qualifyingConvIds = new Set(nonTriggeredIds);
+      if (triggered.length === 0) {
+        qualifyingConvSIds = new Set(nonTriggered.map((c) => c.sId));
       } else {
-        const triggeredConvsWithUserMessages = await MessageModel.findAll({
+        const triggeredWithUserMessages = await MessageModel.findAll({
           attributes: [
             [
               Sequelize.fn("DISTINCT", Sequelize.col("conversationId")),
               "conversationId",
             ],
           ],
-          where: { workspaceId, conversationId: { [Op.in]: triggeredIds } },
+          where: {
+            workspaceId,
+            conversationId: { [Op.in]: triggered.map((c) => c.id) },
+          },
           include: [
             {
               model: UserMessageModel,
@@ -818,18 +828,26 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           ],
           raw: true,
         });
-        qualifyingConvIds = new Set([
-          ...nonTriggeredIds,
-          ...triggeredConvsWithUserMessages.map((m) => m.conversationId),
+
+        qualifyingConvSIds = new Set([
+          ...nonTriggered.map((c) => c.sId),
+          ...triggeredWithUserMessages
+            .map((m) => sIdById.get(m.conversationId))
+            .filter((sId): sId is string => sId !== undefined),
         ]);
       }
     }
 
-    return uniq(
-      participations
-        .filter((p) => qualifyingConvIds.has(p.message!.conversationId))
-        .map((p) => p.agentConfigurationId)
-    );
+    for (const [agentSId, convSIds] of agentToConvSIds) {
+      const qualifying = [...convSIds].filter((sId) =>
+        qualifyingConvSIds.has(sId)
+      );
+      if (qualifying.length > 0) {
+        result.set(agentSId, qualifying);
+      }
+    }
+
+    return result;
   }
 
   static async fetchConversationWithoutContent(

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -25,6 +25,11 @@ import {
   buildAnalysisSystemPrompt,
   buildConversationAnalysisBatchMap,
 } from "@app/lib/reinforced_agent/analyze_conversation";
+import {
+  DEFAULT_MAX_CONVERSATIONS_PER_AGENT,
+  DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
+  DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS,
+} from "@app/lib/reinforced_agent/constants";
 import { filterEligibleAgents } from "@app/lib/reinforced_agent/eligibility";
 import {
   buildReinforcedSpecifications,
@@ -36,6 +41,8 @@ import {
   REINFORCEMENT_AGENT_ID,
   reinforcementConversationTitle,
 } from "@app/lib/reinforced_agent/run_reinforced_analysis";
+import { selectAgentsForReinforcement } from "@app/lib/reinforced_agent/selection";
+import { fetchReinforcementAutoTrackSignals } from "@app/lib/reinforced_agent/signals";
 import {
   prepareReinforcedToolActions,
   type ReinforcedToolActionInfo,
@@ -252,15 +259,27 @@ export async function isAgentReinforcementAllowedActivity({
 }
 
 /**
- * List agent configuration sIds for active (non-global) agents in a workspace.
+ * Selects agent configuration sIds and per-agent conversation budgets for this
+ * workspace run.
+ */
+export async function isAgentReinforcementAllowedActivity({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<boolean> {
+  const auth = await getAuthForWorkspace(workspaceId);
+  return hasReinforcementEnabled(auth);
+}
+
+/**
+ * Selects agent configuration sIds and per-agent conversation budgets for this
+ * workspace run.
  */
 export async function getAgentConfigurationsActivity({
   workspaceId,
-  lookbackWindowDays = 1,
 }: {
   workspaceId: string;
-  lookbackWindowDays?: number;
-}): Promise<string[]> {
+}): Promise<{ agentConfigurationId: string; conversationsToSample: number }[]> {
   const auth = await getAuthForWorkspace(workspaceId);
 
   const agents = await getAgentConfigurationsForView({
@@ -269,17 +288,24 @@ export async function getAgentConfigurationsActivity({
     variant: "extra_light",
   });
 
-  const explicitOnAgents = agents.filter(
-    (a) => a.id > 0 && a.reinforcement === "on"
-  );
+  const inScope = agents.filter((a) => a.id > 0 && a.reinforcement !== "off");
+  const explicitOnAgents = inScope.filter((a) => a.reinforcement === "on");
+  const autoAgents = inScope.filter((a) => a.reinforcement === "auto");
 
-  const eligible = await filterEligibleAgents(
-    auth,
+  const signals = await fetchReinforcementAutoTrackSignals(auth, {
+    agentSIds: autoAgents.map((a) => a.sId),
+    lookbackWindowDays: DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS,
+    pendingSuggestionMaxAgeDays: DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
+  });
+
+  const eligibleAutoAgents = filterEligibleAgents(auth, autoAgents, signals);
+
+  return selectAgentsForReinforcement(auth, {
     explicitOnAgents,
-    lookbackWindowDays
-  );
-
-  return eligible.map((a) => a.sId);
+    eligibleAutoAgents,
+    signals,
+    options: {},
+  });
 }
 
 /**
@@ -288,11 +314,13 @@ export async function getAgentConfigurationsActivity({
 export async function getRecentConversationsForAgentActivity({
   workspaceId,
   agentConfigurationId,
-  conversationLookbackDays = 1,
+  conversationLookbackDays = DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS,
+  maxConversations = DEFAULT_MAX_CONVERSATIONS_PER_AGENT,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   conversationLookbackDays?: number;
+  maxConversations?: number;
 }): Promise<string[]> {
   updateActiveTrace({
     name: "Reinforced Agent Workflow",
@@ -301,15 +329,20 @@ export async function getRecentConversationsForAgentActivity({
 
   const auth = await getAuthForWorkspace(workspaceId);
 
-  const updatedSince = new Date();
-  updatedSince.setHours(
-    updatedSince.getHours() - conversationLookbackDays * 24
-  );
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - conversationLookbackDays);
 
-  return ConversationResource.listRecentConversationsForAgent(auth, {
-    agentConfigurationId,
-    updatedSince,
-  });
+  const convSIdsByAgent = await ConversationResource.getConversationSIdsByAgent(
+    auth,
+    {
+      agentSIds: [agentConfigurationId],
+      cutoffDate,
+      excludeHumanOutOfTheLoop: true,
+    }
+  );
+  const conversationSIds = convSIdsByAgent.get(agentConfigurationId) ?? [];
+  // TODO(https://github.com/dust-tt/tasks/issues/7313): This is a placeholder for the actual sampling logic
+  return conversationSIds.slice(0, maxConversations);
 }
 
 /**

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -27,10 +27,8 @@ import {
 } from "@app/lib/reinforced_agent/analyze_conversation";
 import {
   DEFAULT_MAX_CONVERSATIONS_PER_AGENT,
-  DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
   DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS,
 } from "@app/lib/reinforced_agent/constants";
-import { filterEligibleAgents } from "@app/lib/reinforced_agent/eligibility";
 import {
   buildReinforcedSpecifications,
   classifyToolCalls,
@@ -41,8 +39,7 @@ import {
   REINFORCEMENT_AGENT_ID,
   reinforcementConversationTitle,
 } from "@app/lib/reinforced_agent/run_reinforced_analysis";
-import { selectAgentsForReinforcement } from "@app/lib/reinforced_agent/selection";
-import { fetchReinforcementAutoTrackSignals } from "@app/lib/reinforced_agent/signals";
+import { selectAgentsForReinforcementPipeline } from "@app/lib/reinforced_agent/selection";
 import {
   prepareReinforcedToolActions,
   type ReinforcedToolActionInfo,
@@ -276,24 +273,7 @@ export async function getAgentConfigurationsActivity({
     variant: "extra_light",
   });
 
-  const inScope = agents.filter((a) => a.id > 0 && a.reinforcement !== "off");
-  const explicitOnAgents = inScope.filter((a) => a.reinforcement === "on");
-  const autoAgents = inScope.filter((a) => a.reinforcement === "auto");
-
-  const signals = await fetchReinforcementAutoTrackSignals(auth, {
-    agentSIds: autoAgents.map((a) => a.sId),
-    lookbackWindowDays: DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS,
-    pendingSuggestionMaxAgeDays: DEFAULT_PENDING_SUGGESTION_MAX_AGE_DAYS,
-  });
-
-  const eligibleAutoAgents = filterEligibleAgents(auth, autoAgents, signals);
-
-  return selectAgentsForReinforcement(auth, {
-    explicitOnAgents,
-    eligibleAutoAgents,
-    signals,
-    options: {},
-  });
+  return selectAgentsForReinforcementPipeline(auth, agents, {});
 }
 
 /**

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -247,18 +247,6 @@ async function runReinforcedStep({
 }
 
 /**
- * Check whether the workspace has opted out of agent reinforcement.
- */
-export async function isAgentReinforcementAllowedActivity({
-  workspaceId,
-}: {
-  workspaceId: string;
-}): Promise<boolean> {
-  const auth = await getAuthForWorkspace(workspaceId);
-  return hasReinforcementEnabled(auth);
-}
-
-/**
  * Selects agent configuration sIds and per-agent conversation budgets for this
  * workspace run.
  */

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -142,14 +142,21 @@ export async function reinforcedAgentWorkspaceWorkflow({
     }
   }
 
-  const agentIds = await getAgentConfigurationsActivity({ workspaceId });
+  const selections = await getAgentConfigurationsActivity({ workspaceId });
 
   await concurrentExecutor(
-    agentIds,
-    (agentConfigurationId) =>
+    selections,
+    ({ agentConfigurationId, conversationsToSample }) =>
       executeChild(reinforcedAgentForAgentWorkflow, {
         workflowId: `reinforced-agent-${workspaceId}-${agentConfigurationId}`,
-        args: [{ workspaceId, agentConfigurationId, useBatchMode }],
+        args: [
+          {
+            workspaceId,
+            agentConfigurationId,
+            useBatchMode,
+            conversationsToSample,
+          },
+        ],
         parentClosePolicy: ParentClosePolicy.ABANDON,
       }),
     { concurrency: AGENT_CONCURRENCY }
@@ -200,19 +207,22 @@ export async function reinforcedAgentForAgentWorkflow({
   workspaceId,
   agentConfigurationId,
   useBatchMode,
-  conversationLookbackDays = 1,
   disableNotifications = false,
+  conversationsToSample,
+  conversationLookbackDays,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   useBatchMode: boolean;
-  conversationLookbackDays?: number;
   disableNotifications?: boolean;
+  conversationsToSample?: number;
+  conversationLookbackDays?: number;
 }): Promise<void> {
   const conversationIds = await getRecentConversationsForAgentActivity({
     workspaceId,
     agentConfigurationId,
     conversationLookbackDays,
+    maxConversations: conversationsToSample,
   });
 
   // No conversations to analyze: skip both analysis and aggregation.


### PR DESCRIPTION
## Description

* Implements scoring system we defined in https://www.notion.so/dust-tt/Reinforced-Agent-Auto-Mode-Criteria-33328599d94181568e73f91960dc8240
* The limits are arbitrary. We need to refine this based on cost
* Things I did not include to avoid PR bloat, but will need follow-ups:
** Storing and using last reinforcement run time
** Conversation sampling
** Dynamic lookback window

## Tests
<img width="1117" height="58" alt="Screenshot 2026-04-03 at 1 22 29 PM" src="https://github.com/user-attachments/assets/5f1bde67-49a9-48a3-bdb7-ac77f710fb67" />
<img width="1608" height="803" alt="Screenshot 2026-04-03 at 1 22 33 PM" src="https://github.com/user-attachments/assets/77871161-a9dd-4d18-a213-ca53bea7ea6e" />

## Risk

* Not customer facing, but would appreciate fresh eyes to make sure I mitigated DB load

## Deploy Plan

* Deploy front