### PR TITLE
Deprecate patch

### DIFF
--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -28,7 +28,7 @@ import type {
 } from "@temporalio/workflow";
 import {
   CancellationScope,
-  patched,
+  deprecatePatch,
   proxyActivities,
   proxySinks,
   setHandler,
@@ -246,9 +246,12 @@ export async function agentLoopWorkflow({
       // these runs (not all accumulated runs on the agent message).
       // Pass this execution's runIds and startStep to finalize so tracking
       // workflows only process this execution's runs and actions.
-      const argsWithRunIds = patched("pass-dustRunIds-to-finalize")
-        ? { ...agentLoopArgs, dustRunIds: runIds, startStep }
-        : agentLoopArgs;
+      deprecatePatch("pass-dustRunIds-to-finalize");
+      const argsWithRunIds = {
+        ...agentLoopArgs,
+        dustRunIds: runIds,
+        startStep,
+      };
 
       await CancellationScope.nonCancellable(async () => {
         if (gracefulStopRequested) {
@@ -272,9 +275,12 @@ export async function agentLoopWorkflow({
     await CancellationScope.nonCancellable(async () => {
       // Pass this execution's runIds and startStep to finalize so tracking
       // workflows only process this execution's runs and actions.
-      const argsWithRunIds = patched("pass-dustRunIds-to-finalize")
-        ? { ...agentLoopArgs, dustRunIds: runIds, startStep }
-        : agentLoopArgs;
+      deprecatePatch("pass-dustRunIds-to-finalize");
+      const argsWithRunIds = {
+        ...agentLoopArgs,
+        dustRunIds: runIds,
+        startStep,
+      };
       if (cancelRequested) {
         return finalizeCancelledAgentLoopActivity(authType, argsWithRunIds);
       }


### PR DESCRIPTION
## Summary

Follow-up to #23860. Replaces `patched("pass-dustRunIds-to-finalize")` with `deprecatePatch("pass-dustRunIds-to-finalize")` and removes the conditional branch.

`dustRunIds` and `startStep` are now always passed to finalize activities. Old in-flight workflows that still have the patch marker in their history will replay correctly via `deprecatePatch`.

### Next step

Once all old workflows have completed (~1 week), remove the `deprecatePatch` call entirely.

## Test plan

- [ ] New workflows pass `dustRunIds` + `startStep` unconditionally
- [ ] Old in-flight workflows replay without non-determinism errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)