### PR TITLE
Fix hidden agents appearing in @mention dropdown for conversation participants

### DIFF
--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -12,6 +12,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type {
   RichAgentMentionInConversation,
   RichMention,
@@ -253,8 +254,6 @@ export const suggestionsOfMentions = async (
       variant: "light",
     });
 
-    const activeAgentIds = new Set(agentConfigurations.map((a) => a.sId));
-
     const activeAgents: RichAgentMentionInConversation[] = agentConfigurations
       .filter((a) => a.status === "active")
       .map((a) => ({
@@ -264,12 +263,14 @@ export const suggestionsOfMentions = async (
           participantAgents.find((pa) => pa.id === a.sId)?.lastActivityAt ?? 0,
       }));
 
-    // Include participant agents not already in the fetched configurations
-    // (e.g. the sidekick agent which is excluded from global agent listings).
-    const missingParticipants = participantAgents.filter(
-      (pa) => !activeAgentIds.has(pa.id)
+    // The sidekick agent is excluded from default global agent listings but should
+    // be mentionable when it's a conversation participant.
+    const sidekickParticipant = participantAgents.find(
+      (pa) => pa.id === GLOBAL_AGENTS_SID.SIDEKICK
     );
-    activeAgents.push(...missingParticipants);
+    if (sidekickParticipant) {
+      activeAgents.push(sidekickParticipant);
+    }
 
     const filteredAgents = filterAndSortEditorSuggestionAgents(
       normalizedQuery,


### PR DESCRIPTION
## Description

**Summary**
Hidden or private agents that were used in a conversation were incorrectly appearing in the @mention dropdown for users who don't have access to them. The agent picker button correctly excluded these agents, but the @mention suggestions re-added them.

**Root cause**
PR #21449 ("Allow copilot to be mentioned explicitly") introduced a generic `missingParticipants` mechanism in `suggestionsOfMentions` that re-added any conversation participant agent missing from the main agent list. The intent was to handle the sidekick agent, which is explicitly excluded from default global agent listings in `getGlobalAgents`. But the filter was too broad and also re-added workspace agents that `getAgentConfigurationsForView("list")`  had intentionally excluded due to hidden/private scope.

**Fix**
Replace the generic `missingParticipants` mechanism with an explicit check for the sidekick agent only, which is the sole agent that needs this treatment.

## Tests

Locally.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 