### PR TITLE
[front] chore: fix `conversationSId` naming in API interfaces

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -94,7 +94,7 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
         });
         setTimeout(() => {
           void router.push(
-            `/w/${owner.sId}/conversation/${result.conversationSId}`
+            `/w/${owner.sId}/conversation/${result.conversationId}`
           );
         }, 1000);
       } else {

--- a/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
+++ b/front/components/poke/pages/GlobalAgentFeedbacksPage.tsx
@@ -96,12 +96,12 @@ function makeColumns(): ColumnDef<GlobalAgentFeedbackItem>[] {
         const feedback = row.original;
         if (
           feedback.isConversationShared &&
-          feedback.conversationSId &&
+          feedback.conversationId &&
           feedback.workspaceId !== "unknown"
         ) {
           return (
             <LinkWrapper
-              href={`/poke/${feedback.workspaceId}/conversation/${feedback.conversationSId}`}
+              href={`/poke/${feedback.workspaceId}/conversation/${feedback.conversationId}`}
             >
               <span className="text-blue-600 hover:underline dark:text-blue-400">
                 View

--- a/front/hooks/useOnboardingConversation.ts
+++ b/front/hooks/useOnboardingConversation.ts
@@ -40,9 +40,9 @@ export function useOnboardingConversation({
 
     if (res.ok) {
       const data = (await res.json()) as PostSendOnboardingResponseBody;
-      if (data.conversationSId) {
+      if (data.conversationId) {
         await router.replace(
-          `/w/${workspaceId}/conversation/${data.conversationSId}`
+          `/w/${workspaceId}/conversation/${data.conversationId}`
         );
         return;
       }

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -48,7 +48,7 @@ export async function sendOnboardingConversation(
   owner: LightWorkspaceType,
   featureFlags: WhitelistableFeature[]
 ): Promise<
-  { isOk: true; conversationSId: string } | { isOk: false; error: string }
+  { isOk: true; conversationId: string } | { isOk: false; error: string }
 > {
   if (!showDebugTools(featureFlags)) {
     return { isOk: false, error: "Not allowed" };
@@ -67,10 +67,10 @@ export async function sendOnboardingConversation(
 
   if (response.ok) {
     const data = await response.json();
-    if (!data.conversationSId) {
+    if (!data.conversationId) {
       return { isOk: false, error: "Failed to create onboarding conversation" };
     }
-    return { isOk: true, conversationSId: data.conversationSId };
+    return { isOk: true, conversationId: data.conversationId };
   } else {
     return { isOk: false, error: "Error sending onboarding conversation" };
   }

--- a/front/pages/api/poke/global-agent-feedbacks/index.ts
+++ b/front/pages/api/poke/global-agent-feedbacks/index.ts
@@ -41,7 +41,7 @@ export interface GlobalAgentFeedbackItem {
   isConversationShared: boolean;
   workspaceId: string;
   workspaceName: string;
-  conversationSId: string | null;
+  conversationId: string | null;
   messageSId: string | null;
 }
 
@@ -163,7 +163,7 @@ async function handler(
       isConversationShared: row.isConversationShared,
       workspaceId: workspace?.sId ?? "unknown",
       workspaceName: workspace?.name ?? "Unknown",
-      conversationSId: conversationById.get(row.conversationId) ?? null,
+      conversationId: conversationById.get(row.conversationId) ?? null,
       messageSId: messageSIdByAgentMessageId.get(row.agentMessageId) ?? null,
     };
   });

--- a/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
@@ -8,6 +8,8 @@ import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type PostSendOnboardingResponseBody = {
+  conversationId: string | null;
+  // TODO(2026-04-08 aubin): field kept for retro-compatibility over older front-end, to remove once.
   conversationSId: string | null;
 };
 
@@ -47,7 +49,10 @@ async function handler(
     return apiError(req, res, result.error);
   }
 
-  return res.status(200).json({ conversationSId: result.value });
+  return res.status(200).json({
+    conversationId: result.value,
+    conversationSId: result.value,
+  });
 }
 
 export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

- Follow up of https://github.com/dust-tt/dust/pull/23880, focusing on the changes at the API interface level.
- This PR maintains retro-compatibility over old front-ends/new back-ends by sending both the old and the new field name (except for poke where we break it and require a full page reload).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
