### PR TITLE
Fix steering: new agent message not appearing without reload

### DIFF
--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -52,9 +52,13 @@ export async function publishConversationEvent(
     conversationChannel,
     JSON.stringify(event),
     "user_message_events",
-    // Conversation & message initial states are setup before starting to listen to events so we really care about getting new events.
-    // We are setting a low value to accommodate for reconnections to the event stream.
-    5
+    // Must survive SSE reconnection gaps. In production, load balancers close
+    // idle connections after 60-120s, and the conversation channel goes idle
+    // during agent execution (tokens use the per-message channel). The client
+    // reconnects with a 3-8s delay, so events must remain replayable for
+    // longer than that — especially for steering, where agent_message_new is
+    // the only way the new agent message reaches the UI.
+    60 * 10
   );
 }
 


### PR DESCRIPTION
## Description

Attempt to fix a production-only bug where steering a conversation (sending a new message while the agent is running) causes the new agent response to never appear, requiring a page reload.

**What was happening**
When you steer a conversation (send a new message while the agent is running), the new agent message is created in the background after the running agent stops. The frontend learns about this new message through a real-time event stream: a persistent connection between the browser and our servers.

In production, this connection can be dropped and reconnected for various reasons (load balancer closing idle connections, server-side timeouts, infrastructure events). During agent execution, the connection used for conversation-level events goes idle because streaming tokens use a separate per-message connection. We confirmed with Playwright network monitoring that the conversation SSE does reconnect during the steering flow, even within short interactions (< 60 seconds).

When the browser reconnects, it tries to replay any missed events from a short-lived buffer in Redis. But that buffer expired after just 5 seconds, which is shorter than the reconnection delay (3-8 seconds for error recovery). The event announcing the new agent message was gone, so it never appeared in the UI.

This was not a problem before steering because new agent messages were returned directly in the API response. With steering, the API returns before the new agent message exists, so the real-time event is the only way it reaches the UI.

**Why it works locally**: no load balancer or proxy, so the connection is much more stable.

**Why 10 minutes**
- Matches the default TTL already used for per-message event streams
- Conversation events are infrequent (a handful per conversation: user_message_new, agent_message_new, agent_message_done...), so Redis memory cost is negligible
- The existing deduplication mechanism (eventIds ref in ConversationViewer) prevents duplicate processing on replay
- Covers all reconnection scenarios: error recovery (3-8s), load balancer drops (up to 5 min heartbeat timeout detection), and any other transient disconnection

**Why the previous 5s TTL existed**

The old comment said "We are setting a low value to accommodate for reconnections to the event stream." The intent was to keep the stream small since conversation initial state comes from the API, not from event replay. This was fine before steering, when losing a conversation event was invisible (the API response already contained the new agent message). With steering, that assumption no longer holds.


## Tests

Tested locally and on front edge but since there's no load-balancer on front-edge I'm not sure the fix is fixing. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 