### PR TITLE
[front] Take last subscription, prevent reuse of same id

### DIFF
--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -441,6 +441,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     const res = await this.model.findOne({
       where: { stripeSubscriptionId },
       include: [PlanModel],
+      order: [["createdAt", "DESC"]],
 
       // WORKSPACE_ISOLATION_BYPASS: Used to check if a subscription is not attached to a workspace.
       // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
@@ -456,6 +457,20 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       res.get(),
       renderPlanFromModel({ plan: res.plan })
     );
+  }
+
+  static async isStripeIdAlreadyUsed(
+    stripeSubscriptionId: string
+  ): Promise<boolean> {
+    const res = await this.model.findOne({
+      where: { stripeSubscriptionId },
+
+      // WORKSPACE_ISOLATION_BYPASS: Used to check across all workspaces.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+
+    return res !== null;
   }
 
   static async internalFetchWorkspacesWithFreeEndedSubscriptions(): Promise<{

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -106,20 +106,14 @@ async function handler(
         });
       }
 
-      // Ensure that the stripe subscription is either attached to the current workspace
-      // or is not attached to any workspace.
-      const subscription = await SubscriptionResource.fetchByStripeId(
+      // Ensure the stripe subscription ID has not been used before (same or different workspace).
+      const isAlreadyUsed = await SubscriptionResource.isStripeIdAlreadyUsed(
         stripeSubscription.id
       );
-      const currentWorkspaceSubscription = auth.subscription();
-      const isCurrentWorkspaceSubscription =
-        currentWorkspaceSubscription &&
-        currentWorkspaceSubscription.stripeSubscriptionId ===
-          stripeSubscription.id;
 
-      if (subscription && !isCurrentWorkspaceSubscription) {
+      if (isAlreadyUsed) {
         const errorMessage =
-          "The subscription is already attached to another workspace.";
+          "The Stripe subscription ID is already used by an existing subscription.";
         await pluginRun.recordError(errorMessage);
         return apiError(req, res, {
           status_code: 400,


### PR DESCRIPTION
## Summary

- Order `fetchByStripeId` by `createdAt DESC` to always operate on the most recent subscription when multiple records share the same Stripe subscription ID.
- Add `isStripeIdAlreadyUsed` method to check whether a Stripe subscription ID has ever been used (by any workspace, including the current one).
- Replace the enterprise upgrade check: instead of only blocking reuse by *other* workspaces, block reuse entirely — preventing the same Stripe subscription ID from being attached to a new subscription.

## Context

We have some cases where the same `stripeSubscriptionId` appears on multiple subscription records. `fetchByStripeId` (used by Stripe webhooks, Poke search, etc.) previously returned an arbitrary row; it now returns the most recent one to ensure we operate on the current active subscription.

The enterprise upgrade endpoint (`upgrade_enterprise`) previously allowed reusing a Stripe subscription ID if it was already attached to the current workspace. It now rejects any Stripe subscription ID that already exists in the subscriptions table.

## Test plan

- [ ] Verify Stripe webhook handlers still resolve the correct subscription (latest) when duplicate `stripeSubscriptionId` rows exist
- [ ] Verify enterprise upgrade rejects a Stripe subscription ID already used by the same workspace
- [ ] Verify enterprise upgrade rejects a Stripe subscription ID already used by a different workspace
- [ ] Verify enterprise upgrade succeeds with a fresh Stripe subscription ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)