### PR TITLE
[connectors] Handle Google Drive file size quota errors gracefully

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file/sync_one_file_text_document.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/sync_one_file_text_document.ts
@@ -8,6 +8,7 @@ import {
 } from "@connectors/connectors/google_drive/temporal/mime_types";
 import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
+import { DataSourceQuotaExceededError } from "@connectors/lib/error";
 import type { GoogleDriveConfigModel } from "@connectors/lib/models/google_drive";
 import type { Logger } from "@connectors/logger/logger";
 import type {
@@ -73,18 +74,38 @@ export async function syncOneFileTextDocument(
   }
 
   if (documentContent) {
-    const upsertTimestampMs = await upsertGdriveDocument(
-      dataSourceConfig,
-      file,
-      documentContent,
-      documentId,
-      maxDocumentLen,
-      localLogger,
-      oauth2client,
-      connectorId,
-      startSyncTs,
-      isBatchSync
-    );
+    let upsertTimestampMs: number | undefined;
+    try {
+      upsertTimestampMs = await upsertGdriveDocument(
+        dataSourceConfig,
+        file,
+        documentContent,
+        documentId,
+        maxDocumentLen,
+        localLogger,
+        oauth2client,
+        connectorId,
+        startSyncTs,
+        isBatchSync
+      );
+    } catch (error) {
+      if (error instanceof DataSourceQuotaExceededError) {
+        localLogger.warn(
+          { documentId, fileId: file.id },
+          "File exceeds plan document size limit, marking as skipped"
+        );
+        skipReason = "payload_too_large";
+        await updateGoogleDriveFiles(
+          connectorId,
+          documentId,
+          file,
+          skipReason,
+          undefined
+        );
+        return false;
+      }
+      throw error;
+    }
 
     await updateGoogleDriveFiles(
       connectorId,

--- a/connectors/src/connectors/google_drive/temporal/file/sync_one_file_text_document.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/sync_one_file_text_document.ts
@@ -92,15 +92,7 @@ export async function syncOneFileTextDocument(
       if (error instanceof DataSourceQuotaExceededError) {
         localLogger.warn(
           { documentId, fileId: file.id },
-          "File exceeds plan document size limit, marking as skipped"
-        );
-        skipReason = "payload_too_large";
-        await updateGoogleDriveFiles(
-          connectorId,
-          documentId,
-          file,
-          skipReason,
-          undefined
+          "File exceeds plan document size limit, skipping"
         );
         return false;
       }


### PR DESCRIPTION
## Description

When a Google Drive file exceeds the workspace's plan document size limit during incremental sync, `DataSourceQuotaExceededError` is thrown by `upsertDataSourceDocument` inside `upsertGdriveDocument`. This error was not caught in `syncOneFileTextDocument`, so it propagated to the Temporal activity level causing infinite retries — the workflow gets permanently stuck.

This PR catches the error, logs a warning, and returns `false` to skip the file — matching the Microsoft connector's behavior for the same error class. The file is not permanently marked as skipped, so it will be retried on subsequent sync cycles (allowing it to succeed if the plan limit is later increased).

## Tests

Verified the error propagation path manually. Type-checked with `tsc --noEmit` — no new errors.

## Risk

Low. The only behavioral change is that files exceeding the size limit will now be gracefully skipped instead of causing infinite activity retries.

## Deploy Plan

Standard deploy. No migration needed. Once deployed, currently stuck workflows will self-heal on next retry.