### PR TITLE
[LLM] Route Claude models through Vertex AI

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -581,6 +581,9 @@ const config = {
   getMetronomeWebhookSecret: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("METRONOME_WEBHOOK_SECRET");
   },
+  getVertexAiProjectId: (): string => {
+    return EnvironmentConfig.getEnvVariable("VERTEX_AI_PROJECT_ID");
+  },
 };
 
 export default config;

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -44,7 +44,6 @@ import type {
   StructuredSystemPrompt,
 } from "@app/lib/api/llm/types/options";
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
-import { config } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import assert from "assert";
@@ -125,13 +124,11 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
       apiKey: ANTHROPIC_API_KEY,
     });
 
-    const region =
-      config.getCurrentRegion() === "us-central1" ? "global" : "europe-west1";
-
     // Vertex does not support batches
     this.inferenceClient = this.useVertex
-      ? new AnthropicVertex({
-          region,
+      ? // Routing everything to Europe first to check that Vertex works correctly.
+        new AnthropicVertex({
+          region: "europe-west1",
         })
       : this.client;
   }

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -4,11 +4,13 @@ import type {
   MessageCreateParamsNonStreaming,
 } from "@anthropic-ai/sdk/resources";
 import type { BetaMessageStreamParams } from "@anthropic-ai/sdk/resources/beta/messages";
+import AnthropicVertex from "@anthropic-ai/vertex-sdk";
 
 import type { AnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
 import {
   ANTHROPIC_PROVIDER_ID,
   overwriteLLMParameters,
+  VERTEX_MODEL_ID_MAP,
 } from "@app/lib/api/llm/clients/anthropic/types";
 import {
   toAutoThinkingConfig,
@@ -39,7 +41,9 @@ import type {
   StructuredSystemPrompt,
 } from "@app/lib/api/llm/types/options";
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
+import { config } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import assert from "assert";
 
 /**
@@ -95,12 +99,17 @@ function buildSystemBlocks(
   return system;
 }
 
-export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
+export class AnthropicLLM extends LLM<LLMStreamParameters> {
   private client: Anthropic;
+  private inferenceClient: Anthropic | AnthropicVertex;
   private omittedThinking: boolean;
+  private vertex: boolean;
   constructor(
     auth: Authenticator,
-    llmParameters: LLMParameters & { modelId: AnthropicWhitelistedModelId }
+    llmParameters: LLMParameters & {
+      modelId: AnthropicWhitelistedModelId;
+      vertex?: boolean;
+    }
   ) {
     const params = overwriteLLMParameters(llmParameters);
     super(auth, ANTHROPIC_PROVIDER_ID, params);
@@ -108,24 +117,38 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     assert(ANTHROPIC_API_KEY, "ANTHROPIC_API_KEY credential is required");
     this.omittedThinking = params.omittedThinking ?? false;
 
+    this.vertex = llmParameters.vertex ?? false;
     this.client = new Anthropic({
       apiKey: ANTHROPIC_API_KEY,
     });
+
+    const region =
+      config.getCurrentRegion() === "us-central1" ? "global" : "europe-west1";
+
+    // Vertex does not support batches
+    this.inferenceClient = this.vertex
+      ? new AnthropicVertex({
+          region,
+        })
+      : this.client;
   }
 
-  private buildBaseRequestPayload({
+  private async buildBaseRequestPayload({
     conversation,
     hasConditionalJITTools,
     prompt,
     specifications,
     forceToolCall,
-    omittedThinking = this.omittedThinking,
-  }: LLMStreamParameters): MessageCreateParamsNonStreaming {
-    const messages = conversation.messages.map((msg, index, array) =>
-      toMessage(msg, {
-        isLast: index === array.length - 1,
-        omittedThinking: this.omittedThinking,
-      })
+  }: LLMStreamParameters): Promise<MessageCreateParamsNonStreaming> {
+    const messages = await concurrentExecutor(
+      conversation.messages,
+      (msg, index) =>
+        toMessage(msg, {
+          isLast: index === conversation.messages.length - 1,
+          omittedThinking: this.omittedThinking,
+          convertToBase64: this.vertex,
+        }),
+      { concurrency: 10 }
     );
 
     // Build thinking config, use custom type if specified.
@@ -159,21 +182,9 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
 
   protected buildStreamRequestPayload(
     streamParameters: LLMStreamParameters
-  ): BetaMessageStreamParams {
-    const basePayload = this.buildBaseRequestPayload(streamParameters);
-    const outputFormat = toOutputFormatParam(this.responseFormat);
-
-    const customBetas = this.modelConfig.customBetas;
-
-    return {
-      ...basePayload,
-      stream: true,
-      ...(customBetas && customBetas.length > 0 ? { betas: customBetas } : {}),
-      output_config: outputFormat
-        ? { ...basePayload.output_config, format: outputFormat }
-        : basePayload.output_config,
-      cache_control: { type: "ephemeral" },
-    };
+  ): LLMStreamParameters {
+    // Just capture the parameters; message conversion (async) happens in sendRequest.
+    return streamParameters;
   }
 
   private createCountTokensCallback() {
@@ -187,14 +198,41 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     }
 
     return (body: MessageCountTokensParams) =>
-      this.client.messages.countTokens(body);
+      this.inferenceClient.messages.countTokens({
+        ...body,
+        model: this.getModel(),
+      });
+  }
+
+  private getModel(): string {
+    if (!this.vertex) {
+      return this.modelId;
+    }
+
+    return VERTEX_MODEL_ID_MAP[this.modelId] ?? this.modelId;
   }
 
   protected async *sendRequest(
-    payload: BetaMessageStreamParams
+    streamParameters: LLMStreamParameters
   ): AsyncGenerator<LLMEvent> {
+    const betas = this.modelConfig.customBetas;
+
+    const basePayload = await this.buildBaseRequestPayload(streamParameters);
+    const outputFormat = toOutputFormatParam(this.responseFormat);
+
+    const payload: BetaMessageStreamParams = {
+      ...basePayload,
+      stream: true,
+      betas,
+      output_config: outputFormat
+        ? { ...basePayload.output_config, format: outputFormat }
+        : basePayload.output_config,
+      cache_control: { type: "ephemeral" },
+      model: this.getModel(),
+    };
+
     try {
-      const events = this.client.beta.messages.stream(payload);
+      const events = this.inferenceClient.beta.messages.stream(payload);
 
       yield* streamLLMEvents(
         events,
@@ -217,11 +255,13 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
   protected override async internalSendBatchProcessing(
     conversations: Map<string, LLMStreamParameters>
   ): Promise<string> {
-    const requests = Array.from(conversations.entries()).map(
-      ([customId, streamParams]) => ({
+    const requests = await concurrentExecutor(
+      Array.from(conversations.entries()),
+      async ([customId, streamParams]) => ({
         custom_id: customId,
-        params: this.buildBaseRequestPayload(streamParams),
-      })
+        params: await this.buildBaseRequestPayload(streamParams),
+      }),
+      { concurrency: 10 }
     );
 
     const batch = await this.client.messages.batches.create({ requests });

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -103,12 +103,12 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
   private client: Anthropic;
   private inferenceClient: Anthropic | AnthropicVertex;
   private omittedThinking: boolean;
-  private vertex: boolean;
+  private useVertex: boolean;
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters & {
       modelId: AnthropicWhitelistedModelId;
-      vertex?: boolean;
+      useVertex?: boolean;
     }
   ) {
     const params = overwriteLLMParameters(llmParameters);
@@ -117,7 +117,7 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
     assert(ANTHROPIC_API_KEY, "ANTHROPIC_API_KEY credential is required");
     this.omittedThinking = params.omittedThinking ?? false;
 
-    this.vertex = llmParameters.vertex ?? false;
+    this.useVertex = llmParameters.useVertex ?? false;
     this.client = new Anthropic({
       apiKey: ANTHROPIC_API_KEY,
     });
@@ -126,7 +126,7 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
       config.getCurrentRegion() === "us-central1" ? "global" : "europe-west1";
 
     // Vertex does not support batches
-    this.inferenceClient = this.vertex
+    this.inferenceClient = this.useVertex
       ? new AnthropicVertex({
           region,
         })
@@ -146,7 +146,7 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
         toMessage(msg, {
           isLast: index === conversation.messages.length - 1,
           omittedThinking: this.omittedThinking,
-          convertToBase64: this.vertex,
+          convertToBase64: this.useVertex,
         }),
       { concurrency: 10 }
     );
@@ -205,7 +205,7 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
   }
 
   private getModel(): string {
-    if (!this.vertex) {
+    if (!this.useVertex) {
       return this.modelId;
     }
 

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -6,6 +6,9 @@ import type {
 import type { BetaMessageStreamParams } from "@anthropic-ai/sdk/resources/beta/messages";
 import AnthropicVertex from "@anthropic-ai/vertex-sdk";
 
+const MESSAGE_CONVERSION_CONCURRENCY = 10;
+const BATCH_PAYLOAD_BUILD_CONCURRENCY = 10;
+
 import type { AnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
 import {
   ANTHROPIC_PROVIDER_ID,
@@ -148,7 +151,7 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
           omittedThinking: this.omittedThinking,
           convertToBase64: this.useVertex,
         }),
-      { concurrency: 10 }
+      { concurrency: MESSAGE_CONVERSION_CONCURRENCY }
     );
 
     // Build thinking config, use custom type if specified.
@@ -261,7 +264,7 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
         custom_id: customId,
         params: await this.buildBaseRequestPayload(streamParams),
       }),
-      { concurrency: 10 }
+      { concurrency: BATCH_PAYLOAD_BUILD_CONCURRENCY }
     );
 
     const batch = await this.client.messages.batches.create({ requests });

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -5,10 +5,7 @@ import type {
 } from "@anthropic-ai/sdk/resources";
 import type { BetaMessageStreamParams } from "@anthropic-ai/sdk/resources/beta/messages";
 import AnthropicVertex from "@anthropic-ai/vertex-sdk";
-
-const MESSAGE_CONVERSION_CONCURRENCY = 10;
-const BATCH_PAYLOAD_BUILD_CONCURRENCY = 10;
-
+import config from "@app/lib/api/config";
 import type { AnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
 import {
   ANTHROPIC_PROVIDER_ID,
@@ -47,6 +44,9 @@ import { normalizePrompt } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import assert from "assert";
+
+const MESSAGE_CONVERSION_CONCURRENCY = 10;
+const BATCH_PAYLOAD_BUILD_CONCURRENCY = 10;
 
 /**
  * Maps prompt tiers to Anthropic system blocks with cache breakpoints.
@@ -129,6 +129,7 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
       ? // Routing everything to Europe first to check that Vertex works correctly.
         new AnthropicVertex({
           region: "europe-west1",
+          projectId: config.getVertexAiProjectId(),
         })
       : this.client;
   }

--- a/front/lib/api/llm/clients/anthropic/types.ts
+++ b/front/lib/api/llm/clients/anthropic/types.ts
@@ -100,3 +100,17 @@ export const isAnthropicWhitelistedModelId = (
     modelId
   );
 };
+
+export const VERTEX_MODEL_ID_MAP: Partial<Record<ModelIdType, string>> = {
+  [CLAUDE_4_5_SONNET_20250929_MODEL_ID]: "claude-sonnet-4-5@20250929",
+  [CLAUDE_SONNET_4_6_MODEL_ID]: "claude-sonnet-4-6@default",
+  [CLAUDE_OPUS_4_6_MODEL_ID]: "claude-opus-4-6@default",
+  [CLAUDE_4_5_OPUS_20251101_MODEL_ID]: "claude-opus-4-5@20251101",
+  [CLAUDE_4_5_HAIKU_20251001_MODEL_ID]: "claude-haiku-4-5@20251001",
+};
+
+export function isVertexWhitelistedModelId(
+  modelId: ModelIdType
+): modelId is keyof typeof VERTEX_MODEL_ID_MAP {
+  return modelId in VERTEX_MODEL_ID_MAP;
+}

--- a/front/lib/api/llm/clients/anthropic/types.ts
+++ b/front/lib/api/llm/clients/anthropic/types.ts
@@ -107,6 +107,7 @@ export const VERTEX_MODEL_ID_MAP: Partial<Record<ModelIdType, string>> = {
   [CLAUDE_OPUS_4_6_MODEL_ID]: "claude-opus-4-6@default",
   [CLAUDE_4_5_OPUS_20251101_MODEL_ID]: "claude-opus-4-5@20251101",
   [CLAUDE_4_5_HAIKU_20251001_MODEL_ID]: "claude-haiku-4-5@20251001",
+  [CLAUDE_OPUS_4_7_MODEL_ID]: "claude-opus-4-7@default",
 };
 
 export function isVertexWhitelistedModelId(

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -69,10 +69,12 @@ async function userContentToParam(
         content.image_url.url
       );
 
-      assert(
-        isAcceptedMediaType(mediaType),
-        `Unsupported media type: ${mediaType}`
-      );
+      if (!isAcceptedMediaType(mediaType)) {
+        return {
+          type: "text",
+          text: "Attachement: an unsupported media type was provided.",
+        };
+      }
 
       return {
         type: "image",

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -25,12 +25,28 @@ import type {
 } from "@app/types/assistant/generation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
+import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
 import assert from "assert";
 import compact from "lodash/compact";
 
-function userContentToParam(
-  content: Content
-): TextBlockParam | ImageBlockParam {
+const ACCEPTED_MEDIA_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+type AcceptedMediaType = (typeof ACCEPTED_MEDIA_TYPES)[number];
+
+function isAcceptedMediaType(
+  mediaType: string
+): mediaType is AcceptedMediaType {
+  return ACCEPTED_MEDIA_TYPES.includes(mediaType as AcceptedMediaType);
+}
+
+async function userContentToParam(
+  content: Content,
+  { convertToBase64 }: { convertToBase64?: boolean } = {}
+): Promise<TextBlockParam | ImageBlockParam> {
   switch (content.type) {
     case "text":
       return {
@@ -38,13 +54,36 @@ function userContentToParam(
         text: content.text,
       };
     case "image_url":
+      if (!convertToBase64) {
+        return {
+          type: "image",
+          source: {
+            type: "url",
+            url: content.image_url.url,
+          },
+        };
+      }
+
+      const { mediaType, data } = await trustedFetchImageBase64(
+        content.image_url.url
+      );
+
+      assert(
+        isAcceptedMediaType(mediaType),
+        `Unsupported media type: ${mediaType}`
+      );
+
       return {
         type: "image",
         source: {
-          type: "url",
-          url: content.image_url.url,
+          type: "base64",
+          media_type: mediaType,
+          data,
         },
       };
+
+    default:
+      assertNever(content);
   }
 }
 
@@ -90,30 +129,34 @@ function assistantContentToParam(
   }
 }
 
-function toolResultToParam(
+async function toolResultToParam(
   message: FunctionMessageTypeModel
-): ToolResultBlockParam {
+): Promise<ToolResultBlockParam> {
   return {
     type: "tool_result",
     tool_use_id: message.function_call_id,
     content: isString(message.content)
       ? message.content
-      : message.content.map(userContentToParam),
+      : await Promise.all(message.content.map((c) => userContentToParam(c))),
   };
 }
 
-function functionMessage(message: FunctionMessageTypeModel): MessageParam {
+async function functionMessage(
+  message: FunctionMessageTypeModel
+): Promise<MessageParam> {
   return {
     role: "user",
-    content: [toolResultToParam(message)],
+    content: [await toolResultToParam(message)],
   };
 }
 
-function userMessage(
+async function userMessage(
   message: UserMessageTypeModel,
-  { isLast }: { isLast: boolean }
-): MessageParam {
-  const content = message.content.map(userContentToParam);
+  { isLast, convertToBase64 }: { isLast: boolean; convertToBase64: boolean }
+): Promise<MessageParam> {
+  const content = await Promise.all(
+    message.content.map((c) => userContentToParam(c, { convertToBase64 }))
+  );
 
   // Add cache_control to the last content block if this is the last message.
   if (isLast && content.length > 0) {
@@ -144,16 +187,28 @@ function assistantMessage(
   };
 }
 
-export function toMessage(
+export async function toMessage(
   message: ModelMessageTypeMultiActionsWithoutContentFragment,
-  { isLast, omittedThinking }: { isLast: boolean; omittedThinking: boolean } = {
+  {
+    isLast,
+    omittedThinking,
+    convertToBase64,
+  }: {
+    isLast: boolean;
+    omittedThinking: boolean;
+    convertToBase64?: boolean;
+  } = {
     isLast: false,
     omittedThinking: false,
+    convertToBase64: false,
   }
-): MessageParam {
+): Promise<MessageParam> {
   switch (message.role) {
     case "user":
-      return userMessage(message, { isLast });
+      return userMessage(message, {
+        isLast,
+        convertToBase64: convertToBase64 ?? false,
+      });
     case "function":
       return functionMessage(message);
     case "assistant":

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -10,6 +10,7 @@ import type {
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { extractEncryptedContentFromMetadata } from "@app/lib/api/llm/utils";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   AgentFunctionCallContentType,
   AgentReasoningContentType,
@@ -137,7 +138,11 @@ async function toolResultToParam(
     tool_use_id: message.function_call_id,
     content: isString(message.content)
       ? message.content
-      : await Promise.all(message.content.map((c) => userContentToParam(c))),
+      : await concurrentExecutor(
+          message.content,
+          (c) => userContentToParam(c),
+          { concurrency: 10 }
+        ),
   };
 }
 
@@ -154,8 +159,10 @@ async function userMessage(
   message: UserMessageTypeModel,
   { isLast, convertToBase64 }: { isLast: boolean; convertToBase64: boolean }
 ): Promise<MessageParam> {
-  const content = await Promise.all(
-    message.content.map((c) => userContentToParam(c, { convertToBase64 }))
+  const content = await concurrentExecutor(
+    message.content,
+    (c) => userContentToParam(c, { convertToBase64 }),
+    { concurrency: 10 }
   );
 
   // Add cache_control to the last content block if this is the last message.

--- a/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
@@ -7,15 +7,17 @@ import { describe, expect, it } from "vitest";
 
 describe("toMessage", () => {
   describe("user messages", () => {
-    it("should convert user message with text and function calls", () => {
-      const messages = conversationMessages.map((msg) => toMessage(msg));
+    it("should convert user message with text and function calls", async () => {
+      const messages = await Promise.all(
+        conversationMessages.map((msg) => toMessage(msg))
+      );
 
       expect(messages).toEqual(inputMessages);
     });
 
-    it("should convert assistant message with reasoning/thinking content", () => {
-      const messages = reasoningConversationMessages.map((msg) =>
-        toMessage(msg)
+    it("should convert assistant message with reasoning/thinking content", async () => {
+      const messages = await Promise.all(
+        reasoningConversationMessages.map((msg) => toMessage(msg))
       );
 
       expect(messages).toEqual(reasoningInputMessages);
@@ -23,7 +25,7 @@ describe("toMessage", () => {
   });
 
   describe("cache_control", () => {
-    it("should not add cache_control when isLast is false", () => {
+    it("should not add cache_control when isLast is false", async () => {
       const userMessage = conversationMessages.find(
         (msg) => msg.role === "user"
       );
@@ -31,7 +33,7 @@ describe("toMessage", () => {
         throw new Error("No user message found in test fixtures");
       }
 
-      const result = toMessage(userMessage, {
+      const result = await toMessage(userMessage, {
         isLast: false,
         omittedThinking: false,
       });
@@ -44,7 +46,7 @@ describe("toMessage", () => {
       }
     });
 
-    it("should add cache_control to last content block when isLast is true", () => {
+    it("should add cache_control to last content block when isLast is true", async () => {
       const userMessage = conversationMessages.find(
         (msg) => msg.role === "user"
       );
@@ -52,7 +54,7 @@ describe("toMessage", () => {
         throw new Error("No user message found in test fixtures");
       }
 
-      const result = toMessage(userMessage, {
+      const result = await toMessage(userMessage, {
         isLast: true,
         omittedThinking: false,
       });
@@ -67,7 +69,7 @@ describe("toMessage", () => {
       }
     });
 
-    it("should not add cache_control to non-user messages", () => {
+    it("should not add cache_control to non-user messages", async () => {
       const assistantMessage = conversationMessages.find(
         (msg) => msg.role === "assistant"
       );
@@ -75,7 +77,7 @@ describe("toMessage", () => {
         throw new Error("No assistant message found in test fixtures");
       }
 
-      const result = toMessage(assistantMessage, {
+      const result = await toMessage(assistantMessage, {
         isLast: true,
         omittedThinking: false,
       });

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -1,5 +1,8 @@
 import { AnthropicLLM } from "@app/lib/api/llm/clients/anthropic";
-import { isAnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
+import {
+  isAnthropicWhitelistedModelId,
+  isVertexWhitelistedModelId,
+} from "@app/lib/api/llm/clients/anthropic/types";
 import { FireworksLLM } from "@app/lib/api/llm/clients/fireworks";
 import { isFireworksWhitelistedModelId } from "@app/lib/api/llm/clients/fireworks/types";
 import { GoogleLLM } from "@app/lib/api/llm/clients/google";
@@ -15,6 +18,7 @@ import { isXaiWhitelistedModelId } from "@app/lib/api/llm/clients/xai/types";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 
 export async function getLLM(
@@ -80,7 +84,17 @@ export async function getLLM(
   }
 
   if (isAnthropicWhitelistedModelId(modelId)) {
+    const featureFlags = await getFeatureFlags(auth);
+
+    const vertex =
+      // Vertex does not support structured outputs yet
+      !responseFormat &&
+      featureFlags.includes("use_vertex_for_claude_models") &&
+      !auth.getNonNullablePlan().isByok &&
+      isVertexWhitelistedModelId(modelId);
+
     return new AnthropicLLM(auth, {
+      vertex,
       credentials,
       getTraceInput,
       getTraceOutput,

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -89,7 +89,7 @@ export async function getLLM(
     const useVertex =
       // Vertex does not support structured outputs yet
       !responseFormat &&
-      featureFlags.includes("use_vertex_for_claude_models") &&
+      featureFlags.includes("use_vertex_for_anthropic_models") &&
       !auth.getNonNullablePlan().isByok &&
       isVertexWhitelistedModelId(modelId);
 

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -86,7 +86,7 @@ export async function getLLM(
   if (isAnthropicWhitelistedModelId(modelId)) {
     const featureFlags = await getFeatureFlags(auth);
 
-    const vertex =
+    const useVertex =
       // Vertex does not support structured outputs yet
       !responseFormat &&
       featureFlags.includes("use_vertex_for_claude_models") &&
@@ -94,7 +94,7 @@ export async function getLLM(
       isVertexWhitelistedModelId(modelId);
 
     return new AnthropicLLM(auth, {
-      vertex,
+      useVertex,
       credentials,
       getTraceInput,
       getTraceOutput,

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -87,8 +87,6 @@ export async function getLLM(
     const featureFlags = await getFeatureFlags(auth);
 
     const useVertex =
-      // Vertex does not support structured outputs yet
-      !responseFormat &&
       featureFlags.includes("use_vertex_for_anthropic_models") &&
       !auth.getNonNullablePlan().isByok &&
       isVertexWhitelistedModelId(modelId);

--- a/front/lib/reinforcement/workspace_check.ts
+++ b/front/lib/reinforcement/workspace_check.ts
@@ -21,7 +21,14 @@ export async function hasReinforcementEnabled(
  * Check whether batch mode is allowed for reinforcement in this workspace.
  * Defaults to true when not explicitly set.
  */
-export function isReinforcementBatchModeAllowed(auth: Authenticator): boolean {
+export async function isReinforcementBatchModeAllowed(
+  auth: Authenticator
+): Promise<boolean> {
+  // Vertex AI does not currently support batch processing.
+  if (await hasFeatureFlag(auth, "use_vertex_for_claude_models")) {
+    return false;
+  }
+
   const workspace = auth.getNonNullableWorkspace();
   return workspace.metadata?.allowReinforcementBatchMode !== false;
 }

--- a/front/lib/reinforcement/workspace_check.ts
+++ b/front/lib/reinforcement/workspace_check.ts
@@ -25,7 +25,7 @@ export async function isReinforcementBatchModeAllowed(
   auth: Authenticator
 ): Promise<boolean> {
   // Vertex AI does not currently support batch processing.
-  if (await hasFeatureFlag(auth, "use_vertex_for_claude_models")) {
+  if (await hasFeatureFlag(auth, "use_vertex_for_anthropic_models")) {
     return false;
   }
 

--- a/front/package.json
+++ b/front/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
+    "@anthropic-ai/vertex-sdk": "^0.14.4",
     "@contentful/rich-text-react-renderer": "^16.1.6",
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
@@ -149,6 +150,7 @@
     "fp-ts": "^2.16.5",
     "framer-motion": "^12.7.3",
     "fs-extra": "^11.1.1",
+    "google-auth-library": "^9.15.1",
     "googleapis": "^118.0.0",
     "hot-shots": "^12.1.0",
     "html-escaper": "^3.0.3",

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -503,7 +503,7 @@ export async function getReinforcementSettingsActivity({
 
   return {
     reinforcementEnabled: true,
-    batchModeAllowed: isReinforcementBatchModeAllowed(auth),
+    batchModeAllowed: await isReinforcementBatchModeAllowed(auth),
     globalConsumptionMicroUsd,
     globalCapMicroUsd,
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -491,6 +491,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
+        "@anthropic-ai/vertex-sdk": "^0.14.4",
         "@contentful/rich-text-react-renderer": "^16.1.6",
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
@@ -601,6 +602,7 @@
         "fp-ts": "^2.16.5",
         "framer-motion": "^12.7.3",
         "fs-extra": "^11.1.1",
+        "google-auth-library": "^9.15.1",
         "googleapis": "^118.0.0",
         "hot-shots": "^12.1.0",
         "html-escaper": "^3.0.3",
@@ -1180,6 +1182,16 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@anthropic-ai/vertex-sdk": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.14.4.tgz",
+      "integrity": "sha512-BZUPRWghZxfSFtAxU563wH+jfWBPoedAwsVxG35FhmNsjeV8tyfN+lFriWhCpcZApxA4NdT6Soov+PzfnxxD5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": ">=0.50.3 <1",
+        "google-auth-library": "^9.4.2"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {


### PR DESCRIPTION
## Description

Adds Vertex AI as an alternative inference backend for Claude models, using the existing `AnthropicLLM` client (authentication is the only meaningful difference between Vertex and the standard Anthropic client). When the `use_vertex_for_claude_models` feature flag is enabled, streaming requests are routed through `AnthropicVertex` instead of the standard Anthropic client — with three constraints:

- Only models explicitly listed in `VERTEX_MODEL_ID_MAP` are eligible
- Structured output (response format) is not yet supported on Vertex — those requests fall back to the standard client
- Batch processing is not supported on Vertex — batch requests always go through the standard Anthropic client
- URL sources are not supported (Images are converted to base64 when routing through Vertex)

## Tests

Tested manually and with real integration tests in `llm.test.ts` covering many inputs (conversations with text, images, tools, thinking, etc.) across all supported Vertex models.

## Risk

Low — gated behind a feature flag, BYOK requests are excluded, and any unsupported path (structured output, unlisted model, batch) silently falls back to the standard Anthropic client.

## Deploy Plan

- Secret VERTEX_AI_PROJECT_ID needed (use manage-gcp-secret script from infra)
- secret sync (github action)
- rollout restart front pods (+ agent loop)