### PR TITLE
Add dummy flag for testing purpose

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -127,6 +127,7 @@ export function WorkspacePage() {
 
   const {
     activeSubscription,
+    hasDummyFeature,
     metronomeCustomerId,
     stripeSubscription,
     subscriptions,
@@ -212,6 +213,7 @@ export function WorkspacePage() {
                   extensionConfig={extensionConfig}
                   dataRetention={dataRetention}
                   workosEnvironmentId={workosEnvironmentId}
+                  hasDummyFeature={hasDummyFeature}
                 />
               </TabsContent>
               <TabsContent value="subscriptions">

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -23,6 +23,7 @@ export function WorkspaceInfoTable({
   extensionConfig,
   dataRetention,
   workosEnvironmentId,
+  hasDummyFeature,
 }: {
   owner: WorkspaceType;
   metronomeCustomerId: string | null;
@@ -31,6 +32,7 @@ export function WorkspaceInfoTable({
   extensionConfig: ExtensionConfigurationType | null;
   dataRetention: DataRetentionConfig | undefined;
   workosEnvironmentId: string;
+  hasDummyFeature: boolean;
 }) {
   const { dsyncStatus } = usePokeWorkOSDSyncStatus({ owner });
 
@@ -216,6 +218,12 @@ export function WorkspaceInfoTable({
                   </PokeTableCell>
                 </PokeTableRow>
               </>
+            )}
+            {hasDummyFeature && (
+              <PokeTableRow>
+                <PokeTableCell>Dummy feature</PokeTableCell>
+                <PokeTableCell>Enabled</PokeTableCell>
+              </PokeTableRow>
             )}
           </PokeTableBody>
         </PokeTable>

--- a/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
+++ b/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
@@ -2,7 +2,7 @@
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { getWorkspaceCreationDate } from "@app/lib/api/workspace";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
@@ -25,6 +25,7 @@ export type PokeGetWorkspaceInfo = {
   activeSubscription: SubscriptionType;
   baseUrl: string;
   extensionConfig: ExtensionConfigurationType | null;
+  hasDummyFeature: boolean;
   metronomeCustomerId: string | null;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
   stripeSubscription: Stripe.Subscription | null;
@@ -92,6 +93,11 @@ async function handler(
       const programmaticUsageConfig =
         await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
 
+      const hasDummyFeature = await hasFeatureFlag(
+        auth,
+        "dummy_feature_for_flag_testing"
+      );
+
       let stripeSubscription: Stripe.Subscription | null = null;
       if (activeSubscription.stripeSubscriptionId) {
         stripeSubscription = await getStripeSubscription(
@@ -101,6 +107,7 @@ async function handler(
 
       return res.status(200).json({
         activeSubscription,
+        hasDummyFeature,
         metronomeCustomerId: workspaceResource.metronomeCustomerId ?? null,
         stripeSubscription,
         subscriptions,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -281,6 +281,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     // Not really on_demand but we want to be able to enable it for customers
     stage: "on_demand",
   },
+  dummy_feature_for_flag_testing: {
+    description: "Dummy feature flag used for testing feature flag behavior",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -696,6 +696,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"
   | "discord_bot"
+  | "dummy_feature_for_flag_testing"
   | "dust_academy"
   | "dust_internal_global_agents"
   | "dust_no_spa"


### PR DESCRIPTION
## Description

- Adds a new dummy_feature_for_flag_testing feature flag for testing feature flag behavior (especially global flag rollouts)
- When the flag is enabled (via workspace or global flags), displays a "Dummy feature = Enabled" row at the bottom of the Workspace info table in poke

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Minimal

## Deploy Plan

Front