### PR TITLE
[front] enh: improve UI for multi choice user question

### DIFF
--- a/front/components/assistant/conversation/UserQuestionRequired.tsx
+++ b/front/components/assistant/conversation/UserQuestionRequired.tsx
@@ -125,9 +125,10 @@ export function UserQuestionRequired({
           className="cursor-pointer p-3"
           onClick={() => handleOptionClick(index)}
         >
-          <div className="flex items-start gap-2">
+          <div className="flex items-center gap-3">
             {question.multiSelect && (
               <Checkbox
+                size="xs"
                 checked={selectedOptions.includes(index)}
                 onCheckedChange={() => handleOptionClick(index)}
               />
@@ -163,16 +164,16 @@ export function UserQuestionRequired({
         </div>
       )}
       <div className="flex gap-2">
+        <Button label="Skip" variant="outline" size="xs" onClick={handleSkip} />
         {question.multiSelect && (
           <Button
             label="Submit"
-            variant="highlight"
+            variant="primary"
             size="xs"
             disabled={selectedOptions.length === 0}
             onClick={handleMultiSelectSubmit}
           />
         )}
-        <Button label="Skip" variant="outline" size="xs" onClick={handleSkip} />
       </div>
     </Card>
   );


### PR DESCRIPTION
## Description

This PR iterates on the UI for the output of the `ask_user_question` tool, specifically in multi-select questions.
- Moves the submit button to the right
- Sets it to primary
- Reduces the size of the checkboxes
- Fixes the padding between the checkboxes and the text.

<img width="695" height="381" alt="Screenshot 2026-04-05 at 1 30 47 PM" src="https://github.com/user-attachments/assets/a80071f6-1827-4852-94a5-09cb320a937a" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
