### PR TITLE
[sessions] collapse inline activity in existing conversation unless it's steered

### DIFF
--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -84,7 +84,11 @@ export function InlineActivitySteps({
   const isDone =
     lastAgentStateClassification === "done" || agentMessage.status === "failed";
 
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  // Collapse by default for completed messages (existing conversations),
+  // but keep expanded for active/streaming and steered messages.
+  const [isCollapsed, setIsCollapsed] = useState(
+    isDone && agentMessage.status !== "gracefully_stopped"
+  );
 
   const openBreakdownPanel = (actionId?: string) => {
     if (onOpenDetails) {


### PR DESCRIPTION
## Description
When you open an existing conversation we collapse inline activity by default (except when the message is steered)

Example here: 
https://pr-23871-merge--app.preview.dust.tt/w/0ec9852c2f/conversation/tfMDSvzL32

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
