### PR TITLE
Add field to store last reinforced time for agent

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1818,3 +1818,19 @@ export async function updateAgentReinforcementMode(
     }
   );
 }
+
+export async function recordAgentReinforcementAnalysisCompletion(
+  auth: Authenticator,
+  agentSId: string
+): Promise<void> {
+  await AgentConfigurationModel.update(
+    { lastReinforcementAnalysisAt: new Date() },
+    {
+      where: {
+        sId: agentSId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        status: "active",
+      },
+    }
+  );
+}

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -178,6 +178,8 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
       ),
       tags: tags.map((t) => t.toJSON()).sort(tagsSorter),
       reinforcement: agent.reinforcement,
+      lastReinforcementAnalysisAt:
+        agent.lastReinforcementAnalysisAt?.toISOString() ?? null,
       canRead: isAuthor || isMember || agent.scope === "visible",
       canEdit: isAuthor || isMember,
     };

--- a/front/lib/models/agent/agent.ts
+++ b/front/lib/models/agent/agent.ts
@@ -52,6 +52,8 @@ export class AgentConfigurationModel extends WorkspaceAwareModel<AgentConfigurat
 
   declare reinforcement: AgentReinforcementMode;
 
+  declare lastReinforcementAnalysisAt: Date | null;
+
   declare requestedSpaceIds: number[];
 
   declare author: NonAttribute<UserModel>;
@@ -163,6 +165,11 @@ AgentConfigurationModel.init(
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "auto",
+    },
+    lastReinforcementAnalysisAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
     },
     requestedSpaceIds: {
       type: DataTypes.ARRAY(DataTypes.BIGINT),

--- a/front/migrations/db/migration_564.sql
+++ b/front/migrations/db/migration_564.sql
@@ -1,0 +1,2 @@
+-- Migration created on Apr 4, 2026
+ALTER TABLE "public"."agent_configurations" ADD COLUMN "lastReinforcementAnalysisAt" TIMESTAMP WITH TIME ZONE DEFAULT NULL;

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -1,4 +1,7 @@
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import {
+  getAgentConfigurations,
+  recordAgentReinforcementAnalysisCompletion,
+} from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
@@ -453,6 +456,17 @@ export async function finalizeAggregationActivity({
     },
     "ReinforcedAgent: finalized aggregation"
   );
+}
+
+export async function recordReinforcementWorkflowCompletionActivity({
+  workspaceId,
+  agentConfigurationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+}): Promise<void> {
+  const auth = await getAuthForWorkspace(workspaceId);
+  await recordAgentReinforcementAnalysisCompletion(auth, agentConfigurationId);
 }
 
 /**

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -44,6 +44,12 @@ const { finalizeAggregationActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
 });
 
+const { recordReinforcementWorkflowCompletionActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "5 minutes",
+});
+
 const { startConversationAnalysisBatchActivity } = proxyActivities<
   typeof activities
 >({
@@ -311,6 +317,11 @@ export async function reinforcedAgentForAgentWorkflow({
       disableNotifications,
     });
   }
+
+  await recordReinforcementWorkflowCompletionActivity({
+    workspaceId,
+    agentConfigurationId,
+  });
 }
 
 interface ReinforcedToolActionInfo {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -194,6 +194,7 @@ export const LightAgentConfigurationSchema = z.object({
   requestedGroupIds: z.array(z.array(z.string())),
   requestedSpaceIds: z.array(z.string()),
   reinforcement: z.enum(AGENT_REINFORCEMENT_MODES).optional(),
+  lastReinforcementAnalysisAt: z.string().nullable().optional(),
   canRead: z.boolean(),
   canEdit: z.boolean(),
   omittedThinking: z.boolean().optional(),


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/7310
* Adding field to agent to store last time it was reinforced. This will be used in auto mode as described in https://www.notion.so/dust-tt/Draft-Reinforced-Agent-Auto-Mode-Criteria-33328599d94181568e73f91960dc8240
* I considered creating a separate "reinforced metadata" table, but biased towards this living directly with the agent config

## Tests
<img width="1379" height="454" alt="Screenshot 2026-04-06 at 7 05 07 PM" src="https://github.com/user-attachments/assets/424ef29e-ba50-4d4b-bf3f-3166c88413c2" />

## Risk

* Low

## Deploy Plan

1. migrate
2. deploy front