### PR TITLE
Fix can't mention another agent

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -87,6 +87,17 @@ export const AgentInputBar = ({
         m.visibility !== "deleted"
     );
 
+  // Last agent mentioned by anyone in the conversation. Computed outside useMemo so the
+  // result is a stable object reference (same mention object from the message list) that
+  // won't cause unnecessary recomputation of autoMentions when allMessages array ref changes.
+  const lastAgentMentionInConversation = singleAgentInput
+    ? (allMessages
+        .filter(isUserMessage)
+        .filter((m) => !isHandoverUserMessage(m) && m.visibility !== "deleted")
+        .findLast((m) => m.richMentions.some(isRichAgentMention))
+        ?.richMentions.find(isRichAgentMention) ?? null)
+    : null;
+
   const draftAgent = context.agentBuilderContext?.draftAgent;
 
   const autoMentions = useMemo(() => {
@@ -108,14 +119,11 @@ export const AgentInputBar = ({
         return [currentUserAgentMention];
       }
 
-      const lastAgentMention = allMessages
-        .filter(isUserMessage)
-        .filter((m) => !isHandoverUserMessage(m) && m.visibility !== "deleted")
-        .findLast((m) => m.richMentions.some(isRichAgentMention))
-        ?.richMentions.find(isRichAgentMention);
-
-      if (lastAgentMention && accessibleAgentIds.has(lastAgentMention.id)) {
-        return [lastAgentMention];
+      if (
+        lastAgentMentionInConversation &&
+        accessibleAgentIds.has(lastAgentMentionInConversation.id)
+      ) {
+        return [lastAgentMentionInConversation];
       }
 
       // Ultimate fallback: select the "dust" agent if available.
@@ -144,7 +152,7 @@ export const AgentInputBar = ({
     draftAgent,
     lastUserMessage,
     singleAgentInput,
-    allMessages,
+    lastAgentMentionInConversation,
     accessibleAgentIds,
     agentConfigurations,
   ]);


### PR DESCRIPTION
## Description

Fix the agent picker resetting to the conversation's last agent immediately after manually selecting a different one.

The `autoMentions` useMemo in `AgentInputBar` had `allMessages` (from `methods.data.get()`) as a dependency. This array gets a new reference on every render even when the data hasn't changed, causing `autoMentions` to recompute and return a new array on each render. This triggered the `useHandleMentions` effect repeatedly, which overwrote the user's manual agent selection with the conversation's last agent.

Fix: Extract the fallback agent lookup (`lastAgentMentionInConversation`) outside the `useMemo`. Since `findLast` returns the same mention object reference from the message list as long as the data hasn't changed, using it as a dependency instead of `allMessages` keeps the `useMemo` result stable across  renders.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
