### PR TITLE
[front] fix MCP action details for `ask_user_question` tool

### DIFF
--- a/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
@@ -87,7 +87,7 @@ export function MCPAskUserQuestionActionDetails({
             )}
           </div>
           {isDeclined && (
-            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+            <div className="text-sm text-foreground dark:text-foreground-night">
               User declined to answer
             </div>
           )}

--- a/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
@@ -28,7 +28,7 @@ export function MCPAskUserQuestionActionDetails({
       }
       visual={ChatBubbleBottomCenterTextIcon}
     >
-      {displayContext !== "conversation" && userQuestion && (
+      {displayContext !== "conversation" && userQuestion && outputText && (
         <div className="flex flex-col gap-3 pl-6 pt-4">
           <div className="text-sm font-medium text-foreground dark:text-foreground-night">
             {userQuestion.question}

--- a/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
@@ -18,9 +18,10 @@ export function MCPAskUserQuestionActionDetails({
   const userQuestion = parsed.success ? parsed.data : null;
 
   const outputText = toolOutput?.find(isTextContent)?.text ?? null;
-  const { selectedLabels, customAnswer, isDeclined } = outputText
-    ? parseUserQuestionAnswer(outputText)
-    : { selectedLabels: [], customAnswer: null, isDeclined: false };
+  const { selectedLabels, customAnswer, isDeclined } =
+    outputText && userQuestion
+      ? parseUserQuestionAnswer(outputText, userQuestion.question)
+      : { selectedLabels: [], customAnswer: null, isDeclined: false };
 
   return (
     <ActionDetailsWrapper
@@ -44,28 +45,30 @@ export function MCPAskUserQuestionActionDetails({
               return (
                 <div
                   key={index}
-                  className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night"
+                  className="flex flex-col text-sm text-muted-foreground dark:text-muted-foreground-night"
                 >
-                  <Icon
-                    visual={CheckIcon}
-                    size="xs"
-                    className={
-                      isSelected
-                        ? "text-primary dark:text-primary-night"
-                        : "invisible"
-                    }
-                  />
-                  <span
-                    className={
-                      isSelected
-                        ? "font-medium text-foreground dark:text-foreground-night"
-                        : ""
-                    }
-                  >
-                    {label}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    <Icon
+                      visual={CheckIcon}
+                      size="xs"
+                      className={
+                        isSelected
+                          ? "text-primary dark:text-primary-night"
+                          : "invisible"
+                      }
+                    />
+                    <span
+                      className={
+                        isSelected
+                          ? "font-medium text-foreground dark:text-foreground-night"
+                          : ""
+                      }
+                    >
+                      {label}
+                    </span>
+                  </div>
                   {description && (
-                    <span className="text-xs">{description}</span>
+                    <span className="ml-6 text-xs">{description}</span>
                   )}
                 </div>
               );

--- a/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAskUserQuestionActionDetails.tsx
@@ -2,6 +2,7 @@ import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapp
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { UserQuestionSchema } from "@app/lib/actions/types";
+import { parseUserQuestionAnswer } from "@app/lib/actions/user_question";
 import {
   ChatBubbleBottomCenterTextIcon,
   CheckIcon,
@@ -16,7 +17,10 @@ export function MCPAskUserQuestionActionDetails({
   const parsed = UserQuestionSchema.safeParse(toolParams);
   const userQuestion = parsed.success ? parsed.data : null;
 
-  const answerText = toolOutput?.find(isTextContent)?.text ?? null;
+  const outputText = toolOutput?.find(isTextContent)?.text ?? null;
+  const { selectedLabels, customAnswer, isDeclined } = outputText
+    ? parseUserQuestionAnswer(outputText)
+    : { selectedLabels: [], customAnswer: null, isDeclined: false };
 
   return (
     <ActionDetailsWrapper
@@ -35,25 +39,22 @@ export function MCPAskUserQuestionActionDetails({
           </div>
           <div className="flex flex-col gap-1.5">
             {userQuestion.options.map(({ label, description }, index) => {
-              const isSelected =
-                answerText !== null && answerText.includes(label);
+              const isSelected = selectedLabels.includes(label);
 
               return (
                 <div
                   key={index}
                   className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night"
                 >
-                  {answerText && (
-                    <Icon
-                      visual={CheckIcon}
-                      size="xs"
-                      className={
-                        isSelected
-                          ? "text-primary dark:text-primary-night"
-                          : "invisible"
-                      }
-                    />
-                  )}
+                  <Icon
+                    visual={CheckIcon}
+                    size="xs"
+                    className={
+                      isSelected
+                        ? "text-primary dark:text-primary-night"
+                        : "invisible"
+                    }
+                  />
                   <span
                     className={
                       isSelected
@@ -69,7 +70,24 @@ export function MCPAskUserQuestionActionDetails({
                 </div>
               );
             })}
+            {customAnswer && (
+              <div className="flex items-center gap-2 text-sm">
+                <Icon
+                  visual={CheckIcon}
+                  size="xs"
+                  className="text-primary dark:text-primary-night"
+                />
+                <span className="font-medium text-foreground dark:text-foreground-night">
+                  {customAnswer}
+                </span>
+              </div>
+            )}
           </div>
+          {isDeclined && (
+            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              User declined to answer
+            </div>
+          )}
         </div>
       )}
     </ActionDetailsWrapper>

--- a/front/lib/actions/user_question.ts
+++ b/front/lib/actions/user_question.ts
@@ -3,6 +3,8 @@ import type { UserQuestion, UserQuestionAnswer } from "@app/lib/actions/types";
 export const USER_QUESTION_DECLINED_MESSAGE =
   "User declined to answer. Proceed with your best judgment.";
 
+const CUSTOM_ANSWER_PREFIX = "Other: ";
+
 export function getUserQuestionSelections(
   question: UserQuestion,
   answer: UserQuestionAnswer
@@ -14,7 +16,7 @@ export function getUserQuestionSelections(
     }
   }
   if (answer.customResponse) {
-    selections.push(`Other: ${answer.customResponse}`);
+    selections.push(`${CUSTOM_ANSWER_PREFIX}${answer.customResponse}`);
   }
   return selections;
 }
@@ -29,15 +31,33 @@ export function formatUserQuestionAnswer(
   );
 }
 
-export function parseUserQuestionSelections(outputText: string): string[] {
+export function parseUserQuestionAnswer(
+  outputText: string
+): {
+  selectedLabels: string[];
+  customAnswer: string | null;
+} {
   const selectionsStart = outputText.indexOf('"="');
   if (selectionsStart === -1) {
-    return [];
+    return { selectedLabels: [], customAnswer: null };
   }
   const start = selectionsStart + 3;
   const end = outputText.indexOf('".', start);
   if (end === -1) {
-    return [];
+    return { selectedLabels: [], customAnswer: null };
   }
-  return outputText.slice(start, end).split(", ");
+
+  const parts = outputText.slice(start, end).split(", ");
+  const selectedLabels: string[] = [];
+  let customAnswer: string | null = null;
+
+  for (const part of parts) {
+    if (part.startsWith(CUSTOM_ANSWER_PREFIX)) {
+      customAnswer = part;
+    } else {
+      selectedLabels.push(part);
+    }
+  }
+
+  return { selectedLabels, customAnswer };
 }

--- a/front/lib/actions/user_question.ts
+++ b/front/lib/actions/user_question.ts
@@ -1,0 +1,43 @@
+import type { UserQuestion, UserQuestionAnswer } from "@app/lib/actions/types";
+
+export const USER_QUESTION_DECLINED_MESSAGE =
+  "User declined to answer. Proceed with your best judgment.";
+
+export function getUserQuestionSelections(
+  question: UserQuestion,
+  answer: UserQuestionAnswer
+): string[] {
+  const selections: string[] = [];
+  for (const idx of answer.selectedOptions) {
+    if (idx >= 0 && idx < question.options.length) {
+      selections.push(question.options[idx].label);
+    }
+  }
+  if (answer.customResponse) {
+    selections.push(`Other: ${answer.customResponse}`);
+  }
+  return selections;
+}
+
+export function formatUserQuestionAnswer(
+  question: string,
+  selections: string[]
+): string {
+  return (
+    `User has answered your questions: "${question}"="${selections.join(", ")}". ` +
+    `You can now continue with the user's answers in mind`
+  );
+}
+
+export function parseUserQuestionSelections(outputText: string): string[] {
+  const selectionsStart = outputText.indexOf('"="');
+  if (selectionsStart === -1) {
+    return [];
+  }
+  const start = selectionsStart + 3;
+  const end = outputText.indexOf('".', start);
+  if (end === -1) {
+    return [];
+  }
+  return outputText.slice(start, end).split(", ");
+}

--- a/front/lib/actions/user_question.ts
+++ b/front/lib/actions/user_question.ts
@@ -3,6 +3,9 @@ import type { UserQuestion, UserQuestionAnswer } from "@app/lib/actions/types";
 export const USER_QUESTION_DECLINED_MESSAGE =
   "User declined to answer. Proceed with your best judgment.";
 
+const ANSWER_PREFIX = 'User has answered your question: "';
+const ANSWER_SUFFIX =
+  "\". You can now continue with the user's answers in mind.";
 const CUSTOM_ANSWER_PREFIX = "Other: ";
 
 export function getUserQuestionSelections(
@@ -25,39 +28,36 @@ export function formatUserQuestionAnswer(
   question: string,
   selections: string[]
 ): string {
-  return (
-    `User has answered your questions: "${question}"="${selections.join(", ")}". ` +
-    `You can now continue with the user's answers in mind`
-  );
+  return `${ANSWER_PREFIX}${question}"="${selections.join(", ")}${ANSWER_SUFFIX}`;
 }
 
-export function parseUserQuestionAnswer(outputText: string): {
+export function parseUserQuestionAnswer(
+  outputText: string,
+  question: string
+): {
   selectedLabels: string[];
   customAnswer: string | null;
   isDeclined: boolean;
 } {
-  let  selectedLabels: string[] = [];
+  const selectedLabels: string[] = [];
   let customAnswer: string | null = null;
-  let isDeclined = true;
-  
+  let isDeclined = false;
+
   if (outputText === USER_QUESTION_DECLINED_MESSAGE) {
-    isDeclined = true;
+    return { selectedLabels, customAnswer, isDeclined: true };
+  }
+
+  const prefix = `${ANSWER_PREFIX}${question}"="`;
+  if (!outputText.startsWith(prefix) || !outputText.endsWith(ANSWER_SUFFIX)) {
     return { selectedLabels, customAnswer, isDeclined };
   }
 
-  const selectionsStart = outputText.indexOf('"="');
-  if (selectionsStart === -1) {
-    return { selectedLabels, customAnswer, isDeclined };
-  }
-  const start = selectionsStart + 3;
-  const end = outputText.indexOf('".', start);
-  if (end === -1) {
-    return { selectedLabels, customAnswer, isDeclined };
-  }
+  const selectionsText = outputText.slice(
+    prefix.length,
+    outputText.length - ANSWER_SUFFIX.length
+  );
 
-  const parts = outputText.slice(start, end).split(", ");
-
-  for (const part of parts) {
+  for (const part of selectionsText.split(", ")) {
     if (part.startsWith(CUSTOM_ANSWER_PREFIX)) {
       customAnswer = part;
     } else {

--- a/front/lib/actions/user_question.ts
+++ b/front/lib/actions/user_question.ts
@@ -31,25 +31,31 @@ export function formatUserQuestionAnswer(
   );
 }
 
-export function parseUserQuestionAnswer(
-  outputText: string
-): {
+export function parseUserQuestionAnswer(outputText: string): {
   selectedLabels: string[];
   customAnswer: string | null;
+  isDeclined: boolean;
 } {
+  let  selectedLabels: string[] = [];
+  let customAnswer: string | null = null;
+  let isDeclined = true;
+  
+  if (outputText === USER_QUESTION_DECLINED_MESSAGE) {
+    isDeclined = true;
+    return { selectedLabels, customAnswer, isDeclined };
+  }
+
   const selectionsStart = outputText.indexOf('"="');
   if (selectionsStart === -1) {
-    return { selectedLabels: [], customAnswer: null };
+    return { selectedLabels, customAnswer, isDeclined };
   }
   const start = selectionsStart + 3;
   const end = outputText.indexOf('".', start);
   if (end === -1) {
-    return { selectedLabels: [], customAnswer: null };
+    return { selectedLabels, customAnswer, isDeclined };
   }
 
   const parts = outputText.slice(start, end).split(", ");
-  const selectedLabels: string[] = [];
-  let customAnswer: string | null = null;
 
   for (const part of parts) {
     if (part.startsWith(CUSTOM_ANSWER_PREFIX)) {
@@ -59,5 +65,5 @@ export function parseUserQuestionAnswer(
     }
   }
 
-  return { selectedLabels, customAnswer };
+  return { selectedLabels, customAnswer, isDeclined };
 }

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -1,6 +1,11 @@
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { isUserQuestionResumeState } from "@app/lib/actions/types";
+import {
+  formatUserQuestionAnswer,
+  getUserQuestionSelections,
+  USER_QUESTION_DECLINED_MESSAGE,
+} from "@app/lib/actions/user_question";
 import { ASK_USER_QUESTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/ask_user_question/metadata";
 import { Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -22,7 +27,7 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
         return new Ok([
           {
             type: "text",
-            text: "User declined to answer. Proceed with your best judgment.",
+            text: USER_QUESTION_DECLINED_MESSAGE,
           },
         ]);
       }

--- a/front/lib/api/actions/servers/ask_user_question/tools/index.ts
+++ b/front/lib/api/actions/servers/ask_user_question/tools/index.ts
@@ -13,15 +13,10 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
     const resumeState = agentLoopContext?.runContext?.stepContext?.resumeState;
     if (isUserQuestionResumeState(resumeState) && resumeState.answer) {
       const { answer } = resumeState;
-      const selections: string[] = [];
-      for (const idx of answer.selectedOptions) {
-        if (idx >= 0 && idx < options.length) {
-          selections.push(options[idx].label);
-        }
-      }
-      if (answer.customResponse) {
-        selections.push(`Other: ${answer.customResponse}`);
-      }
+      const selections = getUserQuestionSelections(
+        { question, options, multiSelect },
+        answer
+      );
 
       if (selections.length === 0) {
         return new Ok([
@@ -35,9 +30,7 @@ const handlers: ToolHandlers<typeof ASK_USER_QUESTION_TOOLS_METADATA> = {
       return new Ok([
         {
           type: "text",
-          text:
-            `User has answered your questions: "${question}"="${selections.join(", ")}". ` +
-            "You can now continue with the user's answers in mind",
+          text: formatUserQuestionAnswer(question, selections),
         },
       ]);
     }


### PR DESCRIPTION
## Description

- This PR fixes the MCP action details component for the `ask_user_question` tool following the changes in https://github.com/dust-tt/dust/pull/23864.
- Specifically fixes the case for the custom answer and when the user declines.

Classic selection
<img width="645" height="297" alt="Screenshot 2026-04-07 at 11 25 54 PM" src="https://github.com/user-attachments/assets/cf789b0d-05f1-4113-97f0-53d6ccfcd2bd" />

Custom answer
<img width="645" height="297" alt="Screenshot 2026-04-07 at 11 26 17 PM" src="https://github.com/user-attachments/assets/80c16711-cc90-4c2e-9fff-9d4151af8eb2" />

Deny
<img width="645" height="297" alt="Screenshot 2026-04-07 at 11 28 22 PM" src="https://github.com/user-attachments/assets/03d3fd3d-d8e8-44f7-9810-4da7dcb5202d" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
