### PR TITLE
[BYOK] Increase BYOK keys usage ratio to 100%

### DIFF
--- a/front/lib/api/provider_credentials.ts
+++ b/front/lib/api/provider_credentials.ts
@@ -16,7 +16,7 @@ import assert from "assert";
 import type { z } from "zod";
 
 // Fraction of requests that use BYOK credentials during the transition period.
-const BYOK_TRANSITION_BYOK_KEYS_RATIO = 0.2; // 20%
+const BYOK_TRANSITION_BYOK_KEYS_RATIO = 1; // 100%
 
 export const MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE =
   "An OpenAI API key is required to perform this action. Please configure it in your workspace settings or contact an admin.";


### PR DESCRIPTION
## Description

Bumps `BYOK_TRANSITION_BYOK_KEYS_RATIO` from 20% to 100% so all requests now use BYOK credentials instead of Dust's own keys during the transition period.

## Tests

Tested manually — single constant change with no logic impact.

## Risk

Low risk: the constant was already in use at 20%; this just completes the rollout. Rollback is a one-line revert.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`