### PR TITLE
Metronome webhook endpoint creation

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -541,6 +541,9 @@ const config = {
       "METRONOME_TOOL_USE_BILLABLE_METRIC_ID"
     );
   },
+  getMetronomeWebhookSecret: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("METRONOME_WEBHOOK_SECRET");
+  },
 };
 
 export default config;

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -14,7 +14,7 @@ import type {
 
 let cachedClient: Metronome | null = null;
 
-function getClient(): Metronome {
+export function getMetronomeClient(): Metronome {
   if (!cachedClient) {
     const bearerToken = config.getMetronomeApiKey();
     if (!bearerToken) {
@@ -59,7 +59,7 @@ export async function ingestMetronomeEvents(
     return;
   }
 
-  const client = getClient();
+  const client = getMetronomeClient();
   for (let i = 0; i < events.length; i += METRONOME_INGEST_BATCH_SIZE) {
     const batch = events.slice(i, i + METRONOME_INGEST_BATCH_SIZE);
     await client.v1.usage.ingest({ usage: batch });
@@ -87,7 +87,7 @@ export async function createMetronomeCustomer({
   stripeCustomerId: string;
 }): Promise<Result<{ metronomeCustomerId: string }, Error>> {
   try {
-    const response = await getClient().v1.customers.create({
+    const response = await getMetronomeClient().v1.customers.create({
       name: workspaceName,
       ingest_aliases: [workspaceId],
       ...(stripeCustomerId
@@ -136,7 +136,7 @@ export async function findMetronomeCustomerByAlias(
   workspaceId: string
 ): Promise<Result<string | null, Error>> {
   try {
-    const page = await getClient().v1.customers.list({
+    const page = await getMetronomeClient().v1.customers.list({
       ingest_alias: workspaceId,
     });
     const first = page.data[0];
@@ -171,7 +171,7 @@ export async function createMetronomeContract({
   uniquenessKey: string;
 }): Promise<Result<{ contractId: string }, Error>> {
   try {
-    const response = await getClient().v1.contracts.create({
+    const response = await getMetronomeClient().v1.contracts.create({
       customer_id: metronomeCustomerId,
       package_alias: packageAlias,
       // Metronome requires starting_at on an hour boundary — round down to current hour.
@@ -278,7 +278,7 @@ export async function getMetronomeActiveContract(
   >
 > {
   try {
-    const response = await getClient().v2.contracts.list({
+    const response = await getMetronomeClient().v2.contracts.list({
       customer_id: metronomeCustomerId,
     });
 
@@ -324,7 +324,7 @@ export async function endMetronomeContract({
   endingBefore?: string;
 }): Promise<Result<void, Error>> {
   try {
-    await getClient().v1.contracts.updateEndDate({
+    await getMetronomeClient().v1.contracts.updateEndDate({
       customer_id: metronomeCustomerId,
       contract_id: contractId,
       ...(endingBefore ? { ending_before: endingBefore } : {}),
@@ -358,7 +358,7 @@ export async function getMetronomeContractPackageAliases({
   metronomeContractId: string;
 }): Promise<Result<string[], Error>> {
   try {
-    const contractResponse = await getClient().v1.contracts.retrieve({
+    const contractResponse = await getMetronomeClient().v1.contracts.retrieve({
       customer_id: metronomeCustomerId,
       contract_id: metronomeContractId,
     });
@@ -368,7 +368,7 @@ export async function getMetronomeContractPackageAliases({
       return new Ok([]);
     }
 
-    const packageResponse = await getClient().v1.packages.retrieve({
+    const packageResponse = await getMetronomeClient().v1.packages.retrieve({
       package_id: packageId,
     });
 
@@ -412,7 +412,7 @@ export async function editMetronomeContractSeats({
   const now = new Date().toISOString();
 
   try {
-    await getClient().v2.contracts.edit({
+    await getMetronomeClient().v2.contracts.edit({
       customer_id: metronomeCustomerId,
       contract_id: contractId,
       update_subscriptions: edits.map((edit) => ({
@@ -503,7 +503,7 @@ export async function createMetronomeCommit({
       "[Metronome] Adding commits to contract"
     );
 
-    await getClient().v2.contracts.edit(
+    await getMetronomeClient().v2.contracts.edit(
       {
         customer_id: metronomeCustomerId,
         contract_id: contractId,
@@ -577,7 +577,7 @@ export async function listMetronomeProducts(): Promise<
 > {
   try {
     const products: MetronomeProduct[] = [];
-    for await (const product of getClient().v1.contracts.products.list()) {
+    for await (const product of getMetronomeClient().v1.contracts.products.list()) {
       products.push({ id: product.id, name: product.current.name });
     }
     return new Ok(products);
@@ -595,7 +595,7 @@ export async function listMetronomeBalances(
     return new Ok([]);
   }
 
-  const client = getClient();
+  const client = getMetronomeClient();
 
   try {
     const balances: MetronomeBalance[] = [];
@@ -638,7 +638,7 @@ export async function listMetronomeUsage({
     return new Ok([]);
   }
 
-  const client = getClient();
+  const client = getMetronomeClient();
 
   try {
     const results: MetronomeUsageListResponse[] = [];
@@ -687,7 +687,7 @@ export async function listMetronomeUsageWithGroups({
     return new Ok([]);
   }
 
-  const client = getClient();
+  const client = getMetronomeClient();
 
   try {
     const results: MetronomeUsageWithGroupsResponse[] = [];
@@ -749,7 +749,7 @@ export async function createMetronomeCredit({
   const roundedEndingBefore = ceilToHourISO(new Date(endingBefore));
 
   try {
-    const response = await getClient().v2.contracts.edit(
+    const response = await getMetronomeClient().v2.contracts.edit(
       {
         customer_id: metronomeCustomerId,
         contract_id: contractId,

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -1,0 +1,153 @@
+/** @ignoreswagger */
+import apiConfig from "@app/lib/api/config";
+import { getMetronomeClient } from "@app/lib/metronome/client";
+import logger from "@app/logger/logger";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { pipeline, Writable } from "stream";
+import { promisify } from "util";
+
+type ResponseBody = {
+  success: boolean;
+  message?: string;
+};
+
+// Disable Next.js body parsing so we can read the raw body for signature verification.
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<ResponseBody>>
+): Promise<void> {
+  switch (req.method) {
+    case "GET":
+      return res.status(200).json({ success: true });
+
+    case "POST": {
+      // Collect raw body.
+      let rawBody = Buffer.from("");
+      const collector = new Writable({
+        write(chunk, _encoding, callback) {
+          rawBody = Buffer.concat([rawBody, chunk]);
+          callback();
+        },
+      });
+      await promisify(pipeline)(req, collector);
+
+      const bodyString = rawBody.toString("utf-8");
+
+      // Verify signature using the Metronome SDK.
+      const webhookSecret = apiConfig.getMetronomeWebhookSecret();
+      if (!webhookSecret) {
+        logger.error(
+          "[Metronome Webhook] METRONOME_WEBHOOK_SECRET is not configured"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Webhook secret not configured.",
+          },
+        });
+      }
+
+      let event: { type: string; [key: string]: unknown };
+      try {
+        const client = getMetronomeClient();
+        event = client.webhooks.unwrap(
+          bodyString,
+          req.headers,
+          webhookSecret
+        ) as { type: string; [key: string]: unknown };
+      } catch (err) {
+        logger.error(
+          { error: err },
+          "[Metronome Webhook] Signature verification failed"
+        );
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "internal_server_error",
+            message: "Invalid webhook signature.",
+          },
+        });
+      }
+
+      switch (event.type) {
+        case "alerts.low_remaining_credit_balance_reached":
+          logger.info({ event }, "[Metronome Webhook] Credits exhausted alert");
+          break;
+
+        case "alerts.low_remaining_seat_balance_reached":
+          logger.info(
+            { event },
+            "[Metronome Webhook] Per-seat credits exhausted alert"
+          );
+          break;
+
+        case "alerts.spend_threshold_reached":
+          logger.info({ event }, "[Metronome Webhook] Approaching spend limit");
+          break;
+
+        case "commit.segment.start":
+          logger.info(
+            { event },
+            "[Metronome Webhook] New commit segment started (credits available)"
+          );
+          break;
+
+        case "credit.create":
+          logger.info(
+            { event },
+            "[Metronome Webhook] Credit created (credits available)"
+          );
+          break;
+
+        case "contract.start":
+          logger.info({ event }, "[Metronome Webhook] Contract started");
+          break;
+
+        case "contract.end":
+          logger.info({ event }, "[Metronome Webhook] Contract ended");
+          break;
+
+        case "invoice.finalized":
+          logger.info({ event }, "[Metronome Webhook] Invoice finalized");
+          break;
+
+        case "invoice.billing_provider_error":
+          logger.error(
+            { event },
+            "[Metronome Webhook] Billing provider error on invoice"
+          );
+          break;
+
+        default:
+          logger.info(
+            { eventType: event.type },
+            "[Metronome Webhook] Unhandled event type"
+          );
+          break;
+      }
+
+      return res.status(200).json({ success: true });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(handler);

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -4,6 +4,7 @@ import { getMetronomeClient } from "@app/lib/metronome/client";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { pipeline, Writable } from "stream";
 import { promisify } from "util";
@@ -66,7 +67,7 @@ async function handler(
         ) as { type: string; [key: string]: unknown };
       } catch (err) {
         logger.error(
-          { error: err },
+          { error: normalizeError(err) },
           "[Metronome Webhook] Signature verification failed"
         );
         return apiError(req, res, {


### PR DESCRIPTION
## Description

This PR implements the `/api/metronome/webhook` endpoint to receive and validate Metronome billing events. For now, all events are logged only — actual business logic (Redis cache updates, workspace activation/downgrade) will be added in follow-up PRs.

The endpoint also refactors the Metronome client by renaming `getClient()` to `getMetronomeClient()` and exporting it for reuse in the webhook handler.

## Tests

1. Expose your local endpoint (e.g. with Ngrok)
2. Create a new webhook in [Metronome](https://app.metronome.com/sandbox/connections/api-tokens-webhooks) with your ngrok url. You'll get a webhook secret.
3. Set your webhook secret locally `export METRONOME_WEBHOOK_SECRET=xxx`
4. Click on "Send test notification" [here](https://app.metronome.com/sandbox/connections/api-tokens-webhooks)

## Risk

Low. Endpoint only logs events and returns 200. No business logic changes. Signature verification ensures only authentic Metronome webhooks are processed.

## Deploy Plan

Deploy front. Requires `METRONOME_WEBHOOK_SECRET` environment variable to be set before webhooks can be validated.