### PR TITLE
Update contracts / add annual

### DIFF
--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -9,12 +9,14 @@ import type { Commit, Credit } from "@metronome/sdk/resources/shared";
 
 // Metronome package aliases for contract provisioning.
 // These map to packages configured in the Metronome dashboard.
-export const LEGACY_PRO_29_PACKAGE_ALIAS = "legacy-pro-29";
-export const LEGACY_BUSINESS_39_PACKAGE_ALIAS = "legacy-business-39";
+export const LEGACY_PRO_MONTHLY_PACKAGE_ALIAS = "legacy-pro-monthly";
+export const LEGACY_PRO_ANNUAL_PACKAGE_ALIAS = "legacy-pro-annual";
+export const LEGACY_BUSINESS_PACKAGE_ALIAS = "legacy-business";
 
 export const PRO_OR_BUSINESS_PACKAGE_ALIASES: ReadonlySet<string> = new Set([
-  LEGACY_PRO_29_PACKAGE_ALIAS,
-  LEGACY_BUSINESS_39_PACKAGE_ALIAS,
+  LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
+  LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
+  LEGACY_BUSINESS_PACKAGE_ALIAS,
 ]);
 
 export interface MetronomeEvent {

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -9,8 +9,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { getMetronomeContractPackageAliases } from "@app/lib/metronome/client";
 import {
-  LEGACY_BUSINESS_39_PACKAGE_ALIAS,
-  LEGACY_PRO_29_PACKAGE_ALIAS,
+  LEGACY_BUSINESS_PACKAGE_ALIAS,
+  LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
   PRO_OR_BUSINESS_PACKAGE_ALIASES,
 } from "@app/lib/metronome/types";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -908,12 +908,12 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
               "card",
               "sepa_debit",
             ] satisfies SupportedPaymentMethod[],
-            metronomePackageAlias: LEGACY_BUSINESS_39_PACKAGE_ALIAS,
+            metronomePackageAlias: LEGACY_BUSINESS_PACKAGE_ALIAS,
           }
         : {
             planCode: PRO_PLAN_SEAT_29_CODE,
             allowedPaymentMethods: ["card"] satisfies SupportedPaymentMethod[],
-            metronomePackageAlias: LEGACY_PRO_29_PACKAGE_ALIAS,
+            metronomePackageAlias: LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
           };
 
     const proPlan = await SubscriptionResource.findPlanOrThrow(planCode);

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -62,6 +62,10 @@ interface ProductDef {
     conversion_factor: number;
     operation: "DIVIDE" | "MULTIPLY";
   };
+  quantity_rounding?: {
+    decimal_places: number;
+    rounding_method: "ROUND_UP" | "ROUND_DOWN" | "ROUND_HALF_UP";
+  };
   pricing_group_key?: string[];
   presentation_group_key?: string[];
   tags?: string[];
@@ -104,12 +108,10 @@ interface PackageSubscription {
 }
 
 interface PackageDef {
+  // Base name without version suffix. Version is auto-computed at sync time.
   name: string;
   aliases: Array<{ name: string }>;
   rate_card_name: string;
-  // Omit billing_provider + delivery_method for shadow packages (invoices generated but not delivered).
-  billing_provider?: string;
-  delivery_method?: string;
   subscriptions?: PackageSubscription[];
   // Billing cycle anchored to contract start date (matches Stripe subscription anniversary).
   billing_anchor_date?: "contract_start_date" | "first_billing_period";
@@ -206,19 +208,36 @@ const METRICS: MetricDef[] = [
 const USAGE_TAG = "usage";
 
 const PRODUCTS: ProductDef[] = [
-  // Usage products — all tagged "usage" for credit/commit targeting
+  // --- Legacy usage product (USD, 30% markup baked into quantity_conversion) ---
+  {
+    name: "Programmatic Usage",
+    type: "USAGE",
+    billable_metric_name: "LLM Provider Cost (Programmatic)",
+    // Convert cost_micro_usd to billable USD: multiply by 1.3 (30% markup) / 1_000_000 (micro→USD).
+    // The rate card prices at $1.00/unit so the final amount equals the marked-up cost.
+    quantity_conversion: {
+      conversion_factor: 1.3 / 1_000_000,
+      operation: "MULTIPLY",
+    },
+    // Round up to cents (2 decimal places) — never undercharge.
+    quantity_rounding: { decimal_places: 2, rounding_method: "ROUND_UP" },
+    tags: [USAGE_TAG],
+  },
+  // --- New pricing usage products (AWU) ---
+  // 1 AWU = $0.01. AI Usage: cost_micro_usd / 10_000 = AWU (100 AWU per dollar of cost).
+  // Tool Usage: count × tool_weight = AWU (weight configured per tool category in rate card).
   {
     name: "AI Usage (User)",
     type: "USAGE",
     billable_metric_name: "LLM Provider Cost (User)",
-    quantity_conversion: { conversion_factor: 1000000, operation: "DIVIDE" },
+    quantity_conversion: { conversion_factor: 10_000, operation: "DIVIDE" },
     tags: [USAGE_TAG],
   },
   {
     name: "AI Usage (Programmatic)",
     type: "USAGE",
     billable_metric_name: "LLM Provider Cost (Programmatic)",
-    quantity_conversion: { conversion_factor: 1000000, operation: "DIVIDE" },
+    quantity_conversion: { conversion_factor: 10_000, operation: "DIVIDE" },
     tags: [USAGE_TAG],
   },
   {
@@ -279,7 +298,7 @@ const RATE_CARDS: RateCardDef[] = [
     name: "Legacy Pro $29",
     description:
       "Grandfathered Pro plan. $29/seat via seat subscription. AI usage 30% markup.",
-    aliases: [{ name: "legacy-pro-29" }],
+    aliases: [{ name: "legacy-pro-monthly" }],
     fiat_credit_type_id: USD_CREDIT_TYPE_ID,
     rates: [
       {
@@ -291,19 +310,19 @@ const RATE_CARDS: RateCardDef[] = [
         billing_frequency: "MONTHLY",
       },
       {
-        product_name: "AI Usage (Programmatic)",
+        product_name: "Programmatic Usage",
         starting_at: "2026-04-01T00:00:00.000Z",
         entitled: true,
         rate_type: "FLAT",
-        price: 130,
+        price: 100,
       },
     ],
   },
   {
-    name: "Legacy Business $39",
+    name: "Legacy Business $45",
     description:
-      "Grandfathered Business plan. $39/seat via seat subscription. AI usage 30% markup.",
-    aliases: [{ name: "legacy-business-39" }],
+      "Grandfathered Business plan. $45/seat via seat subscription. AI usage 30% markup.",
+    aliases: [{ name: "legacy-business" }],
     fiat_credit_type_id: USD_CREDIT_TYPE_ID,
     rates: [
       {
@@ -311,18 +330,99 @@ const RATE_CARDS: RateCardDef[] = [
         starting_at: "2026-04-01T00:00:00.000Z",
         entitled: true,
         rate_type: "FLAT",
-        price: 3900,
+        price: 4500,
         billing_frequency: "MONTHLY",
       },
       {
-        product_name: "AI Usage (Programmatic)",
+        product_name: "Programmatic Usage",
         starting_at: "2026-04-01T00:00:00.000Z",
         entitled: true,
         rate_type: "FLAT",
-        price: 130,
+        price: 100,
       },
     ],
   },
+  {
+    name: "Legacy Pro $27 Annual",
+    description:
+      "Grandfathered Pro plan (annual). $27/seat/month billed monthly. AI usage 30% markup.",
+    aliases: [{ name: "legacy-pro-annual" }],
+    fiat_credit_type_id: USD_CREDIT_TYPE_ID,
+    rates: [
+      {
+        product_name: "Workspace Seat",
+        starting_at: "2026-04-01T00:00:00.000Z",
+        entitled: true,
+        rate_type: "FLAT",
+        price: 2700,
+        billing_frequency: "MONTHLY",
+      },
+      {
+        product_name: "Programmatic Usage",
+        starting_at: "2026-04-01T00:00:00.000Z",
+        entitled: true,
+        rate_type: "FLAT",
+        price: 100,
+      },
+    ],
+  },
+  // --- Example: New Business plan with AWU-based usage pricing ---
+  // Seats in USD, AI/Tool usage in AWU (1 AWU = $0.01).
+  // This is a template — uncomment and adjust when new pricing goes live.
+  // {
+  //   name: "Business Plan",
+  //   description: "New Business plan. Pro/Max seats in USD, usage in AWU.",
+  //   aliases: [{ name: "business-plan" }],
+  //   fiat_credit_type_id: USD_CREDIT_TYPE_ID,
+  //   credit_type_conversions: [
+  //     { custom_credit_type_id: AWU_CREDIT_TYPE_ID, fiat_per_custom_credit: 0.01 },
+  //   ],
+  //   rates: [
+  //     // Pro Seat — $30/mo in USD
+  //     {
+  //       product_name: "Workspace Seat",
+  //       starting_at: "2026-04-01T00:00:00.000Z",
+  //       entitled: true,
+  //       rate_type: "FLAT",
+  //       price: 3000,
+  //       billing_frequency: "MONTHLY",
+  //     },
+  //     // AI Usage — 1 AWU per unit (quantity already converted from cost_micro_usd)
+  //     {
+  //       product_name: "AI Usage (User)",
+  //       starting_at: "2026-04-01T00:00:00.000Z",
+  //       entitled: true,
+  //       rate_type: "FLAT",
+  //       price: 1,
+  //       credit_type_id: AWU_CREDIT_TYPE_ID,
+  //     },
+  //     {
+  //       product_name: "AI Usage (Programmatic)",
+  //       starting_at: "2026-04-01T00:00:00.000Z",
+  //       entitled: true,
+  //       rate_type: "FLAT",
+  //       price: 1,
+  //       credit_type_id: AWU_CREDIT_TYPE_ID,
+  //     },
+  //     // Tool Usage — AWU per invocation (price = tool weight in AWU)
+  //     {
+  //       product_name: "Tool Usage (User)",
+  //       starting_at: "2026-04-01T00:00:00.000Z",
+  //       entitled: true,
+  //       rate_type: "FLAT",
+  //       price: 1,
+  //       credit_type_id: AWU_CREDIT_TYPE_ID,
+  //     },
+  //     {
+  //       product_name: "Tool Usage (Programmatic)",
+  //       starting_at: "2026-04-01T00:00:00.000Z",
+  //       entitled: true,
+  //       rate_type: "FLAT",
+  //       price: 1,
+  //       credit_type_id: AWU_CREDIT_TYPE_ID,
+  //     },
+  //   ],
+  // },
 ];
 
 // Seat subscription definition shared by all legacy packages.
@@ -354,18 +454,28 @@ const BILLING_CYCLE_CONFIG = {
 // Package names are versioned (v1, v2, ...) to track pricing changes.
 // Aliases stay stable — code always references the alias, which points to the latest version.
 // Old versions are archived automatically when a new version is created with the same alias.
+// Package names and contract_name are auto-versioned at sync time (e.g., "Legacy Pro $29 v3").
+// The version is derived from existing packages in Metronome: if the current package matches,
+// keep its version; if it needs recreation, increment by 1.
 const PACKAGES: PackageDef[] = [
   {
-    name: "Legacy Pro $29 v1",
-    aliases: [{ name: "legacy-pro-29" }],
+    name: "Legacy Pro $29",
+    aliases: [{ name: "legacy-pro-monthly" }],
     rate_card_name: "Legacy Pro $29",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
     ...BILLING_CYCLE_CONFIG,
   },
   {
-    name: "Legacy Business $39 v1",
-    aliases: [{ name: "legacy-business-39" }],
-    rate_card_name: "Legacy Business $39",
+    name: "Legacy Business $45",
+    aliases: [{ name: "legacy-business" }],
+    rate_card_name: "Legacy Business $45",
+    subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+    ...BILLING_CYCLE_CONFIG,
+  },
+  {
+    name: "Legacy Pro $27 Annual",
+    aliases: [{ name: "legacy-pro-annual" }],
+    rate_card_name: "Legacy Pro $27 Annual",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
     ...BILLING_CYCLE_CONFIG,
   },
@@ -480,6 +590,10 @@ function productMatches(
         conversion_factor: number;
         operation: string;
       } | null;
+      quantity_rounding?: {
+        decimal_places: number;
+        rounding_method: string;
+      } | null;
     };
   },
   desired: ProductDef
@@ -527,6 +641,20 @@ function productMatches(
     }
   }
 
+  // Check quantity_rounding
+  const desiredQr = desired.quantity_rounding;
+  const existingQr = cur.quantity_rounding;
+  if (desiredQr && existingQr) {
+    if (
+      desiredQr.decimal_places !== existingQr.decimal_places ||
+      desiredQr.rounding_method !== existingQr.rounding_method
+    ) {
+      return false;
+    }
+  } else if (!!desiredQr !== !!existingQr) {
+    return false;
+  }
+
   // Check group keys
   if (!arraysEqual(cur.pricing_group_key, desired.pricing_group_key)) {
     return false;
@@ -561,6 +689,10 @@ async function syncProducts(): Promise<void> {
       quantity_conversion?: {
         conversion_factor: number;
         operation: string;
+      } | null;
+      quantity_rounding?: {
+        decimal_places: number;
+        rounding_method: string;
       } | null;
     };
   }
@@ -616,6 +748,7 @@ async function syncProducts(): Promise<void> {
         type: desired.type,
         billable_metric_id: metricId,
         quantity_conversion: desired.quantity_conversion ?? undefined,
+        quantity_rounding: desired.quantity_rounding ?? undefined,
         pricing_group_key: desired.pricing_group_key,
         presentation_group_key: desired.presentation_group_key,
         tags: desired.tags,
@@ -765,9 +898,9 @@ async function syncRateCards(): Promise<void> {
 interface ExistingPackage {
   id: string;
   name: string;
+  contract_name?: string;
   aliases?: Array<{ name: string }>;
   rate_card_id?: string;
-  billing_provider?: string;
   subscriptions?: Array<{
     collection_schedule: string;
     proration: {
@@ -787,11 +920,6 @@ interface ExistingPackage {
 function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
   // Check rate card cascade
   if (recreated.rateCards.has(desired.rate_card_name)) {
-    return false;
-  }
-
-  // Check billing provider
-  if ((ex.billing_provider ?? undefined) !== desired.billing_provider) {
     return false;
   }
 
@@ -888,16 +1016,25 @@ async function syncPackages(): Promise<void> {
     const primaryAlias = desired.aliases[0]?.name;
     const ex = primaryAlias ? byAlias.get(primaryAlias) : undefined;
 
-    if (ex && ex.name === desired.name && packageMatches(ex, desired)) {
-      console.log(`  ✓ ${desired.name} — up to date (${ex.id})`);
+    // Extract current version from existing package name (e.g., "Legacy Pro $29 v3" → 3).
+    const existingVersion = ex?.name
+      ? parseInt(ex.name.match(/\sv(\d+)$/)?.[1] ?? "0", 10)
+      : 0;
+
+    if (ex && packageMatches(ex, desired)) {
+      // Up to date — keep existing version.
+      const versionedName = `${desired.name} v${existingVersion || 1}`;
+      console.log(`  ✓ ${versionedName} — up to date (${ex.id})`);
       ids.packages[desired.name] = ex.id;
     } else {
+      // Needs recreation — increment version.
+      const newVersion = existingVersion + 1;
+      const versionedName = `${desired.name} v${newVersion}`;
+
       if (ex) {
-        const reason =
-          ex.name !== desired.name
-            ? `version change (${ex.name} → ${desired.name})`
-            : "config changed";
-        console.log(`  ↻ ${desired.name} — ${reason}, archiving ${ex.id}`);
+        console.log(
+          `  ↻ ${versionedName} — config changed, archiving ${ex.name} (${ex.id})`
+        );
         try {
           await client.v1.packages.archive({ package_id: ex.id });
         } catch {
@@ -910,9 +1047,7 @@ async function syncPackages(): Promise<void> {
         throw new Error(`Rate card not found: ${desired.rate_card_name}`);
       }
 
-      console.log(
-        `  + Creating: ${desired.name}${desired.billing_provider ? "" : " (shadow — no billing provider)"}`
-      );
+      console.log(`  + Creating: ${versionedName}`);
       // Resolve subscription product IDs
       const subscriptions = (desired.subscriptions ?? []).map((sub) => {
         const productId = ids.products[sub.product_name];
@@ -935,18 +1070,13 @@ async function syncPackages(): Promise<void> {
       });
 
       const created = await client.v1.packages.create({
-        name: desired.name,
+        name: versionedName,
+        contract_name: versionedName,
         aliases: desired.aliases,
         rate_card_id: rateCardId,
         billing_anchor_date: desired.billing_anchor_date,
         ...(desired.usage_statement_schedule
           ? { usage_statement_schedule: desired.usage_statement_schedule }
-          : {}),
-        ...(desired.billing_provider
-          ? {
-              billing_provider: desired.billing_provider,
-              delivery_method: desired.delivery_method,
-            }
           : {}),
         ...(subscriptions.length > 0 ? { subscriptions } : {}),
       } as Parameters<typeof client.v1.packages.create>[0]);

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -15,8 +15,9 @@
 import { getMetronomeClient } from "@app/lib/metronome/client";
 import { provisionSeatsForContract } from "@app/lib/metronome/seats";
 import {
-  LEGACY_BUSINESS_39_PACKAGE_ALIAS,
-  LEGACY_PRO_29_PACKAGE_ALIAS,
+  LEGACY_BUSINESS_PACKAGE_ALIAS,
+  LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
+  LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
 } from "@app/lib/metronome/types";
 import {
   PRO_PLAN_SEAT_29_CODE,
@@ -31,15 +32,14 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { makeScript } from "./helpers";
 import { runOnAllWorkspaces } from "./workspace_helpers";
 
-const plansCodeToPackageAlias: Record<string, string> = {
-  [PRO_PLAN_SEAT_29_CODE]: LEGACY_PRO_29_PACKAGE_ALIAS,
-  [PRO_PLAN_SEAT_39_CODE]: LEGACY_BUSINESS_39_PACKAGE_ALIAS,
-};
-
 // Map from old alias → current alias.
 const ALIAS_MIGRATION: Record<string, string> = {
-  "shadow-pro-29": LEGACY_PRO_29_PACKAGE_ALIAS,
-  "shadow-business-39": LEGACY_BUSINESS_39_PACKAGE_ALIAS,
+  "shadow-pro-29": LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
+  "shadow-business-39": LEGACY_BUSINESS_PACKAGE_ALIAS,
+  "legacy-pro-29": LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
+  "legacy-business-39": LEGACY_BUSINESS_PACKAGE_ALIAS,
+  "legacy-business-45": LEGACY_BUSINESS_PACKAGE_ALIAS,
+  "legacy-pro-27-annual": LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
 };
 
 /**
@@ -55,17 +55,57 @@ async function getPackageInfo(): Promise<{
   const aliasToPackageId: Record<string, string> = {};
   const packageIdToAlias: Record<string, string> = {};
 
-  // Include archived packages so we can identify contracts on old versions.
+  // First pass: collect all packages with their aliases.
+  // Active packages own the alias; archived packages may have lost theirs
+  // (Metronome removes the alias from old versions when a new version claims it).
+  const allPackages: {
+    id: string;
+    name: string | undefined;
+    aliases: string[];
+    archived: boolean;
+  }[] = [];
   for await (const pkg of client.v1.packages.list({
     archive_filter: "ALL",
   })) {
-    for (const alias of pkg.aliases ?? []) {
-      // aliasToPackageId: only keep the latest (non-archived) package per alias.
+    const aliases = (pkg.aliases ?? []).map((a) => a.name);
+    allPackages.push({
+      id: pkg.id,
+      name: pkg.name,
+      aliases,
+      archived: !!pkg.archived_at,
+    });
+
+    for (const alias of aliases) {
       if (!pkg.archived_at) {
-        aliasToPackageId[alias.name] = pkg.id;
+        aliasToPackageId[alias] = pkg.id;
       }
-      // packageIdToAlias: map ALL package IDs (including archived) to their alias.
-      packageIdToAlias[pkg.id] = alias.name;
+      packageIdToAlias[pkg.id] = alias;
+    }
+  }
+
+  // Second pass: for archived packages with no aliases, find the current alias
+  // by matching the name prefix. Package names are versioned ("Name vN"), so
+  // "Legacy Pro $29 v1" shares the prefix "Legacy Pro $29" with "Legacy Pro $29 v2".
+  for (const pkg of allPackages) {
+    if (pkg.archived && pkg.aliases.length === 0) {
+      if (!pkg.name) {
+        continue;
+      }
+      // Strip version suffix (e.g., " v1") to get the base name.
+      const baseName = pkg.name.replace(/\s+v\d+$/, "");
+      // Find a current (non-archived) package with the same base name.
+      const currentPkg = allPackages.find(
+        (p) =>
+          !p.archived &&
+          p.aliases.length > 0 &&
+          p.name?.replace(/\s+v\d+$/, "") === baseName
+      );
+      if (currentPkg) {
+        packageIdToAlias[pkg.id] = currentPkg.aliases[0];
+      } else {
+        // No current version found — store name for logging.
+        packageIdToAlias[pkg.id] = pkg.name;
+      }
     }
   }
 
@@ -90,15 +130,9 @@ async function getSubscriptionInfo(
     return undefined;
   }
 
-  // Determine alias from plan code.
-  const packageAlias = plansCodeToPackageAlias[subscription.getPlan().code];
-
-  if (!packageAlias) {
-    return undefined;
-  }
-
   // Get Stripe subscription start date, rounded to hour boundary (Metronome requirement).
   let startDate: string | undefined;
+  let isAnnual = false;
   try {
     const stripeSubscription = await getStripeSubscription(
       subscription.stripeSubscriptionId
@@ -107,8 +141,14 @@ async function getSubscriptionInfo(
       const startTimestamp =
         stripeSubscription.start_date ??
         stripeSubscription.current_period_start;
+      // Round to hour boundary (Metronome requirement).
       const rounded = Math.floor(startTimestamp / 3600) * 3600;
       startDate = new Date(rounded * 1000).toISOString();
+
+      // Detect annual billing from the Stripe price interval.
+      const interval =
+        stripeSubscription.items?.data[0]?.price?.recurring?.interval;
+      isAnnual = interval === "year";
     }
   } catch (err) {
     logger.warn(
@@ -119,6 +159,20 @@ async function getSubscriptionInfo(
   }
 
   if (!startDate) {
+    return undefined;
+  }
+
+  // Determine alias from plan code + billing interval.
+  const isPro = subscription.getPlan().code === PRO_PLAN_SEAT_29_CODE;
+  const isBusiness = subscription.getPlan().code === PRO_PLAN_SEAT_39_CODE;
+  let packageAlias: string;
+  if (isBusiness) {
+    packageAlias = LEGACY_BUSINESS_PACKAGE_ALIAS;
+  } else if (isPro) {
+    packageAlias = isAnnual
+      ? LEGACY_PRO_ANNUAL_PACKAGE_ALIAS
+      : LEGACY_PRO_MONTHLY_PACKAGE_ALIAS;
+  } else {
     return undefined;
   }
 
@@ -330,19 +384,34 @@ async function migrateWorkspace(
       continue;
     }
 
-    // Create new contract that supersedes the old one.
-    // - transition.type = "SUPERSEDE": Metronome ends the old contract and rolls
-    //   over unused credits/commits to the new one automatically.
-    // - starting_at: same as the old contract.
-    // - No billing_provider_configuration: shadow mode by default.
+    // Metronome does not support SUPERSEDE for package-based contracts.
+    // Approach: end old contract, create new with same starting_at (preserves billing
+    // anchor/cycle), transfer remaining credit/commit balances.
+    const now = new Date(
+      Math.floor(Date.now() / 3_600_000) * 3_600_000
+    ).toISOString();
+
+    // 1. End the old contract.
+    await client.v1.contracts.updateEndDate({
+      customer_id: metronomeCustomerId,
+      contract_id: contract.id,
+      ending_before: now,
+    });
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        contractId: contract.id,
+        endingBefore: now,
+      },
+      "Old contract ended"
+    );
+
+    // 2. Create new contract with same starting_at (preserves billing cycle anchor).
     const newContract = await client.v1.contracts.create({
       customer_id: metronomeCustomerId,
       package_alias: targetAlias,
       starting_at: contract.starting_at,
-      transition: {
-        from_contract_id: contract.id,
-        type: "SUPERSEDE",
-      },
     });
 
     const newContractId = newContract.data.id;
@@ -354,10 +423,10 @@ async function migrateWorkspace(
         newContractId,
         targetAlias,
       },
-      "New contract created (supersedes old, credits/commits rolled over)"
+      "New contract created (same starting_at as old)"
     );
 
-    // Provision seats for all existing members on the new contract.
+    // 3. Provision seats on the new contract.
     await provisionSeatsForContract({
       metronomeCustomerId,
       contractId: newContractId,
@@ -365,7 +434,7 @@ async function migrateWorkspace(
       startingAt: contract.starting_at,
     });
 
-    // Update metronomeContractId on the active subscription.
+    // 4. Update metronomeContractId on the active subscription.
     const activeSubscription =
       await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
 


### PR DESCRIPTION
## Summary

Updates Metronome package configuration: corrects pricing, adds annual Pro plan, renames aliases, and improves the setup script with auto-versioning and quantity rounding.

### Package aliases renamed (price-agnostic)

| Old | New |
|-----|-----|
| `legacy-pro-29` | `legacy-pro-monthly` |
| `legacy-business-39` | `legacy-business` |
| — | `legacy-pro-annual` (new) |

### Pricing corrected

| Plan | Monthly | Annual |
|------|---------|--------|
| Pro | $29/seat/mo | $27/seat/mo (new) |
| Business | $45/seat/mo (was $39) | — |

### Products restructured

- **`Programmatic Usage`** (legacy, USD): 30% markup baked into `quantity_conversion` (÷769,231), `quantity_rounding: ROUND_UP` to cents. Rate card prices at $1.00/unit — markup invisible to customer
- **`AI Usage (User/Programmatic)`** (new pricing, AWU): `quantity_conversion: ÷10,000` (100 AWU per $1 cost)
- **`Tool Usage (User/Programmatic)`** (new pricing, AWU): raw count, priced per tool category
- Example Business Plan rate card added (commented out) showing AWU pricing with `credit_type_conversions`

### Setup script improvements

- **Auto-versioning**: Package names no longer hardcode version — script reads current version from Metronome and increments on recreation (e.g., "Legacy Pro $29 v2" → "Legacy Pro $29 v3")
- **`contract_name`**: Set on packages so contracts show the versioned package name in Metronome UI
- **`quantity_rounding`**: Added to product definitions and comparison logic
- Removed `billing_provider`/`delivery_method` from `PackageDef` — billing provider is set at contract creation time only

### Migration script updates

- Detects annual billing from Stripe subscription `interval` → routes to `legacy-pro-annual` alias
- Old aliases auto-mapped to current (`legacy-pro-29` → `legacy-pro-monthly`, `legacy-business-39` → `legacy-business`, etc.)
- Archived packages with no aliases matched by name prefix to find current version
- Uses end + create (not SUPERSEDE — unsupported for package contracts)

## Test plan

- [ ] Run `metronome_setup.ts` — verify products, rate cards, packages created with correct names/versions
- [ ] Re-run setup — verify idempotent (no unnecessary recreation)
- [ ] Run migration script on test workspace — verify correct alias selected for monthly vs annual
- [ ] Verify Programmatic Usage invoice line shows $1.00/unit (not $1.30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)