### PR TITLE
fix: admins shouldn't update other user triggers

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -275,7 +275,9 @@ export default function AgentBuilder({
             editor: user.id,
           }))
         : [],
-      triggersToUpdate: duplicateAgentId ? [] : triggers,
+      triggersToUpdate: duplicateAgentId
+        ? []
+        : triggers.filter((t) => t.editor === user.id),
       triggersToDelete: [],
       agentSettings: {
         ...currentValues.agentSettings,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -196,9 +196,9 @@ async function handler(
 
       // Batch update triggers
       for (const triggerData of triggers) {
-        const triggerToUpdate = auth.isAdmin()
-          ? allTriggers.find((t) => t.sId === triggerData.sId)
-          : userTriggers.find((t) => t.sId === triggerData.sId);
+        const triggerToUpdate = userTriggers.find(
+          (t) => t.sId === triggerData.sId
+        );
 
         if (!triggerToUpdate) {
           continue; // Skip triggers that the user cannot edit
@@ -206,7 +206,7 @@ async function handler(
 
         const triggerValidation = TriggerSchema.safeParse({
           ...triggerData,
-          editor: auth.getNonNullableUser().id,
+          editor: triggerToUpdate.editor,
         });
 
         if (!triggerValidation.success) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Admins shouldn't take over other user triggers

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front