### PR TITLE
[sparkle] remove background color from avatar with image

### DIFF
--- a/sparkle/src/components/Avatar.tsx
+++ b/sparkle/src/components/Avatar.tsx
@@ -204,28 +204,31 @@ export function Avatar({
       ? "clickable"
       : "default";
 
+  const isImageVisual = typeof visualToUse === "string";
+  const bgColorClass =
+    isImageVisual || hexBgColor
+      ? ""
+      : (backgroundColorToUse ??
+        (name ? getColor(name) : "s-bg-muted-background"));
+
   return (
     <div
       className={cn(
-        typeof visualToUse !== "string" && "s-border s-border-primary-800/10",
+        !isImageVisual && "s-border s-border-primary-800/10",
         avatarVariants({
           size,
           variant,
           rounded: isRounded,
         }),
         busy ? "s-animate-breathing s-cursor-default" : "",
-        typeof visualToUse === "string"
-          ? ""
-          : hexBgColor
-            ? ""
-            : backgroundColorToUse
-              ? backgroundColorToUse
-              : name
-                ? getColor(name)
-                : "s-bg-muted-background",
+        bgColorClass,
         className
       )}
-      style={hexBgColor && typeof visualToUse !== "string" ? { backgroundColor: hexBgColor } : undefined}
+      style={
+        hexBgColor && !isImageVisual
+          ? { backgroundColor: hexBgColor }
+          : undefined
+      }
     >
       {size === "auto" && <div style={{ paddingBottom: "100%" }} />}
       {typeof visualToUse === "string" ? (

--- a/sparkle/src/components/Avatar.tsx
+++ b/sparkle/src/components/Avatar.tsx
@@ -214,16 +214,18 @@ export function Avatar({
           rounded: isRounded,
         }),
         busy ? "s-animate-breathing s-cursor-default" : "",
-        hexBgColor
+        typeof visualToUse === "string"
           ? ""
-          : backgroundColorToUse
-            ? backgroundColorToUse
-            : name
-              ? getColor(name)
-              : "s-bg-muted-background",
+          : hexBgColor
+            ? ""
+            : backgroundColorToUse
+              ? backgroundColorToUse
+              : name
+                ? getColor(name)
+                : "s-bg-muted-background",
         className
       )}
-      style={hexBgColor ? { backgroundColor: hexBgColor } : undefined}
+      style={hexBgColor && typeof visualToUse !== "string" ? { backgroundColor: hexBgColor } : undefined}
     >
       {size === "auto" && <div style={{ paddingBottom: "100%" }} />}
       {typeof visualToUse === "string" ? (


### PR DESCRIPTION
## Description
This PR is to remove the background color when an agent has an avatar image. The only problem is Dust icon avatar's bg is the same as the suggestion card's bg but I thiiiink it's okay?

before:
<img width="152" height="86" alt="CleanShot 2026-04-03 at 23 20 03@2x" src="https://github.com/user-attachments/assets/113278da-6e62-4c30-9e96-4ed4abe7dd2c" />


after:
<img width="144" height="72" alt="CleanShot 2026-04-03 at 23 19 51@2x" src="https://github.com/user-attachments/assets/e66eec72-9cc8-4e73-96ba-343c753d814e" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
