### PR TITLE
Fixes for metronome events

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -59,9 +59,30 @@ export async function ingestMetronomeEvents(
     return;
   }
 
+  // Metronome rejects events older than 34 days — filter them out before
+  // sending to avoid rejecting the entire batch. This happens when Temporal
+  // retries old workflows.
+  const maxAgeMs = 34 * 24 * 60 * 60 * 1000;
+  const cutoff = Date.now() - maxAgeMs;
+  const validEvents = events.filter((e) => {
+    const ts = new Date(e.timestamp).getTime();
+    if (ts < cutoff) {
+      logger.warn(
+        { transactionId: e.transaction_id, timestamp: e.timestamp },
+        "[Metronome] Dropping event — older than 34 days"
+      );
+      return false;
+    }
+    return true;
+  });
+
+  if (validEvents.length === 0) {
+    return;
+  }
+
   const client = getMetronomeClient();
-  for (let i = 0; i < events.length; i += METRONOME_INGEST_BATCH_SIZE) {
-    const batch = events.slice(i, i + METRONOME_INGEST_BATCH_SIZE);
+  for (let i = 0; i < validEvents.length; i += METRONOME_INGEST_BATCH_SIZE) {
+    const batch = validEvents.slice(i, i + METRONOME_INGEST_BATCH_SIZE);
     await client.v1.usage.ingest({ usage: batch });
   }
 }

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -9,6 +9,7 @@ import { createHash } from "crypto";
 import type { MetronomeEvent } from "./types";
 
 const MAX_TRANSACTION_ID_LENGTH = 128;
+const MAX_PROPERTY_VALUE_BYTES = 256;
 
 /**
  * If a transaction_id exceeds Metronome's 128-char limit, keep the first
@@ -21,6 +22,21 @@ function truncateTransactionId(id: string): string {
   }
   const hash = createHash("sha256").update(id).digest("hex").slice(0, 12);
   return `${id.slice(0, MAX_TRANSACTION_ID_LENGTH - 13)}-${hash}`;
+}
+
+/**
+ * Truncate a string property value to fit Metronome's 256-byte limit.
+ */
+function truncatePropertyValue(value: string): string {
+  if (Buffer.byteLength(value, "utf8") <= MAX_PROPERTY_VALUE_BYTES) {
+    return value;
+  }
+  // Truncate conservatively — slice characters until within byte limit.
+  let truncated = value;
+  while (Buffer.byteLength(truncated, "utf8") > MAX_PROPERTY_VALUE_BYTES - 3) {
+    truncated = truncated.slice(0, truncated.length - 1);
+  }
+  return truncated + "...";
 }
 
 // ---------------------------------------------------------------------------
@@ -339,9 +355,11 @@ export function buildToolUseEvents({
         : {}),
       ...(authMethod ? { auth_method: authMethod } : {}),
       ...(apiKeyName ? { api_key_name: apiKeyName } : {}),
-      tool_name: action.toolName,
-      mcp_server_id: action.mcpServerId ?? "",
-      internal_mcp_server_name: action.internalMCPServerName ?? "",
+      tool_name: truncatePropertyValue(action.toolName),
+      mcp_server_id: truncatePropertyValue(action.mcpServerId ?? ""),
+      internal_mcp_server_name: truncatePropertyValue(
+        action.internalMCPServerName ?? ""
+      ),
       tool_category: getToolCategory(action.internalMCPServerName),
       // Constant grouping key — used as presentation_group_key in Metronome to
       // aggregate all tool categories into a single "Tool Usage" invoice line.

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -259,7 +259,8 @@ export async function emitMetronomeUsageEventsActivity(
   const isSubAgentMessage = userMessage?.agenticMessageType !== null;
 
   const programmatic = isProgrammaticUsage(auth, { userMessageOrigin });
-  const timestamp = agentMessageRow.createdAt.toISOString();
+  // Use updatedAt — this is when the agent message finished (not when it was created).
+  const timestamp = agentMessage.updatedAt.toISOString();
   const authMethod = userMessage?.userContextAuthMethod ?? null;
   const agentId = agentMessage.agentConfigurationId ?? null;
   const messageStatus = agentMessage.status ?? "unknown";


### PR DESCRIPTION
## Summary

Three fixes for Metronome event ingestion issues found in production.

### 1. Filter events older than 34 days before ingestion

Metronome rejects events with timestamps >34 days in the past, and a single old event causes the entire batch to fail. This happens when Temporal retries old stuck workflows.

**Fix:** Pre-filter events by timestamp before batching. Each dropped event is logged individually with its transaction ID. Valid events in the same workflow still get ingested.

### 2. Use `updatedAt` instead of `createdAt` for event timestamp

Previously used `agentMessageRow.createdAt` — the time the message was created. For long-running agent loops or delayed processing, this could be far in the past.

**Fix:** Use `agentMessage.updatedAt` — the time the message finished processing. This matches when the usage actually occurred and avoids the 34-day rejection for messages that took a long time to complete.

### 3. Truncate long property values to 256 bytes

Metronome has a 256-byte limit per property value. External MCP tool names can exceed this (and in some cases, LLM chain-of-thought reasoning can leak into the `toolName` field — separate bug to investigate).

**Fix:** Added `truncatePropertyValue()` helper that truncates to 256 bytes with `...` suffix. Applied to `tool_name`, `mcp_server_id`, and `internal_mcp_server_name`.

## Test plan

- [ ] Old Temporal workflow retry → events dropped with warning, no batch failure
- [ ] Long-running agent message → timestamp uses `updatedAt`, within 34-day window
- [ ] External MCP tool with long name → truncated to 256 bytes, event ingested

🤖 Generated with [Claude Code](https://claude.com/claude-code)