### PR TITLE
Gate inline activity behind enable_steering feature flag

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -6,11 +6,9 @@ import config from "@app/lib/api/config";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   forceUserRole,
-  isInlineActivityEnabled,
   isSingleAgentInputEnabled,
   sendOnboardingConversation,
   showDebugTools,
-  toggleInlineActivity,
   toggleSingleAgentInput,
 } from "@app/lib/development";
 import { useAppRouter } from "@app/lib/platform";
@@ -44,7 +42,7 @@ import {
   TestTubeIcon,
   UserIcon,
 } from "@dust-tt/sparkle";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 interface UserMenuProps {
   user: UserTypeWithWorkspaces;
@@ -58,16 +56,6 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
 
   const sendNotification = useSendNotification();
   const privacyMask = usePrivacyMask();
-  const [inlineActivity, setInlineActivity] = useState(isInlineActivityEnabled);
-  const handleToggleInlineActivity = useCallback(() => {
-    const next = toggleInlineActivity();
-    setInlineActivity(next);
-    sendNotification({
-      title: `Inline activity ${next ? "enabled" : "disabled"}`,
-      description: "Reload the page to apply.",
-      type: "success",
-    });
-  }, [sendNotification]);
   const [singleAgentInput, setSingleAgentInput] = useState(() =>
     isSingleAgentInputEnabled()
   );
@@ -289,11 +277,6 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
                     label={`${privacyMask.isEnabled ? "Disable" : "Enable"} Privacy Mask`}
                     onClick={privacyMask.toggle}
                     icon={privacyMask.isEnabled ? EyeSlashIcon : EyeIcon}
-                  />
-                  <DropdownMenuItem
-                    label={`${inlineActivity ? "Disable" : "Enable"} Inline Activity`}
-                    onClick={handleToggleInlineActivity}
-                    icon={TestTubeIcon}
                   />
                   <DropdownMenuItem
                     label={`${singleAgentInput ? "Disable" : "Enable"} Single Agent Input`}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -54,7 +54,6 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useRetryMessage } from "@app/hooks/useRetryMessage";
 import config from "@app/lib/api/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { isInlineActivityEnabled as isDevInlineActivityEnabled } from "@app/lib/development";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
@@ -204,7 +203,7 @@ export function AgentMessage({
   const [streamId, setStreamId] = useState<string>(`message-${sId}`);
   const { hasFeature } = useFeatureFlags();
   const isCollapsibleEnabled = hasFeature("collapsible_messages");
-  const isInlineActivityEnabled = isDevInlineActivityEnabled();
+  const isInlineActivityEnabled = hasFeature("enable_steering");
 
   const [isRetryHandlerProcessing, setIsRetryHandlerProcessing] =
     useState<boolean>(false);
@@ -1064,7 +1063,8 @@ function AgentMessageContent({
   >();
 
   const { vizUrl } = useAuth();
-  const isInlineActivityEnabled = isDevInlineActivityEnabled();
+  const { hasFeature } = useFeatureFlags();
+  const isInlineActivityEnabled = hasFeature("enable_steering");
   const { sId, configuration: agentConfiguration } = agentMessage;
 
   const { postFollowUp } = usePostOnboardingFollowUp({

--- a/front/hooks/conversations/useCancelMessage.ts
+++ b/front/hooks/conversations/useCancelMessage.ts
@@ -1,5 +1,5 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import { isInlineActivityEnabled } from "@app/lib/development";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback } from "react";
@@ -12,6 +12,8 @@ export function useCancelMessage({
   conversationId?: string | null;
 }) {
   const sendNotification = useSendNotification();
+  const { hasFeature } = useFeatureFlags();
+  const isSteeringEnabled = hasFeature("enable_steering");
 
   return useCallback(
     async (messageIds: string[]) => {
@@ -25,7 +27,7 @@ export function useCancelMessage({
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              action: isInlineActivityEnabled() ? "gracefully_stop" : "cancel",
+              action: isSteeringEnabled ? "gracefully_stop" : "cancel",
               messageIds,
             }),
           }
@@ -36,6 +38,6 @@ export function useCancelMessage({
         sendNotification({ type: "error", title: "Failed to cancel message" });
       }
     },
-    [owner.sId, conversationId, sendNotification]
+    [owner.sId, conversationId, sendNotification, isSteeringEnabled]
   );
 }

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -8,21 +8,6 @@ export function showDebugTools(flags: WhitelistableFeature[]) {
   return isDevelopment() || flags.includes("show_debug_tools");
 }
 
-const INLINE_ACTIVITY_KEY = "dust_inline_activity";
-
-export function isInlineActivityEnabled(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  return localStorage.getItem(INLINE_ACTIVITY_KEY) === "true";
-}
-
-export function toggleInlineActivity(): boolean {
-  const next = !isInlineActivityEnabled();
-  localStorage.setItem(INLINE_ACTIVITY_KEY, next ? "true" : "false");
-  return next;
-}
-
 const SINGLE_AGENT_INPUT_KEY = "dust_single_agent_input";
 
 export function isSingleAgentInputEnabled(): boolean {


### PR DESCRIPTION
## Description

Inline activity was previously gated by a localStorage toggle in the dev tools menu. This moves it behind the existing enable_steering feature flag instead, so it can be rolled out per workspace. The dev tools menu item has been removed and the localStorage helpers cleaned up.

## Tests

Locally. 

## Risk

Can of course be rolled back. 

## Deploy Plan

Deploy front. 