### PR TITLE
Add script to generate HTML instructions

### DIFF
--- a/front/lib/md-to-html/extensions.ts
+++ b/front/lib/md-to-html/extensions.ts
@@ -91,7 +91,18 @@ export function buildServerSafeExtensions(): Extensions {
     Heading.configure({
       levels: [1, 2, 3, 4, 5, 6],
     }),
-    Link.configure({
+    // Override Link to suppress title="null" in static renderer output
+    // (same null-attribute issue as OrderedList).
+    Link.extend({
+      renderHTML({ HTMLAttributes }) {
+        const { title, ...rest } = HTMLAttributes;
+        const attrs = { ...rest };
+        if (title !== null && title !== undefined) {
+          attrs.title = title;
+        }
+        return ["a", mergeAttributes(this.options.HTMLAttributes, attrs), 0];
+      },
+    }).configure({
       autolink: false,
       openOnClick: false,
     }),

--- a/front/lib/md-to-html/extensions.ts
+++ b/front/lib/md-to-html/extensions.ts
@@ -1,0 +1,81 @@
+import { InstructionBlockBaseNode } from "@app/lib/md-to-html/instructionBlockNode";
+import { ListItemExtension } from "@app/lib/md-to-html/listItemExtension";
+import type { AnyExtension, Extensions } from "@tiptap/core";
+import { Extension } from "@tiptap/core";
+import { Heading } from "@tiptap/extension-heading";
+import Link from "@tiptap/extension-link";
+import { Markdown } from "@tiptap/markdown";
+import { StarterKit } from "@tiptap/starter-kit";
+
+const BLOCK_ID_ATTRIBUTE = "block-id";
+
+/**
+ * Global extension that teaches the static renderer how to render
+ * block-id attributes as data-block-id in HTML. The actual ID values
+ * are injected into the JSON by addBlockIds() in index.ts, since
+ * MarkdownManager.parse() doesn't run ProseMirror attribute defaults.
+ */
+const BlockIdGlobalExtension = Extension.create({
+  name: "blockIdGlobal",
+
+  addGlobalAttributes() {
+    return [
+      {
+        types: [
+          "heading",
+          "instructionBlock",
+          "orderedList",
+          "paragraph",
+          "bulletList",
+        ],
+        attributes: {
+          [BLOCK_ID_ATTRIBUTE]: {
+            default: null,
+            renderHTML: (attributes) => {
+              if (!attributes[BLOCK_ID_ATTRIBUTE]) {
+                return {};
+              }
+              return {
+                [`data-${BLOCK_ID_ATTRIBUTE}`]: attributes[BLOCK_ID_ATTRIBUTE],
+              };
+            },
+          },
+        },
+      },
+    ];
+  },
+});
+
+/**
+ * Builds a server-safe TipTap extension stack for agent instructions.
+ * Used by MarkdownManager for markdown→JSON parsing and by the static
+ * renderer for JSON→HTML generation.
+ *
+ * No DOM, React, or browser dependencies required.
+ */
+export function buildServerSafeExtensions(): Extensions {
+  return [
+    Markdown,
+    StarterKit.configure({
+      heading: false,
+      hardBreak: false,
+      listItem: false,
+      link: false,
+      blockquote: false,
+      horizontalRule: false,
+      strike: false,
+      // Keep default code extension enabled (frontend uses custom CodeExtension
+      // for escaped backtick handling, but the default works for server-side).
+    }),
+    ListItemExtension,
+    InstructionBlockBaseNode,
+    BlockIdGlobalExtension,
+    Heading.configure({
+      levels: [1, 2, 3, 4, 5, 6],
+    }),
+    Link.configure({
+      autolink: false,
+      openOnClick: false,
+    }),
+  ] as AnyExtension[];
+}

--- a/front/lib/md-to-html/extensions.ts
+++ b/front/lib/md-to-html/extensions.ts
@@ -1,9 +1,10 @@
 import { InstructionBlockBaseNode } from "@app/lib/md-to-html/instructionBlockNode";
 import { ListItemExtension } from "@app/lib/md-to-html/listItemExtension";
 import type { AnyExtension, Extensions } from "@tiptap/core";
-import { Extension } from "@tiptap/core";
+import { Extension, mergeAttributes } from "@tiptap/core";
 import { Heading } from "@tiptap/extension-heading";
 import Link from "@tiptap/extension-link";
+import { OrderedList } from "@tiptap/extension-list";
 import { Markdown } from "@tiptap/markdown";
 import { StarterKit } from "@tiptap/starter-kit";
 
@@ -60,12 +61,29 @@ export function buildServerSafeExtensions(): Extensions {
       heading: false,
       hardBreak: false,
       listItem: false,
+      orderedList: false,
       link: false,
       blockquote: false,
       horizontalRule: false,
       strike: false,
       // Keep default code extension enabled (frontend uses custom CodeExtension
       // for escaped backtick handling, but the default works for server-side).
+    }),
+    // Override OrderedList to suppress type="null" in static renderer output.
+    // The default extension has type with default null, which ProseMirror's DOM
+    // serializer omits but the static renderer serializes as the string "null".
+    OrderedList.extend({
+      renderHTML({ HTMLAttributes }) {
+        const { start, type, ...rest } = HTMLAttributes;
+        const attrs = { ...rest };
+        if (start !== 1) {
+          attrs.start = start;
+        }
+        if (type !== null && type !== undefined) {
+          attrs.type = type;
+        }
+        return ["ol", mergeAttributes(this.options.HTMLAttributes, attrs), 0];
+      },
     }),
     ListItemExtension,
     InstructionBlockBaseNode,

--- a/front/lib/md-to-html/index.test.ts
+++ b/front/lib/md-to-html/index.test.ts
@@ -56,6 +56,30 @@ describe("convertMarkdownToHtml", () => {
     expect(html).not.toContain('type="null"');
   });
 
+  it("does not alter whitespace of HTML tags inside fenced code blocks", () => {
+    const md = `Some text
+
+\`\`\`
+<div>
+  <p>Hello</p>
+  <h1>Title</h1>
+</div>
+\`\`\`
+
+More text`;
+    const html = convertMarkdownToHtml(md);
+    // Code block should be rendered as <pre><code>.
+    expect(html).toContain("<pre>");
+    expect(html).toContain("<code>");
+    // Tags inside code should NOT have extra \n\n inserted by preprocessing.
+    expect(html).not.toContain("\n\n<p>");
+    expect(html).not.toContain("\n\n</p>");
+    expect(html).not.toContain("\n\n<h1>");
+    // Surrounding text should still be normal paragraphs.
+    expect(html).toContain("Some text");
+    expect(html).toContain("More text");
+  });
+
   it("converts fenced code blocks", () => {
     const html = convertMarkdownToHtml("```\ncode block\n```");
     expect(html).toContain("<pre>");

--- a/front/lib/md-to-html/index.test.ts
+++ b/front/lib/md-to-html/index.test.ts
@@ -56,13 +56,6 @@ describe("convertMarkdownToHtml", () => {
     expect(html).not.toContain('type="null"');
   });
 
-  it("does not auto-link email addresses", () => {
-    const html = convertMarkdownToHtml("Contact amelie@dust.tt for help");
-    expect(html).not.toContain("mailto:");
-    expect(html).not.toContain("<a");
-    expect(html).toContain("amelie@dust.tt");
-  });
-
   it("converts fenced code blocks", () => {
     const html = convertMarkdownToHtml("```\ncode block\n```");
     expect(html).toContain("<pre>");

--- a/front/lib/md-to-html/index.test.ts
+++ b/front/lib/md-to-html/index.test.ts
@@ -51,6 +51,11 @@ describe("convertMarkdownToHtml", () => {
     expect(html).toContain("second");
   });
 
+  it("does not render type=\"null\" on ordered lists", () => {
+    const html = convertMarkdownToHtml("1. first\n2. second");
+    expect(html).not.toContain('type="null"');
+  });
+
   it("converts fenced code blocks", () => {
     const html = convertMarkdownToHtml("```\ncode block\n```");
     expect(html).toContain("<pre>");

--- a/front/lib/md-to-html/index.test.ts
+++ b/front/lib/md-to-html/index.test.ts
@@ -56,6 +56,13 @@ describe("convertMarkdownToHtml", () => {
     expect(html).not.toContain('type="null"');
   });
 
+  it("does not auto-link email addresses", () => {
+    const html = convertMarkdownToHtml("Contact amelie@dust.tt for help");
+    expect(html).not.toContain("mailto:");
+    expect(html).not.toContain("<a");
+    expect(html).toContain("amelie@dust.tt");
+  });
+
   it("converts fenced code blocks", () => {
     const html = convertMarkdownToHtml("```\ncode block\n```");
     expect(html).toContain("<pre>");

--- a/front/lib/md-to-html/index.test.ts
+++ b/front/lib/md-to-html/index.test.ts
@@ -1,0 +1,152 @@
+import { convertMarkdownToHtml } from "@app/lib/md-to-html";
+import { describe, expect, it } from "vitest";
+
+describe("convertMarkdownToHtml", () => {
+  it("converts plain text to HTML paragraphs", () => {
+    const html = convertMarkdownToHtml("Hello world");
+    expect(html).toContain("<p");
+    expect(html).toContain("Hello world</p>");
+  });
+
+  it("converts headings", () => {
+    const html = convertMarkdownToHtml("# Heading 1\n\n## Heading 2");
+    expect(html).toContain("<h1");
+    expect(html).toContain("Heading 1</h1>");
+    expect(html).toContain("<h2");
+    expect(html).toContain("Heading 2</h2>");
+  });
+
+  it("converts instruction blocks", () => {
+    const html = convertMarkdownToHtml(
+      "<instructions>\nhello\n</instructions>"
+    );
+    expect(html).toContain('data-type="instruction-block"');
+    expect(html).toContain('data-instruction-type="instructions"');
+    expect(html).toContain("hello");
+  });
+
+  it("converts nested instruction blocks", () => {
+    const html = convertMarkdownToHtml(
+      "<outer>\n<inner>\ntext\n</inner>\n</outer>"
+    );
+    expect(html).toContain('data-instruction-type="outer"');
+    expect(html).toContain('data-instruction-type="inner"');
+    expect(html).toContain("text");
+  });
+
+  it("converts bullet lists", () => {
+    const html = convertMarkdownToHtml("- item 1\n- item 2\n- item 3");
+    expect(html).toContain("<ul");
+    expect(html).toContain("<li>");
+    expect(html).toContain("item 1");
+    expect(html).toContain("item 2");
+    expect(html).toContain("item 3");
+  });
+
+  it("converts ordered lists", () => {
+    const html = convertMarkdownToHtml("1. first\n2. second");
+    expect(html).toContain("<ol");
+    expect(html).toContain("<li>");
+    expect(html).toContain("first");
+    expect(html).toContain("second");
+  });
+
+  it("converts fenced code blocks", () => {
+    const html = convertMarkdownToHtml("```\ncode block\n```");
+    expect(html).toContain("<pre>");
+    expect(html).toContain("<code>");
+    expect(html).toContain("code block");
+  });
+
+  it("converts inline code", () => {
+    const html = convertMarkdownToHtml("Use `myFunction()` here");
+    expect(html).toContain("<code>");
+    expect(html).toContain("myFunction()");
+  });
+
+  it("converts links", () => {
+    const html = convertMarkdownToHtml("[example](https://example.com)");
+    expect(html).toContain("<a");
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain("example");
+  });
+
+  it("converts instruction blocks with headings and lists inside", () => {
+    const md = `<instructions>
+# Title
+
+Some text
+
+- item 1
+- item 2
+</instructions>`;
+    const html = convertMarkdownToHtml(md);
+    expect(html).toContain('data-type="instruction-block"');
+    expect(html).toContain("<h1");
+    expect(html).toContain("Title</h1>");
+    expect(html).toContain("<ul");
+    expect(html).toContain("item 1");
+  });
+
+  it("handles empty instruction blocks without crashing", () => {
+    expect(() => convertMarkdownToHtml("<foo>\n</foo>")).not.toThrow();
+    const html = convertMarkdownToHtml("<foo>\n</foo>");
+    expect(html).toContain('data-instruction-type="foo"');
+  });
+
+  it("strips style and class attributes from output", () => {
+    const html = convertMarkdownToHtml("# Heading\n\nParagraph");
+    expect(html).not.toMatch(/\bstyle="/);
+    expect(html).not.toMatch(/\bclass="/);
+  });
+
+  it("preserves data attributes on instruction blocks", () => {
+    const html = convertMarkdownToHtml(
+      "<instructions>\nhello\n</instructions>"
+    );
+    expect(html).toContain("data-type=");
+    expect(html).toContain("data-instruction-type=");
+  });
+
+  it("adds data-block-id to block-level elements", () => {
+    const html = convertMarkdownToHtml("# Heading\n\nParagraph\n\n- item");
+    const blockIdMatches = html.match(/data-block-id="[a-f0-9]{8}"/g);
+    expect(blockIdMatches).not.toBeNull();
+    expect(blockIdMatches!.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("handles tags with attributes by keeping them escaped", () => {
+    const md = `<task type="main">
+content
+</task>`;
+    expect(() => convertMarkdownToHtml(md)).not.toThrow();
+  });
+
+  it("handles deeply nested instruction blocks", () => {
+    const md = `<prompt>
+<instructions>
+<do>
+something
+</do>
+</instructions>
+</prompt>`;
+    const html = convertMarkdownToHtml(md);
+    expect(html).toContain('data-instruction-type="prompt"');
+    expect(html).toContain("something");
+  });
+
+  it("converts bold and italic", () => {
+    const html = convertMarkdownToHtml("**bold** and *italic*");
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<em>italic</em>");
+  });
+
+  it("wraps output in instructions-root div", () => {
+    const html = convertMarkdownToHtml("Hello");
+    expect(html).toMatch(
+      /^<div data-type="instructions-root" data-block-id="instructions-root">/
+    );
+    expect(html).toMatch(/<\/div>$/);
+    expect(html).toContain("Hello</p>");
+  });
+});

--- a/front/lib/md-to-html/index.ts
+++ b/front/lib/md-to-html/index.ts
@@ -48,34 +48,6 @@ function addBlockIds(node: JSONContent): JSONContent {
 }
 
 /**
- * Removes auto-linked email addresses from the JSON tree. The markdown
- * parser (marked) auto-links bare emails like user@example.com into link
- * nodes with mailto: hrefs, but the frontend editor doesn't — so we
- * unwrap them back to plain text to match.
- */
-function removeAutoLinkedEmails(node: JSONContent): JSONContent {
-  if (node.content) {
-    return {
-      ...node,
-      content: node.content.flatMap((child) => {
-        if (
-          child.type === "text" &&
-          child.marks?.length === 1 &&
-          child.marks[0].type === "link" &&
-          child.marks[0].attrs?.href?.startsWith("mailto:")
-        ) {
-          const { marks: _, ...rest } = child;
-          return [rest];
-        }
-        return [removeAutoLinkedEmails(child)];
-      }),
-    };
-  }
-
-  return node;
-}
-
-/**
  * Wraps rendered HTML in the instructions-root div, matching the
  * frontend editor's InstructionsRootExtension output.
  */
@@ -95,7 +67,7 @@ export function convertMarkdownToHtml(markdown: string): string {
   const preprocessed = preprocessMarkdownForEditor(markdown);
 
   const manager = new MarkdownManager({ extensions });
-  const json = addBlockIds(removeAutoLinkedEmails(manager.parse(preprocessed)));
+  const json = addBlockIds(manager.parse(preprocessed));
 
   const innerHtml = renderToHTMLString({ extensions, content: json });
 

--- a/front/lib/md-to-html/index.ts
+++ b/front/lib/md-to-html/index.ts
@@ -48,6 +48,34 @@ function addBlockIds(node: JSONContent): JSONContent {
 }
 
 /**
+ * Removes auto-linked email addresses from the JSON tree. The markdown
+ * parser (marked) auto-links bare emails like user@example.com into link
+ * nodes with mailto: hrefs, but the frontend editor doesn't — so we
+ * unwrap them back to plain text to match.
+ */
+function removeAutoLinkedEmails(node: JSONContent): JSONContent {
+  if (node.content) {
+    return {
+      ...node,
+      content: node.content.flatMap((child) => {
+        if (
+          child.type === "text" &&
+          child.marks?.length === 1 &&
+          child.marks[0].type === "link" &&
+          child.marks[0].attrs?.href?.startsWith("mailto:")
+        ) {
+          const { marks: _, ...rest } = child;
+          return [rest];
+        }
+        return [removeAutoLinkedEmails(child)];
+      }),
+    };
+  }
+
+  return node;
+}
+
+/**
  * Wraps rendered HTML in the instructions-root div, matching the
  * frontend editor's InstructionsRootExtension output.
  */
@@ -67,7 +95,7 @@ export function convertMarkdownToHtml(markdown: string): string {
   const preprocessed = preprocessMarkdownForEditor(markdown);
 
   const manager = new MarkdownManager({ extensions });
-  const json = addBlockIds(manager.parse(preprocessed));
+  const json = addBlockIds(removeAutoLinkedEmails(manager.parse(preprocessed)));
 
   const innerHtml = renderToHTMLString({ extensions, content: json });
 

--- a/front/lib/md-to-html/index.ts
+++ b/front/lib/md-to-html/index.ts
@@ -1,0 +1,75 @@
+import { buildServerSafeExtensions } from "@app/lib/md-to-html/extensions";
+import { preprocessMarkdownForEditor } from "@app/lib/md-to-html/preprocessMarkdown";
+import { stripHtmlAttributes } from "@app/lib/md-to-html/stripHtmlAttributes";
+import type { JSONContent } from "@tiptap/core";
+import { MarkdownManager } from "@tiptap/markdown";
+import { renderToHTMLString } from "@tiptap/static-renderer";
+
+const INSTRUCTIONS_ROOT_BLOCK_ID = "instructions-root";
+
+const BLOCK_ID_TYPES = new Set([
+  "heading",
+  "instructionBlock",
+  "orderedList",
+  "paragraph",
+  "bulletList",
+]);
+
+function generateShortId(): string {
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Recursively adds block-id attributes to block-level nodes in the JSON,
+ * matching the same node types as the frontend BlockIdExtension.
+ *
+ * This is needed because MarkdownManager.parse() produces raw JSON without
+ * running ProseMirror attribute defaults — so the BlockIdGlobalExtension
+ * in extensions.ts only handles rendering, while this function generates
+ * the actual ID values.
+ */
+function addBlockIds(node: JSONContent): JSONContent {
+  const result = { ...node };
+
+  if (result.type && BLOCK_ID_TYPES.has(result.type)) {
+    result.attrs = {
+      ...result.attrs,
+      "block-id": generateShortId(),
+    };
+  }
+
+  if (result.content) {
+    result.content = result.content.map(addBlockIds);
+  }
+
+  return result;
+}
+
+/**
+ * Wraps rendered HTML in the instructions-root div, matching the
+ * frontend editor's InstructionsRootExtension output.
+ */
+function wrapInInstructionsRoot(html: string): string {
+  return `<div data-type="${INSTRUCTIONS_ROOT_BLOCK_ID}" data-block-id="${INSTRUCTIONS_ROOT_BLOCK_ID}">${html}</div>`;
+}
+
+/**
+ * Converts markdown instructions to clean HTML using the same TipTap
+ * parsing pipeline as the frontend agent builder editor.
+ *
+ * Uses MarkdownManager for markdown→JSON and the static renderer for
+ * JSON→HTML. No DOM or browser environment required.
+ */
+export function convertMarkdownToHtml(markdown: string): string {
+  const extensions = buildServerSafeExtensions();
+  const preprocessed = preprocessMarkdownForEditor(markdown);
+
+  const manager = new MarkdownManager({ extensions });
+  const json = addBlockIds(manager.parse(preprocessed));
+
+  const innerHtml = renderToHTMLString({ extensions, content: json });
+
+  return stripHtmlAttributes(wrapInInstructionsRoot(innerHtml));
+}

--- a/front/lib/md-to-html/instructionBlockNode.ts
+++ b/front/lib/md-to-html/instructionBlockNode.ts
@@ -1,0 +1,149 @@
+import {
+  INSTRUCTION_BLOCK_REGEX,
+  OPENING_TAG_BEGINNING_REGEX,
+} from "@app/lib/md-to-html/instructionBlockUtils";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { MarkdownLexerConfiguration, MarkdownToken } from "@tiptap/core";
+import { mergeAttributes, Node } from "@tiptap/core";
+
+export const INSTRUCTIONS_ROOT_NODE_NAME = "instructionsRoot";
+
+export interface InstructionBlockAttributes {
+  type: string;
+}
+
+export const InstructionBlockBaseNode = Node.create<InstructionBlockAttributes>(
+  {
+    name: "instructionBlock",
+    group: "block",
+    priority: 1000,
+    content: "block+",
+    defining: true,
+    isolating: true,
+    selectable: true,
+
+    addAttributes() {
+      return {
+        type: {
+          default: "instructions",
+          parseHTML: (element) =>
+            element.getAttribute("data-instruction-type") ?? "instructions",
+          renderHTML: (attributes) => ({
+            "data-instruction-type": attributes.type,
+          }),
+        },
+        isCollapsed: {
+          default: false,
+          parseHTML: (element) =>
+            element.getAttribute("data-collapsed") === "true",
+          renderHTML: (attributes) => ({
+            "data-collapsed": attributes.isCollapsed,
+          }),
+        },
+      };
+    },
+
+    parseHTML() {
+      return [
+        {
+          tag: "div[data-type='instruction-block']",
+        },
+      ];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+      return [
+        "div",
+        mergeAttributes(HTMLAttributes, {
+          "data-type": "instruction-block",
+        }),
+        0,
+      ];
+    },
+
+    markdownTokenizer: {
+      name: "instructionBlock",
+      level: "block",
+      start: (src) => {
+        const match = src.match(OPENING_TAG_BEGINNING_REGEX);
+        return match?.index ?? -1;
+      },
+      tokenize: (
+        src: string,
+        _tokens: MarkdownToken[],
+        lexer: MarkdownLexerConfiguration
+      ) => {
+        const match = src.match(INSTRUCTION_BLOCK_REGEX);
+        if (!match) {
+          return undefined;
+        }
+
+        const tagName = match[1] || "instructions";
+        const content = match[2];
+
+        let tokens;
+        try {
+          tokens = lexer.blockTokens(content);
+        } catch (error) {
+          try {
+            tokens = lexer.blockTokens(content.trim());
+            logger.warn("Marked lexer state corruption, passed with trim()", {
+              error: normalizeError(error),
+              sourceString: src,
+              match2: content,
+            });
+          } catch (error) {
+            logger.error(
+              "Marked lexer state corruption, failed with trim(). Fallbacking...",
+              {
+                error: normalizeError(error),
+                sourceString: src,
+                match2: content.trim(),
+              }
+            );
+            return undefined;
+          }
+        }
+
+        return {
+          type: "instructionBlock",
+          raw: match[0],
+          attrs: {
+            type: tagName.toLowerCase(),
+          },
+          text: content,
+          tokens,
+        };
+      },
+    },
+
+    parseMarkdown: (token, helpers) => {
+      const tagType = token.attrs?.type ?? "instructions";
+      const rawContent = helpers.parseChildren(token.tokens ?? []);
+
+      const content = rawContent.flatMap((node) =>
+        node.type === INSTRUCTIONS_ROOT_NODE_NAME
+          ? (node.content ?? [])
+          : [node]
+      );
+
+      return {
+        type: "instructionBlock",
+        attrs: {
+          type: tagType,
+          isCollapsed: false,
+        },
+        content: content.length > 0 ? content : [{ type: "paragraph" }],
+      };
+    },
+
+    renderMarkdown: (node, helpers) => {
+      const tagType = node.attrs?.type ?? "instructions";
+      const children = node.content ?? [];
+
+      const content = helpers.renderChildren(children, "\n\n");
+      return `<${tagType}>\n\n${content}\n\n</${tagType}>`;
+    },
+  }
+);

--- a/front/lib/md-to-html/instructionBlockUtils.ts
+++ b/front/lib/md-to-html/instructionBlockUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Tag name pattern (XML-like, simplified): start with letter/_ then [A-Za-z0-9._:-]*
+ */
+export const TAG_NAME_PATTERN = "[A-Za-z_][A-Za-z0-9._:-]*";
+
+/**
+ * Regex pattern for matching opening/closing XML tags (including empty <> when typing).
+ */
+export const OPENING_TAG_REGEX = new RegExp(`<(${TAG_NAME_PATTERN})?>$`);
+export const OPENING_TAG_BEGINNING_REGEX = new RegExp(
+  `^<(${TAG_NAME_PATTERN})>`,
+  "i"
+);
+export const CLOSING_TAG_REGEX = new RegExp(`^</(${TAG_NAME_PATTERN})?>$`);
+
+export const INSTRUCTION_BLOCK_REGEX = new RegExp(
+  `^<(${TAG_NAME_PATTERN})>([\\s\\S]*?)</\\1>`,
+  "i"
+);

--- a/front/lib/md-to-html/listItemExtension.ts
+++ b/front/lib/md-to-html/listItemExtension.ts
@@ -1,0 +1,74 @@
+import type { JSONContent } from "@tiptap/core";
+import { ListItem } from "@tiptap/extension-list-item";
+
+function isInlineNode(node: JSONContent): boolean {
+  return node.type === "text" || !node.type;
+}
+
+/**
+ * Wraps any inline (non-block) nodes in paragraphs so the result only contains
+ * block-level nodes, as required by the listItem schema ("paragraph block*").
+ */
+function ensureBlockContent(content: JSONContent[]): JSONContent[] {
+  const result: JSONContent[] = [];
+  let pendingInline: JSONContent[] = [];
+
+  const flushInline = () => {
+    if (pendingInline.length > 0) {
+      result.push({ type: "paragraph", content: pendingInline });
+      pendingInline = [];
+    }
+  };
+
+  for (const node of content) {
+    if (isInlineNode(node)) {
+      pendingInline.push(node);
+    } else {
+      flushInline();
+      result.push(node);
+    }
+  }
+  flushInline();
+
+  // Schema requires at least one leading paragraph.
+  if (result.length === 0 || result[0].type !== "paragraph") {
+    result.unshift({ type: "paragraph", content: [] });
+  }
+
+  return result;
+}
+
+// Capture the original parseMarkdown from the base ListItem extension.
+const originalParseMarkdown = ListItem.config.parseMarkdown;
+
+/**
+ * Extends the default ListItem to fix schema violations when parsing markdown
+ * with same-line nested list markers (e.g. "- - text" or "- 1. text").
+ *
+ * The marked tokenizer interprets these as nested lists, producing a listItem
+ * whose content starts with a bulletList/orderedList instead of a paragraph,
+ * or contains loose text nodes that aren't wrapped in paragraphs.
+ * This violates the listItem schema ("paragraph block*") and crashes
+ * ProseMirror with: "Invalid content for node listItem".
+ *
+ * Fix: delegate to the original parseMarkdown, then post-process the result
+ * to ensure content always starts with a paragraph and that all inline nodes
+ * are wrapped in paragraphs.
+ */
+export const ListItemExtension = ListItem.extend({
+  parseMarkdown: (token, helpers) => {
+    if (!originalParseMarkdown) {
+      return [];
+    }
+
+    const result = originalParseMarkdown(token, helpers);
+
+    // The original returns { type: "listItem", content: [...] } or [] for
+    // non-list_item tokens.
+    if (!Array.isArray(result) && "type" in result && result.content) {
+      result.content = ensureBlockContent(result.content);
+    }
+
+    return result;
+  },
+});

--- a/front/lib/md-to-html/preprocessMarkdown.ts
+++ b/front/lib/md-to-html/preprocessMarkdown.ts
@@ -43,13 +43,22 @@ function collectMatchedTagNames(str: string): Set<string> {
  * TODO: Remove when tiptap merges https://github.com/ueberdosis/tiptap/pull/7260
  */
 export function preprocessMarkdownForEditor(markdown: string): string {
-  // Strip fenced code blocks before collecting tag names so that HTML tags
-  // inside code (e.g. JSX/React snippets) are not treated as instruction blocks.
-  const withoutCodeBlocks = markdown.replace(/```[\s\S]*?```/g, "");
-  const matchedPairs = collectMatchedTagNames(withoutCodeBlocks);
+  // Protect fenced code blocks from all preprocessing by replacing them with
+  // placeholders. This prevents HTML tags inside code (e.g. JSX/React snippets)
+  // from being treated as instruction blocks or having their whitespace altered.
+  const codeBlocks: string[] = [];
+  const withPlaceholders = markdown.replace(/```[\s\S]*?```/g, (match) => {
+    codeBlocks.push(match);
+    return `\n\n__CODE_BLOCK_${codeBlocks.length - 1}__\n\n`;
+  });
+
+  const matchedPairs = collectMatchedTagNames(withPlaceholders);
 
   // Step 1: Escape `<` only when not already followed by ZWS (avoids double-escaping round-trips).
-  let processed = markdown.replace(new RegExp(`<(?!${ZWS})`, "g"), `<${ZWS}`);
+  let processed = withPlaceholders.replace(
+    new RegExp(`<(?!${ZWS})`, "g"),
+    `<${ZWS}`
+  );
 
   // Step 2: Normalize indented block-level tags
 
@@ -131,6 +140,11 @@ export function preprocessMarkdownForEditor(markdown: string): string {
       return match;
     }
   );
+
+  // Restore fenced code blocks from placeholders.
+  for (let i = 0; i < codeBlocks.length; i++) {
+    processed = processed.replace(`__CODE_BLOCK_${i}__`, codeBlocks[i]);
+  }
 
   return processed;
 }

--- a/front/lib/md-to-html/preprocessMarkdown.ts
+++ b/front/lib/md-to-html/preprocessMarkdown.ts
@@ -1,0 +1,133 @@
+import { TAG_NAME_PATTERN } from "@app/lib/md-to-html/instructionBlockUtils";
+
+/** Zero-width space to break HTML parsing without affecting display. */
+const ZWS = "\u200B";
+
+/**
+ * Collects tag names that appear in matched instruction-block pairs (supports
+ * nesting). Supports tags with attributes. Recurse into inner content to find nested pairs.
+ */
+function collectMatchedTagNames(str: string): Set<string> {
+  const matched = new Set<string>();
+  let m;
+  // Support attributes: <tag attr="value">...</tag>
+  const regex = new RegExp(
+    `<(${TAG_NAME_PATTERN})[^>]*>([\\s\\S]*?)<\\/\\1>`,
+    "gi"
+  );
+  while ((m = regex.exec(str)) !== null) {
+    matched.add(m[1].toLowerCase());
+    for (const tag of collectMatchedTagNames(m[2])) {
+      matched.add(tag);
+    }
+  }
+  return matched;
+}
+
+/**
+ * Workaround for tiptap/markdown #7256: escape angle brackets so markdown-it
+ * won't parse HTML, except for matched block pairs.
+ *
+ * Why this exists:
+ *   markdown-it strips unrecognized HTML tags (e.g. <agent>, <rules>) from
+ *   content before tiptap's custom tokenizer ever sees them. We insert a
+ *   zero-width space (ZWS) after every `<` to break HTML parsing.
+ *
+ * Strategy (3 steps):
+ *   1. Escape ALL `<` by inserting ZWS → nothing looks like HTML anymore.
+ *   2. Normalize indentation so the tokenizer sees tags as block starts.
+ *   3. Un-escape matched-pair tags that are at line start (block-level) or
+ *      immediately after a parent/sibling tag we just un-escaped (nested blocks).
+ *      Inline matched pairs (e.g. "text <do>this</do>") stay escaped.
+ *
+ * TODO: Remove when tiptap merges https://github.com/ueberdosis/tiptap/pull/7260
+ */
+export function preprocessMarkdownForEditor(markdown: string): string {
+  const matchedPairs = collectMatchedTagNames(markdown);
+
+  // Step 1: Escape `<` only when not already followed by ZWS (avoids double-escaping round-trips).
+  let processed = markdown.replace(new RegExp(`<(?!${ZWS})`, "g"), `<${ZWS}`);
+
+  // Step 2: Normalize indented block-level tags
+
+  // 2a: Add \n\n before opening tags so marked treats them as separate blocks.
+  processed = processed.replace(
+    new RegExp(`(?<!\\n)\\n\\s*(<${ZWS}${TAG_NAME_PATTERN}>)`, "g"),
+    "\n\n$1"
+  );
+  // 2b: Add \n\n before closing tags so they're seen as separate blocks.
+  processed = processed.replace(
+    new RegExp(`(?<!\\n)\\n\\s*(<${ZWS}\\/${TAG_NAME_PATTERN}>)`, "g"),
+    "\n\n$1"
+  );
+  // 2c: Add \n\n after closing tags to generate block separation.
+  processed = processed.replace(
+    new RegExp(`(<${ZWS}\\/${TAG_NAME_PATTERN}>)\\s*\\n(?!\\n)`, "g"),
+    "$1\n\n"
+  );
+  // 2d: Collapse newlines between a matched-pair tag's > and the next <tag>,
+  // e.g. <agent>\n\n<bar> → <agent><bar>, so the tokenizer sees ^<tag> at content start.
+  // Only collapse when the > is from a matched-pair tag (not e.g. --> or ]]>).
+  if (matchedPairs.size > 0) {
+    const tagNamesPattern = Array.from(matchedPairs)
+      .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+      .join("|");
+    processed = processed.replace(
+      new RegExp(
+        `(?<=<${ZWS}\\/?(?:${tagNamesPattern})>)>\\n+\\s*(<${ZWS}${TAG_NAME_PATTERN}>)`,
+        "gi"
+      ),
+      ">$1"
+    );
+  }
+
+  // Step 3: Un-escape matched block-level tags.
+  // Opening tags: un-escape if at line start OR immediately after a previously
+  // un-escaped tag (parent opening or sibling closing — positions recorded from 2d collapse).
+  // Closing tags: un-escape when they have a matching open (tracked via openCount).
+  const escapedTagRegex = new RegExp(
+    `<${ZWS}(\\/?)(${TAG_NAME_PATTERN})([^>]*)>`,
+    "gi"
+  );
+  const openCount = new Map<string, number>();
+  const validNestedPositions = new Set<number>();
+
+  processed = processed.replace(
+    escapedTagRegex,
+    (match, slash, tagName, rest, offset) => {
+      const normalized = tagName.toLowerCase();
+      const isClosing = slash === "/";
+
+      if (isClosing) {
+        const count = openCount.get(normalized) ?? 0;
+        if (count > 0) {
+          openCount.set(normalized, count - 1);
+          validNestedPositions.add(offset + match.length);
+          return `<${slash}${tagName}${rest}>`;
+        }
+        return match;
+      }
+
+      const before = processed.substring(0, offset);
+      const lineStart = before.lastIndexOf("\n") + 1;
+      const textOnLine = before.substring(lineStart);
+      const isAtLineStart = /^\s*$/.test(textOnLine);
+      const isNestedChild = validNestedPositions.has(offset);
+
+      if (matchedPairs.has(normalized) && (isAtLineStart || isNestedChild)) {
+        // Don't un-escape if the tag has attributes — those cause schema violations.
+        // When we skip un-escaping, openCount is NOT incremented, so the closing tag
+        // also stays escaped automatically.
+        if (rest !== "") {
+          return match;
+        }
+        openCount.set(normalized, (openCount.get(normalized) ?? 0) + 1);
+        validNestedPositions.add(offset + match.length);
+        return `<${slash}${tagName}${rest}>`;
+      }
+      return match;
+    }
+  );
+
+  return processed;
+}

--- a/front/lib/md-to-html/preprocessMarkdown.ts
+++ b/front/lib/md-to-html/preprocessMarkdown.ts
@@ -43,7 +43,10 @@ function collectMatchedTagNames(str: string): Set<string> {
  * TODO: Remove when tiptap merges https://github.com/ueberdosis/tiptap/pull/7260
  */
 export function preprocessMarkdownForEditor(markdown: string): string {
-  const matchedPairs = collectMatchedTagNames(markdown);
+  // Strip fenced code blocks before collecting tag names so that HTML tags
+  // inside code (e.g. JSX/React snippets) are not treated as instruction blocks.
+  const withoutCodeBlocks = markdown.replace(/```[\s\S]*?```/g, "");
+  const matchedPairs = collectMatchedTagNames(withoutCodeBlocks);
 
   // Step 1: Escape `<` only when not already followed by ZWS (avoids double-escaping round-trips).
   let processed = markdown.replace(new RegExp(`<(?!${ZWS})`, "g"), `<${ZWS}`);

--- a/front/lib/md-to-html/stripHtmlAttributes.ts
+++ b/front/lib/md-to-html/stripHtmlAttributes.ts
@@ -1,0 +1,17 @@
+import DOMPurify from "isomorphic-dompurify";
+
+/**
+ * Strip style, class, and id attributes from HTML while preserving all tags.
+ * Uses isomorphic-dompurify so it works in both browser and Node.js.
+ */
+export function stripHtmlAttributes(html: string): string {
+  try {
+    return DOMPurify.sanitize(html, {
+      ADD_TAGS: ["*"],
+      FORBID_ATTR: ["style", "class", "id"],
+    });
+  } catch {
+    // Fallback: return the original HTML if sanitization fails.
+    return html;
+  }
+}

--- a/front/package.json
+++ b/front/package.json
@@ -105,6 +105,7 @@
     "@tiptap/pm": "^3.19.0",
     "@tiptap/react": "^3.19.0",
     "@tiptap/starter-kit": "^3.19.0",
+    "@tiptap/static-renderer": "^3.19.0",
     "@tiptap/suggestion": "^3.19.0",
     "@types/adm-zip": "^0.5.7",
     "@types/json-schema": "^7.0.15",

--- a/front/scripts/generate_html_instructions.ts
+++ b/front/scripts/generate_html_instructions.ts
@@ -1,0 +1,115 @@
+import { convertMarkdownToHtml } from "@app/lib/md-to-html";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Op } from "sequelize";
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description: "Optional workspace ID. If omitted, runs on all workspaces.",
+    },
+    agentId: {
+      type: "string",
+      description:
+        "Optional agent sId. Requires workspaceId. If omitted, runs on all agents in the workspace.",
+    },
+  },
+  async ({ workspaceId, agentId }, logger) => {
+    if (agentId && !workspaceId) {
+      logger.error("agentId requires workspaceId");
+      return;
+    }
+
+    let generatedCount = 0;
+    let skippedAlreadyHasHtmlCount = 0;
+    let skippedNoMarkdownCount = 0;
+
+    async function processWorkspace(workspace: LightWorkspaceType) {
+      const where: Record<string, unknown> = {
+        workspaceId: workspace.id,
+        status: "active",
+        instructions: { [Op.ne]: null },
+        instructionsHtml: { [Op.is]: null },
+      };
+
+      if (agentId) {
+        where.sId = agentId;
+      }
+
+      const agents = await AgentConfigurationModel.findAll({
+        where,
+        attributes: ["id", "sId", "name", "workspaceId", "instructions"],
+      });
+
+      for (const agent of agents) {
+        const html = convertMarkdownToHtml(agent.instructions!);
+
+        await AgentConfigurationModel.update(
+          { instructionsHtml: html },
+          { where: { id: agent.id } }
+        );
+
+        generatedCount++;
+        logger.info(
+          {
+            agentSId: agent.sId,
+            agentName: agent.name,
+            workspaceId: workspace.sId,
+            htmlLength: html.length,
+          },
+          "Generated HTML instructions"
+        );
+      }
+    }
+
+    if (workspaceId) {
+      const workspace = await WorkspaceResource.fetchById(workspaceId);
+      if (!workspace) {
+        logger.error({ workspaceId }, "Workspace not found");
+        return;
+      }
+
+      // Count skipped agents for reporting.
+      const lightWorkspace = renderLightWorkspaceType({ workspace });
+
+      const alreadyHasHtml = await AgentConfigurationModel.count({
+        where: {
+          workspaceId: lightWorkspace.id,
+          status: "active",
+          instructions: { [Op.ne]: null },
+          instructionsHtml: { [Op.ne]: null },
+          ...(agentId ? { sId: agentId } : {}),
+        },
+      });
+      skippedAlreadyHasHtmlCount = alreadyHasHtml;
+
+      const noMarkdown = await AgentConfigurationModel.count({
+        where: {
+          workspaceId: lightWorkspace.id,
+          status: "active",
+          instructions: { [Op.is]: null },
+          ...(agentId ? { sId: agentId } : {}),
+        },
+      });
+      skippedNoMarkdownCount = noMarkdown;
+
+      await processWorkspace(lightWorkspace);
+    } else {
+      await runOnAllWorkspaces(processWorkspace);
+    }
+
+    logger.info(
+      {
+        generatedCount,
+        skippedAlreadyHasHtmlCount,
+        skippedNoMarkdownCount,
+      },
+      "Generation complete"
+    );
+  }
+);

--- a/front/scripts/validate_html_instructions.ts
+++ b/front/scripts/validate_html_instructions.ts
@@ -30,7 +30,7 @@ function normalizeHtml(html: string): string {
       .replace(/ +(<\/(?:p|li|h[1-6])>)/g, "$1")
       // Unwrap links whose text matches the href (auto-linked URLs and emails).
       .replace(
-        /<a[^>]*href="(?:mailto:)?([^"]*)"[^>]*>\1<\/a>/g,
+        /<a[^>]*href="(?:mailto:)?([^"]*)"[^>]*>\s*\1\s*<\/a>/g,
         "$1"
       )
       // Normalize leading whitespace after opening block tags.

--- a/front/scripts/validate_html_instructions.ts
+++ b/front/scripts/validate_html_instructions.ts
@@ -28,10 +28,9 @@ function normalizeHtml(html: string): string {
       // The frontend editor may preserve trailing spaces that the
       // markdown parser trims.
       .replace(/ +(<\/(?:p|li|h[1-6])>)/g, "$1")
-      // Unwrap mailto links: <a ...href="mailto:x@y"...>x@y</a> → x@y
-      // The stored HTML may have auto-linked emails from the frontend editor.
+      // Unwrap links whose text matches the href (auto-linked URLs and emails).
       .replace(
-        /<a[^>]*href="mailto:([^"]*)"[^>]*>\1<\/a>/g,
+        /<a[^>]*href="(?:mailto:)?([^"]*)"[^>]*>\1<\/a>/g,
         "$1"
       )
       // Normalize leading whitespace after opening block tags.

--- a/front/scripts/validate_html_instructions.ts
+++ b/front/scripts/validate_html_instructions.ts
@@ -6,8 +6,17 @@ import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { LightWorkspaceType } from "@app/types/user";
 
-function normalizeBlockIds(html: string): string {
-  return html.replace(/data-block-id="[^"]*"/g, 'data-block-id="xxx"');
+function normalizeHtml(html: string): string {
+  return (
+    html
+      // Normalize block-ids to a fixed value.
+      .replace(/data-block-id="[^"]*"/g, 'data-block-id="xxx"')
+      // Unwrap emoji spans: <span data-name="..." data-type="emoji">🟢</span> → 🟢
+      .replace(
+        /<span[^>]*data-type="emoji"[^>]*>([^<]*)<\/span>/g,
+        "$1"
+      )
+  );
 }
 
 makeScript(
@@ -53,29 +62,21 @@ makeScript(
 
         if (!agent.instructionsHtml) {
           noHtmlCount++;
-          logger.info(
-            {
-              agentSId: agent.sId,
-              agentName: agent.name,
-              workspaceId: workspace.sId,
-            },
-            "Agent has markdown but no HTML instructions"
-          );
           continue;
         }
 
         const generated = convertMarkdownToHtml(agent.instructions);
         if (
-          normalizeBlockIds(generated) ===
-          normalizeBlockIds(agent.instructionsHtml)
+          normalizeHtml(generated) ===
+          normalizeHtml(agent.instructionsHtml)
         ) {
           matchCount++;
         } else {
           mismatchCount++;
 
           // Diff on normalized HTML so block-id noise is removed.
-          const normalizedStored = normalizeBlockIds(agent.instructionsHtml);
-          const normalizedGenerated = normalizeBlockIds(generated);
+          const normalizedStored = normalizeHtml(agent.instructionsHtml);
+          const normalizedGenerated = normalizeHtml(generated);
 
           let diffIdx = 0;
           while (

--- a/front/scripts/validate_html_instructions.ts
+++ b/front/scripts/validate_html_instructions.ts
@@ -1,0 +1,129 @@
+import { convertMarkdownToHtml } from "@app/lib/md-to-html";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types/user";
+
+function normalizeBlockIds(html: string): string {
+  return html.replace(/data-block-id="[^"]*"/g, 'data-block-id="xxx"');
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description: "Optional workspace ID to filter by.",
+    },
+    limit: {
+      type: "number",
+      description: "Maximum number of agents to process per workspace.",
+      default: 1000,
+    },
+  },
+  async ({ workspaceId, limit }, logger) => {
+    let matchCount = 0;
+    let mismatchCount = 0;
+    let noHtmlCount = 0;
+    let noInstructionsCount = 0;
+
+    async function validateWorkspace(workspace: LightWorkspaceType) {
+      const agents = await AgentConfigurationModel.findAll({
+        where: {
+          workspaceId: workspace.id,
+          status: "active",
+        },
+        attributes: [
+          "id",
+          "sId",
+          "name",
+          "workspaceId",
+          "instructions",
+          "instructionsHtml",
+        ],
+        limit,
+      });
+
+      for (const agent of agents) {
+        if (!agent.instructions) {
+          noInstructionsCount++;
+          continue;
+        }
+
+        if (!agent.instructionsHtml) {
+          noHtmlCount++;
+          logger.info(
+            {
+              agentSId: agent.sId,
+              agentName: agent.name,
+              workspaceId: workspace.sId,
+            },
+            "Agent has markdown but no HTML instructions"
+          );
+          continue;
+        }
+
+        const generated = convertMarkdownToHtml(agent.instructions);
+        if (
+          normalizeBlockIds(generated) ===
+          normalizeBlockIds(agent.instructionsHtml)
+        ) {
+          matchCount++;
+        } else {
+          mismatchCount++;
+
+          // Find first divergence point for a concise diff.
+          let diffIdx = 0;
+          while (
+            diffIdx < generated.length &&
+            diffIdx < agent.instructionsHtml.length &&
+            generated[diffIdx] === agent.instructionsHtml[diffIdx]
+          ) {
+            diffIdx++;
+          }
+          const contextStart = Math.max(0, diffIdx - 40);
+          const contextEnd = diffIdx + 80;
+
+          logger.warn(
+            {
+              agentSId: agent.sId,
+              agentName: agent.name,
+              workspaceId: workspace.sId,
+              storedLength: agent.instructionsHtml.length,
+              generatedLength: generated.length,
+              diffAtChar: diffIdx,
+              storedSnippet: agent.instructionsHtml.slice(
+                contextStart,
+                contextEnd
+              ),
+              generatedSnippet: generated.slice(contextStart, contextEnd),
+            },
+            "HTML instructions mismatch"
+          );
+        }
+      }
+    }
+
+    if (workspaceId) {
+      const workspace = await WorkspaceResource.fetchById(workspaceId);
+      if (!workspace) {
+        logger.error({ workspaceId }, "Workspace not found");
+        return;
+      }
+      await validateWorkspace(renderLightWorkspaceType({ workspace }));
+    } else {
+      await runOnAllWorkspaces(validateWorkspace);
+    }
+
+    logger.info(
+      {
+        matchCount,
+        mismatchCount,
+        noHtmlCount,
+        noInstructionsCount,
+      },
+      "Validation complete"
+    );
+  }
+);

--- a/front/scripts/validate_html_instructions.ts
+++ b/front/scripts/validate_html_instructions.ts
@@ -73,12 +73,15 @@ makeScript(
         } else {
           mismatchCount++;
 
-          // Find first divergence point for a concise diff.
+          // Diff on normalized HTML so block-id noise is removed.
+          const normalizedStored = normalizeBlockIds(agent.instructionsHtml);
+          const normalizedGenerated = normalizeBlockIds(generated);
+
           let diffIdx = 0;
           while (
-            diffIdx < generated.length &&
-            diffIdx < agent.instructionsHtml.length &&
-            generated[diffIdx] === agent.instructionsHtml[diffIdx]
+            diffIdx < normalizedGenerated.length &&
+            diffIdx < normalizedStored.length &&
+            normalizedGenerated[diffIdx] === normalizedStored[diffIdx]
           ) {
             diffIdx++;
           }
@@ -90,14 +93,14 @@ makeScript(
               agentSId: agent.sId,
               agentName: agent.name,
               workspaceId: workspace.sId,
-              storedLength: agent.instructionsHtml.length,
-              generatedLength: generated.length,
+              storedLength: normalizedStored.length,
+              generatedLength: normalizedGenerated.length,
               diffAtChar: diffIdx,
-              storedSnippet: agent.instructionsHtml.slice(
+              storedSnippet: normalizedStored.slice(contextStart, contextEnd),
+              generatedSnippet: normalizedGenerated.slice(
                 contextStart,
                 contextEnd
               ),
-              generatedSnippet: generated.slice(contextStart, contextEnd),
             },
             "HTML instructions mismatch"
           );

--- a/front/scripts/validate_html_instructions.ts
+++ b/front/scripts/validate_html_instructions.ts
@@ -24,6 +24,18 @@ function normalizeHtml(html: string): string {
       // marks differently, e.g. "✅<strong> Verified</strong>" vs "✅ <strong>Verified</strong>".
       .replace(/ (<(?:strong|em|code|a\b)[^>]*>)/g, "$1 ")
       .replace(/(<\/(?:strong|em|code|a)>) /g, " $1")
+      // Remove trailing whitespace before closing block tags.
+      // The frontend editor may preserve trailing spaces that the
+      // markdown parser trims.
+      .replace(/ +(<\/(?:p|li|h[1-6])>)/g, "$1")
+      // Unwrap mailto links: <a ...href="mailto:x@y"...>x@y</a> → x@y
+      // The stored HTML may have auto-linked emails from the frontend editor.
+      .replace(
+        /<a[^>]*href="mailto:([^"]*)"[^>]*>\1<\/a>/g,
+        "$1"
+      )
+      // Normalize leading whitespace after opening block tags.
+      .replace(/(<(?:p|li|h[1-6])\b[^>]*>) +/g, "$1")
   );
 }
 

--- a/front/scripts/validate_html_instructions.ts
+++ b/front/scripts/validate_html_instructions.ts
@@ -16,6 +16,14 @@ function normalizeHtml(html: string): string {
         /<span[^>]*data-type="emoji"[^>]*>([^<]*)<\/span>/g,
         "$1"
       )
+      // Remove zero-width spaces inserted by preprocessMarkdownForEditor
+      // for standalone < characters that aren't matched tag pairs.
+      .replace(/\u200B/g, "")
+      // Normalize whitespace around inline formatting tags (strong, em, code, a).
+      // The frontend editor and markdown parser may place spaces inside or outside
+      // marks differently, e.g. "✅<strong> Verified</strong>" vs "✅ <strong>Verified</strong>".
+      .replace(/ (<(?:strong|em|code|a\b)[^>]*>)/g, "$1 ")
+      .replace(/(<\/(?:strong|em|code|a)>) /g, " $1")
   );
 }
 

--- a/front/scripts/validate_html_instructions.ts
+++ b/front/scripts/validate_html_instructions.ts
@@ -29,9 +29,10 @@ function normalizeHtml(html: string): string {
       // markdown parser trims.
       .replace(/ +(<\/(?:p|li|h[1-6])>)/g, "$1")
       // Unwrap links whose text matches the href (auto-linked URLs and emails).
+      // Capture surrounding whitespace inside the tag and preserve it.
       .replace(
-        /<a[^>]*href="(?:mailto:)?([^"]*)"[^>]*>\s*\1\s*<\/a>/g,
-        "$1"
+        /<a[^>]*href="(?:mailto:)?([^"]*)"[^>]*>(\s*)\1(\s*)<\/a>/g,
+        "$2$1$3"
       )
       // Normalize leading whitespace after opening block tags.
       .replace(/(<(?:p|li|h[1-6])\b[^>]*>) +/g, "$1")

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,6 +382,7 @@
         "@tiptap/pm": "^3.19.0",
         "@tiptap/react": "^3.19.0",
         "@tiptap/starter-kit": "^3.19.0",
+        "@tiptap/static-renderer": "^3.19.0",
         "@tiptap/suggestion": "^3.19.0",
         "@types/adm-zip": "^0.5.7",
         "@types/json-schema": "^7.0.15",
@@ -21153,16 +21154,16 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.0.tgz",
-      "integrity": "sha512-aC9aROgia/SpJqhsXFiX9TsligL8d+oeoI8W3u00WI45s0VfsqjgeKQLDLF7Tu7hC+7F02teC84SAHuup003VQ==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.21.0.tgz",
+      "integrity": "sha512-IfnQiuEeabDSPr1C/zHFTbnvlTf5z0DE/d/xz4C6bkL4ZBDJ3rr99h2qsaV0l8F+kbNswZMlQdM8rxNlMy95fQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.20.0"
+        "@tiptap/pm": "^3.21.0"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -21588,9 +21589,9 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.0.tgz",
-      "integrity": "sha512-jn+2KnQZn+b+VXr8EFOJKsnjVNaA4diAEr6FOazupMt8W8ro1hfpYtZ25JL87Kao/WbMze55sd8M8BDXLUKu1A==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.21.0.tgz",
+      "integrity": "sha512-I3sNo7oMMsR6FFz1ecvPb9uCF0VQuS2WV67j8Io2M7DJicRWCE/GM5DaiYjTeWBbnByk6BuG0txoJATAqPVliQ==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
@@ -21678,6 +21679,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/static-renderer": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/static-renderer/-/static-renderer-3.21.0.tgz",
+      "integrity": "sha512-S5xZuVsiFs3dAgV63yPLBPKkp+yScU4om0exDAgoNUzH9riFNVgJHwQarNFcTLOrUKrXibJx9gmNG/KVc49zig==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.21.0",
+        "@tiptap/pm": "^3.21.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@tiptap/suggestion": {


### PR DESCRIPTION
## Description

 - Duplicate all required code to be able to call tip tap server side rendering and implement a function `convertMarkdownToHtml(markdown: string)`
 - Add a script to validate the generated HTML is similarto the one currently saved in DB
 - Add a script to generate the HTML from markdown for agents where the markdown is null

## Tests

 - unit tests
 - tested scripts locally

## Risk

 - Introduce a new function which may not stay in sync with what we do in the core product. We can remove the function when the migration is done if needed

## Deploy Plan

 - deploy front 
