### PR TITLE
[steering] Fix default agent selection in project conversations

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -13,7 +13,10 @@ import {
 } from "@app/components/assistant/conversation/types";
 import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
 import { useCancelMessage, useConversation } from "@app/hooks/conversations";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   isRichAgentMention,
   toRichAgentMentionType,
@@ -61,11 +64,21 @@ export const AgentInputBar = ({
   });
 
   const isMobile = useIsMobile();
+  const { hasFeature } = useFeatureFlags();
+  const singleAgentInput = hasFeature("enable_steering");
+  const { agentConfigurations } = useUnifiedAgentConfigurations({
+    workspaceId: context.owner.sId,
+  });
+  const accessibleAgentIds = useMemo(
+    () => new Set(agentConfigurations.map((a) => a.sId)),
+    [agentConfigurations]
+  );
   const methods = useVirtuosoMethods<VirtuosoMessage>();
   const { bottomOffset, listOffset, visibleListHeight } = useVirtuosoLocation();
 
-  const lastUserMessage = methods.data
-    .get()
+  const allMessages = methods.data.get();
+
+  const lastUserMessage = allMessages
     .filter(isUserMessage)
     .findLast(
       (m) =>
@@ -83,16 +96,48 @@ export const AgentInputBar = ({
       return [toRichAgentMentionType(draftAgent)];
     }
 
-    // We only prefill if there is only agent mentions in user's previous message.
+    // We only prefill if there are agent mentions (and only agent mentions) in user's previous message.
     const shouldPrefill =
-      lastUserMessage && lastUserMessage.richMentions.every(isRichAgentMention);
+      lastUserMessage &&
+      lastUserMessage.richMentions.length > 0 &&
+      lastUserMessage.richMentions.every(isRichAgentMention);
 
-    if (!shouldPrefill) {
-      return [];
+    if (shouldPrefill) {
+      return lastUserMessage.richMentions;
     }
 
-    return lastUserMessage.richMentions;
-  }, [draftAgent, lastUserMessage]);
+    // In single-agent mode, if the current user has no agent-only messages (e.g. opening
+    // someone else's conversation in a project), fall back to the last agent mentioned
+    // by anyone in the conversation — but only if the current user can access that agent.
+    if (singleAgentInput) {
+      const lastAgentMention = allMessages
+        .filter(isUserMessage)
+        .filter((m) => !isHandoverUserMessage(m) && m.visibility !== "deleted")
+        .findLast((m) => m.richMentions.some(isRichAgentMention))
+        ?.richMentions.find(isRichAgentMention);
+
+      if (lastAgentMention && accessibleAgentIds.has(lastAgentMention.id)) {
+        return [lastAgentMention];
+      }
+
+      // Ultimate fallback: select the "dust" agent if available.
+      const dustAgent = agentConfigurations.find(
+        (a) => a.sId === GLOBAL_AGENTS_SID.DUST
+      );
+      if (dustAgent) {
+        return [toRichAgentMentionType(dustAgent)];
+      }
+    }
+
+    return [];
+  }, [
+    draftAgent,
+    lastUserMessage,
+    singleAgentInput,
+    allMessages,
+    accessibleAgentIds,
+    agentConfigurations,
+  ]);
 
   // Calculate positions and determine which user messages are navigable.
   const {

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -96,20 +96,18 @@ export const AgentInputBar = ({
       return [toRichAgentMentionType(draftAgent)];
     }
 
-    // We only prefill if there are agent mentions (and only agent mentions) in user's previous message.
-    const shouldPrefill =
-      lastUserMessage &&
-      lastUserMessage.richMentions.length > 0 &&
-      lastUserMessage.richMentions.every(isRichAgentMention);
-
-    if (shouldPrefill) {
-      return lastUserMessage.richMentions;
-    }
-
-    // In single-agent mode, if the current user has no agent-only messages (e.g. opening
-    // someone else's conversation in a project), fall back to the last agent mentioned
-    // by anyone in the conversation — but only if the current user can access that agent.
+    // In single-agent mode, find the last agent mentioned in the conversation.
+    // First from the current user's messages, then from anyone's messages.
     if (singleAgentInput) {
+      const currentUserAgentMention =
+        lastUserMessage?.richMentions.find(isRichAgentMention);
+      if (
+        currentUserAgentMention &&
+        accessibleAgentIds.has(currentUserAgentMention.id)
+      ) {
+        return [currentUserAgentMention];
+      }
+
       const lastAgentMention = allMessages
         .filter(isUserMessage)
         .filter((m) => !isHandoverUserMessage(m) && m.visibility !== "deleted")
@@ -127,6 +125,18 @@ export const AgentInputBar = ({
       if (dustAgent) {
         return [toRichAgentMentionType(dustAgent)];
       }
+
+      return [];
+    }
+
+    // Non-steering mode: prefill all mentions if they are all agent mentions.
+    const shouldPrefill =
+      lastUserMessage &&
+      lastUserMessage.richMentions.length > 0 &&
+      lastUserMessage.richMentions.every(isRichAgentMention);
+
+    if (shouldPrefill) {
+      return lastUserMessage.richMentions;
     }
 
     return [];


### PR DESCRIPTION
## Description

**Summary**
Fix agent picker not defaulting to the last pinged agent when opening someone else's conversation in a project. When the current user has no agent mentions in their messages, fall back to the last agent mentioned by anyone in the conversation (if accessible), then to the "dust" agent. Also fix an `[].every()` vacuous truth bug that short-circuited the fallback when the user's last message had no mentions.

## Root cause
`autoMentions` in `AgentInputBar` only considered the current user's messages. In project conversations started by someone else, the current user often has no messages (or messages without agent mentions), so `autoMentions` returned `[]`. Additionally, `[].every(isRichAgentMention)` returns `true` in JS, causing an early return with an empty array even when the user had a message with zero mentions.

## Test plan
Open a project conversation started by another user with a specific agent (e.g. IncidentQ), the agent picker should show that agent. Reload the page, the same agent should still be selected. Open a conversation where the last agent is not accessible to you, it should fall back to "dust". Verify existing behavior: your own conversations still default to the last agent you pinged.


## Tests

Locally tested the default mention for all use cases. 

## Risk

Break default mention. 

## Deploy Plan

Deploy front. 