### PR TITLE
Add model for skill suggestions

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -61,6 +61,7 @@ import {
   ConversationSkillModel,
 } from "@app/lib/models/skill/conversation_skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
+import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
 import { TagModel } from "@app/lib/models/tags";
 import { AcademyChapterVisitModel } from "@app/lib/resources/storage/models/academy_chapter_visit";
 import { AcademyQuizAttemptModel } from "@app/lib/resources/storage/models/academy_quiz_attempt";
@@ -216,6 +217,7 @@ export function loadAllModels() {
     AgentMessageSkillModel,
     SkillMCPServerConfigurationModel,
     SkillFileAttachmentModel,
+    SkillSuggestionModel,
     WorkspaceVerificationAttemptModel,
     AgentSuggestionModel,
     UserProjectDigestModel,

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -14,6 +14,7 @@ import {
   AgentMessageSkillModel,
   ConversationSkillModel,
 } from "@app/lib/models/skill/conversation_skill";
+import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
@@ -297,6 +298,13 @@ export async function destroyConversation(
     where: {
       workspaceId: owner.id,
       conversationId: conversation.id,
+    },
+  });
+
+  await SkillSuggestionModel.destroy({
+    where: {
+      workspaceId: owner.id,
+      sourceConversationId: conversation.id,
     },
   });
 

--- a/front/lib/models/skill/skill_suggestion.ts
+++ b/front/lib/models/skill/skill_suggestion.ts
@@ -1,0 +1,150 @@
+import { ConversationModel } from "@app/lib/models/agent/conversation";
+import {
+  SkillConfigurationModel,
+  SkillVersionModel,
+} from "@app/lib/models/skill";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type {
+  SkillSuggestionKind,
+  SkillSuggestionPayload,
+  SkillSuggestionSource,
+  SkillSuggestionState,
+} from "@app/types/suggestions/skill_suggestion";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes, Op } from "sequelize";
+
+export class SkillSuggestionModel extends WorkspaceAwareModel<SkillSuggestionModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare skillConfigurationId: ForeignKey<SkillConfigurationModel["id"]>;
+  declare skillVersionId: ForeignKey<SkillVersionModel["id"]>;
+
+  declare kind: SkillSuggestionKind;
+  declare suggestion: SkillSuggestionPayload;
+  declare analysis: string | null;
+
+  declare state: SkillSuggestionState;
+  declare source: SkillSuggestionSource;
+  declare sourceConversationId: ForeignKey<ConversationModel["id"]> | null;
+  declare groupId: string | null;
+
+  declare skillConfiguration: NonAttribute<SkillConfigurationModel>;
+  declare skillVersion: NonAttribute<SkillVersionModel>;
+  declare sourceConversation: NonAttribute<ConversationModel | null>;
+}
+
+SkillSuggestionModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    skillConfigurationId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    skillVersionId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    kind: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    suggestion: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+    },
+    analysis: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    state: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "pending",
+    },
+    source: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    sourceConversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      comment:
+        "FK to the conversation that triggered this suggestion (only set when applicable, e.g. synthetic)",
+    },
+    groupId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+  },
+  {
+    modelName: "skill_suggestion",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "skill_suggestions_list_by_skill_configuration_idx",
+        fields: ["workspaceId", "skillConfigurationId", "state", "kind"],
+        concurrently: true,
+      },
+      {
+        name: "idx_skill_suggestions_workspace_state",
+        fields: ["workspaceId", "state"],
+        concurrently: true,
+      },
+      {
+        name: "skill_suggestions_workspace_skill_config_kind",
+        fields: ["skillConfigurationId"],
+        concurrently: true,
+      },
+      {
+        name: "skill_suggestions_workspace_skill_version",
+        fields: ["skillVersionId"],
+        concurrently: true,
+      },
+      {
+        name: "idx_skill_suggestions_group",
+        fields: ["groupId"],
+        concurrently: true,
+        where: { groupId: { [Op.ne]: null } },
+      },
+    ],
+  }
+);
+
+SkillSuggestionModel.belongsTo(SkillConfigurationModel, {
+  foreignKey: { name: "skillConfigurationId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "skillConfiguration",
+});
+SkillConfigurationModel.hasMany(SkillSuggestionModel, {
+  foreignKey: { name: "skillConfigurationId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "skillSuggestions",
+});
+
+SkillSuggestionModel.belongsTo(SkillVersionModel, {
+  foreignKey: { name: "skillVersionId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "skillVersion",
+});
+SkillVersionModel.hasMany(SkillSuggestionModel, {
+  foreignKey: { name: "skillVersionId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "skillSuggestions",
+});
+
+SkillSuggestionModel.belongsTo(ConversationModel, {
+  foreignKey: { name: "sourceConversationId", allowNull: true },
+  onDelete: "RESTRICT",
+  as: "sourceConversation",
+});

--- a/front/lib/models/skill/skill_suggestion.ts
+++ b/front/lib/models/skill/skill_suggestion.ts
@@ -112,6 +112,11 @@ SkillSuggestionModel.init(
         concurrently: true,
       },
       {
+        name: "idx_skill_suggestions_source_conversation_id",
+        fields: ["sourceConversationId"],
+        concurrently: true,
+      },
+      {
         name: "idx_skill_suggestions_group",
         fields: ["groupId"],
         concurrently: true,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -5067,6 +5067,7 @@ const KNOWN_CONVERSATION_RELATED_MODELS = [
   "project_todo_conversation",
   "project_todo_source",
   "sandbox",
+  "skill_suggestion",
   "user_conversation_reads",
   "user_project_digest",
   "conversation_butler_suggestion",

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -18,6 +18,7 @@ import {
   ConversationSkillModel,
 } from "@app/lib/models/skill/conversation_skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
+import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -2155,6 +2156,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
+        await SkillSuggestionModel.destroy({
+          where: whereWorkspaceIdAndSkillId,
+          transaction,
+        });
+
         await SkillVersionModel.destroy({
           where: whereWorkspaceIdAndSkillId,
           transaction,
@@ -2361,6 +2367,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
 
     await SkillMCPServerConfigurationModel.destroy({
+      where: { workspaceId },
+    });
+
+    await SkillSuggestionModel.destroy({
       where: { workspaceId },
     });
 

--- a/front/migrations/db/migration_565.sql
+++ b/front/migrations/db/migration_565.sql
@@ -1,0 +1,38 @@
+-- Migration created on Apr 07, 2026
+CREATE TABLE IF NOT EXISTS "skill_suggestions" (
+    "id" BIGSERIAL PRIMARY KEY,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "skillConfigurationId" BIGINT NOT NULL REFERENCES "skill_configurations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "skillVersionId" BIGINT NOT NULL REFERENCES "skill_versions" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "kind" VARCHAR(255) NOT NULL,
+    "suggestion" JSONB NOT NULL,
+    "analysis" TEXT,
+    "state" VARCHAR(255) NOT NULL DEFAULT 'pending',
+    "source" VARCHAR(255) NOT NULL,
+    "sourceConversationId" BIGINT REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "groupId" VARCHAR(255)
+);
+COMMENT ON TABLE "skill_suggestions" IS 'AI-generated suggestions to improve skill configurations.';
+COMMENT ON COLUMN "skill_suggestions"."skillConfigurationId" IS 'Skill configuration this suggestion applies to (including suggested-status rows for creates).';
+COMMENT ON COLUMN "skill_suggestions"."skillVersionId" IS 'Skill version row this suggestion was generated from.';
+COMMENT ON COLUMN "skill_suggestions"."kind" IS 'Discriminator for the suggestion type';
+COMMENT ON COLUMN "skill_suggestions"."suggestion" IS 'JSONB payload; structure depends on kind.';
+COMMENT ON COLUMN "skill_suggestions"."analysis" IS 'Optional reasoning for why the suggestion was made.';
+COMMENT ON COLUMN "skill_suggestions"."source" IS 'Origin of the suggestion ';
+COMMENT ON COLUMN "skill_suggestions"."state" IS 'Lifecycle state';
+COMMENT ON COLUMN "skill_suggestions"."sourceConversationId" IS 'Conversation that triggered this suggestion when applicable';
+COMMENT ON COLUMN "skill_suggestions"."groupId" IS 'Optional shared key for batched suggestions';
+
+CREATE INDEX CONCURRENTLY "skill_suggestions_list_by_skill_configuration_idx"
+    ON "skill_suggestions" ("workspaceId", "skillConfigurationId", "state", "kind");
+CREATE INDEX CONCURRENTLY "idx_skill_suggestions_workspace_state"
+    ON "skill_suggestions" ("workspaceId", "state");
+CREATE INDEX CONCURRENTLY "skill_suggestions_workspace_skill_config_kind"
+    ON "skill_suggestions" ("skillConfigurationId");
+CREATE INDEX CONCURRENTLY "skill_suggestions_workspace_skill_version"
+    ON "skill_suggestions" ("skillVersionId");
+CREATE INDEX CONCURRENTLY "idx_skill_suggestions_group"
+    ON "skill_suggestions" ("groupId")
+    WHERE "groupId" IS NOT NULL;

--- a/front/migrations/db/migration_565.sql
+++ b/front/migrations/db/migration_565.sql
@@ -33,6 +33,8 @@ CREATE INDEX CONCURRENTLY "skill_suggestions_workspace_skill_config_kind"
     ON "skill_suggestions" ("skillConfigurationId");
 CREATE INDEX CONCURRENTLY "skill_suggestions_workspace_skill_version"
     ON "skill_suggestions" ("skillVersionId");
+CREATE INDEX CONCURRENTLY "idx_skill_suggestions_source_conversation_id"
+    ON "skill_suggestions" ("sourceConversationId");
 CREATE INDEX CONCURRENTLY "idx_skill_suggestions_group"
     ON "skill_suggestions" ("groupId")
     WHERE "groupId" IS NOT NULL;

--- a/front/types/suggestions/skill_suggestion.ts
+++ b/front/types/suggestions/skill_suggestion.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+export const SKILL_SUGGESTION_STATES = [
+  "pending",
+  "approved",
+  "rejected",
+  "outdated",
+] as const;
+
+export type SkillSuggestionState = (typeof SKILL_SUGGESTION_STATES)[number];
+
+export const SKILL_SUGGESTION_SOURCES = ["reinforcement", "synthetic"] as const;
+
+export type SkillSuggestionSource = (typeof SKILL_SUGGESTION_SOURCES)[number];
+
+export const SKILL_SUGGESTION_KINDS = ["create", "edit_instructions"] as const;
+
+export type SkillSuggestionKind = (typeof SKILL_SUGGESTION_KINDS)[number];
+
+export const SkillCreateSuggestionSchema = z.object({}).strict();
+
+export type SkillCreateSuggestionType = z.infer<
+  typeof SkillCreateSuggestionSchema
+>;
+
+export function isSkillCreateSuggestion(
+  data: unknown
+): data is SkillCreateSuggestionType {
+  return SkillCreateSuggestionSchema.safeParse(data).success;
+}
+
+export const SkillEditInstructionsSuggestionSchema = z.object({
+  instructions: z
+    .string()
+    .describe("Full replacement text for the skill instructions."),
+});
+
+export type SkillEditInstructionsSuggestionType = z.infer<
+  typeof SkillEditInstructionsSuggestionSchema
+>;
+
+export function isSkillEditInstructionsSuggestion(
+  data: unknown
+): data is SkillEditInstructionsSuggestionType {
+  return SkillEditInstructionsSuggestionSchema.safeParse(data).success;
+}
+
+export type SkillSuggestionPayload =
+  | SkillCreateSuggestionType
+  | SkillEditInstructionsSuggestionType;


### PR DESCRIPTION
## Description

* Adding table to store skill suggestions
* Very similar to agent_suggestions with the following changes: FK on skillVersionId, new "groupID" attribute (this is intended to be used to associate suggestions that should be treated as a batch)
* Skills already actually has a "suggest" type in SkillConfigurationModel. This is used for suggestion of new skills. We will point to those SkillConfigurationModel objected for create suggestions.
* Starting with a simpler solution of full text replacement for edit_instructions (there is a chance we end up switching to string match depending on results). I don't think block suggestions are necessary for skills

## Tests

* Ran migration

## Risk

* Low

## Deploy Plan

1. run migration
2. deploy front