### PR TITLE
[Tool Calls] Keep inline loader as last item

### DIFF
--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx
@@ -1,0 +1,113 @@
+import type { LightAgentMessageType } from "@app/types/assistant/conversation";
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { InlineActivitySteps } from "./InlineActivitySteps";
+
+vi.mock(
+  "@app/components/assistant/conversation/ConversationSidePanelContext",
+  () => ({
+    useConversationSidePanelContext: () => ({
+      openPanel: vi.fn(),
+    }),
+  })
+);
+
+vi.mock("@app/components/resources/resources_icons", () => ({
+  InternalActionIcons: {},
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/actions/inline/TimelineRow",
+  () => ({
+    TimelineRow: ({
+      spinner,
+      children,
+      isLast,
+    }: {
+      spinner?: boolean;
+      children?: React.ReactNode;
+      isLast?: boolean;
+    }) => (
+      <div
+        data-testid="timeline-row"
+        data-spinner={spinner ? "true" : "false"}
+        data-is-last={isLast ? "true" : "false"}
+      >
+        {children ?? (spinner ? "loader" : null)}
+      </div>
+    ),
+  })
+);
+
+vi.mock("@dust-tt/sparkle", () => ({
+  AnimatedText: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  ChatBubbleThoughtIcon: () => null,
+  CheckIcon: () => null,
+  ChevronRightIcon: () => null,
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(" "),
+  Icon: () => null,
+  Markdown: ({ content }: { content: string }) => <span>{content}</span>,
+  ToolsIcon: () => null,
+}));
+
+const TEST_AGENT_MESSAGE = {
+  type: "agent_message",
+  sId: "m_123",
+  version: 0,
+  rank: 0,
+  branchId: null,
+  created: 1,
+  completedTs: null,
+  parentMessageId: "u_123",
+  parentAgentMessageId: null,
+  status: "created",
+  content: null,
+  chainOfThought: "",
+  error: null,
+  visibility: "visible",
+  richMentions: [],
+  completionDurationMs: null,
+  reactions: [],
+  configuration: {
+    sId: "a_123",
+    name: "Test Agent",
+    pictureUrl: "",
+    status: "active",
+    canRead: true,
+  },
+  citations: {},
+  generatedFiles: [],
+  activitySteps: [],
+} satisfies LightAgentMessageType;
+
+describe("InlineActivitySteps", () => {
+  it("renders the trailing loader after pending tool calls", () => {
+    render(
+      <InlineActivitySteps
+        agentMessage={TEST_AGENT_MESSAGE}
+        lastAgentStateClassification="thinking"
+        completedSteps={[
+          { type: "thinking", content: "Existing thought", id: "step_1" },
+        ]}
+        pendingToolCalls={[
+          { toolName: "common_utilities__wait", toolCallId: "call_1" },
+        ]}
+      />
+    );
+
+    const rows = screen.getAllByTestId("timeline-row");
+
+    expect(rows.map((row) => row.textContent)).toEqual([
+      "Existing thought",
+      "Preparing to Wait...",
+      "loader",
+    ]);
+    expect(rows.at(-1)).toHaveAttribute("data-spinner", "true");
+    expect(rows.at(-1)).toHaveAttribute("data-is-last", "true");
+  });
+});

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -131,13 +131,27 @@ export function InlineActivitySteps({
   const showActiveWriting = isWriting;
   const activeAction =
     isActing && isAgentMessageWithActions ? actions[actions.length - 1] : null;
+  const hasActiveThinkingContent =
+    showActiveThinking && Boolean(chainOfThought.trim());
+  const activeWritingContent =
+    showActiveWriting && agentMessage.content ? agentMessage.content : "";
+  const hasActiveWritingContent = activeWritingContent.length > 0;
+  const showTrailingLoader =
+    !isDone &&
+    ((showActiveThinking && !hasActiveThinkingContent) ||
+      (showActiveWriting && !hasActiveWritingContent) ||
+      (!showActiveThinking &&
+        !showActiveWriting &&
+        !activeAction &&
+        !showPendingToolCalls));
 
   const hasContent =
     completedSteps.length > 0 ||
-    showActiveThinking ||
-    showActiveWriting ||
+    hasActiveThinkingContent ||
+    hasActiveWritingContent ||
     activeAction ||
-    showPendingToolCalls;
+    showPendingToolCalls ||
+    showTrailingLoader;
 
   if (!hasContent) {
     return null;
@@ -169,9 +183,11 @@ export function InlineActivitySteps({
             {completedSteps.map((step, index) => {
               const isLast =
                 index === completedSteps.length - 1 &&
-                !showActiveThinking &&
-                !showActiveWriting &&
+                !hasActiveThinkingContent &&
+                !hasActiveWritingContent &&
                 !activeAction &&
+                !showPendingToolCalls &&
+                !showTrailingLoader &&
                 !isDone;
 
               switch (step.type) {
@@ -260,33 +276,35 @@ export function InlineActivitySteps({
             })}
 
             {/* Active thinking (streaming CoT) */}
-            {showActiveThinking && (
+            {hasActiveThinkingContent && (
               <TimelineRow
-                icon={chainOfThought ? "circle" : null}
-                spinner={!chainOfThought}
-                isLast={!activeAction && !isDone}
+                icon="circle"
+                isLast={
+                  !activeAction &&
+                  !showPendingToolCalls &&
+                  !showTrailingLoader &&
+                  !isDone
+                }
               >
-                {chainOfThought ? (
-                  <Markdown
-                    content={chainOfThought}
-                    isStreaming={false}
-                    streamingState="streaming"
-                    enableAnimation
-                    animationDurationSeconds={0.3}
-                    delimiter=" "
-                    forcedTextSize="text-sm"
-                    textColor="text-muted-foreground dark:text-muted-foreground-night"
-                    isLastMessage={false}
-                  />
-                ) : null}
+                <Markdown
+                  content={chainOfThought}
+                  isStreaming={false}
+                  streamingState="streaming"
+                  enableAnimation
+                  animationDurationSeconds={0.3}
+                  delimiter=" "
+                  forcedTextSize="text-sm"
+                  textColor="text-muted-foreground dark:text-muted-foreground-night"
+                  isLastMessage={false}
+                />
               </TimelineRow>
             )}
 
             {/* Active writing (streaming content tokens) */}
-            {showActiveWriting && agentMessage.content ? (
+            {hasActiveWritingContent ? (
               <div>
                 <Markdown
-                  content={agentMessage.content}
+                  content={activeWritingContent}
                   isStreaming={false}
                   streamingState="streaming"
                   enableAnimation
@@ -296,7 +314,15 @@ export function InlineActivitySteps({
                 />
               </div>
             ) : showActiveWriting ? (
-              <TimelineRow spinner isLast={!activeAction && !isDone} />
+              <TimelineRow
+                spinner
+                isLast={
+                  !activeAction &&
+                  !showPendingToolCalls &&
+                  !showTrailingLoader &&
+                  !isDone
+                }
+              />
             ) : null}
 
             {/* Active action (tool in progress) */}
@@ -305,7 +331,12 @@ export function InlineActivitySteps({
                 className="cursor-pointer"
                 onClick={() => openBreakdownPanel(activeAction.sId)}
               >
-                <TimelineRow spinner isLast={false}>
+                <TimelineRow
+                  spinner
+                  isLast={
+                    !showPendingToolCalls && !showTrailingLoader && !isDone
+                  }
+                >
                   <span className="text-muted-foreground dark:text-muted-foreground-night flex items-center gap-1">
                     {getActionOneLineLabel(activeAction, "running")}
                     <Icon
@@ -323,7 +354,11 @@ export function InlineActivitySteps({
                 <TimelineRow
                   key={getPendingToolCallKey(pendingToolCall, index)}
                   icon={ToolsIcon}
-                  isLast={!isDone && index === pendingToolCalls.length - 1}
+                  isLast={
+                    !isDone &&
+                    !showTrailingLoader &&
+                    index === pendingToolCalls.length - 1
+                  }
                 >
                   <span className="text-muted-foreground dark:text-muted-foreground-night">
                     Preparing to{" "}
@@ -332,12 +367,7 @@ export function InlineActivitySteps({
                 </TimelineRow>
               ))}
 
-            {/* Pending spinner — shown when between transitions (not done, nothing active) */}
-            {!isDone &&
-              !showActiveThinking &&
-              !showActiveWriting &&
-              !activeAction &&
-              !showPendingToolCalls && <TimelineRow spinner isLast />}
+            {showTrailingLoader && <TimelineRow spinner isLast />}
             {isDone &&
               completedSteps.length > 0 &&
               agentMessage.status !== "gracefully_stopped" && (


### PR DESCRIPTION
## Description
Fixes regression in https://github.com/dust-tt/dust/pull/23773.

When inline activity showed pending tool calls while the agent was still in a spinner-only thinking or writing state, the loader could render above the pending tool row. This keeps the spinner-only loader as the bottom-most live item and leaves content-bearing thinking/writing rows in place.

## Risks
Blast radius: inline activity rendering in assistant conversations while a message is streaming
Risk: low

## Deploy Plan
- deploy front

## Test
- [x] `cd front && NODE_ENV=test TEST_FRONT_DATABASE_URI=postgres://test:test@localhost:5433/dust_front_test_stream_tool_calls TEST_REDIS_URI=redis://localhost:6479 npm test components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx`
