### PR TITLE
Add / Remove connected data from knowledge.

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -543,11 +543,6 @@ export const InputBarAttachmentsPicker = ({
           <div ref={itemsContainerRef}>
             {(showLoader || availableSources.length > 1) && (
               <div className="flex flex-wrap items-center gap-0.5 p-2">
-                {showLoader && (
-                  <div className="flex h-7 items-center justify-center last:grow">
-                    <Spinner size="xs" />
-                  </div>
-                )}
                 {availableSources.length > 1 && (
                   <DropdownMenuFilters
                     filters={availableSources}
@@ -555,6 +550,11 @@ export const InputBarAttachmentsPicker = ({
                     onSelectFilter={handleFilterClick}
                     className="grow"
                   />
+                )}
+                {showLoader && (
+                  <div className="flex h-7 items-center justify-center last:grow">
+                    <Spinner size="xs" />
+                  </div>
                 )}
               </div>
             )}

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -16,6 +16,7 @@ import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import {
   useAddProjectContextContentNode,
   useProjectContextAttachments,
+  useRemoveProjectContextContentNode,
   useRemoveProjectContextFile,
 } from "@app/lib/swr/projects";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
@@ -24,6 +25,7 @@ import type { SpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Avatar,
+  CloudArrowLeftRightIcon,
   DataTable,
   EmptyCTA,
   Icon,
@@ -122,6 +124,11 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     spaceId: space.sId,
   });
 
+  const removeProjectContextContentNode = useRemoveProjectContextContentNode({
+    owner,
+    spaceId: space.sId,
+  });
+
   const addProjectContextContentNode = useAddProjectContextContentNode({
     owner,
     spaceId: space.sId,
@@ -183,6 +190,28 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     }
   };
 
+  const handleDeleteContentNode = async (item: ContextAttachmentItem) => {
+    if (!isContentNodeAttachmentType(item)) {
+      return;
+    }
+    const confirmed = await confirm({
+      title: "Remove content node?",
+      message: `Are you sure you want to remove "${item.title}" from this project?`,
+      validateLabel: "Remove",
+      validateVariant: "warning",
+    });
+
+    if (confirmed) {
+      const result = await removeProjectContextContentNode({
+        nodeId: item.nodeId,
+        nodeDataSourceViewId: item.nodeDataSourceViewId,
+      });
+      if (result.isOk()) {
+        void mutateProjectContextAttachments();
+      }
+    }
+  };
+
   const openAttachment = useCallback(
     (item: ContextAttachmentItem) => {
       if (isFileAttachmentType(item)) {
@@ -229,6 +258,34 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
                   }
                 />
               </div>
+            </DataTable.CellContent>
+          );
+        },
+      },
+      {
+        id: "source",
+        header: "",
+        enableSorting: false,
+        meta: {
+          className: "w-10",
+        },
+        cell: (info: CellContext<ProjectKnowledgeRow, unknown>) => {
+          const row = info.row.original;
+          if (!isContentNodeAttachmentType(row)) {
+            return null;
+          }
+
+          return (
+            <DataTable.CellContent>
+              <Tooltip
+                tooltipTriggerAsChild
+                label="Synced from a connected data source, cannot be directly edited by agents."
+                trigger={
+                  <span className="text-muted-foreground">
+                    <Icon visual={CloudArrowLeftRightIcon} size="sm" />
+                  </span>
+                }
+              />
             </DataTable.CellContent>
           );
         },
@@ -339,7 +396,20 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
               },
             },
           ]
-        : [],
+        : isContentNodeAttachmentType(attachment)
+          ? [
+              {
+                kind: "item" as const,
+                label: "Remove",
+                icon: TrashIcon,
+                variant: "warning" as const,
+                onClick: (e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  void handleDeleteContentNode(attachment);
+                },
+              },
+            ]
+          : [],
     }));
     // eslint-disable-next-line react-hooks/exhaustive-deps -- stable openAttachment / handlers
   }, [attachments]);
@@ -441,7 +511,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
                 name="knowledge-search"
                 value={searchText}
                 onChange={setSearchText}
-                placeholder="Search knowledge..."
+                placeholder="Filter knowledge..."
                 className="w-full"
               />
               <DataTable

--- a/front/lib/api/projects/context.test.ts
+++ b/front/lib/api/projects/context.test.ts
@@ -1,10 +1,14 @@
-import { removeFileFromProject } from "@app/lib/api/projects/context";
+import {
+  removeContentNodeFromProject,
+  removeFileFromProject,
+} from "@app/lib/api/projects/context";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -111,5 +115,211 @@ describe("removeFileFromProject", () => {
     expect(frAfter).toBeTruthy();
     expect(frAfter!.spaceId).toBeNull();
     expect(frAfter!.expiredReason).toBe("file_deleted");
+  });
+});
+
+describe("removeContentNodeFromProject", () => {
+  beforeEach(() => {
+    // keep tests isolated; factories already run in their own DB context
+  });
+
+  it("deletes orphaned project content-node fragments", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const project = await SpaceFactory.project(workspace, user.id);
+    const dsView = await DataSourceViewFactory.folder(
+      workspace,
+      project,
+      auth.user()
+    );
+
+    const fr = await ContentFragmentModel.create({
+      workspaceId: workspace.id,
+      spaceId: project.id,
+      fileId: null,
+      title: "Node",
+      contentType: "text/plain",
+      sourceUrl: null,
+      textBytes: null,
+      userId: auth.getNonNullableUser().id,
+      userContextUsername: "u",
+      userContextFullName: "U",
+      userContextEmail: "u@example.com",
+      userContextProfilePictureUrl: null,
+      nodeId: "node_1",
+      nodeDataSourceViewId: dsView.id,
+      nodeType: "document",
+      version: "latest",
+      expiredReason: null,
+      sId: "cf_test_node_1",
+    });
+
+    const res = await removeContentNodeFromProject(auth, {
+      space: project,
+      nodeId: "node_1",
+      nodeDataSourceViewId: dsView.sId,
+    });
+    expect(res.isOk()).toBe(true);
+
+    const frAfter = await ContentFragmentModel.findOne({
+      where: { id: fr.id, workspaceId: workspace.id },
+    });
+    expect(frAfter).toBeNull();
+  });
+
+  it("marks referenced fragments as expired and clears spaceId", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const project = await SpaceFactory.project(workspace, user.id);
+    const dsView = await DataSourceViewFactory.folder(
+      workspace,
+      project,
+      auth.user()
+    );
+
+    const fr = await ContentFragmentModel.create({
+      workspaceId: workspace.id,
+      spaceId: project.id,
+      fileId: null,
+      title: "Node",
+      contentType: "text/plain",
+      sourceUrl: null,
+      textBytes: null,
+      userId: auth.getNonNullableUser().id,
+      userContextUsername: "u",
+      userContextFullName: "U",
+      userContextEmail: "u@example.com",
+      userContextProfilePictureUrl: null,
+      nodeId: "node_2",
+      nodeDataSourceViewId: dsView.id,
+      nodeType: "document",
+      version: "latest",
+      expiredReason: null,
+      sId: "cf_test_node_2",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    await MessageModel.create({
+      sId: generateRandomModelSId(),
+      rank: 999,
+      conversationId: conversation.id,
+      parentId: null,
+      contentFragmentId: fr.id,
+      workspaceId: workspace.id,
+    });
+
+    const res = await removeContentNodeFromProject(auth, {
+      space: project,
+      nodeId: "node_2",
+      nodeDataSourceViewId: dsView.sId,
+    });
+    expect(res.isOk()).toBe(true);
+
+    const frAfter = await ContentFragmentModel.findOne({
+      where: { id: fr.id, workspaceId: workspace.id },
+    });
+    expect(frAfter).toBeTruthy();
+    expect(frAfter!.spaceId).toBeNull();
+    expect(frAfter!.expiredReason).toBeNull();
+  });
+
+  it("handles both latest and superseded rows (detaches referenced, deletes orphan)", async () => {
+    const { auth, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const project = await SpaceFactory.project(workspace, user.id);
+    const dsView = await DataSourceViewFactory.folder(
+      workspace,
+      project,
+      auth.user()
+    );
+
+    const latest = await ContentFragmentModel.create({
+      workspaceId: workspace.id,
+      spaceId: project.id,
+      fileId: null,
+      title: "Node",
+      contentType: "text/plain",
+      sourceUrl: null,
+      textBytes: null,
+      userId: auth.getNonNullableUser().id,
+      userContextUsername: "u",
+      userContextFullName: "U",
+      userContextEmail: "u@example.com",
+      userContextProfilePictureUrl: null,
+      nodeId: "node_3",
+      nodeDataSourceViewId: dsView.id,
+      nodeType: "document",
+      version: "latest",
+      expiredReason: null,
+      sId: "cf_test_node_3_latest",
+    });
+
+    const superseded = await ContentFragmentModel.create({
+      workspaceId: workspace.id,
+      spaceId: project.id,
+      fileId: null,
+      title: "Node (old)",
+      contentType: "text/plain",
+      sourceUrl: null,
+      textBytes: null,
+      userId: auth.getNonNullableUser().id,
+      userContextUsername: "u",
+      userContextFullName: "U",
+      userContextEmail: "u@example.com",
+      userContextProfilePictureUrl: null,
+      nodeId: "node_3",
+      nodeDataSourceViewId: dsView.id,
+      nodeType: "document",
+      version: "superseded",
+      expiredReason: null,
+      sId: "cf_test_node_3_superseded",
+    });
+
+    // Reference the latest row from a conversation message; superseded stays orphaned.
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    await MessageModel.create({
+      sId: generateRandomModelSId(),
+      rank: 999,
+      conversationId: conversation.id,
+      parentId: null,
+      contentFragmentId: latest.id,
+      workspaceId: workspace.id,
+    });
+
+    const res = await removeContentNodeFromProject(auth, {
+      space: project,
+      nodeId: "node_3",
+      nodeDataSourceViewId: dsView.sId,
+    });
+    expect(res.isOk()).toBe(true);
+
+    const latestAfter = await ContentFragmentModel.findOne({
+      where: { id: latest.id, workspaceId: workspace.id },
+    });
+    expect(latestAfter).toBeTruthy();
+    expect(latestAfter!.spaceId).toBeNull();
+    expect(latestAfter!.expiredReason).toBeNull();
+
+    const supersededAfter = await ContentFragmentModel.findOne({
+      where: { id: superseded.id, workspaceId: workspace.id },
+    });
+    expect(supersededAfter).toBeNull();
   });
 });

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -441,3 +441,87 @@ export async function removeFileFromProject(
 
   return new Ok(undefined);
 }
+
+/**
+ * Removes a project-context content node reference from a project space.
+ *
+ * - Deletes associated ContentFragmentModel rows for this (space,nodeId,nodeDataSourceViewId)
+ *   tuple when they are not referenced by any conversation message.
+ * - If some fragments are referenced by messages, we keep them but detach them from the space
+ *   and mark them expired so conversation rendering can display an appropriate placeholder.
+ */
+export async function removeContentNodeFromProject(
+  auth: Authenticator,
+  {
+    space,
+    nodeId,
+    nodeDataSourceViewId,
+  }: {
+    space: SpaceResource;
+    nodeId: string;
+    nodeDataSourceViewId: string; // data source view sId
+  }
+): Promise<Result<void, Error>> {
+  const dsView = await DataSourceViewResource.fetchById(
+    auth,
+    nodeDataSourceViewId
+  );
+  if (!dsView) {
+    return new Err(new Error("Data source view not found."));
+  }
+
+  const workspaceId = auth.getNonNullableWorkspace().id;
+
+  const projectFragmentIds = await ContentFragmentModel.findAll({
+    attributes: ["id"],
+    where: {
+      workspaceId,
+      spaceId: space.id,
+      fileId: null,
+      nodeId,
+      nodeDataSourceViewId: dsView.id,
+    },
+  }).then((rows) => rows.map((r) => r.id));
+
+  if (projectFragmentIds.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const messagesReferencing = await MessageModel.findAll({
+    attributes: ["contentFragmentId"],
+    where: {
+      workspaceId,
+      contentFragmentId: {
+        [Op.in]: projectFragmentIds,
+      },
+    },
+  });
+
+  const referencedIds = new Set(
+    removeNulls(messagesReferencing.map((m) => m.contentFragmentId))
+  );
+  const orphanIds = projectFragmentIds.filter((id) => !referencedIds.has(id));
+
+  if (orphanIds.length > 0) {
+    await ContentFragmentModel.destroy({
+      where: {
+        workspaceId,
+        id: { [Op.in]: orphanIds },
+      },
+    });
+  }
+
+  if (referencedIds.size > 0) {
+    await ContentFragmentModel.update(
+      { spaceId: null },
+      {
+        where: {
+          workspaceId,
+          id: { [Op.in]: Array.from(referencedIds) },
+        },
+      }
+    );
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/projects/index.ts
+++ b/front/lib/api/projects/index.ts
@@ -6,6 +6,7 @@ export {
   listProjectContentFragments,
   listProjectContextAttachments,
   listProjectContextFiles,
+  removeContentNodeFromProject,
   removeFileFromProject,
 } from "./context";
 export {

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -155,6 +155,60 @@ export function useRemoveProjectContextFile({
   };
 }
 
+export function useRemoveProjectContextContentNode({
+  owner,
+  spaceId,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  return async ({
+    nodeId,
+    nodeDataSourceViewId,
+  }: {
+    nodeId: string;
+    nodeDataSourceViewId: string;
+  }): Promise<Result<void, Error>> => {
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/spaces/${spaceId}/project_context/content_nodes`,
+        {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ nodeId, nodeDataSourceViewId }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to remove content node from project",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      sendNotification({
+        type: "success",
+        title: "Removed from project knowledge",
+      });
+
+      return new Ok(undefined);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to remove content node from project",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
 export function useRenameProjectFile({ owner }: { owner: LightWorkspaceType }) {
   const sendNotification = useSendNotification();
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/content_nodes/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/content_nodes/index.ts
@@ -1,0 +1,116 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { removeContentNodeFromProject } from "@app/lib/api/projects";
+import type { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const DeleteProjectContextContentNodeBodySchema = z.object({
+  nodeId: z.string().min(1, "nodeId is required"),
+  nodeDataSourceViewId: z.string().min(1, "nodeDataSourceViewId is required"),
+});
+
+export type DeleteProjectContextContentNodeResponseBody = Record<string, never>;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<DeleteProjectContextContentNodeResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const { spaceId } = req.query;
+  if (!isString(spaceId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid spaceId query parameter.",
+      },
+    });
+  }
+
+  const space = await SpaceResource.fetchById(auth, spaceId);
+  if (!space || !space.canRead(auth)) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "Space not found.",
+      },
+    });
+  }
+
+  if (!space.isProject()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Only project spaces support project context knowledge removal.",
+      },
+    });
+  }
+
+  if (!space.canWrite(auth)) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "You do not have write access to this project.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "DELETE": {
+      const bodyValidation =
+        DeleteProjectContextContentNodeBodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
+        const errorMessage = bodyValidation.error.errors
+          .map((e) => `${e.path.join(".")}: ${e.message}`)
+          .join(", ");
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${errorMessage}`,
+          },
+        });
+      }
+
+      const r = await removeContentNodeFromProject(auth, {
+        space,
+        nodeId: bodyValidation.data.nodeId,
+        nodeDataSourceViewId: bodyValidation.data.nodeDataSourceViewId,
+      });
+      if (r.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: r.error.message,
+          },
+        });
+      }
+
+      res.status(200).json({});
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "Method not supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Allow adding and removing connected data sources (content nodes) from a project's knowledge tab.
- Add `useRemoveProjectContextContentNode` hook + backend endpoint
- Add "Remove" action for content nodes in `SpaceKnowledgeTab`
- Add a source indicator column (`CloudArrowLeftRightIcon`) with tooltip for synced nodes
- Rename connector label `"Conversations & Context"` → `"Project"`
- Fix attachment picker spinner position (shows after filters, not before)
- Tests for `removeProjectContextContentNode`

## Tests

Local + green (new tests added)

## Risk

Low

## Deploy Plan

Deploy `front`
