### PR TITLE
refactor: add branchId to ConversationWithoutContentType

### DIFF
--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -23,6 +23,7 @@ import type {
   AgenticMessageData,
   AgentMessageType,
   ConversationType,
+  ConversationWithoutContentType,
   MessageVisibility,
   RichMentionWithStatus,
   UserMessageContext,
@@ -242,7 +243,7 @@ export const createAgentMessages = async (
     metadata,
     transaction,
   }: {
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
     metadata:
       | {
           type: "retry";

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -22,7 +22,6 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgenticMessageData,
   AgentMessageType,
-  ConversationType,
   ConversationWithoutContentType,
   MessageVisibility,
   RichMentionWithStatus,
@@ -73,7 +72,7 @@ export async function createUserMessage(
     content,
     transaction,
   }: {
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
     content: string;
     metadata:
       | {

--- a/front/lib/api/assistant/conversation/permissions.ts
+++ b/front/lib/api/assistant/conversation/permissions.ts
@@ -5,10 +5,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import type {
-  ConversationType,
-  ConversationWithoutContentType,
-} from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isProjectConversation } from "@app/types/assistant/conversation";
 import uniq from "lodash/uniq";
 import type { Transaction } from "sequelize";
@@ -93,7 +90,7 @@ export async function canAgentBeUsedInProjectConversation(
     conversation,
   }: {
     configuration: LightAgentConfigurationType;
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
   }
 ): Promise<boolean> {
   if (!isProjectConversation(conversation)) {

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -53,6 +53,7 @@ describe("constructProjectContextSection", () => {
       depth: 0,
       requestedSpaceIds: [],
       metadata: {},
+      branchId: null,
     };
 
     const result = constructProjectContextSection(conversation);
@@ -75,6 +76,7 @@ describe("constructProjectContextSection", () => {
       depth: 0,
       requestedSpaceIds: [],
       metadata: {},
+      branchId: null,
     };
 
     const result = constructProjectContextSection(conversation);

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -871,6 +871,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       spaceId: conversation.space?.sId ?? null,
       depth: conversation.depth,
       metadata: conversation.metadata,
+      branchId: null,
     });
   }
 
@@ -1340,6 +1341,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           spaceId: c.space?.sId ?? null,
           depth: c.depth,
           metadata: c.metadata,
+          branchId: null,
         };
       })
     );
@@ -1391,6 +1393,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       spaceId: null,
       depth: c.depth,
       metadata: c.metadata,
+      branchId: null,
     }));
   }
 
@@ -2420,6 +2423,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       lastReadMs: this.userLastReadAt?.getTime() ?? null,
       depth: this.depth,
       metadata: this.metadata,
+      branchId: null,
     };
   }
 }

--- a/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
@@ -80,6 +80,7 @@ async function handler(
             requestedSpaceIds: c.getRequestedSpaceIdsFromModel(),
             spaceId: c.space?.sId ?? null,
             metadata: c.metadata,
+            branchId: null,
           };
         });
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -356,6 +356,7 @@ export type ConversationWithoutContentType = {
   triggerId: string | null;
   depth: number;
   metadata: ConversationMetadata;
+  branchId: string | null;
 
   // Ideally, this property should be moved to the ConversationType.
   requestedSpaceIds: string[];
@@ -370,7 +371,6 @@ export type ConversationWithoutContentType = {
 export type ConversationType = ConversationWithoutContentType & {
   owner: WorkspaceType;
   visibility: ConversationVisibility;
-  branchId: string | null;
   content: (UserMessageType[] | AgentMessageType[] | ContentFragmentType[])[];
 };
 
@@ -381,7 +381,6 @@ export type ConversationType = ConversationWithoutContentType & {
 export type LightConversationType = ConversationWithoutContentType & {
   owner: WorkspaceType;
   visibility: ConversationVisibility;
-  branchId: string | null;
   content: (LightAgentMessageType | UserMessageTypeWithContentFragments)[];
 };
 


### PR DESCRIPTION
## Description

Move `branchId` from `ConversationType`/`LightConversationType` to the base `ConversationWithoutContentType`. This allows `createUserMessage` and `createAgentMessages` to accept the lighter type, which is needed for the steering promotion path in `updateAgentMessageWithFinalStatus`.

- Add `branchId: string | null` to `ConversationWithoutContentType`
- Remove duplicate `branchId` from `ConversationType` and `LightConversationType`
- Add `branchId: null` to all construction sites
- Change `createAgentMessages` to accept `ConversationWithoutContentType`
- Change `createUserMessage` to accept `ConversationWithoutContentType`

## Tests

- `npx tsgo --noEmit` passes
- `npx biome check` passes
- No runtime behavior change — pure type refactor
- covered by tests
- Tested locally

## Risk

Low — type-only change. `ConversationType` extends `ConversationWithoutContentType` so all existing callers are unaffected.

## Deploy Plan

N/A