### PR TITLE
Remove version column from skill suggestions

### DIFF
--- a/front/lib/models/skill/skill_suggestion.ts
+++ b/front/lib/models/skill/skill_suggestion.ts
@@ -1,8 +1,5 @@
 import { ConversationModel } from "@app/lib/models/agent/conversation";
-import {
-  SkillConfigurationModel,
-  SkillVersionModel,
-} from "@app/lib/models/skill";
+import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -19,7 +16,6 @@ export class SkillSuggestionModel extends WorkspaceAwareModel<SkillSuggestionMod
   declare updatedAt: CreationOptional<Date>;
 
   declare skillConfigurationId: ForeignKey<SkillConfigurationModel["id"]>;
-  declare skillVersionId: ForeignKey<SkillVersionModel["id"]>;
 
   declare kind: SkillSuggestionKind;
   declare suggestion: SkillSuggestionPayload;
@@ -31,7 +27,6 @@ export class SkillSuggestionModel extends WorkspaceAwareModel<SkillSuggestionMod
   declare groupId: string | null;
 
   declare skillConfiguration: NonAttribute<SkillConfigurationModel>;
-  declare skillVersion: NonAttribute<SkillVersionModel>;
   declare sourceConversation: NonAttribute<ConversationModel | null>;
 }
 
@@ -48,10 +43,6 @@ SkillSuggestionModel.init(
       defaultValue: DataTypes.NOW,
     },
     skillConfigurationId: {
-      type: DataTypes.BIGINT,
-      allowNull: false,
-    },
-    skillVersionId: {
       type: DataTypes.BIGINT,
       allowNull: false,
     },
@@ -107,11 +98,6 @@ SkillSuggestionModel.init(
         concurrently: true,
       },
       {
-        name: "skill_suggestions_workspace_skill_version",
-        fields: ["skillVersionId"],
-        concurrently: true,
-      },
-      {
         name: "idx_skill_suggestions_source_conversation_id",
         fields: ["sourceConversationId"],
         concurrently: true,
@@ -133,17 +119,6 @@ SkillSuggestionModel.belongsTo(SkillConfigurationModel, {
 });
 SkillConfigurationModel.hasMany(SkillSuggestionModel, {
   foreignKey: { name: "skillConfigurationId", allowNull: false },
-  onDelete: "RESTRICT",
-  as: "skillSuggestions",
-});
-
-SkillSuggestionModel.belongsTo(SkillVersionModel, {
-  foreignKey: { name: "skillVersionId", allowNull: false },
-  onDelete: "RESTRICT",
-  as: "skillVersion",
-});
-SkillVersionModel.hasMany(SkillSuggestionModel, {
-  foreignKey: { name: "skillVersionId", allowNull: false },
   onDelete: "RESTRICT",
   as: "skillSuggestions",
 });

--- a/front/migrations/db/migration_566.sql
+++ b/front/migrations/db/migration_566.sql
@@ -1,0 +1,6 @@
+-- Migration created on Apr 08, 2026
+-- Drop the skillVersionId column and its index from skill_suggestions
+
+DROP INDEX CONCURRENTLY IF EXISTS "skill_suggestions_workspace_skill_version";
+
+ALTER TABLE "skill_suggestions" DROP COLUMN "skillVersionId";


### PR DESCRIPTION
## Description

Versions are more complex to handle in skil lthan in agent as table work differently.
I could store the version as number | null field and update it when we create the skill version but it would add more work for updating a skill so let's wait and see if we actually need it.

## Tests

no

## Risk

low

## Deploy Plan

lock front
merge
deploy
apply migration
unlock front
