### PR TITLE
Fix: layout, labels and grouping for attachment picker.

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -59,6 +59,8 @@ const getKeyForDataSource = (dataSource: DataSourceType) => {
     return `ds-webcrawler`;
   } else if (!dataSource.connectorProvider) {
     return `ds-folder`;
+  } else if (dataSource.connectorProvider === "dust_project") {
+    return `ds-project`;
   } else {
     return `ds-${dataSource.sId}`;
   }
@@ -81,7 +83,7 @@ interface InputBarAttachmentsPickerProps {
     useCase: "conversation" | "project_context";
     useCaseMetadata: FileUseCaseMetadata;
   };
-  space?: SpaceType;
+  spaceId?: string;
   onFileChange?: () => void;
   externalOpen?: boolean;
   onExternalOpenChange?: (open: boolean) => void;
@@ -212,7 +214,7 @@ export const InputBarAttachmentsPicker = ({
   buttonLabel = undefined,
   buttonVariant = "ghost-secondary",
   toolFileUpload,
-  space,
+  spaceId,
   type,
   onFileChange,
   externalOpen,
@@ -249,14 +251,14 @@ export const InputBarAttachmentsPicker = ({
   const spaceIds = useMemo(() => {
     // We are having a conversation within a specific space, so we only allow datasources/tools from that space and the global space.
     // This is a project v1 limitation.
-    if (space) {
+    if (spaceId) {
       return spaces
-        .filter((s) => s.sId === space.sId || s.kind === "global")
+        .filter((s) => s.sId === spaceId || s.kind === "global")
         .map((s) => s.sId);
     } else {
       return spaces.map((s) => s.sId);
     }
-  }, [spaces, space]);
+  }, [spaces, spaceId]);
 
   const {
     knowledgeResults: searchResultNodes,
@@ -406,16 +408,19 @@ export const InputBarAttachmentsPicker = ({
   const showLoader =
     isSearchLoading || isLoadingNextPage || isSearchValidating || isDebouncing;
 
-  const availableSources: DropdownMenuFilterOption[] = [
-    ...Object.entries(dataSourcesWithResults).map(([key, r]) => ({
-      value: key,
-      label: getDisplayNameForDataSource(r.dataSource, true),
-    })),
-    ...Object.entries(serversWithResults).map(([key, s]) => ({
-      value: key,
-      label: asDisplayToolName(s.server.serverName),
-    })),
-  ];
+  const availableSources: DropdownMenuFilterOption[] = useMemo(
+    () => [
+      ...Object.entries(dataSourcesWithResults).map(([key, r]) => ({
+        value: key,
+        label: getDisplayNameForDataSource(r.dataSource, true),
+      })),
+      ...Object.entries(serversWithResults).map(([key, s]) => ({
+        value: key,
+        label: asDisplayToolName(s.server.serverName),
+      })),
+    ],
+    [dataSourcesWithResults, serversWithResults]
+  );
 
   const selectedFilterKeys = useMemo(
     () =>
@@ -542,18 +547,17 @@ export const InputBarAttachmentsPicker = ({
         {searchQuery ? (
           <div ref={itemsContainerRef}>
             {(showLoader || availableSources.length > 1) && (
-              <div className="flex flex-wrap items-center gap-0.5 p-2">
+              <div className="flex flex-wrap items-center">
                 {availableSources.length > 1 && (
                   <DropdownMenuFilters
                     filters={availableSources}
                     selectedValues={selectedFilterKeys}
                     onSelectFilter={handleFilterClick}
-                    className="grow"
                   />
                 )}
                 {showLoader && (
-                  <div className="flex h-7 items-center justify-center last:grow">
-                    <Spinner size="xs" />
+                  <div className="flex items-center justify-center gap-0.5 p-2 grow">
+                    <Button size="xs" isLoading={true} variant="ghost" />
                   </div>
                 )}
               </div>

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -71,6 +71,9 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   space,
   user,
 }: InputBarButtonsProps) {
+  // Current space is taken from the conversation (if already set) or from the space prop (if provided).
+  const spaceId = conversation?.spaceId ?? space?.sId ?? undefined;
+
   const agentButton = (actions.includes("agents-list") ||
     actions.includes("agents-list-with-actions")) && (
     <AgentPicker
@@ -163,7 +166,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
               conversationId: conversation?.sId,
             },
           }}
-          space={space}
+          spaceId={spaceId}
           type="dropdown"
         />
       </>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -428,6 +428,8 @@ const InputBarContainer = ({
         });
       }
     : undefined;
+  // Current space is taken from the conversation (if already set) or from the space prop (if provided).
+  const spaceId = conversation?.spaceId ?? space?.sId ?? undefined;
 
   const { editor, editorService } = useCustomEditor({
     onEnterKeyDown: onEnterKeyDownWithShake,
@@ -438,7 +440,7 @@ const InputBarContainer = ({
     singleAgentInputEnabled: singleAgentInput,
     owner,
     conversationId: conversation?.sId,
-    spaceId: space?.sId,
+    spaceId,
     onInlineText: handleInlineText,
     shouldSuggestAgentRef: singleAgentInput ? shouldSuggestAgentRef : undefined,
     onFirstAgentMentionPasteRef,
@@ -622,17 +624,17 @@ const InputBarContainer = ({
   const spaceIds = useMemo(() => {
     // We are having a conversation within a specific space, so we only allow datasources/tools from that space and the global space.
     // This is a project v1 limitation.
-    if (space) {
+    if (spaceId) {
       return spaces
-        .filter((s) => s.sId === space.sId || s.kind === "global")
+        .filter((s) => s.sId === spaceId || s.kind === "global")
         .map((s) => s.sId);
     } else {
       return spaces.map((s) => s.sId);
     }
-  }, [spaces, space]);
+  }, [spaces, spaceId]);
 
   const spacesMap = useMemo(
-    () => Object.fromEntries(spaces?.map((space) => [space.sId, space]) || []),
+    () => Object.fromEntries(spaces?.map((s) => [s.sId, s]) || []),
     [spaces]
   );
 
@@ -1160,7 +1162,7 @@ const InputBarContainer = ({
                             conversationId: conversation?.sId,
                           },
                         }}
-                        space={space}
+                        spaceId={space?.sId}
                         type="dropdown"
                         onFileChange={() => setShowKnowledgePicker(false)}
                         externalOpen={showKnowledgePicker}

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -19,6 +19,7 @@ import {
   useRemoveProjectContextContentNode,
   useRemoveProjectContextFile,
 } from "@app/lib/swr/projects";
+import { useSpaces } from "@app/lib/swr/spaces";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { getSupportedFileExtensions } from "@app/types/files";
 import type { SpaceType } from "@app/types/space";
@@ -109,6 +110,12 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
   } | null>(null);
   const [showPreviewSheet, setShowPreviewSheet] = useState(false);
   const confirm = useContext(ConfirmContext);
+
+  const { spaces } = useSpaces({
+    workspaceId: owner.sId,
+    kinds: ["global"],
+  });
+  const globalSpace = spaces.find((space) => space.kind === "global");
 
   const {
     attachments,
@@ -462,7 +469,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
           spaceId: space.sId,
         },
       }}
-      space={space}
+      spaceId={globalSpace?.sId}
       type="dropdown"
     />
   );

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -115,7 +115,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     isDeletable: false,
   },
   dust_project: {
-    name: "Conversations & Context",
+    name: "Project",
     connectorProvider: "dust_project",
     status: "preview",
     isDeletable: false,

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -120,6 +120,11 @@ export function getLocationForDataSourceViewContentNode(
 ) {
   const { dataSource } = node.dataSourceView;
   const { connectorProvider } = dataSource;
+
+  if (connectorProvider === "dust_project" && node.parentTitle) {
+    return node.parentTitle;
+  }
+
   const providerName = connectorProvider
     ? CONNECTOR_CONFIGURATIONS[connectorProvider].name
     : "Folders";

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -37,11 +37,14 @@ function getSetupSuffixForDataSource(
 
 export function getDisplayNameForDataSource(
   ds: DataSourceType,
-  aggregateFolder: boolean = false
+  aggregate: boolean = false
 ) {
   if (ds.connectorProvider) {
+    if (ds.connectorProvider === "dust_project") {
+      return aggregate ? "Projects" : ds.name;
+    }
     if (ds.connectorProvider === "webcrawler") {
-      return aggregateFolder ? "Websites" : ds.name;
+      return aggregate ? "Websites" : ds.name;
     }
     // Not very satisfying to retro-engineer getDefaultDataSourceName but we don't store the suffix by itself.
     // This is a technical debt to have this function.
@@ -51,7 +54,7 @@ export function getDisplayNameForDataSource(
     }
     return CONNECTOR_CONFIGURATIONS[ds.connectorProvider].name;
   } else {
-    return aggregateFolder ? "Folders" : ds.name;
+    return aggregate ? "Folders" : ds.name;
   }
 }
 

--- a/front/lib/swr/search.ts
+++ b/front/lib/swr/search.ts
@@ -8,7 +8,7 @@ import type { DataSourceViewType } from "@app/types/data_source_view";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { EventSourcePolyfill } from "event-source-polyfill";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 export type DataSourceViewContentNode = ContentNodeWithParent & {
   dataSource: DataSourceType;
@@ -167,7 +167,7 @@ export function useUnifiedSearch({
   );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
-  useEffect(() => {
+  useLayoutEffect(() => {
     setKnowledgeResults([]);
     setToolResults([]);
     setNextPageCursor(null);


### PR DESCRIPTION
## Description

Polish and fixes for the attachment picker used in the project knowledge tab.
- Pass `spaceId` (string) instead of the full `space` object — derive it from the conversation's `spaceId` or fallback to the `space` prop
- Wrap `availableSources` in `useMemo` to avoid unnecessary re-renders
- Fix loader styling (shows after filters, not before)
- Add a dedicated key for `dust_project` data sources to avoid grouping them as generic folders
- Fix `getLocationForDataSourceViewContentNode` to show parent title for project nodes
- Switch `useEffect` → `useLayoutEffect` for resetting search results on query change

## Tests

Local + green

## Risk

Low

## Deploy Plan

Deploy `front`
