### PR TITLE
[front] fix: prevent adding the `ask_user_question` tool outside of web app

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -307,11 +307,19 @@ export async function runModel(
     );
   }
 
+  // Filter out ask_user_question for non-web origins (e.g. Slack, API).
+  const filteredMcpActions =
+    userMessage.context.origin !== "web"
+      ? mcpActions.filter((s) => s.serverName !== "ask_user_question")
+      : mcpActions;
+
   const isLastStep = step === agentConfiguration.maxStepsPerRun;
 
   // If we are on the last step, we don't show any action.
   // This will force the agent to run the generation.
-  const availableActions = isLastStep ? [] : mcpActions.flatMap((s) => s.tools);
+  const availableActions = isLastStep
+    ? []
+    : filteredMcpActions.flatMap((s) => s.tools);
 
   let fallbackPrompt = "You are a conversational agent";
   if (agentConfiguration.actions.length || availableActions.length > 0) {
@@ -385,7 +393,7 @@ export async function runModel(
     errorContext: mcpToolsListingError,
     agentsList,
     conversation,
-    serverToolsAndInstructions: mcpActions,
+    serverToolsAndInstructions: filteredMcpActions,
     enabledSkills,
     equippedSkills,
     memoriesContext,


### PR DESCRIPTION
## Description

- This PR prevents adding the `ask_user_question` tool if the user message originates from a platform other than the web app.
- The events emitted by the tool are not handled by the other types of front-end currently.
- Follow up work will add them to the Slack integration, and a release of the Chrome extension will be required as well.

## Tests

- Tested locally (via API).

## Risk

- Low.

## Deploy Plan

- Deploy front.
