### PR TITLE
[connectors] Fix Intercom conversation sync crash when source is null

### DIFF
--- a/connectors/src/connectors/intercom/lib/types.ts
+++ b/connectors/src/connectors/intercom/lib/types.ts
@@ -70,7 +70,7 @@ export type IntercomConversationType = {
     subject: string;
     body: string;
     author: IntercomAuthor;
-  };
+  } | null;
   statistics?: {
     last_close_at?: number;
   };

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -234,19 +234,21 @@ export async function syncConversation({
   const customAttributes = conversation.custom_attributes;
   const tags = conversation.tags?.tags ?? [];
   const tagsAsString = tags.map((tag: IntercomTagType) => tag.name).join(", ");
-  const source = conversation.source.type;
-
-  const firstMessageAuthor = conversation.source.author;
-  const firstMessageContent = turndownService.turndown(
-    conversation.source.body
-  );
+  const source = conversation.source?.type ?? null;
+  const firstMessageAuthor = conversation.source?.author ?? null;
+  const firstMessageContent = conversation.source?.body
+    ? turndownService.turndown(conversation.source.body)
+    : null;
 
   markdown += `# ${convoTitle}\n\n`;
   markdown += `**TAGS: ${tagsAsString ?? "no tags"}**\n`;
   markdown += `**SOURCE: ${source || "unknown"}**\n`;
   markdown += `**CUSTOM ATTRIBUTES: ${JSON.stringify(customAttributes)}**\n\n`;
-  markdown += `**[Message] ${firstMessageAuthor.name} (${firstMessageAuthor.type})**\n`;
-  markdown += `${firstMessageContent}\n\n`;
+
+  if (firstMessageAuthor && firstMessageContent) {
+    markdown += `**[Message] ${firstMessageAuthor.name} (${firstMessageAuthor.type})**\n`;
+    markdown += `${firstMessageContent}\n\n`;
+  }
 
   conversation.conversation_parts.conversation_parts.forEach(
     (part: ConversationPartType) => {


### PR DESCRIPTION
## Description

The Intercom API can return conversations with a `null` `source` field (e.g. bot-initiated, workflow-created, or side conversations). Our code assumed `source` was always present and accessed `.type`, `.author`, and `.body` on it unconditionally, causing a `TypeError: Cannot read properties of null (reading 'type')`.

This has been causing temporal workflows to retry indefinitely. The workflows will self-heal on next retry once this is deployed.

Changes:
- Made `source` nullable in `IntercomConversationType` (`| null`)
- Guarded all `conversation.source` accesses with optional chaining
- Skip the first message section in the markdown when source is absent; the rest of the conversation (parts, tags, attributes) is still synced

## Tests

- Verified no new TypeScript errors introduced (all existing errors are pre-existing `dust_project` type mismatches)
- The fix uses standard optional chaining — the null case simply omits the first message block from the rendered markdown

## Risk

**Low.** The change is purely additive null-safety. When `source` is present, behavior is identical to before. When `source` is null, we now gracefully skip the first message instead of crashing. The conversation is still indexed with all its other data.

## Deploy Plan

Standard connectors deploy