### PR TITLE
[sessions] Strip agent mentions on paste in single-agent mode

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -411,6 +411,14 @@ const InputBarContainer = ({
     spaceId: space?.sId,
     onInlineText: handleInlineText,
     shouldSuggestAgentRef: singleAgentInput ? shouldSuggestAgentRef : undefined,
+    onFirstAgentMentionPaste: singleAgentInput
+      ? (agentId: string) => {
+          const agent = agentsBySId.get(agentId);
+          if (agent) {
+            setSelectedSingleAgent(toRichAgentMentionType(agent));
+          }
+        }
+      : undefined,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";
       let inserted = false;

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -223,6 +223,11 @@ const InputBarContainer = ({
   const [isEmpty, setIsEmpty] = useState(true);
   // A ref so the mention suggestion plugin (which lives outside React) can read it synchronously.
   const shouldSuggestAgentRef = useRef(true);
+  // The editor plugin captures its options once at initialization. Passing a ref lets the plugin
+  // always invoke the latest closure without needing to reinitialize the editor.
+  const onFirstAgentMentionPasteRef = useRef<
+    ((agentId: string) => void) | undefined
+  >(undefined);
   const [isCaptureDropdownOpen, setIsCaptureDropdownOpen] = useState(false);
   const [showKnowledgePicker, setShowKnowledgePicker] = useState(false);
   const plusButtonRef = useRef<HTMLDivElement>(null);
@@ -399,6 +404,15 @@ const InputBarContainer = ({
     [isBlockedByAgentSwitch, onEnterKeyDown, onShake]
   );
 
+  onFirstAgentMentionPasteRef.current = singleAgentInput
+    ? (agentId: string) => {
+        const agent = agentsBySId.get(agentId);
+        if (agent) {
+          setSelectedSingleAgent(toRichAgentMentionType(agent));
+        }
+      }
+    : undefined;
+
   const { editor, editorService } = useCustomEditor({
     onEnterKeyDown: onEnterKeyDownWithShake,
     disableAutoFocus,
@@ -411,13 +425,8 @@ const InputBarContainer = ({
     spaceId: space?.sId,
     onInlineText: handleInlineText,
     shouldSuggestAgentRef: singleAgentInput ? shouldSuggestAgentRef : undefined,
-    onFirstAgentMentionPaste: singleAgentInput
-      ? (agentId: string) => {
-          const agent = agentsBySId.get(agentId);
-          if (agent) {
-            setSelectedSingleAgent(toRichAgentMentionType(agent));
-          }
-        }
+    onFirstAgentMentionPasteRef: singleAgentInput
+      ? onFirstAgentMentionPasteRef
       : undefined,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -228,6 +228,9 @@ const InputBarContainer = ({
   const onFirstAgentMentionPasteRef = useRef<
     ((agentId: string) => void) | undefined
   >(undefined);
+  const onAgentMentionsStrippedRef = useRef<
+    ((count: number) => void) | undefined
+  >(undefined);
   const [isCaptureDropdownOpen, setIsCaptureDropdownOpen] = useState(false);
   const [showKnowledgePicker, setShowKnowledgePicker] = useState(false);
   const plusButtonRef = useRef<HTMLDivElement>(null);
@@ -413,6 +416,19 @@ const InputBarContainer = ({
       }
     : undefined;
 
+  onAgentMentionsStrippedRef.current = singleAgentInput
+    ? (count: number) => {
+        sendNotification({
+          type: "info",
+          title: "Agent mentions removed",
+          description:
+            count === 1
+              ? "1 agent mention was removed. Only one agent can be used at a time."
+              : `${count} agent mentions were removed. Only one agent can be used at a time.`,
+        });
+      }
+    : undefined;
+
   const { editor, editorService } = useCustomEditor({
     onEnterKeyDown: onEnterKeyDownWithShake,
     disableAutoFocus,
@@ -425,9 +441,8 @@ const InputBarContainer = ({
     spaceId: space?.sId,
     onInlineText: handleInlineText,
     shouldSuggestAgentRef: singleAgentInput ? shouldSuggestAgentRef : undefined,
-    onFirstAgentMentionPasteRef: singleAgentInput
-      ? onFirstAgentMentionPasteRef
-      : undefined,
+    onFirstAgentMentionPasteRef,
+    onAgentMentionsStrippedRef,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";
       let inserted = false;

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -203,7 +203,7 @@ const InputBarContainer = ({
     useContext(InputBarContext);
   const [hasUserMention, setHasUserMention] = useState(false);
 
-  const agentsBySId = useMemo(
+  const agentsById = useMemo(
     () => new Map(allAgents.map((a) => [a.sId, a])),
     [allAgents]
   );
@@ -409,7 +409,7 @@ const InputBarContainer = ({
 
   onFirstAgentMentionPasteRef.current = singleAgentInput
     ? (agentId: string) => {
-        const agent = agentsBySId.get(agentId);
+        const agent = agentsById.get(agentId);
         if (agent) {
           setSelectedSingleAgent(toRichAgentMentionType(agent));
         }
@@ -519,7 +519,7 @@ const InputBarContainer = ({
             break;
           case "mention": {
             if (singleAgentInput) {
-              const agent = agentsBySId.get(message.id);
+              const agent = agentsById.get(message.id);
               if (agent) {
                 handleSingleAgentSelect(toRichAgentMentionType(agent));
               }

--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -26,6 +26,9 @@ interface MentionExtensionOptions extends MentionOptions {
   onFirstAgentMentionPasteRef?: RefObject<
     ((agentId: string) => void) | undefined
   >;
+  onAgentMentionsStrippedRef?: RefObject<
+    ((count: number) => void) | undefined
+  >;
 }
 
 export const MentionExtension = Mention.extend<MentionExtensionOptions>({
@@ -34,6 +37,7 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
       ...this.parent?.(),
       owner: {} as WorkspaceType,
       onFirstAgentMentionPasteRef: undefined,
+      onAgentMentionsStrippedRef: undefined,
     } as MentionExtensionOptions;
   },
 
@@ -165,7 +169,8 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
   },
 
   addProseMirrorPlugins(this) {
-    const { owner, onFirstAgentMentionPasteRef } = this.options;
+    const { owner, onFirstAgentMentionPasteRef, onAgentMentionsStrippedRef } =
+      this.options;
     const editor = this.editor;
     const markdownManager = editor.markdown!; // we know it exists because we added the markdown plugin
 
@@ -246,6 +251,7 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
               // routed it from the rich-HTML slice check above).
               if (onFirstAgentMentionPasteRef?.current) {
                 let markdownAgentId: string | null = null;
+                let strippedCount = 0;
                 contentToInsert = processedMarkdown
                   .replaceAll(
                     AGENT_MENTION_REGEX,
@@ -253,12 +259,21 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
                       if (!markdownAgentId) {
                         markdownAgentId = agentId;
                       }
+                      strippedCount++;
                       return "";
                     }
                   )
                   .trim();
                 if (markdownAgentId && !richHtmlAgentId) {
                   onFirstAgentMentionPasteRef?.current(markdownAgentId);
+                }
+                // If richHtmlAgentId already claimed the first agent, all
+                // markdown-stripped mentions are extras; otherwise subtract one.
+                const extraStripped = richHtmlAgentId
+                  ? strippedCount
+                  : strippedCount - 1;
+                if (extraStripped > 0) {
+                  onAgentMentionsStrippedRef?.current?.(extraStripped);
                 }
               }
 

--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -12,6 +12,7 @@ import type { MentionOptions } from "@tiptap/extension-mention";
 import Mention from "@tiptap/extension-mention";
 import { Plugin, TextSelection } from "@tiptap/pm/state";
 import { ReactNodeViewRenderer } from "@tiptap/react";
+import type { RefObject } from "react";
 
 const MENTION_TYPE_ATTRIBUTE = "data-mention-type";
 const MENTION_DESCRIPTION_ATTRIBUTE = "data-description";
@@ -22,7 +23,9 @@ const LEGACY_TYPE_ATTRIBUTE = "data-type";
 
 interface MentionExtensionOptions extends MentionOptions {
   owner: WorkspaceType;
-  onFirstAgentMentionPaste?: (agentId: string) => void;
+  onFirstAgentMentionPasteRef?: RefObject<
+    ((agentId: string) => void) | undefined
+  >;
 }
 
 export const MentionExtension = Mention.extend<MentionExtensionOptions>({
@@ -30,7 +33,7 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
     return {
       ...this.parent?.(),
       owner: {} as WorkspaceType,
-      onFirstAgentMentionPaste: undefined,
+      onFirstAgentMentionPasteRef: undefined,
     } as MentionExtensionOptions;
   },
 
@@ -162,7 +165,7 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
   },
 
   addProseMirrorPlugins(this) {
-    const { owner, onFirstAgentMentionPaste } = this.options;
+    const { owner, onFirstAgentMentionPasteRef } = this.options;
     const editor = this.editor;
     const markdownManager = editor.markdown!; // we know it exists because we added the markdown plugin
 
@@ -178,7 +181,7 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
           // through to parseMentionsOnBackend which will strip them from the
           // serialized markdown before inserting.
           let richHtmlAgentId: string | null = null;
-          if (onFirstAgentMentionPaste) {
+          if (onFirstAgentMentionPasteRef?.current) {
             slice.content.descendants((node) => {
               if (
                 !richHtmlAgentId &&
@@ -189,7 +192,7 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
               }
             });
             if (richHtmlAgentId) {
-              onFirstAgentMentionPaste(richHtmlAgentId);
+              onFirstAgentMentionPasteRef?.current(richHtmlAgentId);
             }
           }
 
@@ -241,7 +244,7 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
               // In single-agent mode, strip all agent mentions from the pasted
               // content and route the first one to the picker (unless we already
               // routed it from the rich-HTML slice check above).
-              if (onFirstAgentMentionPaste) {
+              if (onFirstAgentMentionPasteRef?.current) {
                 let markdownAgentId: string | null = null;
                 contentToInsert = processedMarkdown
                   .replaceAll(
@@ -255,7 +258,7 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
                   )
                   .trim();
                 if (markdownAgentId && !richHtmlAgentId) {
-                  onFirstAgentMentionPaste(markdownAgentId);
+                  onFirstAgentMentionPasteRef?.current(markdownAgentId);
                 }
               }
 

--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -26,9 +26,7 @@ interface MentionExtensionOptions extends MentionOptions {
   onFirstAgentMentionPasteRef?: RefObject<
     ((agentId: string) => void) | undefined
   >;
-  onAgentMentionsStrippedRef?: RefObject<
-    ((count: number) => void) | undefined
-  >;
+  onAgentMentionsStrippedRef?: RefObject<((count: number) => void) | undefined>;
 }
 
 export const MentionExtension = Mention.extend<MentionExtensionOptions>({

--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -1,6 +1,7 @@
 import { MentionComponent } from "@app/components/editor/input_bar/MentionComponent";
 import { clientFetch } from "@app/lib/egress/client";
 import {
+  AGENT_MENTION_REGEX,
   AGENT_MENTION_REGEX_BEGINNING,
   USER_MENTION_REGEX_BEGINNING,
 } from "@app/lib/mentions/format";
@@ -21,6 +22,7 @@ const LEGACY_TYPE_ATTRIBUTE = "data-type";
 
 interface MentionExtensionOptions extends MentionOptions {
   owner: WorkspaceType;
+  onFirstAgentMentionPaste?: (agentId: string) => void;
 }
 
 export const MentionExtension = Mention.extend<MentionExtensionOptions>({
@@ -28,6 +30,7 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
     return {
       ...this.parent?.(),
       owner: {} as WorkspaceType,
+      onFirstAgentMentionPaste: undefined,
     } as MentionExtensionOptions;
   },
 
@@ -159,7 +162,7 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
   },
 
   addProseMirrorPlugins(this) {
-    const { owner } = this.options;
+    const { owner, onFirstAgentMentionPaste } = this.options;
     const editor = this.editor;
     const markdownManager = editor.markdown!; // we know it exists because we added the markdown plugin
 
@@ -170,8 +173,28 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
           // Get text from the slice after TipTap processing.
           const text = slice.content.textBetween(0, slice.content.size, "\n");
 
-          // Only process if text contains @.
-          if (!text.includes("@")) {
+          // In single-agent mode, check if the slice has agent mention nodes
+          // (rich HTML paste). If so, route the first to the picker — then fall
+          // through to parseMentionsOnBackend which will strip them from the
+          // serialized markdown before inserting.
+          let richHtmlAgentId: string | null = null;
+          if (onFirstAgentMentionPaste) {
+            slice.content.descendants((node) => {
+              if (
+                !richHtmlAgentId &&
+                node.type.name === "mention" &&
+                node.attrs.type === "agent"
+              ) {
+                richHtmlAgentId = node.attrs.id;
+              }
+            });
+            if (richHtmlAgentId) {
+              onFirstAgentMentionPaste(richHtmlAgentId);
+            }
+          }
+
+          // Only process if text contains @ or we have agent mention nodes to strip.
+          if (!text.includes("@") && !richHtmlAgentId) {
             return false;
           }
 
@@ -213,16 +236,36 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
           // Send to backend to parse mentions.
           parseMentionsOnBackend(markdown, owner.sId)
             .then((processedMarkdown: string) => {
-              // Use Tiptap's insertContent with JSON structure.
-              // This uses Tiptap's built-in content parsing and validation.
-              editor
-                .chain()
-                .focus()
-                .deleteRange({ from, to })
-                .insertContentAt(from, processedMarkdown, {
+              let contentToInsert = processedMarkdown;
+
+              // In single-agent mode, strip all agent mentions from the pasted
+              // content and route the first one to the picker (unless we already
+              // routed it from the rich-HTML slice check above).
+              if (onFirstAgentMentionPaste) {
+                let markdownAgentId: string | null = null;
+                contentToInsert = processedMarkdown
+                  .replaceAll(
+                    AGENT_MENTION_REGEX,
+                    (_match, _label, agentId) => {
+                      if (!markdownAgentId) {
+                        markdownAgentId = agentId;
+                      }
+                      return "";
+                    }
+                  )
+                  .trim();
+                if (markdownAgentId && !richHtmlAgentId) {
+                  onFirstAgentMentionPaste(markdownAgentId);
+                }
+              }
+
+              const chain = editor.chain().focus().deleteRange({ from, to });
+              if (contentToInsert) {
+                chain.insertContentAt(from, contentToInsert, {
                   contentType: "markdown",
-                })
-                .run();
+                });
+              }
+              chain.run();
             })
             .catch((error: unknown) => {
               logger.error("Failed to parse mentions:", error);

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -191,7 +191,9 @@ export interface CustomEditorProps {
   onInlineText?: (fileId: string, textContent: string) => void;
   // Ref that dynamically controls whether agent suggestions are shown for single agent mode.
   shouldSuggestAgentRef?: React.RefObject<boolean>;
-  onFirstAgentMentionPaste?: (agentId: string) => void;
+  onFirstAgentMentionPasteRef?: React.RefObject<
+    ((agentId: string) => void) | undefined
+  >;
 }
 
 export const buildEditorExtensions = ({
@@ -204,7 +206,7 @@ export const buildEditorExtensions = ({
   onAgentSelect,
   singleAgentInputEnabled,
   shouldSuggestAgentRef,
-  onFirstAgentMentionPaste,
+  onFirstAgentMentionPasteRef,
 }: {
   owner: WorkspaceType;
   conversationId?: string | null;
@@ -215,7 +217,9 @@ export const buildEditorExtensions = ({
   onAgentSelect?: (mention: RichMention) => void;
   singleAgentInputEnabled?: boolean;
   shouldSuggestAgentRef?: React.RefObject<boolean>;
-  onFirstAgentMentionPaste?: (agentId: string) => void;
+  onFirstAgentMentionPasteRef?: React.RefObject<
+    ((agentId: string) => void) | undefined
+  >;
 }) => {
   const extensions = [
     KeyboardShortcutsExtension,
@@ -277,7 +281,7 @@ export const buildEditorExtensions = ({
     }),
     MentionExtension.configure({
       owner,
-      onFirstAgentMentionPaste,
+      onFirstAgentMentionPasteRef,
       HTMLAttributes: {
         class:
           "min-w-0 px-0 py-0 border-none outline-none focus:outline-none focus:border-none ring-0 focus:ring-0 text-highlight-500 font-semibold",
@@ -336,7 +340,7 @@ const useCustomEditor = ({
   longTextPasteCharsThreshold,
   onInlineText,
   shouldSuggestAgentRef,
-  onFirstAgentMentionPaste,
+  onFirstAgentMentionPasteRef,
 }: CustomEditorProps) => {
   const editor = useEditor(
     {
@@ -351,7 +355,7 @@ const useCustomEditor = ({
         onAgentSelect,
         singleAgentInputEnabled,
         shouldSuggestAgentRef,
-        onFirstAgentMentionPaste,
+        onFirstAgentMentionPasteRef,
       }),
       shouldRerenderOnTransaction: true, // necessary to update the editor state (and so the toolbar icons "activation") in real time
       editorProps: {

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -191,6 +191,7 @@ export interface CustomEditorProps {
   onInlineText?: (fileId: string, textContent: string) => void;
   // Ref that dynamically controls whether agent suggestions are shown for single agent mode.
   shouldSuggestAgentRef?: React.RefObject<boolean>;
+  onFirstAgentMentionPaste?: (agentId: string) => void;
 }
 
 export const buildEditorExtensions = ({
@@ -203,6 +204,7 @@ export const buildEditorExtensions = ({
   onAgentSelect,
   singleAgentInputEnabled,
   shouldSuggestAgentRef,
+  onFirstAgentMentionPaste,
 }: {
   owner: WorkspaceType;
   conversationId?: string | null;
@@ -213,6 +215,7 @@ export const buildEditorExtensions = ({
   onAgentSelect?: (mention: RichMention) => void;
   singleAgentInputEnabled?: boolean;
   shouldSuggestAgentRef?: React.RefObject<boolean>;
+  onFirstAgentMentionPaste?: (agentId: string) => void;
 }) => {
   const extensions = [
     KeyboardShortcutsExtension,
@@ -274,6 +277,7 @@ export const buildEditorExtensions = ({
     }),
     MentionExtension.configure({
       owner,
+      onFirstAgentMentionPaste,
       HTMLAttributes: {
         class:
           "min-w-0 px-0 py-0 border-none outline-none focus:outline-none focus:border-none ring-0 focus:ring-0 text-highlight-500 font-semibold",
@@ -332,6 +336,7 @@ const useCustomEditor = ({
   longTextPasteCharsThreshold,
   onInlineText,
   shouldSuggestAgentRef,
+  onFirstAgentMentionPaste,
 }: CustomEditorProps) => {
   const editor = useEditor(
     {
@@ -346,6 +351,7 @@ const useCustomEditor = ({
         onAgentSelect,
         singleAgentInputEnabled,
         shouldSuggestAgentRef,
+        onFirstAgentMentionPaste,
       }),
       shouldRerenderOnTransaction: true, // necessary to update the editor state (and so the toolbar icons "activation") in real time
       editorProps: {

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -194,6 +194,9 @@ export interface CustomEditorProps {
   onFirstAgentMentionPasteRef?: React.RefObject<
     ((agentId: string) => void) | undefined
   >;
+  onAgentMentionsStrippedRef?: React.RefObject<
+    ((count: number) => void) | undefined
+  >;
 }
 
 export const buildEditorExtensions = ({
@@ -207,6 +210,7 @@ export const buildEditorExtensions = ({
   singleAgentInputEnabled,
   shouldSuggestAgentRef,
   onFirstAgentMentionPasteRef,
+  onAgentMentionsStrippedRef,
 }: {
   owner: WorkspaceType;
   conversationId?: string | null;
@@ -219,6 +223,9 @@ export const buildEditorExtensions = ({
   shouldSuggestAgentRef?: React.RefObject<boolean>;
   onFirstAgentMentionPasteRef?: React.RefObject<
     ((agentId: string) => void) | undefined
+  >;
+  onAgentMentionsStrippedRef?: React.RefObject<
+    ((count: number) => void) | undefined
   >;
 }) => {
   const extensions = [
@@ -282,6 +289,7 @@ export const buildEditorExtensions = ({
     MentionExtension.configure({
       owner,
       onFirstAgentMentionPasteRef,
+      onAgentMentionsStrippedRef,
       HTMLAttributes: {
         class:
           "min-w-0 px-0 py-0 border-none outline-none focus:outline-none focus:border-none ring-0 focus:ring-0 text-highlight-500 font-semibold",
@@ -341,6 +349,7 @@ const useCustomEditor = ({
   onInlineText,
   shouldSuggestAgentRef,
   onFirstAgentMentionPasteRef,
+  onAgentMentionsStrippedRef,
 }: CustomEditorProps) => {
   const editor = useEditor(
     {
@@ -356,6 +365,7 @@ const useCustomEditor = ({
         singleAgentInputEnabled,
         shouldSuggestAgentRef,
         onFirstAgentMentionPasteRef,
+        onAgentMentionsStrippedRef,
       }),
       shouldRerenderOnTransaction: true, // necessary to update the editor state (and so the toolbar icons "activation") in real time
       editorProps: {


### PR DESCRIPTION
## Description
This PR hooks into the existing logic to process pasted content and pull out agent names, adding a layer to set the first agent name as the one selected and remove all subsequent ones.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually pasting in the following variants:
1. Text with agent @ mention alone, at the start of, and in the middle of text
2. Text copied from a dust input box pre-single agent with already formatted blue agent tags 
All agent names should be stripped, first agent name should be selected

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
