### PR TITLE
Ensure runIds and tools are not billed multiple times

### DIFF
--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -247,6 +247,12 @@ async function _runModelAndCreateActionsActivity({
     stepContexts,
   } = modelResult;
 
+  // Generation completed (text response, no tool calls) — runModel returns
+  // { actions: [], runId } so we still capture the runId for tracking.
+  if (actions.length === 0) {
+    return { runId, actionBlobs: [] };
+  }
+
   // Enforce a limit on actions per step, reducing by depth (8/8/4/2)
   // to contain cascading fan-out from nested run_agent calls.
   const actionsToRun = actions.slice(

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -770,7 +770,12 @@ export async function runModel(
     });
     localLogger.info("Agent message generation succeeded");
 
-    return null;
+    return {
+      actions: [],
+      runId: dustRunId,
+      functionCallStepContentIds: updatedFunctionCallStepContentIds,
+      stepContexts: [],
+    };
   }
 
   // We have actions.

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -28,6 +28,7 @@ import type {
 } from "@temporalio/workflow";
 import {
   CancellationScope,
+  patched,
   proxyActivities,
   proxySinks,
   setHandler,
@@ -154,11 +155,12 @@ export async function agentLoopWorkflow({
     gracefulStopRequested = true;
   });
 
+  const runIds: string[] = [];
+
   try {
     const { agentMessageId, conversationId } = agentLoopArgs;
 
     await executionScope.run(async () => {
-      const runIds: string[] = [];
       const syncStartTime = Date.now();
       let currentStep = startStep;
       let childWorkflowHandle: ChildWorkflowHandle<
@@ -240,14 +242,22 @@ export async function agentLoopWorkflow({
         syncStartTime
       );
 
+      // Attach this execution's runIds so tracking workflows process only
+      // these runs (not all accumulated runs on the agent message).
+      // Pass this execution's runIds and startStep to finalize so tracking
+      // workflows only process this execution's runs and actions.
+      const argsWithRunIds = patched("pass-dustRunIds-to-finalize")
+        ? { ...agentLoopArgs, dustRunIds: runIds, startStep }
+        : agentLoopArgs;
+
       await CancellationScope.nonCancellable(async () => {
         if (gracefulStopRequested) {
           await finalizeGracefullyStoppedAgentLoopActivity(
             authType,
-            agentLoopArgs
+            argsWithRunIds
           );
         } else {
-          await finalizeSuccessfulAgentLoopActivity(authType, agentLoopArgs);
+          await finalizeSuccessfulAgentLoopActivity(authType, argsWithRunIds);
         }
       });
 
@@ -260,13 +270,18 @@ export async function agentLoopWorkflow({
 
     // Notify error in a non-cancellable scope to ensure it runs even if the workflow is canceled.
     await CancellationScope.nonCancellable(async () => {
+      // Pass this execution's runIds and startStep to finalize so tracking
+      // workflows only process this execution's runs and actions.
+      const argsWithRunIds = patched("pass-dustRunIds-to-finalize")
+        ? { ...agentLoopArgs, dustRunIds: runIds, startStep }
+        : agentLoopArgs;
       if (cancelRequested) {
-        return finalizeCancelledAgentLoopActivity(authType, agentLoopArgs);
+        return finalizeCancelledAgentLoopActivity(authType, argsWithRunIds);
       }
       // Error objects don't survive JSON serialization across the workflow→activity boundary
       // (Error.message is not enumerable), so we extract the relevant fields into a plain object
       // before passing to the activity.
-      await finalizeErroredAgentLoopActivity(authType, agentLoopArgs, {
+      await finalizeErroredAgentLoopActivity(authType, argsWithRunIds, {
         message: workflowError.message,
         name: workflowError.name,
       });
@@ -300,7 +315,7 @@ async function executeStepIteration({
   });
 
   if (!result) {
-    // Generation completed or error occurred.
+    // Error occurred — no runId to capture.
     return {
       runId: null,
       shouldContinue: false,
@@ -308,6 +323,14 @@ async function executeStepIteration({
   }
 
   const { runId, actionBlobs } = result;
+
+  // Generation completed (text response, no tool calls).
+  if (actionBlobs.length === 0) {
+    return {
+      runId,
+      shouldContinue: false,
+    };
+  }
 
   // If at least one action needs approval, we break out of the loop and will resume once all
   // actions have been approved.

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -1,3 +1,4 @@
+import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import {
   isProgrammaticUsage,
   trackProgrammaticCost,
@@ -35,7 +36,7 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import { isDevelopment } from "@app/types/shared/env";
-import { Context } from "@temporalio/activity";
+import { createHash } from "crypto";
 
 export async function recordUsageActivity(workspaceId: string) {
   const workspace = await WorkspaceResource.fetchById(workspaceId);
@@ -160,9 +161,14 @@ export async function trackProgrammaticUsageActivity(
 
   const userMessageOrigin = userMessage.userContextOrigin;
 
+  // Use dustRunIds from this specific agent loop execution if available,
+  // fall back to all accumulated runIds on the message (legacy behavior).
+  const effectiveRunIds = agentLoopArgs.dustRunIds ?? agentMessage.runIds;
+
   if (
     AGENT_MESSAGE_STATUSES_TO_TRACK.includes(agentMessage.status) &&
-    agentMessage.runIds &&
+    effectiveRunIds &&
+    effectiveRunIds.length > 0 &&
     isProgrammaticUsage(auth, { userMessageOrigin })
   ) {
     const localLogger = logger.child({
@@ -180,7 +186,7 @@ export async function trackProgrammaticUsageActivity(
     const result = await trackProgrammaticCost(
       auth,
       {
-        dustRunIds: agentMessage.runIds,
+        dustRunIds: effectiveRunIds,
         userMessageOrigin,
       },
       localLogger
@@ -230,7 +236,14 @@ export async function emitMetronomeUsageEventsActivity(
   });
 
   const agentMessage = agentMessageRow?.agentMessage;
-  if (!agentMessage || !agentMessage.runIds) {
+  if (!agentMessage) {
+    return;
+  }
+
+  // Use dustRunIds from this specific agent loop execution if available,
+  // fall back to all accumulated runIds on the message (legacy behavior).
+  const effectiveRunIds = agentLoopArgs.dustRunIds ?? agentMessage.runIds;
+  if (!effectiveRunIds || effectiveRunIds.length === 0) {
     return;
   }
 
@@ -276,7 +289,7 @@ export async function emitMetronomeUsageEventsActivity(
 
   // Get LLM run usages.
   const runs = await RunResource.listByDustRunIds(auth, {
-    dustRunIds: agentMessage.runIds,
+    dustRunIds: effectiveRunIds,
   });
   const runUsages = (
     await concurrentExecutor(
@@ -288,10 +301,26 @@ export async function emitMetronomeUsageEventsActivity(
     )
   ).flat();
 
-  // Get MCP actions.
-  const mcpActions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
-    agentMessage.id,
-  ]);
+  // Get MCP actions — filter to this execution's steps if startStep is available,
+  // and only include actions with a final status (succeeded/errored/denied).
+  // Actions with blocked/transient status haven't been executed yet and shouldn't be billed.
+  const allMcpActions = await AgentMCPActionResource.listByAgentMessageIds(
+    auth,
+    [agentMessage.id]
+  );
+  const mcpActions = allMcpActions.filter((a) => {
+    const json = a.toJSON();
+    if (!isToolExecutionStatusFinal(json.status)) {
+      return false;
+    }
+    if (
+      agentLoopArgs.startStep !== undefined &&
+      json.step < agentLoopArgs.startStep
+    ) {
+      return false;
+    }
+    return true;
+  });
   const toolActions = mcpActions.map((a) => {
     const json = a.toJSON();
     return {
@@ -303,10 +332,13 @@ export async function emitMetronomeUsageEventsActivity(
     };
   });
 
-  // Use the Temporal workflow run ID as the unique key — each workflow execution
-  // gets a unique runId, even when the workflow ID is reused across retries.
-  const { runId: workflowRunId } = Context.current().info.workflowExecution;
-  const runKey = workflowRunId.slice(0, 12);
+  // Deterministic runKey based on the specific dustRunIds being processed.
+  // Same runIds → same transaction IDs → Metronome deduplicates retries.
+  // Different runIds (new agent loop execution) → different transaction IDs.
+  const runKey = createHash("sha256")
+    .update(effectiveRunIds.sort().join(","))
+    .digest("hex")
+    .slice(0, 8);
 
   // Build and ingest events.
   const llmEvents = buildLlmUsageEvents({

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -128,6 +128,14 @@ export type AgentLoopArgs = {
   userMessageOrigin?: UserMessageOrigin | null;
 
   caching?: ConversationCaching;
+
+  // RunIds from the specific agent loop execution. Used by tracking workflows
+  // to process only this execution's runs (not all accumulated runs on the message).
+  dustRunIds?: string[];
+
+  // The step at which this agent loop execution started. Used to filter MCP actions
+  // to only those from this execution (step >= startStep).
+  startStep?: number;
 };
 
 export type AgentMessageRef = {


### PR DESCRIPTION
fixes: https://github.com/dust-tt/dust/issues/23855

## Summary

Fixes a bug where agent loop restarts caused usage tracking to either double-count or silently drop runs, depending on timing.

### The bug

When the agent loop workflow restarts (validation re-run, retry), each execution calls finalize which launches tracking workflows (`trackProgrammaticUsageWorkflow`, `emitMetronomeUsageEventsWorkflow`). These workflows re-read **all accumulated `runIds`** and **all MCP actions** from the DB — not just those from the current execution.

- **First execution** creates run A → finalize launches tracking → tracks cost(A) ✓
- **Second execution** creates run B → `runIds` in DB is now [A, B] → finalize tries to launch tracking, but `WorkflowExecutionAlreadyStartedError` blocks it (same workflow ID) → **run B is silently dropped**

Same issue for MCP tool actions — actions from all executions are fetched, but only the first tracking workflow runs.

### The fix

**1. Pass `dustRunIds` and `startStep` via `AgentLoopArgs`**

The agent loop workflow already tracks its own `runIds` array locally (`workflows.ts:161`). Now passes `dustRunIds` and `startStep` on `agentLoopArgs` before calling finalize activities. Uses `patched("pass-dustRunIds-to-finalize")` for backward compatibility with in-flight workflows.

**2. Unique workflow IDs per execution**

Tracking workflow IDs now include a hash of the `dustRunIds` (`helpers.ts`). Same runIds = same hash (dedup retries). Different runIds = different hash (new execution gets its own workflow).

**3. Activities use passed runIds**

- `emitMetronomeUsageEventsActivity`: uses `agentLoopArgs.dustRunIds` if available, falls back to `agentMessage.runIds` (backward compatible)
- `trackProgrammaticUsageActivity`: same pattern
- MCP actions filtered by `step >= startStep` when available

**4. Deterministic Metronome transaction IDs**

`runKey` in Metronome event `transaction_id` is now a hash of the effective runIds (not the Temporal workflow runId). Same runs = same transaction IDs = Metronome deduplicates retries. Different runs = different transaction IDs = no data loss.

### Files changed

| File | Change |
|------|--------|
| `types/assistant/agent_run.ts` | Added optional `dustRunIds` and `startStep` to `AgentLoopArgs` |
| `temporal/agent_loop/workflows.ts` | Sets `dustRunIds` + `startStep` on args before finalize (behind `patched()`) |
| `temporal/usage_queue/helpers.ts` | Workflow IDs include `hashRunIds` for per-execution uniqueness |
| `temporal/usage_queue/client.ts` | Reads `dustRunIds` from `agentLoopArgs` for workflow ID hash |
| `temporal/usage_queue/activities.ts` | Both activities use `agentLoopArgs.dustRunIds`/`startStep`, fall back to DB |

## Test plan

- [ ] Single agent loop execution → tracking works as before
- [ ] Agent loop restart (validation re-run) → both executions tracked separately
- [ ] In-flight v2 workflows → `patched()` returns false, legacy behavior preserved
- [ ] Temporal workflow retry → same dustRunIds hash → `WorkflowExecutionAlreadyStartedError` (correct dedup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)