### PR TITLE
[Skills] Add read-only recovery path to dust-call-agent skill

### DIFF
--- a/.claude/skills/dust-call-agent/SKILL.md
+++ b/.claude/skills/dust-call-agent/SKILL.md
@@ -24,4 +24,7 @@ An agent may take long to answer. Avoid repeating an agent call if possible, esp
 - the agent call may not be idempotent, e.g. when creating an issue, if the conversation on Dust has been started, repeating will create two issues;
 - multiple conversations are created in the user's Dust workspace, which bloats their conversation history.
 
-In general, wait for a clear answer. If you decide to time out, make no assumption on success or failure; report back to the user.
+If the CLI timed out but returned a `conversationId` and `messageId`, you can safely fetch the result without side effects:
+`$ dust chat -c <conversationId> --messageId <messageId>`
+
+Otherwise, wait for a clear answer. If you decide to time out with no conversation ID, make no assumption on success or failure; report back to the user.


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/23696

The previous PR was merged before this change was pushed. Adds guidance for the safe read-only recovery path when the CLI times out: if `conversationId`/`messageId` are available, the caller can fetch the result via `--messageId` without risking duplicate side effects.

## Risks

Blast radius: Claude Code skill behavior when calling Dust agents
Risk: none

## Deploy Plan
- pmrr
- No deploy needed (skill file only)