### PR TITLE
[front] chore: cleanup conversation sId references following BACK[10]

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -845,7 +845,7 @@ describe("retryAgentMessage", () => {
 describe("getConversation with branches", () => {
   let auth: Authenticator;
   let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
-  let conversationSId: string;
+  let conversationId: string;
   let branchSId: string;
 
   beforeEach(async () => {
@@ -861,7 +861,7 @@ describe("getConversation with branches", () => {
       title: "Branching conversation",
       requestedSpaceIds: [],
     });
-    conversationSId = conversation.sId;
+    conversationId = conversation.sId;
 
     const beforeBranchUserMessage = await UserMessageModel.create({
       userId: user.id,
@@ -970,7 +970,7 @@ describe("getConversation with branches", () => {
   });
 
   it("returns only main-thread messages when branchId is not provided", async () => {
-    const result = await getConversation(auth, conversationSId);
+    const result = await getConversation(auth, conversationId);
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -994,7 +994,7 @@ describe("getConversation with branches", () => {
   it("returns messages up to the branch point plus branch messages when branchId is provided, and sets branchId on the conversation", async () => {
     const result = await getConversation(
       auth,
-      conversationSId,
+      conversationId,
       false,
       branchSId
     );

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1603,7 +1603,7 @@ export async function createAgentMessageFromText(
     logger.error(
       {
         workspaceId: owner.sId,
-        conversationSId: conversation.sId,
+        conversationId: conversation.sId,
         messageSId: created.messageSId,
       },
       "createAgentMessageFromText: conversation not found for event publish."
@@ -1626,7 +1626,7 @@ export async function createAgentMessageFromText(
     logger.error(
       {
         workspaceId: owner.sId,
-        conversationSId: conversation.sId,
+        conversationId: conversation.sId,
         messageSId: created.messageSId,
       },
       "createAgentMessageFromText: message row missing for batch render."
@@ -1645,7 +1645,7 @@ export async function createAgentMessageFromText(
     logger.error(
       {
         workspaceId: owner.sId,
-        conversationSId: conversation.sId,
+        conversationId: conversation.sId,
         messageSId: created.messageSId,
         error: renderedRes.error,
       },
@@ -1663,7 +1663,7 @@ export async function createAgentMessageFromText(
     logger.error(
       {
         workspaceId: owner.sId,
-        conversationSId: conversation.sId,
+        conversationId: conversation.sId,
         messageSId: created.messageSId,
       },
       "createAgentMessageFromText: rendered agent message not found."

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -213,7 +213,7 @@ function renderUserMessage(
     } else {
       logger.warn(
         {
-          conversationId: message.sId,
+          messageId: message.sId,
           userId: userMessage.userId,
         },
         "User not found for user message while it should have been fetched before. Falling back to user context."
@@ -524,7 +524,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         logger.error(
           {
             workspaceId: auth.getNonNullableWorkspace().sId,
-            conversationId: message.sId,
+            messageId: message.sId,
             agentMessageId: agentMessage.id,
             agentConfigurationId: agentMessage.agentConfigurationId,
             agentConfigurations,
@@ -642,7 +642,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         logger.error(
           {
             workspaceId: auth.getNonNullableWorkspace().sId,
-            conversationId: message.sId,
+            messageId: message.sId,
             agentMessageId: agentMessage.id,
           },
           "Couldn't find parent message for agent message."

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -213,7 +213,7 @@ function renderUserMessage(
     } else {
       logger.warn(
         {
-          conversationSId: message.sId,
+          conversationId: message.sId,
           userId: userMessage.userId,
         },
         "User not found for user message while it should have been fetched before. Falling back to user context."
@@ -524,7 +524,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         logger.error(
           {
             workspaceId: auth.getNonNullableWorkspace().sId,
-            conversationSId: message.sId,
+            conversationId: message.sId,
             agentMessageId: agentMessage.id,
             agentConfigurationId: agentMessage.agentConfigurationId,
             agentConfigurations,
@@ -642,7 +642,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         logger.error(
           {
             workspaceId: auth.getNonNullableWorkspace().sId,
-            conversationSId: message.sId,
+            conversationId: message.sId,
             agentMessageId: agentMessage.id,
           },
           "Couldn't find parent message for agent message."

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -4289,9 +4289,9 @@ describe("markAsActionRequired", () => {
         }
       );
 
-      const conversationSIds = conversations.map((c) => c.sId);
-      expect(conversationSIds).toContain(convo1.sId);
-      expect(conversationSIds).toContain(convo2.sId);
+      const conversationIds = conversations.map((c) => c.sId);
+      expect(conversationIds).toContain(convo1.sId);
+      expect(conversationIds).toContain(convo2.sId);
       expect(conversations.length).toBeGreaterThanOrEqual(2);
     });
 
@@ -4322,9 +4322,9 @@ describe("markAsActionRequired", () => {
         }
       );
 
-      const conversationSIds = conversations.map((c) => c.sId);
-      expect(conversationSIds).toContain(convo1.sId);
-      expect(conversationSIds).not.toContain(convo2.sId);
+      const conversationIds = conversations.map((c) => c.sId);
+      expect(conversationIds).toContain(convo1.sId);
+      expect(conversationIds).not.toContain(convo2.sId);
     });
 
     it("should include deleted conversations when includeDeleted is true", async () => {
@@ -4357,9 +4357,9 @@ describe("markAsActionRequired", () => {
         }
       );
 
-      const conversationSIds = conversations.map((c) => c.sId);
-      expect(conversationSIds).toContain(convo1.sId);
-      expect(conversationSIds).toContain(convo2.sId);
+      const conversationIds = conversations.map((c) => c.sId);
+      expect(conversationIds).toContain(convo1.sId);
+      expect(conversationIds).toContain(convo2.sId);
     });
 
     it("should filter conversations by updatedSince timestamp", async () => {
@@ -4450,12 +4450,12 @@ describe("markAsActionRequired", () => {
         }
       );
 
-      const conversationSIds = conversations.map((c) => c.sId);
+      const conversationIds = conversations.map((c) => c.sId);
       // Verify convo2 and convo3 are included (updated more recently than 4.5 days ago)
-      expect(conversationSIds).toContain(convo2.sId);
-      expect(conversationSIds).toContain(convo3.sId);
+      expect(conversationIds).toContain(convo2.sId);
+      expect(conversationIds).toContain(convo3.sId);
       // Verify convo1 is excluded (updated before 4.5 days ago)
-      expect(conversationSIds).not.toContain(convo1.sId);
+      expect(conversationIds).not.toContain(convo1.sId);
     });
 
     it("should return empty array for space with no conversations", async () => {
@@ -4566,9 +4566,9 @@ describe("markAsActionRequired", () => {
         }
       );
 
-      const conversationSIds = conversations.map((c) => c.sId);
+      const conversationIds = conversations.map((c) => c.sId);
       // convo2 should be included (updated after threshold, not deleted)
-      expect(conversationSIds).toContain(convo2.sId);
+      expect(conversationIds).toContain(convo2.sId);
       // convo1 should be included (deleted but includeDeleted=true)
       // Note: convo1 was updated 4 days ago, so it won't pass updatedSince filter
       // This test verifies the combination works, even if convo1 is filtered out by updatedSince

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2293,14 +2293,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   static async batchMarkAsReadAndClearActionRequired(
     auth: Authenticator,
-    conversationSIds: string[]
+    conversationIds: string[]
   ) {
     const conversations = await ConversationResource.fetchByIds(
       auth,
-      conversationSIds
+      conversationIds
     );
 
-    const conversationIds = conversations.map((c) => c.id);
+    const conversationModelIds = conversations.map((c) => c.id);
 
     const userModelId = auth.getNonNullableUser().id;
     const workspaceModelId = auth.getNonNullableWorkspace().id;
@@ -2309,7 +2309,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       { actionRequired: false },
       {
         where: {
-          conversationId: { [Op.in]: conversationIds },
+          conversationId: { [Op.in]: conversationModelIds },
           workspaceId: workspaceModelId,
           userId: userModelId,
         },
@@ -2319,7 +2319,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     // Update the existing UserConversationReads entries
     const existingReads = await UserConversationReadsModel.findAll({
       where: {
-        conversationId: { [Op.in]: conversationIds },
+        conversationId: { [Op.in]: conversationModelIds },
         userId: userModelId,
         workspaceId: workspaceModelId,
       },
@@ -2337,15 +2337,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
 
     // Create entries for conversations that do not have one yet
-    const conversationIdsWithExistingReads = new Set(
+    const conversationModelIdsWithExistingReads = new Set(
       existingReads.map((read) => read.conversationId)
     );
-    const conversationIdsNeedingNewReads = conversationIds.filter(
-      (id) => !conversationIdsWithExistingReads.has(id)
+    const conversationModelIdsNeedingNewReads = conversationModelIds.filter(
+      (id) => !conversationModelIdsWithExistingReads.has(id)
     );
     await UserConversationReadsModel.bulkCreate(
-      conversationIdsNeedingNewReads.map((conversationId) => ({
-        conversationId,
+      conversationModelIdsNeedingNewReads.map((conversationModelId) => ({
+        conversationId: conversationModelId,
         userId: userModelId,
         workspaceId: workspaceModelId,
         lastReadAt: new Date(),

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1608,20 +1608,20 @@ async function maybeDeleteCoreArtifactsForIndexedFile(
   }
 
   if (file.useCase === "conversation") {
-    const conversationSId = file.useCaseMetadata?.conversationId;
-    if (!conversationSId) {
+    const conversationId = file.useCaseMetadata?.conversationId;
+    if (!conversationId) {
       return;
     }
     const cRes = await ConversationResource.fetchConversationWithoutContent(
       auth,
-      conversationSId
+      conversationId
     );
     if (cRes.isErr()) {
       logger.warn(
         {
           workspaceId: auth.workspace()?.sId,
           fileId: file.sId,
-          conversationSId,
+          conversationId,
         },
         "File delete: conversation not found; skipping Core cleanup."
       );
@@ -1636,7 +1636,7 @@ async function maybeDeleteCoreArtifactsForIndexedFile(
         {
           workspaceId: auth.workspace()?.sId,
           fileId: file.sId,
-          conversationSId,
+          conversationId,
         },
         "File delete: conversation data source not found; skipping Core cleanup."
       );

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversations/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversations/index.test.ts
@@ -181,9 +181,9 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversations", () => {
     expect(Array.isArray(data.conversations)).toBe(true);
     expect(data.conversations.length).toBeGreaterThanOrEqual(2);
 
-    const conversationSIds = data.conversations.map((c: any) => c.sId);
-    expect(conversationSIds).toContain(convo1.sId);
-    expect(conversationSIds).toContain(convo2.sId);
+    const conversationIds = data.conversations.map((c: any) => c.sId);
+    expect(conversationIds).toContain(convo1.sId);
+    expect(conversationIds).toContain(convo2.sId);
 
     // Verify conversation structure
     const firstConvo = data.conversations.find(
@@ -246,9 +246,9 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversations", () => {
 
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
-    const conversationSIds = data.conversations.map((c: any) => c.sId);
-    expect(conversationSIds).toContain(convo1.sId);
-    expect(conversationSIds).toContain(convo2.sId); // Deleted conversation should be included
+    const conversationIds = data.conversations.map((c: any) => c.sId);
+    expect(conversationIds).toContain(convo1.sId);
+    expect(conversationIds).toContain(convo2.sId); // Deleted conversation should be included
   });
 
   it("should filter conversations by updatedSince", async () => {
@@ -343,10 +343,10 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversations", () => {
 
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
-    const conversationSIds = data.conversations.map((c: any) => c.sId);
-    expect(conversationSIds).toContain(convo2.sId); // Updated 4 days ago
-    expect(conversationSIds).toContain(convo3.sId); // Updated 2 days ago
-    expect(conversationSIds).not.toContain(convo1.sId); // Updated 6 days ago (excluded)
+    const conversationIds = data.conversations.map((c: any) => c.sId);
+    expect(conversationIds).toContain(convo2.sId); // Updated 4 days ago
+    expect(conversationIds).toContain(convo3.sId); // Updated 2 days ago
+    expect(conversationIds).not.toContain(convo1.sId); // Updated 6 days ago (excluded)
   });
 
   it("should return empty array for space with no conversations", async () => {

--- a/front/scripts/dev/seed_conversations.ts
+++ b/front/scripts/dev/seed_conversations.ts
@@ -207,7 +207,7 @@ async function createConversation(
   }
 
   logger.info(
-    { conversationSId: conversation.sId, index: conv.index },
+    { conversationId: conversation.sId, index: conv.index },
     "Conversation created"
   );
 }

--- a/front/scripts/seed/factories/seedAnalytics.ts
+++ b/front/scripts/seed/factories/seedAnalytics.ts
@@ -21,7 +21,7 @@ import type { SeedContext } from "./types";
  */
 export async function seedAnalytics(
   ctx: SeedContext,
-  conversationSIds: string[]
+  conversationIds: string[]
 ): Promise<void> {
   const { auth, workspace, execute, logger } = ctx;
 
@@ -30,7 +30,7 @@ export async function seedAnalytics(
     return;
   }
 
-  if (conversationSIds.length === 0) {
+  if (conversationIds.length === 0) {
     logger.info("No conversations to index analytics for");
     return;
   }
@@ -38,7 +38,7 @@ export async function seedAnalytics(
   // Find all conversations by sId (skip permission filtering for seed script).
   const conversations = await ConversationResource.fetchByIds(
     auth,
-    conversationSIds,
+    conversationIds,
     { dangerouslySkipPermissionFiltering: true, includeDeleted: true }
   );
 
@@ -80,8 +80,8 @@ export async function seedAnalytics(
 
   for (const message of messages) {
     const { agentMessage } = message;
-    const conversationSId = conversationIdToSId.get(message.conversationId);
-    if (!agentMessage || !conversationSId) {
+    const conversationId = conversationIdToSId.get(message.conversationId);
+    if (!agentMessage || !conversationId) {
       continue;
     }
 
@@ -120,7 +120,7 @@ export async function seedAnalytics(
     const document: AgentMessageAnalyticsData = {
       agent_id: agentMessage.agentConfigurationId,
       agent_version: agentMessage.agentConfigurationVersion.toString(),
-      conversation_id: conversationSId,
+      conversation_id: conversationId,
       context_origin: "web",
       latency_ms: agentMessage.modelInteractionDurationMs ?? 0,
       message_id: message.sId,

--- a/front/scripts/seed/factories/seedFeedbacks.ts
+++ b/front/scripts/seed/factories/seedFeedbacks.ts
@@ -12,7 +12,7 @@ export async function seedFeedbacks(
   for (const feedbackAsset of feedbackAssets) {
     logger.info(
       {
-        conversationSId: feedbackAsset.conversationSId,
+        conversationId: feedbackAsset.conversationId,
         agentMessageSId: feedbackAsset.agentMessageSId,
       },
       "Creating feedback"
@@ -22,13 +22,13 @@ export async function seedFeedbacks(
       // Find the conversation (skip permission filtering for seed script)
       const conversation = await ConversationResource.fetchById(
         auth,
-        feedbackAsset.conversationSId,
+        feedbackAsset.conversationId,
         { dangerouslySkipPermissionFiltering: true, includeDeleted: true }
       );
 
       if (!conversation) {
         logger.warn(
-          { conversationSId: feedbackAsset.conversationSId },
+          { conversationId: feedbackAsset.conversationId },
           "Conversation not found for feedback, skipping"
         );
         continue;

--- a/front/scripts/seed/factories/types.ts
+++ b/front/scripts/seed/factories/types.ts
@@ -70,7 +70,7 @@ export interface ConversationsAsset {
 }
 
 export interface FeedbackAsset {
-  conversationSId: string;
+  conversationId: string;
   agentMessageSId: string;
   thumbDirection: "up" | "down";
   content: string | null;

--- a/front/scripts/seed/reinforced-agents/assets/feedbacks.json
+++ b/front/scripts/seed/reinforced-agents/assets/feedbacks.json
@@ -1,24 +1,24 @@
 [
   {
-    "conversationSId": "RAConv01",
+    "conversationId": "RAConv01",
     "agentMessageSId": "RAAMsg02",
     "thumbDirection": "down",
     "content": "The bot should provide specific escalation contacts (IT helpdesk email, phone number, Slack channel) instead of vaguely saying 'contact the IT department'."
   },
   {
-    "conversationSId": "RAConv02",
+    "conversationId": "RAConv02",
     "agentMessageSId": "RAAMsg03",
     "thumbDirection": "down",
     "content": "The response is too terse and ignores the urgency. Should acknowledge the time pressure, provide step-by-step troubleshooting, and offer a fallback like using Slack web."
   },
   {
-    "conversationSId": "RAConv04",
+    "conversationId": "RAConv04",
     "agentMessageSId": "RAAMsg07",
     "thumbDirection": "down",
     "content": "After multiple messages the bot still couldn't provide any actionable help. It should know the Google Workspace admin contact or at least the IT support ticket system."
   },
   {
-    "conversationSId": "RAConv05",
+    "conversationId": "RAConv05",
     "agentMessageSId": "RAAMsg08",
     "thumbDirection": "up",
     "content": null

--- a/front/scripts/seed/reinforced-agents/seedReinforcedAgents.ts
+++ b/front/scripts/seed/reinforced-agents/seedReinforcedAgents.ts
@@ -59,7 +59,7 @@ export async function seedReinforcedAgents(
 
   if (!skipAnalytics) {
     ctx.logger.info("Indexing analytics to Elasticsearch...");
-    const conversationSIds = conversations.map((c) => c.sId);
-    await seedAnalytics(ctx, conversationSIds);
+    const conversationIds = conversations.map((c) => c.sId);
+    await seedAnalytics(ctx, conversationIds);
   }
 }

--- a/front/scripts/seed/sidekick/assets/feedbacks.json
+++ b/front/scripts/seed/sidekick/assets/feedbacks.json
@@ -1,12 +1,12 @@
 [
   {
-    "conversationSId": "SidekickConv01",
+    "conversationId": "SidekickConv01",
     "agentMessageSId": "SidekickAMsg01",
     "thumbDirection": "down",
     "content": "The agent should be able to search the internet for recent news. It's useless without web access."
   },
   {
-    "conversationSId": "SidekickConv02",
+    "conversationId": "SidekickConv02",
     "agentMessageSId": "SidekickAMsg03",
     "thumbDirection": "down",
     "content": null

--- a/front/scripts/seed/sidekick/seed.ts
+++ b/front/scripts/seed/sidekick/seed.ts
@@ -118,8 +118,8 @@ makeScript({}, async ({ execute }, logger) => {
 
   // 7. Index analytics to Elasticsearch (enables feedbacks to appear in insights)
   logger.info("Indexing analytics to Elasticsearch...");
-  const conversationSIds = conversations.map((c) => c.sId);
-  await seedAnalytics(ctx, conversationSIds);
+  const conversationIds = conversations.map((c) => c.sId);
+  await seedAnalytics(ctx, conversationIds);
 
   // 8. Create templates (with sidekickInstructions)
   logger.info("Seeding templates...");

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -624,7 +624,7 @@ export async function processTranscriptActivity(
     if (cfRes.isErr()) {
       localLogger.error(
         {
-          conversationSid: initialConversation.sId,
+          conversationId: initialConversation.sId,
           error: cfRes.error,
         },
         "[processTranscriptActivity] Error creating file for content fragment. Stopping."
@@ -643,7 +643,7 @@ export async function processTranscriptActivity(
       localLogger.error(
         {
           agentConfigurationId,
-          conversationSid: initialConversation.sId,
+          conversationId: initialConversation.sId,
           error: contentFragmentRes.error,
         },
         "[processTranscriptActivity] Error creating content fragment. Stopping."
@@ -661,7 +661,7 @@ export async function processTranscriptActivity(
       localLogger.error(
         {
           agentConfigurationId,
-          conversationSid: initialConversation.sId,
+          conversationId: initialConversation.sId,
           panic: true,
           error: conversationRes.error,
         },
@@ -688,7 +688,7 @@ export async function processTranscriptActivity(
       localLogger.error(
         {
           agentConfigurationId,
-          conversationSid: conversation.sId,
+          conversationId: conversation.sId,
           error: messageRes.error,
         },
         "[processTranscriptActivity] Error creating message. Stopping."
@@ -702,7 +702,7 @@ export async function processTranscriptActivity(
       localLogger.error(
         {
           agentConfigurationId,
-          conversationSid: conversation.sId,
+          conversationId: conversation.sId,
           error: updatedRes.error,
         },
         "[processTranscriptActivity] Error getting conversation after creation. Stopping."
@@ -763,7 +763,7 @@ export async function processTranscriptActivity(
     localLogger.info(
       {
         agentConfigurationId,
-        conversationSid: conversation.sId,
+        conversationId: conversation.sId,
       },
       "[processTranscriptActivity] Sent processed transcript email."
     );

--- a/front/temporal/reinforced_agent/activities.ts
+++ b/front/temporal/reinforced_agent/activities.ts
@@ -296,12 +296,12 @@ export async function getRecentConversationsForAgentActivity({
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - conversationLookbackDays);
 
-  const conversationSIds = await listRecentConversationsForAgent(workspaceId, {
+  const conversationIds = await listRecentConversationsForAgent(workspaceId, {
     agentConfigurationId,
     cutoffDate,
   });
   // TODO(https://github.com/dust-tt/tasks/issues/7313): This is a placeholder for the actual sampling logic
-  return conversationSIds.slice(0, maxConversations);
+  return conversationIds.slice(0, maxConversations);
 }
 
 /**


### PR DESCRIPTION
## Description

- This PR enforces the coding rule about string ID/model ID references for conversations.
- Focuses on non-breaking changes (local changes, logs, ...). A separate PR will cover the non-retro-compatible changes.
- `conversationId` refers to the string ID, `conversationModelId` to the model ID.

## Tests

- Checked locally.

## Risk

- Low, mostly local changes.

## Deploy Plan

- Deploy front.