### PR TITLE
Track frame sharing views and email verification in PostHog

### DIFF
--- a/front/components/pages/share/EmailVerificationFlow.tsx
+++ b/front/components/pages/share/EmailVerificationFlow.tsx
@@ -7,6 +7,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import type { ReactNode } from "react";
 import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
+import { usePostHog } from "posthog-js/react";
 import { z } from "zod";
 
 interface VerificationLayoutProps {
@@ -66,6 +67,7 @@ interface EmailStepFormProps {
 
 function EmailStepForm({ onCodeSent, shareToken }: EmailStepFormProps) {
   const doSendOtp = useSendOtpVerification({ shareToken });
+  const posthog = usePostHog();
 
   const {
     register,
@@ -81,6 +83,9 @@ function EmailStepForm({ onCodeSent, shareToken }: EmailStepFormProps) {
   const onSubmit = async (data: EmailFormValues) => {
     const result = await doSendOtp(data.email);
     if (result.success) {
+      posthog.capture("frame_email_verification_requested", {
+        email: data.email,
+      });
       onCodeSent(data.email);
     } else {
       setError("email", {
@@ -130,6 +135,7 @@ interface CodeStepFormProps {
 function CodeStepForm({ email, onVerified, shareToken }: CodeStepFormProps) {
   const doSendOtp = useSendOtpVerification({ shareToken });
   const doVerifyCode = useVerifyOtpCode({ shareToken });
+  const posthog = usePostHog();
   const [isResending, setIsResending] = useState(false);
   const [resent, setResent] = useState(false);
 
@@ -148,6 +154,8 @@ function CodeStepForm({ email, onVerified, shareToken }: CodeStepFormProps) {
   const onSubmit = async (data: CodeFormValues) => {
     const result = await doVerifyCode(email, data.code);
     if (result.success) {
+      posthog.identify(email);
+      posthog.capture("frame_email_verified", { email });
       onVerified();
     } else {
       setError("code", {

--- a/front/components/pages/share/EmailVerificationFlow.tsx
+++ b/front/components/pages/share/EmailVerificationFlow.tsx
@@ -4,10 +4,10 @@ import config from "@app/lib/api/config";
 import { useSendOtpVerification, useVerifyOtpCode } from "@app/lib/swr/share";
 import { Button, Input, Label } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { usePostHog } from "posthog-js/react";
 import type { ReactNode } from "react";
 import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
-import { usePostHog } from "posthog-js/react";
 import { z } from "zod";
 
 interface VerificationLayoutProps {

--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -8,6 +8,7 @@ import { useShareFrameMetadata } from "@app/lib/swr/share";
 import { getFaviconPath } from "@app/lib/utils";
 import Custom404 from "@app/pages/404";
 import { Spinner } from "@dust-tt/sparkle";
+import { usePostHog } from "posthog-js/react";
 import { useEffect, useMemo, useState } from "react";
 
 // Origins from which the share frame is considered as embedded.
@@ -16,6 +17,7 @@ const EMBEDDED_ORIGINS = ["https://dust.tt/blog/"];
 
 export function SharedFramePage() {
   const token = usePathParam("token");
+  const posthog = usePostHog();
 
   const [isVerified, setIsVerified] = useState(false);
 
@@ -35,9 +37,24 @@ export function SharedFramePage() {
 
   // Only fetch the frame once metadata has resolved. Metadata handles the region redirect, so we
   // need to wait for the correct region to be established before firing this request.
-  const { error: frameError, mutateFrame } = usePublicFrame({
+  const {
+    frameMetadata,
+    error: frameError,
+    mutateFrame,
+  } = usePublicFrame({
     shareToken: shareMetadata ? token : null,
   });
+
+  // Track frame view once the frame successfully loads.
+  useEffect(() => {
+    if (!frameMetadata || !shareMetadata) {
+      return;
+    }
+    posthog.capture("frame_shared_view", {
+      workspace_id: shareMetadata.workspaceId,
+      requires_email_verification: shareMetadata.requiresEmailVerification,
+    });
+  }, [frameMetadata, shareMetadata, posthog]);
 
   // Show the email form when:
   // 1. Metadata says the scope requires email verification, AND


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The share page had no custom instrumentation. Only the automatic pageview. This adds three events to cover the different ways someone accesses a shared frame:
- a `frame_shared_view` when the frame successfully loads (with whether email verification was required and used)
- `frame_email_verification_requested` when an external viewer submits their email
- `frame_email_verified` on successful OTP completion

The identify call on verification is the interesting one. fI an external viewer later signs up for Dust, PostHog will stitch their
pre-signup frame view to their new profile, giving us a direct signal on sharing as an acquisition channel.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
