### PR TITLE
feat: sort members in member selection table

### DIFF
--- a/front/components/assistant/conversation/space/ManageUsersPanel.tsx
+++ b/front/components/assistant/conversation/space/ManageUsersPanel.tsx
@@ -203,7 +203,8 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
     ];
   }, [mode, currentMembers, currentEditors, toggleEditor]);
 
-  const initialMembers = mode === "editors-only" ? props.editors : undefined;
+  const initialMembers =
+    mode === "editors-only" ? props.editors : props.currentProjectMembers;
 
   const canSave =
     !isSaving && (mode !== "space-members" || currentEditors.size > 0);

--- a/front/components/members/MemberSelectionTable.tsx
+++ b/front/components/members/MemberSelectionTable.tsx
@@ -66,6 +66,7 @@ export function MemberSelectionTable({
     pageIndex: pagination.pageIndex,
     pageSize: pagination.pageSize,
     buildersOnly,
+    disabled: !searchText,
   });
 
   // Internal map to resolve sId -> UserType, seeded with initialMembers and
@@ -81,15 +82,16 @@ export function MemberSelectionTable({
     }
   }
 
-  // Selected users first, then unselected
+  // When not searching, show selected members; when searching, show search results.
   const rows = useMemo(() => {
-    const selectedMembers = members.filter((m) => selectedMemberIds.has(m.sId));
-    const unselectedMembers = members.filter(
-      (m) => !selectedMemberIds.has(m.sId)
-    );
-    const sortedMembers = [...selectedMembers, ...unselectedMembers];
-    return getMemberTableRows(sortedMembers);
-  }, [members, selectedMemberIds]);
+    if (!searchText) {
+      const selectedUsers = Array.from(selectedMemberIds)
+        .map((sId) => userMapRef.current.get(sId))
+        .filter((u): u is UserType => !!u);
+      return getMemberTableRows(selectedUsers);
+    }
+    return getMemberTableRows(members);
+  }, [searchText, selectedMemberIds, members]);
 
   const rowSelectionState: RowSelectionState = useMemo(
     () =>
@@ -164,7 +166,7 @@ export function MemberSelectionTable({
             columns={columns}
             pagination={pagination}
             setPagination={setPagination}
-            totalRowCount={totalMembersCount}
+            totalRowCount={searchText ? totalMembersCount : rows.length}
             rowSelection={rowSelectionState}
             setRowSelection={handleRowSelectionChange}
             enableRowSelection

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -370,6 +370,7 @@ export function CreateOrEditSpaceModal({
                   setSelectedGroups(groups);
                   setIsDirty(true);
                 }}
+                initialMembers={spaceInfo?.members}
               />
             )}
           </div>

--- a/front/components/spaces/RestrictedAccessBody.tsx
+++ b/front/components/spaces/RestrictedAccessBody.tsx
@@ -30,6 +30,7 @@ interface RestrictedAccessBodyProps {
   onManagementTypeChange: (managementType: MembersManagementType) => void;
   onMembersUpdated: (members: UserType[]) => void;
   onGroupsUpdated: (groups: GroupType[]) => void;
+  initialMembers?: UserType[];
 }
 
 export function RestrictedAccessBody({
@@ -42,6 +43,7 @@ export function RestrictedAccessBody({
   onManagementTypeChange,
   onMembersUpdated,
   onGroupsUpdated,
+  initialMembers,
 }: RestrictedAccessBodyProps) {
   const confirm = useContext(ConfirmContext);
 
@@ -152,7 +154,7 @@ export function RestrictedAccessBody({
           owner={owner}
           selectedMemberIds={selectedMemberIds}
           onSelectionChange={handleMemberSelectionChange}
-          initialMembers={selectedMembers}
+          initialMembers={initialMembers}
         />
       )}
 

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -148,7 +148,7 @@ export function useSearchMembers({
   return {
     members: data?.members ?? emptyArray(),
     totalMembersCount: data?.total ?? 0,
-    isLoading: !error && !data,
+    isLoading: !error && !data && !disabled,
     isError: !!error,
     mutate,
     mutateRegardlessOfQueryParams,


### PR DESCRIPTION
## Description

This PR updates the member selection table so that, when there is no active search, it shows the currently selected members instead of a paginated search result list.

This is related to https://github.com/dust-tt/dust/pull/23568 and to https://github.com/dust-tt/dust/pull/22646. The approach from #22646 tried to solve the problem by sorting search results client-side, but that created a few UX and consistency issues, like members moving around when selected/unselected and discrepancies in pagination. Instead of re-introducing that behavior, this PR takes a simpler approach:

- when the user is not searching, the table displays the selected members directly
- when the user is searching, the table displays the search results as usual

This keeps the non-search state focused on the current selection, while avoiding the problems of client-side reordering within paginated search results.

## Tests

Manually tested across all four pages where this component is used:

- Create/edit space
- Project members page
- Agent builder
- Skill builder

## Risk
- Changing the behavior of a component reused in multiple places

## Deploy Plan

Standard deployment, no special considerations needed