### PR TITLE
[sessions] Route agent card clicks to the single-agent picker

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -10,6 +10,7 @@ import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
+import { isSingleAgentInputEnabled } from "@app/lib/development";
 import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
 import { classNames } from "@app/lib/utils";
@@ -60,7 +61,8 @@ export function ConversationContainerVirtuoso({
 
   const [planLimitReached, setPlanLimitReached] = useState(false);
 
-  const { setSelectedAgent } = useContext(InputBarContext);
+  const { setSelectedAgent, setSelectedSingleAgent } =
+    useContext(InputBarContext);
 
   const router = useAppRouter();
 
@@ -230,7 +232,11 @@ export function ConversationContainerVirtuoso({
           )}
           <AgentBrowserContainer
             onAgentConfigurationClick={(agent) => {
-              setSelectedAgent(toRichAgentMentionType(agent));
+              if (isSingleAgentInputEnabled()) {
+                setSelectedSingleAgent(toRichAgentMentionType(agent));
+              } else {
+                setSelectedAgent(toRichAgentMentionType(agent));
+              }
             }}
             owner={owner}
             user={user}

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -83,6 +83,10 @@ const useHandleMentions = (
 
   useEffect(() => {
     if (selectedAgent) {
+      if (singleAgentInput) {
+        setSelectedSingleAgent(selectedAgent);
+        return;
+      }
       if (!editorService.hasMention(selectedAgent)) {
         // Schedule insertion to avoid synchronous editor updates during React render/effects.
         queueMicrotask(() => {
@@ -98,7 +102,13 @@ const useHandleMentions = (
     } else if (pendingInputText) {
       queueMicrotask(() => editorService.insertText(pendingInputText));
     }
-  }, [selectedAgent, pendingInputText, editorService]);
+  }, [
+    selectedAgent,
+    pendingInputText,
+    editorService,
+    setSelectedSingleAgent,
+    singleAgentInput,
+  ]);
 
   return { stickyMentionsTextContent };
 };


### PR DESCRIPTION
## Description
In single-agent input mode, clicking an agent card now sets the agent picker button instead of inserting an @mention into the editor text. Legacy mode is unchanged, guarded by isSingleAgentInputEnabled().

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Test by:
1. Enabling single agent mode
2. On main page, click on multiple agent cards (favorited/edited by me, etc) and see that each click now replaces the previously selected agent instead of adding the agent name to the input box
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
