### PR TITLE
[front] enh: improve rendering of `ask_user_question` answers

### DIFF
--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -59,9 +59,6 @@ export const UserQuestionAnswerSchema = z.object({
 
 export type UserQuestionAnswer = z.infer<typeof UserQuestionAnswerSchema>;
 
-export const USER_QUESTION_DECLINED_MESSAGE =
-  "User declined to answer. Proceed with your best judgment.";
-
 const UserQuestionResumeStateSchema = z.object({
   type: z.literal("user_question"),
   question: UserQuestionSchema,

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -59,6 +59,9 @@ export const UserQuestionAnswerSchema = z.object({
 
 export type UserQuestionAnswer = z.infer<typeof UserQuestionAnswerSchema>;
 
+export const USER_QUESTION_DECLINED_MESSAGE =
+  "User declined to answer. Proceed with your best judgment.";
+
 const UserQuestionResumeStateSchema = z.object({
   type: z.literal("user_question"),
   question: UserQuestionSchema,

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -26,15 +26,21 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
         selections.push(`Other: ${answer.customResponse}`);
       }
 
-      const answerText =
-        selections.length > 0
-          ? selections.join(", ")
-          : "User declined to answer. Proceed with your best judgment.";
+      if (selections.length === 0) {
+        return new Ok([
+          {
+            type: "text",
+            text: USER_QUESTION_DECLINED_MESSAGE,
+          },
+        ]);
+      }
 
       return new Ok([
         {
           type: "text",
-          text: `${typedQuestion.question}: ${answerText}`,
+          text:
+            `User has answered your questions: "${question}"="${selections.join(", ")}". ` +
+            `You can now continue with the user's answers in mind`,
         },
       ]);
     }

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -1,7 +1,9 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { UserQuestion } from "@app/lib/actions/types";
-import { isUserQuestionResumeState } from "@app/lib/actions/types";
+import {
+  isUserQuestionResumeState,
+  USER_QUESTION_DECLINED_MESSAGE,
+} from "@app/lib/actions/types";
 import { ASK_USER_QUESTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/ask_user_question/metadata";
 import { Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -11,19 +13,13 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
     { question, options, multiSelect },
     { agentLoopContext }
   ) => {
-    const typedQuestion: UserQuestion = {
-      question,
-      options,
-      multiSelect,
-    };
-
     const resumeState = agentLoopContext?.runContext?.stepContext?.resumeState;
     if (isUserQuestionResumeState(resumeState) && resumeState.answer) {
       const { answer } = resumeState;
       const selections: string[] = [];
       for (const idx of answer.selectedOptions) {
-        if (idx >= 0 && idx < typedQuestion.options.length) {
-          selections.push(typedQuestion.options[idx].label);
+        if (idx >= 0 && idx < options.length) {
+          selections.push(options[idx].label);
         }
       }
       if (answer.customResponse) {
@@ -49,8 +45,8 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
         resource: {
           mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
           type: "tool_user_answer_required",
-          question: typedQuestion,
-          text: `Asking user: ${typedQuestion.question}`,
+          question: { question, options, multiSelect },
+          text: `Asking user: ${question}`,
           uri: "",
         },
       },

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -37,7 +37,7 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
           type: "text",
           text:
             `User has answered your questions: "${question}"="${selections.join(", ")}". ` +
-            `You can now continue with the user's answers in mind`,
+            "You can now continue with the user's answers in mind",
         },
       ]);
     }

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -1,9 +1,6 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import {
-  isUserQuestionResumeState,
-  USER_QUESTION_DECLINED_MESSAGE,
-} from "@app/lib/actions/types";
+import { isUserQuestionResumeState } from "@app/lib/actions/types";
 import { ASK_USER_QUESTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/ask_user_question/metadata";
 import { Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -30,7 +27,7 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
         return new Ok([
           {
             type: "text",
-            text: USER_QUESTION_DECLINED_MESSAGE,
+            text: "User declined to answer. Proceed with your best judgment.",
           },
         ]);
       }


### PR DESCRIPTION
## Description

- This PR improves how the answers of the `ask_user_questions` are rendered for the model.
- Had an example locally where I answered to the question with a question and got the model slightly confused as to whether I had answered or not.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
