### PR TITLE
feat: Track time since last reinforced workflow per agent (#7310)

### DIFF
--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -178,6 +178,7 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
       ),
       tags: tags.map((t) => t.toJSON()).sort(tagsSorter),
       reinforcement: agent.reinforcement,
+      lastAnalysedAt: agent.lastAnalysedAt?.toISOString() ?? null,
       canRead: isAuthor || isMember || agent.scope === "visible",
       canEdit: isAuthor || isMember,
     };

--- a/front/lib/models/agent/agent.ts
+++ b/front/lib/models/agent/agent.ts
@@ -52,6 +52,8 @@ export class AgentConfigurationModel extends WorkspaceAwareModel<AgentConfigurat
 
   declare reinforcement: AgentReinforcementMode;
 
+  declare lastAnalysedAt: Date | null;
+
   declare requestedSpaceIds: number[];
 
   declare author: NonAttribute<UserModel>;
@@ -163,6 +165,11 @@ AgentConfigurationModel.init(
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "auto",
+    },
+    lastAnalysedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
     },
     requestedSpaceIds: {
       type: DataTypes.ARRAY(DataTypes.BIGINT),

--- a/front/lib/reinforced_agent/eligibility.test.ts
+++ b/front/lib/reinforced_agent/eligibility.test.ts
@@ -122,4 +122,51 @@ describe("filterEligibleAgents", () => {
     const result = await filterEligibleAgents(auth, [agent], 30);
     expect(result).toEqual([]);
   });
+
+  it("excludes agents with lastAnalysedAt within MIN_HOURS_BETWEEN_WORKFLOWS", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    await createRecentAgentMessage(auth, workspace, agent, daysAgo(2));
+
+    // Set lastAnalysedAt to 12 hours ago (within 23 hour window).
+    const twelveHoursAgo = new Date(Date.now() - 12 * 60 * 60 * 1000);
+    const agentWithRecentAnalysis: LightAgentConfigurationType = {
+      ...agent,
+      lastAnalysedAt: twelveHoursAgo.toISOString(),
+    };
+
+    const result = await filterEligibleAgents(
+      auth,
+      [agentWithRecentAnalysis],
+      30
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("includes agents with lastAnalysedAt older than MIN_HOURS_BETWEEN_WORKFLOWS", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    await createRecentAgentMessage(auth, workspace, agent, daysAgo(2));
+
+    // Set lastAnalysedAt to 25 hours ago (outside 23 hour window).
+    const twentyFiveHoursAgo = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    const agentWithOldAnalysis: LightAgentConfigurationType = {
+      ...agent,
+      lastAnalysedAt: twentyFiveHoursAgo.toISOString(),
+    };
+
+    const result = await filterEligibleAgents(auth, [agentWithOldAnalysis], 30);
+    expect(result.map((a) => a.sId)).toEqual([agent.sId]);
+  });
+
+  it("includes agents with lastAnalysedAt = null (never analyzed before)", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    await createRecentAgentMessage(auth, workspace, agent, daysAgo(2));
+
+    const agentNeverAnalyzed: LightAgentConfigurationType = {
+      ...agent,
+      lastAnalysedAt: null,
+    };
+
+    const result = await filterEligibleAgents(auth, [agentNeverAnalyzed], 30);
+    expect(result.map((a) => a.sId)).toEqual([agent.sId]);
+  });
 });

--- a/front/lib/reinforced_agent/eligibility.ts
+++ b/front/lib/reinforced_agent/eligibility.ts
@@ -7,6 +7,7 @@ import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 
 const PENDING_SUGGESTION_MAX_AGE_DAYS = 30;
+const MIN_HOURS_BETWEEN_WORKFLOWS = 23;
 
 function recordReinforcedAgentEligibilityMetrics({
   workspaceId,
@@ -48,7 +49,7 @@ function recordReinforcedAgentEligibilityMetrics({
 }
 
 // An agent is eligible if: reinforcement is not "off", it is workspace-owned (id > 0),
-// has no recent pending suggestions, and either:
+// has no recent pending suggestions, has not been analyzed recently, and either:
 //   (a) has explicit human feedback in the lookback window, or
 //   (b) has recent qualifying conversations in the lookback window.
 export async function filterEligibleAgents(
@@ -57,9 +58,29 @@ export async function filterEligibleAgents(
   lookbackWindowDays: number
 ): Promise<LightAgentConfigurationType[]> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
-  const candidates = agents.filter(
-    (a) => a.reinforcement !== "off" && a.id > 0
+  
+  // Filter out agents with reinforcement off, non-positive id, or recently analyzed.
+  const minTimeSinceLastAnalysis = new Date();
+  minTimeSinceLastAnalysis.setHours(
+    minTimeSinceLastAnalysis.getHours() - MIN_HOURS_BETWEEN_WORKFLOWS
   );
+  
+  const candidates = agents.filter((a) => {
+    if (a.reinforcement === "off" || a.id <= 0) {
+      return false;
+    }
+    
+    // If lastAnalysedAt is set and within the minimum time window, exclude.
+    if (a.lastAnalysedAt) {
+      const lastAnalysedDate = new Date(a.lastAnalysedAt);
+      if (lastAnalysedDate > minTimeSinceLastAnalysis) {
+        return false;
+      }
+    }
+    
+    return true;
+  });
+  
   if (candidates.length === 0) {
     recordReinforcedAgentEligibilityMetrics({
       workspaceId,

--- a/front/migrations/db/migration_564.sql
+++ b/front/migrations/db/migration_564.sql
@@ -1,0 +1,2 @@
+-- Migration created on Apr 4, 2026
+ALTER TABLE "public"."agent_configurations" ADD COLUMN "lastAnalysedAt" TIMESTAMP WITH TIME ZONE DEFAULT NULL;

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -442,6 +442,49 @@ export async function finalizeAggregationActivity({
 }
 
 /**
+ * Record that a reinforced workflow has completed for an agent.
+ * Updates the lastAnalysedAt timestamp on the active agent configuration.
+ */
+export async function recordWorkflowCompletionActivity({
+  workspaceId,
+  agentConfigurationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+}): Promise<void> {
+  const auth = await getAuthForWorkspace(workspaceId);
+
+  const [agentConfig] = await getAgentConfigurations(auth, {
+    agentIds: [agentConfigurationId],
+    variant: "light",
+  });
+
+  if (!agentConfig) {
+    logger.warn(
+      { agentConfigurationId, workspaceId },
+      "ReinforcedAgent: agent not found for recordWorkflowCompletion"
+    );
+    return;
+  }
+
+  await AgentConfigurationModel.update(
+    { lastAnalysedAt: new Date() },
+    {
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        sId: agentConfigurationId,
+        status: "active",
+      },
+    }
+  );
+
+  logger.info(
+    { agentConfigurationId, workspaceId },
+    "ReinforcedAgent: recorded workflow completion timestamp"
+  );
+}
+
+/**
  * Single step of aggregation for reinforcement (streaming mode).
  *
  * Mirrors `analyzeConversationStepActivity` but for the aggregation phase.

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -38,6 +38,10 @@ const { finalizeAggregationActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
 });
 
+const { recordWorkflowCompletionActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+});
+
 const { startConversationAnalysisBatchActivity } = proxyActivities<
   typeof activities
 >({
@@ -290,6 +294,12 @@ export async function reinforcedAgentForAgentWorkflow({
       disableNotifications,
     });
   }
+
+  // Record workflow completion timestamp.
+  await recordWorkflowCompletionActivity({
+    workspaceId,
+    agentConfigurationId,
+  });
 }
 
 interface ReinforcedToolActionInfo {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -194,6 +194,7 @@ export const LightAgentConfigurationSchema = z.object({
   requestedGroupIds: z.array(z.array(z.string())),
   requestedSpaceIds: z.array(z.string()),
   reinforcement: z.enum(AGENT_REINFORCEMENT_MODES).optional(),
+  lastAnalysedAt: z.string().nullable().optional(),
   canRead: z.boolean(),
   canEdit: z.boolean(),
   omittedThinking: z.boolean().optional(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Implements #7310 to track when each agent version was last analyzed by the reinforced agent workflow. This prevents double-runs and enables prioritization of agents that haven't been analyzed recently.

### Changes:

1. **Database Migration**: Added `lastAnalysedAt` TIMESTAMP column to `agent_configurations` table (nullable, defaults to NULL)

2. **Model & Type Updates**:
   - Updated `AgentConfigurationModel` to include `lastAnalysedAt: Date | null`
   - Added field to `LightAgentConfigurationSchema` as optional nullable string
   - Updated `enrichAgentConfigurations` to serialize the timestamp

3. **Workflow Recording**:
   - Created `recordWorkflowCompletionActivity` that updates `lastAnalysedAt` on the active agent configuration
   - Integrated activity call at the end of `reinforcedAgentForAgentWorkflow` (both batch and streaming paths)
   - Activity uses in-place update pattern following existing precedent (status, scope, reinforcement)

4. **Eligibility Filtering**:
   - Added `MIN_HOURS_BETWEEN_WORKFLOWS = 23` constant to avoid double-runs in 24h cycle
   - Updated `filterEligibleAgents` to exclude agents where `lastAnalysedAt` is within the last 23 hours
   - Filter runs early before expensive DB queries (alongside `reinforcement !== "off"` and `id > 0` checks)

5. **Tests**: Added comprehensive test coverage for:
   - Agents with `lastAnalysedAt` within MIN_HOURS_BETWEEN_WORKFLOWS (should be excluded)
   - Agents with `lastAnalysedAt` older than MIN_HOURS_BETWEEN_WORKFLOWS (should be included)
   - Agents with `lastAnalysedAt = null` (never analyzed, should be included)

## Tests

- Added 3 new test cases to `eligibility.test.ts` covering all scenarios
- Tests follow existing pattern in the test file using `AgentConfigurationFactory` and `ConversationFactory`

## Risk

**Low risk**:
- Column is nullable and defaults to NULL, so existing agents are unaffected
- In-place update pattern follows existing approach used for `status`, `scope`, and `reinforcement`
- Filtering logic is additive (makes eligibility more restrictive, doesn't remove existing checks)
- When a user edits their agent (creating a new version), the new version will be eligible immediately since `lastAnalysedAt` won't be set

**Safe rollback**: Yes - the filtering can be temporarily disabled by removing the lastAnalysedAt check, and the column can remain in place.

## Deploy Plan

1. Deploy migration to add `lastAnalysedAt` column (nullable, no impact on existing data)
2. Deploy application code with new activity and filtering logic
3. Monitor metrics via `reinforced_agent.eligibility.*` StatsD metrics to verify filtering is working as expected
4. No special considerations needed - the feature activates automatically as workflows complete and populate timestamps
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dust4ai.slack.com/archives/C08KSKG0953/p1775261521109929?thread_ts=1775261521.109929&cid=C08KSKG0953)

<div><a href="https://cursor.com/agents/bc-89ce1ea5-b156-59d8-b97e-43e0bcac0b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89ce1ea5-b156-59d8-b97e-43e0bcac0b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

