### PR TITLE
Show text content segments in the inline activity timeline

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -249,6 +249,7 @@ export function AgentMessage({
   const { shouldStream, streamError } = useAgentMessageStream({
     agentMessage: agentMessage,
     conversationId,
+    isInlineActivityEnabled,
     owner,
     onEventCallback: useCallback(
       (eventPayload: {
@@ -917,7 +918,11 @@ export function AgentMessage({
           streaming={shouldStream}
           streamError={streamError}
           lastTokenClassification={
-            agentMessage.streaming.agentState === "thinking" ? "tokens" : null
+            isInlineActivityEnabled
+              ? null
+              : agentMessage.streaming.agentState === "thinking"
+                ? "tokens"
+                : null
           }
           activeReferences={activeReferences}
           setActiveReferences={setActiveReferences}
@@ -1337,24 +1342,28 @@ function AgentMessageContent({
         />
       )}
 
-      {agentMessage.content !== null && (
-        <div>
-          <CitationsContext.Provider value={citationsContextValue}>
-            <AgentMessageMarkdown
-              content={sanitizeVisualizationContent(agentMessage.content)}
-              owner={owner}
-              isStreaming={streaming && lastTokenClassification === "tokens"}
-              streamingState={getStreamingState(
-                streaming && lastTokenClassification === "tokens",
-                agentMessage.status
-              )}
-              isLastMessage={isLastMessage}
-              additionalMarkdownComponents={additionalMarkdownComponents}
-              additionalMarkdownPlugins={additionalMarkdownPlugins}
-            />
-          </CitationsContext.Provider>
-        </div>
-      )}
+      {agentMessage.content !== null &&
+        !(
+          isInlineActivityEnabled &&
+          agentMessage.streaming.agentState !== "done"
+        ) && (
+          <div>
+            <CitationsContext.Provider value={citationsContextValue}>
+              <AgentMessageMarkdown
+                content={sanitizeVisualizationContent(agentMessage.content)}
+                owner={owner}
+                isStreaming={streaming && lastTokenClassification === "tokens"}
+                streamingState={getStreamingState(
+                  streaming && lastTokenClassification === "tokens",
+                  agentMessage.status
+                )}
+                isLastMessage={isLastMessage}
+                additionalMarkdownComponents={additionalMarkdownComponents}
+                additionalMarkdownPlugins={additionalMarkdownPlugins}
+              />
+            </CitationsContext.Provider>
+          </div>
+        )}
       {generatedFiles.length > 0 && (
         <div className="mt-2 grid grid-cols-5 gap-1">
           {getCitations({

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -100,6 +100,7 @@ export function InlineActivitySteps({
   };
 
   const isThinking = lastAgentStateClassification === "thinking";
+  const isWriting = lastAgentStateClassification === "writing";
   const isActing = lastAgentStateClassification === "acting";
   const showPendingToolCalls = pendingToolCalls.length > 0;
 
@@ -127,12 +128,14 @@ export function InlineActivitySteps({
   // Show active thinking whenever the agent is thinking.
   // Dedup in appendThinkingStep handles duplicate content at capture time.
   const showActiveThinking = isThinking;
+  const showActiveWriting = isWriting;
   const activeAction =
     isActing && isAgentMessageWithActions ? actions[actions.length - 1] : null;
 
   const hasContent =
     completedSteps.length > 0 ||
     showActiveThinking ||
+    showActiveWriting ||
     activeAction ||
     showPendingToolCalls;
 
@@ -167,6 +170,7 @@ export function InlineActivitySteps({
               const isLast =
                 index === completedSteps.length - 1 &&
                 !showActiveThinking &&
+                !showActiveWriting &&
                 !activeAction &&
                 !isDone;
 
@@ -211,6 +215,16 @@ export function InlineActivitySteps({
                         isLastMessage={false}
                       />
                     </TimelineRow>
+                  );
+                case "content":
+                  return (
+                    <div key={step.id}>
+                      <Markdown
+                        content={step.content}
+                        isStreaming={false}
+                        isLastMessage={false}
+                      />
+                    </div>
                   );
                 case "action": {
                   const actionIcon = step.internalMCPServerName
@@ -268,6 +282,23 @@ export function InlineActivitySteps({
               </TimelineRow>
             )}
 
+            {/* Active writing (streaming content tokens) */}
+            {showActiveWriting && agentMessage.content ? (
+              <div>
+                <Markdown
+                  content={agentMessage.content}
+                  isStreaming={false}
+                  streamingState="streaming"
+                  enableAnimation
+                  animationDurationSeconds={0.3}
+                  delimiter=" "
+                  isLastMessage={false}
+                />
+              </div>
+            ) : showActiveWriting ? (
+              <TimelineRow spinner isLast={!activeAction && !isDone} />
+            ) : null}
+
             {/* Active action (tool in progress) */}
             {isActing && activeAction && (
               <div
@@ -304,6 +335,7 @@ export function InlineActivitySteps({
             {/* Pending spinner — shown when between transitions (not done, nothing active) */}
             {!isDone &&
               !showActiveThinking &&
+              !showActiveWriting &&
               !activeAction &&
               !showPendingToolCalls && <TimelineRow spinner isLast />}
             {isDone &&

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -219,9 +219,62 @@ function appendThinkingStep(
   return [...steps, { type: "thinking", content: cotContent, id }];
 }
 
+function appendContentStep(
+  steps: InlineActivityStep[],
+  textContent: string,
+  id: string
+): InlineActivityStep[] {
+  return [...steps, { type: "content", content: textContent, id }];
+}
+
+/**
+ * Flush the current pending segment (CoT or content) as an activity step.
+ *
+ * In inline activity mode, a pending "tokens" segment is flushed as a content
+ * step and `content.current` is cleared so the next segment starts fresh.
+ * In non-inline mode, content is left untouched (it accumulates as the body).
+ *
+ * Returns the updated steps and whether the body content was cleared.
+ */
+function flushPendingSegment({
+  lastClassification,
+  chainOfThought,
+  content,
+  isInlineActivityEnabled,
+  steps,
+  suffix,
+}: {
+  lastClassification: { current: "tokens" | "chain_of_thought" | null };
+  chainOfThought: { current: string };
+  content: { current: string };
+  isInlineActivityEnabled: boolean;
+  steps: InlineActivityStep[];
+  suffix: string;
+}): { steps: InlineActivityStep[]; contentCleared: boolean } {
+  const cls = lastClassification.current;
+  if (cls === "chain_of_thought" && chainOfThought.current) {
+    const cotToFlush = chainOfThought.current;
+    chainOfThought.current = "";
+    return {
+      steps: appendThinkingStep(steps, cotToFlush, `thinking-${suffix}`),
+      contentCleared: false,
+    };
+  }
+  if (cls === "tokens" && content.current && isInlineActivityEnabled) {
+    const textToFlush = content.current;
+    content.current = "";
+    return {
+      steps: appendContentStep(steps, textToFlush, `content-${suffix}`),
+      contentCleared: true,
+    };
+  }
+  return { steps, contentCleared: false };
+}
+
 interface UseAgentMessageStreamParams {
   agentMessage: MessageTemporaryState;
   conversationId: string | null;
+  isInlineActivityEnabled: boolean;
   owner: LightWorkspaceType;
   onEventCallback?: (event: {
     eventId: string;
@@ -234,6 +287,7 @@ interface UseAgentMessageStreamParams {
 export function useAgentMessageStream({
   agentMessage,
   conversationId,
+  isInlineActivityEnabled,
   owner,
   onEventCallback: customOnEventCallback,
   streamId,
@@ -256,9 +310,13 @@ export function useAgentMessageStream({
   );
 
   const chainOfThought = useRef(agentMessage.chainOfThought ?? "");
+  // In inline mode, content.current tracks the current text segment only
+  // (cleared on each flush). In non-inline mode, it accumulates all text.
   const content = useRef(agentMessage.content ?? "");
-  // Tracks whether response token generation has started, to flush CoT once.
-  const writingStarted = useRef(false);
+  // Tracks the last token classification to detect transitions between
+  // thinking (chain_of_thought) and writing (tokens), flushing completed
+  // segments as activity steps on each switch.
+  const lastClassification = useRef<"tokens" | "chain_of_thought" | null>(null);
 
   const buildEventSourceURL = useCallback(
     (lastEvent: string | null) => {
@@ -303,8 +361,6 @@ export function useAgentMessageStream({
             (eventPayload.data.classification === "tokens" ||
               eventPayload.data.classification === "chain_of_thought")
           ) {
-            // If this is a fresh mount with existing content and we're getting generation_tokens,
-            // we need to clear the content first to avoid duplication
             content.current = "";
             chainOfThought.current = "";
             isFreshMountWithContent.current = false;
@@ -317,32 +373,55 @@ export function useAgentMessageStream({
             classification === "tokens" ||
             classification === "chain_of_thought"
           ) {
-            // First "tokens" event means thinking → writing: flush pending CoT once.
+            // Detect classification transitions and flush completed segments.
             if (
-              classification === "tokens" &&
-              !writingStarted.current &&
-              chainOfThought.current
+              lastClassification.current !== null &&
+              classification !== lastClassification.current
             ) {
-              writingStarted.current = true;
-              const cotToFlush = chainOfThought.current;
-              chainOfThought.current = "";
+              const newAgentState =
+                classification === "tokens" && isInlineActivityEnabled
+                  ? "writing"
+                  : "thinking";
+              methods.data.map((m) => {
+                if (!isMessageTemporayState(m) || m.sId !== sId) {
+                  return m;
+                }
+                const { steps, contentCleared } = flushPendingSegment({
+                  lastClassification,
+                  chainOfThought,
+                  content,
+                  isInlineActivityEnabled,
+                  steps: m.streaming.inlineActivitySteps,
+                  suffix: `pre-${Date.now()}`,
+                });
+                return {
+                  ...m,
+                  ...(contentCleared ? { content: "" } : {}),
+                  streaming: {
+                    ...m.streaming,
+                    agentState: newAgentState,
+                    inlineActivitySteps: steps,
+                  },
+                };
+              });
+            } else if (
+              isInlineActivityEnabled &&
+              lastClassification.current === null &&
+              classification === "tokens"
+            ) {
+              // First tokens event in inline mode — set agentState to writing.
               methods.data.map((m) => {
                 if (!isMessageTemporayState(m) || m.sId !== sId) {
                   return m;
                 }
                 return {
                   ...m,
-                  streaming: {
-                    ...m.streaming,
-                    inlineActivitySteps: appendThinkingStep(
-                      m.streaming.inlineActivitySteps,
-                      cotToFlush,
-                      `thinking-pretokens-${Date.now()}`
-                    ),
-                  },
+                  streaming: { ...m.streaming, agentState: "writing" },
                 };
               });
             }
+
+            lastClassification.current = classification;
 
             if (classification === "tokens") {
               content.current += generationTokens.text;
@@ -404,23 +483,21 @@ export function useAgentMessageStream({
 
         case "tool_params":
           const toolParams = eventPayload.data;
-          writingStarted.current = false;
-          // Snapshot CoT before it gets cleared by updateMessageWithAction.
-          const cotAtToolParams = chainOfThought.current;
-          chainOfThought.current = "";
           methods.data.map((m) => {
             if (!isMessageTemporayState(m) || m.sId !== sId) {
               return m;
             }
-            const steps = cotAtToolParams
-              ? appendThinkingStep(
-                  m.streaming.inlineActivitySteps,
-                  cotAtToolParams,
-                  `thinking-${Date.now()}`
-                )
-              : m.streaming.inlineActivitySteps;
+            const { steps, contentCleared } = flushPendingSegment({
+              lastClassification,
+              chainOfThought,
+              content,
+              isInlineActivityEnabled,
+              steps: m.streaming.inlineActivitySteps,
+              suffix: `toolparams-${Date.now()}`,
+            });
             return {
               ...updateMessageWithAction(m, toolParams.action),
+              ...(contentCleared ? { content: "" } : {}),
               streaming: {
                 ...m.streaming,
                 agentState: "acting",
@@ -432,6 +509,7 @@ export function useAgentMessageStream({
               },
             };
           });
+          lastClassification.current = null;
           break;
 
         case "tool_notification":
@@ -473,23 +551,23 @@ export function useAgentMessageStream({
         case "tool_error":
         case "agent_error":
           const error = eventPayload.data.error;
-          const cotAtError = chainOfThought.current;
-          chainOfThought.current = "";
           methods.data.map((m) => {
             if (!isMessageTemporayState(m) || m.sId !== sId) {
               return m;
             }
-            const steps = cotAtError
-              ? appendThinkingStep(
-                  m.streaming.inlineActivitySteps,
-                  cotAtError,
-                  `thinking-error-${Date.now()}`
-                )
-              : m.streaming.inlineActivitySteps;
+            const { steps, contentCleared } = flushPendingSegment({
+              lastClassification,
+              chainOfThought,
+              content,
+              isInlineActivityEnabled,
+              steps: m.streaming.inlineActivitySteps,
+              suffix: `error-${Date.now()}`,
+            });
             return {
               ...m,
               status: "failed",
               error: error,
+              ...(contentCleared ? { content: null } : {}),
               streaming: {
                 ...m.streaming,
                 agentState: "done",
@@ -511,28 +589,47 @@ export function useAgentMessageStream({
           );
           break;
 
-        case "agent_generation_cancelled":
-          methods.data.map((m) =>
-            isMessageTemporayState(m) && m.sId === sId
-              ? {
-                  ...m,
-                  status: "cancelled",
-                  streaming: {
-                    ...m.streaming,
-                    agentState: "done",
-                    pendingToolCalls: [],
-                  },
-                }
-              : m
-          );
+        case "agent_generation_cancelled": {
+          methods.data.map((m) => {
+            if (!isMessageTemporayState(m) || m.sId !== sId) {
+              return m;
+            }
+            const { steps, contentCleared } = flushPendingSegment({
+              lastClassification,
+              chainOfThought,
+              content,
+              isInlineActivityEnabled,
+              steps: m.streaming.inlineActivitySteps,
+              suffix: `cancel-${Date.now()}`,
+            });
+            return {
+              ...m,
+              status: "cancelled",
+              ...(contentCleared ? { content: null } : {}),
+              streaming: {
+                ...m.streaming,
+                agentState: "done",
+                inlineActivitySteps: steps,
+                pendingToolCalls: [],
+              },
+            };
+          });
           break;
+        }
 
         case "agent_message_gracefully_stopped":
         case "agent_message_success": {
           const messageSuccess = eventPayload.data;
-          // Safety net: flush any remaining CoT not yet captured.
+          // Flush any remaining CoT (but not content — the final text segment
+          // becomes the message body via the server's canonical message).
           const cotAtSuccess = chainOfThought.current;
           chainOfThought.current = "";
+          // In inline activity mode, content.current tracks only the final
+          // text segment (intermediate segments were flushed to content steps).
+          // The server's full message includes ALL text, so we override with
+          // the tracked final segment. In non-inline mode, we trust the server.
+          const finalSegment = content.current;
+          lastClassification.current = null;
           methods.data.map((m) => {
             if (!isMessageTemporayState(m) || m.sId !== sId) {
               return m;
@@ -547,6 +644,9 @@ export function useAgentMessageStream({
             return {
               ...m,
               ...getLightAgentMessageFromAgentMessage(messageSuccess.message),
+              ...(isInlineActivityEnabled
+                ? { content: finalSegment || null }
+                : {}),
               streaming: {
                 ...m.streaming,
                 agentState: "done",
@@ -566,7 +666,7 @@ export function useAgentMessageStream({
         customOnEventCallback(eventPayload);
       }
     },
-    [customOnEventCallback, methods, sId]
+    [customOnEventCallback, isInlineActivityEnabled, methods, sId]
   );
 
   const { isError } = useEventSource(

--- a/front/lib/api/assistant/activity_steps.ts
+++ b/front/lib/api/assistant/activity_steps.ts
@@ -44,6 +44,16 @@ export async function contentsToActivitySteps(
 ): Promise<InlineActivityStep[]> {
   const actionsByCallId = new Map(actions.map((a) => [a.functionCallId, a]));
 
+  // Find the last text_content index — that item stays as the message body
+  // and should NOT become a content activity step.
+  let lastTextContentIndex = -1;
+  for (let i = contents.length - 1; i >= 0; i--) {
+    if (isAgentTextContent(contents[i].content)) {
+      lastTextContentIndex = i;
+      break;
+    }
+  }
+
   const steps: InlineActivityStep[] = [];
 
   for (const [index, c] of contents.entries()) {
@@ -74,6 +84,16 @@ export async function contentsToActivitySteps(
           type: "thinking",
           content: parsedContent.chainOfThought,
           id: `cot-${c.step}-${index}`,
+        });
+      }
+
+      // Create a content step for every intermediate text segment.
+      // The last text_content stays as the message body and is not a step.
+      if (index !== lastTextContentIndex && parsedContent.content?.trim()) {
+        steps.push({
+          type: "content",
+          content: parsedContent.content,
+          id: `content-${c.step}-${index}`,
         });
       }
       continue;

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -713,6 +713,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
           agentConfiguration,
           message.sId
         );
+
         return new Ok({
           ...getLightAgentMessageFromAgentMessage(m),
           activitySteps,

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -251,6 +251,7 @@ export type BaseAgentMessageType = {
 
 export type InlineActivityStep =
   | { type: "thinking"; content: string; id: string }
+  | { type: "content"; content: string; id: string }
   | {
       type: "action";
       label: string;

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -26,6 +26,8 @@ export const CLAUDE_SONNET_4_6_MODEL_ID = "claude-sonnet-4-6" as const;
 
 export const ANTHROPIC_TOKEN_COUNT_ADJUSTMENT = 1.3;
 
+// @todo isInlineActivityEnabled.
+// When it's ungated we can remove this meta prompt and let the model decide if it wants to output text before tool calls or not based on the activity type.
 export const CLAUDE_4_NATIVE_REASONING_META_PROMPT =
   `
 When executing multiple tool calls, output text only after all tools have completed.


### PR DESCRIPTION
## Description

**What**

When the model produces visible text between tool calls, that text now appears as a content step in the activity timeline instead of accumulating silently in the message body. Only the final text segment (after the last tool call) becomes the message body. This gives users a clear chronological view of what the agent said at each stage of its work.

<kbd>
<img width="1484" height="1009" alt="Screenshot 2026-04-05 at 23 56 42" src="https://github.com/user-attachments/assets/2f1d206e-b82f-4204-8a34-61539aad9bf5" />
</kbd>


**How**

Added new "content" variant is added to InlineActivityStep. 

The streaming hook tracks classification switches (thinking vs tokens) and flushes completed text segments as content steps when the classification changes or a tool call arrives. 

The flush PendingSegment helper centralizes this logic and handles the difference between inline and non-inline modes: in inline mode, content.current is cleared after each flush so it only ever holds the current segment; in non-inline mode, it accumulates as before and content steps are simply not created.

The "writing" agentState (which existed but was unused) is now activated when the model generates visible tokens. Content steps render as plain Markdown outside of TimelineRow, and the active writing state streams text with animation in the timeline. The message body is hidden during all active streaming states when inline activity is enabled, and shown only on completion with the final text segment.

For completed messages (page reload), contentsToActivitySteps creates content steps for all text_content items except the last one (which stays as the body). The content assembly in messages.ts now passes only the last text fragment to the parser for non-reasoning models, matching the reasoning path that already did this.

All changes are gated behind isInlineActivityEnabled at the rendering and streaming levels. Non-inline mode is supposed to be unaffected.

## Tests

Locally. 

## Risk

Mostly break streaming logic. 
Can be rolled back. 

## Deploy Plan

Deploy front. 

As soon as we ungate inline activity, we should uncomment this: https://github.com/dust-tt/dust/blob/main/front/lib/api/assistant/generation.ts#L153