### PR TITLE
[Tool Calls] Publish tool_call_started over assistant SSE

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -370,6 +370,7 @@ export function AgentMessage({
             break;
           }
           case "end-of-stream":
+          case "tool_call_started":
           case "tool_error":
           case "tool_notification":
           case "tool_params":

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -382,6 +382,9 @@ export function useAgentMessageStream({
           );
           break;
 
+        case "tool_call_started":
+          break;
+
         case "tool_error":
         case "agent_error":
           const error = eventPayload.data.error;

--- a/front/hooks/useChildAgentStream.ts
+++ b/front/hooks/useChildAgentStream.ts
@@ -69,6 +69,7 @@ function childAgentStreamReducer(
     // Events we don't use for the child stream display.
     case "end-of-stream":
     case "agent_action_success":
+    case "tool_call_started":
     case "tool_params":
     case "tool_notification":
     case "agent_context_pruned":

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -17,6 +17,7 @@ import type {
   AgentActionSuccessEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
+  AgentToolCallStartedEvent,
 } from "@app/types/assistant/agent";
 import type { GenerationTokensEvent } from "@app/types/assistant/generation";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -189,6 +190,7 @@ export async function* getMessagesEvents(
       | AgentActionRunningEvents
       | AgentActionSuccessEvent
       | AgentGenerationCancelledEvent
+      | AgentToolCallStartedEvent
       | GenerationTokensEvent
     ) & {
       step: number;

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -115,6 +115,7 @@ function isMessageEventParams(
     case "agent_message_success":
     case "agent_message_gracefully_stopped":
     case "generation_tokens":
+    case "tool_call_started":
     case "tool_approve_execution":
     case "tool_error":
     case "tool_file_auth_required":

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -12,6 +12,7 @@ import type {
   AgentMessageDoneEvent,
   AgentMessageGracefullyStoppedEvent,
   AgentMessageSuccessEvent,
+  AgentToolCallStartedEvent,
   ToolErrorEvent,
 } from "@app/types/assistant/agent";
 import type {
@@ -33,6 +34,7 @@ export type AgentMessageEvents =
   | AgentGenerationCancelledEvent
   | AgentMessageGracefullyStoppedEvent
   | AgentMessageSuccessEvent
+  | AgentToolCallStartedEvent
   | GenerationTokensEvent
   | ToolErrorEvent
   | ToolAskUserQuestionEvent

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -1109,6 +1109,7 @@
  *         propertyName: type
  *       oneOf:
  *         - $ref: '#/components/schemas/PrivateGenerationTokensEvent'
+ *         - $ref: '#/components/schemas/PrivateToolCallStartedEvent'
  *         - $ref: '#/components/schemas/PrivateAgentActionSuccessEvent'
  *         - $ref: '#/components/schemas/PrivateAgentMessageSuccessEvent'
  *         - $ref: '#/components/schemas/PrivateAgentErrorEvent'
@@ -1142,6 +1143,27 @@
  *         delimiterClassification:
  *           type: string
  *           description: Present when classification is opening_delimiter or closing_delimiter
+ *         step:
+ *           type: integer
+ *     PrivateToolCallStartedEvent:
+ *       type: object
+ *       required: [type, created, configurationId, messageId, toolName]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [tool_call_started]
+ *         created:
+ *           type: integer
+ *         configurationId:
+ *           type: string
+ *         messageId:
+ *           type: string
+ *         toolCallId:
+ *           type: string
+ *         toolCallIndex:
+ *           type: integer
+ *         toolName:
+ *           type: string
  *         step:
  *           type: integer
  *     PrivateAgentActionSuccessEvent:

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -10545,6 +10545,9 @@
             "$ref": "#/components/schemas/PrivateGenerationTokensEvent"
           },
           {
+            "$ref": "#/components/schemas/PrivateToolCallStartedEvent"
+          },
+          {
             "$ref": "#/components/schemas/PrivateAgentActionSuccessEvent"
           },
           {
@@ -10621,6 +10624,45 @@
           "delimiterClassification": {
             "type": "string",
             "description": "Present when classification is opening_delimiter or closing_delimiter"
+          },
+          "step": {
+            "type": "integer"
+          }
+        }
+      },
+      "PrivateToolCallStartedEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "configurationId",
+          "messageId",
+          "toolName"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "tool_call_started"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "configurationId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "toolCallId": {
+            "type": "string"
+          },
+          "toolCallIndex": {
+            "type": "integer"
+          },
+          "toolName": {
+            "type": "string"
           },
           "step": {
             "type": "integer"

--- a/front/temporal/agent_loop/lib/get_output_from_llm.test.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.test.ts
@@ -1,0 +1,39 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { resolveStableToolCallName } from "@app/temporal/agent_loop/lib/get_output_from_llm";
+import { describe, expect, it } from "vitest";
+
+const specifications: AgentActionSpecification[] = [
+  {
+    name: "create_interactive_content_file",
+    description: "Create an interactive content file.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "common_utilities__wait",
+    description: "Wait for a duration.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+];
+
+describe("resolveStableToolCallName", () => {
+  it("returns the exact tool name when it matches a known specification", () => {
+    expect(
+      resolveStableToolCallName(
+        specifications,
+        "create_interactive_content_file"
+      )
+    ).toBe("create_interactive_content_file");
+  });
+
+  it("does not treat a partial streamed tool name as stable", () => {
+    expect(
+      resolveStableToolCallName(specifications, "create_inter")
+    ).toBeNull();
+  });
+});

--- a/front/temporal/agent_loop/lib/get_output_from_llm.test.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.test.ts
@@ -1,5 +1,8 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { resolveStableToolCallName } from "@app/temporal/agent_loop/lib/get_output_from_llm";
+import {
+  getToolCallStartDeduplicationKeys,
+  resolveStableToolCallName,
+} from "@app/temporal/agent_loop/lib/get_output_from_llm";
 import { describe, expect, it } from "vitest";
 
 const specifications: AgentActionSpecification[] = [
@@ -35,5 +38,25 @@ describe("resolveStableToolCallName", () => {
     expect(
       resolveStableToolCallName(specifications, "create_inter")
     ).toBeNull();
+  });
+});
+
+describe("getToolCallStartDeduplicationKeys", () => {
+  it("uses both id and index when both are available", () => {
+    expect(
+      getToolCallStartDeduplicationKeys({
+        stableToolName: "create_interactive_content_file",
+        toolCallId: "call_123",
+        toolCallIndex: 0,
+      })
+    ).toEqual(["id:call_123", "index:0"]);
+  });
+
+  it("falls back to name only when neither id nor index is available", () => {
+    expect(
+      getToolCallStartDeduplicationKeys({
+        stableToolName: "create_interactive_content_file",
+      })
+    ).toEqual(["name:create_interactive_content_file"]);
   });
 });

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -31,6 +31,30 @@ export function resolveStableToolCallName(
   return exactMatch?.name ?? null;
 }
 
+export function getToolCallStartDeduplicationKeys({
+  stableToolName,
+  toolCallId,
+  toolCallIndex,
+}: {
+  stableToolName: string;
+  toolCallId?: string;
+  toolCallIndex?: number;
+}): string[] {
+  const keys: string[] = [];
+
+  if (toolCallId) {
+    keys.push(`id:${toolCallId}`);
+  }
+  if (toolCallIndex !== undefined) {
+    keys.push(`index:${toolCallIndex}`);
+  }
+  if (keys.length === 0) {
+    keys.push(`name:${stableToolName}`);
+  }
+
+  return keys;
+}
+
 class LLMStreamTimeoutError extends Error {
   constructor(
     public readonly elapsedMs: number,
@@ -186,9 +210,7 @@ export async function getOutputFromLLMStream(
   const actions: Output["actions"] = [];
   let generation = "";
   let nativeChainOfThought = "";
-  const publishedToolCallStartIds = new Set<string>();
-  const publishedToolCallStartIndices = new Set<number>();
-  const publishedToolCallStartNames = new Set<string>();
+  const publishedToolCallStartKeys = new Set<string>();
 
   const logContext = {
     workspaceId: conversation.owner.sId,
@@ -261,12 +283,14 @@ export async function getOutputFromLLMStream(
             continue;
           }
 
+          const deduplicationKeys = getToolCallStartDeduplicationKeys({
+            stableToolName,
+            toolCallId: event.content.id,
+            toolCallIndex: event.content.index,
+          });
+
           if (
-            (event.content.id &&
-              publishedToolCallStartIds.has(event.content.id)) ||
-            (event.content.index !== undefined &&
-              publishedToolCallStartIndices.has(event.content.index)) ||
-            publishedToolCallStartNames.has(stableToolName)
+            deduplicationKeys.some((key) => publishedToolCallStartKeys.has(key))
           ) {
             continue;
           }
@@ -288,13 +312,9 @@ export async function getOutputFromLLMStream(
             step,
           });
 
-          if (event.content.id) {
-            publishedToolCallStartIds.add(event.content.id);
+          for (const key of deduplicationKeys) {
+            publishedToolCallStartKeys.add(key);
           }
-          if (event.content.index !== undefined) {
-            publishedToolCallStartIndices.add(event.content.index);
-          }
-          publishedToolCallStartNames.add(stableToolName);
           continue;
         }
         case "tool_call_delta":

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -237,6 +237,25 @@ export async function getOutputFromLLMStream(
           nativeChainOfThought += event.content.delta;
           continue;
         }
+        case "tool_call_started": {
+          await updateResourceAndPublishEvent(auth, {
+            event: {
+              type: "tool_call_started",
+              created: Date.now(),
+              configurationId: agentConfiguration.sId,
+              messageId: agentMessage.sId,
+              ...(event.content.id ? { toolCallId: event.content.id } : {}),
+              ...(event.content.index !== undefined
+                ? { toolCallIndex: event.content.index }
+                : {}),
+              toolName: event.content.name,
+            },
+            agentMessage,
+            conversation,
+            step,
+          });
+          continue;
+        }
         case "tool_call_delta":
           // tool_call_delta events act as heartbeat signals during tool call
           // streaming, preventing the LLM stream timeout when the model is

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -20,6 +20,17 @@ const HEARTBEAT_LOG_INTERVAL = 6; // Every minute (6 * 10s)
 const LLM_EVENT_TIMEOUT_MINUTES = 2;
 const LLM_EVENT_TIMEOUT_MS = LLM_EVENT_TIMEOUT_MINUTES * 60 * 1000;
 
+export function resolveStableToolCallName(
+  specifications: GetOutputRequestParams["specifications"],
+  streamedToolName: string
+): string | null {
+  const exactMatch = specifications.find(
+    (specification) => specification.name === streamedToolName
+  );
+
+  return exactMatch?.name ?? null;
+}
+
 class LLMStreamTimeoutError extends Error {
   constructor(
     public readonly elapsedMs: number,
@@ -175,6 +186,9 @@ export async function getOutputFromLLMStream(
   const actions: Output["actions"] = [];
   let generation = "";
   let nativeChainOfThought = "";
+  const publishedToolCallStartIds = new Set<string>();
+  const publishedToolCallStartIndices = new Set<number>();
+  const publishedToolCallStartNames = new Set<string>();
 
   const logContext = {
     workspaceId: conversation.owner.sId,
@@ -238,6 +252,25 @@ export async function getOutputFromLLMStream(
           continue;
         }
         case "tool_call_started": {
+          const stableToolName = resolveStableToolCallName(
+            specifications,
+            event.content.name
+          );
+
+          if (!stableToolName) {
+            continue;
+          }
+
+          if (
+            (event.content.id &&
+              publishedToolCallStartIds.has(event.content.id)) ||
+            (event.content.index !== undefined &&
+              publishedToolCallStartIndices.has(event.content.index)) ||
+            publishedToolCallStartNames.has(stableToolName)
+          ) {
+            continue;
+          }
+
           await updateResourceAndPublishEvent(auth, {
             event: {
               type: "tool_call_started",
@@ -248,12 +281,20 @@ export async function getOutputFromLLMStream(
               ...(event.content.index !== undefined
                 ? { toolCallIndex: event.content.index }
                 : {}),
-              toolName: event.content.name,
+              toolName: stableToolName,
             },
             agentMessage,
             conversation,
             step,
           });
+
+          if (event.content.id) {
+            publishedToolCallStartIds.add(event.content.id);
+          }
+          if (event.content.index !== undefined) {
+            publishedToolCallStartIndices.add(event.content.index);
+          }
+          publishedToolCallStartNames.add(stableToolName);
           continue;
         }
         case "tool_call_delta":

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -350,6 +350,16 @@ export type AgentDisabledErrorEvent = {
   };
 };
 
+export type AgentToolCallStartedEvent = {
+  type: "tool_call_started";
+  created: number;
+  configurationId: string;
+  messageId: string;
+  toolCallId?: string;
+  toolCallIndex?: number;
+  toolName: string;
+};
+
 // Event sent once the action is completed, we're moving to generating a message if applicable.
 export type AgentActionSuccessEvent = {
   type: "agent_action_success";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1467,6 +1467,19 @@ export type AgentActionSpecificEvent = z.infer<
   typeof AgentActionSpecificEventSchema
 >;
 
+const AgentToolCallStartedEventSchema = z.object({
+  type: z.literal("tool_call_started"),
+  created: z.number(),
+  configurationId: z.string(),
+  messageId: z.string(),
+  toolCallId: z.string().optional(),
+  toolCallIndex: z.number().optional(),
+  toolName: z.string(),
+});
+export type AgentToolCallStartedEvent = z.infer<
+  typeof AgentToolCallStartedEventSchema
+>;
+
 const AgentActionSuccessEventSchema = z.object({
   type: z.literal("agent_action_success"),
   created: z.number(),
@@ -1575,6 +1588,7 @@ const AgentMessageEventTypeSchema = z.object({
   data: z.union([
     AgentErrorEventSchema,
     AgentActionSpecificEventSchema,
+    AgentToolCallStartedEventSchema,
     AgentActionSuccessEventSchema,
     AgentContextPrunedEventSchema,
     AgentGenerationCancelledEventSchema,

--- a/x/pr/stream_tool_call.md
+++ b/x/pr/stream_tool_call.md
@@ -35,6 +35,11 @@ Interactive Content File` ()
 Important: this does not change tool execution itself. It only exposes an
 earlier moment in the same execution chain.
 
+Important nuance: provider adapters may emit several internal
+`tool_call_started` updates while a tool name is still streaming. The public
+assistant SSE event should remain a single stable start signal for a given tool
+call, not a raw stream of partial-name updates.
+
 ## End-to-End Flow
 
 Changes affect 3 layers.
@@ -163,6 +168,9 @@ Behavior:
 Details:
 
 - this is the backend/public-wire seam
+- if a provider emits several internal `tool_call_started` updates for the same
+  call, coalesce them before publishing to assistant SSE
+- only publish a stable tool name to assistant SSE, not a partial streamed name
 - still deployable without a visible UI change
 
 ### 6: Main Conversation Message Shows `Preparing to call ...`
@@ -176,6 +184,8 @@ Scope:
 Behavior:
 
 - store pending tool calls when `tool_call_started` arrives
+- key pending tool calls by `toolCallId` when available, otherwise by
+  `toolCallIndex`
 - remove only the matching pending tool call when `tool_params` or
   `agent_action_success` arrives
 - render the pending state in the main message surface


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/23634, https://github.com/dust-tt/dust/pull/23636, https://github.com/dust-tt/dust/pull/23695, and https://github.com/dust-tt/dust/pull/23703.

This publishes the normalized `tool_call_started` event through assistant SSE, adds the shared event typing on the front and SDK sides, and documents the private SSE payload in swagger.

The frontend accepts the new event explicitly but still ignores it in rendering for now; the pending-tool-call UI comes in the next PR.

## Risks
Blast radius: assistant message SSE consumers and type contracts for agent message events.
Risk: low

## Deploy Plan
- pmrr 
- deploy front