### PR TITLE
feat: implement mergeConversationTodosIntoProject for follow_ups

### DIFF
--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -1,38 +1,323 @@
-// TODO: implement "merge".
-//
-// This module will merge the latest conversation_todo_versioned snapshots for all
-// conversations in a project into project_todo rows. It is called by
-// mergeTodosForProjectActivity, which itself is invoked by the per-project
-// projectMergeWorkflow at most once per MERGE_THROTTLE_MS (1 hour by default).
-//
-// High-level algorithm (to be implemented):
-//
-//   1. Fetch all ConversationTodoVersioned snapshots (latest per conversation) for
-//      conversations that belong to the given spaceId.
-//   2. For each item (actionItem / keyDecision / notableFact):
-//        - Resolve target users (assigneeUserId, relevantUserIds, or conversation participants).
-//        - For each target user, look up existing agent-created ProjectTodo via
-//          ProjectTodoResource.fetchByConversationSource(auth, {
-//            sourceConversationModelId, conversationTodoItemSId, userId
-//          }).
-//        - not found  → ProjectTodoResource.makeNew() + addSource({ conversationTodoItemSId })
-//        - found, changed  → existing.createVersion()
-//        - found, unchanged → skip
-//   3. For each agent-created ProjectTodo whose conversationTodoItemSId is absent from
-//      the latest snapshot → createVersion({ status: "done", markedAsDoneByType: "agent" }).
-//
-// Category mapping:
-//   actionItems  (open)    → "follow_ups",      status: "todo"
-//   actionItems  (done)    → "follow_ups",      status: "done"
-//   keyDecisions (open)    → "key_decisions",   status: "todo"
-//   keyDecisions (decided) → "key_decisions",   status: "done"
-//   notableFacts           → "notable_updates", status: "todo"
-
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { getFastestWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationTodoVersionedResource } from "@app/lib/resources/conversation_todo_versioned_resource";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { ModelId } from "@app/types/shared/model_id";
+import { z } from "zod";
+
+// sId used as `createdByAgentConfigurationId` / `markedAsDoneByAgentConfigurationId`
+// for all todos managed by the merge algorithm.
+const MERGER_AGENT_ID = "conversation_todo_merger";
+
+// ── Layer 2 helpers ──────────────────────────────────────────────────────────
+
+// Calls the LLM with a single batched request: given a list of completed
+// action item texts and a list of open user-created follow_up todos (with
+// their stable sIds), returns the sIds of todos that are clearly resolved.
+async function callMatchCompletedItemsLLM(
+  auth: Authenticator,
+  {
+    model,
+    doneActionItemTexts,
+    openUserTodos,
+    spaceId,
+    workspaceId,
+  }: {
+    model: ModelConfigurationType;
+    doneActionItemTexts: string[];
+    openUserTodos: Array<{ sId: string; text: string }>;
+    spaceId: string;
+    workspaceId: string;
+  }
+): Promise<string[]> {
+  const specification: AgentActionSpecification = {
+    name: "match_completed_items",
+    description:
+      "Given a list of completed action items from conversations and a list of " +
+      "open user todos, identify which open todos have been resolved by those " +
+      "action items. Return only high-confidence matches.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        resolved_todo_sids: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "sIds of user todos that are clearly resolved by the completed " +
+            "action items. Include only high-confidence matches.",
+        },
+      },
+      required: ["resolved_todo_sids"],
+    },
+  };
+
+  const doneItemsText = doneActionItemTexts
+    .map((text, i) => `${i + 1}. ${text}`)
+    .join("\n");
+
+  const openTodosText = openUserTodos
+    .map((t) => `- sId: ${t.sId} | ${t.text}`)
+    .join("\n");
+
+  const prompt =
+    "You are a project assistant. Identify which open user todos have been " +
+    "completed based on recent conversation activity.\n\n" +
+    "Completed action items from conversations:\n" +
+    doneItemsText +
+    "\n\nOpen user todos (with their stable sIds):\n" +
+    openTodosText +
+    "\n\nYou MUST call the match_completed_items tool. Return the sIds of todos " +
+    "that are clearly resolved. Only include high-confidence matches.";
+
+  const conv: ModelConversationTypeMultiActions = {
+    messages: [
+      {
+        role: "user",
+        name: "todo_merger",
+        content: [{ type: "text", text: prompt }],
+      },
+    ],
+  };
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      providerId: model.providerId,
+      modelId: model.modelId,
+      functionCall: specification.name,
+      useCache: false,
+    },
+    {
+      conversation: conv,
+      prompt,
+      specifications: [specification],
+      forceToolCall: specification.name,
+    },
+    {
+      context: {
+        operationType: "project_todo_merge_follow_ups",
+        spaceId,
+        workspaceId,
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    logger.error(
+      { spaceId, workspaceId, error: res.error },
+      "Project todo merge: Layer 2 LLM call failed"
+    );
+    return [];
+  }
+
+  const action = res.value.actions?.[0];
+  if (!action?.arguments) {
+    logger.warn(
+      { spaceId, workspaceId },
+      "Project todo merge: no tool call in Layer 2 LLM response"
+    );
+    return [];
+  }
+
+  const parsed = z
+    .object({ resolved_todo_sids: z.array(z.string()) })
+    .safeParse(action.arguments);
+
+  if (!parsed.success) {
+    logger.warn(
+      { spaceId, workspaceId, error: parsed.error },
+      "Project todo merge: failed to parse Layer 2 LLM response"
+    );
+    return [];
+  }
+
+  // Filter to only sIds that actually exist in our input set.
+  const validSIds = new Set(openUserTodos.map((t) => t.sId));
+  return parsed.data.resolved_todo_sids.filter((sId) => validSIds.has(sId));
+}
+
+// ── Main merge function ──────────────────────────────────────────────────────
 
 export async function mergeConversationTodosIntoProject(
-  _auth: Authenticator,
+  auth: Authenticator,
   { spaceId }: { spaceId: string }
 ): Promise<void> {
-  void spaceId;
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+
+  const space = await SpaceResource.fetchById(auth, spaceId);
+  if (!space) {
+    logger.warn(
+      { spaceId, workspaceId: owner.sId },
+      "Project todo merge: space not found, skipping"
+    );
+    return;
+  }
+  const spaceModelId: ModelId = space.id;
+
+  // Fetch latest conversation snapshots for the space and existing
+  // agent-linked follow_up todos for the current user concurrently.
+  const [snapshots, linkedTodos] = await Promise.all([
+    ConversationTodoVersionedResource.fetchLatestForSpace(auth, {
+      spaceModelId,
+    }),
+    ProjectTodoResource.fetchLinkedFollowUpsForSpace(auth, { spaceModelId }),
+  ]);
+
+  // ── Layer 1: Algorithm — agent-linked follow_up todos ─────────────────────
+  //
+  // For each open action item in the latest snapshots:
+  //   - Not found → create a new agent-linked todo + source link.
+  //   - Found, text changed → append a new version.
+  //   - Found, unchanged → skip.
+  //
+  // For each existing linked todo whose source item is no longer open in any
+  // snapshot → mark as done.
+
+  // Lookup: "(conversationModelId):(conversationTodoItemSId)" → linked entry.
+  const linkedByKey = new Map<string, (typeof linkedTodos)[number]>();
+  for (const linked of linkedTodos) {
+    const key = `${linked.sourceConversationModelId}:${linked.conversationTodoItemSId}`;
+    linkedByKey.set(key, linked);
+  }
+
+  // Collect keys still open in the latest snapshots and texts of done items.
+  const activeItemKeys = new Set<string>();
+  const doneActionItemTexts: string[] = [];
+
+  for (const snapshot of snapshots) {
+    for (const item of snapshot.actionItems) {
+      const key = `${snapshot.conversationId}:${item.sId}`;
+
+      if (item.status === "open") {
+        activeItemKeys.add(key);
+
+        const linked = linkedByKey.get(key);
+        if (!linked) {
+          // Create a new agent-linked todo for this action item.
+          const newTodo = await ProjectTodoResource.makeNew(auth, {
+            spaceId: spaceModelId,
+            userId: user.id,
+            createdByType: "agent",
+            createdByUserId: null,
+            createdByAgentConfigurationId: MERGER_AGENT_ID,
+            markedAsDoneByType: null,
+            markedAsDoneByUserId: null,
+            markedAsDoneByAgentConfigurationId: null,
+            category: "follow_ups",
+            text: item.text,
+            version: 1,
+            status: "todo",
+            doneAt: null,
+            actorRationale: null,
+          });
+          await newTodo.addSource(auth, {
+            sourceType: "conversation",
+            sourceConversationId: snapshot.conversationId,
+            conversationTodoItemSId: item.sId,
+          });
+        } else if (linked.todo.text !== item.text) {
+          // Text changed in the conversation — append a new version.
+          await linked.todo.createVersion(auth, { text: item.text });
+        }
+        // Text unchanged → nothing to do.
+      } else {
+        // Done item — collect for Layer 2 AI matching.
+        doneActionItemTexts.push(item.text);
+      }
+    }
+  }
+
+  // Retire linked todos whose source item is no longer open in any snapshot.
+  for (const linked of linkedTodos) {
+    const key = `${linked.sourceConversationModelId}:${linked.conversationTodoItemSId}`;
+    if (!activeItemKeys.has(key) && linked.todo.status === "todo") {
+      await linked.todo.createVersion(auth, {
+        status: "done",
+        doneAt: new Date(),
+        markedAsDoneByType: "agent",
+        markedAsDoneByUserId: null,
+        markedAsDoneByAgentConfigurationId: MERGER_AGENT_ID,
+        actorRationale: "Action item resolved in conversation.",
+      });
+    }
+  }
+
+  logger.info(
+    {
+      spaceId,
+      workspaceId: owner.sId,
+      snapshotCount: snapshots.length,
+      linkedTodoCount: linkedTodos.length,
+      doneItemCount: doneActionItemTexts.length,
+    },
+    "Project todo merge: Layer 1 complete"
+  );
+
+  // ── Layer 2: AI — auto-close user-created follow_up todos ─────────────────
+  //
+  // When there are done action items, ask the LLM whether any open
+  // user-created (unlinked) todos in the space were resolved by them.
+  // A single batched LLM call handles all matches to avoid per-item costs.
+
+  if (doneActionItemTexts.length === 0) {
+    return;
+  }
+
+  const openUserTodos =
+    await ProjectTodoResource.fetchOpenUnlinkedFollowUpsForSpace(auth, {
+      spaceModelId,
+    });
+
+  if (openUserTodos.length === 0) {
+    return;
+  }
+
+  const model = await getFastestWhitelistedModel(auth);
+  if (!model) {
+    logger.warn(
+      { spaceId, workspaceId: owner.sId },
+      "Project todo merge: no whitelisted model for Layer 2, skipping"
+    );
+    return;
+  }
+
+  const resolvedSIds = await callMatchCompletedItemsLLM(auth, {
+    model,
+    doneActionItemTexts,
+    openUserTodos: openUserTodos.map((t) => ({ sId: t.sId, text: t.text })),
+    spaceId,
+    workspaceId: owner.sId,
+  });
+
+  for (const sId of resolvedSIds) {
+    const todo = openUserTodos.find((t) => t.sId === sId);
+    if (!todo) {
+      continue;
+    }
+    await todo.createVersion(auth, {
+      status: "done",
+      doneAt: new Date(),
+      markedAsDoneByType: "agent",
+      markedAsDoneByUserId: null,
+      markedAsDoneByAgentConfigurationId: MERGER_AGENT_ID,
+      actorRationale: "Completed based on conversation activity.",
+    });
+  }
+
+  logger.info(
+    {
+      spaceId,
+      workspaceId: owner.sId,
+      openUserTodoCount: openUserTodos.length,
+      resolvedCount: resolvedSIds.length,
+    },
+    "Project todo merge: Layer 2 complete"
+  );
 }

--- a/front/lib/resources/conversation_todo_versioned_resource.ts
+++ b/front/lib/resources/conversation_todo_versioned_resource.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ConversationTodoVersionedModel } from "@app/lib/resources/storage/models/conversation_todo_versioned";
@@ -15,7 +16,7 @@ import type {
   ModelStatic,
   Transaction,
 } from "sequelize";
-import { col, fn } from "sequelize";
+import { col, fn, Op } from "sequelize";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -147,6 +148,62 @@ export class ConversationTodoVersionedResource extends BaseResource<Conversation
     });
 
     return row ? new this(ConversationTodoVersionedModel, row.get()) : null;
+  }
+
+  // Returns the latest ConversationTodoVersioned snapshot for each active
+  // (non-deleted, non-test) conversation in the given space. Used by the
+  // project merge algorithm to scan all relevant conversation activity.
+  static async fetchLatestForSpace(
+    auth: Authenticator,
+    { spaceModelId }: { spaceModelId: ModelId }
+  ): Promise<ConversationTodoVersionedResource[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    // Step 1: Find all active conversations in the space.
+    const conversations = await ConversationModel.findAll({
+      where: {
+        workspaceId,
+        spaceId: spaceModelId,
+        visibility: { [Op.notIn]: ["deleted", "test"] },
+      },
+      attributes: ["id"],
+    });
+
+    if (conversations.length === 0) {
+      return [];
+    }
+
+    const conversationIds = conversations.map((c) => c.id);
+
+    // Step 2: Fetch all versioned snapshots for those conversations ordered by
+    // (conversationId ASC, version DESC) so the first occurrence per
+    // conversationId is the latest snapshot.
+    const rows = await ConversationTodoVersionedModel.findAll({
+      where: {
+        workspaceId,
+        conversationId: { [Op.in]: conversationIds },
+      },
+      order: [
+        ["conversationId", "ASC"],
+        ["version", "DESC"],
+      ],
+    });
+
+    // Deduplicate: keep the first (highest version) snapshot per conversation.
+    const latestByConversationId = new Map<
+      ModelId,
+      ConversationTodoVersionedResource
+    >();
+    for (const row of rows) {
+      if (!latestByConversationId.has(row.conversationId)) {
+        latestByConversationId.set(
+          row.conversationId,
+          new this(ConversationTodoVersionedModel, row.get())
+        );
+      }
+    }
+
+    return Array.from(latestByConversationId.values());
   }
 
   async delete(

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -21,6 +21,7 @@ import type {
   ModelStatic,
   Transaction,
 } from "sequelize";
+import { Op } from "sequelize";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -189,6 +190,200 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
   }
 
+  // ── Merge helpers ────────────────────────────────────────────────────────
+
+  // Returns all follow_up todos for the current user in the space that are
+  // linked to a specific conversation action item via
+  // (sourceConversationId, conversationTodoItemSId). Used by Layer 1 of the
+  // merge algorithm.
+  //
+  // Sources are always attached to version-1 rows (created by makeNew). We
+  // look up the latest version for each linked sId so the caller always
+  // receives the current state of each todo.
+  static async fetchLinkedFollowUpsForSpace(
+    auth: Authenticator,
+    { spaceModelId }: { spaceModelId: ModelId }
+  ): Promise<
+    Array<{
+      todo: ProjectTodoResource;
+      sourceConversationModelId: ModelId;
+      conversationTodoItemSId: string;
+    }>
+  > {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const userId = auth.getNonNullableUser().id;
+
+    // Step 1: Get all version-1 follow_up rows for the user in this space.
+    const v1Rows = await ProjectTodoModel.findAll({
+      where: {
+        workspaceId,
+        spaceId: spaceModelId,
+        category: "follow_ups",
+        userId,
+        version: 1,
+      },
+    });
+
+    if (v1Rows.length === 0) {
+      return [];
+    }
+
+    const v1Ids = v1Rows.map((r) => r.id);
+
+    // Step 2: Find source links with a conversationTodoItemSId for those rows.
+    const sources = await ProjectTodoSourceModel.findAll({
+      where: {
+        workspaceId,
+        projectTodoId: { [Op.in]: v1Ids },
+        conversationTodoItemSId: { [Op.ne]: null },
+      },
+    });
+
+    if (sources.length === 0) {
+      return [];
+    }
+
+    // Step 3: Build (v1 row id → source) and (sId → source) mappings. Keep
+    // only the first source per v1 row in case there are duplicates.
+    const sourceByV1Id = new Map<
+      ModelId,
+      { sourceConversationModelId: ModelId; conversationTodoItemSId: string }
+    >();
+    for (const source of sources) {
+      if (
+        source.conversationTodoItemSId &&
+        source.sourceConversationId !== null &&
+        !sourceByV1Id.has(source.projectTodoId)
+      ) {
+        sourceByV1Id.set(source.projectTodoId, {
+          sourceConversationModelId: source.sourceConversationId,
+          conversationTodoItemSId: source.conversationTodoItemSId,
+        });
+      }
+    }
+
+    const sourceBySId = new Map<
+      string,
+      { sourceConversationModelId: ModelId; conversationTodoItemSId: string }
+    >();
+    for (const v1 of v1Rows) {
+      const src = sourceByV1Id.get(v1.id);
+      if (src) {
+        sourceBySId.set(v1.sId, src);
+      }
+    }
+
+    if (sourceBySId.size === 0) {
+      return [];
+    }
+
+    // Step 4: Fetch the latest version for each linked sId.
+    const sIds = Array.from(sourceBySId.keys());
+    const latestRows = await ProjectTodoModel.findAll({
+      where: {
+        workspaceId,
+        spaceId: spaceModelId,
+        userId,
+        sId: { [Op.in]: sIds },
+      },
+      order: [
+        ["sId", "ASC"],
+        ["version", "DESC"],
+      ],
+    });
+
+    // Deduplicate: keep the first occurrence per sId (highest version).
+    const latestBySId = new Map<string, ProjectTodoModel>();
+    for (const row of latestRows) {
+      if (!latestBySId.has(row.sId)) {
+        latestBySId.set(row.sId, row);
+      }
+    }
+
+    return Array.from(latestBySId.entries()).flatMap(([sId, row]) => {
+      const src = sourceBySId.get(sId);
+      if (!src) {
+        return [];
+      }
+      return [{ todo: new this(ProjectTodoModel, row.get()), ...src }];
+    });
+  }
+
+  // Returns the latest version of each open follow_up todo for the current
+  // user in the space that has NO conversationTodoItemSId source link —
+  // i.e., user-created (unlinked) todos. Used by Layer 2 of the merge
+  // algorithm to identify todos the AI can auto-close.
+  static async fetchOpenUnlinkedFollowUpsForSpace(
+    auth: Authenticator,
+    { spaceModelId }: { spaceModelId: ModelId }
+  ): Promise<ProjectTodoResource[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const userId = auth.getNonNullableUser().id;
+
+    // Step 1: Get all version-1 follow_up rows for the user in this space.
+    const v1Rows = await ProjectTodoModel.findAll({
+      where: {
+        workspaceId,
+        spaceId: spaceModelId,
+        category: "follow_ups",
+        userId,
+        version: 1,
+      },
+    });
+
+    if (v1Rows.length === 0) {
+      return [];
+    }
+
+    const v1Ids = v1Rows.map((r) => r.id);
+
+    // Step 2: Find which v1 rows have a conversationTodoItemSId source link.
+    const linkedSources = await ProjectTodoSourceModel.findAll({
+      where: {
+        workspaceId,
+        projectTodoId: { [Op.in]: v1Ids },
+        conversationTodoItemSId: { [Op.ne]: null },
+      },
+      attributes: ["projectTodoId"],
+    });
+
+    const linkedV1Ids = new Set(linkedSources.map((s) => s.projectTodoId));
+
+    // Step 3: Determine sIds for unlinked (user-created) todos.
+    const unlinkedSIds = v1Rows
+      .filter((r) => !linkedV1Ids.has(r.id))
+      .map((r) => r.sId);
+
+    if (unlinkedSIds.length === 0) {
+      return [];
+    }
+
+    // Step 4: Fetch all versions for unlinked sIds, ordered by (sId, version
+    // DESC) so we can deduplicate to the latest version per sId.
+    const allVersionRows = await ProjectTodoModel.findAll({
+      where: {
+        workspaceId,
+        spaceId: spaceModelId,
+        userId,
+        sId: { [Op.in]: unlinkedSIds },
+      },
+      order: [
+        ["sId", "ASC"],
+        ["version", "DESC"],
+      ],
+    });
+
+    const latestBySId = new Map<string, ProjectTodoResource>();
+    for (const row of allVersionRows) {
+      if (!latestBySId.has(row.sId)) {
+        latestBySId.set(row.sId, new this(ProjectTodoModel, row.get()));
+      }
+    }
+
+    // Return only open ones — "done" filter applied on the latest version.
+    return Array.from(latestBySId.values()).filter((t) => t.status === "todo");
+  }
+
   // ── Output conversation links (todo => conversation) ────────────────────
 
   async addOutputConversation(
@@ -228,9 +423,11 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     {
       sourceType,
       sourceConversationId,
+      conversationTodoItemSId,
     }: {
       sourceType: ProjectTodoSourceType;
       sourceConversationId: ModelId | null;
+      conversationTodoItemSId?: string;
     },
     transaction?: Transaction
   ): Promise<void> {
@@ -240,6 +437,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
         projectTodoId: this.id,
         sourceType,
         sourceConversationId: sourceConversationId ?? null,
+        conversationTodoItemSId: conversationTodoItemSId ?? null,
       },
       { transaction }
     );

--- a/front/lib/resources/storage/models/project_todo.ts
+++ b/front/lib/resources/storage/models/project_todo.ts
@@ -334,6 +334,10 @@ export class ProjectTodoSourceModel extends WorkspaceAwareModel<ProjectTodoSourc
   declare projectTodoId: ForeignKey<ProjectTodoModel["id"]>;
   declare sourceType: ProjectTodoSourceType;
   declare sourceConversationId: ForeignKey<ConversationModel["id"]> | null;
+  // Stable sId of the ConversationTodoVersioned action item that produced this
+  // todo. Set when sourceType is "conversation" and the todo was created by the
+  // merge algorithm. Null for user-created todos and pre-migration rows.
+  declare conversationTodoItemSId: string | null;
 
   declare projectTodo: NonAttribute<ProjectTodoModel>;
   declare sourceConversation: NonAttribute<ConversationModel | null>;
@@ -360,6 +364,13 @@ ProjectTodoSourceModel.init(
       allowNull: true,
       comment: "Set when sourceType is conversation.",
     },
+    conversationTodoItemSId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      comment:
+        "Stable sId of the ConversationTodoVersioned action item that produced " +
+        "this todo. Null for user-created todos and pre-migration rows.",
+    },
   },
   {
     modelName: "project_todo_source",
@@ -378,6 +389,11 @@ ProjectTodoSourceModel.init(
       {
         name: "project_todo_sources_sourceConversationId_idx",
         fields: ["sourceConversationId"],
+        concurrently: true,
+      },
+      {
+        name: "project_todo_sources_conv_item_sId_idx",
+        fields: ["sourceConversationId", "conversationTodoItemSId"],
         concurrently: true,
       },
     ],

--- a/front/migrations/db/migration_564.sql
+++ b/front/migrations/db/migration_564.sql
@@ -1,0 +1,4 @@
+-- Migration created on Apr 07, 2026
+ALTER TABLE "public"."project_todo_source" ADD COLUMN "conversationTodoItemSId" VARCHAR(255);
+CREATE INDEX CONCURRENTLY "project_todo_sources_conv_item_sId_idx"
+  ON "public"."project_todo_source" ("sourceConversationId", "conversationTodoItemSId");


### PR DESCRIPTION
## Description

Two-layer merge for `follow_up` project todos:

Layer 1 (algorithm): agent-linked todos matched via exact (sourceConversationId, conversationTodoItemSId) key. Opens new todos for open action items, updates text on change, make as done todos whose source item is no longer open in any conversation snapshot.

Layer 2 (AI): single batched LLM call per run matches texts of done conversation action items against open user-created (unlinked) follow_up todos and auto-closes high-confidence matches.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
