### PR TITLE
Backfill script

### DIFF
--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -235,7 +235,7 @@ export function buildLlmUsageEvents({
   return [...groups.values()].map((group) => ({
     transaction_id: `llm-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${group.providerId}-${group.modelId}`,
     customer_id: workspaceId,
-    event_type: "llm_usage",
+    event_type: "llm_usage_v2",
     timestamp,
     properties: {
       workspace_id: workspaceId,
@@ -342,7 +342,7 @@ export function buildToolUseEvents({
       `tool-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`
     ),
     customer_id: workspaceId,
-    event_type: "tool_use",
+    event_type: "tool_use_v2",
     timestamp,
     properties: {
       workspace_id: workspaceId,

--- a/front/migrations/20260408_backfill_metronome_events.ts
+++ b/front/migrations/20260408_backfill_metronome_events.ts
@@ -1,0 +1,412 @@
+/**
+ * Backfill Metronome usage events (llm_usage_v2 / tool_use_v2) for all
+ * completed agent messages from the last N days.
+ *
+ * Directly builds and ingests events — no Temporal workflows.
+ *
+ * Usage:
+ *   npx tsx migrations/20260408_backfill_metronome_events.ts [--days 30] [--until <ISO>] [--execute] [-w workspaceSId]
+ *
+ * Without --execute, runs in dry-run mode (counts messages, no events emitted).
+ */
+
+import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { USAGE_ORIGINS_CLASSIFICATION } from "@app/lib/api/programmatic_usage/common";
+import { Authenticator } from "@app/lib/auth";
+import { ingestMetronomeEvents } from "@app/lib/metronome/client";
+import type { MetronomeEvent } from "@app/lib/metronome/types";
+import {
+  buildLlmUsageEvents,
+  buildToolUseEvents,
+  getToolCategory,
+} from "@app/lib/metronome/events";
+import {
+  AgentMessageModel,
+  ConversationModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
+import { KeyModel } from "@app/lib/resources/storage/models/keys";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+import type { LightWorkspaceType } from "@app/types/user";
+import { createHash } from "crypto";
+import { Op } from "sequelize";
+
+const BATCH_SIZE = 2000;
+
+async function backfillWorkspace(
+  workspace: LightWorkspaceType,
+  since: Date,
+  until: Date | undefined,
+  execute: boolean,
+  logger: Logger
+): Promise<{
+  total: number;
+  emitted: number;
+  skipped: number;
+  errors: number;
+}> {
+  let total = 0;
+  let emitted = 0;
+  let skipped = 0;
+  let errors = 0;
+  let lastId = 0;
+
+  const INGEST_BATCH_SIZE = 100;
+  let pendingEvents: MetronomeEvent[] = [];
+
+  async function flushEvents() {
+    if (pendingEvents.length === 0) {
+      return;
+    }
+    await ingestMetronomeEvents(pendingEvents);
+    emitted += pendingEvents.length;
+    pendingEvents = [];
+  }
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  logger.info(
+    { workspaceId: workspace.sId, workspaceModelId: workspace.id },
+    "Starting workspace"
+  );
+
+  // Cache conversation numeric id → sId to avoid repeated lookups.
+  const conversationSIdCache = new Map<number, string>();
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // Query agent messages with a subquery on AgentMessageModel to avoid
+    // expensive joins. ConversationModel sId resolved from cache.
+    const rows = await MessageModel.findAll({
+      where: {
+        id: { [Op.gt]: lastId },
+        workspaceId: workspace.id,
+      },
+      include: [
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          required: true,
+          where: {
+            status: ["succeeded", "cancelled", "gracefully_stopped"],
+            updatedAt: {
+              [Op.gte]: since,
+              ...(until ? { [Op.lt]: until } : {}),
+            },
+          },
+        },
+      ],
+      order: [["id", "ASC"]],
+      limit: BATCH_SIZE,
+    });
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        batchSize: rows.length,
+        lastId,
+        total,
+        emitted,
+        skipped,
+        errors,
+      },
+      "Processing batch"
+    );
+
+    // Pre-fetch all parent user messages for this batch in one query.
+    const parentIds = rows
+      .map((r) => r.parentId)
+      .filter((id): id is number => id !== null);
+    const parentRows =
+      parentIds.length > 0
+        ? await MessageModel.findAll({
+            where: { id: parentIds, workspaceId: workspace.id },
+            include: [
+              {
+                model: UserMessageModel,
+                as: "userMessage",
+                required: true,
+                include: [
+                  { model: UserModel, required: false },
+                  { model: KeyModel, as: "key", required: false },
+                ],
+              },
+            ],
+          })
+        : [];
+    const parentById = new Map(parentRows.map((r) => [r.id, r]));
+
+    // Pre-fetch conversation sIds for uncached conversations.
+    const uncachedConvIds = [
+      ...new Set(
+        rows
+          .map((r) => r.conversationId)
+          .filter((id) => !conversationSIdCache.has(id))
+      ),
+    ];
+    if (uncachedConvIds.length > 0) {
+      const convs = await ConversationModel.findAll({
+        where: { id: uncachedConvIds, workspaceId: workspace.id },
+        attributes: ["id", "sId"],
+      });
+      for (const c of convs) {
+        conversationSIdCache.set(c.id, c.sId);
+      }
+    }
+
+    for (const row of rows) {
+      lastId = row.id;
+      total++;
+
+      const agentMessage = row.agentMessage;
+      if (!agentMessage?.runIds) {
+        skipped++;
+        continue;
+      }
+
+      try {
+        const userMessageRow = row.parentId
+          ? (parentById.get(row.parentId) ?? null)
+          : null;
+
+        if (!userMessageRow?.userMessage) {
+          skipped++;
+          continue;
+        }
+
+        const userMessage = userMessageRow.userMessage;
+        const userId = userMessage.user?.sId ?? null;
+        const userMessageOrigin: UserMessageOrigin =
+          userMessage.userContextOrigin ?? "web";
+        const parentAgentMessageId = userMessage.agenticOriginMessageId ?? null;
+        const isSubAgentMessage = userMessage.agenticMessageType !== null;
+        const authMethod = userMessage.userContextAuthMethod ?? null;
+        const agentId = agentMessage.agentConfigurationId ?? null;
+        const messageStatus = agentMessage.status ?? "unknown";
+        const timestamp = agentMessage.updatedAt.toISOString();
+
+        // Determine programmatic usage from the user message context.
+        const isProgrammatic =
+          userMessageOrigin !== "zendesk" &&
+          (authMethod === "api_key" ||
+            USAGE_ORIGINS_CLASSIFICATION[userMessageOrigin] === "programmatic");
+
+        // API key name from the joined KeyModel.
+        const apiKeyName = (userMessage as any).key?.name ?? null;
+
+        // Get run usages.
+        const runs = await RunResource.listByDustRunIds(auth, {
+          dustRunIds: agentMessage.runIds,
+        });
+        const runUsages = (
+          await concurrentExecutor(runs, (run) => run.listRunUsages(auth), {
+            concurrency: 10,
+          })
+        ).flat();
+
+        // Get MCP actions — only final status (succeeded/errored/denied).
+        const allMcpActions =
+          await AgentMCPActionResource.listByAgentMessageIds(auth, [
+            agentMessage.id,
+          ]);
+        const mcpActions = allMcpActions.filter((a) =>
+          isToolExecutionStatusFinal(a.toJSON().status)
+        );
+        const toolActions = mcpActions.map((a) => {
+          const json = a.toJSON();
+          return {
+            toolName: json.toolName,
+            mcpServerId: json.mcpServerId,
+            internalMCPServerName: json.internalMCPServerName,
+            status: json.status,
+            executionDurationMs: json.executionDurationMs,
+          };
+        });
+
+        // Deterministic runKey — hash of runIds, same as live code.
+        const effectiveRunIds = agentMessage.runIds ?? [];
+        const runKey = createHash("sha256")
+          .update(effectiveRunIds.sort().join(","))
+          .digest("hex")
+          .slice(0, 8);
+
+        const conversationId =
+          conversationSIdCache.get(row.conversationId) ?? "";
+
+        const llmEvents = buildLlmUsageEvents({
+          workspaceId: workspace.sId,
+          conversationId,
+          userId,
+          agentMessageId: row.sId,
+          agentId,
+          parentAgentMessageId,
+          runKey,
+          runUsages,
+          origin: userMessageOrigin,
+          isProgrammaticUsage: isProgrammatic,
+          authMethod,
+          apiKeyName,
+          messageStatus,
+          isSubAgentMessage,
+          timestamp,
+        });
+
+        const toolEvents = buildToolUseEvents({
+          workspaceId: workspace.sId,
+          conversationId,
+          userId,
+          agentMessageId: row.sId,
+          agentId,
+          parentAgentMessageId,
+          runKey,
+          actions: toolActions,
+          origin: userMessageOrigin,
+          isProgrammaticUsage: isProgrammatic,
+          authMethod,
+          apiKeyName,
+          messageStatus,
+          isSubAgentMessage,
+          timestamp,
+        });
+
+        const allEvents = [...llmEvents, ...toolEvents];
+
+        if (allEvents.length === 0) {
+          skipped++;
+          continue;
+        }
+
+        if (!execute) {
+          emitted += allEvents.length;
+          continue;
+        }
+
+        pendingEvents.push(...allEvents);
+        if (pendingEvents.length >= INGEST_BATCH_SIZE) {
+          await flushEvents();
+        }
+      } catch (err) {
+        errors++;
+        if (errors <= 10) {
+          logger.warn(
+            { messageId: row.sId, error: String(err) },
+            "Error processing message"
+          );
+        }
+      }
+    }
+  }
+
+  // Flush any remaining events.
+  if (execute) {
+    await flushEvents();
+  }
+
+  return { total, emitted, skipped, errors };
+}
+
+makeScript(
+  {
+    days: {
+      alias: "d",
+      describe: "Number of days to backfill (default: 30, max: 34)",
+      type: "number" as const,
+      default: 30,
+    },
+    until: {
+      alias: "u",
+      describe:
+        "Only backfill messages finalized before this ISO date. Use the deploy time of v2 code to avoid overlap with live events.",
+      type: "string" as const,
+    },
+    wId: {
+      type: "string" as const,
+      demandOption: false,
+      describe:
+        "Workspace sId to backfill (optional, processes all if omitted)",
+    },
+    fromWorkspaceId: {
+      type: "number" as const,
+      demandOption: false,
+      describe:
+        "Start from this workspace numeric model id (for resuming interrupted runs)",
+    },
+  },
+  async (args, logger) => {
+    const days = Math.min(args.days ?? 30, 34);
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    const until = args.until ? new Date(args.until) : undefined;
+
+    logger.info(
+      {
+        days,
+        since: since.toISOString(),
+        until: until?.toISOString() ?? "now",
+        workspaceId: args.wId ?? "all",
+        fromWorkspaceId: args.fromWorkspaceId ?? "start",
+        execute: args.execute,
+      },
+      "Starting backfill"
+    );
+
+    let grandTotal = 0;
+    let grandEmitted = 0;
+    let grandSkipped = 0;
+    let grandErrors = 0;
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const result = await backfillWorkspace(
+          workspace,
+          since,
+          until,
+          args.execute,
+          logger
+        );
+
+        grandTotal += result.total;
+        grandEmitted += result.emitted;
+        grandSkipped += result.skipped;
+        grandErrors += result.errors;
+
+        if (result.total > 0) {
+          logger.info(
+            {
+              workspaceId: workspace.sId,
+              workspaceModelId: workspace.id,
+              ...result,
+            },
+            "Workspace done"
+          );
+        }
+      },
+      { wId: args.wId, fromWorkspaceId: args.fromWorkspaceId }
+    );
+
+    logger.info(
+      {
+        total: grandTotal,
+        emitted: grandEmitted,
+        skipped: grandSkipped,
+        errors: grandErrors,
+        days,
+        execute: args.execute,
+      },
+      args.execute
+        ? "Backfill complete"
+        : "Dry-run complete — use --execute to emit events"
+    );
+  }
+);

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -128,7 +128,7 @@ interface PackageDef {
 const METRICS: MetricDef[] = [
   {
     name: "LLM Provider Cost (Programmatic)",
-    event_type_filter: { in_values: ["llm_usage"] },
+    event_type_filter: { in_values: ["llm_usage_v2"] },
     property_filters: [
       { name: "cost_micro_usd", exists: true },
       { name: "is_programmatic_usage", in_values: ["true"] },
@@ -138,7 +138,7 @@ const METRICS: MetricDef[] = [
   },
   {
     name: "LLM Provider Cost (User)",
-    event_type_filter: { in_values: ["llm_usage"] },
+    event_type_filter: { in_values: ["llm_usage_v2"] },
     property_filters: [
       { name: "cost_micro_usd", exists: true },
       { name: "is_programmatic_usage", in_values: ["false"] },
@@ -148,7 +148,7 @@ const METRICS: MetricDef[] = [
   },
   {
     name: "Tool Invocations (Programmatic)",
-    event_type_filter: { in_values: ["tool_use"] },
+    event_type_filter: { in_values: ["tool_use_v2"] },
     property_filters: [
       { name: "count", exists: true },
       { name: "is_programmatic_usage", in_values: ["true"] },
@@ -161,7 +161,7 @@ const METRICS: MetricDef[] = [
   },
   {
     name: "Tool Invocations (User)",
-    event_type_filter: { in_values: ["tool_use"] },
+    event_type_filter: { in_values: ["tool_use_v2"] },
     property_filters: [
       { name: "count", exists: true },
       { name: "is_programmatic_usage", in_values: ["false"] },
@@ -516,6 +516,12 @@ async function syncMetrics(): Promise<void> {
     aggregation_key?: string;
     aggregation_type?: string;
     group_keys?: string[][];
+    event_type_filter?: { in_values: string[] };
+    property_filters?: Array<{
+      name: string;
+      exists?: boolean;
+      in_values?: string[];
+    }>;
   }> = [];
   for await (const m of client.v1.billableMetrics.list()) {
     existing.push(m as (typeof existing)[number]);
@@ -536,12 +542,20 @@ async function syncMetrics(): Promise<void> {
     const groupKeysMatch =
       JSON.stringify(ex?.group_keys ?? []) ===
       JSON.stringify(desired.group_keys ?? []);
+    const eventTypeMatch =
+      JSON.stringify(ex?.event_type_filter?.in_values?.sort() ?? []) ===
+      JSON.stringify([...desired.event_type_filter.in_values].sort());
+    const propertyFiltersMatch =
+      JSON.stringify(ex?.property_filters ?? []) ===
+      JSON.stringify(desired.property_filters ?? []);
     const configMatch =
       ex &&
       ex.aggregation_key === desired.aggregation_key &&
       ex.aggregation_type?.toLowerCase() ===
         desired.aggregation_type.toLowerCase() &&
-      groupKeysMatch;
+      groupKeysMatch &&
+      eventTypeMatch &&
+      propertyFiltersMatch;
 
     if (ex && configMatch) {
       console.log(`  ✓ ${desired.name} — up to date (${ex.id})`);
@@ -1113,23 +1127,44 @@ async function main(): Promise<void> {
     }
   }
 
-  // Output constants for lib/metronome/constants.ts
-  const prefix = ENV === "production" ? "PROD" : "DEV";
+  // Output all IDs as TypeScript constants — paste into lib/metronome/constants.ts.
+  function toConstName(prefix: string, name: string): string {
+    return `${prefix}_${name
+      .toUpperCase()
+      .replace(/[^A-Z0-9]+/g, "_")
+      .replace(/^_|_$/g, "")}`;
+  }
+
+  const envPrefix = ENV === "production" ? "PROD" : "DEV";
   console.log(
-    `\n=== Constants (${ENV}) — paste into lib/metronome/constants.ts ===`
+    `\n=== TypeScript constants (${ENV}) — paste into lib/metronome/constants.ts ===\n`
   );
-  console.log(
-    `const ${prefix}_FREE_CREDIT_PRODUCT_ID = "${ids.products["Free Monthly Credits"] ?? ""}";`
-  );
-  console.log(
-    `const ${prefix}_COMMIT_PRODUCT_ID = "${ids.products["Prepaid Commit"] ?? ""}";`
-  );
-  console.log(
-    `const ${prefix}_LLM_PROGRAMMATIC_BILLABLE_METRIC_ID =\n  "${ids.metrics["LLM Provider Cost (Programmatic)"] ?? ""}";`
-  );
-  console.log(
-    `const ${prefix}_TOOL_PROGRAMMATIC_BILLABLE_METRIC_ID =\n  "${ids.metrics["Tool Invocations (Programmatic)"] ?? ""}";`
-  );
+
+  console.log("// Metrics");
+  for (const [name, id] of Object.entries(ids.metrics)) {
+    console.log(`const ${toConstName(envPrefix + "_METRIC", name)} = "${id}";`);
+  }
+
+  console.log("\n// Products");
+  for (const [name, id] of Object.entries(ids.products)) {
+    console.log(
+      `const ${toConstName(envPrefix + "_PRODUCT", name)} = "${id}";`
+    );
+  }
+
+  console.log("\n// Rate Cards");
+  for (const [name, id] of Object.entries(ids.rateCards)) {
+    console.log(
+      `const ${toConstName(envPrefix + "_RATE_CARD", name)} = "${id}";`
+    );
+  }
+
+  console.log("\n// Packages");
+  for (const [name, id] of Object.entries(ids.packages)) {
+    console.log(
+      `const ${toConstName(envPrefix + "_PACKAGE", name)} = "${id}";`
+    );
+  }
 
   console.log("\n✓ Done");
 }

--- a/front/scripts/workspace_helpers.ts
+++ b/front/scripts/workspace_helpers.ts
@@ -3,15 +3,44 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { LightWorkspaceType } from "@app/types/user";
 
+/**
+ * Run a worker function on workspaces.
+ *
+ * - If `wId` is provided, runs on that single workspace.
+ * - Otherwise runs on all workspaces, ordered by numeric model id.
+ * - `fromWorkspaceId` skips workspaces with model id < this value (for resuming).
+ */
 export async function runOnAllWorkspaces(
   worker: (workspace: LightWorkspaceType) => Promise<void>,
-  { concurrency }: { concurrency: number } = { concurrency: 1 }
+  {
+    concurrency = 1,
+    wId,
+    fromWorkspaceId,
+  }: {
+    concurrency?: number;
+    wId?: string;
+    fromWorkspaceId?: number;
+  } = {}
 ) {
-  const workspaces = await WorkspaceResource.listAll();
+  let workspaces: LightWorkspaceType[];
 
-  await concurrentExecutor(
-    workspaces,
-    (workspace) => worker(renderLightWorkspaceType({ workspace })),
-    { concurrency }
-  );
+  if (wId) {
+    const workspace = await WorkspaceResource.fetchById(wId);
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${wId}`);
+    }
+    workspaces = [renderLightWorkspaceType({ workspace })];
+  } else {
+    const all = await WorkspaceResource.listAll("ASC");
+    const filtered = fromWorkspaceId
+      ? all.filter((w) => w.id >= fromWorkspaceId)
+      : all;
+    workspaces = filtered.map((w) =>
+      renderLightWorkspaceType({ workspace: w })
+    );
+  }
+
+  await concurrentExecutor(workspaces, (workspace) => worker(workspace), {
+    concurrency,
+  });
 }

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -220,6 +220,18 @@ export async function emitMetronomeUsageEventsActivity(
   const { agentMessageId, conversationId, userMessageId } = agentLoopArgs;
   const userMessageOrigin = agentLoopArgs.userMessageOrigin ?? "web";
 
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      agentMessageId,
+      conversationId,
+      messageModelId: agentLoopArgs.dustRunIds ? "with-dustRunIds" : "legacy",
+      dustRunIds: agentLoopArgs.dustRunIds,
+      startStep: agentLoopArgs.startStep,
+    },
+    "[Metronome] Processing usage events"
+  );
+
   // Query agent message with its run IDs.
   const agentMessageRow = await MessageModel.findOne({
     where: {


### PR DESCRIPTION
## Summary

Backfill script for Metronome v2 usage events (`llm_usage_v2` / `tool_use_v2`) and related changes.

### Backfill script (`scripts/backfill_metronome_events.ts`)

Queries the DB directly for all completed agent messages within a time window, builds v2 events with the new properties (`agent_id`, `api_key_name`, `auth_method`, `conversation_id`, `message_status`), and ingests them into Metronome.

**Usage:**
```
npx tsx scripts/backfill_metronome_events.ts --days 30 --until "2026-04-08T10:00:00Z" --execute
npx tsx scripts/backfill_metronome_events.ts --days 30 -w abc123 --execute  # single workspace
npx tsx scripts/backfill_metronome_events.ts --days 30                      # dry-run
```

**How it works:**
- Paginated cursor-based scan of `MessageModel` joined with `AgentMessageModel` (status: succeeded/cancelled/gracefully_stopped, updatedAt in range)
- For each message: resolves workspace, user message, run usages, MCP actions
- Builds `llm_usage_v2` and `tool_use_v2` events using the same event builders as live code
- `runKey` = hash of `agentMessage.runIds` (deterministic, matches live code)
- MCP actions filtered to final status only (`succeeded`/`errored`/`denied`)
- Ingests directly via `ingestMetronomeEvents` — no Temporal workflows involved

**Parameters:**
- `--days` / `-d`: lookback window (default 30, max 34 — Metronome's ingestion limit)
- `--until` / `-u`: only backfill messages finalized before this ISO date. Set to the deploy time of v2 code to avoid overlap with live events
- `--workspaceId` / `-w`: filter to a single workspace
- `--execute`: actually ingest events (dry-run by default)

### Event type change to v2

- `llm_usage` → `llm_usage_v2`, `tool_use` → `tool_use_v2`
- Metrics in `metronome_setup.ts` updated to filter on v2 event types
- Old v1 events on different metrics — no double counting between old and new

### Other changes

- **`activities.ts`**: Added log in `emitMetronomeUsageEventsActivity` to track processed messages (workspaceId, agentMessageId, dustRunIds, startStep)

### Known limitations

- **34-day limit**: Metronome rejects events older than 34 days. The script pre-filters by `updatedAt` and the `ingestMetronomeEvents` function drops events that are too old
- **No per-execution run scoping for backfill**: For past messages, `dustRunIds` was never recorded per workflow execution. The backfill uses all accumulated `runIds` from the agent message. For messages where the agent loop restarted, all runs are included in a single set of events (same as the old v1 behavior)
- **Edge case overlap at deploy boundary**: Messages that started before the `--until` cutoff but are confirmed/resumed after v2 deploys may have their first execution's runs counted by both backfill and live code. Acceptable — small window, minimal impact
- **Backfill uses all MCP actions**: No `startStep` filtering for backfill (not available for past messages). Only final-status actions are included, so blocked/pending actions are not double-counted

## Test plan

- [ ] Dry-run: counts messages without ingesting
- [ ] Single workspace backfill: `--workspaceId` filters correctly
- [ ] `--until` cutoff: only messages finalized before the date are processed
- [ ] Events appear in Metronome with correct v2 event type
- [ ] `usage.listWithGroups` returns backfilled data grouped by new properties
- [ ] No overlap with live v2 events when `--until` set to deploy time

🤖 Generated with [Claude Code](https://claude.com/claude-code)