### PR TITLE
Show spinner on pending user messages (steering)

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -544,7 +544,13 @@ export const ConversationViewer = ({
             break;
 
           case "user_message_promoted":
-            // TODO(steering): implement promotion of user message.
+            if (ref.current) {
+              ref.current.data.map((m) =>
+                isUserMessage(m) && m.sId === event.messageId
+                  ? { ...m, visibility: "visible" }
+                  : m
+              );
+            }
             break;
 
           case "agent_message_new":

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -41,6 +41,7 @@ import {
   LinkIcon,
   MoreIcon,
   PencilSquareIcon,
+  Spinner,
   Toolbar,
   Tooltip,
   TrashIcon,
@@ -350,15 +351,18 @@ export function UserMessage({
                 type="user"
                 className={cn(shouldShowBiggerUserMessage && "@sm:min-w-100")}
               >
-                {isDeleted ? (
-                  <DeletedMessage />
-                ) : (
-                  <UserMessageMarkdown
-                    owner={owner}
-                    message={message}
-                    isLastMessage={isLastMessage}
-                  />
-                )}
+                <div className="flex items-center gap-2">
+                  {message.visibility === "pending" && <Spinner size="xs" />}
+                  {isDeleted ? (
+                    <DeletedMessage />
+                  ) : (
+                    <UserMessageMarkdown
+                      owner={owner}
+                      message={message}
+                      isLastMessage={isLastMessage}
+                    />
+                  )}
+                </div>
               </ConversationMessageContent>
               {showBottomActionMenu && (
                 <ActionMenu

--- a/x/spolu/steering/plan.md
+++ b/x/spolu/steering/plan.md
@@ -120,7 +120,7 @@ the terminal event — this adds the promotion logic:
   publish `AgentMessageNewEvent`, launch new agent loop.
 - The `"succeeded"` path acts as safety net (graceful stop signal lost or arrived too late).
 
-### - [ ] PR 3.5 — Frontend: pending message display with spinner
+### - [x] PR 3.5 — Frontend: pending message display with spinner
 
 - In user message rendering component, when `visibility === "pending"`, render the message
   with a muted/greyed-out style and a spinner indicator.


### PR DESCRIPTION
## Description

Handle `user_message_promoted` events to change status of pending user message getting promoted.

Add a small spinner to the left of the user message bubble when `visibility === "pending"`. The spinner indicates the message is waiting for the running agent loop to gracefully stop before being promoted.

<img width="726" height="315" alt="Screenshot 2026-04-05 at 10 02 35" src="https://github.com/user-attachments/assets/f61da754-bb2c-4fcb-9045-681175374cb7" />


## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`