### PR TITLE
[front] - fix(analytics): remote mcp server display name

### DIFF
--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -9,12 +9,12 @@ import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
+import type { AvailableTool } from "@app/lib/api/assistant/observability/tool_usage";
 import {
   useWorkspaceTools,
   useWorkspaceToolUsage,
 } from "@app/lib/swr/workspaces";
 import { formatShortDate } from "@app/lib/utils/timestamps";
-import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
 import {
   Button,
   ButtonsSwitch,
@@ -46,24 +46,33 @@ interface ToolUsageChartPoint {
   values: Record<string, number>;
 }
 
-function getToolSelectorLabel(selectedTools: string[]): string {
+function getToolSelectorLabel(
+  selectedTools: string[],
+  displayNameMap: Map<string, string>
+): string {
   if (selectedTools.length === 0) {
     return "Select tools";
   }
   if (selectedTools.length === 1) {
-    return asDisplayToolName(selectedTools[0]);
+    return displayNameMap.get(selectedTools[0]) ?? selectedTools[0];
   }
   return `${selectedTools.length} tools`;
+}
+
+function buildDisplayNameMap(tools: AvailableTool[]): Map<string, string> {
+  return new Map(tools.map((t) => [t.serverName, t.displayName]));
 }
 
 interface ToolUsageTooltipProps extends TooltipContentProps<number, string> {
   displayMode: ToolUsageDisplayMode;
   toolsWithData: string[];
+  displayNameMap: Map<string, string>;
 }
 
 function ToolUsageTooltip({
   displayMode,
   toolsWithData,
+  displayNameMap,
   active,
   payload,
 }: ToolUsageTooltipProps) {
@@ -82,7 +91,7 @@ function ToolUsageTooltip({
 
   const values = toolsWithData.map((tool) => point.values[tool] ?? 0);
   const rows = toolsWithData.map((tool, idx) => ({
-    label: asDisplayToolName(tool),
+    label: displayNameMap.get(tool) ?? tool,
     value: values[idx].toLocaleString(),
     colorClassName: getIndexedColor(tool, toolsWithData),
   }));
@@ -117,6 +126,11 @@ export function WorkspaceToolUsageChart({
     days: period,
     disabled: !workspaceId,
   });
+
+  const displayNameMap = useMemo(
+    () => buildDisplayNameMap(availableTools),
+    [availableTools]
+  );
 
   // Auto-select first 3 tools when available tools are loaded
   useEffect(() => {
@@ -223,7 +237,7 @@ export function WorkspaceToolUsageChart({
 
   const legendItems: LegendItem[] = toolsWithData.map((tool) => ({
     key: tool,
-    label: asDisplayToolName(tool),
+    label: displayNameMap.get(tool) ?? tool,
     colorClassName: getIndexedColor(tool, toolsWithData),
   }));
 
@@ -231,7 +245,7 @@ export function WorkspaceToolUsageChart({
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button
-          label={getToolSelectorLabel(selectedTools)}
+          label={getToolSelectorLabel(selectedTools, displayNameMap)}
           size="xs"
           variant="outline"
           isSelect
@@ -246,7 +260,7 @@ export function WorkspaceToolUsageChart({
           {availableTools.map((tool) => (
             <DropdownMenuCheckboxItem
               key={tool.serverName}
-              label={asDisplayToolName(tool.serverName)}
+              label={displayNameMap.get(tool.serverName) ?? tool.serverName}
               checked={selectedTools.includes(tool.serverName)}
               disabled={
                 !selectedTools.includes(tool.serverName) &&
@@ -338,6 +352,7 @@ export function WorkspaceToolUsageChart({
               {...props}
               displayMode={displayMode}
               toolsWithData={toolsWithData}
+              displayNameMap={displayNameMap}
             />
           )}
           cursor={false}
@@ -355,7 +370,7 @@ export function WorkspaceToolUsageChart({
             type={period === 7 || period === 14 ? "linear" : "monotone"}
             strokeWidth={2}
             dataKey={(point: ToolUsageChartPoint) => point.values[tool] ?? 0}
-            name={asDisplayToolName(tool)}
+            name={displayNameMap.get(tool) ?? tool}
             className={getIndexedColor(tool, toolsWithData)}
             stroke="currentColor"
             dot={false}

--- a/front/lib/api/assistant/observability/tool_execution.ts
+++ b/front/lib/api/assistant/observability/tool_execution.ts
@@ -1,10 +1,11 @@
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
 import type { estypes } from "@elastic/elasticsearch";
 
 import { buildConfigBreakdown, MISSING_CONFIG_NAME } from "./tool_breakdown";
+import { resolveServerDisplayNames } from "./tool_usage";
 
 const DEFAULT_METRIC_VALUE = 0;
 
@@ -45,6 +46,7 @@ type ToolExecutionAggs = {
 };
 
 export async function fetchToolExecutionMetrics(
+  auth: Authenticator,
   baseQuery: estypes.QueryDslQueryContainer
 ): Promise<Result<ToolExecutionByVersion[], Error>> {
   const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
@@ -99,6 +101,11 @@ export async function fetchToolExecutionMetrics(
     result.value.aggregations?.by_version?.buckets
   );
 
+  const allServerNames = versionBuckets.flatMap((vb) =>
+    bucketsToArray<ServerBucket>(vb.tools?.servers?.buckets).map((b) => b.key)
+  );
+  const displayMap = await resolveServerDisplayNames(auth, allServerNames);
+
   const byVersion: ToolExecutionByVersion[] = versionBuckets.map((vb) => {
     const serverBuckets = bucketsToArray<ServerBucket>(
       vb.tools?.servers?.buckets
@@ -118,10 +125,9 @@ export async function fetchToolExecutionMetrics(
           ? Math.round((succeeded / total) * 100)
           : DEFAULT_METRIC_VALUE;
 
-      const serverDisplayName = asDisplayToolName(sb.key);
       const breakdown = buildConfigBreakdown(sb.configs);
 
-      tools[serverDisplayName] = {
+      tools[displayMap.get(sb.key) ?? sb.key] = {
         count: total,
         successRate,
         mcpViewBreakdown:

--- a/front/lib/api/assistant/observability/tool_execution.ts
+++ b/front/lib/api/assistant/observability/tool_execution.ts
@@ -1,11 +1,13 @@
+import {
+  buildConfigBreakdown,
+  MISSING_CONFIG_NAME,
+} from "@app/lib/api/assistant/observability/tool_breakdown";
+import { resolveServerDisplayNames } from "@app/lib/api/assistant/observability/tool_usage";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
-
-import { buildConfigBreakdown, MISSING_CONFIG_NAME } from "./tool_breakdown";
-import { resolveServerDisplayNames } from "./tool_usage";
 
 const DEFAULT_METRIC_VALUE = 0;
 

--- a/front/lib/api/assistant/observability/tool_latency.ts
+++ b/front/lib/api/assistant/observability/tool_latency.ts
@@ -1,7 +1,10 @@
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
+
+import { resolveServerDisplayNames } from "./tool_usage";
 
 const DEFAULT_METRIC_VALUE = 0;
 
@@ -94,6 +97,7 @@ function buildLatencyRows(
 }
 
 export async function fetchToolLatencyMetricsByName(
+  auth: Authenticator,
   baseQuery: estypes.QueryDslQueryContainer,
   { view, serverName }: { view: ToolLatencyView; serverName?: string }
 ): Promise<Result<ToolLatencyRow[], Error>> {
@@ -162,6 +166,16 @@ export async function fetchToolLatencyMetricsByName(
   const rows = buildLatencyRows(
     result.value.aggregations?.tools?.succeeded?.by_name
   );
+
+  if (view === "server") {
+    const displayMap = await resolveServerDisplayNames(
+      auth,
+      rows.map((r) => r.name)
+    );
+    for (const row of rows) {
+      row.name = displayMap.get(row.name) ?? row.name;
+    }
+  }
 
   return new Ok(rows);
 }

--- a/front/lib/api/assistant/observability/tool_latency.ts
+++ b/front/lib/api/assistant/observability/tool_latency.ts
@@ -1,10 +1,9 @@
+import { resolveServerDisplayNames } from "@app/lib/api/assistant/observability/tool_usage";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
-
-import { resolveServerDisplayNames } from "./tool_usage";
 
 const DEFAULT_METRIC_VALUE = 0;
 

--- a/front/lib/api/assistant/observability/tool_step_index.ts
+++ b/front/lib/api/assistant/observability/tool_step_index.ts
@@ -1,10 +1,11 @@
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
 import type { estypes } from "@elastic/elasticsearch";
 
 import { buildConfigBreakdown, MISSING_CONFIG_NAME } from "./tool_breakdown";
+import { resolveServerDisplayNames } from "./tool_usage";
 
 const DEFAULT_METRIC_VALUE = 0;
 
@@ -42,6 +43,7 @@ type ToolStepIndexAggs = {
 };
 
 export async function fetchToolStepIndexDistribution(
+  auth: Authenticator,
   baseQuery: estypes.QueryDslQueryContainer
 ): Promise<Result<ToolStepIndexByStep[], Error>> {
   const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
@@ -97,6 +99,11 @@ export async function fetchToolStepIndexDistribution(
     result.value.aggregations?.steps?.by_step?.buckets
   );
 
+  const allServerNames = stepBuckets.flatMap((sb) =>
+    bucketsToArray<ServerBucket>(sb.servers?.buckets).map((b) => b.key)
+  );
+  const displayMap = await resolveServerDisplayNames(auth, allServerNames);
+
   const byStep: ToolStepIndexByStep[] = stepBuckets.map((sb) => {
     const serverBuckets = bucketsToArray<ServerBucket>(sb.servers?.buckets);
 
@@ -104,7 +111,7 @@ export async function fetchToolStepIndexDistribution(
     serverBuckets.forEach((serverBucket) => {
       const breakdown = buildConfigBreakdown(serverBucket.configs);
 
-      tools[asDisplayToolName(serverBucket.key)] = {
+      tools[displayMap.get(serverBucket.key) ?? serverBucket.key] = {
         count: serverBucket.doc_count ?? DEFAULT_METRIC_VALUE,
         breakdown: Object.keys(breakdown).length > 0 ? breakdown : undefined,
       };

--- a/front/lib/api/assistant/observability/tool_usage.ts
+++ b/front/lib/api/assistant/observability/tool_usage.ts
@@ -3,8 +3,11 @@ import {
   formatUTCDateFromMillis,
   searchAnalytics,
 } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
 import type { estypes } from "@elastic/elasticsearch";
 
 export type ToolUsagePoint = {
@@ -16,6 +19,7 @@ export type ToolUsagePoint = {
 
 export type AvailableTool = {
   serverName: string;
+  displayName: string;
   totalExecutions: number;
 };
 
@@ -202,8 +206,25 @@ export async function fetchAvailableTools(
 
   const tools: AvailableTool[] = toolBuckets.map((bucket) => ({
     serverName: bucket.key,
+    displayName: bucket.key,
     totalExecutions: bucket.doc_count,
   }));
 
   return new Ok(tools);
+}
+
+export async function resolveToolDisplayNames(
+  auth: Authenticator,
+  tools: AvailableTool[]
+): Promise<AvailableTool[]> {
+  const remoteNameMap = await RemoteMCPServerResource.resolveNamesBySIds(
+    auth,
+    tools.map((t) => t.serverName)
+  );
+
+  return tools.map((tool) => ({
+    ...tool,
+    displayName:
+      remoteNameMap.get(tool.serverName) ?? asDisplayToolName(tool.serverName),
+  }));
 }

--- a/front/lib/api/assistant/observability/tool_usage.ts
+++ b/front/lib/api/assistant/observability/tool_usage.ts
@@ -213,18 +213,34 @@ export async function fetchAvailableTools(
   return new Ok(tools);
 }
 
+export async function resolveServerDisplayNames(
+  auth: Authenticator,
+  serverNames: string[]
+): Promise<Map<string, string>> {
+  const unique = [...new Set(serverNames)];
+  const remoteNameMap = await RemoteMCPServerResource.resolveNamesBySIds(
+    auth,
+    unique
+  );
+
+  const displayMap = new Map<string, string>();
+  for (const name of unique) {
+    displayMap.set(name, remoteNameMap.get(name) ?? asDisplayToolName(name));
+  }
+  return displayMap;
+}
+
 export async function resolveToolDisplayNames(
   auth: Authenticator,
   tools: AvailableTool[]
 ): Promise<AvailableTool[]> {
-  const remoteNameMap = await RemoteMCPServerResource.resolveNamesBySIds(
+  const displayMap = await resolveServerDisplayNames(
     auth,
     tools.map((t) => t.serverName)
   );
 
   return tools.map((tool) => ({
     ...tool,
-    displayName:
-      remoteNameMap.get(tool.serverName) ?? asDisplayToolName(tool.serverName),
+    displayName: displayMap.get(tool.serverName) ?? tool.serverName,
   }));
 }

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -188,11 +188,6 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     });
   }
 
-  /**
-   * Resolve a list of MCP server sIds to their cached human-readable names.
-   * Non-remote sIds are silently ignored.
-   * Returns a Map from sId to cachedName (only includes servers with a cachedName).
-   */
   static async resolveNamesBySIds(
     auth: Authenticator,
     sIds: string[]

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -4,7 +4,10 @@ import type {
   InternalAllowedIconType,
 } from "@app/components/resources/resources_icons";
 import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
-import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import {
+  getServerTypeAndIdFromSId,
+  remoteMCPServerNameToSId,
+} from "@app/lib/actions/mcp_helper";
 import type { MCPToolType, RemoteMCPServerType } from "@app/lib/api/mcp";
 import type { MCPOAuthConnectionMetadataType } from "@app/lib/api/oauth/providers/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -19,7 +22,10 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
+import {
+  getResourceIdFromSId,
+  isResourceSId,
+} from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -180,6 +186,32 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     return this.baseFetch(auth, {
       where: { id: { [Op.in]: ids } },
     });
+  }
+
+  /**
+   * Resolve a list of MCP server sIds to their cached human-readable names.
+   * Non-remote sIds are silently ignored.
+   * Returns a Map from sId to cachedName (only includes servers with a cachedName).
+   */
+  static async resolveNamesBySIds(
+    auth: Authenticator,
+    sIds: string[]
+  ): Promise<Map<string, string>> {
+    const remoteSIds = sIds.filter((sId) =>
+      isResourceSId("remote_mcp_server", sId)
+    );
+    if (remoteSIds.length === 0) {
+      return new Map();
+    }
+    const modelIds = remoteSIds.map((sId) => getServerTypeAndIdFromSId(sId).id);
+    const servers = await this.fetchByModelIds(auth, modelIds);
+    const nameMap = new Map<string, string>();
+    for (const server of servers) {
+      if (server.cachedName) {
+        nameMap.set(server.sId, server.cachedName);
+      }
+    }
+    return nameMap;
   }
 
   static async listByWorkspace(auth: Authenticator) {

--- a/front/pages/api/w/[wId]/analytics/tool-usage-export.ts
+++ b/front/pages/api/w/[wId]/analytics/tool-usage-export.ts
@@ -3,6 +3,7 @@ import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability
 import {
   fetchAvailableTools,
   fetchToolUsageMetrics,
+  resolveToolDisplayNames,
 } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -70,7 +71,7 @@ async function handler(
         });
       }
 
-      const tools = toolsResult.value;
+      const tools = await resolveToolDisplayNames(auth, toolsResult.value);
       const rows: ToolUsageExportRow[] = [];
 
       for (const tool of tools) {
@@ -91,7 +92,7 @@ async function handler(
         for (const point of usageResult.value) {
           rows.push({
             date: point.date,
-            toolName: tool.serverName,
+            toolName: tool.displayName,
             executions: point.executionCount,
             uniqueUsers: point.uniqueUsers,
           });

--- a/front/pages/api/w/[wId]/analytics/tools.ts
+++ b/front/pages/api/w/[wId]/analytics/tools.ts
@@ -1,7 +1,10 @@
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { AvailableTool } from "@app/lib/api/assistant/observability/tool_usage";
-import { fetchAvailableTools } from "@app/lib/api/assistant/observability/tool_usage";
+import {
+  fetchAvailableTools,
+  resolveToolDisplayNames,
+} from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -67,8 +70,10 @@ async function handler(
         });
       }
 
+      const tools = await resolveToolDisplayNames(auth, toolsResult.value);
+
       return res.status(200).json({
-        tools: toolsResult.value,
+        tools,
       });
     }
     default:

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
@@ -76,7 +76,10 @@ async function handler(
         version,
       });
 
-      const toolExecutionResult = await fetchToolExecutionMetrics(baseQuery);
+      const toolExecutionResult = await fetchToolExecutionMetrics(
+        auth,
+        baseQuery
+      );
 
       if (toolExecutionResult.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency.ts
@@ -100,6 +100,7 @@ async function handler(
         }
 
         const toolLatencyResult = await fetchToolLatencyMetricsByName(
+          auth,
           baseQuery,
           {
             view,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index.ts
@@ -76,7 +76,7 @@ async function handler(
         version,
       });
 
-      const result = await fetchToolStepIndexDistribution(baseQuery);
+      const result = await fetchToolStepIndexDistribution(auth, baseQuery);
 
       if (result.isErr()) {
         return apiError(req, res, {

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -303,7 +303,6 @@ async function collectToolUsageFromMessage(
     serverConfigs.map((cfg) => [cfg.id.toString(), cfg.sId])
   );
 
-  // Resolve remote MCP server IDs to human-readable names.
   const mcpServerIds = [
     ...new Set(
       actionResources.flatMap((a) =>

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -25,6 +25,7 @@ import { AgentMCPServerConfigurationResource } from "@app/lib/resources/agent_mc
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/global/registry";
@@ -302,20 +303,41 @@ async function collectToolUsageFromMessage(
     serverConfigs.map((cfg) => [cfg.id.toString(), cfg.sId])
   );
 
-  return actionResources.map((actionResource) => ({
-    step_index: actionResource.stepContent.step,
-    server_name:
-      actionResource.metadata.internalMCPServerName ??
-      actionResource.metadata.mcpServerId ??
-      "unknown",
-    tool_name:
-      actionResource.functionCallName.split(TOOL_NAME_SEPARATOR).pop() ??
-      actionResource.functionCallName,
-    mcp_server_configuration_sid:
-      configIdToSId.get(actionResource.mcpServerConfigurationId) ?? undefined,
-    execution_time_ms: actionResource.executionDurationMs,
-    status: actionResource.status,
-  }));
+  // Resolve remote MCP server IDs to human-readable names.
+  const mcpServerIds = [
+    ...new Set(
+      actionResources.flatMap((a) =>
+        !a.metadata.internalMCPServerName && a.metadata.mcpServerId
+          ? [a.metadata.mcpServerId]
+          : []
+      )
+    ),
+  ];
+  const remoteServerNameMap = await RemoteMCPServerResource.resolveNamesBySIds(
+    auth,
+    mcpServerIds
+  );
+
+  return actionResources.map((actionResource) => {
+    const { internalMCPServerName, mcpServerId } = actionResource.metadata;
+    const serverName =
+      internalMCPServerName ??
+      (mcpServerId && remoteServerNameMap.get(mcpServerId)) ??
+      mcpServerId ??
+      "unknown";
+
+    return {
+      step_index: actionResource.stepContent.step,
+      server_name: serverName,
+      tool_name:
+        actionResource.functionCallName.split(TOOL_NAME_SEPARATOR).pop() ??
+        actionResource.functionCallName,
+      mcp_server_configuration_sid:
+        configIdToSId.get(actionResource.mcpServerConfigurationId) ?? undefined,
+      execution_time_ms: actionResource.executionDurationMs,
+      status: actionResource.status,
+    };
+  });
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #7256 where remote MCP servers were displaying as encoded strings (e.g., "Rms Ejh Zxdg W3w 9s Tm Orzr 1k") instead of human-readable names in analytics charts and CSV exports. The issue occurred because analytics code was using `asDisplayToolName()` which converts snake_case to Title Case, but this doesn't work for remote MCP server sIds (e.g., `rms_EjhZxdgW3w9sTm0Rzr1K`). 

The fix introduces `resolveServerDisplayNames()` and `resolveToolDisplayNames()` utilities in `tool_usage.ts` that query `RemoteMCPServerResource.resolveNamesBySIds()` to retrieve the cached display names for remote MCP servers. All observability API endpoints (`tool_execution`, `tool_latency`, `tool_step_index`, `tool-usage-export`) and the analytics queue now use this resolution logic before returning data. The `WorkspaceToolUsageChart` component is updated to use a pre-built display name map for consistency across dropdowns, legends, and tooltips.

Note: we are not backfilling existing data as it is too expensive.

## Tests

- [x] Locally
- [x] front-edge

## Risk

Low

## Deploy Plan

Deploy front