### PR TITLE
Add Hover for agent card title

### DIFF
--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -69,8 +69,13 @@ export const AssistantCard = React.forwardRef<
           <div
             className={cn("-s-mt-0.5 s-flex s-flex-col", action && "s-pr-8")}
           >
-            <h3 className="s-heading-base s-line-clamp-1 s-overflow-hidden s-text-ellipsis s-break-all">
-              {title}
+            <h3>
+              <TruncatedText
+                lineClamp={1}
+                className="s-heading-base s-overflow-hidden s-text-ellipsis s-break-all"
+              >
+                {title}
+              </TruncatedText>
             </h3>
             <p
               className={cn(


### PR DESCRIPTION
## Description

Very long name are not visible on the main page, so I added a hoverable to show them

<img width="2056" height="1552" alt="image" src="https://github.com/user-attachments/assets/cf4ebaa9-788d-44af-a221-3cdf2ce8442c" />


## Tests

Tested locally

## Risk

low

## Deploy Plan

deploy front 
