### PR TITLE
[front] enh: rework action details sidebar UI for single actions

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -426,14 +426,14 @@ export function GenericActionDetails({
           {displayContext === "sidebar-single-action" ? (
             <>
               <div>
-                <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+                <span className="font-medium text-foreground dark:text-foreground-night">
                   Inputs
                 </span>
                 <RenderToolItemMarkdown text={inputs} type="input" />
               </div>
               {action.output && (
                 <div>
-                  <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+                  <span className="font-medium text-foreground dark:text-foreground-night">
                     Output
                   </span>
                   <div className="my-2 flex flex-col gap-2">

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -423,50 +423,84 @@ export function GenericActionDetails({
     >
       {displayContext !== "conversation" && (
         <div className="dd-privacy-mask flex flex-col gap-4 py-4 pl-6">
-          <Collapsible defaultOpen={false}>
-            <CollapsibleTrigger>
-              <div
-                className={cn(
-                  "text-foreground dark:text-foreground-night",
-                  "flex flex-row items-center gap-x-2"
-                )}
-              >
-                <span className="heading-base">Inputs</span>
+          {displayContext === "sidebar-single-action" ? (
+            <>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+                  Inputs
+                </span>
+                <RenderToolItemMarkdown text={inputs} type="input" />
               </div>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <RenderToolItemMarkdown text={inputs} type="input" />
-            </CollapsibleContent>
-          </Collapsible>
+              {action.output && (
+                <div>
+                  <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+                    Output
+                  </span>
+                  <div className="my-2 flex flex-col gap-2">
+                    {action.output
+                      .filter(
+                        (o) => isTextContent(o) || isResourceContentWithText(o)
+                      )
+                      .map((o, index) => (
+                        <RenderToolItemMarkdown
+                          key={index}
+                          text={getOutputText(o)}
+                          type="output"
+                        />
+                      ))}
+                  </div>
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              <Collapsible defaultOpen={false}>
+                <CollapsibleTrigger>
+                  <div
+                    className={cn(
+                      "text-foreground dark:text-foreground-night",
+                      "flex flex-row items-center gap-x-2"
+                    )}
+                  >
+                    <span className="heading-base">Inputs</span>
+                  </div>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <RenderToolItemMarkdown text={inputs} type="input" />
+                </CollapsibleContent>
+              </Collapsible>
 
-          {action.output && (
-            <Collapsible defaultOpen={false}>
-              <CollapsibleTrigger>
-                <div
-                  className={cn(
-                    "text-foreground dark:text-foreground-night",
-                    "flex flex-row items-center gap-x-2"
-                  )}
-                >
-                  <span className="heading-base">Output</span>
-                </div>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <div className="flex flex-col gap-2 my-2">
-                  {action.output
-                    .filter(
-                      (o) => isTextContent(o) || isResourceContentWithText(o)
-                    )
-                    .map((o, index) => (
-                      <RenderToolItemMarkdown
-                        key={index}
-                        text={getOutputText(o)}
-                        type="output"
-                      />
-                    ))}
-                </div>
-              </CollapsibleContent>
-            </Collapsible>
+              {action.output && (
+                <Collapsible defaultOpen={false}>
+                  <CollapsibleTrigger>
+                    <div
+                      className={cn(
+                        "text-foreground dark:text-foreground-night",
+                        "flex flex-row items-center gap-x-2"
+                      )}
+                    >
+                      <span className="heading-base">Output</span>
+                    </div>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <div className="my-2 flex flex-col gap-2">
+                      {action.output
+                        .filter(
+                          (o) =>
+                            isTextContent(o) || isResourceContentWithText(o)
+                        )
+                        .map((o, index) => (
+                          <RenderToolItemMarkdown
+                            key={index}
+                            text={getOutputText(o)}
+                            type="output"
+                          />
+                        ))}
+                    </div>
+                  </CollapsibleContent>
+                </Collapsible>
+              )}
+            </>
           )}
 
           {action.generatedFiles.filter((f) => !f.hidden).length > 0 && (

--- a/front/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
@@ -50,22 +50,35 @@ export function MCPConversationCatFileDetails({
       }
       visual={DocumentIcon}
     >
-      {displayContext === "sidebar" && (
+      {displayContext !== "conversation" && (
         <div className="flex flex-col gap-4 pl-6 pt-4">
-          <Collapsible defaultOpen={false}>
-            <CollapsibleTrigger>
-              <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+          {displayContext === "sidebar-single-action" ? (
+            <div>
+              <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
                 Preview
               </span>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
               <div className="py-2">
                 <CodeBlock className="language-text max-h-32 overflow-y-auto">
                   {truncatedContent}
                 </CodeBlock>
               </div>
-            </CollapsibleContent>
-          </Collapsible>
+            </div>
+          ) : (
+            <Collapsible defaultOpen={false}>
+              <CollapsibleTrigger>
+                <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                  Preview
+                </span>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="py-2">
+                  <CodeBlock className="language-text max-h-32 overflow-y-auto">
+                    {truncatedContent}
+                  </CodeBlock>
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          )}
         </div>
       )}
     </ActionDetailsWrapper>

--- a/front/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
@@ -54,7 +54,7 @@ export function MCPConversationCatFileDetails({
         <div className="flex flex-col gap-4 pl-6 pt-4">
           {displayContext === "sidebar-single-action" ? (
             <div>
-              <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+              <span className="font-medium text-foreground dark:text-foreground-night">
                 Preview
               </span>
               <div className="py-2">

--- a/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
@@ -62,7 +62,7 @@ export function DataSourceNodeContentDetails({
           )}
         </div>
 
-        {displayContext === "sidebar" && sourceUrl && text && (
+        {displayContext !== "conversation" && sourceUrl && text && (
           <Markdown
             content={text}
             isStreaming={false}

--- a/front/components/actions/mcp/details/MCPDataWarehousesBrowseDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDataWarehousesBrowseDetails.tsx
@@ -41,7 +41,7 @@ export function MCPDataWarehousesBrowseDetails({
           </div>
         )}
 
-        {displayContext === "sidebar" && data.length > 0 && (
+        {displayContext !== "conversation" && data.length > 0 && (
           <div className="flex flex-col gap-2">
             {data.map((node, index) => {
               const IconComponent = getDocumentIcon(node.connectorProvider);

--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -81,7 +81,7 @@ export function MCPExtractActionDetails({
         {jsonSchema &&
           (displayContext === "sidebar-single-action" ? (
             <div>
-              <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+              <span className="font-medium text-foreground dark:text-foreground-night">
                 Schema
               </span>
               <div className="py-2">
@@ -119,7 +119,7 @@ export function MCPExtractActionDetails({
           <div>
             {displayContext === "sidebar-single-action" ? (
               <>
-                <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+                <span className="font-medium text-foreground dark:text-foreground-night">
                   Results
                 </span>
                 <MCPExtractActionResults
@@ -224,7 +224,7 @@ function MCPExtractActionResults({
       {resultResource.snippet &&
         (displayContext === "sidebar-single-action" ? (
           <div>
-            <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+            <span className="font-medium text-foreground dark:text-foreground-night">
               Preview
             </span>
             <div className="py-2">

--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -1,5 +1,8 @@
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import type {
+  ActionDetailsDisplayContext,
+  ToolExecutionDetailsProps,
+} from "@app/components/actions/mcp/details/types";
 import {
   isExtractQueryResourceType,
   isExtractResultResourceType,
@@ -38,6 +41,7 @@ interface MCPExtractActionResultsProps {
     contentType: string;
     snippet: string | null;
   };
+  displayContext: ActionDetailsDisplayContext;
 }
 
 export function MCPExtractActionDetails({
@@ -74,40 +78,70 @@ export function MCPExtractActionDetails({
           />
         </div>
 
-        {jsonSchema && (
-          <div>
-            <Collapsible defaultOpen={false}>
-              <CollapsibleTrigger>
-                <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                  Schema
-                </span>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <div className="py-2">
-                  <CodeBlock
-                    className="language-json max-h-60 overflow-y-auto"
-                    wrapLongLines={true}
-                  >
-                    {JSON.stringify(jsonSchema, null, 2)}
-                  </CodeBlock>
-                </div>
-              </CollapsibleContent>
-            </Collapsible>
-          </div>
-        )}
+        {jsonSchema &&
+          (displayContext === "sidebar-single-action" ? (
+            <div>
+              <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+                Schema
+              </span>
+              <div className="py-2">
+                <CodeBlock
+                  className="language-json max-h-60 overflow-y-auto"
+                  wrapLongLines={true}
+                >
+                  {JSON.stringify(jsonSchema, null, 2)}
+                </CodeBlock>
+              </div>
+            </div>
+          ) : (
+            <div>
+              <Collapsible defaultOpen={false}>
+                <CollapsibleTrigger>
+                  <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                    Schema
+                  </span>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="py-2">
+                    <CodeBlock
+                      className="language-json max-h-60 overflow-y-auto"
+                      wrapLongLines={true}
+                    >
+                      {JSON.stringify(jsonSchema, null, 2)}
+                    </CodeBlock>
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
+            </div>
+          ))}
 
-        {displayContext === "sidebar" && (
+        {displayContext !== "conversation" && (
           <div>
-            <Collapsible defaultOpen={false}>
-              <CollapsibleTrigger>
-                <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+            {displayContext === "sidebar-single-action" ? (
+              <>
+                <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
                   Results
                 </span>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <MCPExtractActionResults resultResource={resultResource} />
-              </CollapsibleContent>
-            </Collapsible>
+                <MCPExtractActionResults
+                  resultResource={resultResource}
+                  displayContext={displayContext}
+                />
+              </>
+            ) : (
+              <Collapsible defaultOpen={false}>
+                <CollapsibleTrigger>
+                  <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                    Results
+                  </span>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <MCPExtractActionResults
+                    resultResource={resultResource}
+                    displayContext={displayContext}
+                  />
+                </CollapsibleContent>
+              </Collapsible>
+            )}
           </div>
         )}
       </div>
@@ -147,6 +181,7 @@ function MCPExtractActionQuery({
 
 function MCPExtractActionResults({
   resultResource,
+  displayContext,
 }: MCPExtractActionResultsProps) {
   const [isDownloading, setIsDownloading] = useState(false);
 
@@ -186,14 +221,12 @@ function MCPExtractActionResults({
         </Citation>
       </div>
 
-      {resultResource.snippet && (
-        <Collapsible defaultOpen={false}>
-          <CollapsibleTrigger>
-            <span className="text-sm font-semibold text-muted-foreground dark:text-muted-foreground-night">
+      {resultResource.snippet &&
+        (displayContext === "sidebar-single-action" ? (
+          <div>
+            <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
               Preview
             </span>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
             <div className="py-2">
               <CodeBlock
                 className="language-json max-h-60 overflow-y-auto"
@@ -202,9 +235,26 @@ function MCPExtractActionResults({
                 {resultResource.snippet}
               </CodeBlock>
             </div>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
+          </div>
+        ) : (
+          <Collapsible defaultOpen={false}>
+            <CollapsibleTrigger>
+              <span className="text-sm font-semibold text-muted-foreground dark:text-muted-foreground-night">
+                Preview
+              </span>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="py-2">
+                <CodeBlock
+                  className="language-json max-h-60 overflow-y-auto"
+                  wrapLongLines={true}
+                >
+                  {resultResource.snippet}
+                </CodeBlock>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        ))}
     </div>
   );
 }

--- a/front/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
@@ -68,7 +68,7 @@ function DatabaseSchemaSection({
   if (displayContext === "sidebar-single-action") {
     return (
       <div>
-        <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+        <span className="font-medium text-foreground dark:text-foreground-night">
           Database Schema
         </span>
         <div className="py-2">
@@ -120,7 +120,7 @@ function ExampleRowsSection({
   if (displayContext === "sidebar-single-action") {
     return (
       <div>
-        <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+        <span className="font-medium text-foreground dark:text-foreground-night">
           Sample Data
         </span>
         <div className="py-2">

--- a/front/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
@@ -1,5 +1,8 @@
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import type {
+  ActionDetailsDisplayContext,
+  ToolExecutionDetailsProps,
+} from "@app/components/actions/mcp/details/types";
 import type {
   DatabaseSchemaResourceType,
   ExampleRowsResourceType,
@@ -37,14 +40,18 @@ export function MCPGetDatabaseSchemaActionDetails({
       }
       visual={TableIcon}
     >
-      {displayContext === "sidebar" && (
+      {displayContext !== "conversation" && (
         <div className="flex flex-col gap-4 pl-6 pt-4">
-          <>
-            <DatabaseSchemaSection schemas={schemaBlocks} />
-            {exampleRowsBlocks.length > 0 && (
-              <ExampleRowsSection examples={exampleRowsBlocks} />
-            )}
-          </>
+          <DatabaseSchemaSection
+            schemas={schemaBlocks}
+            displayContext={displayContext}
+          />
+          {exampleRowsBlocks.length > 0 && (
+            <ExampleRowsSection
+              examples={exampleRowsBlocks}
+              displayContext={displayContext}
+            />
+          )}
         </div>
       )}
     </ActionDetailsWrapper>
@@ -53,9 +60,32 @@ export function MCPGetDatabaseSchemaActionDetails({
 
 function DatabaseSchemaSection({
   schemas,
+  displayContext,
 }: {
   schemas: DatabaseSchemaResourceType[];
+  displayContext: ActionDetailsDisplayContext;
 }) {
+  if (displayContext === "sidebar-single-action") {
+    return (
+      <div>
+        <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+          Database Schema
+        </span>
+        <div className="py-2">
+          {schemas.map((schema, idx) => (
+            <CodeBlock
+              key={idx}
+              className="language-sql max-h-96 overflow-y-auto"
+              wrapLongLines={true}
+            >
+              {schema.text}
+            </CodeBlock>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <Collapsible defaultOpen={false}>
       <CollapsibleTrigger>
@@ -82,9 +112,32 @@ function DatabaseSchemaSection({
 
 function ExampleRowsSection({
   examples,
+  displayContext,
 }: {
   examples: ExampleRowsResourceType[];
+  displayContext: ActionDetailsDisplayContext;
 }) {
+  if (displayContext === "sidebar-single-action") {
+    return (
+      <div>
+        <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+          Sample Data
+        </span>
+        <div className="py-2">
+          {examples.map((example, idx) => (
+            <CodeBlock
+              key={idx}
+              className="language-csv max-h-60 overflow-y-auto"
+              wrapLongLines={true}
+            >
+              {example.text}
+            </CodeBlock>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <Collapsible defaultOpen={false}>
       <CollapsibleTrigger>

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -132,7 +132,7 @@ export function MCPRunAgentActionDetails({
     childStreamIds,
     owner,
     // We only stream when we are in the sidebar, in the conversation we only show the query.
-    disabled: displayContext !== "sidebar",
+    disabled: displayContext === "conversation",
   });
 
   const { agentConfiguration: childAgent } = useAgentConfiguration({
@@ -335,25 +335,24 @@ function MCPRunAgentActionDetailsDisplay({
               </div>
             )}
             {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-            {childAgent && (chainOfThought || response) && (
-              <Collapsible defaultOpen={true}>
-                <div className="flex items-center justify-between py-2">
-                  <CollapsibleTrigger>
-                    <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+            {childAgent &&
+              (chainOfThought || response) &&
+              (displayContext === "sidebar-single-action" ? (
+                <>
+                  <div className="flex items-center justify-between py-2">
+                    <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
                       @{childAgent.name}'s Answer
                     </span>
-                  </CollapsibleTrigger>
-                  {conversationUrl && (
-                    <Button
-                      icon={ExternalLinkIcon}
-                      label="View full conversation"
-                      variant="outline"
-                      onClick={() => window.open(conversationUrl, "_blank")}
-                      size="xs"
-                    />
-                  )}
-                </div>
-                <CollapsibleContent>
+                    {conversationUrl && (
+                      <Button
+                        icon={ExternalLinkIcon}
+                        label="View full conversation"
+                        variant="outline"
+                        onClick={() => window.open(conversationUrl, "_blank")}
+                        size="xs"
+                      />
+                    )}
+                  </div>
                   <div className="flex flex-col gap-4">
                     {chainOfThought && (
                       <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
@@ -422,9 +421,97 @@ function MCPRunAgentActionDetailsDisplay({
                       </div>
                     )}
                   </div>
-                </CollapsibleContent>
-              </Collapsible>
-            )}
+                </>
+              ) : (
+                <Collapsible defaultOpen={true}>
+                  <div className="flex items-center justify-between py-2">
+                    <CollapsibleTrigger>
+                      <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                        @{childAgent.name}'s Answer
+                      </span>
+                    </CollapsibleTrigger>
+                    {conversationUrl && (
+                      <Button
+                        icon={ExternalLinkIcon}
+                        label="View full conversation"
+                        variant="outline"
+                        onClick={() => window.open(conversationUrl, "_blank")}
+                        size="xs"
+                      />
+                    )}
+                  </div>
+                  <CollapsibleContent>
+                    <div className="flex flex-col gap-4">
+                      {chainOfThought && (
+                        <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
+                          <ContentMessage
+                            title="Agent thoughts"
+                            variant="primary"
+                            size="lg"
+                          >
+                            <Markdown
+                              content={chainOfThought}
+                              isStreaming={isStreamingChainOfThought}
+                              forcedTextSize="text-sm"
+                              textColor="text-muted-foreground"
+                              isLastMessage={false}
+                            />
+                          </ContentMessage>
+                        </div>
+                      )}
+                      {response && (
+                        <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
+                          <ContentMessage
+                            title="Response"
+                            variant="primary"
+                            size="lg"
+                          >
+                            <CitationsContext.Provider
+                              value={{
+                                references,
+                                updateActiveReferences,
+                              }}
+                            >
+                              <Markdown
+                                content={response}
+                                isStreaming={isStreamingResponse}
+                                forcedTextSize="text-sm"
+                                textColor="text-muted-foreground"
+                                isLastMessage={false}
+                                additionalMarkdownPlugins={
+                                  additionalMarkdownPlugins
+                                }
+                                additionalMarkdownComponents={
+                                  additionalMarkdownComponents
+                                }
+                              />
+                            </CitationsContext.Provider>
+
+                            {activeReferences.length > 0 && (
+                              <div className="mt-4">
+                                <CitationGrid variant="grid">
+                                  {activeReferences
+                                    .sort((a, b) => a.index - b.index)
+                                    .map(({ document, index }) => (
+                                      <AttachmentCitation
+                                        key={index}
+                                        attachmentCitation={markdownCitationToAttachmentCitation(
+                                          document
+                                        )}
+                                        owner={owner}
+                                        conversationId={null}
+                                      />
+                                    ))}
+                                </CitationGrid>
+                              </div>
+                            )}
+                          </ContentMessage>
+                        </div>
+                      )}
+                    </div>
+                  </CollapsibleContent>
+                </Collapsible>
+              ))}
             {generatedFiles.length > 0 && (
               <div className="flex flex-col gap-2">
                 {generatedFiles.map((file) => (

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -340,7 +340,7 @@ function MCPRunAgentActionDetailsDisplay({
               (displayContext === "sidebar-single-action" ? (
                 <>
                   <div className="flex items-center justify-between py-2">
-                    <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+                    <span className="font-medium text-foreground dark:text-foreground-night">
                       @{childAgent.name}'s Answer
                     </span>
                     {conversationUrl && (

--- a/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
@@ -140,7 +140,10 @@ export function MCPSandboxActionDetails({
       {displayContext === "conversation" ? (
         <ConversationView {...viewProps} />
       ) : (
-        <SidebarView {...viewProps} useCollapsible={displayContext === "sidebar-all-actions"} />
+        <SidebarView
+          {...viewProps}
+          useCollapsible={displayContext === "sidebar-all-actions"}
+        />
       )}
     </ActionDetailsWrapper>
   );

--- a/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
@@ -140,7 +140,7 @@ export function MCPSandboxActionDetails({
       {displayContext === "conversation" ? (
         <ConversationView {...viewProps} />
       ) : (
-        <SidebarView {...viewProps} />
+        <SidebarView {...viewProps} useCollapsible={displayContext === "sidebar-all-actions"} />
       )}
     </ActionDetailsWrapper>
   );
@@ -242,6 +242,10 @@ function ConversationView({
   );
 }
 
+interface SidebarViewFullProps extends SandboxViewProps {
+  useCollapsible: boolean;
+}
+
 function SidebarView({
   command,
   summary,
@@ -249,7 +253,8 @@ function SidebarView({
   isRawMode,
   isRunning,
   exitCode,
-}: SandboxViewProps) {
+  useCollapsible,
+}: SidebarViewFullProps) {
   return (
     <div className="flex flex-col gap-4 py-4 pl-6">
       {!isRawMode && (
@@ -264,8 +269,38 @@ function SidebarView({
 
       {isRawMode && (
         <>
-          {command && (
-            <Collapsible defaultOpen={true}>
+          {command &&
+            (useCollapsible ? (
+              <Collapsible defaultOpen={true}>
+                <CollapsibleTrigger>
+                  <div
+                    className={cn(
+                      "text-foreground dark:text-foreground-night",
+                      "flex flex-row items-center gap-x-2"
+                    )}
+                  >
+                    <span className="heading-base">Command</span>
+                  </div>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="py-2">
+                    <Markdown content={`\`\`\`bash\n${command}\n\`\`\``} />
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
+            ) : (
+              <div>
+                <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+                  Command
+                </span>
+                <div className="py-2">
+                  <Markdown content={`\`\`\`bash\n${command}\n\`\`\``} />
+                </div>
+              </div>
+            ))}
+
+          {useCollapsible ? (
+            <Collapsible defaultOpen={!!rawOutputText}>
               <CollapsibleTrigger>
                 <div
                   className={cn(
@@ -273,29 +308,26 @@ function SidebarView({
                     "flex flex-row items-center gap-x-2"
                   )}
                 >
-                  <span className="heading-base">Command</span>
+                  <span className="heading-base">Output</span>
                 </div>
               </CollapsibleTrigger>
               <CollapsibleContent>
                 <div className="py-2">
-                  <Markdown content={`\`\`\`bash\n${command}\n\`\`\``} />
+                  {rawOutputText ? (
+                    <Markdown content={`\`\`\`\n${rawOutputText}\n\`\`\``} />
+                  ) : (
+                    <p className="text-sm italic text-muted-foreground dark:text-muted-foreground-night">
+                      {isRunning ? "Waiting for output…" : "(no output)"}
+                    </p>
+                  )}
                 </div>
               </CollapsibleContent>
             </Collapsible>
-          )}
-
-          <Collapsible defaultOpen={!!rawOutputText}>
-            <CollapsibleTrigger>
-              <div
-                className={cn(
-                  "text-foreground dark:text-foreground-night",
-                  "flex flex-row items-center gap-x-2"
-                )}
-              >
-                <span className="heading-base">Output</span>
-              </div>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
+          ) : (
+            <div>
+              <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+                Output
+              </span>
               <div className="py-2">
                 {rawOutputText ? (
                   <Markdown content={`\`\`\`\n${rawOutputText}\n\`\`\``} />
@@ -305,8 +337,8 @@ function SidebarView({
                   </p>
                 )}
               </div>
-            </CollapsibleContent>
-          </Collapsible>
+            </div>
+          )}
 
           <ExitCodeBadge exitCode={exitCode} />
         </>

--- a/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
@@ -293,7 +293,7 @@ function SidebarView({
               </Collapsible>
             ) : (
               <div>
-                <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+                <span className="font-medium text-foreground dark:text-foreground-night">
                   Command
                 </span>
                 <div className="py-2">
@@ -328,7 +328,7 @@ function SidebarView({
             </Collapsible>
           ) : (
             <div>
-              <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+              <span className="font-medium text-foreground dark:text-foreground-night">
                 Output
               </span>
               <div className="py-2">

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -216,15 +216,13 @@ export function SearchResultDetails({
               />
             )}
           </div>
-          {actionOutput && displayContext === "sidebar" && (
+          {actionOutput && (
             <div>
-              <Collapsible defaultOpen={false}>
-                <CollapsibleTrigger>
-                  <span className="text-sm font-bold text-foreground dark:text-foreground-night">
+              {displayContext === "sidebar-single-action" ? (
+                <>
+                  <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
                     Results
                   </span>
-                </CollapsibleTrigger>
-                <CollapsibleContent>
                   {singleFileContentText && (
                     <Markdown
                       content={singleFileContentText}
@@ -234,8 +232,27 @@ export function SearchResultDetails({
                     />
                   )}
                   <PaginatedCitationsGrid items={citations} />
-                </CollapsibleContent>
-              </Collapsible>
+                </>
+              ) : (
+                <Collapsible defaultOpen={false}>
+                  <CollapsibleTrigger>
+                    <span className="text-sm font-bold text-foreground dark:text-foreground-night">
+                      Results
+                    </span>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    {singleFileContentText && (
+                      <Markdown
+                        content={singleFileContentText}
+                        isStreaming={false}
+                        forcedTextSize="text-sm"
+                        textColor="text-muted-foreground dark:text-muted-foreground-night"
+                      />
+                    )}
+                    <PaginatedCitationsGrid items={citations} />
+                  </CollapsibleContent>
+                </Collapsible>
+              )}
             </div>
           )}
         </div>

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -27,6 +27,7 @@ import {
   CollapsibleTrigger,
   ContentBlockWrapper,
   ContentMessage,
+  cn,
   FaviconIcon,
   InformationCircleIcon,
   Markdown,
@@ -203,10 +204,22 @@ export function SearchResultDetails({
       ) : (
         <div className="flex flex-col gap-4 pl-6 pt-4">
           <div className="flex flex-col gap-1">
-            <span className="text-sm font-bold text-foreground dark:text-foreground-night">
+            <span
+              className={cn(
+                displayContext === "sidebar-single-action" ? "font-medium" : "",
+                "text-foreground dark:text-foreground-night"
+              )}
+            >
               Query
             </span>
-            <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
+            <div
+              className={cn(
+                displayContext === "sidebar-single-action"
+                  ? ""
+                  : "text-sm font-normal",
+                "text-muted-foreground dark:text-muted-foreground-night"
+              )}
+            >
               {displayQuery}
             </div>
             {warning && (
@@ -216,24 +229,24 @@ export function SearchResultDetails({
               />
             )}
           </div>
-          {actionOutput && (
-            <div>
-              {displayContext === "sidebar-single-action" ? (
-                <>
-                  <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
-                    Results
-                  </span>
-                  {singleFileContentText && (
-                    <Markdown
-                      content={singleFileContentText}
-                      isStreaming={false}
-                      forcedTextSize="text-sm"
-                      textColor="text-muted-foreground dark:text-muted-foreground-night"
-                    />
-                  )}
-                  <PaginatedCitationsGrid items={citations} />
-                </>
-              ) : (
+          {actionOutput &&
+            (displayContext === "sidebar-single-action" ? (
+              <div className="flex flex-col gap-2">
+                <span className="font-medium text-foreground dark:text-foreground-night">
+                  Results
+                </span>
+                {singleFileContentText && (
+                  <Markdown
+                    content={singleFileContentText}
+                    isStreaming={false}
+                    forcedTextSize="text-sm"
+                    textColor="text-muted-foreground dark:text-muted-foreground-night"
+                  />
+                )}
+                <PaginatedCitationsGrid items={citations} />
+              </div>
+            ) : (
+              <div>
                 <Collapsible defaultOpen={false}>
                   <CollapsibleTrigger>
                     <span className="text-sm font-bold text-foreground dark:text-foreground-night">
@@ -252,9 +265,8 @@ export function SearchResultDetails({
                     <PaginatedCitationsGrid items={citations} />
                   </CollapsibleContent>
                 </Collapsible>
-              )}
-            </div>
-          )}
+              </div>
+            ))}
         </div>
       )}
     </ActionDetailsWrapper>

--- a/front/components/actions/mcp/details/types.ts
+++ b/front/components/actions/mcp/details/types.ts
@@ -2,7 +2,11 @@ import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_inter
 import type { LightWorkspaceType } from "@app/types/user";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
-export type ActionDetailsDisplayContext = "conversation" | "sidebar";
+export type ActionDetailsDisplayContext =
+  | "conversation"
+  // TODO(2026-04-07 inline activity): the "all actions" display will be deprecated with the ship of inline activity.
+  | "sidebar-all-actions"
+  | "sidebar-single-action";
 
 // Generic interface for every component that displays details for a certain type of tool output.
 export interface ToolExecutionDetailsProps {

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -443,7 +443,7 @@ function AgentSingleActionPanel({
       />
       <div className="flex-1 overflow-y-auto p-4 pb-12">
         <MCPActionDetails
-          displayContext="sidebar"
+          displayContext="sidebar-single-action"
           action={action}
           lastNotification={null}
           owner={owner}

--- a/front/components/assistant/conversation/actions/PanelAgentStep.tsx
+++ b/front/components/assistant/conversation/actions/PanelAgentStep.tsx
@@ -87,7 +87,7 @@ export function PanelAgentStep({
         return (
           <div key={`action-${entry.action.id}`}>
             <MCPActionDetails
-              displayContext="sidebar"
+              displayContext="sidebar-all-actions"
               action={entry.action}
               lastNotification={streamProgress ?? null}
               owner={owner}
@@ -109,7 +109,7 @@ export function PanelAgentStep({
             return (
               <div key={`streaming-action-${action.id}`} className="mb-4">
                 <MCPActionDetails
-                  displayContext="sidebar"
+                  displayContext="sidebar-all-actions"
                   action={action}
                   lastNotification={lastNotification}
                   owner={owner}


### PR DESCRIPTION
## Description

- This PR reworks the UI for the action details components when displayed individually in the side panel, e.g. if the inline activity mode is enabled.
- With the inline activity UI, actions are visualized individually in the side panel. Having a single action to display removes the need for collapsing most of the content compared to the layout UI where all the actions are displayed in the same sidebar.
- Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=4838-11491&p=f&t=XrKINSs83BGVGbmB-0).
- This PR adds a new type of `ActionDetailsDisplayContext` for the single-action display.
- This code is temporary, the goal is to make it easy to cleanup all of the code for the display context `sidebar-all-actions` once we ship the inline activity UI.

<img width="900" height="506" alt="Screenshot 2026-04-07 at 4 58 57 PM" src="https://github.com/user-attachments/assets/75a24e5e-28c5-49a6-9047-a785bd5cb718" />

## Tests

- Checked locally.

## Risk

- Low, mostly additive.

## Deploy Plan

- Deploy front.
