### PR TITLE
Add NEXT_PUBLIC_DUST_CLIENT_FACING_URL in config

### DIFF
--- a/extension/platforms/front/webpack.config.ts
+++ b/extension/platforms/front/webpack.config.ts
@@ -121,6 +121,8 @@ export const getConfig = ({ env }: { env: Environment }) => {
         DATADOG_ENV: isDevelopment ? "dev" : "prod",
         DUST_EXTENSION_VERSION: `front-${version}`,
         NEXT_PUBLIC_DUST_APP_URL: process.env.NEXT_PUBLIC_DUST_APP_URL || "",
+        NEXT_PUBLIC_DUST_CLIENT_FACING_URL:
+          process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL || "",
         NEXT_PUBLIC_NOVU_API_URL: process.env.NEXT_PUBLIC_NOVU_API_URL || "",
         NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER:
           process.env.NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER || "",


### PR DESCRIPTION
## Description

`NEXT_PUBLIC_DUST_CLIENT_FACING_URL` was missing in the Frontapp extension config, preventing it form working properly in prod.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy Front extension
