### PR TITLE
[front] enh: Add human readable timestamp to sbx logs

### DIFF
--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -305,15 +305,14 @@ const ContentFragmentView = ({ message }: ContentFragmentViewProps) => {
   );
 };
 
-function getDatadogSandboxLogsUrl(
-  conversationId: string,
-  conversationCreatedMs: number
-): string {
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+function getDatadogSandboxLogsUrl(conversationId: string): string {
   const nowMs = Date.now();
-  const fromMs = conversationCreatedMs;
+  const fromMs = nowMs - ONE_HOUR_MS;
   const query = `service:sandbox-runner @conversation_id:${conversationId}`;
 
-  return `https://app.datadoghq.eu/logs?query=${encodeURIComponent(query)}&from_ts=${fromMs}&to_ts=${nowMs}&live=true`;
+  return `https://app.datadoghq.eu/logs?query=${encodeURIComponent(query)}&cols=service,@timestamp_utc&from_ts=${fromMs}&to_ts=${nowMs}&live=true`;
 }
 
 export function ConversationPage() {
@@ -472,10 +471,7 @@ export function ConversationPage() {
               target="_blank"
             />
             <Button
-              href={getDatadogSandboxLogsUrl(
-                conversationId,
-                conversation.created
-              )}
+              href={getDatadogSandboxLogsUrl(conversationId)}
               label="Sandbox Logs"
               variant="primary"
               size="xs"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -298,7 +298,7 @@ SHELLEOF`,
   .withToolManifest()
   .register({
     imageName: "dust-base",
-    tag: "0.7.1",
+    tag: "0.7.2",
   });
 
 const IMAGES: readonly SandboxImage[] = [DUST_BASE_IMAGE];

--- a/front/lib/api/sandbox/image/telemetry/enrich.lua
+++ b/front/lib/api/sandbox/image/telemetry/enrich.lua
@@ -65,5 +65,7 @@ function enrich_message(tag, timestamp, record)
         record["message"] = command
     end
 
+    record["timestamp_utc"] = os.date("!%Y-%m-%d %H:%M:%S", timestamp)
+
     return 2, timestamp, record
 end


### PR DESCRIPTION
## Description

- Add human readable timestamp (in UTC) to logs sent to DataDog
- The timestamp we're putting is the journalctl insertion timestamp, so very close to the actual wall clock time of when things happened.
- Update poke link to have the column shown by default

## Tests

[Tested locally
](https://app.datadoghq.eu/logs?query=service%3Asandbox-runner%20%40conversation_id%3ARRMkydFmqd&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=service%2C%40timestamp_utc&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1775635937879&to_ts=1775635968512&live=true)
## Risk

None

## Deploy Plan

- Deploy front