### PR TITLE
Allow switch to business plan

### DIFF
--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -5,6 +5,7 @@ import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import {
+  isEntreprisePlanPrefix,
   isProPlan,
   isUpgraded,
   isWhitelistedBusinessPlan,
@@ -378,7 +379,8 @@ export function SubscriptionPage() {
     });
 
   const plan = subscription.plan;
-  const isWorkspaceOnProPlan = isProPlan(plan);
+  const isWorkspaceOnProPlan =
+    isProPlan(plan) || isEntreprisePlanPrefix(plan.code);
   const isWorkspaceWhitelistedBusinessPlan = isWhitelistedBusinessPlan(owner);
   const canUpsellToBusinessPlan =
     isWorkspaceOnProPlan && isWorkspaceWhitelistedBusinessPlan;

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -786,8 +786,9 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     }
 
     const isOnProPlan = await this.isSubscriptionOnProOrBusinessPlan(owner);
-    if (!isOnProPlan) {
-      return new Err(new Error("Workspace is not on a Pro plan"));
+    const isOnEnterprisePlan = isEntreprisePlanPrefix(this.plan.code);
+    if (!isOnProPlan && !isOnEnterprisePlan) {
+      return new Err(new Error("Workspace is not on a Pro or Enterprise plan"));
     }
 
     const businessPlan = await SubscriptionResource.findPlanOrThrow(


### PR DESCRIPTION
## Summary

- Allow workspaces on Enterprise plans (ENT_* prefix) to upgrade to the Business seat-based plan, not just workspaces on Pro plans.
- Update the subscription page UI to show the Business plan upsell for Enterprise workspaces (when whitelisted).

## Context

Related to dust-tt/tasks#7357. Customers on `ENT_DEFAULT` plans need to switch to Enterprise Seat-Based plans. The upgrade-to-business flow was previously gated to Pro plan workspaces only. This change extends eligibility to Enterprise plan workspaces as well, so they can see and select the seat-based plan in admin when the whitelist flag is active.

## Tests

- [ ] Verify a workspace on an Enterprise plan with the business whitelist flag can see and use the Business plan upgrade option
- [ ] Verify a workspace on a Pro plan still works as before
- [ ] Verify a workspace on a free plan cannot access the upgrade flow

## Risk

Low — only widens an existing check. No changes to billing logic or Stripe interactions.

## Deploy Plan

Standard deploy, no special steps needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)