### PR TITLE
[Conversation] Clarify pruned context chip copy

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -126,14 +126,17 @@ function PrunedContextChip() {
     <Tooltip
       label={
         <div className="flex flex-col gap-2 py-2">
-          <div className="font-semibold">
-            This conversation reached its size limit
-          </div>
+          <div className="font-semibold">Some context was trimmed</div>
           <div className="flex flex-col gap-2 text-justify text-sm text-muted-foreground dark:text-muted-foreground-night">
             <p>
-              The agent can only process so much information at once. We removed
-              some <strong>data from earlier steps</strong> to make room. For
-              better accuracy, start a fresh conversation.
+              Dust had to trim some retrieved context to fit the model&apos;s
+              context window while generating this message. This can happen
+              because earlier conversation state or tool output from this
+              message was too large.
+            </p>
+            <p>
+              For best accuracy, narrow the request or start a fresh
+              conversation.
             </p>
             <p>
               <a
@@ -151,7 +154,7 @@ function PrunedContextChip() {
       className="max-w-sm"
       trigger={
         <Chip
-          label="Context limit reached"
+          label="Context trimmed"
           size="xs"
           color="white"
           icon={InformationCircleIcon}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -126,17 +126,17 @@ function PrunedContextChip() {
     <Tooltip
       label={
         <div className="flex flex-col gap-2 py-2">
-          <div className="font-semibold">Some context was trimmed</div>
+          <div className="font-semibold">Tool output was trimmed</div>
           <div className="flex flex-col gap-2 text-justify text-sm text-muted-foreground dark:text-muted-foreground-night">
             <p>
-              Dust had to trim some retrieved context to fit the model&apos;s
-              context window while generating this message. This can happen
-              because earlier conversation state or tool output from this
-              message was too large.
+              Dust had to trim part of the tool output for this message to fit
+              the model&apos;s context window. This usually means a search or
+              other tool returned more data than the model could process at
+              once.
             </p>
             <p>
-              For best accuracy, narrow the request or start a fresh
-              conversation.
+              For best accuracy, narrow the request or reduce the amount of
+              retrieved data, then try again.
             </p>
             <p>
               <a
@@ -154,7 +154,7 @@ function PrunedContextChip() {
       className="max-w-sm"
       trigger={
         <Chip
-          label="Context trimmed"
+          label="Tool output trimmed"
           size="xs"
           color="white"
           icon={InformationCircleIcon}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -126,17 +126,19 @@ function PrunedContextChip() {
     <Tooltip
       label={
         <div className="flex flex-col gap-2 py-2">
-          <div className="font-semibold">Tool output was trimmed</div>
+          <div className="font-semibold">
+            This conversation reached its size limit
+          </div>
           <div className="flex flex-col gap-2 text-justify text-sm text-muted-foreground dark:text-muted-foreground-night">
             <p>
-              Dust had to trim part of the tool output for this message to fit
-              the model&apos;s context window. This usually means a search or
-              other tool returned more data than the model could process at
-              once.
+              Dust had to trim part of the tool output used to generate this
+              message to fit the model&apos;s context window. This usually
+              happens when a search or other tool returns more data than the
+              model can process at once.
             </p>
             <p>
-              For best accuracy, narrow the request or reduce the amount of
-              retrieved data, then try again.
+              For best accuracy, start a fresh conversation or narrow the
+              request.
             </p>
             <p>
               <a
@@ -154,7 +156,7 @@ function PrunedContextChip() {
       className="max-w-sm"
       trigger={
         <Chip
-          label="Tool output trimmed"
+          label="Context limit reached"
           size="xs"
           color="white"
           icon={InformationCircleIcon}


### PR DESCRIPTION
## Description
Context: https://github.com/dust-tt/tasks/issues/7285

This updates the pruned-context chip copy to describe what actually happened when context is trimmed while generating a message.

It keeps the existing signal and only changes the label and tooltip wording so they cover both earlier conversation context and oversized tool output in the current turn.

## Risks
Blast radius: assistant conversation UI for agent messages that show the pruned-context chip
Risk: low

## Deploy Plan
- pmrr
- deploy front