### PR TITLE
[Steering] Hide agent header on steered agent messages

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -169,6 +169,7 @@ function PrunedContextChip() {
 
 interface AgentMessageProps {
   conversationId: string;
+  hideHeader: boolean;
   isLastMessage: boolean;
   agentMessage: MessageTemporaryState;
   messageFeedback: FeedbackSelectorBaseProps;
@@ -188,6 +189,7 @@ interface AgentMessageProps {
 
 export function AgentMessage({
   conversationId,
+  hideHeader,
   isLastMessage,
   agentMessage,
   messageFeedback,
@@ -970,35 +972,37 @@ export function AgentMessage({
 
   return (
     <ConversationMessageContainer messageType="agent" type="agent">
-      <div className="inline-flex items-center gap-2 px-5">
-        <ConversationMessageAvatar
-          avatarUrl={agentConfiguration.pictureUrl}
-          name={agentConfiguration.name}
-          isBusy={agentMessage.status === "created"}
-          isDisabled={isArchived}
-          type="agent"
-        />
-        <ConversationMessageTitle
-          name={agentConfiguration.name}
-          timestamp={timestamp}
-          infoChip={
-            agentMessage.prunedContext ? <PrunedContextChip /> : undefined
-          }
-          completionStatus={
-            hideCompletionStatus ? undefined : (
-              <AgentMessageCompletionStatus
-                agentMessage={agentMessage}
-                onClick={
-                  onCompletionStatusClick
-                    ? () => onCompletionStatusClick(agentMessage.sId)
-                    : undefined
-                }
-              />
-            )
-          }
-          renderName={renderName}
-        />
-      </div>
+      {!hideHeader && (
+        <div className="inline-flex items-center gap-2 px-5">
+          <ConversationMessageAvatar
+            avatarUrl={agentConfiguration.pictureUrl}
+            name={agentConfiguration.name}
+            isBusy={agentMessage.status === "created"}
+            isDisabled={isArchived}
+            type="agent"
+          />
+          <ConversationMessageTitle
+            name={agentConfiguration.name}
+            timestamp={timestamp}
+            infoChip={
+              agentMessage.prunedContext ? <PrunedContextChip /> : undefined
+            }
+            completionStatus={
+              hideCompletionStatus ? undefined : (
+                <AgentMessageCompletionStatus
+                  agentMessage={agentMessage}
+                  onClick={
+                    onCompletionStatusClick
+                      ? () => onCompletionStatusClick(agentMessage.sId)
+                      : undefined
+                  }
+                />
+              )
+            }
+            renderName={renderName}
+          />
+        </div>
+      )}
 
       <div className="group flex w-full min-w-0 flex-col gap-2 @sm:px-5 px-5">
         {renderMessageContent()}

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -139,6 +139,26 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       getMessageDate(prevData).toDateString() ===
         getMessageDate(data).toDateString();
 
+    const isSteeredAgentMessage = useMemo((): boolean => {
+      if (!isMessageTemporayState(data)) {
+        return false;
+      }
+      const messages = methods.data.get();
+      const currentIndex = messages.findIndex((m) => m.sId === data.sId);
+      for (let i = currentIndex - 1; i >= 0; i--) {
+        const m = messages[i];
+        if (isMessageTemporayState(m)) {
+          // An agent message is considered steered if the previous agent message (skipping user
+          // messages) is in gracefully_stopped or created state and from the same agent.
+          return (
+            (m.status === "gracefully_stopped" || m.status === "created") &&
+            m.configuration.sId === data.configuration.sId
+          );
+        }
+      }
+      return false;
+    }, [data, methods.data]);
+
     const triggeringUser = useMemo((): UserType | null => {
       if (isMessageTemporayState(data)) {
         const parentMessageId = data.parentMessageId;
@@ -157,8 +177,8 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
     }
 
     if (isHiddenMessage(data)) {
-      // This is hacky but in case of handover we generate a user message from the agent and we want to hide it in the conversation
-      // because it has no value to display.
+      // This is hacky but in case of handover we generate a user message from the agent and we want
+      // to hide it in the conversation because it has no value to display.
       return null;
     }
 
@@ -195,6 +215,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               user={context.user}
               triggeringUser={triggeringUser}
               conversationId={context.conversation.sId}
+              hideHeader={isSteeredAgentMessage}
               isLastMessage={!nextData}
               agentMessage={data}
               messageFeedback={messageFeedbackWithSubmit}


### PR DESCRIPTION
## Description

When an agent message follows a gracefully stopped (or still running) agent message from the same agent, hide the avatar and title row to visually merge the stopped execution with the follow-up response. This makes steering and stop feel much more fluid by avoiding the visual repetition of the agent header between consecutive turns from the same agent.

- `MessageItem.tsx`: Added `isSteeredAgentMessage` — scans backward through the message list (skipping user messages) to find the previous agent message. Returns `true` if it was `gracefully_stopped` or `created` and from the same agent configuration.
- `AgentMessage.tsx`: Added `hideHeader` prop. When `true`, the avatar + name + completion status row is not rendered.

<img width="880" height="865" alt="Screenshot 2026-04-07 at 13 53 01" src="https://github.com/user-attachments/assets/5bd5b2d5-4df3-42ad-9df4-82ad602a2ace" />

## Tests

Local tests

## Risk

Low — purely cosmetic change gated behind the existing `enable_steering` feature flag (gracefully_stopped status only appears when steering is enabled). No backend changes. Safe to rollback by reverting the PR.

## Deploy Plan

- deploy `front`