### PR TITLE
[front] feat: add action details component for `ask_user_question` tool

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -6,13 +6,13 @@ import {
   makeQueryTextForList,
 } from "@app/components/actions/mcp/details/input_rendering";
 import { MCPAgentManagementActionDetails } from "@app/components/actions/mcp/details/MCPAgentManagementActionDetails";
-import { MCPAskUserQuestionActionDetails } from "@app/components/actions/mcp/details/MCPAskUserQuestionActionDetails";
 import {
   MCPAgentMemoryEditActionDetails,
   MCPAgentMemoryEraseActionDetails,
   MCPAgentMemoryRecordActionDetails,
   MCPAgentMemoryRetrieveActionDetails,
 } from "@app/components/actions/mcp/details/MCPAgentMemoryActionDetails";
+import { MCPAskUserQuestionActionDetails } from "@app/components/actions/mcp/details/MCPAskUserQuestionActionDetails";
 import { MCPBrowseActionDetails } from "@app/components/actions/mcp/details/MCPBrowseActionDetails";
 import { MCPConversationCatFileDetails } from "@app/components/actions/mcp/details/MCPConversationFilesActionDetails";
 import {

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -6,6 +6,7 @@ import {
   makeQueryTextForList,
 } from "@app/components/actions/mcp/details/input_rendering";
 import { MCPAgentManagementActionDetails } from "@app/components/actions/mcp/details/MCPAgentManagementActionDetails";
+import { MCPAskUserQuestionActionDetails } from "@app/components/actions/mcp/details/MCPAskUserQuestionActionDetails";
 import {
   MCPAgentMemoryEditActionDetails,
   MCPAgentMemoryEraseActionDetails,
@@ -381,6 +382,10 @@ export function MCPActionDetails({
 
   if (internalMCPServerName === "sandbox") {
     return <MCPSandboxActionDetails {...toolOutputDetailsProps} />;
+  }
+
+  if (internalMCPServerName === "ask_user_question") {
+    return <MCPAskUserQuestionActionDetails {...toolOutputDetailsProps} />;
   }
 
   return (

--- a/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
@@ -1,0 +1,35 @@
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { UserQuestionSchema } from "@app/lib/actions/types";
+import { ChatBubbleBottomCenterTextIcon } from "@dust-tt/sparkle";
+
+export function MCPAskUserQuestionActionDetails({
+  toolOutput,
+  toolParams,
+  displayContext,
+}: ToolExecutionDetailsProps) {
+  const parsed = UserQuestionSchema.safeParse(toolParams);
+  const question = parsed.success ? parsed.data.question : null;
+
+  const answerText = toolOutput?.find(isTextContent)?.text ?? null;
+
+  return (
+    <ActionDetailsWrapper
+      displayContext={displayContext}
+      actionName={
+        displayContext === "conversation"
+          ? "Asking a question"
+          : "Asked a question"
+      }
+      visual={ChatBubbleBottomCenterTextIcon}
+    >
+      {displayContext !== "conversation" && (
+        <div className="flex flex-col gap-2 pl-6 pt-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {question && <div className="font-medium">{question}</div>}
+          {answerText && <div>{answerText}</div>}
+        </div>
+      )}
+    </ActionDetailsWrapper>
+  );
+}

--- a/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
@@ -64,7 +64,7 @@ export function MCPAskUserQuestionActionDetails({
                     {label}
                   </span>
                   {description && (
-                    <span className="text-xs">{option.description}</span>
+                    <span className="text-xs">{description}</span>
                   )}
                 </div>
               );

--- a/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
@@ -2,7 +2,11 @@ import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapp
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { UserQuestionSchema } from "@app/lib/actions/types";
-import { ChatBubbleBottomCenterTextIcon } from "@dust-tt/sparkle";
+import {
+  ChatBubbleBottomCenterTextIcon,
+  CheckIcon,
+  Icon,
+} from "@dust-tt/sparkle";
 
 export function MCPAskUserQuestionActionDetails({
   toolOutput,
@@ -10,7 +14,7 @@ export function MCPAskUserQuestionActionDetails({
   displayContext,
 }: ToolExecutionDetailsProps) {
   const parsed = UserQuestionSchema.safeParse(toolParams);
-  const question = parsed.success ? parsed.data.question : null;
+  const userQuestion = parsed.success ? parsed.data : null;
 
   const answerText = toolOutput?.find(isTextContent)?.text ?? null;
 
@@ -24,10 +28,48 @@ export function MCPAskUserQuestionActionDetails({
       }
       visual={ChatBubbleBottomCenterTextIcon}
     >
-      {displayContext !== "conversation" && (
-        <div className="flex flex-col gap-2 pl-6 pt-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
-          {question && <div className="font-medium">{question}</div>}
-          {answerText && <div>{answerText}</div>}
+      {displayContext !== "conversation" && userQuestion && (
+        <div className="flex flex-col gap-3 pl-6 pt-4">
+          <div className="text-sm font-medium text-foreground dark:text-foreground-night">
+            {userQuestion.question}
+          </div>
+          <div className="flex flex-col gap-1">
+            {userQuestion.options.map(({ label, description }, index) => {
+              const isSelected =
+                answerText !== null && answerText.includes(label);
+
+              return (
+                <div
+                  key={index}
+                  className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night"
+                >
+                  {answerText && (
+                    <Icon
+                      visual={CheckIcon}
+                      size="xs"
+                      className={
+                        isSelected
+                          ? "text-primary dark:text-primary-night"
+                          : "invisible"
+                      }
+                    />
+                  )}
+                  <span
+                    className={
+                      isSelected
+                        ? "font-medium text-foreground dark:text-foreground-night"
+                        : ""
+                    }
+                  >
+                    {label}
+                  </span>
+                  {description && (
+                    <span className="text-xs">{option.description}</span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
       )}
     </ActionDetailsWrapper>

--- a/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
@@ -33,7 +33,7 @@ export function MCPAskUserQuestionActionDetails({
           <div className="text-sm font-medium text-foreground dark:text-foreground-night">
             {userQuestion.question}
           </div>
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-1.5">
             {userQuestion.options.map(({ label, description }, index) => {
               const isSelected =
                 answerText !== null && answerText.includes(label);

--- a/front/components/assistant/conversation/UserQuestionRequired.tsx
+++ b/front/components/assistant/conversation/UserQuestionRequired.tsx
@@ -26,14 +26,11 @@ export function UserQuestionRequired({
 }: UserQuestionRequiredProps) {
   const { user } = useAuth();
   const { removeCompletedAction } = useBlockedActionsContext();
+  const { answerQuestion, isSubmitting, errorMessage } =
+    useAnswerUserQuestion({ owner });
+
   const [selectedOptions, setSelectedOptions] = useState<number[]>([]);
   const [customResponse, setCustomResponse] = useState("");
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  const { answerQuestion, isSubmitting } = useAnswerUserQuestion({
-    owner,
-    onError: setErrorMessage,
-  });
 
   const { question } = blockedAction;
   const isTriggeredByCurrentUser = blockedAction.userId === user?.sId;

--- a/front/components/assistant/conversation/UserQuestionRequired.tsx
+++ b/front/components/assistant/conversation/UserQuestionRequired.tsx
@@ -26,8 +26,9 @@ export function UserQuestionRequired({
 }: UserQuestionRequiredProps) {
   const { user } = useAuth();
   const { removeCompletedAction } = useBlockedActionsContext();
-  const { answerQuestion, isSubmitting, errorMessage } =
-    useAnswerUserQuestion({ owner });
+  const { answerQuestion, isSubmitting, errorMessage } = useAnswerUserQuestion({
+    owner,
+  });
 
   const [selectedOptions, setSelectedOptions] = useState<number[]>([]);
   const [customResponse, setCustomResponse] = useState("");

--- a/front/hooks/useAnswerUserQuestion.ts
+++ b/front/hooks/useAnswerUserQuestion.ts
@@ -8,9 +8,7 @@ interface UseAnswerUserQuestionParams {
   owner: LightWorkspaceType;
 }
 
-export function useAnswerUserQuestion({
-  owner,
-}: UseAnswerUserQuestionParams) {
+export function useAnswerUserQuestion({ owner }: UseAnswerUserQuestionParams) {
   const { fetcher } = useFetcher();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);

--- a/front/hooks/useAnswerUserQuestion.ts
+++ b/front/hooks/useAnswerUserQuestion.ts
@@ -6,15 +6,14 @@ import { useCallback, useState } from "react";
 
 interface UseAnswerUserQuestionParams {
   owner: LightWorkspaceType;
-  onError: (errorMessage: string) => void;
 }
 
 export function useAnswerUserQuestion({
   owner,
-  onError,
 }: UseAnswerUserQuestionParams) {
   const { fetcher } = useFetcher();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const answerQuestion = useCallback(
     async ({
@@ -29,6 +28,7 @@ export function useAnswerUserQuestion({
       answer: UserQuestionAnswer;
     }) => {
       setIsSubmitting(true);
+      setErrorMessage(null);
 
       try {
         await fetcher(
@@ -50,14 +50,14 @@ export function useAnswerUserQuestion({
         if (isAPIErrorResponse(e) && e.error.type === "action_not_blocked") {
           return { success: true };
         }
-        onError("Failed to submit answer. Please try again.");
+        setErrorMessage("Failed to submit answer. Please try again.");
         return { success: false };
       } finally {
         setIsSubmitting(false);
       }
     },
-    [owner.sId, onError, fetcher]
+    [owner.sId, fetcher]
   );
 
-  return { answerQuestion, isSubmitting };
+  return { answerQuestion, isSubmitting, errorMessage };
 }


### PR DESCRIPTION
## Description

- This PR adds an MCP action details component for the `ask_user_question` tool.

Replaces
<img width="694" height="666" alt="Screenshot 2026-04-06 at 8 47 57 AM" src="https://github.com/user-attachments/assets/b2b6b00a-873f-4eaa-91e0-0b1af3f146f5" />

with
<img width="682" height="666" alt="Screenshot 2026-04-06 at 8 52 37 AM" src="https://github.com/user-attachments/assets/0d793466-2775-4104-aca5-a57da0a5b38e" />


## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
