### PR TITLE
[front] chore: enforce coding rule BACK10 on transcript configurations

### DIFF
--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -134,8 +134,7 @@ async function handler(
       if (newStatus !== undefined) {
         logger.info(
           {
-            transcriptsConfigurationId: transcriptsConfiguration.id,
-            transcriptsConfigurationSid: transcriptsConfiguration.sId,
+            transcriptsConfigurationId: transcriptsConfiguration.sId,
             status: newStatus,
           },
           "Setting transcript configuration status."
@@ -202,8 +201,7 @@ async function handler(
       if (shouldStartWorkflow) {
         logger.info(
           {
-            transcriptsConfigurationId: updatedTranscriptsConfiguration.id,
-            transcriptsConfigurationSid: updatedTranscriptsConfiguration.sId,
+            transcriptsConfigurationId: updatedTranscriptsConfiguration.sId,
           },
           "Starting transcript retrieval workflow."
         );

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -79,8 +79,7 @@ export async function retrieveNewTranscriptsActivity(
   }
 
   const localLogger = mainLogger.child({
-    transcriptsConfigurationId: transcriptsConfiguration.id,
-    transcriptsConfigurationSid: transcriptsConfiguration.sId,
+    transcriptsConfigurationId: transcriptsConfiguration.sId,
   });
 
   const workspace = await WorkspaceResource.fetchByModelId(

--- a/front/temporal/labs/transcripts/client.ts
+++ b/front/temporal/labs/transcripts/client.ts
@@ -54,8 +54,7 @@ async function getScheduleOptions(
       cronExpressions: ["*/5 * * * *"],
     },
     memo: {
-      transcriptsConfigurationId: transcriptsConfiguration.id,
-      transcriptsConfigurationSid: transcriptsConfiguration.sId,
+      transcriptsConfigurationId: transcriptsConfiguration.sId,
       IsProcessingTranscripts: transcriptsConfiguration.isActive(),
       IsStoringTranscripts: transcriptsConfiguration.dataSourceViewId !== null,
     },
@@ -74,8 +73,7 @@ export async function launchRetrieveTranscriptsWorkflow(
 
   const childLogger = logger.child({
     scheduleId,
-    transcriptsConfigurationId: transcriptsConfiguration.id,
-    transcriptsConfigurationSid: transcriptsConfiguration.sId,
+    transcriptsConfigurationId: transcriptsConfiguration.sId,
   });
 
   // Try to update existing schedule first
@@ -117,8 +115,7 @@ export async function stopRetrieveTranscriptsWorkflow(
 
   const childLogger = logger.child({
     scheduleId,
-    transcriptsConfigurationId: transcriptsConfiguration.id,
-    transcriptsConfigurationSid: transcriptsConfiguration.sId,
+    transcriptsConfigurationId: transcriptsConfiguration.sId,
   });
 
   try {

--- a/front/temporal/labs/transcripts/utils/gong.ts
+++ b/front/temporal/labs/transcripts/utils/gong.ts
@@ -211,8 +211,7 @@ export async function retrieveGongTranscriptContent(
       localLogger.error(
         {
           fileId,
-          transcriptsConfigurationId: transcriptsConfiguration.id,
-          transcriptsConfigurationSid: transcriptsConfiguration.sId,
+          transcriptsConfigurationId: transcriptsConfiguration.sId,
         },
         "[retrieveGongTranscripts] User not found. Skipping."
       );
@@ -236,8 +235,7 @@ export async function retrieveGongTranscriptContent(
         localLogger.error(
           {
             fileId,
-            transcriptsConfigurationId: transcriptsConfiguration.id,
-            transcriptsConfigurationSid: transcriptsConfiguration.sId,
+            transcriptsConfigurationId: transcriptsConfiguration.sId,
             status: response.status,
           },
           "[retrieveGongTranscripts] Error fetching Gong users. Skipping."
@@ -269,8 +267,7 @@ export async function retrieveGongTranscriptContent(
       localLogger.error(
         {
           fileId,
-          transcriptsConfigurationId: transcriptsConfiguration.id,
-          transcriptsConfigurationSid: transcriptsConfiguration.sId,
+          transcriptsConfigurationId: transcriptsConfiguration.sId,
           userEmail: user.email,
         },
         "[retrieveGongTranscripts] Gong user not found. Skipping."
@@ -304,8 +301,7 @@ export async function retrieveGongTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.id,
-        transcriptsConfigurationSid: transcriptsConfiguration.sId,
+        transcriptsConfigurationId: transcriptsConfiguration.sId,
       },
       "[retrieveGongTranscripts] Error fetching call from Gong. Skipping."
     );
@@ -325,8 +321,7 @@ export async function retrieveGongTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.id,
-        transcriptsConfigurationSid: transcriptsConfiguration.sId,
+        transcriptsConfigurationId: transcriptsConfiguration.sId,
       },
       "[retrieveGongTranscripts] Call data not found from Gong. Skipping."
     );

--- a/front/temporal/labs/transcripts/utils/gong.ts
+++ b/front/temporal/labs/transcripts/utils/gong.ts
@@ -209,10 +209,7 @@ export async function retrieveGongTranscriptContent(
 
     if (!user) {
       localLogger.error(
-        {
-          fileId,
-          transcriptsConfigurationId: transcriptsConfiguration.sId,
-        },
+        { fileId },
         "[retrieveGongTranscripts] User not found. Skipping."
       );
       return null;
@@ -235,7 +232,6 @@ export async function retrieveGongTranscriptContent(
         localLogger.error(
           {
             fileId,
-            transcriptsConfigurationId: transcriptsConfiguration.sId,
             status: response.status,
           },
           "[retrieveGongTranscripts] Error fetching Gong users. Skipping."
@@ -267,7 +263,6 @@ export async function retrieveGongTranscriptContent(
       localLogger.error(
         {
           fileId,
-          transcriptsConfigurationId: transcriptsConfiguration.sId,
           userEmail: user.email,
         },
         "[retrieveGongTranscripts] Gong user not found. Skipping."
@@ -299,10 +294,7 @@ export async function retrieveGongTranscriptContent(
 
   if (!call.ok) {
     localLogger.error(
-      {
-        fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.sId,
-      },
+      { fileId },
       "[retrieveGongTranscripts] Error fetching call from Gong. Skipping."
     );
     throw new Error("Error fetching call from Gong. Skipping.");
@@ -319,10 +311,7 @@ export async function retrieveGongTranscriptContent(
 
   if (!callData) {
     localLogger.error(
-      {
-        fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.sId,
-      },
+      { fileId },
       "[retrieveGongTranscripts] Call data not found from Gong. Skipping."
     );
     return null;

--- a/front/temporal/labs/transcripts/utils/modjo.ts
+++ b/front/temporal/labs/transcripts/utils/modjo.ts
@@ -631,8 +631,8 @@ export async function retrieveModjoTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.id,
-        transcriptsConfigurationSid: transcriptsConfiguration.sId,
+        transcriptsConfigurationModelId: transcriptsConfiguration.id,
+        transcriptsConfigurationId: transcriptsConfiguration.sId,
         status: response.status,
         error: errorText,
       },
@@ -666,8 +666,8 @@ export async function retrieveModjoTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.id,
-        transcriptsConfigurationSid: transcriptsConfiguration.sId,
+        transcriptsConfigurationModelId: transcriptsConfiguration.id,
+        transcriptsConfigurationId: transcriptsConfiguration.sId,
       },
       "[processTranscriptActivity] Call data not found from Modjo. Skipping."
     );

--- a/front/temporal/labs/transcripts/utils/modjo.ts
+++ b/front/temporal/labs/transcripts/utils/modjo.ts
@@ -631,7 +631,6 @@ export async function retrieveModjoTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.sId,
         status: response.status,
         error: errorText,
       },
@@ -663,10 +662,7 @@ export async function retrieveModjoTranscriptContent(
 
   if (!callData) {
     localLogger.error(
-      {
-        fileId,
-        transcriptsConfigurationId: transcriptsConfiguration.sId,
-      },
+      { fileId },
       "[processTranscriptActivity] Call data not found from Modjo. Skipping."
     );
     return null;

--- a/front/temporal/labs/transcripts/utils/modjo.ts
+++ b/front/temporal/labs/transcripts/utils/modjo.ts
@@ -631,7 +631,6 @@ export async function retrieveModjoTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationModelId: transcriptsConfiguration.id,
         transcriptsConfigurationId: transcriptsConfiguration.sId,
         status: response.status,
         error: errorText,
@@ -666,7 +665,6 @@ export async function retrieveModjoTranscriptContent(
     localLogger.error(
       {
         fileId,
-        transcriptsConfigurationModelId: transcriptsConfiguration.id,
         transcriptsConfigurationId: transcriptsConfiguration.sId,
       },
       "[processTranscriptActivity] Call data not found from Modjo. Skipping."


### PR DESCRIPTION
## Description

- This PR enforces the coding rule BACK10 relative to naming of string IDs/model IDs variables.
- Focuses on the labs transcript configuration.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
