### PR TITLE
[front] - feat(metronome): endpoints

### DIFF
--- a/front/lib/api/credits/metronome_balances.ts
+++ b/front/lib/api/credits/metronome_balances.ts
@@ -1,0 +1,149 @@
+import type { Authenticator } from "@app/lib/auth";
+import { listMetronomeBalances } from "@app/lib/metronome/client";
+import type {
+  MetronomeCommit,
+  MetronomeCredit,
+} from "@app/lib/metronome/types";
+import { METRONOME_CENTS_TO_MICRO_USD } from "@app/lib/metronome/types";
+import { apiError } from "@app/logger/withlogging";
+import type {
+  CreditDisplayData,
+  CreditType,
+  GetCreditsResponseBody,
+} from "@app/types/credits";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+function mapMetronomeType(
+  entry: MetronomeCommit | MetronomeCredit
+): CreditType {
+  switch (entry.type) {
+    case "CREDIT":
+      return "free";
+    case "PREPAID":
+      return "committed";
+    case "POSTPAID":
+      return "payg";
+    default:
+      assertNeverAndIgnore(entry);
+      return "free";
+  }
+}
+
+function getScheduleTotals(entry: MetronomeCommit | MetronomeCredit): {
+  initialAmountCents: number;
+  startDate: number | null;
+  expirationDate: number | null;
+} {
+  const items = entry.access_schedule?.schedule_items ?? [];
+  if (items.length === 0) {
+    return { initialAmountCents: 0, startDate: null, expirationDate: null };
+  }
+
+  let totalAmount = 0;
+  let earliestStart = Infinity;
+  let latestEnd = -Infinity;
+
+  for (const item of items) {
+    totalAmount += item.amount;
+    const start = new Date(item.starting_at).getTime();
+    const end = new Date(item.ending_before).getTime();
+    if (start < earliestStart) {
+      earliestStart = start;
+    }
+    if (end > latestEnd) {
+      latestEnd = end;
+    }
+  }
+
+  return {
+    initialAmountCents: totalAmount,
+    startDate: earliestStart === Infinity ? null : earliestStart,
+    expirationDate: latestEnd === -Infinity ? null : latestEnd,
+  };
+}
+
+function toDisplayData(
+  entry: MetronomeCommit | MetronomeCredit
+): CreditDisplayData {
+  const type = mapMetronomeType(entry);
+  const { initialAmountCents, startDate, expirationDate } =
+    getScheduleTotals(entry);
+
+  const initialAmountMicroUsd =
+    initialAmountCents * METRONOME_CENTS_TO_MICRO_USD;
+  const balanceCents = entry.balance ?? 0;
+  const remainingAmountMicroUsd = balanceCents * METRONOME_CENTS_TO_MICRO_USD;
+  const consumedAmountMicroUsd = Math.max(
+    0,
+    initialAmountMicroUsd - remainingAmountMicroUsd
+  );
+
+  return {
+    sId: entry.id,
+    type,
+    initialAmountMicroUsd,
+    remainingAmountMicroUsd,
+    consumedAmountMicroUsd,
+    startDate,
+    expirationDate,
+    boughtByUser: null,
+  };
+}
+
+export async function handleMetronomeBalancesRequest(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetCreditsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can view credits.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const workspace = auth.getNonNullableWorkspace();
+      const { metronomeCustomerId } = workspace;
+      if (!metronomeCustomerId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Workspace is not configured for Metronome billing.",
+          },
+        });
+      }
+
+      const result = await listMetronomeBalances(metronomeCustomerId);
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve Metronome balances: ${result.error.message}`,
+          },
+        });
+      }
+
+      const credits: CreditDisplayData[] = result.value.map(toDisplayData);
+
+      return res.status(200).json({ credits });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}

--- a/front/lib/api/credits/metronome_balances.ts
+++ b/front/lib/api/credits/metronome_balances.ts
@@ -33,34 +33,30 @@ function mapMetronomeType(
 
 function getScheduleTotals(entry: MetronomeCommit | MetronomeCredit): {
   initialAmountCents: number;
-  startDate: number | null;
-  expirationDate: number | null;
+  startDateMs: number | null;
+  expirationDateMs: number | null;
 } {
   const items = entry.access_schedule?.schedule_items ?? [];
   if (items.length === 0) {
-    return { initialAmountCents: 0, startDate: null, expirationDate: null };
+    return { initialAmountCents: 0, startDateMs: null, expirationDateMs: null };
   }
 
-  let totalAmount = 0;
-  let earliestStart = Infinity;
-  let latestEnd = -Infinity;
+  let totalAmountCents = 0;
+  let earliestStartMs = new Date(items[0].starting_at).getTime();
+  let latestEndMs = new Date(items[0].ending_before).getTime();
 
   for (const item of items) {
-    totalAmount += item.amount;
-    const start = new Date(item.starting_at).getTime();
-    const end = new Date(item.ending_before).getTime();
-    if (start < earliestStart) {
-      earliestStart = start;
-    }
-    if (end > latestEnd) {
-      latestEnd = end;
-    }
+    totalAmountCents += item.amount;
+    const startMs = new Date(item.starting_at).getTime();
+    const endMs = new Date(item.ending_before).getTime();
+    earliestStartMs = Math.min(earliestStartMs, startMs);
+    latestEndMs = Math.max(latestEndMs, endMs);
   }
 
   return {
-    initialAmountCents: totalAmount,
-    startDate: earliestStart === Infinity ? null : earliestStart,
-    expirationDate: latestEnd === -Infinity ? null : latestEnd,
+    initialAmountCents: totalAmountCents,
+    startDateMs: earliestStartMs,
+    expirationDateMs: latestEndMs,
   };
 }
 
@@ -68,7 +64,7 @@ function toDisplayData(
   entry: MetronomeCommit | MetronomeCredit
 ): CreditDisplayData {
   const type = mapMetronomeType(entry);
-  const { initialAmountCents, startDate, expirationDate } =
+  const { initialAmountCents, startDateMs, expirationDateMs } =
     getScheduleTotals(entry);
 
   const initialAmountMicroUsd =
@@ -86,8 +82,8 @@ function toDisplayData(
     initialAmountMicroUsd,
     remainingAmountMicroUsd,
     consumedAmountMicroUsd,
-    startDate,
-    expirationDate,
+    startDate: startDateMs,
+    expirationDate: expirationDateMs,
     boughtByUser: null,
   };
 }

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -717,10 +717,6 @@ export async function listMetronomeUsageWithGroups({
   }
 }
 
-// ---------------------------------------------------------------------------
-// Credits
-// ---------------------------------------------------------------------------
-
 /**
  * Create a credit grant on a Metronome customer.
  * Used for monthly free programmatic credits on legacy plans.

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -19,6 +19,8 @@ export const PRO_OR_BUSINESS_PACKAGE_ALIASES: ReadonlySet<string> = new Set([
   LEGACY_BUSINESS_39_PACKAGE_ALIAS,
 ]);
 
+import type { Commit, Credit } from "@metronome/sdk/resources/shared";
+
 export interface MetronomeEvent {
   transaction_id: string;
   customer_id: string;

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -19,8 +19,6 @@ export const PRO_OR_BUSINESS_PACKAGE_ALIASES: ReadonlySet<string> = new Set([
   LEGACY_BUSINESS_39_PACKAGE_ALIAS,
 ]);
 
-import type { Commit, Credit } from "@metronome/sdk/resources/shared";
-
 export interface MetronomeEvent {
   transaction_id: string;
   customer_id: string;

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -51,27 +51,35 @@ function resetPostPurchaseRefreshCount(workspaceId: string): void {
 
 export function useCredits({
   workspaceId,
+  metronomeCustomerId,
   disabled,
 }: {
   workspaceId: string;
+  metronomeCustomerId?: string | null;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const creditsFetcher: Fetcher<GetCreditsResponseBody> = fetcher;
 
+  const endpoint = metronomeCustomerId
+    ? `/api/w/${workspaceId}/credits/metronome-balances`
+    : `/api/w/${workspaceId}/credits`;
+
   const { data, error, mutate, isValidating } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/credits`,
+    endpoint,
     creditsFetcher,
     {
       disabled,
-      refreshInterval: () => {
-        const count = getPostPurchaseRefreshCount(workspaceId);
-        if (count < 5) {
-          incrementPostPurchaseRefreshCount(workspaceId);
-          return 5000;
-        }
-        return 0;
-      },
+      refreshInterval: metronomeCustomerId
+        ? undefined
+        : () => {
+            const count = getPostPurchaseRefreshCount(workspaceId);
+            if (count < 5) {
+              incrementPostPurchaseRefreshCount(workspaceId);
+              return 5000;
+            }
+            return 0;
+          },
     }
   );
 

--- a/front/pages/api/w/[wId]/credits/metronome-balances.ts
+++ b/front/pages/api/w/[wId]/credits/metronome-balances.ts
@@ -1,0 +1,18 @@
+/** @ignoreswagger */
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { handleMetronomeBalancesRequest } from "@app/lib/api/credits/metronome_balances";
+import type { Authenticator } from "@app/lib/auth";
+import type { GetCreditsResponseBody } from "@app/types/credits";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetCreditsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  return handleMetronomeBalancesRequest(req, res, auth);
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

This PRR adds a new API endpoint to fetch credit balances from Metronome for workspaces configured with Metronome billing. This is part of the broader Metronome billing integration, building on top of the client functions added in #23796. The endpoint retrieves balance data (commits and credits) via `listMetronomeBalances()` and transforms it into the existing `CreditDisplayData` format. The `useCredits` SWR hook is updated to conditionally fetch from the new `/credits/metronome-balances` endpoint when `metronomeCustomerId` is present, otherwise it falls back to the legacy credits endpoint.

## Tests

- [x] Locally

## Risk

Low. The new endpoint is only accessible for workspaces with `metronomeCustomerId` set, otherwise it returns a 400 error. The changes to the `useCredits` hook are backward compatible

## Deploy Plan

Deploy front.