### PR TITLE
[sessions] Disable submit when switching agents during an active agent loop

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -1,5 +1,5 @@
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
-import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import type {
   VirtuosoMessage,
@@ -35,7 +35,7 @@ import {
   useVirtuosoLocation,
   useVirtuosoMethods,
 } from "@virtuoso.dev/message-list";
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
 
@@ -46,7 +46,7 @@ export const AgentInputBar = ({
 }) => {
   const [blockedActionIndex, setBlockedActionIndex] = useState<number>(0);
   const [isStopping, setIsStopping] = useState<boolean>(false);
-  const generationContext = useContext(GenerationContext);
+  const generationContext = useGenerationContext();
   const { getBlockedActions, hasPendingValidations, startPulsingAction } =
     useBlockedActionsContext();
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -11,7 +11,7 @@ import { DeletedMessage } from "@app/components/assistant/conversation/DeletedMe
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
 import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
-import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { GoogleDriveFileAuthorizationRequired } from "@app/components/assistant/conversation/GoogleDriveFileAuthorizationRequired";
 import { useAutoOpenInteractiveContent } from "@app/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent";
 import { MCPServerPersonalAuthenticationRequired } from "@app/components/assistant/conversation/MCPServerPersonalAuthenticationRequired";
@@ -424,12 +424,7 @@ export function AgentMessage({
   );
 
   // GenerationContext: to know if we are generating or not.
-  const generationContext = useContext(GenerationContext);
-  if (!generationContext) {
-    throw new Error(
-      "AgentMessage must be used within a GenerationContextProvider"
-    );
-  }
+  const generationContext = useGenerationContext();
 
   useEffect(() => {
     if (shouldStream) {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -436,11 +436,18 @@ export function AgentMessage({
       generationContext.addGeneratingMessage({
         messageId: sId,
         conversationId,
+        agentId: agentMessage.configuration.sId,
       });
     } else {
       generationContext.removeGeneratingMessage({ messageId: sId });
     }
-  }, [shouldStream, generationContext, sId, conversationId]);
+  }, [
+    shouldStream,
+    generationContext,
+    sId,
+    conversationId,
+    agentMessage.configuration.sId,
+  ]);
 
   const isGlobalAgent = isGlobalAgentId(agentMessage.configuration.sId);
 

--- a/front/components/assistant/conversation/GenerationContextProvider.tsx
+++ b/front/components/assistant/conversation/GenerationContextProvider.tsx
@@ -1,5 +1,11 @@
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
 
 type GeneratingMessage = {
   messageId: string;

--- a/front/components/assistant/conversation/GenerationContextProvider.tsx
+++ b/front/components/assistant/conversation/GenerationContextProvider.tsx
@@ -4,6 +4,7 @@ import { createContext, useCallback, useMemo, useState } from "react";
 type GeneratingMessage = {
   messageId: string;
   conversationId: string;
+  agentId?: string;
 };
 
 type GenerationContextType = {
@@ -11,6 +12,7 @@ type GenerationContextType = {
   addGeneratingMessage: (params: {
     messageId: string;
     conversationId: string;
+    agentId?: string;
   }) => void;
   removeGeneratingMessage: (params: { messageId: string }) => void;
   getConversationGeneratingMessages: (
@@ -37,15 +39,17 @@ export const GenerationContextProvider = ({
     ({
       messageId,
       conversationId,
+      agentId,
     }: {
       messageId: string;
       conversationId: string;
+      agentId?: string;
     }) => {
       setGeneratingMessages((prev) => {
         if (prev.some((m) => m.messageId === messageId)) {
           return prev;
         }
-        return [...prev, { messageId, conversationId }];
+        return [...prev, { messageId, conversationId, agentId }];
       });
     },
     []

--- a/front/components/assistant/conversation/GenerationContextProvider.tsx
+++ b/front/components/assistant/conversation/GenerationContextProvider.tsx
@@ -1,5 +1,5 @@
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
-import { createContext, useCallback, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
 
 type GeneratingMessage = {
   messageId: string;
@@ -20,9 +20,21 @@ type GenerationContextType = {
   ) => GeneratingMessage[];
 };
 
-export const GenerationContext = createContext<
-  GenerationContextType | undefined
->(undefined);
+const GenerationContext = createContext<GenerationContextType | undefined>(
+  undefined
+);
+
+export function useGenerationContext(): GenerationContextType {
+  const context = useContext(GenerationContext);
+
+  if (!context) {
+    throw new Error(
+      "useGenerationContext must be used within a GenerationContextProvider"
+    );
+  }
+
+  return context;
+}
 
 export const GenerationContextProvider = ({
   children,

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -1,5 +1,5 @@
 import { useFileDrop } from "@app/components/assistant/conversation/FileUploaderContext";
-import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBarAttachments } from "@app/components/assistant/conversation/input_bar/InputBarAttachments";
 import type { InputBarContainerProps } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import InputBarContainer, {
@@ -128,7 +128,7 @@ export const InputBar = React.memo(function InputBar({
     [getAndClearPendingInputText]
   );
 
-  const generationContext = useContext(GenerationContext);
+  const { getConversationGeneratingMessages } = useGenerationContext();
 
   // In single-agent mode, block submission when the selected agent differs from
   // the agent that is currently generating a response.
@@ -137,9 +137,7 @@ export const InputBar = React.memo(function InputBar({
       return null;
     }
     const generatingMessages =
-      generationContext?.getConversationGeneratingMessages(
-        conversation?.sId ?? ""
-      ) ?? [];
+      getConversationGeneratingMessages(conversation?.sId ?? "");
     const blockingAgentId = generatingMessages.find(
       (gm) => gm.agentId && gm.agentId !== selectedSingleAgent.id
     )?.agentId;
@@ -151,7 +149,7 @@ export const InputBar = React.memo(function InputBar({
     );
   }, [
     selectedSingleAgent,
-    generationContext,
+    getConversationGeneratingMessages,
     conversation?.sId,
     agentConfigurations,
   ]);

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -34,7 +34,7 @@ import type { SpaceType } from "@app/types/space";
 import type { UserType, WorkspaceType } from "@app/types/user";
 // biome-ignore lint/plugin/noBulkLodash: existing usage
 import _ from "lodash";
-import React, { useContext, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 const DEFAULT_INPUT_BAR_ACTIONS = [...INPUT_BAR_ACTIONS];
 
@@ -83,6 +83,7 @@ export const InputBar = React.memo(function InputBar({
   const [isLocalSubmitting, setIsLocalSubmitting] = useState(isSubmitting);
   const { hasFeature } = useFeatureFlags();
   const singleAgentInput = hasFeature("enable_steering");
+  const [isShaking, setIsShaking] = useState(false);
 
   const [attachedNodes, setAttachedNodes] = useState<
     DataSourceViewContentNode[]
@@ -133,7 +134,7 @@ export const InputBar = React.memo(function InputBar({
   // In single-agent mode, block submission when the selected agent differs from
   // the agent that is currently generating a response.
   const blockedByGeneratingAgentName = useMemo(() => {
-    if (!isSingleAgentInputEnabled() || !selectedSingleAgent) {
+    if (!singleAgentInput || !selectedSingleAgent) {
       return null;
     }
     const generatingMessages =
@@ -148,6 +149,7 @@ export const InputBar = React.memo(function InputBar({
       agentConfigurations.find((a) => a.sId === blockingAgentId)?.name ?? null
     );
   }, [
+    singleAgentInput,
     selectedSingleAgent,
     getConversationGeneratingMessages,
     conversation?.sId,
@@ -372,6 +374,11 @@ export const InputBar = React.memo(function InputBar({
     setAttachedNodes([]);
   };
 
+  const handleShake = useCallback(() => {
+    setIsShaking(true);
+    setTimeout(() => setIsShaking(false), 520);
+  }, []);
+
   useEffect(() => {
     setIsLocalSubmitting(isSubmitting);
   }, [isSubmitting]);
@@ -380,6 +387,7 @@ export const InputBar = React.memo(function InputBar({
     <div className="flex w-full flex-col">
       <div
         className={classNames(
+          isShaking && "animate-shake",
           "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch sm:flex-row",
           "rounded-2xl transition-all",
           "bg-muted-background dark:bg-muted-background-night",
@@ -444,6 +452,7 @@ export const InputBar = React.memo(function InputBar({
             getDraft={getDraft}
             user={user}
             blockedByGeneratingAgentName={blockedByGeneratingAgentName}
+            onShake={handleShake}
           />
         </div>
       </div>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -1,4 +1,5 @@
 import { useFileDrop } from "@app/components/assistant/conversation/FileUploaderContext";
+import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBarAttachments } from "@app/components/assistant/conversation/input_bar/InputBarAttachments";
 import type { InputBarContainerProps } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import InputBarContainer, {
@@ -127,6 +128,36 @@ export const InputBar = React.memo(function InputBar({
     [getAndClearPendingInputText]
   );
 
+  const generationContext = useContext(GenerationContext);
+
+  // In single-agent mode, block submission when the selected agent differs from
+  // the agent that is currently generating a response.
+  const blockedByGeneratingAgentName = useMemo(() => {
+    if (!isSingleAgentInputEnabled() || !selectedSingleAgent) {
+      return null;
+    }
+    const generatingMessages =
+      generationContext?.getConversationGeneratingMessages(
+        conversation?.sId ?? ""
+      ) ?? [];
+    const blockingAgentId = generatingMessages.find(
+      (gm) => gm.agentId && gm.agentId !== selectedSingleAgent.id
+    )?.agentId;
+    if (!blockingAgentId) {
+      return null;
+    }
+    return (
+      agentConfigurations.find((a) => a.sId === blockingAgentId)?.name ?? null
+    );
+  }, [
+    selectedSingleAgent,
+    generationContext,
+    conversation?.sId,
+    agentConfigurations,
+  ]);
+
+  const isBlockedByAgentSwitch = blockedByGeneratingAgentName !== null;
+
   // Tools selection
 
   const [selectedMCPServerViews, setSelectedMCPServerViews] = useState<
@@ -202,7 +233,12 @@ export const InputBar = React.memo(function InputBar({
     resetEditorText,
     setLoading
   ) => {
-    if (isLocalSubmitting || isEmpty || fileUploaderService.isProcessingFiles) {
+    if (
+      isLocalSubmitting ||
+      isEmpty ||
+      fileUploaderService.isProcessingFiles ||
+      isBlockedByAgentSwitch
+    ) {
       return;
     }
 
@@ -409,6 +445,7 @@ export const InputBar = React.memo(function InputBar({
             saveDraft={saveDraft}
             getDraft={getDraft}
             user={user}
+            blockedByGeneratingAgentName={blockedByGeneratingAgentName}
           />
         </div>
       </div>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -34,7 +34,13 @@ import type { SpaceType } from "@app/types/space";
 import type { UserType, WorkspaceType } from "@app/types/user";
 // biome-ignore lint/plugin/noBulkLodash: existing usage
 import _ from "lodash";
-import React, { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 const DEFAULT_INPUT_BAR_ACTIONS = [...INPUT_BAR_ACTIONS];
 
@@ -137,8 +143,9 @@ export const InputBar = React.memo(function InputBar({
     if (!singleAgentInput || !selectedSingleAgent) {
       return null;
     }
-    const generatingMessages =
-      getConversationGeneratingMessages(conversation?.sId ?? "");
+    const generatingMessages = getConversationGeneratingMessages(
+      conversation?.sId ?? ""
+    );
     const blockingAgentId = generatingMessages.find(
       (gm) => gm.agentId && gm.agentId !== selectedSingleAgent.id
     )?.agentId;

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -383,7 +383,6 @@ export const InputBar = React.memo(function InputBar({
 
   const handleShake = useCallback(() => {
     setIsShaking(true);
-    setTimeout(() => setIsShaking(false), 520);
   }, []);
 
   useEffect(() => {
@@ -393,6 +392,7 @@ export const InputBar = React.memo(function InputBar({
   return (
     <div className="flex w-full flex-col">
       <div
+        onAnimationEnd={() => setIsShaking(false)}
         className={classNames(
           isShaking && "animate-shake",
           "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch sm:flex-row",

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -17,7 +17,7 @@ import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { getSupportedFileExtensions } from "@app/types/files";
 import type { SpaceType } from "@app/types/space";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { Avatar, Button, RobotIcon } from "@dust-tt/sparkle";
+import { Avatar, Button, cn, RobotIcon } from "@dust-tt/sparkle";
 import React from "react";
 
 interface InputBarButtonsProps {
@@ -27,6 +27,7 @@ interface InputBarButtonsProps {
   buttonSize: "xs" | "sm";
   clientType: string;
   conversation?: ConversationWithoutContentType;
+  disableAgentSelector: boolean;
   disableInput: boolean;
   editorService: ReturnType<typeof useCustomEditor>["editorService"];
   fileInputRef: React.MutableRefObject<HTMLInputElement | null>;
@@ -52,6 +53,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   buttonSize,
   clientType,
   conversation,
+  disableAgentSelector,
   disableInput,
   editorService,
   fileInputRef,
@@ -98,6 +100,9 @@ export const InputBarButtons = React.memo(function InputBarButtons({
                 <Avatar size="xxs" visual={selectedAgent.pictureUrl} />
               )}
               label={selectedAgent.label}
+              className={cn(
+                disableAgentSelector && "bg-gray-150 dark:bg-gray-800"
+              )}
             />
           ) : (
             <Button
@@ -105,6 +110,9 @@ export const InputBarButtons = React.memo(function InputBarButtons({
               size={buttonSize}
               icon={RobotIcon}
               label="Agent"
+              className={cn(
+                disableAgentSelector && "bg-gray-150 dark:bg-gray-800"
+              )}
             />
           )
         ) : undefined

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -131,6 +131,7 @@ export interface InputBarContainerProps {
   actions: InputBarAction[];
   allAgents: LightAgentConfigurationType[];
   attachedNodes: DataSourceViewContentNode[];
+  blockedByGeneratingAgentName: string | null;
   conversation?: ConversationWithoutContentType;
   space?: SpaceType;
   disableAutoFocus: boolean;
@@ -190,7 +191,9 @@ const InputBarContainer = ({
   selectedSkills,
   saveDraft,
   user,
+  blockedByGeneratingAgentName,
 }: InputBarContainerProps) => {
+  const isBlockedByAgentSwitch = blockedByGeneratingAgentName !== null;
   const { subscription } = useAuth();
   const isMobile = useIsMobile();
   const { hasFeature } = useFeatureFlags();
@@ -260,6 +263,7 @@ const InputBarContainer = ({
   const shouldSuggestAgentRef = useRef(true);
   const [isCaptureDropdownOpen, setIsCaptureDropdownOpen] = useState(false);
   const [showKnowledgePicker, setShowKnowledgePicker] = useState(false);
+  const [isShaking, setIsShaking] = useState(false);
   const plusButtonRef = useRef<HTMLDivElement>(null);
   const clientType = useClientType();
 
@@ -422,8 +426,21 @@ const InputBarContainer = ({
     [editorRef, fileUploaderService, sendNotification]
   );
 
+  // Wrap onEnterKeyDown so that a blocked Enter attempt triggers the shake animation.
+  const onEnterKeyDownWithShake: typeof onEnterKeyDown = useCallback(
+    (isEmpty, markdownAndMentions, resetEditorText, setLoading) => {
+      if (isBlockedByAgentSwitch) {
+        setIsShaking(true);
+        setTimeout(() => setIsShaking(false), 820);
+        return;
+      }
+      onEnterKeyDown(isEmpty, markdownAndMentions, resetEditorText, setLoading);
+    },
+    [isBlockedByAgentSwitch, onEnterKeyDown]
+  );
+
   const { editor, editorService } = useCustomEditor({
-    onEnterKeyDown,
+    onEnterKeyDown: onEnterKeyDownWithShake,
     disableAutoFocus,
     disableUserMentions,
     onUrlDetected: handleUrlDetected,
@@ -1184,13 +1201,23 @@ const InputBarContainer = ({
               isSubmitting && voiceTranscriberService.status !== "transcribing"
             }
             icon={ArrowUpIcon}
-            variant="highlight"
+            variant={isBlockedByAgentSwitch ? "ghost-secondary" : "highlight"}
             disabled={
               isEmpty ||
               isSubmitting ||
               disableInput ||
               voiceTranscriberService.status !== "idle"
             }
+            tooltip={
+              blockedByGeneratingAgentName
+                ? `Wait for @${blockedByGeneratingAgentName} to finish before switching agent`
+                : undefined
+            }
+            className={cn(
+              isShaking && "animate-shake",
+              isBlockedByAgentSwitch &&
+                "hover:s-bg-transparent dark:hover:s-bg-transparent hover:s-text-muted-foreground dark:hover:s-text-muted-foreground-night"
+            )}
             onClick={async (e: React.MouseEvent<HTMLButtonElement>) => {
               e.preventDefault();
               e.stopPropagation();

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -132,6 +132,7 @@ export interface InputBarContainerProps {
   allAgents: LightAgentConfigurationType[];
   attachedNodes: DataSourceViewContentNode[];
   blockedByGeneratingAgentName: string | null;
+  onShake: () => void;
   conversation?: ConversationWithoutContentType;
   space?: SpaceType;
   disableAutoFocus: boolean;
@@ -192,6 +193,7 @@ const InputBarContainer = ({
   saveDraft,
   user,
   blockedByGeneratingAgentName,
+  onShake,
 }: InputBarContainerProps) => {
   const isBlockedByAgentSwitch = blockedByGeneratingAgentName !== null;
   const { subscription } = useAuth();
@@ -263,7 +265,6 @@ const InputBarContainer = ({
   const shouldSuggestAgentRef = useRef(true);
   const [isCaptureDropdownOpen, setIsCaptureDropdownOpen] = useState(false);
   const [showKnowledgePicker, setShowKnowledgePicker] = useState(false);
-  const [isShaking, setIsShaking] = useState(false);
   const plusButtonRef = useRef<HTMLDivElement>(null);
   const clientType = useClientType();
 
@@ -430,13 +431,12 @@ const InputBarContainer = ({
   const onEnterKeyDownWithShake: typeof onEnterKeyDown = useCallback(
     (isEmpty, markdownAndMentions, resetEditorText, setLoading) => {
       if (isBlockedByAgentSwitch) {
-        setIsShaking(true);
-        setTimeout(() => setIsShaking(false), 820);
+        onShake();
         return;
       }
       onEnterKeyDown(isEmpty, markdownAndMentions, resetEditorText, setLoading);
     },
-    [isBlockedByAgentSwitch, onEnterKeyDown]
+    [isBlockedByAgentSwitch, onEnterKeyDown, onShake]
   );
 
   const { editor, editorService } = useCustomEditor({
@@ -1062,6 +1062,7 @@ const InputBarContainer = ({
                     buttonSize={buttonSize}
                     clientType={clientType}
                     conversation={conversation}
+                    disableAgentSelector={isBlockedByAgentSwitch}
                     disableInput={disableInput}
                     editorService={editorService}
                     fileInputRef={fileInputRef}
@@ -1214,7 +1215,6 @@ const InputBarContainer = ({
                 : undefined
             }
             className={cn(
-              isShaking && "animate-shake",
               isBlockedByAgentSwitch &&
                 "hover:s-bg-transparent dark:hover:s-bg-transparent hover:s-text-muted-foreground dark:hover:s-text-muted-foreground-night"
             )}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1207,6 +1207,7 @@ const InputBarContainer = ({
               isEmpty ||
               isSubmitting ||
               disableInput ||
+              isBlockedByAgentSwitch ||
               voiceTranscriberService.status !== "idle"
             }
             tooltip={

--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -141,7 +141,7 @@ export function useConversationDrafts({
   // Save draft for current conversation (debounced).
   const saveDraft = useCallback(
     (text: string, agentMention?: RichAgentMention | null) => {
-      if (!shouldUseDraft || !userId) {
+      if (!shouldUseDraft || !userId || !text.trim()) {
         return;
       }
 

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -472,17 +472,14 @@ module.exports = {
           },
         },
         shake: {
-          "10%, 90%": {
-            transform: "translate3d(-1px, 0, 0)",
+          "0%, 100%": {
+            transform: "translate3d(0, 0, 0)",
           },
-          "20%, 80%": {
-            transform: "translate3d(2px, 0, 0)",
+          "20%, 60%": {
+            transform: "translate3d(-1.5px, 0, 0)",
           },
-          "30%, 50%, 70%": {
-            transform: "translate3d(-2px, 0, 0)",
-          },
-          "40%, 60%": {
-            transform: "translate3d(2px, 0, 0)",
+          "40%, 80%": {
+            transform: "translate3d(1.5px, 0, 0)",
           },
         },
         marquee: {
@@ -505,7 +502,7 @@ module.exports = {
         breathing: "breathing 4s infinite ease-in-out",
         "breathing-scale": "breathing-scale 3s infinite ease-in-out",
         "cursor-blink": "cursor-blink 0.9s infinite;",
-        shake: "shake 0.82s cubic-bezier(.36,.07,.19,.97) both",
+        shake: "shake 0.5s ease-in-out both",
         reload: "reload 1000ms ease-out",
         fadeout: "fadeout 500ms ease-out",
         marquee: "marquee 25s linear infinite",


### PR DESCRIPTION
## Description
When single-agent input is enabled, block submission and shake the input bar (on Enter key only) when the selected agent differs from the currently generating agent. Show a tooltip on the send button and agent picker with the blocking agent's name.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually by:
1. Enabling single agent mode
2. Starting a long thinking agent message
3. Switching the agent
4. Try to hit enter key - see the button shake
5. Hover over submit button - see it is disabled and tooltip has text "Wait for @agent_name to finish before switching agent"
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, behind flag
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
