### PR TITLE
[front] - feat(metronome): add balance and usage API client functions

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -526,6 +526,16 @@ const config = {
       "METRONOME_COMMIT_PRODUCT_ID"
     );
   },
+  getMetronomeLlmUsageBillableMetricId: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "METRONOME_LLM_USAGE_BILLABLE_METRIC_ID"
+    );
+  },
+  getMetronomeToolUseBillableMetricId: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "METRONOME_TOOL_USE_BILLABLE_METRIC_ID"
+    );
+  },
 };
 
 export default config;

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -575,14 +575,6 @@ export async function listMetronomeProducts(): Promise<
   }
 }
 
-// ---------------------------------------------------------------------------
-// Balances (commits + credits)
-// ---------------------------------------------------------------------------
-
-/**
- * List all commits and credits for a customer with current balances.
- * Returns a union of Commit | Credit from the contracts.listBalances API.
- */
 export async function listMetronomeBalances(
   metronomeCustomerId: string
 ): Promise<Result<MetronomeBalance[], Error>> {
@@ -606,16 +598,8 @@ export async function listMetronomeBalances(
   }
 }
 
-// ---------------------------------------------------------------------------
-// Usage queries
-// ---------------------------------------------------------------------------
-
 type WindowSize = "HOUR" | "DAY" | "NONE";
 
-/**
- * Retrieve aggregated usage data for given customers and metrics.
- * Uses v1.usage.list — suitable for ungrouped aggregate views.
- */
 export async function listMetronomeUsage({
   customerIds,
   billableMetricIds,
@@ -657,10 +641,6 @@ export async function listMetronomeUsage({
   }
 }
 
-/**
- * Retrieve usage data for a single customer and metric, broken down by group keys.
- * Uses v1.usage.listWithGroups — requires group keys pre-configured on the metric.
- */
 export async function listMetronomeUsageWithGroups({
   customerId,
   billableMetricId,

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -582,9 +582,11 @@ export async function listMetronomeBalances(
     return new Ok([]);
   }
 
+  const client = getClient();
+
   try {
     const balances: MetronomeBalance[] = [];
-    for await (const entry of getClient().v1.contracts.listBalances({
+    for await (const entry of client.v1.contracts.listBalances({
       customer_id: metronomeCustomerId,
       include_balance: true,
       include_contract_balances: true,
@@ -623,9 +625,11 @@ export async function listMetronomeUsage({
     return new Ok([]);
   }
 
+  const client = getClient();
+
   try {
     const results: MetronomeUsageListResponse[] = [];
-    for await (const entry of getClient().v1.usage.list({
+    for await (const entry of client.v1.usage.list({
       starting_on: startingOn,
       ending_before: endingBefore,
       window_size: windowSize,
@@ -670,9 +674,11 @@ export async function listMetronomeUsageWithGroups({
     return new Ok([]);
   }
 
+  const client = getClient();
+
   try {
     const results: MetronomeUsageWithGroupsResponse[] = [];
-    for await (const entry of getClient().v1.usage.listWithGroups({
+    for await (const entry of client.v1.usage.listWithGroups({
       customer_id: customerId,
       billable_metric_id: billableMetricId,
       starting_on: startingOn,

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -578,12 +578,18 @@ export async function listMetronomeProducts(): Promise<
 export async function listMetronomeBalances(
   metronomeCustomerId: string
 ): Promise<Result<MetronomeBalance[], Error>> {
+  if (!config.getMetronomeApiKey()) {
+    return new Ok([]);
+  }
+
   try {
     const balances: MetronomeBalance[] = [];
     for await (const entry of getClient().v1.contracts.listBalances({
       customer_id: metronomeCustomerId,
       include_balance: true,
       include_contract_balances: true,
+      covering_date: new Date().toISOString(),
+      exclude_zero_balances: true,
     })) {
       balances.push(entry);
     }
@@ -613,6 +619,10 @@ export async function listMetronomeUsage({
   endingBefore: string;
   windowSize: WindowSize;
 }): Promise<Result<MetronomeUsageListResponse[], Error>> {
+  if (!config.getMetronomeApiKey()) {
+    return new Ok([]);
+  }
+
   try {
     const results: MetronomeUsageListResponse[] = [];
     for await (const entry of getClient().v1.usage.list({
@@ -656,6 +666,10 @@ export async function listMetronomeUsageWithGroups({
   windowSize: WindowSize;
   groupKey: string[];
 }): Promise<Result<MetronomeUsageWithGroupsResponse[], Error>> {
+  if (!config.getMetronomeApiKey()) {
+    return new Ok([]);
+  }
+
   try {
     const results: MetronomeUsageWithGroupsResponse[] = [];
     for await (const entry of getClient().v1.usage.listWithGroups({

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -5,7 +5,12 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import Metronome, { ConflictError } from "@metronome/sdk";
 
-import type { MetronomeEvent } from "./types";
+import type {
+  MetronomeBalance,
+  MetronomeEvent,
+  MetronomeUsageListResponse,
+  MetronomeUsageWithGroupsResponse,
+} from "./types";
 
 let cachedClient: Metronome | null = null;
 
@@ -566,6 +571,135 @@ export async function listMetronomeProducts(): Promise<
   } catch (err) {
     const error = normalizeError(err);
     logger.error({ error }, "[Metronome] Failed to list products");
+    return new Err(error);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Balances (commits + credits)
+// ---------------------------------------------------------------------------
+
+/**
+ * List all commits and credits for a customer with current balances.
+ * Returns a union of Commit | Credit from the contracts.listBalances API.
+ */
+export async function listMetronomeBalances(
+  metronomeCustomerId: string
+): Promise<Result<MetronomeBalance[], Error>> {
+  try {
+    const balances: MetronomeBalance[] = [];
+    for await (const entry of getClient().v1.contracts.listBalances({
+      customer_id: metronomeCustomerId,
+      include_balance: true,
+      include_contract_balances: true,
+    })) {
+      balances.push(entry);
+    }
+    return new Ok(balances);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId },
+      "[Metronome] Failed to list balances"
+    );
+    return new Err(error);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Usage queries
+// ---------------------------------------------------------------------------
+
+type WindowSize = "HOUR" | "DAY" | "NONE";
+
+/**
+ * Retrieve aggregated usage data for given customers and metrics.
+ * Uses v1.usage.list — suitable for ungrouped aggregate views.
+ */
+export async function listMetronomeUsage({
+  customerIds,
+  billableMetricIds,
+  startingOn,
+  endingBefore,
+  windowSize,
+}: {
+  customerIds: string[];
+  billableMetricIds?: string[];
+  startingOn: string;
+  endingBefore: string;
+  windowSize: WindowSize;
+}): Promise<Result<MetronomeUsageListResponse[], Error>> {
+  try {
+    const results: MetronomeUsageListResponse[] = [];
+    for await (const entry of getClient().v1.usage.list({
+      starting_on: startingOn,
+      ending_before: endingBefore,
+      window_size: windowSize,
+      customer_ids: customerIds,
+      ...(billableMetricIds
+        ? { billable_metrics: billableMetricIds.map((id) => ({ id })) }
+        : {}),
+    })) {
+      results.push({
+        billableMetricId: entry.billable_metric_id,
+        billableMetricName: entry.billable_metric_name,
+        customerId: entry.customer_id,
+        startTimestamp: entry.start_timestamp,
+        endTimestamp: entry.end_timestamp,
+        value: entry.value,
+      });
+    }
+    return new Ok(results);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error({ error }, "[Metronome] Failed to list usage");
+    return new Err(error);
+  }
+}
+
+/**
+ * Retrieve usage data for a single customer and metric, broken down by group keys.
+ * Uses v1.usage.listWithGroups — requires group keys pre-configured on the metric.
+ */
+export async function listMetronomeUsageWithGroups({
+  customerId,
+  billableMetricId,
+  startingOn,
+  endingBefore,
+  windowSize,
+  groupKey,
+}: {
+  customerId: string;
+  billableMetricId: string;
+  startingOn: string;
+  endingBefore: string;
+  windowSize: WindowSize;
+  groupKey: string[];
+}): Promise<Result<MetronomeUsageWithGroupsResponse[], Error>> {
+  try {
+    const results: MetronomeUsageWithGroupsResponse[] = [];
+    for await (const entry of getClient().v1.usage.listWithGroups({
+      customer_id: customerId,
+      billable_metric_id: billableMetricId,
+      starting_on: startingOn,
+      ending_before: endingBefore,
+      window_size: windowSize,
+      group_key: groupKey,
+    })) {
+      results.push({
+        startingOn: entry.starting_on,
+        endingBefore: entry.ending_before,
+        value: entry.value,
+        group: entry.group ?? null,
+      });
+    }
+    return new Ok(results);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, customerId, billableMetricId },
+      "[Metronome] Failed to list usage with groups"
+    );
     return new Err(error);
   }
 }

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -27,21 +27,10 @@ export interface MetronomeEvent {
   properties: Record<string, string | number>;
 }
 
-// ---------------------------------------------------------------------------
-// Balances — re-export the SDK union type for commits + credits.
-// ---------------------------------------------------------------------------
-
 export type MetronomeBalance = Commit | Credit;
-
-// Re-export for convenience in handlers.
 export type { Commit as MetronomeCommit, Credit as MetronomeCredit };
 
-// Metronome stores USD amounts in cents. Dust uses microUsd (1 dollar = 1_000_000).
 export const METRONOME_CENTS_TO_MICRO_USD = 10_000;
-
-// ---------------------------------------------------------------------------
-// Usage query responses
-// ---------------------------------------------------------------------------
 
 export interface MetronomeUsageListResponse {
   billableMetricId: string;

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -17,10 +17,44 @@ export const PRO_OR_BUSINESS_PACKAGE_ALIASES: ReadonlySet<string> = new Set([
   LEGACY_BUSINESS_39_PACKAGE_ALIAS,
 ]);
 
+import type { Commit, Credit } from "@metronome/sdk/resources/shared";
+
 export interface MetronomeEvent {
   transaction_id: string;
   customer_id: string;
   event_type: string;
   timestamp: string;
   properties: Record<string, string | number>;
+}
+
+// ---------------------------------------------------------------------------
+// Balances — re-export the SDK union type for commits + credits.
+// ---------------------------------------------------------------------------
+
+export type MetronomeBalance = Commit | Credit;
+
+// Re-export for convenience in handlers.
+export type { Commit as MetronomeCommit, Credit as MetronomeCredit };
+
+// Metronome stores USD amounts in cents. Dust uses microUsd (1 dollar = 1_000_000).
+export const METRONOME_CENTS_TO_MICRO_USD = 10_000;
+
+// ---------------------------------------------------------------------------
+// Usage query responses
+// ---------------------------------------------------------------------------
+
+export interface MetronomeUsageListResponse {
+  billableMetricId: string;
+  billableMetricName: string;
+  customerId: string;
+  startTimestamp: string;
+  endTimestamp: string;
+  value: number | null;
+}
+
+export interface MetronomeUsageWithGroupsResponse {
+  startingOn: string;
+  endingBefore: string;
+  value: number | null;
+  group: Record<string, string> | null;
 }

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -5,6 +5,8 @@
  * MetronomeEvent is our own type — stricter than the SDK's UsageIngestParams
  * because we enforce `properties: Record<string, string | number>` (no unknown).
  */
+import type { Commit, Credit } from "@metronome/sdk/resources/shared";
+
 // Metronome package aliases for contract provisioning.
 // These map to packages configured in the Metronome dashboard.
 export const LEGACY_PRO_29_PACKAGE_ALIAS = "legacy-pro-29";
@@ -16,8 +18,6 @@ export const PRO_OR_BUSINESS_PACKAGE_ALIASES: ReadonlySet<string> = new Set([
   LEGACY_PRO_29_PACKAGE_ALIAS,
   LEGACY_BUSINESS_39_PACKAGE_ALIAS,
 ]);
-
-import type { Commit, Credit } from "@metronome/sdk/resources/shared";
 
 export interface MetronomeEvent {
   transaction_id: string;


### PR DESCRIPTION
## Description

Adds client functions to query Metronome balance and usage data. This introduces three new functions to `front/lib/metronome/client.ts`:
- `listMetronomeBalances()` — fetches all commits and credits with current balances via `v1.contracts.listBalances`
- `listMetronomeUsage()` — retrieves aggregated usage data for multiple customers and metrics via `v1.usage.list` (ungrouped view)
- `listMetronomeUsageWithGroups()` - retrieves usage data for a single customer/metric broken down by group keys via `v1.usage.listWithGroups` (e.g., by origin, model, user)

Also exports helper functions `getMetronomeLlmUsageBillableMetricId()` and `getMetronomeToolUseBillableMetricId()` from config to retrieve billable metric IDs from environment variables.

## Tests

N/A

## Risk

None, new functions only, no callers yet.

## Deploy Plan

Deploy front