### PR TITLE
[front] enh: Add link to context window docs in related error

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -52,6 +52,7 @@ import { useAgentMessageStream } from "@app/hooks/useAgentMessageStream";
 import { useDeleteAgentMessage } from "@app/hooks/useDeleteAgentMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useRetryMessage } from "@app/hooks/useRetryMessage";
+import { CONTEXT_WINDOW_DOC_URL } from "@app/lib/api/assistant/errors";
 import config from "@app/lib/api/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
@@ -118,9 +119,6 @@ import {
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 
-const UNDERTAND_LLMS_CONTEXT_WINDOW_URL =
-  "https://docs.dust.tt/docs/understanding-llms-context-windows";
-
 function PrunedContextChip() {
   return (
     <Tooltip
@@ -142,7 +140,7 @@ function PrunedContextChip() {
             </p>
             <p>
               <a
-                href={UNDERTAND_LLMS_CONTEXT_WINDOW_URL}
+                href={CONTEXT_WINDOW_DOC_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline hover:text-foreground dark:hover:text-foreground-night"

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -1,3 +1,4 @@
+import { CONTEXT_WINDOW_DOC_URL } from "@app/lib/api/assistant/errors";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import type { GenericErrorContent } from "@app/types/assistant/agent";
 import { isAgentErrorCategory } from "@app/types/assistant/agent";
@@ -14,6 +15,10 @@ interface ErrorMessageProps {
 }
 
 export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
+  const isContextWindowExceeded =
+    isAgentErrorCategory(error.metadata?.category) &&
+    error.metadata?.category === "context_window_exceeded";
+
   const errorIsRetryable =
     isAgentErrorCategory(error.metadata?.category) &&
     (error.metadata?.category === "retryable_model_error" ||
@@ -30,7 +35,22 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
       className="flex flex-col gap-3"
       icon={InformationCircleIcon}
     >
-      <div className="whitespace-normal break-words">{error.message}</div>
+      <div className="whitespace-normal break-words">
+        {error.message}
+        {isContextWindowExceeded && (
+          <>
+            {" "}
+            <a
+              href={CONTEXT_WINDOW_DOC_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-foreground dark:hover:text-foreground-night"
+            >
+              Learn more
+            </a>
+          </>
+        )}
+      </div>
       <div className="flex flex-col gap-2 pt-3 sm:flex-row">
         <Button
           variant="outline"

--- a/front/lib/api/assistant/errors.ts
+++ b/front/lib/api/assistant/errors.ts
@@ -1,3 +1,6 @@
+export const CONTEXT_WINDOW_DOC_URL =
+  "https://docs.dust.tt/docs/understanding-llms-context-windows";
+
 const CONTEXT_WINDOW_EXCEEDED_TITLE = "Context window exceeded";
 const CONTEXT_WINDOW_EXCEEDED_MESSAGE =
   "Your message or retrieved data is too large. " +


### PR DESCRIPTION
## Description

<img width="586" height="141" alt="CleanShot 2026-04-08 at 08 57 50" src="https://github.com/user-attachments/assets/75aece34-ddea-4c66-b489-ed0f63ea2d8b" />

Add a link to context window documentation in our context window exceed msg.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- Deploy front