### PR TITLE
Add: project semantic search also search in connected data.

### DIFF
--- a/front/lib/api/assistant/jit/projects.ts
+++ b/front/lib/api/assistant/jit/projects.ts
@@ -1,17 +1,67 @@
 import { DEFAULT_PROJECT_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/constants";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
+import type { ContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import {
+  isContentFragmentDataSourceNode,
+  isContentNodeAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
 import { getProjectContextDataSourceView } from "@app/lib/api/assistant/jit/utils";
+import { listProjectContextAttachments } from "@app/lib/api/projects";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isProjectConversation } from "@app/types/assistant/conversation";
 
 /**
- * Get the project_search MCP server for searching project context files.
+ * One config per data source view; merges parent node ids when several project context
+ * nodes point at the same view (same pattern as skill knowledge merging).
+ */
+function mergeContentNodeDataSourceConfigurations(
+  workspaceId: string,
+  nodes: ContentNodeAttachmentType[]
+): DataSourceConfiguration[] {
+  const byViewId = new Map<
+    string,
+    { hasFullView: boolean; parentIds: Set<string> }
+  >();
+
+  for (const node of nodes) {
+    const viewId = node.nodeDataSourceViewId;
+    let agg = byViewId.get(viewId);
+    if (!agg) {
+      agg = { hasFullView: false, parentIds: new Set() };
+      byViewId.set(viewId, agg);
+    }
+    if (isContentFragmentDataSourceNode(node)) {
+      agg.hasFullView = true;
+    } else {
+      agg.parentIds.add(node.nodeId);
+    }
+  }
+
+  return Array.from(byViewId.entries()).map(([dataSourceViewId, agg]) => ({
+    workspaceId,
+    dataSourceViewId,
+    filter: {
+      parents: agg.hasFullView
+        ? null
+        : {
+            in: Array.from(agg.parentIds),
+            not: [],
+          },
+      tags: null,
+    },
+  }));
+}
+
+/**
+ * Get the project_search MCP server for searching project context: uploaded files
+ * (project context data source view) plus searchable content-node references attached to the project.
  * Only available with "projects" feature flag and if conversation is in a project.
  */
 export async function getProjectSearchServer(
@@ -51,6 +101,31 @@ export async function getProjectSearchServer(
     return null;
   }
 
+  const space = await SpaceResource.fetchById(auth, conversation.spaceId);
+  let contentNodeDataSources: DataSourceConfiguration[] = [];
+  if (!space) {
+    logger.warn(
+      {
+        conversationId: conversation.sId,
+        spaceId: conversation.spaceId,
+      },
+      "Space not found when building project search data sources; skipping attached nodes"
+    );
+  } else {
+    const projectContextAttachments = await listProjectContextAttachments(
+      auth,
+      space
+    );
+    const searchableContentNodes = projectContextAttachments.filter(
+      (a): a is ContentNodeAttachmentType =>
+        isContentNodeAttachmentType(a) && a.isSearchable
+    );
+    contentNodeDataSources = mergeContentNodeDataSourceConfigurations(
+      owner.sId,
+      searchableContentNodes
+    );
+  }
+
   const dataSources: DataSourceConfiguration[] = [
     {
       workspaceId: owner.sId,
@@ -60,6 +135,7 @@ export async function getProjectSearchServer(
         tags: null,
       },
     },
+    ...contentNodeDataSources,
   ];
 
   return {


### PR DESCRIPTION
## Description

Extend the project semantic search (`getProjectSearchServer`) to also cover connected data attached to the project, not just uploaded files.
- Fetch project context attachments at JIT time and extract searchable content-node references
- Add `mergeContentNodeDataSourceConfigurations` helper to build `DataSourceConfiguration[]` from those nodes, batching by data source view and merging parent IDs

## Tests

Local + green

## Risk

Low

## Deploy Plan

Deploy `front`
