### PR TITLE
[front] fix: allow builder API keys to update skills

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1407,6 +1407,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   canWrite(auth: Authenticator): boolean {
+    // API keys with at least builder role can write to any skill.
+    if (auth.isKey() && auth.isBuilder()) {
+      return true;
+    }
+
     if (!this.editorGroup) {
       return false;
     }


### PR DESCRIPTION
## Description

- The API endpoint for upserting skills currently cannot update skills.
- The current permission check fails, for write actions it checks that either the authenticated user is in the editor group (not the case for API keys as there's no user), or the auth is an admin (not the case for non-system keys).
- This PR adds a custom rule to allow API keys to update skills.
- Does not give more access as creating an API key is an admin action.

## Tests

- Will test through the github action.

## Risk

- Low.

## Deploy Plan

- Deploy front.
