### PR TITLE
[Remote MCP] netsuite icon fix

### DIFF
--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -248,6 +248,7 @@ export function CreateMCPServerDialog({
     const submitRes = await submitCreateMCPServerDialogForm({
       owner,
       internalMCPServer,
+      defaultServerId: defaultServerConfig?.id,
       values,
       // Pass workflow state as separate params (not from form).
       authorization,

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -58,6 +58,7 @@ type DiscoverOAuthMetadataFn = (
 
 type CreateRemoteMCPServerFn = (args: {
   url: string;
+  defaultServerId?: number;
   includeGlobal: boolean;
   sharedSecret?: string;
   oauthConnection?: MCPConnectionType;
@@ -82,6 +83,7 @@ type CreateInternalMCPServerFn = (
 interface SubmitCreateMCPServerDialogFormParams {
   owner: WorkspaceType;
   internalMCPServer?: MCPServerType;
+  defaultServerId?: number;
   values: CreateMCPServerDialogFormValues;
   // Workflow state - managed via useState in the dialog, not in form state.
   // These are server-derived values, not user input.
@@ -97,6 +99,7 @@ interface SubmitCreateMCPServerDialogFormParams {
 export async function submitCreateMCPServerDialogForm({
   owner,
   internalMCPServer,
+  defaultServerId,
   values,
   authorization,
   remoteMCPServerOAuthDiscoveryDone,
@@ -276,6 +279,7 @@ export async function submitCreateMCPServerDialogForm({
   if (values.remoteServerUrl) {
     const createRes = await createWithURL({
       url: values.remoteServerUrl,
+      defaultServerId,
       includeGlobal: true,
       sharedSecret:
         values.authMethod === "bearer" ? values.sharedSecret : undefined,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -384,18 +384,23 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
   const createWithURL = useCallback(
     async ({
       url,
+      defaultServerId,
       includeGlobal,
       sharedSecret,
       oauthConnection,
       customHeaders,
     }: {
       url: string;
+      defaultServerId?: number;
       includeGlobal: boolean;
       sharedSecret?: string;
       oauthConnection?: MCPConnectionType;
       customHeaders?: { key: string; value: string }[];
     }): Promise<Result<CreateMCPServerResponseBody, Error>> => {
       const body: any = { url, serverType: "remote", includeGlobal };
+      if (defaultServerId !== undefined) {
+        body.defaultServerId = defaultServerId;
+      }
       if (sharedSecret) {
         body.sharedSecret = sharedSecret;
       }

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -53,6 +53,7 @@ const PostQueryParamsSchema = t.union([
   t.type({
     serverType: t.literal("remote"),
     url: t.string,
+    defaultServerId: t.union([t.number, t.undefined]),
     includeGlobal: t.union([t.boolean, t.undefined]),
     sharedSecret: t.union([t.string, t.undefined]),
     useCase: t.union([
@@ -221,9 +222,13 @@ async function handler(
 
           const metadata = r.value;
 
-          const defaultConfig = DEFAULT_REMOTE_MCP_SERVERS.find(
-            (config) => config.url === url
-          );
+          const defaultConfig =
+            DEFAULT_REMOTE_MCP_SERVERS.find((config) => config.url === url) ??
+            (body.defaultServerId !== undefined
+              ? DEFAULT_REMOTE_MCP_SERVERS.find(
+                  (config) => config.id === body.defaultServerId
+                )
+              : undefined);
 
           const name = defaultConfig?.name ?? metadata.name;
           if (name.length > MAX_NAME_LENGTH) {


### PR DESCRIPTION
## Description

Fixes icon display for NetSuite remote MCP server. When creating a remote MCP server from a default configuration with a non-standard URL (NetSuite has an empty URL string since it's account-specific), the server creation code previously only looked up the default config by URL. This failed for NetSuite, causing it to use a fallback icon instead of the NetSuiteLogo. The fix passes the `defaultServerId` parameter through the creation flow (`CreateMCPServerDialog` → `submitCreateMCPServerDialogForm` → `createWithURL` → API endpoint), allowing the backend to look up the default configuration by ID as a fallback when URL matching fails.

## Tests

Manually tested NetSuite MCP server creation displays correct icon.

## Risk

Low. The `defaultServerId` parameter is optional and only used as a fallback lookup mechanism.

## Deploy Plan

Deploy front.