### PR TITLE
[MCP Views] Fix flaky sharing email assertion

### DIFF
--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
@@ -8,6 +8,7 @@ import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory"
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import sgMail from "@sendgrid/mail";
+import { escape } from "html-escaper";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
@@ -235,7 +236,9 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/mcp_views", () => {
       expect(message.dynamic_template_data.subject).toBe(
         "[Dust] Agents to reconfigure after sharing Notion"
       );
-      expect(message.dynamic_template_data.body).toContain(workspace.name);
+      expect(message.dynamic_template_data.body).toContain(
+        escape(workspace.name)
+      );
       expect(message.dynamic_template_data.body).toContain(
         "Needs Reconfiguration"
       );


### PR DESCRIPTION
## Description
Fixes a flaky test surfaced while validating https://github.com/dust-tt/dust/pull/23773.

The email body escapes the workspace name before rendering HTML, but the test was asserting against the raw faker-generated workspace name. That made the test flaky when the workspace name contained characters that get HTML-escaped.

Example from the failing CI run:
- raw workspace name: `Romaguera, O'Reilly and Cremin`
- rendered email body: `Romaguera, O&#39;Reilly and Cremin`

The assertion now checks the escaped workspace name instead of the raw one.

## Risks
Blast radius: one MCP sharing API test assertion
Risk: none

## Deploy Plan
- none (test-only)

## Test
- [x] `cd front && NODE_ENV=test TEST_FRONT_DATABASE_URI=postgres://test:test@localhost:5433/dust_front_test_stream_tool_calls TEST_REDIS_URI=redis://localhost:6479 npm test pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts`
