### PR TITLE
Promote pending messages and create agent message in updateAgentMessageWithFinalStatus

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2576,12 +2576,13 @@ export async function updateAgentMessageWithFinalStatus(
 ): Promise<{
   completedTs: number;
   status: "succeeded" | "cancelled" | "failed" | "gracefully_stopped";
-  agentMessages: AgentMessageType[];
 }> {
   const completedAt = new Date();
   const owner = auth.getNonNullableWorkspace();
 
-  const { agentMessages } = await withTransaction(async (t) => {
+  // TODO(steering): use promotedUserMessages and agentMessages to publish
+  // events and launch the new agent loop.
+  await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
     await AgentMessageModel.update(
@@ -2652,15 +2653,16 @@ export async function updateAgentMessageWithFinalStatus(
 
       await ConversationResource.markAsUpdated(auth, { conversation, t });
 
-      // Render the last pending message to pass to createAgentMessages.
-      const renderedUserMessages = await batchRenderUserMessagesWithoutMentions(
+      // Render all promoted user messages.
+      const promotedUserMessages = await batchRenderUserMessagesWithoutMentions(
         auth,
         {
-          messages: [pendingMessages[pendingMessages.length - 1]],
+          messages: pendingMessages,
           transaction: t,
         }
       );
 
+      // Create a new agent message using the last promoted user message.
       const { agentMessages } = await createAgentMessages(auth, {
         conversation,
         metadata: {
@@ -2669,20 +2671,19 @@ export async function updateAgentMessageWithFinalStatus(
           agentConfigurations: [agentMessage.configuration],
           skipToolsValidation: agentMessage.skipToolsValidation,
           nextMessageRank,
-          userMessage: renderedUserMessages[0],
+          userMessage: promotedUserMessages[promotedUserMessages.length - 1],
         },
         transaction: t,
       });
 
-      return { agentMessages };
+      return { promotedUserMessages, agentMessages };
     } else {
-      return { agentMessages: [] };
+      return { promotedUserMessages: [], agentMessages: [] };
     }
   });
 
   return {
     completedTs: completedAt.getTime(),
     status,
-    agentMessages,
   };
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2644,6 +2644,8 @@ export async function updateAgentMessageWithFinalStatus(
             id: pendingMessages.map((m) => m.id),
             workspaceId: owner.id,
           },
+          // Skip validation — rows are already valid, we're only updating visibility.
+          validate: false,
           transaction: t,
         }
       );

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2643,7 +2643,10 @@ export async function updateAgentMessageWithFinalStatus(
             id: pendingMessages.map((m) => m.id),
             workspaceId: owner.id,
           },
-          // Skip validation — rows are already valid, we're only updating visibility.
+          // Skip validation: Sequelize bulk update constructs a dummy instance with only the
+          // updated fields, so the beforeValidate hook (which checks that exactly one of
+          // userMessageId/agentMessageId/ contentFragmentId is set) fails because all three are
+          // undefined. The rows are already valid, we're only updating visibility.
           validate: false,
           transaction: t,
         }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -19,7 +19,10 @@ import {
   updateConversationRequirements,
 } from "@app/lib/api/assistant/conversation/permissions";
 import { ensureConversationTitle } from "@app/lib/api/assistant/conversation/title";
-import { batchRenderMessages } from "@app/lib/api/assistant/messages";
+import {
+  batchRenderMessages,
+  batchRenderUserMessagesWithoutMentions,
+} from "@app/lib/api/assistant/messages";
 import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import {
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR,
@@ -2555,7 +2558,7 @@ export async function isConversationEventAllowedForAuth(
  * Finalize an agent message terminal status behind the conversation advisory lock.
  *
  * This ensures the status transition is serialized against other conversation operations (e.g.
- * postUserMessage's pending path in the future).
+ * postUserMessage's pending path).
  */
 export async function updateAgentMessageWithFinalStatus(
   auth: Authenticator,
@@ -2573,13 +2576,12 @@ export async function updateAgentMessageWithFinalStatus(
 ): Promise<{
   completedTs: number;
   status: "succeeded" | "cancelled" | "failed" | "gracefully_stopped";
-  promotedUserMessages: string[];
-  agentMessageId: string | null;
+  agentMessages: AgentMessageType[];
 }> {
   const completedAt = new Date();
-  const workspaceId = auth.getNonNullableWorkspace().id;
+  const owner = auth.getNonNullableWorkspace();
 
-  const result = await withTransaction(async (t) => {
+  const { agentMessages } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
     await AgentMessageModel.update(
@@ -2597,73 +2599,90 @@ export async function updateAgentMessageWithFinalStatus(
       {
         where: {
           id: agentMessage.agentMessageId,
-          workspaceId,
+          workspaceId: owner.id,
         },
         transaction: t,
       }
     );
 
-    // Promote pending messages when the agent loop ends (gracefully stopped or
-    // succeeded as safety net). Also create a new agent message so the caller
-    // can launch a new agent loop.
-    if (status === "gracefully_stopped" || status === "succeeded") {
-      const pendingMessages = await MessageModel.findAll({
-        where: {
-          conversationId: conversation.id,
-          workspaceId,
-          visibility: "pending",
+    // Promote *all* pending messages when the agent loop ends. If a pending message exists it will
+    // be promoted and will trigger the ending agentMessage. The `enableSteering` invariants of
+    // postUserMessage ensure that we have only one running agentic loop so we can just recreate a
+    // new agentMesssage for the same agent as the one that finished.
+    //
+    // There is an edge case here for API interactions which are not subject to the steering
+    // invariant in which case we could have more than one running agent message and could pick the
+    // wrong agent compared to user attempt. But should ~never happen so the simplicity is worth it.
+    const pendingMessages = await MessageModel.findAll({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: owner.id,
+        visibility: "pending",
+      },
+      include: [
+        { model: UserMessageModel, as: "userMessage", required: false },
+      ],
+      order: [["rank", "ASC"]],
+      transaction: t,
+    });
+
+    if (pendingMessages.length > 0) {
+      await MessageModel.update(
+        { visibility: "visible" },
+        {
+          where: {
+            id: pendingMessages.map((m) => m.id),
+            workspaceId: owner.id,
+          },
+          transaction: t,
+        }
+      );
+
+      const nextMessageRank =
+        ((await MessageModel.max<number | null, MessageModel>("rank", {
+          where: {
+            workspaceId: owner.id,
+            conversationId: conversation.id,
+            branchId: conversation.branchId
+              ? getResourceIdFromSId(conversation.branchId)
+              : null,
+          },
+          transaction: t,
+        })) ?? -1) + 1;
+
+      await ConversationResource.markAsUpdated(auth, { conversation, t });
+
+      // Render the last pending message to pass to createAgentMessages.
+      const renderedUserMessages = await batchRenderUserMessagesWithoutMentions(
+        auth,
+        {
+          messages: [pendingMessages[pendingMessages.length - 1]],
+          transaction: t,
+        }
+      );
+
+      const { agentMessages } = await createAgentMessages(auth, {
+        conversation,
+        metadata: {
+          type: "create",
+          mentions: [{ configurationId: agentMessage.configuration.sId }],
+          agentConfigurations: [agentMessage.configuration],
+          skipToolsValidation: agentMessage.skipToolsValidation,
+          nextMessageRank,
+          userMessage: renderedUserMessages[0],
         },
-        order: [["rank", "ASC"]],
         transaction: t,
       });
 
-      if (pendingMessages.length > 0) {
-        await MessageModel.update(
-          { visibility: "visible" },
-          {
-            where: { id: pendingMessages.map((m) => m.id) },
-            transaction: t,
-          }
-        );
-
-        // Create a new agent message for the same agent configuration.
-        const lastPendingMessage = pendingMessages[pendingMessages.length - 1];
-        const newAgentMessageRow = await AgentMessageModel.create(
-          {
-            status: "created",
-            agentConfigurationId: agentMessage.configuration.sId,
-            agentConfigurationVersion: agentMessage.configuration.version,
-            workspaceId,
-            skipToolsValidation: false,
-          },
-          { transaction: t }
-        );
-        const newMessageRow = await MessageModel.create(
-          {
-            sId: generateRandomModelSId(),
-            rank: lastPendingMessage.rank + 1,
-            conversationId: conversation.id,
-            branchId: lastPendingMessage.branchId,
-            parentId: lastPendingMessage.id,
-            agentMessageId: newAgentMessageRow.id,
-            workspaceId,
-          },
-          { transaction: t }
-        );
-
-        return {
-          promotedUserMessages: pendingMessages.map((m) => m.sId),
-          agentMessageId: newMessageRow.sId,
-        };
-      }
+      return { agentMessages };
+    } else {
+      return { agentMessages: [] };
     }
-
-    return { promotedUserMessages: [], agentMessageId: null };
   });
 
   return {
     completedTs: completedAt.getTime(),
     status,
-    ...result,
+    agentMessages,
   };
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2704,11 +2704,6 @@ export async function updateAgentMessageWithFinalStatus(
         { conversationId: conversation.sId }
       );
     }
-
-    await triggerConversationUnreadNotifications(auth, {
-      conversationId: conversation.sId,
-      messageId: promotedUserMessages[promotedUserMessages.length - 1].sId,
-    });
   }
 
   if (newAgentMessage) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2607,16 +2607,15 @@ export async function updateAgentMessageWithFinalStatus(
         }
       );
 
-      // Promote *all* pending messages when the agent loop ends. If a pending
-      // message exists it will be promoted and will trigger the ending
-      // agentMessage. The `enableSteering` invariants of postUserMessage ensure
-      // that we have only one running agentic loop so we can just recreate a
-      // new agentMessage for the same agent as the one that finished.
+      // Promote *all* pending messages when the agent loop ends. If a pending message exists it
+      // will be promoted and will trigger the ending agentMessage. The `enableSteering` invariants
+      // of postUserMessage ensure that we have only one running agentic loop so we can just
+      // recreate a new agentMessage for the same agent as the one that finished.
       //
-      // There is an edge case here for API interactions which are not subject
-      // to the steering invariant in which case we could have more than one
-      // running agent message and could pick the wrong agent compared to user
-      // attempt. But should ~never happen so the simplicity is worth it.
+      // There is an edge case here for API interactions which are not subject to the steering
+      // invariant in which case we could have more than one running agent message and could pick
+      // the wrong agent compared to user attempt. But should ~never happen so the simplicity is
+      // worth it.
       const pendingMessages = await MessageModel.findAll({
         where: {
           conversationId: conversation.id,
@@ -2705,10 +2704,29 @@ export async function updateAgentMessageWithFinalStatus(
         { conversationId: conversation.sId }
       );
     }
+
+    await triggerConversationUnreadNotifications(auth, {
+      conversationId: conversation.sId,
+      messageId: promotedUserMessages[promotedUserMessages.length - 1].sId,
+    });
   }
 
   if (newAgentMessage) {
     await publishAgentMessagesEvents(conversation, [newAgentMessage]);
+
+    void emitAuditLogEvent({
+      auth,
+      action: "agent.executed",
+      targets: [
+        buildAuditLogTarget("workspace", owner),
+        buildAuditLogTarget("agent", newAgentMessage.configuration),
+      ],
+      metadata: {
+        conversationId: conversation.sId,
+        agentName: newAgentMessage.configuration.name,
+        origin: "steering",
+      },
+    });
 
     await runAgentLoopWorkflow({
       auth,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -38,6 +38,7 @@ import {
 } from "@app/lib/api/assistant/rate_limits";
 import {
   publishAgentMessagesEvents,
+  publishConversationEvent,
   publishMessageEventsOnMessagePostOrEdit,
 } from "@app/lib/api/assistant/streaming/events";
 import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types";
@@ -121,6 +122,7 @@ import type {
   RichMentionWithStatus,
   UserMessageContext,
   UserMessageType,
+  UserMessageTypeWithoutMentions,
 } from "@app/types/assistant/conversation";
 import {
   ConversationError,
@@ -2580,54 +2582,61 @@ export async function updateAgentMessageWithFinalStatus(
   const completedAt = new Date();
   const owner = auth.getNonNullableWorkspace();
 
-  // TODO(steering): use promotedUserMessages and agentMessages to publish
-  // events and launch the new agent loop.
-  await withTransaction(async (t) => {
-    await getConversationRankVersionLock(auth, conversation, t);
+  const { promotedUserMessages, agentMessage: newAgentMessage } =
+    await withTransaction(async (t) => {
+      await getConversationRankVersionLock(auth, conversation, t);
 
-    await AgentMessageModel.update(
-      {
-        status,
-        completedAt,
-        ...(error
-          ? {
-              errorCode: error.code,
-              errorMessage: error.message,
-              errorMetadata: error.metadata,
-            }
-          : {}),
-      },
-      {
-        where: {
-          id: agentMessage.agentMessageId,
-          workspaceId: owner.id,
+      await AgentMessageModel.update(
+        {
+          status,
+          completedAt,
+          ...(error
+            ? {
+                errorCode: error.code,
+                errorMessage: error.message,
+                errorMetadata: error.metadata,
+              }
+            : {}),
         },
+        {
+          where: {
+            id: agentMessage.agentMessageId,
+            workspaceId: owner.id,
+          },
+          transaction: t,
+        }
+      );
+
+      // Promote *all* pending messages when the agent loop ends. If a pending
+      // message exists it will be promoted and will trigger the ending
+      // agentMessage. The `enableSteering` invariants of postUserMessage ensure
+      // that we have only one running agentic loop so we can just recreate a
+      // new agentMessage for the same agent as the one that finished.
+      //
+      // There is an edge case here for API interactions which are not subject
+      // to the steering invariant in which case we could have more than one
+      // running agent message and could pick the wrong agent compared to user
+      // attempt. But should ~never happen so the simplicity is worth it.
+      const pendingMessages = await MessageModel.findAll({
+        where: {
+          conversationId: conversation.id,
+          workspaceId: owner.id,
+          visibility: "pending",
+        },
+        include: [
+          { model: UserMessageModel, as: "userMessage", required: false },
+        ],
+        order: [["rank", "ASC"]],
         transaction: t,
+      });
+
+      if (pendingMessages.length === 0) {
+        return {
+          promotedUserMessages: [] as UserMessageTypeWithoutMentions[],
+          agentMessage: null as AgentMessageType | null,
+        };
       }
-    );
 
-    // Promote *all* pending messages when the agent loop ends. If a pending message exists it will
-    // be promoted and will trigger the ending agentMessage. The `enableSteering` invariants of
-    // postUserMessage ensure that we have only one running agentic loop so we can just recreate a
-    // new agentMesssage for the same agent as the one that finished.
-    //
-    // There is an edge case here for API interactions which are not subject to the steering
-    // invariant in which case we could have more than one running agent message and could pick the
-    // wrong agent compared to user attempt. But should ~never happen so the simplicity is worth it.
-    const pendingMessages = await MessageModel.findAll({
-      where: {
-        conversationId: conversation.id,
-        workspaceId: owner.id,
-        visibility: "pending",
-      },
-      include: [
-        { model: UserMessageModel, as: "userMessage", required: false },
-      ],
-      order: [["rank", "ASC"]],
-      transaction: t,
-    });
-
-    if (pendingMessages.length > 0) {
       await MessageModel.update(
         { visibility: "visible" },
         {
@@ -2676,11 +2685,36 @@ export async function updateAgentMessageWithFinalStatus(
         transaction: t,
       });
 
-      return { promotedUserMessages, agentMessages };
-    } else {
-      return { promotedUserMessages: [], agentMessages: [] };
+      return {
+        promotedUserMessages,
+        agentMessage: agentMessages[0] ?? null,
+      };
+    });
+
+  // Publish events and launch agent loop outside of the advisory lock.
+  if (promotedUserMessages.length > 0) {
+    for (const userMsg of promotedUserMessages) {
+      await publishConversationEvent(
+        {
+          type: "user_message_promoted",
+          created: Date.now(),
+          messageId: userMsg.sId,
+        },
+        { conversationId: conversation.sId }
+      );
     }
-  });
+  }
+
+  if (newAgentMessage) {
+    await publishAgentMessagesEvents(conversation, [newAgentMessage]);
+
+    await runAgentLoopWorkflow({
+      auth,
+      agentMessages: [newAgentMessage],
+      conversation,
+      userMessage: promotedUserMessages[promotedUserMessages.length - 1],
+    });
+  }
 
   return {
     completedTs: completedAt.getTime(),

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2573,10 +2573,13 @@ export async function updateAgentMessageWithFinalStatus(
 ): Promise<{
   completedTs: number;
   status: "succeeded" | "cancelled" | "failed" | "gracefully_stopped";
+  promotedUserMessages: string[];
+  agentMessageId: string | null;
 }> {
   const completedAt = new Date();
+  const workspaceId = auth.getNonNullableWorkspace().id;
 
-  await withTransaction(async (t) => {
+  const result = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
     await AgentMessageModel.update(
@@ -2594,12 +2597,73 @@ export async function updateAgentMessageWithFinalStatus(
       {
         where: {
           id: agentMessage.agentMessageId,
-          workspaceId: auth.getNonNullableWorkspace().id,
+          workspaceId,
         },
         transaction: t,
       }
     );
+
+    // Promote pending messages when the agent loop ends (gracefully stopped or
+    // succeeded as safety net). Also create a new agent message so the caller
+    // can launch a new agent loop.
+    if (status === "gracefully_stopped" || status === "succeeded") {
+      const pendingMessages = await MessageModel.findAll({
+        where: {
+          conversationId: conversation.id,
+          workspaceId,
+          visibility: "pending",
+        },
+        order: [["rank", "ASC"]],
+        transaction: t,
+      });
+
+      if (pendingMessages.length > 0) {
+        await MessageModel.update(
+          { visibility: "visible" },
+          {
+            where: { id: pendingMessages.map((m) => m.id) },
+            transaction: t,
+          }
+        );
+
+        // Create a new agent message for the same agent configuration.
+        const lastPendingMessage = pendingMessages[pendingMessages.length - 1];
+        const newAgentMessageRow = await AgentMessageModel.create(
+          {
+            status: "created",
+            agentConfigurationId: agentMessage.configuration.sId,
+            agentConfigurationVersion: agentMessage.configuration.version,
+            workspaceId,
+            skipToolsValidation: false,
+          },
+          { transaction: t }
+        );
+        const newMessageRow = await MessageModel.create(
+          {
+            sId: generateRandomModelSId(),
+            rank: lastPendingMessage.rank + 1,
+            conversationId: conversation.id,
+            branchId: lastPendingMessage.branchId,
+            parentId: lastPendingMessage.id,
+            agentMessageId: newAgentMessageRow.id,
+            workspaceId,
+          },
+          { transaction: t }
+        );
+
+        return {
+          promotedUserMessages: pendingMessages.map((m) => m.sId),
+          agentMessageId: newMessageRow.sId,
+        };
+      }
+    }
+
+    return { promotedUserMessages: [], agentMessageId: null };
   });
 
-  return { completedTs: completedAt.getTime(), status };
+  return {
+    completedTs: completedAt.getTime(),
+    status,
+    ...result,
+  };
 }

--- a/front/lib/api/assistant/conversation/agent_loop.ts
+++ b/front/lib/api/assistant/conversation/agent_loop.ts
@@ -4,7 +4,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type {
   AgentMessageType,
-  ConversationType,
+  ConversationWithoutContentType,
   UserMessageTypeWithoutMentions,
 } from "@app/types/assistant/conversation";
 import assert from "assert";
@@ -20,7 +20,7 @@ export const runAgentLoopWorkflow = async ({
 }: {
   auth: Authenticator;
   agentMessages: AgentMessageType[];
-  conversation: ConversationType;
+  conversation: ConversationWithoutContentType;
   userMessage: UserMessageTypeWithoutMentions;
 }) => {
   await concurrentExecutor(

--- a/x/spolu/steering/plan.md
+++ b/x/spolu/steering/plan.md
@@ -106,22 +106,19 @@ Behind `enable_steering` feature flag:
 - After commit: publish `UserMessageNewEvent` (pending), call `gracefullyStopAgentLoop()`
   with `reason: "steering"`.
 
-### - [ ] PR 3.3 — `finalizeGracefulStopAgentMessage`
+### - [x] PR 3.3+3.4 — Promote pending messages in `updateAgentMessageWithFinalStatus`
 
-- Add `finalizeGracefulStopAgentMessage()` in `front/lib/api/assistant/conversation.ts`:
-  - Acquires conversation advisory lock.
-  - Sets agent message status to `"gracefully_stopped"`.
-  - Finds pending messages, promotes visibility to `"visible"`.
-  - Creates one `AgentMessage` + `MessageModel`.
-- Update `finalizeGracefullyStoppedAgentLoopActivity` to call this function, publish
-  `UserMessagePromotedEvent` events, publish `AgentMessageNewEvent`, launch new agent loop.
+Extend `updateAgentMessageWithFinalStatus()` in `conversation.ts` to promote pending messages
+inside the same advisory-locked transaction when status is `"gracefully_stopped"` or
+`"succeeded"` (safety net). The existing flow already handles setting the status and emitting
+the terminal event — this adds the promotion logic:
 
-### - [ ] PR 3.4 — Safety net in `finalizeAgentMessage` for succeeded path
-
-- Update `finalizeAgentMessage()` to check for orphaned pending messages when `status` is
-  `"succeeded"` and promote them (same logic as `finalizeGracefulStopAgentMessage`).
-- This handles the edge case where the graceful stop signal was lost or arrived after the loop
-  already decided to exit naturally.
+- Inside the locked transaction: find pending messages, promote visibility to `"visible"`,
+  create one `AgentMessage` + `MessageModel`.
+- Return promoted messages + new agent message info to the caller.
+- In `finalizeGracefullyStoppedAgentLoopActivity`: publish `UserMessagePromotedEvent` events,
+  publish `AgentMessageNewEvent`, launch new agent loop.
+- The `"succeeded"` path acts as safety net (graceful stop signal lost or arrived too late).
 
 ### - [ ] PR 3.5 — Frontend: pending message display with spinner
 


### PR DESCRIPTION
## Description

Extend `updateAgentMessageWithFinalStatus` to promote pending messages and create a new agent message inside the advisory-locked transaction when the agent loop ends (whatever the final status).

- Query pending `MessageModel` rows (with `UserMessageModel` included) inside the transaction
- Promote visibility `"pending"` → `"visible"`
- Render the pending message via `batchRenderUserMessagesWithoutMentions` (transaction-safe)
- Create a new `AgentMessage` + `MessageModel` for the same agent via `createAgentMessages`
- Publish events and launch the new agent loop

## Tests

Tested locally both with and without the `enable_steering` feature flag

## Risk

Medium — changes the advisory-locked transaction to include promotion logic. The transaction is kept short (model queries only, no external calls). The `batchRenderUserMessagesWithoutMentions` only queries `UserModel` within the transaction.

## Deploy Plan

- deploy `front`