### PR TITLE
Project knowledge: fix last updated sorting, add last sync as last updated for connected data.

### DIFF
--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -69,6 +69,15 @@ function formatDate(timestamp: number): string {
   return date;
 }
 
+function getLastUpdatedTimestamp(row: ContextAttachmentItem): number | null {
+  return (
+    ("lastUpdatedAt" in row ? row.lastUpdatedAt : undefined) ??
+    ("updatedAt" in row ? row.updatedAt : undefined) ??
+    ("createdAt" in row ? row.createdAt : undefined) ??
+    null
+  );
+}
+
 export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {
   return (
     <FileDropProvider>
@@ -258,22 +267,20 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
       },
       {
         id: "lastUpdated",
-        accessorKey: "title",
+        accessorFn: (row) => getLastUpdatedTimestamp(row) ?? 0,
         header: "Last updated",
+        sortingFn: "basic",
         meta: {
           className: "w-[100px]",
         },
         cell: (info: CellContext<ProjectKnowledgeRow, unknown>) => {
           const row = info.row.original;
-          if (isFileAttachmentType(row)) {
-            const ts = row.updatedAt ?? row.createdAt ?? null;
-            return (
-              <DataTable.BasicCellContent
-                label={ts != null ? formatDate(ts) : "—"}
-              />
-            );
-          }
-          return <DataTable.BasicCellContent label="—" />;
+          const ts = getLastUpdatedTimestamp(row);
+          return (
+            <DataTable.BasicCellContent
+              label={ts != null ? formatDate(ts) : "—"}
+            />
+          );
         },
       },
       {

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -59,6 +59,7 @@ export type ContentNodeAttachmentType = BaseConversationAttachmentType & {
   nodeDataSourceViewId: string;
   nodeType: ContentNodeType;
   sourceUrl: string | null;
+  lastUpdatedAt?: number | null; //Last sync / update timestamp for the underlying data source node (Core node timestamp).
 };
 
 export type LargePasteType = {

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -1,9 +1,11 @@
 import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   getAttachmentFromContentFragment,
+  isContentNodeAttachmentType,
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
+import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import type {
   UpsertDocumentArgs,
   UpsertTableArgs,
@@ -14,6 +16,7 @@ import { fetchProjectDataSource } from "@app/lib/api/projects/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
@@ -125,7 +128,61 @@ export async function listProjectContextAttachments(
     merged.set(key, { ...attachment, isInProjectContext: true });
   }
 
-  return Array.from(merged.values());
+  const attachments = Array.from(merged.values());
+
+  // Enrich content-node attachments with the underlying Core node timestamp (last sync / update).
+  // We batch by dataSourceView to avoid one Core call per row.
+  const contentNodeAttachments = attachments.filter(
+    isContentNodeAttachmentType
+  );
+  if (contentNodeAttachments.length === 0) {
+    return attachments;
+  }
+
+  const byView = new Map<string, string[]>();
+  for (const a of contentNodeAttachments) {
+    const ids = byView.get(a.nodeDataSourceViewId) ?? [];
+    ids.push(a.nodeId);
+    byView.set(a.nodeDataSourceViewId, ids);
+  }
+
+  const lastUpdatedByViewAndNode = new Map<
+    string,
+    Map<string, number | null>
+  >();
+
+  await Promise.all(
+    Array.from(byView.entries()).map(async ([dsViewSId, nodeIds]) => {
+      const dsView = await DataSourceViewResource.fetchById(auth, dsViewSId);
+      if (!dsView) {
+        return;
+      }
+
+      const res = await getContentNodesForDataSourceView(dsView, {
+        internalIds: nodeIds,
+        viewType: "all",
+      });
+      if (res.isErr()) {
+        return;
+      }
+
+      const m = new Map<string, number | null>();
+      for (const n of res.value.nodes) {
+        m.set(n.internalId, n.lastUpdatedAt);
+      }
+      lastUpdatedByViewAndNode.set(dsViewSId, m);
+    })
+  );
+
+  return attachments.map((a) => {
+    if (!isContentNodeAttachmentType(a)) {
+      return a;
+    }
+    const ts =
+      lastUpdatedByViewAndNode.get(a.nodeDataSourceViewId)?.get(a.nodeId) ??
+      null;
+    return { ...a, lastUpdatedAt: ts };
+  });
 }
 
 /**


### PR DESCRIPTION
## Description

- Fix `lastUpdated` column sorting in the project knowledge table (was incorrectly using `title` as the sort key)
- Add `lastUpdatedAt` to `ContentNodeAttachmentType` (sourced from the Core node's last sync timestamp)
- Backend: fetch and enrich content-node attachments with Core timestamps, batched by data source view

## Tests

Local + green

## Risk

Low

## Deploy Plan

Deploy `front`
