### PR TITLE
[BYOK] Disable agent builder UI when no healthy providers

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -17,6 +17,7 @@ import { useClientType } from "@app/lib/context/clientType";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useSpaces } from "@app/lib/swr/spaces";
+import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import {
   getAgentBuilderRoute,
   getConversationRoute,
@@ -145,7 +146,7 @@ export function ConversationMenu({
   displayOpenInBrowser,
   openDetailsInNewTab,
 }: ConversationMenuProps) {
-  const { user } = useAuth();
+  const { user, providersHealth } = useAuth();
   const { hasFeature, featureFlags } = useFeatureFlags();
   const confirm = useContext(ConfirmContext);
 
@@ -423,6 +424,7 @@ export function ConversationMenu({
             <DropdownMenuItem
               label="Convert to agent"
               icon={SidekickIcon}
+              disabled={!hasHealthyProviders(providersHealth)}
               onClick={async () => {
                 const confirmed = await confirm({
                   title: "Shrink-wrap",

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -33,13 +33,14 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useProjectsSectionCollapsed } from "@app/hooks/useProjectsSectionCollapsed";
 import { useSearchProjects } from "@app/hooks/useSearchProjects";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { CONVERSATIONS_UPDATED_EVENT } from "@app/lib/notifications/events";
 import { useAppRouter } from "@app/lib/platform";
 import { SKILL_ICON } from "@app/lib/skill";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import {
   getAgentBuilderRoute,
   getConversationRoute,
@@ -398,6 +399,9 @@ export function AgentSidebarMenu({
   const activeSpaceId = useActiveSpaceId();
   const { hasFeature } = useFeatureFlags();
   const moveConversationToProject = useMoveConversationToProject(owner);
+
+  const { providersHealth } = useAuth();
+  const noHealthyProviders = !hasHealthyProviders(providersHealth);
 
   const agentsSearchInputRef = useRef<HTMLInputElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -856,6 +860,7 @@ export function AgentSidebarMenu({
                               <DropdownMenuSubTrigger
                                 icon={PlusIcon}
                                 label="New agent"
+                                disabled={noHealthyProviders}
                               />
                               <DropdownMenuPortal>
                                 <DropdownMenuSubContent className="pointer-events-auto">
@@ -913,6 +918,7 @@ export function AgentSidebarMenu({
                                 <DropdownMenuSubTrigger
                                   icon={PencilSquareIcon}
                                   label="Edit agent"
+                                  disabled={noHealthyProviders}
                                 />
                                 <DropdownMenuPortal>
                                   <DropdownMenuSubContent className="pointer-events-auto">

--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { useUpdateUserFavorite } from "@app/lib/swr/assistants";
+import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import {
   getAgentBuilderRoute,
   getConversationRoute,
@@ -44,7 +45,7 @@ export function AgentDetailsButtonBar({
   isAgentConfigurationValidating,
   owner,
 }: AgentDetailsButtonBarProps) {
-  const { user } = useAuth();
+  const { user, providersHealth } = useAuth();
 
   const { updateUserFavorite, isUpdatingFavorite } = useUpdateUserFavorite({
     owner,
@@ -123,7 +124,7 @@ export function AgentDetailsButtonBar({
               ? getAgentBuilderRoute(owner.sId, agentConfiguration.sId)
               : undefined
           }
-          disabled={!canEditAgent}
+          disabled={!canEditAgent || !hasHealthyProviders(providersHealth)}
           variant="outline"
           icon={PencilSquareIcon}
         />
@@ -159,6 +160,9 @@ export function AgentDetailsDropdownMenu({
 }: AgentDetailsDropdownMenuProps) {
   const sendNotification = useSendNotification();
   const router = useAppRouter();
+
+  const { providersHealth } = useAuth();
+  const noHealthyProviders = !hasHealthyProviders(providersHealth);
 
   const [showDeletionModal, setShowDeletionModal] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
@@ -230,6 +234,7 @@ export function AgentDetailsDropdownMenu({
         canEditAgent && (
           <DropdownMenuItem
             label="Edit agent"
+            disabled={noHealthyProviders}
             onClick={(e) => {
               e.stopPropagation();
               void router.push(
@@ -263,6 +268,7 @@ export function AgentDetailsDropdownMenu({
         <>
           <DropdownMenuItem
             label="Duplicate (New)"
+            disabled={noHealthyProviders}
             data-gtm-label="agentDuplicationButton"
             data-gtm-location="agentDetails"
             icon={ClipboardIcon}

--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -124,7 +124,7 @@ export function AgentDetailsButtonBar({
               ? getAgentBuilderRoute(owner.sId, agentConfiguration.sId)
               : undefined
           }
-          disabled={!canEditAgent || !hasHealthyProviders(providersHealth)}
+          disabled={!canEditAgent || !hasHealthyProviders(providersHealth)}
           variant="outline"
           icon={PencilSquareIcon}
         />

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -425,7 +425,9 @@ export function AssistantsTable({
                     "data-gtm-label": "assistantEditButton",
                     "data-gtm-location": "assistantDetails",
                     icon: PencilSquareIcon,
-                    disabled: (!agentConfiguration.canEdit && !isAdmin(owner)) || noHealthyProviders,
+                    disabled:
+                      (!agentConfiguration.canEdit && !isAdmin(owner)) ||
+                      noHealthyProviders,
                     onClick: (e: React.MouseEvent) => {
                       e.stopPropagation();
                       void router.push(

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -4,6 +4,7 @@ import { GlobalAgentAction } from "@app/components/assistant/manager/GlobalAgent
 import { TableTagSelector } from "@app/components/assistant/manager/TableTagSelector";
 import { assistantUsageMessage } from "@app/components/assistant/Usage";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useTags } from "@app/lib/swr/tags";
 import {
@@ -11,6 +12,7 @@ import {
   formatTimestampToFriendlyDate,
   tagsSorter,
 } from "@app/lib/utils";
+import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type {
   AgentConfigurationScope,
@@ -345,6 +347,9 @@ export function AssistantsTable({
   const { tags } = useTags({ owner });
   const sortedTags = useMemo(() => [...tags].sort(tagsSorter), [tags]);
 
+  const { providersHealth } = useAuth();
+  const noHealthyProviders = !hasHealthyProviders(providersHealth);
+
   const [showDeleteDialog, setShowDeleteDialog] = useState<{
     open: boolean;
     agentConfiguration: LightAgentConfigurationType | undefined;
@@ -420,7 +425,7 @@ export function AssistantsTable({
                     "data-gtm-label": "assistantEditButton",
                     "data-gtm-location": "assistantDetails",
                     icon: PencilSquareIcon,
-                    disabled: !agentConfiguration.canEdit && !isAdmin(owner),
+                    disabled: (!agentConfiguration.canEdit && !isAdmin(owner)) || noHealthyProviders,
                     onClick: (e: React.MouseEvent) => {
                       e.stopPropagation();
                       void router.push(
@@ -469,6 +474,7 @@ export function AssistantsTable({
                       );
                     },
                     kind: "item" as const,
+                    disabled: noHealthyProviders,
                   },
                   {
                     label: "Archive",

--- a/front/components/pages/CustomErrorPage.tsx
+++ b/front/components/pages/CustomErrorPage.tsx
@@ -1,0 +1,43 @@
+import { LinkWrapper } from "@app/lib/platform";
+import { Button, ExclamationCircleIcon, Icon } from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+
+// biome-ignore lint/plugin/nextjsPageComponentNaming: pre-existing
+export default function CustomErrorPage({
+  title,
+  description,
+  href,
+  label,
+  icon,
+}: {
+  title: string;
+  description: string;
+  href: string;
+  label: string;
+  icon: ComponentType;
+}) {
+  return (
+    <div className="flex h-dvh items-center justify-center">
+      <div className="flex flex-col gap-3 text-center">
+        <div className="flex flex-col items-center">
+          <div>
+            <Icon
+              visual={ExclamationCircleIcon}
+              size="lg"
+              className="dark:text-golder-400-night text-golden-400"
+            />
+          </div>
+          <p className="heading-xl leading-7 text-foreground dark:text-foreground-night">
+            {title}
+          </p>
+          <p className="copy-sm leading-tight text-muted-foreground dark:text-muted-foreground-night">
+            {description}
+          </p>
+        </div>
+        <LinkWrapper href={href}>
+          <Button variant="outline" label={label} icon={icon} />
+        </LinkWrapper>
+      </div>
+    </div>
+  );
+}

--- a/front/components/pages/CustomErrorPage.tsx
+++ b/front/components/pages/CustomErrorPage.tsx
@@ -2,6 +2,14 @@ import { LinkWrapper } from "@app/lib/platform";
 import { Button, ExclamationCircleIcon, Icon } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
+interface CustomErrorPageProps {
+  title: string;
+  description: string;
+  href: string;
+  label: string;
+  icon: ComponentType;
+}
+
 // biome-ignore lint/plugin/nextjsPageComponentNaming: pre-existing
 export default function CustomErrorPage({
   title,
@@ -9,13 +17,7 @@ export default function CustomErrorPage({
   href,
   label,
   icon,
-}: {
-  title: string;
-  description: string;
-  href: string;
-  label: string;
-  icon: ComponentType;
-}) {
+}: CustomErrorPageProps) {
   return (
     <div className="flex h-dvh items-center justify-center">
       <div className="flex flex-col gap-3 text-center">

--- a/front/components/pages/builder/agents/EditAgentPage.tsx
+++ b/front/components/pages/builder/agents/EditAgentPage.tsx
@@ -1,14 +1,16 @@
 import AgentBuilder from "@app/components/agent_builder/AgentBuilder";
 import { AgentBuilderProvider } from "@app/components/agent_builder/AgentBuilderContext";
+import { NotAvailableErrorPage } from "@app/components/pages/builder/agents/NotAvailableErrorPage";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
+import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import Custom404 from "@app/pages/404";
 import { Spinner } from "@dust-tt/sparkle";
 
 export function EditAgentPage() {
   const owner = useWorkspace();
-  const { user, isAdmin } = useAuth();
+  const { user, isAdmin, providersHealth } = useAuth();
   const agentId = useRequiredPathParam("aId");
 
   const {
@@ -27,6 +29,10 @@ export function EditAgentPage() {
     (agentConfiguration && !agentConfiguration.canEdit && !isAdmin)
   ) {
     return <Custom404 />;
+  }
+
+  if (!hasHealthyProviders(providersHealth)) {
+    return <NotAvailableErrorPage isAdmin={isAdmin} owner={owner} />;
   }
 
   if (isAgentConfigurationLoading || !agentConfiguration) {

--- a/front/components/pages/builder/agents/NewAgentPage.tsx
+++ b/front/components/pages/builder/agents/NewAgentPage.tsx
@@ -2,6 +2,7 @@ import AgentBuilder from "@app/components/agent_builder/AgentBuilder";
 import { AgentBuilderProvider } from "@app/components/agent_builder/AgentBuilderContext";
 import type { BuilderFlow } from "@app/components/agent_builder/types";
 import { BUILDER_FLOWS } from "@app/components/agent_builder/types";
+import { NotAvailableErrorPage } from "@app/components/pages/builder/agents/NotAvailableErrorPage";
 import { throwIfInvalidAgentConfiguration } from "@app/lib/actions/types/guards";
 import {
   useAuth,
@@ -13,14 +14,13 @@ import {
   useAgentConfiguration,
   useAssistantTemplate,
 } from "@app/lib/swr/assistants";
+import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import Custom404 from "@app/pages/404";
 import type {
   AgentConfigurationScope,
   AgentConfigurationType,
 } from "@app/types/assistant/agent";
 import { Spinner } from "@dust-tt/sparkle";
-import { NotAvailableErrorPage } from "@app/components/pages/builder/agents/NotAvailableErrorPage";
-import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 
 function isBuilderFlow(value: string): value is BuilderFlow {
   return BUILDER_FLOWS.some((flow) => flow === value);

--- a/front/components/pages/builder/agents/NewAgentPage.tsx
+++ b/front/components/pages/builder/agents/NewAgentPage.tsx
@@ -19,6 +19,8 @@ import type {
   AgentConfigurationType,
 } from "@app/types/assistant/agent";
 import { Spinner } from "@dust-tt/sparkle";
+import { NotAvailableErrorPage } from "@app/components/pages/builder/agents/NotAvailableErrorPage";
+import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 
 function isBuilderFlow(value: string): value is BuilderFlow {
   return BUILDER_FLOWS.some((flow) => flow === value);
@@ -26,7 +28,7 @@ function isBuilderFlow(value: string): value is BuilderFlow {
 
 export function NewAgentPage() {
   const owner = useWorkspace();
-  const { user, isAdmin, isBuilder } = useAuth();
+  const { user, isAdmin, isBuilder, providersHealth } = useAuth();
   const { featureFlags } = useFeatureFlags();
 
   const flowParam = useSearchParam("flow");
@@ -72,6 +74,10 @@ export function NewAgentPage() {
 
   if (isRestrictedFromAgentCreation) {
     return <Custom404 />;
+  }
+
+  if (!hasHealthyProviders(providersHealth)) {
+    return <NotAvailableErrorPage isAdmin={isAdmin} owner={owner} />;
   }
 
   if (

--- a/front/components/pages/builder/agents/NotAvailableErrorPage.tsx
+++ b/front/components/pages/builder/agents/NotAvailableErrorPage.tsx
@@ -2,13 +2,15 @@ import CustomErrorPage from "@app/components/pages/CustomErrorPage";
 import type { LightWorkspaceType } from "@app/types/user";
 import { BrainIcon, LoginIcon } from "@dust-tt/sparkle";
 
+interface NotAvailableErrorPageProps {
+  isAdmin: boolean;
+  owner: LightWorkspaceType;
+}
+
 export function NotAvailableErrorPage({
   isAdmin,
   owner,
-}: {
-  isAdmin: boolean;
-  owner: LightWorkspaceType;
-}) {
+}: NotAvailableErrorPageProps) {
   const restOfProps = isAdmin
     ? {
         href: `/w/${owner.sId}/model-providers`,

--- a/front/components/pages/builder/agents/NotAvailableErrorPage.tsx
+++ b/front/components/pages/builder/agents/NotAvailableErrorPage.tsx
@@ -1,0 +1,31 @@
+import CustomErrorPage from "@app/components/pages/CustomErrorPage";
+import type { LightWorkspaceType } from "@app/types/user";
+import { BrainIcon, LoginIcon } from "@dust-tt/sparkle";
+
+export function NotAvailableErrorPage({
+  isAdmin,
+  owner,
+}: {
+  isAdmin: boolean;
+  owner: LightWorkspaceType;
+}) {
+  const restOfProps = isAdmin
+    ? {
+        href: `/w/${owner.sId}/model-providers`,
+        label: "Configure model providers",
+        icon: BrainIcon,
+        description:
+          "Providers must be configured in your workspace to use the agent builder.",
+      }
+    : {
+        href: "/",
+        label: "Back to homepage",
+        icon: LoginIcon,
+        description:
+          "No provider is configured in your workspace. Contact your administrator.",
+      };
+
+  return (
+    <CustomErrorPage title="Agent builder is not available" {...restOfProps} />
+  );
+}

--- a/front/lib/utils/providersHealth.ts
+++ b/front/lib/utils/providersHealth.ts
@@ -1,0 +1,11 @@
+import type { ProvidersHealth } from "@app/types/provider_credential";
+
+export function hasHealthyProviders(
+  providersHealth: ProvidersHealth | null
+): boolean {
+  // BYOK workspaces can't have a null providersHealth
+  if (!providersHealth) {
+    return true;
+  }
+  return Object.values(providersHealth).some(Boolean);
+}

--- a/front/pages/404.tsx
+++ b/front/pages/404.tsx
@@ -1,35 +1,15 @@
-import { LinkWrapper } from "@app/lib/platform";
-import {
-  Button,
-  ExclamationCircleIcon,
-  Icon,
-  LoginIcon,
-} from "@dust-tt/sparkle";
+import CustomErrorPage from "@app/components/pages/CustomErrorPage";
+import { LoginIcon } from "@dust-tt/sparkle";
 
 // biome-ignore lint/plugin/nextjsPageComponentNaming: pre-existing
 export default function Custom404() {
   return (
-    <div className="flex h-dvh items-center justify-center">
-      <div className="flex flex-col gap-3 text-center">
-        <div className="flex flex-col items-center">
-          <div>
-            <Icon
-              visual={ExclamationCircleIcon}
-              size="lg"
-              className="dark:text-golder-400-night text-golden-400"
-            />
-          </div>
-          <p className="heading-xl leading-7 text-foreground dark:text-foreground-night">
-            404: Page not found
-          </p>
-          <p className="copy-sm leading-tight text-muted-foreground dark:text-muted-foreground-night">
-            Looks like this page took an unscheduled coffee break.
-          </p>
-        </div>
-        <LinkWrapper href="/">
-          <Button variant="outline" label="Back to homepage" icon={LoginIcon} />
-        </LinkWrapper>
-      </div>
-    </div>
+    <CustomErrorPage
+      title="404: Page not found"
+      description="Looks like this page took an unscheduled coffee break."
+      href="/"
+      label="Back to homepage"
+      icon={LoginIcon}
+    />
   );
 }


### PR DESCRIPTION
## Description

Disable all agent create/edit/duplicate entry points when no model provider is healthy in BYOK workspaces. Builder pages (new/edit) show a dedicated error screen directing admins to configure providers; buttons across the sidebar, conversation menu, agent details, and assistants table are disabled.

Also extracts the 404 page layout into a reusable `CustomErrorPage` component.

<img width="739" height="508" alt="image" src="https://github.com/user-attachments/assets/6c729faa-e322-4bb9-93a7-d0633d1b72ac" />


## Tests

Manual testing — verified buttons are disabled and error pages render correctly when no providers are healthy, and that everything works normally when providers are available.

## Risk

Low — frontend-only, no API changes. Non-BYOK workspaces are unaffected (`hasHealthyProviders` returns `true` when `providersHealth` is null).

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`