### PR TITLE
Move Metronome IDs from env vars to constants

### DIFF
--- a/front/lib/api/analytics/metronome_usage.ts
+++ b/front/lib/api/analytics/metronome_usage.ts
@@ -1,4 +1,3 @@
-import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import {
@@ -6,6 +5,10 @@ import {
   listMetronomeUsage,
   listMetronomeUsageWithGroups,
 } from "@app/lib/metronome/client";
+import {
+  getLlmProgrammaticBillableMetricId,
+  getToolProgrammaticBillableMetricId,
+} from "@app/lib/metronome/constants";
 import type { MetronomeBalance } from "@app/lib/metronome/types";
 import { METRONOME_CENTS_TO_MICRO_USD } from "@app/lib/metronome/types";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -188,17 +191,8 @@ export async function handleMetronomeUsageRequest(
         });
       }
 
-      const llmMetricId = config.getMetronomeLlmUsageBillableMetricId();
-      const toolMetricId = config.getMetronomeToolUseBillableMetricId();
-      if (!llmMetricId || !toolMetricId) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Metronome billable metric IDs are not configured.",
-          },
-        });
-      }
+      const llmMetricId = getLlmProgrammaticBillableMetricId();
+      const toolMetricId = getToolProgrammaticBillableMetricId();
 
       const {
         groupBy,

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -521,26 +521,6 @@ const config = {
   getMetronomeApiKey: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("METRONOME_API_KEY");
   },
-  getMetronomeFreeCreditProductId: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable(
-      "METRONOME_FREE_CREDIT_PRODUCT_ID"
-    );
-  },
-  getMetronomeCommitProductId: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable(
-      "METRONOME_COMMIT_PRODUCT_ID"
-    );
-  },
-  getMetronomeLlmUsageBillableMetricId: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable(
-      "METRONOME_LLM_USAGE_BILLABLE_METRIC_ID"
-    );
-  },
-  getMetronomeToolUseBillableMetricId: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable(
-      "METRONOME_TOOL_USE_BILLABLE_METRIC_ID"
-    );
-  },
   getMetronomeWebhookSecret: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("METRONOME_WEBHOOK_SECRET");
   },

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -1,7 +1,7 @@
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
-import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { createMetronomeCommit } from "@app/lib/metronome/client";
+import { getCommitProductId } from "@app/lib/metronome/constants";
 import type { CustomerFacingInvoiceInfo } from "@app/lib/plans/stripe";
 import {
   ENTERPRISE_N30_PAYMENTS_DAYS,
@@ -521,14 +521,7 @@ async function addMetronomeCommitsForWorkspace({
         CREDIT_EXPIRATION_DAYS * 24 * 60 * 60 * 1000
     );
 
-  const productId = config.getMetronomeCommitProductId();
-  if (!productId) {
-    return new Err(
-      new Error(
-        "[Commit Purchase] Metronome commit product ID not configured; cannot add commits for credit purchase"
-      )
-    );
-  }
+  const productId = getCommitProductId();
 
   const result = await createMetronomeCommit({
     metronomeCustomerId,

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -1,0 +1,41 @@
+import { isDevelopment } from "@app/types/shared/env";
+
+// Metronome product and billable metric IDs per environment.
+// Created by metronome_setup.ts, stable across runs.
+
+const DEV_FREE_CREDIT_PRODUCT_ID = "04f41dd1-ba27-42e3-93d5-6121712a4b67";
+const DEV_COMMIT_PRODUCT_ID = "5f4331b7-4bf6-488b-9a0c-51bd139ac91c";
+
+const DEV_LLM_PROGRAMMATIC_BILLABLE_METRIC_ID =
+  "2ea30b38-690c-4ecb-8bdf-378d9e9d160b";
+const DEV_TOOL_PROGRAMMATIC_BILLABLE_METRIC_ID =
+  "90bbb915-9122-4ffa-b14a-40fc4d2a3e0f";
+
+const PROD_FREE_CREDIT_PRODUCT_ID = "7379999c-5492-4e68-968f-345a26f6da63";
+const PROD_COMMIT_PRODUCT_ID = "1408c9fc-dea1-4269-bd6d-1bc0aa1f1218";
+const PROD_LLM_PROGRAMMATIC_BILLABLE_METRIC_ID =
+  "c92011f4-d59b-4691-a518-0ad9eb3a0128";
+const PROD_TOOL_PROGRAMMATIC_BILLABLE_METRIC_ID =
+  "9b3a1c0f-1504-44f1-9d8b-7a247d149756";
+
+export function getFreeCreditProductId() {
+  return isDevelopment()
+    ? DEV_FREE_CREDIT_PRODUCT_ID
+    : PROD_FREE_CREDIT_PRODUCT_ID;
+}
+
+export function getCommitProductId() {
+  return isDevelopment() ? DEV_COMMIT_PRODUCT_ID : PROD_COMMIT_PRODUCT_ID;
+}
+
+export function getLlmProgrammaticBillableMetricId() {
+  return isDevelopment()
+    ? DEV_LLM_PROGRAMMATIC_BILLABLE_METRIC_ID
+    : PROD_LLM_PROGRAMMATIC_BILLABLE_METRIC_ID;
+}
+
+export function getToolProgrammaticBillableMetricId() {
+  return isDevelopment()
+    ? DEV_TOOL_PROGRAMMATIC_BILLABLE_METRIC_ID
+    : PROD_TOOL_PROGRAMMATIC_BILLABLE_METRIC_ID;
+}

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -28,6 +28,7 @@ import {
   createMetronomeCredit,
   getMetronomeActiveContract,
 } from "@app/lib/metronome/client";
+import { getFreeCreditProductId } from "@app/lib/metronome/constants";
 import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
@@ -196,14 +197,7 @@ async function grantMetronomeFreeCredits({
       return;
     }
 
-    const productId = apiConfig.getMetronomeFreeCreditProductId();
-    if (!productId) {
-      logger.error(
-        { workspaceId: workspace.sId },
-        `[Stripe Webhook] Metronome product "Free Monthly Credits" not found`
-      );
-      return;
-    }
+    const productId = getFreeCreditProductId();
 
     // Count active members and compute bracket amount.
     const memberCount = await MembershipResource.countActiveSeatsInWorkspace(

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -647,7 +647,8 @@ function productMatches(
   if (desiredQr && existingQr) {
     if (
       desiredQr.decimal_places !== existingQr.decimal_places ||
-      desiredQr.rounding_method !== existingQr.rounding_method
+      desiredQr.rounding_method.toUpperCase() !==
+        existingQr.rounding_method.toUpperCase()
     ) {
       return false;
     }
@@ -1111,6 +1112,24 @@ async function main(): Promise<void> {
       console.log(`  ${name}: ${id}`);
     }
   }
+
+  // Output constants for lib/metronome/constants.ts
+  const prefix = ENV === "production" ? "PROD" : "DEV";
+  console.log(
+    `\n=== Constants (${ENV}) — paste into lib/metronome/constants.ts ===`
+  );
+  console.log(
+    `const ${prefix}_FREE_CREDIT_PRODUCT_ID = "${ids.products["Free Monthly Credits"] ?? ""}";`
+  );
+  console.log(
+    `const ${prefix}_COMMIT_PRODUCT_ID = "${ids.products["Prepaid Commit"] ?? ""}";`
+  );
+  console.log(
+    `const ${prefix}_LLM_PROGRAMMATIC_BILLABLE_METRIC_ID =\n  "${ids.metrics["LLM Provider Cost (Programmatic)"] ?? ""}";`
+  );
+  console.log(
+    `const ${prefix}_TOOL_PROGRAMMATIC_BILLABLE_METRIC_ID =\n  "${ids.metrics["Tool Invocations (Programmatic)"] ?? ""}";`
+  );
 
   console.log("\n✓ Done");
 }


### PR DESCRIPTION
## Summary
- Move Metronome product/metric IDs from environment variables (`config.ts`) to a dedicated `lib/metronome/constants.ts` file with dev/prod values, following the same pattern as `stripe.ts`
- Remove null checks at call sites since getters now always return a string
- Fix `metronome_setup.ts` case-insensitive comparison for `rounding_method` (was causing product re-creation on every run)
- Add constants output at end of `metronome_setup.ts` for easy copy-paste into `constants.ts`

## Tests
- Ran `metronome_setup.ts` and confirmed "Programmatic Usage" is no longer re-created on subsequent runs
- Type-check passes

## Risk
Low — no behavior change, just moving IDs from env vars to code constants.

## Deploy Plan
After merging, the env vars `METRONOME_FREE_CREDIT_PRODUCT_ID`, `METRONOME_COMMIT_PRODUCT_ID`, `METRONOME_LLM_USAGE_BILLABLE_METRIC_ID`, and `METRONOME_TOOL_USE_BILLABLE_METRIC_ID` can be removed from deployment configs.