### PR TITLE
Add support for official Notion MCP under a flag

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -323,6 +323,7 @@ export const INTERNAL_MCP_SERVERS = {
     availability: "manual",
     allowMultipleInstances: true,
     isRestricted: undefined,
+    supersededByFeatureFlag: "official_notion_mcp",
     isPreview: false,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
@@ -1118,6 +1119,10 @@ type InternalMCPServerEntryCommon = {
         isDeepDiveDisabled: boolean;
       }) => boolean)
     | undefined;
+  // When set, the internal server is hidden from the "Add Tool" menu when this
+  // feature flag is enabled (superseded by a remote server). Existing server
+  // views continue to work.
+  supersededByFeatureFlag?: WhitelistableFeature;
   isPreview: boolean;
   // Defines which arguments require per-agent approval for "medium" stake tools.
   // When a tool has "medium" stake, the user must approve the specific combination
@@ -1364,4 +1369,11 @@ export function isInternalMCPServerAvailableInDirectExecution(
 ): boolean {
   const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
   return server.availableInDirectExecution !== false;
+}
+
+export function getInternalMCPServerSupersededByFeatureFlag(
+  name: InternalMCPServerNameType
+): WhitelistableFeature | undefined {
+  const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
+  return server.supersededByFeatureFlag;
 }

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -322,7 +322,8 @@ export const INTERNAL_MCP_SERVERS = {
     id: 11,
     availability: "manual",
     allowMultipleInstances: true,
-    isRestricted: undefined,
+    isRestricted: ({ featureFlags }) =>
+      featureFlags.includes("official_notion_mcp"),
     isPreview: false,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -323,7 +323,6 @@ export const INTERNAL_MCP_SERVERS = {
     availability: "manual",
     allowMultipleInstances: true,
     isRestricted: undefined,
-    supersededByFeatureFlag: "official_notion_mcp",
     isPreview: false,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
@@ -1119,10 +1118,6 @@ type InternalMCPServerEntryCommon = {
         isDeepDiveDisabled: boolean;
       }) => boolean)
     | undefined;
-  // When set, the internal server is hidden from the "Add Tool" menu when this
-  // feature flag is enabled (superseded by a remote server). Existing server
-  // views continue to work.
-  supersededByFeatureFlag?: WhitelistableFeature;
   isPreview: boolean;
   // Defines which arguments require per-agent approval for "medium" stake tools.
   // When a tool has "medium" stake, the user must approve the specific combination
@@ -1369,11 +1364,4 @@ export function isInternalMCPServerAvailableInDirectExecution(
 ): boolean {
   const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
   return server.availableInDirectExecution !== false;
-}
-
-export function getInternalMCPServerSupersededByFeatureFlag(
-  name: InternalMCPServerNameType
-): WhitelistableFeature | undefined {
-  const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
-  return server.supersededByFeatureFlag;
 }

--- a/front/lib/actions/mcp_internal_actions/remote_servers.ts
+++ b/front/lib/actions/mcp_internal_actions/remote_servers.ts
@@ -1182,6 +1182,112 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
       },
     },
   },
+  {
+    id: 10016,
+    name: "Notion",
+    description:
+      "Notion tools for searching, creating, and managing pages, databases, and comments in your Notion workspace.",
+    url: "https://mcp.notion.com/mcp",
+    icon: "NotionLogo",
+    documentationUrl:
+      "https://developers.notion.com/guides/mcp/get-started-with-mcp",
+    authMethod: "oauth-dynamic",
+    featureFlag: "official_notion_mcp",
+    toolStakes: {
+      "notion-search": "never_ask",
+      "notion-fetch": "never_ask",
+      "notion-get-comments": "never_ask",
+      "notion-get-teams": "never_ask",
+      "notion-get-users": "never_ask",
+      "notion-get-user": "never_ask",
+      "notion-get-self": "never_ask",
+      "notion-query-data-sources": "never_ask",
+      "notion-query-database-view": "never_ask",
+      "notion-create-pages": "low",
+      "notion-update-page": "low",
+      "notion-move-pages": "low",
+      "notion-duplicate-page": "low",
+      "notion-create-database": "low",
+      "notion-update-data-source": "low",
+      "notion-create-view": "low",
+      "notion-update-view": "low",
+      "notion-create-comment": "low",
+    },
+    toolDisplayLabels: {
+      "notion-search": {
+        running: "Searching in Notion",
+        done: "Searched in Notion",
+      },
+      "notion-fetch": {
+        running: "Fetching from Notion",
+        done: "Fetched from Notion",
+      },
+      "notion-create-pages": {
+        running: "Creating pages in Notion",
+        done: "Created pages in Notion",
+      },
+      "notion-update-page": {
+        running: "Updating page in Notion",
+        done: "Updated page in Notion",
+      },
+      "notion-move-pages": {
+        running: "Moving pages in Notion",
+        done: "Moved pages in Notion",
+      },
+      "notion-duplicate-page": {
+        running: "Duplicating page in Notion",
+        done: "Duplicated page in Notion",
+      },
+      "notion-create-database": {
+        running: "Creating database in Notion",
+        done: "Created database in Notion",
+      },
+      "notion-update-data-source": {
+        running: "Updating data source in Notion",
+        done: "Updated data source in Notion",
+      },
+      "notion-create-view": {
+        running: "Creating view in Notion",
+        done: "Created view in Notion",
+      },
+      "notion-update-view": {
+        running: "Updating view in Notion",
+        done: "Updated view in Notion",
+      },
+      "notion-query-data-sources": {
+        running: "Querying data sources in Notion",
+        done: "Queried data sources in Notion",
+      },
+      "notion-query-database-view": {
+        running: "Querying database view in Notion",
+        done: "Queried database view in Notion",
+      },
+      "notion-create-comment": {
+        running: "Creating comment in Notion",
+        done: "Created comment in Notion",
+      },
+      "notion-get-comments": {
+        running: "Loading comments from Notion",
+        done: "Loaded comments from Notion",
+      },
+      "notion-get-teams": {
+        running: "Loading teams from Notion",
+        done: "Loaded teams from Notion",
+      },
+      "notion-get-users": {
+        running: "Loading users from Notion",
+        done: "Loaded users from Notion",
+      },
+      "notion-get-user": {
+        running: "Loading user from Notion",
+        done: "Loaded user from Notion",
+      },
+      "notion-get-self": {
+        running: "Loading bot info from Notion",
+        done: "Loaded bot info from Notion",
+      },
+    },
+  },
 ];
 
 export const isDefaultRemoteMcpServerURL = (url: string | undefined) => {

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -34,6 +34,7 @@ import { destroyMCPServerViewDependencies } from "@app/lib/models/agent/actions/
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -75,6 +76,19 @@ export class InternalMCPServerInMemoryResource {
     }
 
     const name = r.value.name;
+
+    const isEnabled = await isEnabledForWorkspace(auth, name);
+    if (!isEnabled) {
+      // This means a server which could not be newly created is being used from an existing MCP server view.
+      // This is not a problem, but we log it to get a sense of whether it happens often and for which server names.
+      logger.info(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          serverName: name,
+        },
+        "Initializing restricted internal MCP server from existing view"
+      );
+    }
 
     const availability = getAvailabilityOfInternalMCPServerById(id);
 

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -20,12 +20,14 @@ import {
   getAvailabilityOfInternalMCPServerById,
   getInternalMCPServerMetadata,
   getInternalMCPServerNameAndWorkspaceId,
+  getInternalMCPServerSupersededByFeatureFlag,
   isAutoInternalMCPServerName,
   matchesInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isEnabledForWorkspace } from "@app/lib/actions/mcp_internal_actions/enabled";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { InternalMCPServerCredentialModel } from "@app/lib/models/agent/actions/internal_mcp_server_credentials";
 import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
@@ -310,13 +312,23 @@ export class InternalMCPServerInMemoryResource {
   static async listAvailableInternalMCPServers(auth: Authenticator) {
     // Hide servers with flags that are not enabled for the workspace.
     const names: InternalMCPServerNameType[] = [];
+    const featureFlags = await getFeatureFlags(auth);
 
     for (const name of AVAILABLE_INTERNAL_MCP_SERVER_NAMES) {
       const isEnabled = await isEnabledForWorkspace(auth, name);
 
-      if (isEnabled) {
-        names.push(name);
+      if (!isEnabled) {
+        continue;
       }
+
+      // Hide internal servers that are superseded by a remote server when the
+      // feature flag is enabled. Existing server views are not affected.
+      const supersededBy = getInternalMCPServerSupersededByFeatureFlag(name);
+      if (supersededBy && featureFlags.includes(supersededBy)) {
+        continue;
+      }
+
+      names.push(name);
     }
 
     const ids = names.map((name) =>

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -26,7 +26,6 @@ import {
 import { isEnabledForWorkspace } from "@app/lib/actions/mcp_internal_actions/enabled";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { InternalMCPServerCredentialModel } from "@app/lib/models/agent/actions/internal_mcp_server_credentials";
 import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
@@ -76,11 +75,6 @@ export class InternalMCPServerInMemoryResource {
     }
 
     const name = r.value.name;
-
-    const isEnabled = await isEnabledForWorkspace(auth, name);
-    if (!isEnabled) {
-      return null;
-    }
 
     const availability = getAvailabilityOfInternalMCPServerById(id);
 
@@ -311,22 +305,13 @@ export class InternalMCPServerInMemoryResource {
   static async listAvailableInternalMCPServers(auth: Authenticator) {
     // Hide servers with flags that are not enabled for the workspace.
     const names: InternalMCPServerNameType[] = [];
-    const featureFlags = await getFeatureFlags(auth);
 
     for (const name of AVAILABLE_INTERNAL_MCP_SERVER_NAMES) {
       const isEnabled = await isEnabledForWorkspace(auth, name);
 
-      if (!isEnabled) {
-        continue;
+      if (isEnabled) {
+        names.push(name);
       }
-
-      // Hide internal Notion server when the official Notion MCP is enabled.
-      // Existing server views are not affected.
-      if (name === "notion" && featureFlags.includes("official_notion_mcp")) {
-        continue;
-      }
-
-      names.push(name);
     }
 
     const ids = names.map((name) =>

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -20,7 +20,6 @@ import {
   getAvailabilityOfInternalMCPServerById,
   getInternalMCPServerMetadata,
   getInternalMCPServerNameAndWorkspaceId,
-  getInternalMCPServerSupersededByFeatureFlag,
   isAutoInternalMCPServerName,
   matchesInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -321,10 +320,12 @@ export class InternalMCPServerInMemoryResource {
         continue;
       }
 
-      // Hide internal servers that are superseded by a remote server when the
-      // feature flag is enabled. Existing server views are not affected.
-      const supersededBy = getInternalMCPServerSupersededByFeatureFlag(name);
-      if (supersededBy && featureFlags.includes(supersededBy)) {
+      // Hide internal Notion server when the official Notion MCP is enabled.
+      // Existing server views are not affected.
+      if (
+        name === "notion" &&
+        featureFlags.includes("official_notion_mcp")
+      ) {
         continue;
       }
 

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -322,10 +322,7 @@ export class InternalMCPServerInMemoryResource {
 
       // Hide internal Notion server when the official Notion MCP is enabled.
       // Existing server views are not affected.
-      if (
-        name === "notion" &&
-        featureFlags.includes("official_notion_mcp")
-      ) {
+      if (name === "notion" && featureFlags.includes("official_notion_mcp")) {
         continue;
       }
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -275,6 +275,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Gong MCP tool for sales conversation analytics",
     stage: "dust_only",
   },
+  official_notion_mcp: {
+    description:
+      "Use the official Notion MCP server instead of the internal one",
+    stage: "dust_only",
+  },
   use_dust_keys: {
     description:
       "Force BYOK workspaces to use Dust-managed keys instead of customer-provided keys",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -714,6 +714,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "monday_tool"
   | "noop_model_feature"
   | "notion_private_integration"
+  | "official_notion_mcp"
   | "openai_o1_custom_assistants_feature"
   | "openai_o1_feature"
   | "openai_o1_high_reasoning_feature"


### PR DESCRIPTION
## Description

- Add support for Notion's official MCP server (https://mcp.notion.com/mcp) as a remote MCP server, gated behind the official_notion_mcp feature flag (dust_only)
- When the flag is enabled, the official Notion appears in "Add Tool" and the internal Notion implementation is hidden from the menu
- Existing internal Notion server views continue to work regardless of the flag
- Also, made a general change to allow existing MCP server views to keep on working even if isRestricted prevents new ones from being created
 
## Tests

Manually tried with and without the new flag

## Risk

Low as under flag

## Deploy Plan

Front