### PR TITLE
Add seatType on memberships

### DIFF
--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -4,6 +4,7 @@ import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspa
 import type {
   MembershipOriginType,
   MembershipRoleType,
+  MembershipSeatType,
 } from "@app/types/memberships";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes, Op } from "sequelize";
@@ -17,6 +18,7 @@ export class MembershipModel extends WorkspaceAwareModel<MembershipModel> {
   declare startAt: Date;
   declare endAt: Date | null;
   declare firstUsedAt: Date | null;
+  declare seatType: CreationOptional<MembershipSeatType>;
 
   declare userId: ForeignKey<UserModel["id"]>;
   declare user: NonAttribute<UserModel>;
@@ -53,6 +55,11 @@ MembershipModel.init(
     firstUsedAt: {
       type: DataTypes.DATE,
       allowNull: true,
+    },
+    seatType: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "free",
     },
   },
   {

--- a/front/migrations/db/migration_630.sql
+++ b/front/migrations/db/migration_630.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 11, 2026
+ALTER TABLE "public"."memberships" ADD COLUMN "seatType" VARCHAR(255) NOT NULL DEFAULT 'free';

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -21,3 +21,16 @@ export function isMembershipOriginType(
 ): value is MembershipOriginType {
   return MEMBERSHIP_ORIGIN_TYPES.includes(value as MembershipOriginType);
 }
+
+export const MEMBERSHIP_SEAT_TYPES = ["free", "pro", "max"] as const;
+
+export type MembershipSeatType = (typeof MEMBERSHIP_SEAT_TYPES)[number];
+
+export function isMembershipSeatType(
+  value: unknown
+): value is MembershipSeatType {
+  return (
+    typeof value === "string" &&
+    MEMBERSHIP_SEAT_TYPES.includes(value as MembershipSeatType)
+  );
+}


### PR DESCRIPTION
## Description

This PR adds a `seatType` column to `MembershipModel`. Default value "free". 
Migration to backfill existing memberships.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front and run migration
