### PR TITLE
[connectors] fix: handle new event `AgentToolCallStartedEvent` in slack bot stream handler

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -647,6 +647,7 @@ async function streamAgentAnswerToSlack(
 
       case "agent_context_pruned":
       case "agent_message_done":
+      case "tool_call_started":
       // TODO(2026-04-02 ask-user-question): add support for the AskUserQuestion tool on Slack.
       // Temporarily we will not add the tool for messages coming from Slack to avoid receiving this event at all here.
       case "tool_ask_user_question":

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -16,6 +16,7 @@ import type {
   AgentMessageDoneEvent,
   AgentMessagePublicType,
   AgentMessageSuccessEvent,
+  AgentToolCallStartedEvent,
   APIError,
   AppsCheckRequestType,
   BlockedActionsResponseType,
@@ -165,6 +166,7 @@ type AgentEvent =
   | AgentGenerationCancelledEvent
   | AgentMessageSuccessEvent
   | AgentMessageDoneEvent
+  | AgentToolCallStartedEvent
   | GenerationTokensEvent
   | UserMessageErrorEvent
   | ToolErrorEvent;


### PR DESCRIPTION
## Description

- The stream handler of the Slack bot currently crashes on every tool use, on an `assertNever` (logs [here](https://app.datadoghq.eu/logs?query=%22Unexpected%20exception%20answering%20to%20Slack%20Chat%20Bot%20message%22%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ1fDgSm8RU6MAAAABhBWjFmRGhOZEFBRG1KTGdMWW82NEJBQUwAAABdMTE5ZDVmMTItOGM2NC00ODM5LTgyMGMtMjQ3ZWZmYmM5YWYxLXN5bnRoZXRpYy10aW1lLTE3NzU0MTU2MDAwMDAwMDAwMDBjLTE3NzU0MTY1NDQzNTYwMDAwMDFvAAAgkQ&fromUser=true&link_event_id=8575732084649581009&link_monitor_id=22042330&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1775415670000&to_ts=1775416270000&live=false)).
- A new type of event is emitted for tool call start.
- This PR fixes the `assertNever` by treating it as a no-op.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
