### PR TITLE
Fixes in metronome provisioning

### DIFF
--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -134,10 +134,20 @@ export async function provisionSeatsForContract({
     return new Ok(undefined);
   }
 
-  return await editMetronomeContractSeats({
-    metronomeCustomerId,
-    contractId,
-    edits: [{ subscriptionId, addSeatIds: memberIds }],
-    startingAt,
-  });
+  // Metronome limits to 500 seats per subscription edit. Batch if needed.
+  const SEAT_BATCH_SIZE = 500;
+  for (let i = 0; i < memberIds.length; i += SEAT_BATCH_SIZE) {
+    const batch = memberIds.slice(i, i + SEAT_BATCH_SIZE);
+    const result = await editMetronomeContractSeats({
+      metronomeCustomerId,
+      contractId,
+      edits: [{ subscriptionId, addSeatIds: batch }],
+      startingAt,
+    });
+    if (result.isErr()) {
+      return result;
+    }
+  }
+
+  return new Ok(undefined);
 }

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -974,9 +974,15 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     subscriptionModelId: ModelId,
     metronomeContractId: string
   ): Promise<void> {
-    await SubscriptionModel.update(
-      { metronomeContractId },
-      { where: { id: subscriptionModelId } }
+    const subscription = await SubscriptionModel.findByPk(subscriptionModelId);
+    if (!subscription) {
+      throw new Error(`Subscription not found: ${subscriptionModelId}`);
+    }
+
+    await subscription.update({ metronomeContractId });
+
+    await SubscriptionResource.invalidateSubscriptionCache(
+      subscription.workspaceId
     );
   }
 

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -276,12 +276,22 @@ async function migrateWorkspace(
     );
 
     // Provision seats for all existing members.
-    await provisionSeatsForContract({
+    const seatResult = await provisionSeatsForContract({
       metronomeCustomerId,
       contractId: newContractId,
       workspace,
       startingAt: subInfo.startDate,
     });
+    if (seatResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          contractId: newContractId,
+          error: seatResult.error.message,
+        },
+        "Failed to provision seats on new contract"
+      );
+    }
 
     // Update metronomeContractId on the subscription.
     await SubscriptionResource.updateMetronomeContractId(
@@ -427,12 +437,22 @@ async function migrateWorkspace(
     );
 
     // 3. Provision seats on the new contract.
-    await provisionSeatsForContract({
+    const seatResult2 = await provisionSeatsForContract({
       metronomeCustomerId,
       contractId: newContractId,
       workspace,
       startingAt: contract.starting_at,
     });
+    if (seatResult2.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          contractId: newContractId,
+          error: seatResult2.error.message,
+        },
+        "Failed to provision seats on new contract"
+      );
+    }
 
     // 4. Update metronomeContractId on the active subscription.
     const activeSubscription =


### PR DESCRIPTION
## Summary

Three fixes for Metronome contract provisioning found during production migration.

### 1. Batch seat provisioning (500 seat limit)

Metronome limits subscriptions to 500 seats per edit call. Workspaces with more than 500 members failed with `422 Subscription cannot have more than 500 seats`.

**Fix:** `provisionSeatsForContract` in `seats.ts` now batches `addSeatIds` in chunks of 500. Stops on first error.

### 2. Flush subscription cache after `updateMetronomeContractId`

`updateMetronomeContractId` was a static update that didn't invalidate the Redis subscription cache. After migrating a workspace, cached reads still returned the old (null) `metronomeContractId`.

**Fix:** Now fetches the subscription first (to get `workspaceId`), then calls `invalidateSubscriptionCache` after the update.

### 3. Log seat provisioning errors in migration script

`provisionSeatsForContract` returns `Result<void, Error>` but the migration script was ignoring the result. Errors were silently swallowed.

**Fix:** Both call sites in `migrate_metronome_contracts.ts` now check `seatResult.isErr()` and log the error.

## Test plan

- [ ] Workspace with >500 members → seats provisioned in batches, no 422 error
- [ ] After contract migration → `fetchActiveByWorkspaceModelId` returns updated `metronomeContractId`
- [ ] Seat provisioning failure → error logged with workspace and contract IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)