### PR TITLE
[front] chore: enforce coding rule BACK10 on branch ID tests

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -987,12 +987,7 @@ describe("getConversation with branches", () => {
   });
 
   it("returns messages up to the branch point plus branch messages when branchId is provided, and sets branchId on the conversation", async () => {
-    const result = await getConversation(
-      auth,
-      conversationId,
-      false,
-      branchId
-    );
+    const result = await getConversation(auth, conversationId, false, branchId);
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -19,7 +19,6 @@ import {
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
-import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -846,7 +845,7 @@ describe("getConversation with branches", () => {
   let auth: Authenticator;
   let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
   let conversationId: string;
-  let branchSId: string;
+  let branchId: string;
 
   beforeEach(async () => {
     const setup = await createResourceTest({});
@@ -932,17 +931,13 @@ describe("getConversation with branches", () => {
       contentFragmentId: null,
     });
 
-    const branch = await ConversationBranchModel.create({
-      workspaceId: workspace.id,
+    const branch = await ConversationBranchResource.makeNew(auth, {
       state: "open",
       previousMessageId: atBranchMessage.id,
       conversationId: conversation.id,
       userId: user.id,
     });
-    branchSId = makeSId("conversation_branch", {
-      id: branch.id,
-      workspaceId: workspace.id,
-    });
+    branchId = branch.sId;
 
     const branchUserMessage = await UserMessageModel.create({
       userId: user.id,
@@ -996,13 +991,13 @@ describe("getConversation with branches", () => {
       auth,
       conversationId,
       false,
-      branchSId
+      branchId
     );
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       const conv = result.value;
-      expect(conv.branchId).toBe(branchSId);
+      expect(conv.branchId).toBe(branchId);
 
       const userMessages = conv.content.flat().filter(isUserMessageType);
       const contents = userMessages.map((m) => m.content);
@@ -2295,13 +2290,13 @@ describe("postUserMessage", () => {
         }
 
         expect(projectConversation.branchId).toBeDefined();
-        const branchSId = projectConversation.branchId!;
+        const branchId = projectConversation.branchId!;
 
         const conversationWithBranch = await getConversation(
           auth,
           projectConversation.sId,
           false,
-          branchSId
+          branchId
         );
         expect(conversationWithBranch.isOk()).toBe(true);
         if (conversationWithBranch.isErr()) {
@@ -2338,7 +2333,7 @@ describe("postUserMessage", () => {
         expect(secondUserMessageRow).not.toBeNull();
         const branchRow = await ConversationBranchResource.fetchById(
           auth,
-          branchSId
+          branchId
         );
         expect(branchRow).not.toBeNull();
         expect(secondUserMessageRow!.branchId).toBe(branchRow!.id);
@@ -3096,7 +3091,7 @@ describe("isConversationEventAllowedForAuth", () => {
   let auth: Authenticator;
   let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
   let otherAuth: Authenticator;
-  let branchSId: string;
+  let branchId: string;
 
   beforeEach(async () => {
     const setup = await createResourceTest({});
@@ -3142,17 +3137,13 @@ describe("isConversationEventAllowedForAuth", () => {
       contentFragmentId: null,
     });
 
-    const branch = await ConversationBranchModel.create({
-      workspaceId: workspace.id,
+    const branch = await ConversationBranchResource.makeNew(auth, {
       state: "open",
       previousMessageId: baseMessage.id,
       conversationId: conversation.id,
       userId: user.id,
     });
-    branchSId = makeSId("conversation_branch", {
-      id: branch.id,
-      workspaceId: workspace.id,
-    });
+    branchId = branch.sId;
   });
 
   it("returns true for agent_message_done event", async () => {
@@ -3235,7 +3226,7 @@ describe("isConversationEventAllowedForAuth", () => {
       created: Date.now(),
       messageId: "msg-1",
       message: {
-        branchId: branchSId,
+        branchId,
         contentFragments: [],
       } as unknown as UserMessageNewEvent["message"],
     };
@@ -3249,7 +3240,7 @@ describe("isConversationEventAllowedForAuth", () => {
       created: Date.now(),
       messageId: "msg-1",
       message: {
-        branchId: branchSId,
+        branchId,
         contentFragments: [],
       } as unknown as UserMessageNewEvent["message"],
     };
@@ -3294,7 +3285,7 @@ describe("isConversationEventAllowedForAuth", () => {
       created: Date.now(),
       configurationId: "config-1",
       messageId: "msg-1",
-      message: { branchId: branchSId } as AgentMessageType,
+      message: { branchId } as AgentMessageType,
     };
     const result = await isConversationEventAllowedForAuth(auth, { event });
     expect(result).toBe(true);
@@ -3306,7 +3297,7 @@ describe("isConversationEventAllowedForAuth", () => {
       created: Date.now(),
       configurationId: "config-1",
       messageId: "msg-1",
-      message: { branchId: branchSId } as AgentMessageType,
+      message: { branchId } as AgentMessageType,
     };
     const result = await isConversationEventAllowedForAuth(otherAuth, {
       event,

--- a/front/lib/api/assistant/conversation/branches.test.ts
+++ b/front/lib/api/assistant/conversation/branches.test.ts
@@ -62,17 +62,13 @@ describe("mergeConversationBranch", () => {
       contentFragmentId: null,
     });
 
-    const branch = await ConversationBranchModel.create({
-      workspaceId: workspace.id,
+    const branch = await ConversationBranchResource.makeNew(auth, {
       state: "open",
       previousMessageId: baseMessage.id,
       conversationId: conversation.id,
       userId: user.id,
     });
-    const branchSId = ConversationBranchResource.modelIdToSId({
-      id: branch.id,
-      workspaceId: branch.workspaceId,
-    });
+    const branchId = branch.sId;
 
     // Branch user message (rank 1 in branch).
     const branchedUserMessage = await UserMessageModel.create({
@@ -144,7 +140,7 @@ describe("mergeConversationBranch", () => {
     ]);
 
     const mergeRes = await mergeConversationBranch(auth, {
-      branchId: branchSId,
+      branchId,
       conversationId: conversation.sId,
     });
     if (mergeRes.isErr()) {
@@ -270,20 +266,16 @@ describe("mergeConversationBranch", () => {
       contentFragmentId: null,
     });
 
-    const branch = await ConversationBranchModel.create({
-      workspaceId: workspace.id,
+    const branch = await ConversationBranchResource.makeNew(otherAuth, {
       state: "open",
       previousMessageId: baseMessage.id,
       conversationId: conversation.id,
       userId: owner.id,
     });
-    const branchSId = ConversationBranchResource.modelIdToSId({
-      id: branch.id,
-      workspaceId: branch.workspaceId,
-    });
+    const branchId = branch.sId;
 
     const res = await mergeConversationBranch(otherAuth, {
-      branchId: branchSId,
+      branchId,
       conversationId: conversation.sId,
     });
     expect(res.isErr()).toBe(true);
@@ -331,20 +323,15 @@ describe("mergeConversationBranch", () => {
       contentFragmentId: null,
     });
 
-    const branch = await ConversationBranchModel.create({
-      workspaceId: workspace.id,
+    const branch = await ConversationBranchResource.makeNew(auth, {
       state: "merged",
       previousMessageId: baseMessage.id,
       conversationId: conversation.id,
       userId: user.id,
     });
-    const branchSId = ConversationBranchResource.modelIdToSId({
-      id: branch.id,
-      workspaceId: branch.workspaceId,
-    });
 
     const res = await mergeConversationBranch(auth, {
-      branchId: branchSId,
+      branchId: branch.sId,
       conversationId: conversation.sId,
     });
     expect(res.isErr()).toBe(true);
@@ -394,20 +381,15 @@ describe("closeConversationBranch", () => {
       contentFragmentId: null,
     });
 
-    const branch = await ConversationBranchModel.create({
-      workspaceId: workspace.id,
+    const branch = await ConversationBranchResource.makeNew(auth, {
       state: "open",
       previousMessageId: baseMessage.id,
       conversationId: conversation.id,
       userId: user.id,
     });
-    const branchSId = ConversationBranchResource.modelIdToSId({
-      id: branch.id,
-      workspaceId: branch.workspaceId,
-    });
 
     const res = await closeConversationBranch(auth, {
-      branchId: branchSId,
+      branchId: branch.sId,
       conversationId: conversation.sId,
     });
     if (res.isErr()) {
@@ -451,13 +433,13 @@ describe("closeConversationBranch", () => {
 
   it("should return branch_not_found when branch belongs to someone else", async () => {
     const workspace = await WorkspaceFactory.basic();
-    const owner = await UserFactory.basic();
-    const other = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, owner, { role: "user" });
-    await MembershipFactory.associate(workspace, other, { role: "user" });
+    const user = await UserFactory.basic();
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
 
     const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      other.sId,
+      otherUser.sId,
       workspace.sId
     );
 
@@ -469,7 +451,7 @@ describe("closeConversationBranch", () => {
     });
 
     const baseUserMessage = await UserMessageModel.create({
-      userId: owner.id,
+      userId: user.id,
       workspaceId: workspace.id,
       content: "Base",
       userContextUsername: "testuser",
@@ -492,20 +474,15 @@ describe("closeConversationBranch", () => {
       contentFragmentId: null,
     });
 
-    const branch = await ConversationBranchModel.create({
-      workspaceId: workspace.id,
+    const branch = await ConversationBranchResource.makeNew(otherAuth, {
       state: "open",
       previousMessageId: baseMessage.id,
       conversationId: conversation.id,
-      userId: owner.id,
-    });
-    const branchSId = ConversationBranchResource.modelIdToSId({
-      id: branch.id,
-      workspaceId: branch.workspaceId,
+      userId: user.id,
     });
 
     const res = await closeConversationBranch(otherAuth, {
-      branchId: branchSId,
+      branchId: branch.sId,
       conversationId: conversation.sId,
     });
     expect(res.isErr()).toBe(true);
@@ -553,20 +530,15 @@ describe("closeConversationBranch", () => {
       contentFragmentId: null,
     });
 
-    const branch = await ConversationBranchModel.create({
-      workspaceId: workspace.id,
+    const branch = await ConversationBranchResource.makeNew(auth, {
       state: "closed",
       previousMessageId: baseMessage.id,
       conversationId: conversation.id,
       userId: user.id,
     });
-    const branchSId = ConversationBranchResource.modelIdToSId({
-      id: branch.id,
-      workspaceId: branch.workspaceId,
-    });
 
     const res = await closeConversationBranch(auth, {
-      branchId: branchSId,
+      branchId: branch.sId,
       conversationId: conversation.sId,
     });
     expect(res.isErr()).toBe(true);

--- a/front/lib/resources/conversation_branch_resource.test.ts
+++ b/front/lib/resources/conversation_branch_resource.test.ts
@@ -4,9 +4,7 @@ import {
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
-import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
-import { makeSId } from "@app/lib/resources/string_ids";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -19,8 +17,8 @@ describe("ConversationBranchResource permissions", () => {
   let otherAuth: Authenticator;
   let adminAuth: Authenticator;
 
-  let ownerBranchSId: string;
-  let otherBranchSId: string;
+  let ownerBranchId: string;
+  let otherBranchId: string;
 
   beforeEach(async () => {
     workspace = await WorkspaceFactory.basic();
@@ -101,61 +99,52 @@ describe("ConversationBranchResource permissions", () => {
       contentFragmentId: null,
     });
 
-    const ownerBranch = await ConversationBranchModel.create({
-      workspaceId: workspace.id,
+    const ownerBranch = await ConversationBranchResource.makeNew(ownerAuth, {
       state: "open",
       previousMessageId: ownerBaseMessage.id,
       conversationId: conversation.id,
       userId: ownerUser.id,
     });
 
-    const otherBranch = await ConversationBranchModel.create({
-      workspaceId: workspace.id,
+    const otherBranch = await ConversationBranchResource.makeNew(otherAuth, {
       state: "open",
       previousMessageId: otherBaseMessage.id,
       conversationId: conversation.id,
       userId: otherUser.id,
     });
 
-    ownerBranchSId = makeSId("conversation_branch", {
-      id: ownerBranch.id,
-      workspaceId: workspace.id,
-    });
-
-    otherBranchSId = makeSId("conversation_branch", {
-      id: otherBranch.id,
-      workspaceId: workspace.id,
-    });
+    ownerBranchId = ownerBranch.sId;
+    otherBranchId = otherBranch.sId;
   });
 
   it("fetchById should only return branches readable by the caller", async () => {
     const ownerBranchForOwner = await ConversationBranchResource.fetchById(
       ownerAuth,
-      ownerBranchSId
+      ownerBranchId
     );
     expect(ownerBranchForOwner).not.toBeNull();
     expect(ownerBranchForOwner?.userId).toBe(ownerAuth.getNonNullableUser().id);
 
     const ownerBranchForOther = await ConversationBranchResource.fetchById(
       otherAuth,
-      ownerBranchSId
+      ownerBranchId
     );
     expect(ownerBranchForOther).toBeNull();
 
     const ownerBranchForAdmin = await ConversationBranchResource.fetchById(
       adminAuth,
-      ownerBranchSId
+      ownerBranchId
     );
     expect(ownerBranchForAdmin).not.toBeNull();
     expect(ownerBranchForAdmin?.userId).toBeDefined();
   });
 
   it("fetchByIds should filter out branches the user cannot read", async () => {
-    const allBranchSIds = [ownerBranchSId, otherBranchSId];
+    const allBranchIDs = [ownerBranchId, otherBranchId];
 
     const ownerBranches = await ConversationBranchResource.fetchByIds(
       ownerAuth,
-      allBranchSIds
+      allBranchIDs
     );
     const ownerBranchIds = ownerBranches.map((b) => b.userId);
     expect(ownerBranchIds).toContain(ownerAuth.getNonNullableUser().id);
@@ -163,7 +152,7 @@ describe("ConversationBranchResource permissions", () => {
 
     const otherBranches = await ConversationBranchResource.fetchByIds(
       otherAuth,
-      allBranchSIds
+      allBranchIDs
     );
     const otherBranchIds = otherBranches.map((b) => b.userId);
     expect(otherBranchIds).toContain(otherAuth.getNonNullableUser().id);
@@ -171,7 +160,7 @@ describe("ConversationBranchResource permissions", () => {
 
     const adminBranches = await ConversationBranchResource.fetchByIds(
       adminAuth,
-      allBranchSIds
+      allBranchIDs
     );
     const adminBranchIds = adminBranches.map((b) => b.userId);
     expect(adminBranchIds).toContain(ownerAuth.getNonNullableUser().id);

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -7,7 +7,6 @@ import {
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
-import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
 import {
   getReinforcementMetadata,
   REINFORCEMENT_METADATA_KEYS,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3381,12 +3381,11 @@ describe("Space Handling", () => {
       });
       assert(mainMessage, "No main message found");
 
-      const branch = await ConversationBranchModel.create({
+      const branch = await ConversationBranchResource.makeNew(ownerAuth, {
         state: "open",
         previousMessageId: mainMessage.id,
         conversationId: conversationResource.id,
         userId: ownerUser.id,
-        workspaceId: workspace.id,
       });
 
       const branchUserMessageRow = await UserMessageModel.create({
@@ -3402,11 +3401,6 @@ describe("Space Handling", () => {
         clientSideMCPServerIds: [],
       });
 
-      const branchSId = ConversationBranchResource.modelIdToSId({
-        id: branch.id,
-        workspaceId: workspace.id,
-      });
-
       const branchMessage = await MessageModel.create({
         sId: generateRandomModelSId(),
         rank: 1,
@@ -3415,7 +3409,6 @@ describe("Space Handling", () => {
         userMessageId: branchUserMessageRow.id,
         workspaceId: workspace.id,
         branchId: branch.id,
-        branchSId,
       });
 
       const okResult = await ConversationResource.getMessageByIdInConversation(
@@ -3960,12 +3953,11 @@ describe("Space Handling", () => {
       });
 
       // Create a branch from that message
-      const branch = await ConversationBranchModel.create({
+      const branch = await ConversationBranchResource.makeNew(auth, {
         state: "open",
         previousMessageId: mainMessage.id,
         conversationId: conversationResource.id,
         userId: user.id,
-        workspaceId: workspace.id,
       });
 
       // Create a branch user message at the same rank, attached to the branch


### PR DESCRIPTION
## Description

- This PR enforces the coding rule BACK10 relative to naming of string IDs/model IDs variables.
- Focuses on `branchsId` references in conversation tests.

## Tests

- Yes.

## Risk

- N/A, no runtime change.

## Deploy Plan

- No deploy.
