### PR TITLE
[Steering] Hide user message time header after steered agent messages

### DIFF
--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -159,6 +159,15 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       return false;
     }, [data, methods.data]);
 
+    // Hide the user message time header when it follows a created or gracefully stopped agent
+    // message (steering flow) to save vertical space.
+    const isPreviousAgentMessageSteered =
+      prevData !== null &&
+      isUserMessage(data) &&
+      isMessageTemporayState(prevData) &&
+      (prevData.status === "gracefully_stopped" ||
+        prevData.status === "created");
+
     const triggeringUser = useMemo((): UserType | null => {
       if (isMessageTemporayState(data)) {
         const parentMessageId = data.parentMessageId;
@@ -203,7 +212,9 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               citations={citations}
               conversationId={context.conversation.sId}
               currentUserId={context.user.sId}
-              isFirstInGroup={!isPreviousMessageSameSender}
+              isFirstInGroup={
+                !isPreviousMessageSameSender && !isPreviousAgentMessageSteered
+              }
               isLastMessage={!nextData}
               message={data}
               owner={context.owner}


### PR DESCRIPTION
## Description

When a user message follows a `created` or `gracefully_stopped` agent message (steering flow), hide the timestamp to save vertical space. Uses `prevData` directly — no backward scanning needed since `prevData` for a steering user message is the agent message itself.

<img width="739" height="1198" alt="Screenshot 2026-04-07 at 14 39 55" src="https://github.com/user-attachments/assets/0c014e6f-85bc-46e6-ab4c-dc2b8b149d7c" />

## Tests 

Tested locally

## Risk

Low — cosmetic-only change. The `gracefully_stopped` status only appears when steering is enabled (feature flag). Safe to rollback.

## Deploy Plan

- deploy `front`