### PR TITLE
[Tool Calls] Keep inline loader below pending tool row

### DIFF
--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -131,6 +131,9 @@ export function InlineActivitySteps({
   const latestPendingToolCall = showPendingToolCalls
     ? pendingToolCalls[pendingToolCalls.length - 1]
     : null;
+  const showTrailingLoader =
+    (showActiveThinking && !chainOfThought) ||
+    (showActiveWriting && !agentMessage.content);
   const activeAction =
     isActing && isAgentMessageWithActions ? actions[actions.length - 1] : null;
 
@@ -264,12 +267,17 @@ export function InlineActivitySteps({
             })}
 
             {/* Active thinking (streaming CoT) */}
-            {showActiveThinking && (
+            {showActiveThinking && chainOfThought && (
               <ThinkingStep
                 content={chainOfThought}
                 isStreaming
                 isMessageDone={false}
-                isLast={!activeAction && !isDone}
+                isLast={
+                  !activeAction &&
+                  !latestPendingToolCall &&
+                  !showTrailingLoader &&
+                  !isDone
+                }
               />
             )}
 
@@ -286,8 +294,6 @@ export function InlineActivitySteps({
                   isLastMessage={false}
                 />
               </div>
-            ) : showActiveWriting ? (
-              <TimelineRow spinner isLast={!activeAction && !isDone} />
             ) : null}
 
             {/* Active action (tool in progress) */}
@@ -301,12 +307,14 @@ export function InlineActivitySteps({
 
             {latestPendingToolCall &&
               renderRunningToolRow({
-                isLast: !isDone,
+                isLast: !isDone && !showTrailingLoader,
                 label: getToolCallDisplayLabel(
                   latestPendingToolCall.toolName,
                   "running"
                 ),
               })}
+
+            {showTrailingLoader && <TimelineRow spinner isLast={!isDone} />}
 
             {/* Pending spinner — shown when between transitions (not done, nothing active) */}
             {!isDone &&


### PR DESCRIPTION
## Description
Fixes regression in https://github.com/dust-tt/dust/pull/23859.

Spinner-only thinking and writing states are now treated as a trailing loader in the inline activity timeline, so the live loader stays below the pending tool row instead of rendering above it.

## Risks
Blast radius: inline activity rendering for live thinking/writing states around pending tool calls.
Risk: low

## Deploy Plan
- pmrr
- deploy front