### PR TITLE
fix(steering): use promoted user's auth for agent loop after pending message promotion

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -50,8 +50,7 @@ import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
 import { isModelAvailable, isProviderWhitelisted } from "@app/lib/assistant";
-import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
 import {
@@ -2540,111 +2539,134 @@ export async function updateAgentMessageWithFinalStatus(
   const completedAt = new Date();
   const owner = auth.getNonNullableWorkspace();
 
-  const { promotedUserMessages, agentMessage: newAgentMessage } =
-    await withTransaction(async (t) => {
-      await getConversationRankVersionLock(auth, conversation, t);
+  const {
+    promotedUserMessages,
+    promotedAuth,
+    agentMessage: newAgentMessage,
+  } = await withTransaction(async (t) => {
+    await getConversationRankVersionLock(auth, conversation, t);
 
-      await AgentMessageModel.update(
-        {
-          status,
-          completedAt,
-          ...(error
-            ? {
-                errorCode: error.code,
-                errorMessage: error.message,
-                errorMetadata: error.metadata,
-              }
-            : {}),
+    await AgentMessageModel.update(
+      {
+        status,
+        completedAt,
+        ...(error
+          ? {
+              errorCode: error.code,
+              errorMessage: error.message,
+              errorMetadata: error.metadata,
+            }
+          : {}),
+      },
+      {
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: owner.id,
         },
-        {
-          where: {
-            id: agentMessage.agentMessageId,
-            workspaceId: owner.id,
-          },
-          transaction: t,
-        }
-      );
-
-      // Promote *all* pending messages when the agent loop ends. If a pending message exists it
-      // will be promoted and will trigger the ending agentMessage. The `enableSteering` invariants
-      // of postUserMessage ensure that we have only one running agentic loop so we can just
-      // recreate a new agentMessage for the same agent as the one that finished.
-      //
-      // There is an edge case here for API interactions which are not subject to the steering
-      // invariant in which case we could have more than one running agent message and could pick
-      // the wrong agent compared to user attempt. But should ~never happen so the simplicity is
-      // worth it.
-      const pendingMessages =
-        await ConversationResource.getPendingUserMessagesInConversation(auth, {
-          conversation,
-          transaction: t,
-        });
-
-      if (pendingMessages.length === 0) {
-        return {
-          promotedUserMessages: [] as UserMessageTypeWithoutMentions[],
-          agentMessage: null as AgentMessageType | null,
-        };
+        transaction: t,
       }
+    );
 
-      await MessageModel.update(
-        { visibility: "visible" },
-        {
-          where: {
-            id: pendingMessages.map((m) => m.id),
-            workspaceId: owner.id,
-          },
-          // Skip validation: Sequelize bulk update constructs a dummy instance with only the
-          // updated fields, so the beforeValidate hook (which checks that exactly one of
-          // userMessageId/agentMessageId/ contentFragmentId is set) fails because all three are
-          // undefined. The rows are already valid, we're only updating visibility.
-          validate: false,
-          transaction: t,
-        }
-      );
-
-      const nextMessageRank =
-        ((await MessageModel.max<number | null, MessageModel>("rank", {
-          where: {
-            workspaceId: owner.id,
-            conversationId: conversation.id,
-            branchId: conversation.branchId
-              ? getResourceIdFromSId(conversation.branchId)
-              : null,
-          },
-          transaction: t,
-        })) ?? -1) + 1;
-
-      await ConversationResource.markAsUpdated(auth, { conversation, t });
-
-      // Render all promoted user messages.
-      const promotedUserMessages = await batchRenderUserMessagesWithoutMentions(
-        auth,
-        {
-          messages: pendingMessages,
-          transaction: t,
-        }
-      );
-
-      // Create a new agent message using the last promoted user message.
-      const { agentMessages } = await createAgentMessages(auth, {
+    // Promote *all* pending messages when the agent loop ends. If a pending message exists it
+    // will be promoted and will trigger the ending agentMessage. The `enableSteering` invariants
+    // of postUserMessage ensure that we have only one running agentic loop so we can just
+    // recreate a new agentMessage for the same agent as the one that finished.
+    //
+    // There is an edge case here for API interactions which are not subject to the steering
+    // invariant in which case we could have more than one running agent message and could pick
+    // the wrong agent compared to user attempt. But should ~never happen so the simplicity is
+    // worth it.
+    const pendingMessages =
+      await ConversationResource.getPendingUserMessagesInConversation(auth, {
         conversation,
-        metadata: {
-          type: "create",
-          mentions: [{ configurationId: agentMessage.configuration.sId }],
-          agentConfigurations: [agentMessage.configuration],
-          skipToolsValidation: agentMessage.skipToolsValidation,
-          nextMessageRank,
-          userMessage: promotedUserMessages[promotedUserMessages.length - 1],
-        },
         transaction: t,
       });
 
+    if (pendingMessages.length === 0) {
       return {
-        promotedUserMessages,
-        agentMessage: agentMessages[0] ?? null,
+        promotedUserMessages: [] as UserMessageTypeWithoutMentions[],
+        promotedAuth: auth,
+        agentMessage: null as AgentMessageType | null,
       };
+    }
+
+    await MessageModel.update(
+      { visibility: "visible" },
+      {
+        where: {
+          id: pendingMessages.map((m) => m.id),
+          workspaceId: owner.id,
+        },
+        // Skip validation: Sequelize bulk update constructs a dummy instance with only the
+        // updated fields, so the beforeValidate hook (which checks that exactly one of
+        // userMessageId/agentMessageId/ contentFragmentId is set) fails because all three are
+        // undefined. The rows are already valid, we're only updating visibility.
+        validate: false,
+        transaction: t,
+      }
+    );
+
+    const nextMessageRank =
+      ((await MessageModel.max<number | null, MessageModel>("rank", {
+        where: {
+          workspaceId: owner.id,
+          conversationId: conversation.id,
+          branchId: conversation.branchId
+            ? getResourceIdFromSId(conversation.branchId)
+            : null,
+        },
+        transaction: t,
+      })) ?? -1) + 1;
+
+    // Render all promoted user messages.
+    const promotedUserMessages = await batchRenderUserMessagesWithoutMentions(
+      auth,
+      {
+        messages: pendingMessages,
+        transaction: t,
+      }
+    );
+
+    // The new agent message is triggered by the last steering message (being promoted here from
+    // pending to visible). We need to use the promotedAuth of the associated user if it differs
+    // from the user who owns the current agent message.
+    const promotedUserMessage =
+      promotedUserMessages[promotedUserMessages.length - 1];
+    const promotedUser = promotedUserMessage.user;
+    let promotedAuth = auth;
+    if (promotedUser && promotedUser.sId !== auth.user()?.sId) {
+      promotedAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        promotedUser.sId,
+        owner.sId,
+        { transaction: t }
+      );
+    }
+
+    await ConversationResource.markAsUpdated(promotedAuth, {
+      conversation,
+      t,
     });
+
+    // Create a new agent message using the last promoted user message.
+    const { agentMessages } = await createAgentMessages(promotedAuth, {
+      conversation,
+      metadata: {
+        type: "create",
+        mentions: [{ configurationId: agentMessage.configuration.sId }],
+        agentConfigurations: [agentMessage.configuration],
+        skipToolsValidation: agentMessage.skipToolsValidation,
+        nextMessageRank,
+        userMessage: promotedUserMessages[promotedUserMessages.length - 1],
+      },
+      transaction: t,
+    });
+
+    return {
+      promotedUserMessages,
+      promotedAuth,
+      agentMessage: agentMessages[0] ?? null,
+    };
+  });
 
   // Publish events and launch agent loop outside of the advisory lock.
   if (promotedUserMessages.length > 0) {
@@ -2664,7 +2686,7 @@ export async function updateAgentMessageWithFinalStatus(
     await publishAgentMessagesEvents(conversation, [newAgentMessage]);
 
     void emitAuditLogEvent({
-      auth,
+      auth: promotedAuth,
       action: "agent.executed",
       targets: [
         buildAuditLogTarget("workspace", owner),
@@ -2678,7 +2700,7 @@ export async function updateAgentMessageWithFinalStatus(
     });
 
     await runAgentLoopWorkflow({
-      auth,
+      auth: promotedAuth,
       agentMessages: [newAgentMessage],
       conversation,
       userMessage: promotedUserMessages[promotedUserMessages.length - 1],

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -208,9 +208,11 @@ export class Authenticator {
   private static async fetchRoleGroupsAndSubscription({
     user,
     workspace,
+    transaction,
   }: {
     user: UserResource;
     workspace: WorkspaceResource;
+    transaction?: Transaction;
   }): Promise<{
     role: RoleType;
     groupModelIds: ModelId[];
@@ -222,12 +224,17 @@ export class Authenticator {
       MembershipResource.getActiveRoleForUserInWorkspace({
         user,
         workspace: lightWorkspace,
+        transaction,
       }),
       GroupResource.dangerouslyListUserGroupsForAuth({
         user,
         workspace: lightWorkspace,
+        transaction,
       }),
-      SubscriptionResource.fetchActiveByWorkspaceModelId(lightWorkspace.id),
+      SubscriptionResource.fetchActiveByWorkspaceModelId(
+        lightWorkspace.id,
+        transaction
+      ),
     ]);
 
     return {
@@ -296,13 +303,15 @@ export class Authenticator {
 
   private static async fetchByokProvidersHealth(
     workspace: WorkspaceResource | null | undefined,
-    subscription: SubscriptionResource | null
+    subscription: SubscriptionResource | null,
+    transaction?: Transaction
   ): Promise<ProvidersHealth | null> {
     if (!workspace || !subscription?.getPlan().isByok) {
       return null;
     }
     return ProviderCredentialResource.fetchProvidersHealthByWorkspaceId(
-      workspace.id
+      workspace.id,
+      transaction
     );
   }
 
@@ -375,11 +384,12 @@ export class Authenticator {
    */
   static async fromUserIdAndWorkspaceId(
     uId: string,
-    wId: string
+    wId: string,
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<Authenticator> {
     const [workspace, user] = await Promise.all([
-      WorkspaceResource.fetchById(wId),
-      UserResource.fetchById(uId),
+      WorkspaceResource.fetchById(wId, transaction),
+      UserResource.fetchById(uId, transaction),
     ]);
 
     let role: RoleType = "none";
@@ -390,6 +400,7 @@ export class Authenticator {
       const authData = await this.fetchRoleGroupsAndSubscription({
         user,
         workspace,
+        transaction,
       });
       role = authData.role;
       groupModelIds = authData.groupModelIds;
@@ -398,7 +409,8 @@ export class Authenticator {
 
     const providersHealth = await this.fetchByokProvidersHealth(
       workspace,
-      subscription
+      subscription,
+      transaction
     );
 
     return new Authenticator({

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -117,10 +117,12 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
   ) => `provider_credentials:workspaceId:${workspaceModelId}`;
 
   private static async _baseFetchUncached(
-    workspaceModelId: ModelId
+    workspaceModelId: ModelId,
+    transaction?: Transaction
   ): Promise<CachedProviderCredential[]> {
     const models = await ProviderCredentialResource.model.findAll({
       where: { workspaceId: workspaceModelId },
+      transaction,
     });
 
     const resources = await concurrentExecutor(
@@ -378,7 +380,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     transaction?: Transaction
   ): Promise<Partial<Record<ByokModelProviderIdType, boolean>>> {
     const cached = transaction
-      ? await this._baseFetchUncached(workspaceId)
+      ? await this._baseFetchUncached(workspaceId, transaction)
       : await this.baseFetchCached(workspaceId);
 
     return Object.fromEntries(cached.map((c) => [c.providerId, c.isHealthy]));

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -30,7 +30,7 @@ import { redactString } from "@app/types/shared/utils/string_utils";
 import { GoogleGenAI } from "@google/genai";
 import assert from "assert";
 import OpenAI from "openai";
-import type { Attributes, ModelStatic } from "sequelize";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
 
 const API_KEY_REVEAL_WINDOW_MINUTES = 2;
 const PROVIDER_CREDENTIALS_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
@@ -374,9 +374,12 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
    * Bypasses auth check for use during Authenticator initialization.
    */
   static async fetchProvidersHealthByWorkspaceId(
-    workspaceId: ModelId
+    workspaceId: ModelId,
+    transaction?: Transaction
   ): Promise<Partial<Record<ByokModelProviderIdType, boolean>>> {
-    const cached = await this.baseFetchCached(workspaceId);
+    const cached = transaction
+      ? await this._baseFetchUncached(workspaceId)
+      : await this.baseFetchCached(workspaceId);
 
     return Object.fromEntries(cached.map((c) => [c.providerId, c.isHealthy]));
   }


### PR DESCRIPTION
## Summary

Fixes https://github.com/dust-tt/tasks/issues/7366

- When a pending user message is promoted after a graceful stop, the new agent loop was running with the **original user's auth** (User A) instead of the **promoted user's auth** (User B). This caused tool approval events to have the wrong `userId`, leading to a confused UI: User A saw approval buttons (shouldn't), User B saw "Waiting for User B to confirm" (couldn't approve).
- Creates a proper `Authenticator` for the promoted user inside the advisory-locked transaction and uses it for `createAgentMessages`, `runAgentLoopWorkflow`, and audit logs.
- Makes `Authenticator.fromUserIdAndWorkspaceId` transaction-compatible by threading the `transaction` parameter through all internal resource queries (`WorkspaceResource`, `UserResource`, `MembershipResource`, `GroupResource`, `SubscriptionResource`, `ProviderCredentialResource`).

## Tests

Local tests

### Test plan

- [x] User A triggers an agent that uses a high-stake tool requiring approval
- [x] While waiting for approval, User B sends a steering message (becomes pending)
- [x] User A approves the tool, agent gracefully stops, pending messages are promoted
- [x] Verify the new agent message's tool approval is shown to User B (not User A)
- [x] Verify User B can approve/decline the tool
- [x] Verify User A sees "Waiting for User B to confirm"

## Deploy

- deploy `front`