### PR TITLE
Show search query in inline activity timeline labels

### DIFF
--- a/front/lib/api/assistant/activity_steps.ts
+++ b/front/lib/api/assistant/activity_steps.ts
@@ -1,4 +1,8 @@
 import {
+  isSearchInputType,
+  isWebsearchInputType,
+} from "@app/lib/actions/mcp_internal_actions/types";
+import {
   AgentMessageContentParser,
   getCoTDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
@@ -13,6 +17,27 @@ import {
 import type { InlineActivityStep } from "@app/types/assistant/conversation";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 
+const MAX_QUERY_DISPLAY_LENGTH = 60;
+
+function truncateQuery(query: string): string {
+  return query.length > MAX_QUERY_DISPLAY_LENGTH
+    ? query.slice(0, MAX_QUERY_DISPLAY_LENGTH) + "…"
+    : query;
+}
+
+function getQueryLabel(action: AgentMCPActionWithOutputType): string | null {
+  if (action.toolName === "websearch" && isWebsearchInputType(action.params)) {
+    return truncateQuery(action.params.query);
+  }
+  if (
+    action.toolName === "semantic_search" &&
+    isSearchInputType(action.params)
+  ) {
+    return truncateQuery(action.params.query);
+  }
+  return null;
+}
+
 /**
  * Compute the display label for an action (one-line summary).
  * Pure function with no browser dependencies — usable server-side and client-side.
@@ -21,6 +46,13 @@ export function getActionOneLineLabel(
   action: AgentMCPActionWithOutputType,
   context: "running" | "done" = "done"
 ): string {
+  const queryLabel = getQueryLabel(action);
+  if (queryLabel) {
+    return context === "running"
+      ? `Searching "${queryLabel}"`
+      : `Searched "${queryLabel}"`;
+  }
+
   if (action.displayLabels) {
     return action.displayLabels[context];
   }

--- a/front/lib/api/assistant/activity_steps.ts
+++ b/front/lib/api/assistant/activity_steps.ts
@@ -21,19 +21,28 @@ const MAX_QUERY_DISPLAY_LENGTH = 60;
 
 function truncateQuery(query: string): string {
   return query.length > MAX_QUERY_DISPLAY_LENGTH
-    ? query.slice(0, MAX_QUERY_DISPLAY_LENGTH) + "…"
+    ? query.slice(0, MAX_QUERY_DISPLAY_LENGTH) + "\u2026"
     : query;
 }
 
-function getQueryLabel(action: AgentMCPActionWithOutputType): string | null {
+function getToolInlineLabel(
+  action: AgentMCPActionWithOutputType,
+  context: "running" | "done"
+): string | null {
   if (action.toolName === "websearch" && isWebsearchInputType(action.params)) {
-    return truncateQuery(action.params.query);
+    const q = truncateQuery(action.params.query);
+    return context === "running"
+      ? `Searching \u201c${q}\u201d`
+      : `Searched \u201c${q}\u201d`;
   }
   if (
     action.toolName === "semantic_search" &&
     isSearchInputType(action.params)
   ) {
-    return truncateQuery(action.params.query);
+    const q = truncateQuery(action.params.query);
+    return context === "running"
+      ? `Searching \u201c${q}\u201d`
+      : `Searched \u201c${q}\u201d`;
   }
   return null;
 }
@@ -46,19 +55,11 @@ export function getActionOneLineLabel(
   action: AgentMCPActionWithOutputType,
   context: "running" | "done" = "done"
 ): string {
-  const queryLabel = getQueryLabel(action);
-  if (queryLabel) {
-    return context === "running"
-      ? `Searching "${queryLabel}"`
-      : `Searched "${queryLabel}"`;
-  }
-
-  if (action.displayLabels) {
-    return action.displayLabels[context];
-  }
-  return action.functionCallName
-    ? asDisplayName(action.functionCallName)
-    : "Tool";
+  return (
+    getToolInlineLabel(action, context) ??
+    action.displayLabels?.[context] ??
+    (action.functionCallName ? asDisplayName(action.functionCallName) : "Tool")
+  );
 }
 
 /**


### PR DESCRIPTION
## Description

Instead of generic "Searching the web" / "Searching data sources", display the actual query for websearch and semantic_search tools in the inline activity timeline. Truncates at 60 chars.

Very pragmatic to put this code here, I think fair cause we're unsure wether we'll want the same title in the side panel or here. Happy to refactor later if we have a better idea. 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
