### PR TITLE
Handle seats and memberships

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -1,21 +1,160 @@
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
+  emitAuditLogEventDirect,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import type { Authenticator } from "@app/lib/auth";
+import { addSeat, removeSeat } from "@app/lib/metronome/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
+import type {
+  MembershipOriginType,
+  MembershipRoleType,
+} from "@app/types/memberships";
+import { Ok, type Result } from "@app/types/shared/result";
+import type {
+  ActiveRoleType,
+  LightWorkspaceType,
+  UserType,
+} from "@app/types/user";
 import type { Transaction } from "sequelize";
+
+async function addSeatForWorkspace(
+  workspace: LightWorkspaceType,
+  userId: string
+): Promise<Result<void, Error>> {
+  if (!workspace.metronomeCustomerId) {
+    return new Ok(undefined);
+  }
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  if (!subscription?.metronomeContractId) {
+    return new Ok(undefined);
+  }
+  return await addSeat({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    contractId: subscription.metronomeContractId,
+    userId,
+    workspaceId: workspace.sId,
+  });
+}
+
+async function removeSeatForWorkspace(
+  workspace: LightWorkspaceType,
+  userId: string
+): Promise<Result<void, Error>> {
+  if (!workspace.metronomeCustomerId) {
+    return new Ok(undefined);
+  }
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  if (!subscription?.metronomeContractId) {
+    return new Ok(undefined);
+  }
+  return await removeSeat({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    contractId: subscription.metronomeContractId,
+    userId,
+    workspaceId: workspace.sId,
+  });
+}
+
+/**
+ * Create a membership with tracking, audit logging, and Metronome seat provisioning.
+ */
+export async function createAndTrackMembership({
+  user,
+  workspace,
+  role,
+  origin,
+}: {
+  user: UserResource;
+  workspace: WorkspaceResource | WorkspaceModel | LightWorkspaceType;
+  role: ActiveRoleType;
+  origin: MembershipOriginType;
+}) {
+  const w =
+    workspace instanceof WorkspaceModel ||
+    workspace instanceof WorkspaceResource
+      ? renderLightWorkspaceType({ workspace })
+      : workspace;
+  const m = await MembershipResource.createMembership({
+    role,
+    user,
+    workspace: w,
+    origin,
+  });
+
+  void ServerSideTracking.trackCreateMembership({
+    user: user.toJSON(),
+    workspace: w,
+    role: m.role,
+    startAt: m.startAt,
+  });
+
+  void emitAuditLogEventDirect({
+    workspace: w,
+    action: "membership.created",
+    actor: {
+      type: "user",
+      id: user.sId,
+      name: user.fullName() ?? "unknown",
+    },
+    targets: [
+      buildAuditLogTarget("workspace", w),
+      buildAuditLogTarget("user", {
+        sId: user.sId,
+        name: user.fullName() ?? "unknown",
+      }),
+    ],
+    context: { location: "internal" },
+    metadata: {
+      role,
+      origin,
+    },
+  });
+
+  // Update workspace subscription usage when a new user joins.
+  await launchUpdateUsageWorkflow({ workspaceId: workspace.sId });
+
+  // Add seat in Metronome if workspace is Metronome-billed.
+  const addSeatResult = await addSeatForWorkspace(w, user.sId);
+  if (addSeatResult.isErr()) {
+    logger.error(
+      {
+        panic: true,
+        workspaceId: workspace.sId,
+        userId: user.sId,
+        error: addSeatResult.error,
+      },
+      "Failed to add seat for new member"
+    );
+  }
+
+  return m;
+}
 
 export async function revokeAndTrackMembership(
   auth: Authenticator,
   user: UserResource,
-  transaction?: Transaction
+  {
+    transaction,
+    allowLastAdminRevocation = false,
+  }: {
+    transaction?: Transaction;
+    allowLastAdminRevocation?: boolean;
+  } = {}
 ) {
   const workspace = auth.getNonNullableWorkspace();
 
@@ -23,6 +162,7 @@ export async function revokeAndTrackMembership(
     user,
     workspace,
     transaction,
+    allowLastAdminRevocation,
   });
 
   if (revokeResult.isOk()) {
@@ -65,7 +205,101 @@ export async function revokeAndTrackMembership(
         previousRole: revokeResult.value.role,
       },
     });
+
+    // Remove seat in Metronome if workspace is Metronome-billed.
+    const removeSeatResult = await removeSeatForWorkspace(workspace, user.sId);
+    if (removeSeatResult.isErr()) {
+      logger.error(
+        {
+          panic: true,
+          workspaceId: workspace.sId,
+          userId: user.sId,
+          error: removeSeatResult.error,
+        },
+        "Failed to remove seat for revoked member"
+      );
+    }
   }
 
   return revokeResult;
+}
+
+/**
+ * Update a membership role with tracking and Metronome seat provisioning.
+ * If the membership was revoked and is being re-activated (allowTerminated),
+ * automatically adds a Metronome seat.
+ */
+export async function updateMembershipRoleAndTrack({
+  user,
+  workspace,
+  newRole,
+  allowTerminated = false,
+  allowLastAdminRemoval = false,
+  author,
+}: {
+  user: UserResource;
+  workspace: LightWorkspaceType;
+  newRole: Exclude<MembershipRoleType, "revoked">;
+  allowTerminated?: boolean;
+  allowLastAdminRemoval?: boolean;
+  author: UserType | "no-author";
+}): Promise<
+  Result<
+    { previousRole: MembershipRoleType; newRole: MembershipRoleType },
+    {
+      type:
+        | "not_found"
+        | "already_on_role"
+        | "membership_already_terminated"
+        | "last_admin";
+    }
+  >
+> {
+  // Check if the membership is currently revoked (for seat provisioning after re-activation).
+  let wasRevoked = false;
+  if (allowTerminated) {
+    const currentMembership =
+      await MembershipResource.getLatestMembershipOfUserInWorkspace({
+        user,
+        workspace,
+      });
+    wasRevoked = currentMembership?.isRevoked() ?? false;
+  }
+
+  const updateRes = await MembershipResource.updateMembershipRole({
+    user,
+    workspace,
+    newRole,
+    allowTerminated,
+    allowLastAdminRemoval,
+    author,
+  });
+
+  if (updateRes.isOk()) {
+    void ServerSideTracking.trackUpdateMembershipRole({
+      user: user.toJSON(),
+      workspace,
+      previousRole: updateRes.value.previousRole,
+      role: updateRes.value.newRole,
+    });
+
+    // If a revoked membership was re-activated, add a Metronome seat and update usage.
+    if (wasRevoked) {
+      const addSeatResult = await addSeatForWorkspace(workspace, user.sId);
+      if (addSeatResult.isErr()) {
+        logger.error(
+          {
+            panic: true,
+            workspaceId: workspace.sId,
+            userId: user.sId,
+            error: addSeatResult.error,
+          },
+          "Failed to add seat for re-activated member"
+        );
+      }
+      await launchUpdateUsageWorkflow({ workspaceId: workspace.sId });
+    }
+  }
+
+  return updateRes;
 }

--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -1,7 +1,7 @@
 import {
-  buildAuditLogTarget,
-  emitAuditLogEventDirect,
-} from "@app/lib/api/audit/workos_audit";
+  createAndTrackMembership,
+  updateMembershipRoleAndTrack,
+} from "@app/lib/api/membership";
 import { evaluateWorkspaceSeatAvailability } from "@app/lib/api/workspace";
 import { AuthFlowError, SSOEnforcedError } from "@app/lib/iam/errors";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -11,77 +11,15 @@ import {
 } from "@app/lib/iam/workspaces";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { ServerSideTracking } from "@app/lib/tracking/server";
 import type { UTMParams } from "@app/lib/utils/utm";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
-import type { MembershipOriginType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { ActiveRoleType, LightWorkspaceType } from "@app/types/user";
-
-export async function createAndLogMembership({
-  user,
-  workspace,
-  role,
-  origin,
-}: {
-  user: UserResource;
-  workspace: WorkspaceResource | WorkspaceModel | LightWorkspaceType;
-  role: ActiveRoleType;
-  origin: MembershipOriginType;
-}) {
-  const w =
-    workspace instanceof WorkspaceModel ||
-    workspace instanceof WorkspaceResource
-      ? renderLightWorkspaceType({ workspace })
-      : workspace;
-  const m = await MembershipResource.createMembership({
-    role,
-    user,
-    workspace: w,
-    origin,
-  });
-
-  void ServerSideTracking.trackCreateMembership({
-    user: user.toJSON(),
-    workspace: w,
-    role: m.role,
-    startAt: m.startAt,
-  });
-
-  void emitAuditLogEventDirect({
-    workspace: w,
-    action: "membership.created",
-    actor: {
-      type: "user",
-      id: user.sId,
-      name: user.fullName() ?? "unknown",
-    },
-    targets: [
-      buildAuditLogTarget("workspace", w),
-      buildAuditLogTarget("user", {
-        sId: user.sId,
-        name: user.fullName() ?? "unknown",
-      }),
-    ],
-    context: { location: "internal" },
-    metadata: {
-      role,
-      origin,
-    },
-  });
-
-  // Update workspace subscription usage when a new user joins.
-  await launchUpdateUsageWorkflow({ workspaceId: workspace.sId });
-
-  return m;
-}
+import type { LightWorkspaceType } from "@app/types/user";
 
 // `membershipInvite` flow: we know we can add the user to the associated `workspaceId` as all the
 // checks (decoding the JWT) have been run before. Simply create the membership if it does not
@@ -144,7 +82,7 @@ export async function handleMembershipInvite({
   });
 
   if (m?.isRevoked()) {
-    const updateRes = await MembershipResource.updateMembershipRole({
+    const updateRes = await updateMembershipRoleAndTrack({
       user,
       workspace: lightWorkspace,
       newRole: membershipInvite.initialRole,
@@ -160,17 +98,10 @@ export async function handleMembershipInvite({
         )
       );
     }
-
-    void ServerSideTracking.trackUpdateMembershipRole({
-      user: user.toJSON(),
-      workspace: lightWorkspace,
-      previousRole: updateRes.value.previousRole,
-      role: updateRes.value.newRole,
-    });
   }
 
   if (!m) {
-    await createAndLogMembership({
+    await createAndTrackMembership({
       workspace: lightWorkspace,
       user,
       role: membershipInvite.initialRole,
@@ -226,7 +157,7 @@ export async function handleEnterpriseSignUpFlow(
   // Initialize membership if it's not present or has been previously revoked. In the case of
   // enterprise connections, Dust access is overridden by the identity management service.
   if (!membership || membership.isRevoked()) {
-    await createAndLogMembership({
+    await createAndTrackMembership({
       workspace: lightWorkspace,
       user,
       role: pendingMembershipInvitation?.initialRole ?? "user",
@@ -339,7 +270,7 @@ export async function handleRegularSignupFlow(
     }
 
     if (!m) {
-      await createAndLogMembership({
+      await createAndTrackMembership({
         workspace: lightWorkspace,
         user,
         role: "user",
@@ -351,7 +282,7 @@ export async function handleRegularSignupFlow(
   } else if (!targetWorkspace && activeMemberships.length === 0) {
     const workspace = await createWorkspace(session, utmParams);
     const lightWorkspace = renderLightWorkspaceType({ workspace });
-    await createAndLogMembership({
+    await createAndTrackMembership({
       workspace: lightWorkspace,
       user,
       role: "admin",

--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -1,7 +1,7 @@
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/client";
+import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -67,8 +67,7 @@ export async function handleMetronomeSetupCheckout({
   }
 
   const provisionResult = await provisionMetronomeCustomerAndContract({
-    workspaceId: workspace.sId,
-    workspaceName: workspace.name,
+    workspace: renderLightWorkspaceType({ workspace }),
     stripeCustomerId,
     packageAlias: metronomePackageAlias,
     uniquenessKey: sessionId,

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -169,13 +169,15 @@ export async function createMetronomeContract({
   metronomeCustomerId: string;
   packageAlias: string;
   uniquenessKey: string;
-}): Promise<Result<{ contractId: string }, Error>> {
+}): Promise<Result<{ contractId: string; startingAt: string }, Error>> {
+  // Metronome requires starting_at on an hour boundary — round down to current hour.
+  const startingAt = floorToHourISO(new Date());
+
   try {
     const response = await getMetronomeClient().v1.contracts.create({
       customer_id: metronomeCustomerId,
       package_alias: packageAlias,
-      // Metronome requires starting_at on an hour boundary — round down to current hour.
-      starting_at: floorToHourISO(new Date()),
+      starting_at: startingAt,
       uniqueness_key: uniquenessKey,
     });
 
@@ -187,13 +189,16 @@ export async function createMetronomeContract({
       },
       "[Metronome] Contract created"
     );
-    return new Ok({ contractId: response.data.id });
+    return new Ok({ contractId: response.data.id, startingAt });
   } catch (err) {
     if (err instanceof ConflictError) {
       const existingContract =
         await getMetronomeActiveContract(metronomeCustomerId);
       if (existingContract.isOk() && existingContract.value) {
-        return new Ok({ contractId: existingContract.value.contractId });
+        return new Ok({
+          contractId: existingContract.value.contractId,
+          startingAt,
+        });
       }
     }
 
@@ -204,61 +209,6 @@ export async function createMetronomeContract({
     );
     return new Err(error);
   }
-}
-
-/**
- * Ensure a Metronome customer and contract exist for a workspace.
- * Creates the customer if missing, then creates a contract via the package alias.
- * Used from both Stripe webhook (checkout) and Poke (admin upgrade).
- */
-export async function provisionMetronomeCustomerAndContract({
-  workspaceId,
-  workspaceName,
-  stripeCustomerId,
-  packageAlias,
-  uniquenessKey,
-}: {
-  workspaceId: string;
-  workspaceName: string;
-  stripeCustomerId: string;
-  packageAlias: string;
-  uniquenessKey: string;
-}): Promise<
-  Result<{ metronomeCustomerId: string; metronomeContractId: string }, Error>
-> {
-  // Find or create customer.
-  let metronomeCustomerId: string | null = null;
-
-  const findResult = await findMetronomeCustomerByAlias(workspaceId);
-  if (findResult.isOk()) {
-    metronomeCustomerId = findResult.value;
-  }
-
-  if (!metronomeCustomerId) {
-    const createResult = await createMetronomeCustomer({
-      workspaceId,
-      workspaceName,
-      stripeCustomerId,
-    });
-    if (createResult.isErr()) {
-      return new Err(createResult.error);
-    }
-    metronomeCustomerId = createResult.value.metronomeCustomerId;
-  }
-
-  const contractResult = await createMetronomeContract({
-    metronomeCustomerId,
-    packageAlias,
-    uniquenessKey,
-  });
-  if (contractResult.isErr()) {
-    return new Err(contractResult.error);
-  }
-
-  return new Ok({
-    metronomeCustomerId,
-    metronomeContractId: contractResult.value.contractId,
-  });
 }
 
 /**
@@ -311,27 +261,26 @@ export async function getMetronomeActiveContract(
 }
 
 /**
- * End (cancel) a Metronome contract.
- * Pass endingBefore to end at a specific time, or omit to make the contract open-ended.
+ * End (cancel) a Metronome contract at the next hour boundary.
+ * Metronome requires ending_before on an hour boundary; we ceil to avoid
+ * dropping usage in the current partial hour.
  */
 export async function endMetronomeContract({
   metronomeCustomerId,
   contractId,
-  endingBefore,
 }: {
   metronomeCustomerId: string;
   contractId: string;
-  endingBefore?: string;
 }): Promise<Result<void, Error>> {
   try {
     await getMetronomeClient().v1.contracts.updateEndDate({
       customer_id: metronomeCustomerId,
       contract_id: contractId,
-      ...(endingBefore ? { ending_before: endingBefore } : {}),
+      ending_before: ceilToHourISO(new Date()),
     });
 
     logger.info(
-      { metronomeCustomerId, contractId, endingBefore },
+      { metronomeCustomerId, contractId },
       "[Metronome] Contract ended"
     );
     return new Ok(undefined);
@@ -404,12 +353,15 @@ export async function editMetronomeContractSeats({
   metronomeCustomerId,
   contractId,
   edits,
+  startingAt,
 }: {
   metronomeCustomerId: string;
   contractId: string;
   edits: SeatSubscriptionEdit[];
+  startingAt?: string;
 }): Promise<Result<void, Error>> {
-  const now = new Date().toISOString();
+  // Metronome requires starting_at on an hour boundary — round down to current hour.
+  const now = startingAt ?? floorToHourISO(new Date());
 
   try {
     await getMetronomeClient().v2.contracts.edit({

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -1,0 +1,72 @@
+import {
+  createMetronomeContract,
+  createMetronomeCustomer,
+  findMetronomeCustomerByAlias,
+} from "@app/lib/metronome/client";
+import { provisionSeatsForContract } from "@app/lib/metronome/seats";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+
+/**
+ * Ensure a Metronome customer and contract exist for a workspace.
+ * Creates the customer if missing, then creates a contract via the package alias.
+ * Used from both Stripe webhook (checkout) and Poke (admin upgrade).
+ */
+export async function provisionMetronomeCustomerAndContract({
+  workspace,
+  stripeCustomerId,
+  packageAlias,
+  uniquenessKey,
+}: {
+  workspace: LightWorkspaceType;
+  stripeCustomerId: string;
+  packageAlias: string;
+  uniquenessKey: string;
+}): Promise<
+  Result<{ metronomeCustomerId: string; metronomeContractId: string }, Error>
+> {
+  // Find or create customer.
+  let metronomeCustomerId: string | null = null;
+
+  const findResult = await findMetronomeCustomerByAlias(workspace.sId);
+  if (findResult.isOk()) {
+    metronomeCustomerId = findResult.value;
+  }
+
+  if (!metronomeCustomerId) {
+    const createResult = await createMetronomeCustomer({
+      workspaceId: workspace.sId,
+      workspaceName: workspace.name,
+      stripeCustomerId,
+    });
+    if (createResult.isErr()) {
+      return new Err(createResult.error);
+    }
+    metronomeCustomerId = createResult.value.metronomeCustomerId;
+  }
+
+  const contractResult = await createMetronomeContract({
+    metronomeCustomerId,
+    packageAlias,
+    uniquenessKey,
+  });
+  if (contractResult.isErr()) {
+    return new Err(contractResult.error);
+  }
+
+  const { contractId: metronomeContractId, startingAt } = contractResult.value;
+
+  // Provision all existing workspace members as seats on the new contract.
+  await provisionSeatsForContract({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+    workspace,
+    startingAt,
+  });
+
+  return new Ok({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+}

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1,0 +1,143 @@
+import {
+  editMetronomeContractSeats,
+  getMetronomeClient,
+} from "@app/lib/metronome/client";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+
+/**
+ * Find the default SEAT_BASED subscription on a contract.
+ * For legacy packages there's only one; for new pricing, this returns the first
+ * SEAT_BASED subscription (Guest/Pro/Max — caller decides which to use).
+ */
+export async function getDefaultSeatProductId(
+  metronomeCustomerId: string,
+  contractId: string
+): Promise<string | undefined> {
+  const client = getMetronomeClient();
+  const response = await client.v2.contracts.list({
+    customer_id: metronomeCustomerId,
+  });
+  const contract = response.data.find((c) => c.id === contractId);
+  if (!contract?.subscriptions?.length) {
+    return undefined;
+  }
+
+  const seatSub = contract.subscriptions.find(
+    (s) => s.quantity_management_mode === "SEAT_BASED"
+  );
+  return seatSub?.id ?? undefined;
+}
+
+/**
+ * Add a single member as a seat on a contract's default seat subscription.
+ * Called from membership create hook.
+ */
+export async function addSeat({
+  metronomeCustomerId,
+  contractId,
+  userId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  userId: string;
+  workspaceId: string;
+}): Promise<Result<void, Error>> {
+  const seatProductId = await getDefaultSeatProductId(
+    metronomeCustomerId,
+    contractId
+  );
+  if (!seatProductId) {
+    return new Err(new Error("No SEAT_BASED subscription found on contract"));
+  }
+
+  return await editMetronomeContractSeats({
+    metronomeCustomerId,
+    contractId,
+    edits: [{ subscriptionId: seatProductId, addSeatIds: [userId] }],
+  });
+}
+
+/**
+ * Remove a single member's seat from a contract.
+ * Called from membership revoke hook.
+ */
+export async function removeSeat({
+  metronomeCustomerId,
+  contractId,
+  userId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  userId: string;
+  workspaceId: string;
+}): Promise<Result<void, Error>> {
+  const seatProductId = await getDefaultSeatProductId(
+    metronomeCustomerId,
+    contractId
+  );
+  if (!seatProductId) {
+    return new Err(new Error("No SEAT_BASED subscription found on contract"));
+  }
+
+  return await editMetronomeContractSeats({
+    metronomeCustomerId,
+    contractId,
+    edits: [{ subscriptionId: seatProductId, removeSeatIds: [userId] }],
+  });
+}
+
+/**
+ * Add all active workspace members as seats on a contract's default seat subscription.
+ * Called after contract creation (both new provisioning and migration).
+ */
+export async function provisionSeatsForContract({
+  metronomeCustomerId,
+  contractId,
+  workspace,
+  startingAt,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  workspace: LightWorkspaceType;
+  startingAt: string;
+}): Promise<Result<void, Error>> {
+  const subscriptionId = await getDefaultSeatProductId(
+    metronomeCustomerId,
+    contractId
+  );
+  if (!subscriptionId) {
+    logger.warn(
+      { workspaceId: workspace.sId, contractId },
+      "[Metronome] No SEAT_BASED subscription found on contract — cannot provision seats"
+    );
+    return new Err(new Error("No SEAT_BASED subscription found on contract"));
+  }
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+  });
+  const memberIds = memberships
+    .map((m) => m.user?.sId)
+    .filter((s): s is string => !!s);
+
+  if (memberIds.length === 0) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "[Metronome] No active members — no seats to provision"
+    );
+    return new Ok(undefined);
+  }
+
+  return await editMetronomeContractSeats({
+    metronomeCustomerId,
+    contractId,
+    edits: [{ subscriptionId, addSeatIds: memberIds }],
+    startingAt,
+  });
+}

--- a/front/pages/api/create-new-workspace.ts
+++ b/front/pages/api/create-new-workspace.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { createAndLogMembership } from "@app/lib/api/signup";
+import { createAndTrackMembership } from "@app/lib/api/membership";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { createWorkspace } from "@app/lib/iam/workspaces";
@@ -59,7 +59,7 @@ async function handler(
     });
   }
 
-  await createAndLogMembership({
+  await createAndTrackMembership({
     user: u,
     workspace,
     role: "admin",

--- a/front/pages/api/poke/workspaces/[wId]/roles.ts
+++ b/front/pages/api/poke/workspaces/[wId]/roles.ts
@@ -5,11 +5,10 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { updateMembershipRoleAndTrack } from "@app/lib/api/membership";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { MembershipResource } from "@app/lib/resources/membership_resource";
-import { ServerSideTracking } from "@app/lib/tracking/server";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -75,11 +74,10 @@ async function handler(
         });
       }
 
-      const updateRes = await MembershipResource.updateMembershipRole({
+      const updateRes = await updateMembershipRoleAndTrack({
         user,
         workspace: owner,
         newRole: role,
-        // We allow to re-activate a terminated membership when updating the role here.
         allowTerminated: true,
         author: auth.user()?.toJSON() ?? "no-author",
       });
@@ -115,13 +113,6 @@ async function handler(
       }
 
       if (updateRes.isOk()) {
-        void ServerSideTracking.trackUpdateMembershipRole({
-          user: user.toJSON(),
-          workspace: owner,
-          previousRole: updateRes.value.previousRole,
-          role: updateRes.value.newRole,
-        });
-
         void emitAuditLogEvent({
           auth,
           action: "membership.role_updated",

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -27,8 +27,8 @@ import { handleMetronomeSetupCheckout } from "@app/lib/metronome/checkout";
 import {
   createMetronomeCredit,
   getMetronomeActiveContract,
-  provisionMetronomeCustomerAndContract,
 } from "@app/lib/metronome/client";
+import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
@@ -126,8 +126,7 @@ async function shadowProvisionMetronome({
 }): Promise<void> {
   try {
     const result = await provisionMetronomeCustomerAndContract({
-      workspaceId: workspace.sId,
-      workspaceName: workspace.name,
+      workspace: renderLightWorkspaceType({ workspace }),
       stripeCustomerId,
       packageAlias: metronomePackageAlias,
       uniquenessKey: sessionId,

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -5,13 +5,15 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { revokeAndTrackMembership } from "@app/lib/api/membership";
+import {
+  revokeAndTrackMembership,
+  updateMembershipRoleAndTrack,
+} from "@app/lib/api/membership";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { showDebugTools } from "@app/lib/development";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -203,11 +205,10 @@ async function handler(
 
         const allowLastAdminRemoval = showDebugTools(featureFlags);
 
-        const updateRes = await MembershipResource.updateMembershipRole({
+        const updateRes = await updateMembershipRoleAndTrack({
           user,
           workspace: owner,
           newRole: role,
-          // We allow to re-activate a terminated membership when updating the role here.
           allowTerminated: true,
           allowLastAdminRemoval,
           author: auth.user()?.toJSON() ?? "no-author",
@@ -244,13 +245,6 @@ async function handler(
         }
 
         if (updateRes.isOk()) {
-          void ServerSideTracking.trackUpdateMembershipRole({
-            user: user.toJSON(),
-            workspace: owner,
-            previousRole: updateRes.value.previousRole,
-            role: updateRes.value.newRole,
-          });
-
           void emitAuditLogEvent({
             auth,
             action: "membership.role_updated",

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -7,6 +7,7 @@ import { deleteWebhookSource } from "@app/lib/api/webhook_source";
 import { deleteWorksOSOrganizationWithWorkspace } from "@app/lib/api/workos/organization";
 import { areAllSubscriptionsCanceled } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
+import { endMetronomeContract } from "@app/lib/metronome/client";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import {
   AgentChildAgentConfigurationModel,
@@ -63,6 +64,7 @@ import {
 } from "@app/lib/resources/storage/models/user";
 import { UserProjectDigestModel } from "@app/lib/resources/storage/models/user_project_digest";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -711,6 +713,28 @@ export async function deleteWorkspaceActivity({
     return;
   }
   const workspace = auth.getNonNullableWorkspace();
+
+  // End the Metronome contract if one exists.
+  if (workspace.metronomeCustomerId) {
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    const subscription = workspaceResource
+      ? await SubscriptionResource.fetchActiveByWorkspaceModelId(
+          workspaceResource.id
+        )
+      : null;
+    if (subscription?.metronomeContractId) {
+      const endResult = await endMetronomeContract({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        contractId: subscription.metronomeContractId,
+      });
+      if (endResult.isErr()) {
+        hardDeleteLogger.error(
+          { workspaceId, error: endResult.error.message },
+          "Failed to end Metronome contract"
+        );
+      }
+    }
+  }
 
   await SubscriptionModel.destroy({
     where: {

--- a/front/scripts/dev/create_test_workspaces.ts
+++ b/front/scripts/dev/create_test_workspaces.ts
@@ -1,4 +1,4 @@
-import { createAndLogMembership } from "@app/lib/api/signup";
+import { createAndTrackMembership } from "@app/lib/api/membership";
 import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
 import { PlanModel } from "@app/lib/models/plan";
 import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
@@ -63,7 +63,7 @@ async function createTestWorkspaces(
 
     logger.info(`Workspace ${name} created.`);
 
-    await createAndLogMembership({
+    await createAndTrackMembership({
       user,
       workspace,
       role: "admin",

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -10,7 +10,7 @@
  * Requires: METRONOME_API_KEY env var
  */
 
-import Metronome from "@metronome/sdk";
+import { getMetronomeClient } from "@app/lib/metronome/client";
 
 if (!process.env.METRONOME_API_KEY) {
   console.error("METRONOME_API_KEY env var required");
@@ -20,9 +20,7 @@ if (!process.env.METRONOME_API_KEY) {
 const ENV =
   process.env.METRONOME_ENV === "production" ? "production" : "sandbox";
 
-const client = new Metronome({
-  bearerToken: process.env.METRONOME_API_KEY,
-});
+const client = getMetronomeClient();
 
 // Credit type IDs per environment (created via Metronome UI, not API-manageable).
 const CREDIT_TYPES = {
@@ -242,7 +240,7 @@ const PRODUCTS: ProductDef[] = [
   // Legacy seat product — SUBSCRIPTION type, managed via Metronome seat subscriptions.
   // Seats synced from membership create/revoke hooks (same as new pricing).
   {
-    name: "Legacy Seat",
+    name: "Workspace Seat",
     type: "SUBSCRIPTION",
   },
   // MAU products — USAGE on MAX gauge, billed once at end of period.
@@ -285,7 +283,7 @@ const RATE_CARDS: RateCardDef[] = [
     fiat_credit_type_id: USD_CREDIT_TYPE_ID,
     rates: [
       {
-        product_name: "Legacy Seat",
+        product_name: "Workspace Seat",
         starting_at: "2026-04-01T00:00:00.000Z",
         entitled: true,
         rate_type: "FLAT",
@@ -309,7 +307,7 @@ const RATE_CARDS: RateCardDef[] = [
     fiat_credit_type_id: USD_CREDIT_TYPE_ID,
     rates: [
       {
-        product_name: "Legacy Seat",
+        product_name: "Workspace Seat",
         starting_at: "2026-04-01T00:00:00.000Z",
         entitled: true,
         rate_type: "FLAT",
@@ -330,7 +328,7 @@ const RATE_CARDS: RateCardDef[] = [
 // Seat subscription definition shared by all legacy packages.
 const LEGACY_SEAT_SUBSCRIPTION: PackageSubscription = {
   temporary_id: "legacy-seat-sub",
-  product_name: "Legacy Seat",
+  product_name: "Workspace Seat",
   billing_frequency: "MONTHLY",
   collection_schedule: "ADVANCE",
   quantity_management_mode: "SEAT_BASED",

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -12,6 +12,8 @@
  * Without --execute, runs in dry-run mode (logs what would happen, no changes).
  */
 
+import { getMetronomeClient } from "@app/lib/metronome/client";
+import { provisionSeatsForContract } from "@app/lib/metronome/seats";
 import {
   LEGACY_BUSINESS_39_PACKAGE_ALIAS,
   LEGACY_PRO_29_PACKAGE_ALIAS,
@@ -26,7 +28,6 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
 import type { LightWorkspaceType } from "@app/types/user";
-import Metronome from "@metronome/sdk";
 import { makeScript } from "./helpers";
 import { runOnAllWorkspaces } from "./workspace_helpers";
 
@@ -34,10 +35,6 @@ const plansCodeToPackageAlias: Record<string, string> = {
   [PRO_PLAN_SEAT_29_CODE]: LEGACY_PRO_29_PACKAGE_ALIAS,
   [PRO_PLAN_SEAT_39_CODE]: LEGACY_BUSINESS_39_PACKAGE_ALIAS,
 };
-
-const client = new Metronome({
-  bearerToken: process.env.METRONOME_API_KEY,
-});
 
 // Map from old alias → current alias.
 const ALIAS_MIGRATION: Record<string, string> = {
@@ -54,6 +51,7 @@ async function getPackageInfo(): Promise<{
   aliasToPackageId: Record<string, string>;
   packageIdToAlias: Record<string, string>;
 }> {
+  const client = getMetronomeClient();
   const aliasToPackageId: Record<string, string> = {};
   const packageIdToAlias: Record<string, string> = {};
 
@@ -141,6 +139,7 @@ async function migrateWorkspace(
   },
   packageAliasFilter?: string
 ): Promise<void> {
+  const client = getMetronomeClient();
   const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
   if (!workspaceResource?.metronomeCustomerId) {
     return; // No Metronome customer — skip.
@@ -221,6 +220,14 @@ async function migrateWorkspace(
       },
       "New contract created (aligned to Stripe subscription start)"
     );
+
+    // Provision seats for all existing members.
+    await provisionSeatsForContract({
+      metronomeCustomerId,
+      contractId: newContractId,
+      workspace,
+      startingAt: subInfo.startDate,
+    });
 
     // Update metronomeContractId on the subscription.
     await SubscriptionResource.updateMetronomeContractId(
@@ -350,6 +357,14 @@ async function migrateWorkspace(
       "New contract created (supersedes old, credits/commits rolled over)"
     );
 
+    // Provision seats for all existing members on the new contract.
+    await provisionSeatsForContract({
+      metronomeCustomerId,
+      contractId: newContractId,
+      workspace,
+      startingAt: contract.starting_at,
+    });
+
     // Update metronomeContractId on the active subscription.
     const activeSubscription =
       await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
@@ -393,11 +408,6 @@ makeScript(
     },
   },
   async (args, logger) => {
-    if (!process.env.METRONOME_API_KEY) {
-      logger.error("METRONOME_API_KEY env var required");
-      return;
-    }
-
     const packageAliasFilter = args.packageAlias;
     if (packageAliasFilter) {
       logger.info(

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -2,7 +2,10 @@ import {
   buildAuditLogTarget,
   emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
-import { createAndLogMembership } from "@app/lib/api/signup";
+import {
+  createAndTrackMembership,
+  revokeAndTrackMembership,
+} from "@app/lib/api/membership";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import { determineUserRoleFromGroups } from "@app/lib/api/user";
 import { getWorkOS } from "@app/lib/api/workos/client";
@@ -30,7 +33,6 @@ import {
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
@@ -1044,7 +1046,7 @@ async function handleCreateOrUpdateWorkOSUser(
     return;
   }
 
-  await createAndLogMembership({
+  await createAndTrackMembership({
     user: createdOrUpdatedUser,
     workspace,
     role: "user",
@@ -1124,9 +1126,7 @@ async function handleDeleteWorkOSUser(
     }
   }
 
-  const membershipRevokeResult = await MembershipResource.revokeMembership({
-    user,
-    workspace,
+  const membershipRevokeResult = await revokeAndTrackMembership(auth, user, {
     allowLastAdminRevocation: true,
   });
 
@@ -1144,27 +1144,7 @@ async function handleDeleteWorkOSUser(
     throw membershipRevokeResult.error;
   }
 
-  const deleteTriggerResult = await TriggerResource.deleteAllForUser(
-    auth,
-    user
-  );
-  if (deleteTriggerResult.isErr()) {
-    logger.error(
-      {
-        workspaceId: workspace.sId,
-        userId: user.sId,
-        error: deleteTriggerResult.error,
-      },
-      "Failed to delete triggers for revoked user"
-    );
-  }
-
-  void ServerSideTracking.trackRevokeMembership({
-    user: user.toJSON(),
-    workspace,
-    ...membershipRevokeResult.value,
-  });
-
+  // Emit SCIM-specific audit event in addition to the generic membership.revoked.
   void emitAuditLogEventDirect({
     workspace,
     action: "scim.user_deprovisioned",


### PR DESCRIPTION
## Summary

Consolidates all membership mutation side effects (tracking, audit logging, Metronome seat management) into three wrapper functions in `lib/api/membership.ts`. Ensures every code path that creates, revokes, or re-activates a membership also manages the corresponding Metronome seat.

### Membership wrappers (`lib/api/membership.ts`)

- **`createAndTrackMembership`** (moved from `signup.ts`): create + tracking + audit + `addSeat` (fire-and-forget)
- **`revokeAndTrackMembership`** (extended): revoke + triggers + tracking + audit + `removeSeat`. Now accepts `allowLastAdminRevocation` option for SCIM deprovisioning
- **`updateMembershipRoleAndTrack`** (new): role update + tracking + `addSeat` on re-activation (detects revoked state before update)

### Callers updated to use wrappers

| Path | Wrapper |
|------|---------|
| Signup, invite, enterprise join, SCIM provisioning | `createAndTrackMembership` |
| Admin revoke, poke revoke | `revokeAndTrackMembership` |
| SCIM deprovisioning | `revokeAndTrackMembership` (with `allowLastAdminRevocation: true`) |
| Admin role change (`/members/[uId]`) | `updateMembershipRoleAndTrack` |
| Poke role change (`/poke/.../roles`) | `updateMembershipRoleAndTrack` |
| Invite re-activation | `updateMembershipRoleAndTrack` |

### Seat management (`lib/metronome/seats.ts`)

- `addSeat` / `removeSeat` — single seat add/remove on contract's default SEAT_BASED subscription
- `getDefaultSeatSubscriptionId` — finds SEAT_BASED subscription via V2 API

### Contract provisioning (`lib/metronome/client.ts`)

- `provisionSeatsForContract` — bulk seat assignment after contract creation, called inside `provisionMetronomeCustomerAndContract`
- Seats provisioned with `startingAt` matching contract start (avoids proration on first invoice)
- `editMetronomeContractSeats` now accepts optional `startingAt` parameter
- Shared `getMetronomeClient()` singleton exported for all Metronome SDK access

### Workspace deletion (`poke/temporal/activities.ts`)

- Ends Metronome contract via `endMetronomeContract` before destroying subscriptions

### Other changes

- `metronome_setup.ts`: Uses shared `getMetronomeClient()`, renamed "Legacy Seat" → "Workspace Seat" (customer-facing product name)
- `migrate_metronome_contracts.ts`: Uses `provisionSeatsForContract` from `client.ts` instead of inline implementation

## Test plan

- [ ] Create a membership → verify seat added in Metronome
- [ ] Revoke a membership → verify seat removed
- [ ] Re-activate a revoked membership via role update → verify seat added
- [ ] SCIM deprovisioning → verify seat removed
- [ ] Contract creation → verify all existing members provisioned as seats
- [ ] Workspace deletion → verify contract ended

🤖 Generated with [Claude Code](https://claude.com/claude-code)