### PR TITLE
[Tool Calls] Show pending tool calls in inline activity

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1312,6 +1312,7 @@ function AgentMessageContent({
           agentMessage={agentMessage}
           lastAgentStateClassification={agentMessage.streaming.agentState}
           completedSteps={agentMessage.streaming.inlineActivitySteps}
+          pendingToolCalls={agentMessage.streaming.pendingToolCalls}
           onOpenDetails={onOpenDetails}
         />
       ) : (

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -1,8 +1,12 @@
 import { TimelineRow } from "@app/components/assistant/conversation/actions/inline/TimelineRow";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import type { AgentStateClassification } from "@app/components/assistant/conversation/types";
+import type {
+  AgentStateClassification,
+  PendingToolCall,
+} from "@app/components/assistant/conversation/types";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
 import { getInternalMCPServerIconByName } from "@app/lib/actions/mcp_internal_actions/constants";
+import { getToolCallDisplayLabel } from "@app/lib/actions/tool_display_labels";
 import { getActionOneLineLabel } from "@app/lib/api/assistant/activity_steps";
 import { formatDurationString } from "@app/lib/utils/timestamps";
 import type {
@@ -28,6 +32,7 @@ interface InlineActivityStepsProps {
   agentMessage: LightAgentMessageType | LightAgentMessageWithActionsType;
   lastAgentStateClassification: AgentStateClassification;
   completedSteps: InlineActivityStep[];
+  pendingToolCalls: PendingToolCall[];
   onOpenDetails?: (messageId: string) => void;
 }
 
@@ -66,6 +71,7 @@ export function InlineActivitySteps({
   agentMessage,
   lastAgentStateClassification,
   completedSteps,
+  pendingToolCalls,
   onOpenDetails,
 }: InlineActivityStepsProps) {
   const isAgentMessageWithActions =
@@ -94,6 +100,7 @@ export function InlineActivitySteps({
 
   const isThinking = lastAgentStateClassification === "thinking";
   const isActing = lastAgentStateClassification === "acting";
+  const showPendingToolCalls = pendingToolCalls.length > 0;
 
   const headerLabel =
     agentMessage.completionDurationMs !== null
@@ -123,7 +130,10 @@ export function InlineActivitySteps({
     isActing && isAgentMessageWithActions ? actions[actions.length - 1] : null;
 
   const hasContent =
-    completedSteps.length > 0 || showActiveThinking || activeAction;
+    completedSteps.length > 0 ||
+    showActiveThinking ||
+    activeAction ||
+    showPendingToolCalls;
 
   if (!hasContent) {
     return null;
@@ -276,10 +286,29 @@ export function InlineActivitySteps({
               </div>
             )}
 
+            {showPendingToolCalls &&
+              pendingToolCalls.map((pendingToolCall, index) => (
+                <TimelineRow
+                  key={
+                    pendingToolCall.toolCallId ??
+                    pendingToolCall.toolCallIndex ??
+                    `${pendingToolCall.toolName}-${index}`
+                  }
+                  icon={ToolsIcon}
+                  isLast={!isDone && index === pendingToolCalls.length - 1}
+                >
+                  <span className="text-muted-foreground dark:text-muted-foreground-night">
+                    Preparing to{" "}
+                    {getToolCallDisplayLabel(pendingToolCall.toolName)}...
+                  </span>
+                </TimelineRow>
+              ))}
+
             {/* Pending spinner — shown when between transitions (not done, nothing active) */}
-            {!isDone && !showActiveThinking && !activeAction && (
-              <TimelineRow spinner isLast />
-            )}
+            {!isDone &&
+              !showActiveThinking &&
+              !activeAction &&
+              !showPendingToolCalls && <TimelineRow spinner isLast />}
             {isDone &&
               completedSteps.length > 0 &&
               agentMessage.status !== "gracefully_stopped" && (


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/23769.

Render pending tool calls in the inline "Work" timeline by reusing the existing `pendingToolCalls` streaming state from the previous PR. Pending rows are shown as non-clickable "Preparing to …" entries, while real running actions keep the existing spinner/details behavior.

<img width="1134" height="738" alt="Screenshot 2026-04-06 at 15 50 54" src="https://github.com/user-attachments/assets/f11173ce-1d51-456b-b6cf-80e099f1a05e" />


## Risks
Blast radius: inline activity rendering in assistant conversations
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `cd front && NODE_ENV=test TEST_FRONT_DATABASE_URI=postgres://test:test@localhost:5433/dust_front_test_stream_tool_calls TEST_REDIS_URI=redis://localhost:6479 npm test hooks/useAgentMessageStream.test.ts`
- [ ] Trigger a tool call locally and confirm the inline "Work" timeline shows pending "Preparing to …" rows before `tool_params`, and keeps remaining pending rows visible while another tool is already acting.
