### PR TITLE
Add resource for skill suggestions

### DIFF
--- a/front/lib/resources/skill_suggestion_resource.test.ts
+++ b/front/lib/resources/skill_suggestion_resource.test.ts
@@ -415,7 +415,6 @@ describe("SkillSuggestionResource", () => {
 
       const json = suggestion.toJSON();
 
-      expect(json.id).toBe(suggestion.id);
       expect(json.sId).toBe(suggestion.sId);
       expect(json.kind).toBe("edit_instructions");
       expect(json.suggestion).toEqual({ instructions: "New instructions" });

--- a/front/lib/resources/skill_suggestion_resource.test.ts
+++ b/front/lib/resources/skill_suggestion_resource.test.ts
@@ -1,0 +1,431 @@
+import { Authenticator } from "@app/lib/auth";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("SkillSuggestionResource", () => {
+  let workspace: WorkspaceType;
+  let authenticator: Authenticator;
+  let skill: SkillResource;
+
+  beforeEach(async () => {
+    const testSetup = await createResourceTest({ role: "builder" });
+    workspace = testSetup.workspace;
+    authenticator = testSetup.authenticator;
+
+    skill = await SkillFactory.create(authenticator);
+
+    // Refresh authenticator to pick up the skill's editor group membership
+    // (created during SkillResource.makeNew).
+    await authenticator.refresh();
+  });
+
+  describe("canWrite", () => {
+    it("should return true for admin", async () => {
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+
+      const suggestion = await SkillSuggestionFactory.create(
+        authenticator,
+        skill
+      );
+
+      expect(suggestion.canWrite(adminAuth)).toBe(true);
+    });
+
+    it("should return false for non-admin", async () => {
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      const suggestion = await SkillSuggestionFactory.create(
+        authenticator,
+        skill
+      );
+
+      expect(suggestion.canWrite(otherAuth)).toBe(false);
+    });
+  });
+
+  describe("baseFetch / fetchById / fetchByIds", () => {
+    it("should create and fetch a suggestion by id", async () => {
+      const suggestion = await SkillSuggestionFactory.create(
+        authenticator,
+        skill,
+        {
+          suggestion: { instructions: "Be more detailed" },
+          analysis: "Improving instructions",
+          source: "reinforcement",
+        }
+      );
+
+      expect(suggestion).toBeDefined();
+      expect(suggestion.sId).toMatch(/^ssu_/);
+      expect(suggestion.workspaceId).toBe(workspace.id);
+      expect(suggestion.skillConfigurationId).toBe(skill.id);
+      expect(suggestion.kind).toBe("edit_instructions");
+      expect(suggestion.state).toBe("pending");
+      expect(suggestion.source).toBe("reinforcement");
+
+      const fetched = await SkillSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched).toBeDefined();
+      expect(fetched?.sId).toBe(suggestion.sId);
+      expect(fetched?.kind).toBe("edit_instructions");
+    });
+
+    it("should fetch multiple suggestions by ids", async () => {
+      const s1 = await SkillSuggestionFactory.create(authenticator, skill);
+      const s2 = await SkillSuggestionFactory.create(authenticator, skill);
+
+      const fetched = await SkillSuggestionResource.fetchByIds(authenticator, [
+        s1.sId,
+        s2.sId,
+      ]);
+      expect(fetched).toHaveLength(2);
+      expect(fetched.map((s) => s.sId).sort()).toEqual([s1.sId, s2.sId].sort());
+    });
+
+    it("should not return suggestion when user is not an editor of the skill", async () => {
+      const suggestion = await SkillSuggestionFactory.create(
+        authenticator,
+        skill
+      );
+
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      const fetched = await SkillSuggestionResource.fetchById(
+        otherAuth,
+        suggestion.sId
+      );
+      expect(fetched).toBeNull();
+    });
+  });
+
+  describe("listBySkillConfigurationId", () => {
+    it("should list all suggestions for a skill", async () => {
+      await SkillSuggestionFactory.create(authenticator, skill);
+      await SkillSuggestionFactory.create(authenticator, skill);
+
+      const suggestions =
+        await SkillSuggestionResource.listBySkillConfigurationId(
+          authenticator,
+          skill.sId
+        );
+
+      expect(suggestions).toHaveLength(2);
+    });
+
+    it("should filter by state", async () => {
+      await SkillSuggestionFactory.create(authenticator, skill, {
+        state: "pending",
+      });
+      await SkillSuggestionFactory.create(authenticator, skill, {
+        state: "approved",
+      });
+
+      const pendingSuggestions =
+        await SkillSuggestionResource.listBySkillConfigurationId(
+          authenticator,
+          skill.sId,
+          { states: ["pending"] }
+        );
+
+      expect(pendingSuggestions).toHaveLength(1);
+      expect(pendingSuggestions[0].state).toBe("pending");
+    });
+
+    it("should filter by kind", async () => {
+      await SkillSuggestionFactory.create(authenticator, skill, {
+        kind: "edit_instructions",
+      });
+      await SkillSuggestionFactory.create(authenticator, skill, {
+        kind: "create",
+        suggestion: {},
+      });
+
+      const editSuggestions =
+        await SkillSuggestionResource.listBySkillConfigurationId(
+          authenticator,
+          skill.sId,
+          { kind: "edit_instructions" }
+        );
+
+      expect(editSuggestions).toHaveLength(1);
+      expect(editSuggestions[0].kind).toBe("edit_instructions");
+    });
+
+    it("should exclude synthetic suggestions by default", async () => {
+      await SkillSuggestionFactory.create(authenticator, skill, {
+        source: "reinforcement",
+      });
+      await SkillSuggestionFactory.create(authenticator, skill, {
+        source: "synthetic",
+      });
+
+      const suggestions =
+        await SkillSuggestionResource.listBySkillConfigurationId(
+          authenticator,
+          skill.sId
+        );
+
+      expect(suggestions).toHaveLength(1);
+      expect(suggestions[0].source).toBe("reinforcement");
+    });
+
+    it("should return only synthetic suggestions when filtering by source", async () => {
+      await SkillSuggestionFactory.create(authenticator, skill, {
+        source: "reinforcement",
+      });
+      await SkillSuggestionFactory.create(authenticator, skill, {
+        source: "synthetic",
+      });
+
+      const suggestions =
+        await SkillSuggestionResource.listBySkillConfigurationId(
+          authenticator,
+          skill.sId,
+          { sources: ["synthetic"] }
+        );
+
+      expect(suggestions).toHaveLength(1);
+      expect(suggestions[0].source).toBe("synthetic");
+    });
+
+    it("should limit the number of returned suggestions and return most recent first", async () => {
+      const created = [];
+      for (let i = 0; i < 3; i++) {
+        const suggestion = await SkillSuggestionFactory.create(
+          authenticator,
+          skill,
+          {
+            suggestion: { instructions: `instruction-${i}` },
+          }
+        );
+        created.push(suggestion);
+      }
+
+      const suggestions =
+        await SkillSuggestionResource.listBySkillConfigurationId(
+          authenticator,
+          skill.sId,
+          { limit: 2 }
+        );
+
+      expect(suggestions).toHaveLength(2);
+      // Most recent first.
+      expect(suggestions[0].sId).toBe(created[2].sId);
+      expect(suggestions[1].sId).toBe(created[1].sId);
+    });
+
+    it("should return empty array for non-existent skill", async () => {
+      const suggestions =
+        await SkillSuggestionResource.listBySkillConfigurationId(
+          authenticator,
+          "non_existent_sid"
+        );
+
+      expect(suggestions).toHaveLength(0);
+    });
+
+    it("should not return suggestions when user is not an editor of the skill", async () => {
+      await SkillSuggestionFactory.create(authenticator, skill);
+
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      const suggestions =
+        await SkillSuggestionResource.listBySkillConfigurationId(
+          otherAuth,
+          skill.sId
+        );
+
+      expect(suggestions).toHaveLength(0);
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete a suggestion", async () => {
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const suggestion = await SkillSuggestionFactory.create(
+        authenticator,
+        skill
+      );
+      const sId = suggestion.sId;
+
+      const result = await suggestion.delete(adminAuth);
+      expect(result.isOk()).toBe(true);
+
+      const fetched = await SkillSuggestionResource.fetchById(
+        authenticator,
+        sId
+      );
+      expect(fetched).toBeNull();
+    });
+
+    it("should fail to delete when user does not have permission", async () => {
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      const suggestion = await SkillSuggestionFactory.create(
+        authenticator,
+        skill
+      );
+
+      const result = await suggestion.delete(otherAuth);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toBe(
+          "User does not have permission to edit this skill"
+        );
+      }
+    });
+  });
+
+  describe("deleteExpiredSynthetic", () => {
+    it("should delete synthetic suggestions older than cutoff date", async () => {
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+
+      const recent = await SkillSuggestionFactory.create(authenticator, skill, {
+        source: "synthetic",
+      });
+      const old = await SkillSuggestionFactory.create(authenticator, skill, {
+        source: "synthetic",
+      });
+      await SkillSuggestionFactory.setCreatedAt(
+        old,
+        new Date(Date.now() - 40 * 24 * 60 * 60 * 1000)
+      );
+
+      // Also create a non-synthetic suggestion that should not be deleted.
+      const reinforcement = await SkillSuggestionFactory.create(
+        authenticator,
+        skill,
+        { source: "reinforcement" }
+      );
+      await SkillSuggestionFactory.setCreatedAt(
+        reinforcement,
+        new Date(Date.now() - 40 * 24 * 60 * 60 * 1000)
+      );
+
+      const cutoffDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+      const deletedCount = await SkillSuggestionResource.deleteExpiredSynthetic(
+        adminAuth,
+        cutoffDate
+      );
+
+      expect(deletedCount).toBe(1);
+
+      // Recent synthetic should still exist.
+      const fetchedRecent = await SkillSuggestionResource.fetchById(
+        authenticator,
+        recent.sId
+      );
+      expect(fetchedRecent).toBeDefined();
+
+      // Old reinforcement should still exist.
+      const fetchedReinforcement = await SkillSuggestionResource.fetchById(
+        authenticator,
+        reinforcement.sId
+      );
+      expect(fetchedReinforcement).toBeDefined();
+    });
+
+    it("should fail when user is not an admin", async () => {
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      await expect(
+        SkillSuggestionResource.deleteExpiredSynthetic(otherAuth, new Date())
+      ).rejects.toThrow(
+        "Only workspace admins can delete expired synthetic suggestions"
+      );
+    });
+
+    it("should respect the limit parameter", async () => {
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+
+      // Create 3 old synthetic suggestions.
+      for (let i = 0; i < 3; i++) {
+        const s = await SkillSuggestionFactory.create(authenticator, skill, {
+          source: "synthetic",
+        });
+        await SkillSuggestionFactory.setCreatedAt(
+          s,
+          new Date(Date.now() - 40 * 24 * 60 * 60 * 1000)
+        );
+      }
+
+      const cutoffDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+      const deletedCount = await SkillSuggestionResource.deleteExpiredSynthetic(
+        adminAuth,
+        cutoffDate,
+        { limit: 2 }
+      );
+
+      expect(deletedCount).toBe(2);
+    });
+  });
+
+  describe("toJSON", () => {
+    it("should return a properly formatted JSON object", async () => {
+      const suggestion = await SkillSuggestionFactory.create(
+        authenticator,
+        skill,
+        {
+          suggestion: { instructions: "New instructions" },
+          analysis: "Improved clarity",
+        }
+      );
+
+      const json = suggestion.toJSON();
+
+      expect(json.id).toBe(suggestion.id);
+      expect(json.sId).toBe(suggestion.sId);
+      expect(json.kind).toBe("edit_instructions");
+      expect(json.suggestion).toEqual({ instructions: "New instructions" });
+      expect(json.analysis).toBe("Improved clarity");
+      expect(json.state).toBe("pending");
+      expect(json.source).toBe("reinforcement");
+      expect(json.skillConfigurationId).toBe(skill.sId);
+      expect(json.sourceConversationId).toBeNull();
+      expect(typeof json.createdAt).toBe("number");
+      expect(typeof json.updatedAt).toBe("number");
+    });
+  });
+});

--- a/front/lib/resources/skill_suggestion_resource.ts
+++ b/front/lib/resources/skill_suggestion_resource.ts
@@ -1,0 +1,312 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
+import { SkillConfigurationModel } from "@app/lib/models/skill";
+import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type {
+  SkillSuggestionKind,
+  SkillSuggestionSource,
+  SkillSuggestionState,
+  SkillSuggestionType,
+} from "@app/types/suggestions/skill_suggestion";
+import { parseSkillSuggestionData } from "@app/types/suggestions/skill_suggestion";
+import type {
+  Attributes,
+  CreationAttributes,
+  ModelStatic,
+  WhereOptions,
+} from "sequelize";
+import { Op } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface SkillSuggestionResource
+  extends ReadonlyAttributesType<SkillSuggestionModel> {}
+
+/**
+ * Resource for managing skill suggestions.
+ *
+ * IMPORTANT: Access to suggestions requires edit permissions on the associated skill.
+ * Users can only create, read, update, or delete suggestions for skills they can edit.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> {
+  static model: ModelStatic<SkillSuggestionModel> = SkillSuggestionModel;
+
+  readonly editorsGroupId: ModelId | null;
+  readonly skillConfigurationSId: string;
+  readonly sourceConversationSId: string | null;
+
+  constructor(
+    model: ModelStatic<SkillSuggestionModel>,
+    blob: Attributes<SkillSuggestionModel>,
+    editorsGroupId: ModelId | null,
+    skillConfigurationSId: string,
+    sourceConversationSId: string | null
+  ) {
+    super(SkillSuggestionModel, blob);
+    this.editorsGroupId = editorsGroupId;
+    this.skillConfigurationSId = skillConfigurationSId;
+    this.sourceConversationSId = sourceConversationSId;
+  }
+
+  /**
+   * Check if the user has permission to write (edit/delete) this suggestion's skill.
+   */
+  canWrite(auth: Authenticator): boolean {
+    if (auth.isAdmin()) {
+      return true;
+    }
+    if (this.editorsGroupId === null) {
+      return false;
+    }
+    return auth.hasGroupByModelId(this.editorsGroupId);
+  }
+
+  static async createSuggestionForSkill(
+    auth: Authenticator,
+    skill: SkillResource,
+    blob: Omit<
+      CreationAttributes<SkillSuggestionModel>,
+      "workspaceId" | "skillConfigurationId"
+    >
+  ): Promise<SkillSuggestionResource> {
+    const owner = auth.getNonNullableWorkspace();
+
+    if (!skill.canWrite(auth)) {
+      throw new Error("User does not have permission to edit this skill");
+    }
+
+    const suggestion = await SkillSuggestionModel.create({
+      ...blob,
+      skillConfigurationId: skill.id,
+      workspaceId: owner.id,
+    });
+
+    return new this(
+      SkillSuggestionModel,
+      suggestion.get(),
+      skill.editorGroup?.id ?? null,
+      skill.sId,
+      null
+    );
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    options?: ResourceFindOptions<SkillSuggestionModel>
+  ) {
+    const { where, ...otherOptions } = options ?? {};
+    const owner = auth.getNonNullableWorkspace();
+
+    const suggestions = await SkillSuggestionModel.findAll({
+      where: {
+        ...where,
+        workspaceId: owner.id,
+      },
+      include: [
+        {
+          model: SkillConfigurationModel,
+          as: "skillConfiguration",
+          required: true,
+        },
+        {
+          model: ConversationModel,
+          as: "sourceConversation",
+          required: false,
+          attributes: ["sId"],
+        },
+      ],
+      ...otherOptions,
+    });
+
+    if (suggestions.length === 0) {
+      return [];
+    }
+
+    // Get unique skill configuration IDs to check permissions.
+    const skillConfigIds = [
+      ...new Set(suggestions.map((s) => s.skillConfigurationId)),
+    ];
+
+    const skillResources = await SkillResource.fetchByModelIds(
+      auth,
+      skillConfigIds
+    );
+
+    const skillResourceByModelId = new Map(
+      skillResources.map((s) => [s.id, s])
+    );
+
+    // Filter suggestions to only include those for skills the user can edit.
+    return removeNulls(
+      suggestions.map((suggestion) => {
+        const skillResource = skillResourceByModelId.get(
+          suggestion.skillConfigurationId
+        );
+        if (!skillResource || !skillResource.canWrite(auth)) {
+          return null;
+        }
+        return new this(
+          SkillSuggestionModel,
+          suggestion.get(),
+          skillResource.editorGroup?.id ?? null,
+          skillResource.sId,
+          suggestion.sourceConversation?.sId ?? null
+        );
+      })
+    );
+  }
+
+  static async fetchByIds(
+    auth: Authenticator,
+    ids: string[]
+  ): Promise<SkillSuggestionResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        id: removeNulls(ids.map(getResourceIdFromSId)),
+      },
+    });
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    id: string
+  ): Promise<SkillSuggestionResource | null> {
+    const [suggestion] = await this.fetchByIds(auth, [id]);
+    return suggestion ?? null;
+  }
+
+  /**
+   * Lists all suggestions for a skill identified by its sId.
+   * Optionally filter by state, source, and kind.
+   */
+  static async listBySkillConfigurationId(
+    auth: Authenticator,
+    skillId: string,
+    filters?: {
+      states?: SkillSuggestionState[];
+      sources?: SkillSuggestionSource[];
+      kind?: SkillSuggestionKind;
+      limit?: number;
+    }
+  ): Promise<SkillSuggestionResource[]> {
+    const skillModelId = getResourceIdFromSId(skillId);
+    if (skillModelId === null) {
+      return [];
+    }
+
+    // Build the where clause with optional filters.
+    // By default, exclude synthetic suggestions unless an explicit sources
+    // filter is provided.
+    const sourceFilter =
+      filters?.sources && filters.sources.length > 0
+        ? { source: filters.sources }
+        : { source: { [Op.ne]: "synthetic" } };
+
+    const whereClause: WhereOptions<SkillSuggestionModel> = {
+      skillConfigurationId: skillModelId,
+      ...(filters?.states &&
+        filters.states.length > 0 && { state: filters.states }),
+      ...sourceFilter,
+      ...(filters?.kind && { kind: filters.kind }),
+    };
+
+    return this.baseFetch(auth, {
+      where: whereClause,
+      order: [["createdAt", "DESC"]],
+      limit: filters?.limit,
+    });
+  }
+
+  async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
+    if (!this.canWrite(auth)) {
+      return new Err(
+        new Error("User does not have permission to edit this skill")
+      );
+    }
+
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        id: this.id,
+      },
+    });
+
+    return new Ok(undefined);
+  }
+
+  /**
+   * Deletes all synthetic suggestions older than the given cutoff date.
+   * Requires admin permissions. Returns the number of deleted rows.
+   */
+  static async deleteExpiredSynthetic(
+    auth: Authenticator,
+    cutoffDate: Date,
+    { limit }: { limit?: number } = {}
+  ): Promise<number> {
+    if (!auth.isAdmin()) {
+      throw new Error(
+        "Only workspace admins can delete expired synthetic suggestions"
+      );
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+
+    return SkillSuggestionModel.destroy({
+      where: {
+        workspaceId: owner.id,
+        source: "synthetic",
+        createdAt: { [Op.lt]: cutoffDate },
+      },
+      limit,
+    });
+  }
+
+  get sId(): string {
+    return SkillSuggestionResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("skill_suggestion", {
+      id,
+      workspaceId,
+    });
+  }
+
+  toJSON(): SkillSuggestionType {
+    const suggestionData = parseSkillSuggestionData({
+      kind: this.kind,
+      suggestion: this.suggestion,
+    });
+
+    return {
+      id: this.id,
+      sId: this.sId,
+      createdAt: this.createdAt.getTime(),
+      updatedAt: this.updatedAt.getTime(),
+      skillConfigurationId: this.skillConfigurationSId,
+      analysis: this.analysis,
+      state: this.state,
+      source: this.source,
+      sourceConversationId: this.sourceConversationSId,
+      ...suggestionData,
+    };
+  }
+}

--- a/front/lib/resources/skill_suggestion_resource.ts
+++ b/front/lib/resources/skill_suggestion_resource.ts
@@ -297,7 +297,6 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
     });
 
     return {
-      id: this.id,
       sId: this.sId,
       createdAt: this.createdAt.getTime(),
       updatedAt: this.updatedAt.getTime(),

--- a/front/lib/resources/skill_suggestion_resource.ts
+++ b/front/lib/resources/skill_suggestion_resource.ts
@@ -221,7 +221,10 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
 
     return this.baseFetch(auth, {
       where: whereClause,
-      order: [["createdAt", "DESC"]],
+      order: [
+        ["createdAt", "DESC"],
+        ["id", "DESC"],
+      ],
       limit: filters?.limit,
     });
   }

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -60,6 +60,9 @@ export const RESOURCES_PREFIX = {
   // Agent suggestions.
   agent_suggestion: "asu",
 
+  // Skill suggestions.
+  skill_suggestion: "ssu",
+
   // Workspace verification.
   workspace_verification_attempt: "wva",
 

--- a/front/tests/utils/SkillSuggestionFactory.ts
+++ b/front/tests/utils/SkillSuggestionFactory.ts
@@ -1,0 +1,71 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import type {
+  SkillSuggestionKind,
+  SkillSuggestionPayload,
+  SkillSuggestionSource,
+  SkillSuggestionState,
+} from "@app/types/suggestions/skill_suggestion";
+
+export class SkillSuggestionFactory {
+  static async create(
+    auth: Authenticator,
+    skill: SkillResource,
+    overrides: Partial<{
+      kind: SkillSuggestionKind;
+      suggestion: SkillSuggestionPayload;
+      analysis: string | null;
+      state: SkillSuggestionState;
+      source: SkillSuggestionSource;
+    }> = {}
+  ): Promise<SkillSuggestionResource> {
+    return SkillSuggestionResource.createSuggestionForSkill(auth, skill, {
+      kind: overrides.kind ?? "edit_instructions",
+      suggestion: overrides.suggestion ?? {
+        instructions: "Updated skill instructions",
+      },
+      analysis: overrides.analysis ?? "Improved instructions",
+      state: overrides.state ?? "pending",
+      source: overrides.source ?? "reinforcement",
+    });
+  }
+
+  static async createEditInstructions(
+    auth: Authenticator,
+    skill: SkillResource,
+    overrides: Partial<{
+      suggestion: { instructions: string };
+      analysis: string | null;
+      state: SkillSuggestionState;
+      source: SkillSuggestionSource;
+    }> = {}
+  ): Promise<SkillSuggestionResource> {
+    return this.create(auth, skill, {
+      kind: "edit_instructions",
+      suggestion: overrides.suggestion ?? {
+        instructions: "Updated skill instructions",
+      },
+      analysis: overrides.analysis,
+      state: overrides.state,
+      source: overrides.source,
+    });
+  }
+
+  static async setCreatedAt(
+    suggestion: SkillSuggestionResource,
+    createdAt: Date
+  ): Promise<void> {
+    // biome-ignore lint/plugin/noRawSql: Raw SQL is the only reliable way to backdate timestamps in tests
+    await frontSequelize.query(
+      `UPDATE skill_suggestions SET "createdAt" = :createdAt, "updatedAt" = :createdAt WHERE id = :id`,
+      {
+        replacements: {
+          createdAt: createdAt.toISOString(),
+          id: suggestion.id,
+        },
+      }
+    );
+  }
+}

--- a/front/types/suggestions/skill_suggestion.ts
+++ b/front/types/suggestions/skill_suggestion.ts
@@ -48,3 +48,37 @@ export function isSkillEditInstructionsSuggestion(
 export type SkillSuggestionPayload =
   | SkillCreateSuggestionType
   | SkillEditInstructionsSuggestionType;
+
+export const SkillSuggestionDataSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("create"),
+    suggestion: SkillCreateSuggestionSchema,
+  }),
+  z.object({
+    kind: z.literal("edit_instructions"),
+    suggestion: SkillEditInstructionsSuggestionSchema,
+  }),
+]);
+
+export type SkillSuggestionData = z.infer<typeof SkillSuggestionDataSchema>;
+
+export function parseSkillSuggestionData(data: unknown): SkillSuggestionData {
+  return SkillSuggestionDataSchema.parse(data);
+}
+
+const BaseSkillSuggestionSchema = z.object({
+  id: z.number(),
+  sId: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  skillConfigurationId: z.string(),
+  analysis: z.string().nullable(),
+  state: z.enum(SKILL_SUGGESTION_STATES),
+  source: z.enum(SKILL_SUGGESTION_SOURCES),
+  sourceConversationId: z.string().nullable(),
+});
+
+export const SkillSuggestionSchema =
+  BaseSkillSuggestionSchema.and(SkillSuggestionDataSchema);
+
+export type SkillSuggestionType = z.infer<typeof SkillSuggestionSchema>;

--- a/front/types/suggestions/skill_suggestion.ts
+++ b/front/types/suggestions/skill_suggestion.ts
@@ -77,7 +77,8 @@ const BaseSkillSuggestionSchema = z.object({
   sourceConversationId: z.string().nullable(),
 });
 
-export const SkillSuggestionSchema =
-  BaseSkillSuggestionSchema.and(SkillSuggestionDataSchema);
+export const SkillSuggestionSchema = BaseSkillSuggestionSchema.and(
+  SkillSuggestionDataSchema
+);
 
 export type SkillSuggestionType = z.infer<typeof SkillSuggestionSchema>;

--- a/front/types/suggestions/skill_suggestion.ts
+++ b/front/types/suggestions/skill_suggestion.ts
@@ -67,7 +67,6 @@ export function parseSkillSuggestionData(data: unknown): SkillSuggestionData {
 }
 
 const BaseSkillSuggestionSchema = z.object({
-  id: z.number(),
   sId: z.string(),
   createdAt: z.number(),
   updatedAt: z.number(),


### PR DESCRIPTION
## Description

Add the resource 

## Tests

Add tests for the resource

```
 ✓ lib/resources/skill_suggestion_resource.test.ts (19 tests) 2064ms
   ✓ SkillSuggestionResource (19)
     ✓ canWrite (2)
       ✓ should return true for admin 186ms
       ✓ should return false for non-admin 108ms
     ✓ baseFetch / fetchById / fetchByIds (3)
       ✓ should create and fetch a suggestion by id 125ms
       ✓ should fetch multiple suggestions by ids 94ms
       ✓ should not return suggestion when user is not an editor of the skill 120ms
     ✓ listBySkillConfigurationId (8)
       ✓ should list all suggestions for a skill 96ms
       ✓ should filter by state 168ms
       ✓ should filter by kind 85ms
       ✓ should exclude synthetic suggestions by default 141ms
       ✓ should return only synthetic suggestions when filtering by source 79ms
       ✓ should limit the number of returned suggestions and return most recent first 76ms
       ✓ should return empty array for non-existent skill 56ms
       ✓ should not return suggestions when user is not an editor of the skill 98ms
     ✓ delete (2)
       ✓ should delete a suggestion 76ms
       ✓ should fail to delete when user does not have permission 167ms
     ✓ deleteExpiredSynthetic (3)
       ✓ should delete synthetic suggestions older than cutoff date 174ms
       ✓ should fail when user is not an admin 75ms
       ✓ should respect the limit parameter 75ms
     ✓ toJSON (1)
       ✓ should return a properly formatted JSON object 63ms

 Test Files  1 passed (1)
      Tests  19 passed (19)
   Start at  12:08:04
   Duration  27.54s (transform 5.69s, setup 399ms, import 9.59s, tests 2.06s, environment 317ms)
```

## Risk

low

## Deploy Plan

deploy front
