### PR TITLE
Fix cross-region shared frame loading by sequencing metadata before frame fetch

### DIFF
--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -33,9 +33,10 @@ export function SharedFramePage() {
       shareToken: token,
     });
 
-  // Fetch the frame to check if the user is already authorized.
+  // Only fetch the frame once metadata has resolved. Metadata handles the region redirect, so we
+  // need to wait for the correct region to be established before firing this request.
   const { error: frameError, mutateFrame } = usePublicFrame({
-    shareToken: token,
+    shareToken: shareMetadata ? token : null,
   });
 
   // Show the email form when:


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR superseeds https://github.com/dust-tt/dust/pull/23740

When a user opens a shared frame that lives in a different region than the one they land on, the metadata endpoint (`/api/share/frame/[token]`) handles the cross-region lookup and updates the `RegionContext` to point at the correct region.
This was working before `usePublicFrame` was introduced. The problem is that `usePublicFrame` fires in parallel with `useShareFrameMetadata` on mount, racing against the region switch. The frame request hits the wrong region, gets a 404, and only succeeds after `RegionContext` invalidates the SWR cache and forces a retry. In the meantime, the user sees either a blank state or a spurious error flash. The fix is to not fire `usePublicFrame` until metadata has resolved. Since metadata is what establishes the correct region, waiting for it means the frame request always goes to the right place on the first attempt.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
