### PR TITLE
 Gate single agent input behind enable_steering feature flag

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -6,10 +6,8 @@ import config from "@app/lib/api/config";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   forceUserRole,
-  isSingleAgentInputEnabled,
   sendOnboardingConversation,
   showDebugTools,
-  toggleSingleAgentInput,
 } from "@app/lib/development";
 import { useAppRouter } from "@app/lib/platform";
 import type { SubscriptionType } from "@app/types/plan";
@@ -42,7 +40,7 @@ import {
   TestTubeIcon,
   UserIcon,
 } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 interface UserMenuProps {
   user: UserTypeWithWorkspaces;
@@ -56,19 +54,6 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
 
   const sendNotification = useSendNotification();
   const privacyMask = usePrivacyMask();
-  const [singleAgentInput, setSingleAgentInput] = useState(() =>
-    isSingleAgentInputEnabled()
-  );
-  const handleToggleSingleAgentInput = () => {
-    const next = toggleSingleAgentInput();
-    setSingleAgentInput(next);
-    sendNotification({
-      title: `Single agent input ${next ? "enabled" : "disabled"}`,
-      description: "Reload the page to apply.",
-      type: "success",
-    });
-  };
-
   const { clearAllDraftsFromUser } = useConversationDrafts({
     workspaceId: owner.sId,
     userId: user.sId,
@@ -277,11 +262,6 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
                     label={`${privacyMask.isEnabled ? "Disable" : "Enable"} Privacy Mask`}
                     onClick={privacyMask.toggle}
                     icon={privacyMask.isEnabled ? EyeSlashIcon : EyeIcon}
-                  />
-                  <DropdownMenuItem
-                    label={`${singleAgentInput ? "Disable" : "Enable"} Single Agent Input`}
-                    onClick={handleToggleSingleAgentInput}
-                    icon={TestTubeIcon}
                   />
                   {owner.role === "admin" && (
                     <DropdownMenuItem

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -12,8 +12,7 @@ import { ConversationViewer } from "@app/components/assistant/conversation/Conve
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import { useAuth } from "@app/lib/auth/AuthContext";
-import { isSingleAgentInputEnabled } from "@app/lib/development";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
@@ -91,6 +90,9 @@ function PreviewContent({
   isTrialPlan,
   isAdmin,
 }: PreviewContentProps) {
+  const { hasFeature } = useFeatureFlags();
+  const singleAgentInput = hasFeature("enable_steering");
+
   return (
     <>
       <div className={currentPanel ? "hidden" : "flex h-full flex-col"}>
@@ -109,7 +111,7 @@ function PreviewContent({
                 draftAgent: draftAgent ?? undefined,
                 isSubmitting: isSavingDraftAgent,
                 resetConversation,
-                actionsToShow: isSingleAgentInputEnabled()
+                actionsToShow: singleAgentInput
                   ? ["attachment", "agents-list"]
                   : ["attachment"],
               }}
@@ -137,7 +139,7 @@ function PreviewContent({
               }
               draftKey={`agent-${draftAgent?.name}-builder-preview`}
               actions={
-                isSingleAgentInputEnabled()
+                singleAgentInput
                   ? ["attachment", "agents-list"]
                   : ["attachment"]
               }

--- a/front/components/agent_builder/AgentBuilderSidekick.tsx
+++ b/front/components/agent_builder/AgentBuilderSidekick.tsx
@@ -11,8 +11,7 @@ import {
   getSidekickSuggestionPlugin,
   sidekickSuggestionDirective,
 } from "@app/components/markdown/suggestion/SidekickSuggestionDirective";
-import { useAuth } from "@app/lib/auth/AuthContext";
-import { isSingleAgentInputEnabled } from "@app/lib/development";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -78,6 +77,8 @@ function SidekickContent({
   clientSideMCPServerIds,
 }: SidekickContentProps) {
   const { subscription } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+  const singleAgentInput = hasFeature("enable_steering");
   const agentBuilderContext = useMemo(
     () => ({
       isSubmitting: false,
@@ -85,12 +86,17 @@ function SidekickContent({
       actionsToShow: [
         "attachment",
         ...(subscription.plan.isByok ? [] : ["voice" as const]),
-        ...(isSingleAgentInputEnabled() ? ["agents-list" as const] : []),
+        ...(singleAgentInput ? ["agents-list" as const] : []),
       ] satisfies InputBarAction[],
       clientSideMCPServerIds,
       skipToolsValidation: true,
     }),
-    [resetConversation, clientSideMCPServerIds, subscription.plan.isByok]
+    [
+      resetConversation,
+      clientSideMCPServerIds,
+      subscription.plan.isByok,
+      singleAgentInput,
+    ]
   );
 
   const additionalMarkdownComponents: Components = useMemo(

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -13,7 +13,7 @@ import {
   useConversationTools,
 } from "@app/hooks/conversations";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { isSingleAgentInputEnabled } from "@app/lib/development";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { TRACKING_AREAS, trackEvent } from "@app/lib/tracking";
@@ -80,6 +80,8 @@ export const InputBar = React.memo(function InputBar({
   shouldUseDraft = true,
 }: InputBarProps) {
   const [isLocalSubmitting, setIsLocalSubmitting] = useState(isSubmitting);
+  const { hasFeature } = useFeatureFlags();
+  const singleAgentInput = hasFeature("enable_steering");
 
   const [attachedNodes, setAttachedNodes] = useState<
     DataSourceViewContentNode[]
@@ -205,7 +207,6 @@ export const InputBar = React.memo(function InputBar({
     }
 
     const { mentions: rawMentions, markdown } = markdownAndMentions;
-    const singleAgentInput = isSingleAgentInputEnabled();
     // When single-agent input is enabled, inject the selected agent into mentions
     // since it's no longer in the editor as a mention node.
     const hasUserMention = rawMentions.some((m) => m.type === "user");

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -15,11 +15,10 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceTranscriberService } from "@app/hooks/useVoiceTranscriberService";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
-import { isSingleAgentInputEnabled } from "@app/lib/development";
 import { getSkillIcon } from "@app/lib/skill";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -194,7 +193,8 @@ const InputBarContainer = ({
 }: InputBarContainerProps) => {
   const { subscription } = useAuth();
   const isMobile = useIsMobile();
-  const singleAgentInput = isSingleAgentInputEnabled();
+  const { hasFeature } = useFeatureFlags();
+  const singleAgentInput = hasFeature("enable_steering");
   const { selectedSingleAgent, setSelectedSingleAgent } =
     useContext(InputBarContext);
   const [hasUserMention, setHasUserMention] = useState(false);

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -1,6 +1,6 @@
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { EditorService } from "@app/components/editor/input_bar/useCustomEditor";
-import { isSingleAgentInputEnabled } from "@app/lib/development";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type {
   RichAgentMention,
   RichMention,
@@ -18,7 +18,8 @@ const useHandleMentions = (
   draftAgentRestoredRef?: MutableRefObject<boolean>
 ) => {
   const stickyMentionsTextContent = useRef<string | null>(null);
-  const singleAgentInput = isSingleAgentInputEnabled();
+  const { hasFeature } = useFeatureFlags();
+  const singleAgentInput = hasFeature("enable_steering");
   const { setSelectedSingleAgent } = useContext(InputBarContext);
 
   // In single agent mode, sync the selected agent from sticky mentions

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -8,21 +8,6 @@ export function showDebugTools(flags: WhitelistableFeature[]) {
   return isDevelopment() || flags.includes("show_debug_tools");
 }
 
-const SINGLE_AGENT_INPUT_KEY = "dust_single_agent_input";
-
-export function isSingleAgentInputEnabled(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  return localStorage.getItem(SINGLE_AGENT_INPUT_KEY) === "true";
-}
-
-export function toggleSingleAgentInput(): boolean {
-  const next = !isSingleAgentInputEnabled();
-  localStorage.setItem(SINGLE_AGENT_INPUT_KEY, next ? "true" : "false");
-  return next;
-}
-
 export async function forceUserRole(
   user: UserType,
   owner: LightWorkspaceType,


### PR DESCRIPTION
## Description

Single agent input was previously gated by a localStorage toggle in the dev tools menu. This moves it behind the existing enable_steering feature flag instead, so it can be rolled out per workspace. The dev tools menu item has been removed and the localStorage helpers in development.ts cleaned up.
    

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 