### PR TITLE
feat(mobile): tool approvals

### DIFF
--- a/x/adrsimon/mobile/Dust/Config/AppConfig.swift
+++ b/x/adrsimon/mobile/Dust/Config/AppConfig.swift
@@ -62,5 +62,17 @@ enum AppConfig {
         static func conversationAttachments(workspaceId: String, conversationId: String) -> String {
             "/api/w/\(workspaceId)/assistant/conversations/\(conversationId)/attachments"
         }
+
+        static func blockedActions(workspaceId: String, conversationId: String) -> String {
+            "/api/w/\(workspaceId)/assistant/conversations/\(conversationId)/actions/blocked"
+        }
+
+        static func validateAction(workspaceId: String, conversationId: String, messageId: String) -> String {
+            "/api/v1/w/\(workspaceId)/assistant/conversations/\(conversationId)/messages/\(messageId)/validate-action"
+        }
+
+        static func retryMessage(workspaceId: String, conversationId: String, messageId: String) -> String {
+            "/api/v1/w/\(workspaceId)/assistant/conversations/\(conversationId)/messages/\(messageId)/retry"
+        }
     }
 }

--- a/x/adrsimon/mobile/Dust/Models/Message.swift
+++ b/x/adrsimon/mobile/Dust/Models/Message.swift
@@ -92,13 +92,147 @@ struct ActiveAction: Equatable, Identifiable {
     let serverName: String?
 }
 
+enum ActionApproval: String {
+    case approved
+    case rejected
+    case alwaysApproved = "always_approved"
+}
+
+enum ToolStake: String, Decodable {
+    case low, medium, high
+    case neverAsk = "never_ask"
+}
+
+enum ErrorCategory: String, Decodable {
+    case retryableModelError = "retryable_model_error"
+    case streamError = "stream_error"
+}
+
+struct ToolApprovalInfo: Equatable {
+    let actionId: String
+    let messageId: String
+    let conversationId: String
+    let toolName: String?
+    let mcpServerName: String?
+    let agentName: String?
+    let stake: ToolStake?
+    let inputs: [String: ToolInputValue]?
+    let argumentsRequiringApproval: [String]?
+
+    var canAlwaysAllow: Bool {
+        stake == .low || stake == .medium
+    }
+
+    /// Pre-computed displayable inputs.
+    let displayableInputs: [(key: String, value: String)]
+
+    init(
+        actionId: String,
+        messageId: String,
+        conversationId: String,
+        toolName: String?,
+        mcpServerName: String?,
+        agentName: String?,
+        stake: ToolStake?,
+        inputs: [String: ToolInputValue]?,
+        argumentsRequiringApproval: [String]?
+    ) {
+        self.actionId = actionId
+        self.messageId = messageId
+        self.conversationId = conversationId
+        self.toolName = toolName
+        self.mcpServerName = mcpServerName
+        self.agentName = agentName
+        self.stake = stake
+        self.inputs = inputs
+        self.argumentsRequiringApproval = argumentsRequiringApproval
+
+        self.displayableInputs = (inputs ?? [:]).compactMap { key, val in
+            guard let display = val.displayValue else { return nil }
+            let truncated = display.count > 300
+                ? String(display.prefix(300)) + "…"
+                : display
+            return (key: key.humanized, value: truncated)
+        }
+        .sorted { $0.key < $1.key }
+    }
+
+    static func == (lhs: ToolApprovalInfo, rhs: ToolApprovalInfo) -> Bool {
+        lhs.actionId == rhs.actionId
+    }
+
+    init(from event: ToolApproveExecutionEvent, fallbackMessageId: String, fallbackConversationId: String) {
+        self.init(
+            actionId: event.actionId ?? "",
+            messageId: event.messageId ?? fallbackMessageId,
+            conversationId: event.conversationId ?? fallbackConversationId,
+            toolName: event.metadata?.toolName,
+            mcpServerName: event.metadata?.mcpServerName,
+            agentName: event.metadata?.agentName,
+            stake: event.stake.flatMap(ToolStake.init(rawValue:)),
+            inputs: event.inputs,
+            argumentsRequiringApproval: event.argumentsRequiringApproval
+        )
+    }
+
+    init(from action: BlockedAction, fallbackConversationId: String) {
+        self.init(
+            actionId: action.actionId ?? "",
+            messageId: action.messageId ?? "",
+            conversationId: action.conversationId ?? fallbackConversationId,
+            toolName: action.metadata?.toolName,
+            mcpServerName: action.metadata?.mcpServerName,
+            agentName: action.metadata?.agentName,
+            stake: action.stake.flatMap(ToolStake.init(rawValue:)),
+            inputs: action.inputs,
+            argumentsRequiringApproval: action.argumentsRequiringApproval
+        )
+    }
+}
+
+private extension String {
+    var humanized: String {
+        let spaced = unicodeScalars.reduce("") { result, scalar in
+            if CharacterSet.uppercaseLetters.contains(scalar), !result.isEmpty {
+                return result + " " + String(scalar)
+            }
+            return result + String(scalar)
+        }
+        return spaced
+            .replacing("_", with: " ")
+            .split(separator: " ")
+            .map { $0.prefix(1).uppercased() + $0.dropFirst().lowercased() }
+            .joined(separator: " ")
+    }
+}
+
+struct ErrorInfo: Equatable {
+    let code: String?
+    let message: String
+    let category: ErrorCategory?
+    let errorTitle: String?
+    let messageId: String
+
+    var isRetryable: Bool {
+        category == .retryableModelError || category == .streamError
+    }
+
+    init(from error: StreamingError, messageId: String) {
+        self.code = error.code
+        self.message = error.message
+        self.category = error.metadata?.category.flatMap(ErrorCategory.init(rawValue:))
+        self.errorTitle = error.metadata?.errorTitle
+        self.messageId = messageId
+    }
+}
+
 enum AgentStreamingPhase: Equatable {
     case idle
     case thinking
     case generating
-    case personalAuthRequired(provider: String)
-    case fileAuthRequired(fileName: String)
-    case approvalRequired
+    case personalAuthRequired(provider: String, toolName: String)
+    case fileAuthRequired(fileName: String, toolName: String)
+    case approvalRequired(approval: ToolApprovalInfo)
 }
 
 enum ConversationMessage: Identifiable {

--- a/x/adrsimon/mobile/Dust/Models/StreamingEvent.swift
+++ b/x/adrsimon/mobile/Dust/Models/StreamingEvent.swift
@@ -223,9 +223,96 @@ struct ToolFileAuthError: Decodable {
     let message: String
 }
 
-struct ToolApproveExecutionEvent: Decodable {}
+struct ToolApproveExecutionEvent: Decodable {
+    let created: Double?
+    let conversationId: String?
+    let messageId: String?
+    let actionId: String?
+    let configurationId: String?
+    let stake: String?
+    let metadata: ToolApprovalMetadata?
+    let inputs: [String: ToolInputValue]?
+    let argumentsRequiringApproval: [String]?
+}
+
+struct ToolApprovalMetadata: Decodable {
+    let toolName: String?
+    let mcpServerName: String?
+    let agentName: String?
+}
+
+/// Lightweight wrapper for heterogeneous JSON values in tool inputs.
+enum ToolInputValue: Decodable, Equatable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let str = try? container.decode(String.self) {
+            self = .string(str)
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let num = try? container.decode(Double.self) {
+            self = .number(num)
+        } else {
+            self = .null
+        }
+    }
+
+    var displayValue: String? {
+        switch self {
+        case let .string(str): str.isEmpty ? nil : str
+        case let .number(num): String(num)
+        case let .bool(val): val ? "Yes" : "No"
+        case .null: nil
+        }
+    }
+}
 
 struct StreamingError: Decodable {
     let code: String?
     let message: String
+    let metadata: StreamingErrorMetadata?
+}
+
+struct StreamingErrorMetadata: Decodable {
+    let category: String?
+    let errorTitle: String?
+}
+
+// MARK: - Blocked Actions (fetched on conversation load)
+
+struct BlockedActionsResponse: Decodable {
+    let blockedActions: [BlockedAction]
+}
+
+enum BlockedActionStatus: String, Decodable {
+    case blockedValidationRequired = "blocked_validation_required"
+    case blockedAuthenticationRequired = "blocked_authentication_required"
+    case blockedFileAuthorizationRequired = "blocked_file_authorization_required"
+    case blockedChildActionInputRequired = "blocked_child_action_input_required"
+    case blockedUserAnswerRequired = "blocked_user_answer_required"
+}
+
+struct BlockedAction: Decodable {
+    let status: BlockedActionStatus
+    let conversationId: String?
+    let messageId: String?
+    let actionId: String?
+    let configurationId: String?
+    let stake: String?
+    let metadata: ToolApprovalMetadata?
+    let inputs: [String: ToolInputValue]?
+    let argumentsRequiringApproval: [String]?
+    let authError: ToolPersonalAuthError?
+    let fileAuthorizationInfo: BlockedFileAuthInfo?
+}
+
+struct BlockedFileAuthInfo: Decodable {
+    let fileName: String?
+    let toolName: String?
 }

--- a/x/adrsimon/mobile/Dust/Services/ConversationService.swift
+++ b/x/adrsimon/mobile/Dust/Services/ConversationService.swift
@@ -100,7 +100,70 @@ enum ConversationService {
         )
     }
 
+    static func fetchBlockedActions(
+        workspaceId: String,
+        conversationId: String,
+        tokenProvider: TokenProvider
+    ) async throws -> [BlockedAction] {
+        let endpoint = AppConfig.Endpoints.blockedActions(
+            workspaceId: workspaceId,
+            conversationId: conversationId
+        )
+        let response: BlockedActionsResponse = try await APIClient.authenticatedGet(
+            endpoint, tokenProvider: tokenProvider, snakeCase: false
+        )
+        return response.blockedActions
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    static func validateAction(
+        workspaceId: String,
+        conversationId: String,
+        messageId: String,
+        actionId: String,
+        approved: ActionApproval,
+        tokenProvider: TokenProvider
+    ) async throws {
+        let endpoint = AppConfig.Endpoints.validateAction(
+            workspaceId: workspaceId,
+            conversationId: conversationId,
+            messageId: messageId
+        )
+        try await APIClient.authenticatedSend(
+            endpoint,
+            method: "POST",
+            body: ValidateActionRequest(actionId: actionId, approved: approved.rawValue),
+            tokenProvider: tokenProvider
+        )
+    }
+
+    static func retryMessage(
+        workspaceId: String,
+        conversationId: String,
+        messageId: String,
+        tokenProvider: TokenProvider
+    ) async throws {
+        let endpoint = AppConfig.Endpoints.retryMessage(
+            workspaceId: workspaceId,
+            conversationId: conversationId,
+            messageId: messageId
+        )
+        try await APIClient.authenticatedSend(
+            endpoint,
+            method: "POST",
+            body: RetryMessageRequest(),
+            tokenProvider: tokenProvider
+        )
+    }
+
     // MARK: - Request Bodies
+
+    private struct ValidateActionRequest: Encodable {
+        let actionId: String
+        let approved: String
+    }
+
+    private struct RetryMessageRequest: Encodable {}
 
     private struct MarkAsReadRequest: Encodable {
         let read: Bool

--- a/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
@@ -4,6 +4,7 @@ import os
 private let logger = Logger(subsystem: AppConfig.bundleId, category: "ConversationDetail")
 
 @MainActor
+// swiftlint:disable:next type_body_length
 final class ConversationDetailViewModel: ObservableObject {
     enum State {
         case loading
@@ -21,6 +22,10 @@ final class ConversationDetailViewModel: ObservableObject {
     @Published var activeActions: [ActiveAction] = []
     /// sId of the message currently being streamed.
     @Published var streamingMessageId: String?
+    /// Error info for the last failed agent message (if any).
+    @Published var lastError: ErrorInfo?
+    /// Whether a validate-action request is in-flight.
+    @Published var isValidatingAction = false
 
     private let conversation: Conversation
     private let workspaceId: String
@@ -61,11 +66,9 @@ final class ConversationDetailViewModel: ObservableObject {
             lastValue = response.lastValue
             state = .loaded
 
-            // Start streaming for any in-progress agent message
             startStreamingIfNeeded()
-
-            // Start listening for conversation-level events (new messages, title changes)
             startConversationEvents()
+            await reconcileBlockedActions()
 
             markAsRead()
         } catch {
@@ -153,7 +156,7 @@ final class ConversationDetailViewModel: ObservableObject {
                     )
                 }
 
-                try? await Task.sleep(nanoseconds: retryDelay)
+                try? await Task.sleep(for: .nanoseconds(retryDelay))
                 retryDelay = min(retryDelay * 2, maxDelay)
             }
         }
@@ -191,8 +194,8 @@ final class ConversationDetailViewModel: ObservableObject {
         }
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     private func startMessageStream(for messageId: String) {
-        // Don't restart if already streaming this message
         if streamingMessageId == messageId { return }
 
         messageStreamTask?.cancel()
@@ -200,6 +203,7 @@ final class ConversationDetailViewModel: ObservableObject {
         let currentGeneration = streamGeneration
         streamingMessageId = messageId
         streamingPhase = .thinking
+        lastError = nil
 
         messageStreamTask = Task { [weak self] in
             guard let self else { return }
@@ -235,13 +239,20 @@ final class ConversationDetailViewModel: ObservableObject {
             }
 
             // Stream ended — only clean up if we're still the active generation
+            // and not in a blocking state (approval/auth persist until resolved)
             if streamGeneration == currentGeneration {
-                streamingPhase = .idle
-                streamingMessageId = nil
+                switch streamingPhase {
+                case .approvalRequired, .personalAuthRequired, .fileAuthRequired:
+                    break
+                case .idle, .thinking, .generating:
+                    streamingPhase = .idle
+                    streamingMessageId = nil
+                }
             }
         }
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     private func handleMessageEvent(_ event: StreamingEventData, messageId: String) async {
         switch event {
         case let .generationTokens(tokens):
@@ -259,27 +270,43 @@ final class ConversationDetailViewModel: ObservableObject {
 
         case let .agentActionSuccess(event):
             activeActions.removeAll { $0.id == event.action.id }
-            if activeActions.isEmpty, streamingPhase != .generating {
+            if activeActions.isEmpty, streamingPhase != .generating, streamingPhase != .thinking {
                 streamingPhase = .thinking
             }
 
         case let .agentMessageSuccess(success):
             finalizeMessage(messageId: messageId, status: .succeeded, from: success.message)
 
-        case .agentError, .toolError:
+        case let .agentError(event):
+            lastError = ErrorInfo(from: event.error, messageId: messageId)
+            finalizeMessage(messageId: messageId, status: .failed)
+
+        case let .toolError(event):
+            lastError = ErrorInfo(from: event.error, messageId: messageId)
             finalizeMessage(messageId: messageId, status: .failed)
 
         case .agentGenerationCancelled:
             finalizeMessage(messageId: messageId, status: .cancelled)
 
         case let .toolPersonalAuthRequired(event):
-            streamingPhase = .personalAuthRequired(provider: event.authError.provider)
+            streamingPhase = .personalAuthRequired(
+                provider: event.authError.provider,
+                toolName: event.authError.toolName
+            )
 
         case let .toolFileAuthRequired(event):
-            streamingPhase = .fileAuthRequired(fileName: event.fileAuthError.fileName)
+            streamingPhase = .fileAuthRequired(
+                fileName: event.fileAuthError.fileName,
+                toolName: event.fileAuthError.toolName
+            )
 
-        case .toolApproveExecution:
-            streamingPhase = .approvalRequired
+        case let .toolApproveExecution(event):
+            let approval = ToolApprovalInfo(
+                from: event,
+                fallbackMessageId: messageId,
+                fallbackConversationId: conversation.sId
+            )
+            streamingPhase = .approvalRequired(approval: approval)
 
         case .toolNotification, .agentContextPruned, .endOfStream, .unknown:
             break
@@ -297,13 +324,13 @@ final class ConversationDetailViewModel: ObservableObject {
                 break
             }
         }
-        switch tokens.classification {
-        case .chainOfThought:
-            streamingPhase = .thinking
-        case .tokens:
-            streamingPhase = .generating
-        case .openingDelimiter, .closingDelimiter:
-            break
+        let newPhase: AgentStreamingPhase? = switch tokens.classification {
+        case .chainOfThought: .thinking
+        case .tokens: .generating
+        case .openingDelimiter, .closingDelimiter: nil
+        }
+        if let newPhase, streamingPhase != newPhase {
+            streamingPhase = newPhase
         }
     }
 
@@ -320,7 +347,6 @@ final class ConversationDetailViewModel: ObservableObject {
         streamingMessageId = nil
     }
 
-    /// Mutate the agent message with the given sId in-place and trigger a publish.
     private func updateAgentMessage(id: String, mutate: (inout AgentMessage) -> Void) {
         guard let index = messages.firstIndex(where: { $0.id == id }),
               case var .agent(agentMsg) = messages[index]
@@ -328,5 +354,86 @@ final class ConversationDetailViewModel: ObservableObject {
 
         mutate(&agentMsg)
         messages[index] = .agent(agentMsg)
+    }
+
+    // MARK: - Tool Approval
+
+    func validateAction(approved: ActionApproval) async {
+        guard case let .approvalRequired(info) = streamingPhase else { return }
+        isValidatingAction = true
+        defer { isValidatingAction = false }
+
+        do {
+            try await ConversationService.validateAction(
+                workspaceId: workspaceId,
+                conversationId: info.conversationId,
+                messageId: info.messageId,
+                actionId: info.actionId,
+                approved: approved,
+                tokenProvider: tokenProvider
+            )
+            streamingPhase = .thinking
+        } catch {
+            logger.error("Failed to validate action: \(error)")
+        }
+    }
+
+    // MARK: - Blocked Actions Reconciliation
+
+    /// Fetches any blocked actions from the server and sets the streaming phase accordingly.
+    /// This handles the case where we attach to a conversation that's already blocked.
+    private func reconcileBlockedActions() async {
+        do {
+            let blocked = try await ConversationService.fetchBlockedActions(
+                workspaceId: workspaceId,
+                conversationId: conversation.sId,
+                tokenProvider: tokenProvider
+            )
+            guard let action = blocked.first else { return }
+
+            // Find the message this action belongs to and ensure we're tracking it
+            if let messageId = action.messageId {
+                if streamingMessageId == nil {
+                    streamingMessageId = messageId
+                }
+            }
+
+            switch action.status {
+            case .blockedValidationRequired:
+                let approval = ToolApprovalInfo(from: action, fallbackConversationId: conversation.sId)
+                streamingPhase = .approvalRequired(approval: approval)
+
+            case .blockedAuthenticationRequired:
+                let provider = action.metadata?.mcpServerName ?? "Unknown"
+                let toolName = action.metadata?.toolName ?? ""
+                streamingPhase = .personalAuthRequired(provider: provider, toolName: toolName)
+
+            case .blockedFileAuthorizationRequired:
+                let fileName = action.fileAuthorizationInfo?.fileName ?? "Unknown"
+                let toolName = action.fileAuthorizationInfo?.toolName ?? action.metadata?.toolName ?? ""
+                streamingPhase = .fileAuthRequired(fileName: fileName, toolName: toolName)
+
+            case .blockedChildActionInputRequired, .blockedUserAnswerRequired:
+                break
+            }
+        } catch {
+            logger.error("Failed to fetch blocked actions: \(error)")
+        }
+    }
+
+    // MARK: - Retry
+
+    func retryMessage(messageId: String) async {
+        lastError = nil
+        do {
+            try await ConversationService.retryMessage(
+                workspaceId: workspaceId,
+                conversationId: conversation.sId,
+                messageId: messageId,
+                tokenProvider: tokenProvider
+            )
+        } catch {
+            logger.error("Failed to retry message: \(error)")
+        }
     }
 }

--- a/x/adrsimon/mobile/Dust/Views/CatchUpView.swift
+++ b/x/adrsimon/mobile/Dust/Views/CatchUpView.swift
@@ -13,6 +13,7 @@ struct CatchUpView: View {
 
     let currentUserEmail: String
     let onDismiss: (Set<String>) -> Void
+    var onOpenConversation: ((Conversation) -> Void)?
 
     private static let swipeHintStart: CGFloat = 30
     private static let swipeCommitThreshold: CGFloat = 80
@@ -23,7 +24,8 @@ struct CatchUpView: View {
         workspaceId: String,
         tokenProvider: TokenProvider,
         currentUserEmail: String,
-        onDismiss: @escaping (Set<String>) -> Void
+        onDismiss: @escaping (Set<String>) -> Void,
+        onOpenConversation: ((Conversation) -> Void)? = nil
     ) {
         _viewModel = StateObject(
             wrappedValue: CatchUpViewModel(
@@ -34,6 +36,7 @@ struct CatchUpView: View {
         )
         self.currentUserEmail = currentUserEmail
         self.onDismiss = onDismiss
+        self.onOpenConversation = onOpenConversation
     }
 
     var body: some View {
@@ -90,23 +93,36 @@ struct CatchUpView: View {
     // MARK: - Conversation Title
 
     private var conversationTitle: some View {
-        HStack(spacing: 8) {
-            Circle()
-                .fill(viewModel.currentConversation?.actionRequired == true
-                    ? Color.golden400 : Color.highlight500)
-                .frame(width: 8, height: 8)
+        Button {
+            guard let conversation = viewModel.currentConversation else { return }
+            onDismiss(viewModel.markedAsReadIds)
+            onOpenConversation?(conversation)
+        } label: {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(viewModel.currentConversation?.actionRequired == true
+                        ? Color.golden400 : Color.highlight500)
+                    .frame(width: 8, height: 8)
 
-            Text(viewModel.currentConversation?.title ?? "New conversation")
-                .sparkleLabelSm()
-                .foregroundStyle(Color.dustForeground)
-                .lineLimit(1)
-                .truncationMode(.tail)
+                Text(viewModel.currentConversation?.title ?? "New conversation")
+                    .sparkleLabelSm()
+                    .foregroundStyle(Color.dustForeground)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
 
-            Spacer()
+                Spacer()
+
+                SparkleIcon.arrowRight.image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 12, height: 12)
+                    .foregroundStyle(Color.dustFaint)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(.ultraThinMaterial, in: .capsule)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-        .background(.ultraThinMaterial, in: .capsule)
+        .buttonStyle(.plain)
         .padding(.horizontal, 8)
         .padding(.top, 8)
     }
@@ -134,6 +150,10 @@ struct CatchUpView: View {
                                 message: message,
                                 currentUserEmail: currentUserEmail
                             )
+                        }
+
+                        if viewModel.currentConversation?.actionRequired == true {
+                            ActionRequiredBanner()
                         }
                     }
                     .padding(.top, 48)
@@ -311,5 +331,28 @@ struct CatchUpView: View {
             guard viewModel.isDone else { return }
             onDismiss(viewModel.markedAsReadIds)
         }
+    }
+}
+
+// MARK: - Action Required Banner
+
+struct ActionRequiredBanner: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            SparkleIcon.stopSign.image
+                .resizable()
+                .scaledToFit()
+                .frame(width: 14, height: 14)
+                .foregroundStyle(Color.golden500)
+
+            Text("This conversation needs your action. Open it to respond.")
+                .sparkleCopyXs()
+                .foregroundStyle(Color.dustFaint)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.dustMutedBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.top, 12)
     }
 }

--- a/x/adrsimon/mobile/Dust/Views/Components/MessageBubbleView.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/MessageBubbleView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import MarkdownUI
 import SparkleTokens
 import SwiftUI
@@ -7,7 +8,12 @@ struct MessageBubbleView: View {
     let currentUserEmail: String
     var streamingPhase: AgentStreamingPhase = .idle
     var activeActions: [ActiveAction] = []
+    var lastError: ErrorInfo?
+    var isValidatingAction: Bool = false
     var onFragmentTap: ((ContentFragment) -> Void)?
+    var onValidateAction: ((ActionApproval) -> Void)?
+    var onRetry: ((String) -> Void)?
+    var onOpenInBrowser: (() -> Void)?
 
     var body: some View {
         switch message {
@@ -21,7 +27,12 @@ struct MessageBubbleView: View {
             AgentMessageBubble(
                 message: msg,
                 streamingPhase: streamingPhase,
-                activeActions: activeActions
+                activeActions: activeActions,
+                lastError: lastError,
+                isValidatingAction: isValidatingAction,
+                onValidateAction: onValidateAction,
+                onRetry: onRetry,
+                onOpenInBrowser: onOpenInBrowser
             )
         }
     }
@@ -86,6 +97,11 @@ struct AgentMessageBubble: View {
     let message: AgentMessage
     var streamingPhase: AgentStreamingPhase = .idle
     var activeActions: [ActiveAction] = []
+    var lastError: ErrorInfo?
+    var isValidatingAction: Bool = false
+    var onValidateAction: ((ActionApproval) -> Void)?
+    var onRetry: ((String) -> Void)?
+    var onOpenInBrowser: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -105,10 +121,36 @@ struct AgentMessageBubble: View {
                 )
             }
 
-            // Show content (streamed or final)
             if let content = message.content, !content.isEmpty {
                 StreamingMarkdownView(rawContent: content, isStreaming: message.isStreaming)
                     .textSelection(!message.isStreaming)
+            }
+
+            if message.isStreaming {
+                switch streamingPhase {
+                case let .approvalRequired(approval):
+                    ToolApprovalInlineView(
+                        approval: approval,
+                        isLoading: isValidatingAction,
+                        onValidate: onValidateAction
+                    )
+                case let .personalAuthRequired(provider, _):
+                    AuthRequiredView(
+                        label: "Authentication required for \(provider)",
+                        onOpenInBrowser: onOpenInBrowser
+                    )
+                case let .fileAuthRequired(fileName, _):
+                    AuthRequiredView(
+                        label: "File access required for \(fileName)",
+                        onOpenInBrowser: onOpenInBrowser
+                    )
+                case .idle, .thinking, .generating:
+                    EmptyView()
+                }
+            }
+
+            if message.status == .failed, let error = lastError {
+                ErrorCardView(error: error, onRetry: { onRetry?(message.sId) })
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -222,7 +264,7 @@ private struct FlowLayout: Layout {
 
 // swiftlint:enable identifier_name
 
-// MARK: - Streaming Status
+// MARK: - Streaming Status (thinking / acting / generating)
 
 struct StreamingStatusView: View {
     let phase: AgentStreamingPhase
@@ -230,18 +272,7 @@ struct StreamingStatusView: View {
     let chainOfThought: String?
 
     var body: some View {
-        if isBlockingState {
-            blockingChip
-        } else {
-            statusArea
-        }
-    }
-
-    // MARK: - Thinking / Acting / Generating
-
-    private var statusArea: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Chain of thought text, visible while it streams in
             if let text = chainOfThought, !text.isEmpty {
                 Text(text)
                     .sparkleCopyXs()
@@ -250,7 +281,6 @@ struct StreamingStatusView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            // Active actions
             if !activeActions.isEmpty {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(activeActions) { action in
@@ -258,8 +288,7 @@ struct StreamingStatusView: View {
                     }
                 }
                 .padding(.top, chainOfThought?.isEmpty == false ? 6 : 0)
-            } else {
-                // Thinking or generating (no active actions)
+            } else if !isBlockingPhase {
                 HStack(spacing: 6) {
                     PulsingDot()
                         .frame(width: 14, height: 14)
@@ -275,54 +304,237 @@ struct StreamingStatusView: View {
         .padding(.vertical, 4)
     }
 
-    // MARK: - Blocking states
-
-    private var blockingChip: some View {
-        HStack(spacing: 6) {
-            blockingIcon
-                .frame(width: 14, height: 14)
-
-            Text(blockingLabel)
-                .sparkleCopyXs()
-                .foregroundStyle(Color.warning600)
-                .lineLimit(1)
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .background(Color.warning100)
-        .clipShape(Capsule())
-    }
-
-    @ViewBuilder
-    private var blockingIcon: some View {
-        switch phase {
-        case .approvalRequired:
-            SparkleIcon.stopSign.image
-                .resizable()
-                .scaledToFit()
-                .foregroundStyle(Color.warning600)
-        default:
-            SparkleIcon.lock.image
-                .resizable()
-                .scaledToFit()
-                .foregroundStyle(Color.warning600)
-        }
-    }
-
-    private var blockingLabel: String {
-        switch phase {
-        case let .personalAuthRequired(provider): "Authentication required (\(provider))"
-        case let .fileAuthRequired(fileName): "File access required (\(fileName))"
-        case .approvalRequired: "Approval required"
-        default: ""
-        }
-    }
-
-    private var isBlockingState: Bool {
+    private var isBlockingPhase: Bool {
         switch phase {
         case .personalAuthRequired, .fileAuthRequired, .approvalRequired: true
         default: false
         }
+    }
+}
+
+// MARK: - Tool Approval
+
+struct ToolApprovalInlineView: View {
+    let approval: ToolApprovalInfo
+    var isLoading: Bool = false
+    var onValidate: ((ActionApproval) -> Void)?
+
+    @State private var showDetails = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Button {
+                guard !approval.displayableInputs.isEmpty else { return }
+                withAnimation(.easeInOut(duration: 0.2)) { showDetails.toggle() }
+            } label: {
+                HStack(spacing: 8) {
+                    ToolApprovalIconView(serverName: approval.mcpServerName)
+                        .frame(width: 20, height: 20)
+
+                    Text(title)
+                        .sparkleLabelSm()
+                        .foregroundStyle(Color.dustForeground)
+
+                    if !approval.displayableInputs.isEmpty {
+                        Spacer()
+                        (showDetails ? SparkleIcon.chevronUp : SparkleIcon.chevronDown).image
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 10, height: 10)
+                            .foregroundStyle(Color.dustFaint)
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if showDetails {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(approval.displayableInputs, id: \.key) { input in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(input.key)
+                                .sparkleLabelXs()
+                                .foregroundStyle(Color.dustFaint)
+                            Text(input.value)
+                                .sparkleCopyXs()
+                                .foregroundStyle(Color.dustForeground)
+                                .lineLimit(6)
+                        }
+                    }
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.dustMutedBackground)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+
+            Divider()
+                .foregroundStyle(Color.dustBorder)
+
+            ToolApprovalActionButtons(
+                canAlwaysAllow: approval.canAlwaysAllow,
+                isLoading: isLoading,
+                onValidate: onValidate
+            )
+        }
+        .padding(12)
+        .liquidGlassRoundedRect()
+    }
+
+    private var title: String {
+        let server = approval.mcpServerName ?? "Tool"
+        if let tool = approval.toolName {
+            return "Allow \(server) to \(tool)?"
+        }
+        return "\(server) requires approval"
+    }
+}
+
+struct ToolApprovalIconView: View {
+    let serverName: String?
+
+    var body: some View {
+        if let name = serverName, let icon = MCPServerIcon.icon(for: name) {
+            icon.image
+                .resizable()
+                .scaledToFit()
+        } else {
+            SparkleIcon.cog6Tooth.image
+                .resizable()
+                .scaledToFit()
+                .foregroundStyle(Color.dustFaint)
+        }
+    }
+}
+
+struct ToolApprovalActionButtons: View {
+    var canAlwaysAllow: Bool = false
+    var isLoading: Bool = false
+    var onValidate: ((ActionApproval) -> Void)?
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if canAlwaysAllow {
+                Button { onValidate?(.alwaysApproved) } label: {
+                    Text("Always allow")
+                        .sparkleLabelXs()
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color.highlight)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+            }
+
+            Button { onValidate?(.approved) } label: {
+                Text(canAlwaysAllow ? "Allow once" : "Allow")
+                    .sparkleLabelXs()
+                    .foregroundStyle(canAlwaysAllow ? Color.dustForeground : .white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(canAlwaysAllow ? Color.clear : Color.highlight)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+
+            Button { onValidate?(.rejected) } label: {
+                Text("Decline")
+                    .sparkleLabelXs()
+                    .foregroundStyle(Color.dustForeground)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+            }
+        }
+        .disabled(isLoading)
+        .opacity(isLoading ? 0.5 : 1.0)
+    }
+}
+
+// MARK: - Auth / File Access Required
+
+struct AuthRequiredView: View {
+    let label: String
+    var onOpenInBrowser: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                SparkleIcon.lock.image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 16, height: 16)
+                    .foregroundStyle(Color.dustFaint)
+
+                Text(label)
+                    .sparkleLabelSm()
+                    .foregroundStyle(Color.dustForeground)
+            }
+
+            Text("Connect this service in the web app to continue.")
+                .sparkleCopyXs()
+                .foregroundStyle(Color.dustFaint)
+
+            if let onOpenInBrowser {
+                Button(action: onOpenInBrowser) {
+                    HStack(spacing: 4) {
+                        SparkleIcon.externalLink.image
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 12, height: 12)
+                        Text("Open in Dust")
+                            .sparkleLabelXs()
+                    }
+                    .foregroundStyle(Color.dustForeground)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                }
+                .liquidGlassRoundedRect(cornerRadius: 10)
+            }
+        }
+        .padding(12)
+        .liquidGlassRoundedRect()
+    }
+}
+
+// MARK: - Error Card
+
+struct ErrorCardView: View {
+    let error: ErrorInfo
+    var onRetry: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                SparkleIcon.exclamationCircle.image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 14, height: 14)
+                    .foregroundStyle(Color.warning)
+
+                Text(error.errorTitle ?? "Something went wrong")
+                    .sparkleLabelSm()
+                    .foregroundStyle(Color.warning)
+            }
+
+            Text(error.message)
+                .sparkleCopyXs()
+                .foregroundStyle(Color.dustForeground)
+
+            if error.isRetryable, let onRetry {
+                Button(action: onRetry) {
+                    HStack(spacing: 4) {
+                        SparkleIcon.arrowPath.image
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 12, height: 12)
+                        Text("Retry")
+                            .sparkleLabelXs()
+                    }
+                    .foregroundStyle(Color.highlight)
+                }
+            }
+        }
+        .padding(12)
+        .liquidGlassRoundedRect()
     }
 }
 

--- a/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
+++ b/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
@@ -170,9 +170,25 @@ struct ConversationDetailView: View {
                                     currentUserEmail: currentUserEmail,
                                     streamingPhase: isStreaming ? viewModel.streamingPhase : .idle,
                                     activeActions: isStreaming ? viewModel.activeActions : [],
+                                    lastError: viewModel.lastError?.messageId == message.id
+                                        ? viewModel.lastError : nil,
+                                    isValidatingAction: viewModel.isValidatingAction,
                                     onFragmentTap: { fragment in
                                         guard fragment.fileId != nil else { return }
                                         selectedFragment = fragment
+                                    },
+                                    onValidateAction: { approval in
+                                        Task { await viewModel.validateAction(approved: approval) }
+                                    },
+                                    onRetry: { messageId in
+                                        Task { await viewModel.retryMessage(messageId: messageId) }
+                                    },
+                                    onOpenInBrowser: {
+                                        let base = AppConfig.appURL
+                                        let path = "/w/\(workspaceId)/assistant/\(conversation.sId)"
+                                        if let url = URL(string: base + path) {
+                                            UIApplication.shared.open(url)
+                                        }
                                     }
                                 )
                                 .id(message.id)

--- a/x/adrsimon/mobile/Dust/Views/MainContainerView.swift
+++ b/x/adrsimon/mobile/Dust/Views/MainContainerView.swift
@@ -115,6 +115,10 @@ struct MainContainerView: View {
                     onDismiss: { markedIds in
                         showCatchUp = false
                         viewModel.markConversationsAsRead(markedIds)
+                    },
+                    onOpenConversation: { conversation in
+                        showCatchUp = false
+                        selectedConversation = conversation
                     }
                 )
             }


### PR DESCRIPTION
## Summary
- Tool approval UI in `MessageBubbleView`: approve/deny/always-allow actions for agent tool calls
- Tool approval handling in catch-up view
- Streaming event parsing for tool approval states