### PR TITLE
[connectors] Handle malformed/deleted drive errors in Microsoft incremental sync

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -879,7 +879,18 @@ export async function syncDeltaForRootNodesInDrive({
       "No delta link for root node, populating delta"
     );
     const internalId = node.internalId;
-    await populateDeltas(connectorId, [internalId]);
+    try {
+      await populateDeltas(connectorId, [internalId]);
+    } catch (error) {
+      if (isItemNotFoundError(error) || isMalformedDriveError(error)) {
+        logger.info(
+          { error: error.message, driveId },
+          "Drive not found or malformed during delta population, skipping"
+        );
+        return;
+      }
+      throw error;
+    }
     node =
       (await MicrosoftNodeResource.fetchByInternalId(
         connectorId,
@@ -891,12 +902,26 @@ export async function syncDeltaForRootNodesInDrive({
       );
     }
   }
-  const { results, deltaLink } = await getDeltaData({
-    logger,
-    client,
-    node,
-    heartbeat,
-  });
+
+  let results: DriveItem[];
+  let deltaLink: string;
+  try {
+    ({ results, deltaLink } = await getDeltaData({
+      logger,
+      client,
+      node,
+      heartbeat,
+    }));
+  } catch (error) {
+    if (isItemNotFoundError(error) || isMalformedDriveError(error)) {
+      logger.info(
+        { error: error.message, driveId },
+        "Drive not found or malformed, skipping"
+      );
+      return;
+    }
+    throw error;
+  }
   const uniqueChangedItems = removeAllButLastOccurences(results);
 
   const sortedChangedItems: DriveItem[] = [];
@@ -1210,7 +1235,18 @@ export async function fetchDeltaForRootNodesInDrive({
       "No delta link for root node, populating delta"
     );
     const internalId = node.internalId;
-    await populateDeltas(connectorId, [internalId]);
+    try {
+      await populateDeltas(connectorId, [internalId]);
+    } catch (error) {
+      if (isItemNotFoundError(error) || isMalformedDriveError(error)) {
+        logger.info(
+          { error: error.message, driveId },
+          "Drive not found or malformed during delta population, skipping"
+        );
+        return { gcsFilePath: null };
+      }
+      throw error;
+    }
     node =
       (await MicrosoftNodeResource.fetchByInternalId(
         connectorId,

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -68,6 +68,7 @@ import {
   cacheWithRedis,
   INTERNAL_MIME_TYPES,
   isDevelopment,
+  normalizeError,
 } from "@connectors/types";
 import type { LoggerInterface } from "@dust-tt/client";
 import { removeNulls } from "@dust-tt/client";
@@ -884,7 +885,7 @@ export async function syncDeltaForRootNodesInDrive({
     } catch (error) {
       if (isItemNotFoundError(error) || isMalformedDriveError(error)) {
         logger.info(
-          { error: error.message, driveId },
+          { error: normalizeError(error).message, driveId },
           "Drive not found or malformed during delta population, skipping"
         );
         return;
@@ -915,7 +916,7 @@ export async function syncDeltaForRootNodesInDrive({
   } catch (error) {
     if (isItemNotFoundError(error) || isMalformedDriveError(error)) {
       logger.info(
-        { error: error.message, driveId },
+        { error: normalizeError(error).message, driveId },
         "Drive not found or malformed, skipping"
       );
       return;
@@ -1240,7 +1241,7 @@ export async function fetchDeltaForRootNodesInDrive({
     } catch (error) {
       if (isItemNotFoundError(error) || isMalformedDriveError(error)) {
         logger.info(
-          { error: error.message, driveId },
+          { error: normalizeError(error).message, driveId },
           "Drive not found or malformed during delta population, skipping"
         );
         return { gcsFilePath: null };


### PR DESCRIPTION
## Description

When a Microsoft drive is deleted or becomes invalid, the Graph API returns a 400 error with "malformed" in the message. The `populateDeltas()` call — which initializes delta links for nodes that don't have one yet — was outside the existing try-catch that gracefully handles `isMalformedDriveError`. This caused the incremental sync workflow to retry the activity indefinitely.

This fix wraps `populateDeltas()` with the same error handling pattern already used for `getDeltaData()`: catch `isItemNotFoundError` and `isMalformedDriveError`, then skip the drive gracefully instead of retrying forever.

Applied to both code paths:
- `fetchDeltaForRootNodesInDrive` (V2) — returns `{ gcsFilePath: null }` to skip
- `syncDeltaForRootNodesInDrive` (V1 legacy) — returns early; also added missing try-catch around `getDeltaData` for consistency

## Tests

Verified no new type errors are introduced (`tsc --noEmit`). The fix follows the exact same pattern already established in the codebase for handling these Graph API errors.

## Risk

Low. The change only adds error handling for a known, well-defined error class (`isMalformedDriveError`, `isItemNotFoundError`) that was already handled in adjacent code paths. Drives that are genuinely malformed/deleted will be cleaned up by the existing garbage collection workflow.

## Deploy Plan

Standard deploy. Once deployed, the stuck incremental sync workflows will resolve on their next retry — the activity will skip the invalid drive and continue.