### PR TITLE
Add new props for grouping in events

### DIFF
--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -152,11 +152,15 @@ export function buildLlmUsageEvents({
   conversationId,
   userId,
   agentMessageId,
+  agentId,
   parentAgentMessageId,
   runKey,
   runUsages,
   origin,
   isProgrammaticUsage,
+  authMethod,
+  apiKeyName,
+  messageStatus,
   isSubAgentMessage,
   timestamp,
 }: {
@@ -164,11 +168,15 @@ export function buildLlmUsageEvents({
   conversationId: string;
   userId: string | null;
   agentMessageId: string;
+  agentId: string | null;
   parentAgentMessageId: string | null;
   runKey: string;
   runUsages: RunUsageType[];
   origin: UserMessageOrigin;
   isProgrammaticUsage: boolean;
+  authMethod: string | null;
+  apiKeyName: string | null;
+  messageStatus: string;
   isSubAgentMessage: boolean;
   timestamp: string;
 }): MetronomeEvent[] {
@@ -217,6 +225,8 @@ export function buildLlmUsageEvents({
       workspace_id: workspaceId,
       ...(userId ? { user_id: userId } : {}),
       agent_message_id: agentMessageId,
+      conversation_id: conversationId,
+      ...(agentId ? { agent_id: agentId } : {}),
       ...(parentAgentMessageId
         ? { parent_agent_message_id: parentAgentMessageId }
         : {}),
@@ -229,6 +239,9 @@ export function buildLlmUsageEvents({
       // Provider cost without markup — markup is applied in Metronome rate card.
       cost_micro_usd: group.costMicroUsd,
       is_programmatic_usage: isProgrammaticUsage ? "true" : "false",
+      ...(authMethod ? { auth_method: authMethod } : {}),
+      ...(apiKeyName ? { api_key_name: apiKeyName } : {}),
+      message_status: messageStatus,
       is_sub_agent_message: isSubAgentMessage ? "true" : "false",
       origin,
     },
@@ -260,11 +273,15 @@ export function buildToolUseEvents({
   conversationId,
   userId,
   agentMessageId,
+  agentId,
   parentAgentMessageId,
   runKey,
   actions,
   origin,
   isProgrammaticUsage,
+  authMethod,
+  apiKeyName,
+  messageStatus,
   isSubAgentMessage,
   timestamp,
 }: {
@@ -272,11 +289,15 @@ export function buildToolUseEvents({
   conversationId: string;
   userId: string | null;
   agentMessageId: string;
+  agentId: string | null;
   parentAgentMessageId: string | null;
   runKey: string;
   actions: ToolAction[];
   origin: UserMessageOrigin;
   isProgrammaticUsage: boolean;
+  authMethod: string | null;
+  apiKeyName: string | null;
+  messageStatus: string;
   isSubAgentMessage: boolean;
   timestamp: string;
 }): MetronomeEvent[] {
@@ -311,9 +332,13 @@ export function buildToolUseEvents({
       workspace_id: workspaceId,
       ...(userId ? { user_id: userId } : {}),
       agent_message_id: agentMessageId,
+      conversation_id: conversationId,
+      ...(agentId ? { agent_id: agentId } : {}),
       ...(parentAgentMessageId
         ? { parent_agent_message_id: parentAgentMessageId }
         : {}),
+      ...(authMethod ? { auth_method: authMethod } : {}),
+      ...(apiKeyName ? { api_key_name: apiKeyName } : {}),
       tool_name: action.toolName,
       mcp_server_id: action.mcpServerId ?? "",
       internal_mcp_server_name: action.internalMCPServerName ?? "",
@@ -325,6 +350,7 @@ export function buildToolUseEvents({
       count,
       total_execution_duration_ms: totalDurationMs,
       is_programmatic_usage: isProgrammaticUsage ? "true" : "false",
+      message_status: messageStatus,
       is_sub_agent_message: isSubAgentMessage ? "true" : "false",
       origin,
     },

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -22,6 +22,7 @@ import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { reportUsageForSubscriptionItems } from "@app/lib/plans/usage";
 import { countActiveUsersForPeriodInWorkspace } from "@app/lib/plans/usage/mau";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
@@ -259,6 +260,18 @@ export async function emitMetronomeUsageEventsActivity(
 
   const programmatic = isProgrammaticUsage(auth, { userMessageOrigin });
   const timestamp = agentMessageRow.createdAt.toISOString();
+  const authMethod = userMessage?.userContextAuthMethod ?? null;
+  const agentId = agentMessage.agentConfigurationId ?? null;
+  const messageStatus = agentMessage.status ?? "unknown";
+
+  // Resolve API key name from the stored numeric FK.
+  let apiKeyName: string | null = null;
+  if (userMessage?.userContextApiKeyId) {
+    const key = await KeyResource.fetchByModelId(
+      userMessage.userContextApiKeyId
+    );
+    apiKeyName = key?.name ?? null;
+  }
 
   // Get LLM run usages.
   const runs = await RunResource.listByDustRunIds(auth, {
@@ -300,11 +313,15 @@ export async function emitMetronomeUsageEventsActivity(
     conversationId,
     userId,
     agentMessageId,
+    agentId,
     parentAgentMessageId,
     runKey,
     runUsages,
     origin: userMessageOrigin,
     isProgrammaticUsage: programmatic,
+    authMethod,
+    apiKeyName,
+    messageStatus,
     isSubAgentMessage,
     timestamp,
   });
@@ -314,11 +331,15 @@ export async function emitMetronomeUsageEventsActivity(
     conversationId,
     userId,
     agentMessageId,
+    agentId,
     parentAgentMessageId,
     runKey,
     actions: toolActions,
     origin: userMessageOrigin,
     isProgrammaticUsage: programmatic,
+    authMethod,
+    apiKeyName,
+    messageStatus,
     isSubAgentMessage,
     timestamp,
   });


### PR DESCRIPTION
## Summary

Adds new properties to Metronome `llm_usage` and `tool_use` events to enable the same grouping dimensions available in the ES `agent_message_analytics` index. This allows replacing the programmatic usage graph data source with Metronome's usage APIs (`client.v1.usage.listWithGroups`).

### New properties on both `llm_usage` and `tool_use` events

| Property | Source | Notes |
|----------|--------|-------|
| `conversation_id` | Conversation sId | Enables grouping by conversation |
| `agent_id` | `AgentMessageModel.agentConfigurationId` | Enables grouping by agent |
| `auth_method` | `UserMessageModel.userContextAuthMethod` | `"api_key"`, `"user_session"`, etc. Optional |
| `api_key_id` | `KeyResource.name` (resolved from `UserMessageModel.userContextApiKeyId`) | API key name. Present when `auth_method = "api_key"`. Optional |
| `message_status` | `AgentMessageModel.status` | Overall agent message status (`succeeded`, `failed`, `cancelled`, `gracefully_stopped`) |

### Grouping dimensions now available in Metronome

These match the ES index fields, enabling the same analytics via `client.v1.usage.listWithGroups`:

- `origin` — usage by channel (web, slack, api, zapier)
- `model_id` — cost per model
- `provider_id` — cost per provider
- `user_id` — per-user breakdown
- `agent_id` — usage by agent (new)
- `api_key_id` — usage by API key (new)
- `conversation_id` — usage by conversation (new)
- `auth_method` — filter by auth type (new)
- `message_status` — filter by success/failure (new)
- `is_programmatic_usage` — user vs API split
- `tool_category` — tool cost by tier (tool events only)

### Also closes dust-tt/tasks#7492 (E2)

`parent_agent_message_id` was already implemented — confirmed and closed.

## Test plan

- [ ] Verify events include new properties in Metronome sandbox
- [ ] Query `usage.listWithGroups` grouped by `agent_id` — returns data
- [ ] Query grouped by `api_key_id` — returns data for programmatic usage
- [ ] Verify `message_status` reflects actual agent message status

🤖 Generated with [Claude Code](https://claude.com/claude-code)