### PR TITLE
feat: update firefox extension permissions

### DIFF
--- a/extension/platforms/firefox/manifests/manifest.production.json
+++ b/extension/platforms/firefox/manifests/manifest.production.json
@@ -6,7 +6,8 @@
       "data_collection_permissions": {
         "required": [
           "personallyIdentifyingInfo",
-          "authenticationInfo"
+          "authenticationInfo",
+          "websiteContent"
         ],
         "optional": [
           "technicalAndInteraction"

--- a/extension/platforms/firefox/manifests/manifest.release.json
+++ b/extension/platforms/firefox/manifests/manifest.release.json
@@ -6,7 +6,8 @@
       "data_collection_permissions": {
         "required": [
           "personallyIdentifyingInfo",
-          "authenticationInfo"
+          "authenticationInfo",
+          "websiteContent"
         ],
         "optional": [
           "technicalAndInteraction"


### PR DESCRIPTION
## Description

This PR adds the `websiteContent` permission to the required data collection permissions for the Firefox extension to match the permissions of the Chrome extension.

## Tests

Manually

## Risks

Low risk. 

## Deploy Plan

Standard deployment.