### PR TITLE
Fix: removal of files from project's context.

### DIFF
--- a/.claude/skills/dust-test/SKILL.md
+++ b/.claude/skills/dust-test/SKILL.md
@@ -109,4 +109,4 @@ describe ("createConversation", () => {
 3. Identify the 2-4 most important functions/behaviors to test
 4. Find or create appropriate factories for test data
 5. Write concise, focused tests
-6. Run tests with `npm test` to verify they pass
+6. Run tests with `npm test -- filetotest` to verify they pass

--- a/front/AGENTS.md
+++ b/front/AGENTS.md
@@ -38,6 +38,9 @@ front/
     - Use `npm run lint` to run ESLint
 - Read `runbooks/TEST.md` for all things related to testing.
 
+# Running tests
+- Use `npm run test -- filetotest
+
 # Runbooks
 
 Runbooks for various typical development tasks are located under `runbooks/`:

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -15,8 +15,8 @@ import {
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import {
   useAddProjectContextContentNode,
-  useDeleteProjectFile,
   useProjectContextAttachments,
+  useRemoveProjectContextFile,
 } from "@app/lib/swr/projects";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { getSupportedFileExtensions } from "@app/types/files";
@@ -117,7 +117,10 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     spaceId: space.sId,
   });
 
-  const deleteProjectFile = useDeleteProjectFile({ owner });
+  const removeProjectContextFile = useRemoveProjectContextFile({
+    owner,
+    spaceId: space.sId,
+  });
 
   const addProjectContextContentNode = useAddProjectContextContentNode({
     owner,
@@ -173,7 +176,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     });
 
     if (confirmed) {
-      const result = await deleteProjectFile(item.fileId);
+      const result = await removeProjectContextFile(item.fileId);
       if (result.isOk()) {
         void mutateProjectContextAttachments();
       }

--- a/front/lib/api/projects/context.test.ts
+++ b/front/lib/api/projects/context.test.ts
@@ -1,0 +1,115 @@
+import { removeFileFromProject } from "@app/lib/api/projects/context";
+import { MessageModel } from "@app/lib/models/agent/conversation";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import { FileModel } from "@app/lib/resources/storage/models/files";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("removeFileFromProject", () => {
+  beforeEach(() => {
+    // keep tests isolated; factories already run in their own DB context
+  });
+
+  it("deletes the file and deletes orphaned project content fragments", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const project = await SpaceFactory.project(workspace, user.id);
+    const file = await ProjectFileFactory.create(auth, user, project, {
+      contentType: "text/plain",
+      fileName: "proj.txt",
+      fileSize: 123,
+      status: "ready",
+    });
+
+    const frBefore = await ContentFragmentModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        spaceId: project.id,
+        fileId: file.id,
+      },
+    });
+    expect(frBefore).toBeTruthy();
+
+    const res = await removeFileFromProject(auth, {
+      space: project,
+      fileId: file.sId,
+    });
+    expect(res.isOk()).toBe(true);
+
+    const fileAfter = await FileModel.findOne({
+      where: { workspaceId: workspace.id, id: file.id },
+    });
+    expect(fileAfter).toBeNull();
+
+    const frAfter = await ContentFragmentModel.findOne({
+      where: { id: frBefore!.id, workspaceId: workspace.id },
+    });
+    expect(frAfter).toBeNull();
+  });
+
+  it("marks referenced project fragments as expired and clears spaceId", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const project = await SpaceFactory.project(workspace, user.id);
+    const file = await ProjectFileFactory.create(auth, user, project, {
+      contentType: "text/plain",
+      fileName: "referenced.txt",
+      fileSize: 321,
+      status: "ready",
+    });
+
+    const fr = await ContentFragmentModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        spaceId: project.id,
+        fileId: file.id,
+      },
+    });
+    expect(fr).toBeTruthy();
+
+    // Create a conversation + message referencing this project fragment.
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    await MessageModel.create({
+      sId: generateRandomModelSId(),
+      rank: 999,
+      conversationId: conversation.id,
+      parentId: null,
+      contentFragmentId: fr!.id,
+      workspaceId: workspace.id,
+    });
+
+    const res = await removeFileFromProject(auth, {
+      space: project,
+      fileId: file.sId,
+    });
+    expect(res.isOk()).toBe(true);
+
+    const fileAfter = await FileModel.findOne({
+      where: { workspaceId: workspace.id, id: file.id },
+    });
+    expect(fileAfter).toBeNull();
+
+    const frAfter = await ContentFragmentModel.findOne({
+      where: { id: fr!.id, workspaceId: workspace.id },
+    });
+    expect(frAfter).toBeTruthy();
+    expect(frAfter!.spaceId).toBeNull();
+    expect(frAfter!.expiredReason).toBe("file_deleted");
+  });
+});

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -15,10 +15,12 @@ import { PROJECT_CONTEXT_FOLDER_ID } from "@app/lib/api/projects/constants";
 import { fetchProjectDataSource } from "@app/lib/api/projects/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
+import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import logger from "@app/logger/logger";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
 import { isSupportedDelimitedTextContentType } from "@app/types/files";
@@ -26,6 +28,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { slugify } from "@app/types/shared/utils/string_utils";
+import { Op } from "sequelize";
 
 export async function listProjectContentFragments(
   auth: Authenticator,
@@ -356,4 +359,85 @@ export async function addContentNodeToProject(
   }
 
   return new Ok(fragmentRes.value);
+}
+
+/**
+ * Removes a project-context file from a project space.
+ *
+ * - Always deletes the file itself.
+ * - Deletes associated ContentFragmentModel rows for this (space,file) pair when they are not
+ *   referenced by any conversation message.
+ * - If some fragments are referenced by messages, we keep them but detach them from the space
+ *   and mark them expired so conversation rendering can display an appropriate placeholder.
+ */
+export async function removeFileFromProject(
+  auth: Authenticator,
+  {
+    space,
+    fileId,
+  }: {
+    space: SpaceResource;
+    fileId: string; // file sId
+  }
+): Promise<Result<void, Error>> {
+  const file = await FileResource.fetchById(auth, fileId);
+  if (!file) {
+    return new Err(new Error("File not found."));
+  }
+
+  // Best-effort cleanup of the project content fragments for this file.
+  const workspaceId = auth.getNonNullableWorkspace().id;
+  const projectFragmentIds = await ContentFragmentModel.findAll({
+    attributes: ["id"],
+    where: {
+      workspaceId,
+      spaceId: space.id,
+      fileId: file.id,
+    },
+  }).then((rows) => rows.map((r) => r.id));
+
+  if (projectFragmentIds.length > 0) {
+    const messagesReferencing = await MessageModel.findAll({
+      attributes: ["contentFragmentId"],
+      where: {
+        workspaceId,
+        contentFragmentId: {
+          [Op.in]: projectFragmentIds,
+        },
+      },
+    });
+
+    const referencedIds = new Set(
+      removeNulls(messagesReferencing.map((m) => m.contentFragmentId))
+    );
+    const orphanIds = projectFragmentIds.filter((id) => !referencedIds.has(id));
+
+    if (orphanIds.length > 0) {
+      await ContentFragmentModel.destroy({
+        where: {
+          workspaceId,
+          id: { [Op.in]: orphanIds },
+        },
+      });
+    }
+
+    if (referencedIds.size > 0) {
+      await ContentFragmentModel.update(
+        { spaceId: null, expiredReason: "file_deleted" },
+        {
+          where: {
+            workspaceId,
+            id: { [Op.in]: Array.from(referencedIds) },
+          },
+        }
+      );
+    }
+  }
+
+  const deleteRes = await file.delete(auth);
+  if (deleteRes.isErr()) {
+    return new Err(deleteRes.error);
+  }
+
+  return new Ok(undefined);
 }

--- a/front/lib/api/projects/index.ts
+++ b/front/lib/api/projects/index.ts
@@ -6,6 +6,7 @@ export {
   listProjectContentFragments,
   listProjectContextAttachments,
   listProjectContextFiles,
+  removeFileFromProject,
 } from "./context";
 export {
   fetchProjectDataSource,

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -109,20 +109,29 @@ export function useAddProjectContextContentNode({
   };
 }
 
-export function useDeleteProjectFile({ owner }: { owner: LightWorkspaceType }) {
+export function useRemoveProjectContextFile({
+  owner,
+  spaceId,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+}) {
   const sendNotification = useSendNotification();
 
   return async (fileId: string): Promise<Result<void, Error>> => {
     try {
-      const res = await clientFetch(`/api/w/${owner.sId}/files/${fileId}`, {
-        method: "DELETE",
-      });
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/spaces/${spaceId}/project_context/files/${fileId}`,
+        {
+          method: "DELETE",
+        }
+      );
 
       if (!res.ok) {
         const errorData = await getErrorFromResponse(res);
         sendNotification({
           type: "error",
-          title: "Failed to delete file",
+          title: "Failed to remove file from project",
           description: errorData.message,
         });
         return new Err(new Error(errorData.message));
@@ -130,7 +139,7 @@ export function useDeleteProjectFile({ owner }: { owner: LightWorkspaceType }) {
 
       sendNotification({
         type: "success",
-        title: "File deleted",
+        title: "Removed from project knowledge",
       });
 
       return new Ok(undefined);
@@ -138,7 +147,7 @@ export function useDeleteProjectFile({ owner }: { owner: LightWorkspaceType }) {
       const errorMessage = normalizeError(e).message;
       sendNotification({
         type: "error",
-        title: "Failed to delete file",
+        title: "Failed to remove file from project",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/files/[fileId].ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/files/[fileId].ts
@@ -1,0 +1,90 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { removeFileFromProject } from "@app/lib/api/projects";
+import type { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type DeleteProjectContextFileResponseBody = Record<string, never>;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<DeleteProjectContextFileResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const { spaceId, fileId } = req.query;
+  if (!isString(spaceId) || !isString(fileId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid spaceId or fileId query parameter.",
+      },
+    });
+  }
+
+  const space = await SpaceResource.fetchById(auth, spaceId);
+  if (!space || !space.canRead(auth)) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "Space not found.",
+      },
+    });
+  }
+
+  if (!space.isProject()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Only project spaces support project context knowledge removal.",
+      },
+    });
+  }
+
+  if (!space.canWrite(auth)) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "You do not have write access to this project.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "DELETE": {
+      const r = await removeFileFromProject(auth, { space, fileId });
+      if (r.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: r.error.message,
+          },
+        });
+      }
+      res.status(200).json({});
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "Method not supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/files/fileId.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/files/fileId.test.ts
@@ -1,0 +1,74 @@
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import { FileModel } from "@app/lib/resources/storage/models/files";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./[fileId]";
+
+describe("/api/w/[wId]/spaces/[spaceId]/project_context/files/[fileId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("DELETE removes the file from project context and returns 200", async () => {
+    const { auth, req, res, workspace, user } =
+      await createPrivateApiMockRequest({
+        method: "DELETE",
+        role: "user",
+      });
+
+    const project = await SpaceFactory.project(workspace, user.id);
+    const file = await ProjectFileFactory.create(auth, user, project, {
+      contentType: "text/plain",
+      fileName: "to-remove.txt",
+      fileSize: 123,
+      status: "ready",
+    });
+
+    const fr = await ContentFragmentModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        spaceId: project.id,
+        fileId: file.id,
+      },
+    });
+    expect(fr).toBeTruthy();
+
+    req.query.spaceId = project.sId;
+    req.query.fileId = file.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const fileAfter = await FileModel.findOne({
+      where: { workspaceId: workspace.id, id: file.id },
+    });
+    expect(fileAfter).toBeNull();
+  });
+
+  it("returns 400 when space is not a project", async () => {
+    const { auth, req, res, globalSpace, user } =
+      await createPrivateApiMockRequest({
+        method: "DELETE",
+        role: "user",
+      });
+
+    const file = await ProjectFileFactory.create(auth, user, globalSpace, {
+      contentType: "text/plain",
+      fileName: "nope.txt",
+      fileSize: 10,
+      status: "ready",
+    });
+
+    req.query.spaceId = globalSpace.sId;
+    req.query.fileId = file.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+});

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -14,7 +14,9 @@ import type { DataSourceViewContentNode } from "./data_source_view";
 import type { AllSupportedFileContentType } from "./files";
 import type { ModelId } from "./shared/model_id";
 
-export type ContentFragmentExpiredReason = "data_source_deleted";
+export type ContentFragmentExpiredReason =
+  | "data_source_deleted"
+  | "file_deleted";
 
 export type ContentFragmentContextType = {
   username: string | null;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -947,7 +947,10 @@ const ContentFragmentNodeData = z.object({
   spaceName: z.string(),
 });
 
-const ContentFragmentExpiredReasonSchema = z.literal("data_source_deleted");
+const ContentFragmentExpiredReasonSchema = z.union([
+  z.literal("data_source_deleted"),
+  z.literal("file_deleted"),
+]);
 
 const BaseContentFragmentSchema = z.object({
   type: z.literal("content_fragment"),


### PR DESCRIPTION
## Description

Fix file removal from a project's context — the previous `useDeleteProjectFile` hook didn't pass `spaceId`, leaving orphaned content fragments. Switched to `useRemoveProjectContextFile`.

Also adds tests covering the two removal scenarios: orphaned fragments deleted, and fragments referenced by a conversation message marked as expired.

## Tests

Green (new tests added)

## Risk

Low

## Deploy Plan

Deploy `front`
