### PR TITLE
Add optional `from` field to Gmail send/draft tools for send-as alias…

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -377,8 +377,9 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_arguments_requiring_approval: {
-      create_draft: ["to"],
-      send_mail: ["to"],
+      create_draft: ["to", "from"],
+      send_mail: ["to", "from"],
+      create_reply_draft: ["from"],
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -377,9 +377,8 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_arguments_requiring_approval: {
-      create_draft: ["to", "from"],
+      create_draft: ["to"],
       send_mail: ["to", "from"],
-      create_reply_draft: ["from"],
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -39,13 +39,6 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe("The email addresses to BCC"),
-      from: z
-        .string()
-        .email()
-        .optional()
-        .describe(
-          "Optional. The email address to send from. Must be configured as a send-as alias in the user's Gmail settings (e.g. a shared Google Group address like team@company.com). If omitted, Gmail will use the authenticated user's primary address."
-        ),
       subject: z.string().describe("The subject line of the email"),
       contentType: z
         .enum(["text/plain", "text/html"])
@@ -167,13 +160,6 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe("Override the BCC recipients for the reply."),
-      from: z
-        .string()
-        .email()
-        .optional()
-        .describe(
-          "Optional. The email address to send from. Must be configured as a send-as alias in the user's Gmail settings (e.g. a shared Google Group address like team@company.com). If omitted, Gmail will use the authenticated user's primary address."
-        ),
     },
     stake: "medium",
     displayLabels: {

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -39,6 +39,13 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe("The email addresses to BCC"),
+      from: z
+        .string()
+        .email()
+        .optional()
+        .describe(
+          "Optional. The email address to send from. Must be configured as a send-as alias in the user's Gmail settings (e.g. a shared Google Group address like team@company.com). If omitted, Gmail will use the authenticated user's primary address."
+        ),
       subject: z.string().describe("The subject line of the email"),
       contentType: z
         .enum(["text/plain", "text/html"])
@@ -160,6 +167,13 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe("Override the BCC recipients for the reply."),
+      from: z
+        .string()
+        .email()
+        .optional()
+        .describe(
+          "Optional. The email address to send from. Must be configured as a send-as alias in the user's Gmail settings (e.g. a shared Google Group address like team@company.com). If omitted, Gmail will use the authenticated user's primary address."
+        ),
     },
     stake: "medium",
     displayLabels: {
@@ -182,6 +196,13 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe("The email addresses to BCC"),
+      from: z
+        .string()
+        .email()
+        .optional()
+        .describe(
+          "Optional. The email address to send from. Must be configured as a send-as alias in the user's Gmail settings (e.g. a shared Google Group address like team@company.com). If omitted, Gmail will use the authenticated user's primary address."
+        ),
       subject: z.string().describe("The subject line of the email"),
       contentType: z
         .enum(["text/plain", "text/html"])

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -155,7 +155,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   },
 
   create_draft: async (
-    { to, cc, bcc, from, subject, contentType, body },
+    { to, cc, bcc, subject, contentType, body },
     { authInfo }
   ) => {
     const accessToken = authInfo?.token;
@@ -168,7 +168,6 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       to,
       cc,
       bcc,
-      from,
       subject,
       contentType,
       body,
@@ -486,7 +485,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   },
 
   create_reply_draft: async (
-    { messageId, body, contentType = "text/plain" as const, to, cc, bcc, from },
+    { messageId, body, contentType = "text/plain" as const, to, cc, bcc },
     { authInfo }
   ) => {
     const accessToken = authInfo?.token;
@@ -532,8 +531,8 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     const originalDate = getHeaderValue(headers, "Date");
 
     // Validate user-provided email addresses to prevent header injection
-    if (to?.length || cc?.length || bcc?.length || from) {
-      const validationError = validateEmailAddresses(to ?? [], cc, bcc, from);
+    if (to?.length || cc?.length || bcc?.length) {
+      const validationError = validateEmailAddresses(to ?? [], cc, bcc);
       if (validationError) {
         return validationError;
       }
@@ -575,7 +574,6 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     // Construct the reply message
     const messageLines = [
       `To: ${replyTo}`,
-      from ? `From: ${from}` : null,
       replyCc ? `Cc: ${replyCc}` : null,
       replyBcc ? `Bcc: ${replyBcc}` : null,
       `Subject: ${encodedSubject}`,

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -645,6 +645,31 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       return new Err(new MCPError("Authentication required"));
     }
 
+    // If a from alias was requested, verify it's a configured send-as address
+    // before sending. Gmail silently falls back to the primary address if the
+    // alias isn't set up, so we fail early to surface the issue.
+    if (from) {
+      const sendAsResponse = await fetchFromGmail(
+        "/gmail/v1/users/me/settings/sendAs",
+        accessToken,
+        { method: "GET" }
+      );
+      if (sendAsResponse.ok) {
+        const sendAsResult = await sendAsResponse.json();
+        const aliases: { sendAsEmail: string }[] = sendAsResult.sendAs ?? [];
+        const aliasConfigured = aliases.some(
+          (a) => a.sendAsEmail.toLowerCase() === from.toLowerCase()
+        );
+        if (!aliasConfigured) {
+          return new Err(
+            new MCPError(
+              `"${from}" is not configured as a send-as alias in Gmail settings. The email was not sent.`
+            )
+          );
+        }
+      }
+    }
+
     // Build and encode the email message
     const encodedMessageResult = buildAndEncodeEmail({
       to,

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -51,6 +51,7 @@ function buildAndEncodeEmail(params: {
   to: string[];
   cc?: string[];
   bcc?: string[];
+  from?: string;
   subject: string;
   contentType: string;
   body: string;
@@ -70,6 +71,7 @@ function buildAndEncodeEmail(params: {
   // Create the email message with proper headers and content.
   const messageLines = [
     `To: ${params.to.join(", ")}`,
+    params.from ? `From: ${params.from}` : null,
     params.cc?.length ? `Cc: ${params.cc.join(", ")}` : null,
     params.bcc?.length ? `Bcc: ${params.bcc.join(", ")}` : null,
     `Subject: ${encodedSubject}`,
@@ -147,7 +149,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   },
 
   create_draft: async (
-    { to, cc, bcc, subject, contentType, body },
+    { to, cc, bcc, from, subject, contentType, body },
     { authInfo }
   ) => {
     const accessToken = authInfo?.token;
@@ -160,6 +162,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       to,
       cc,
       bcc,
+      from,
       subject,
       contentType,
       body,
@@ -477,7 +480,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   },
 
   create_reply_draft: async (
-    { messageId, body, contentType = "text/plain" as const, to, cc, bcc },
+    { messageId, body, contentType = "text/plain" as const, to, cc, bcc, from },
     { authInfo }
   ) => {
     const accessToken = authInfo?.token;
@@ -566,6 +569,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     // Construct the reply message
     const messageLines = [
       `To: ${replyTo}`,
+      from ? `From: ${from}` : null,
       replyCc ? `Cc: ${replyCc}` : null,
       replyBcc ? `Bcc: ${replyBcc}` : null,
       `Subject: ${encodedSubject}`,
@@ -629,7 +633,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   },
 
   send_mail: async (
-    { to, cc, bcc, subject, contentType, body },
+    { to, cc, bcc, from, subject, contentType, body },
     { authInfo }
   ) => {
     const accessToken = authInfo?.token;
@@ -642,6 +646,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       to,
       cc,
       bcc,
+      from,
       subject,
       contentType,
       body,

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -35,9 +35,14 @@ import assert from "assert";
 function validateEmailAddresses(
   to: string[],
   cc?: string[],
-  bcc?: string[]
+  bcc?: string[],
+  from?: string
 ): Err<MCPError> | null {
-  for (const addr of [...to, ...(cc ?? []), ...(bcc ?? [])]) {
+  const allAddresses = [...to, ...(cc ?? []), ...(bcc ?? [])];
+  if (from) {
+    allAddresses.push(from);
+  }
+  for (const addr of allAddresses) {
     if (addr.includes("\r") || addr.includes("\n")) {
       return new Err(new MCPError("Invalid email address"));
     }
@@ -62,7 +67,8 @@ function buildAndEncodeEmail(params: {
   const validationError = validateEmailAddresses(
     params.to,
     params.cc,
-    params.bcc
+    params.bcc,
+    params.from
   );
   if (validationError) {
     return validationError;
@@ -526,8 +532,8 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     const originalDate = getHeaderValue(headers, "Date");
 
     // Validate user-provided email addresses to prevent header injection
-    if (to?.length || cc?.length || bcc?.length) {
-      const validationError = validateEmailAddresses(to ?? [], cc, bcc);
+    if (to?.length || cc?.length || bcc?.length || from) {
+      const validationError = validateEmailAddresses(to ?? [], cc, bcc, from);
       if (validationError) {
         return validationError;
       }


### PR DESCRIPTION

## Description
Allows sending from a configured send-as alias (e.g. a shared Google Group address) by setting the From header in the MIME message. Gmail honors this with the existing gmail.compose scope.
Added `from` param that gmail will respect if the address is configured as an alias on your account. If it isn't configured as an alias, you'll get an error and prompted to edit
<img width="672" height="380" alt="Screenshot 2026-04-06 at 2 45 40 PM" src="https://github.com/user-attachments/assets/908e28b2-4335-4497-a871-5015e97101bd" />
<img width="680" height="298" alt="Screenshot 2026-04-06 at 2 45 33 PM" src="https://github.com/user-attachments/assets/fca85dd9-c3be-4252-ad68-067d46a8b9d1" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
