### PR TITLE
[front] enh: use infinite scroll on content node tree

### DIFF
--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -1,3 +1,4 @@
+import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getVisualForContentNode } from "@app/lib/content_nodes";
 import { classNames } from "@app/lib/utils";
@@ -11,10 +12,12 @@ import {
   IconButton,
   ListCheckIcon,
   SearchInput,
+  Spinner,
   Tree,
+  useSheetViewport,
 } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
-import React, { useCallback, useContext, useState } from "react";
+import React, { useCallback, useContext, useRef, useState } from "react";
 
 const unselectedChildren = (
   selection: Record<string, ContentNodeTreeItemStatus>,
@@ -105,6 +108,44 @@ const useContentNodeTreeContext = () => {
   return context;
 };
 
+interface ContentNodeTreeInfiniteScrollProps {
+  loadMore?: () => void;
+  hasMore: boolean;
+  isLoadingMore: boolean;
+}
+
+function ContentNodeTreeInfiniteScroll({
+  loadMore,
+  hasMore,
+  isLoadingMore,
+}: ContentNodeTreeInfiniteScrollProps) {
+  const sheetViewport = useSheetViewport();
+  const isLoadingMoreRef = useRef(isLoadingMore);
+  isLoadingMoreRef.current = isLoadingMore;
+
+  const handleNextPage = useCallback(() => {
+    if (loadMore && !isLoadingMoreRef.current) {
+      loadMore();
+    }
+  }, [loadMore]);
+
+  return (
+    <InfiniteScroll
+      nextPage={handleNextPage}
+      hasMore={hasMore}
+      showLoader={isLoadingMore}
+      loader={
+        <div className="flex justify-center py-2">
+          <Spinner size="sm" />
+        </div>
+      }
+      options={
+        sheetViewport ? { root: sheetViewport, rootMargin: "400px" } : undefined
+      }
+    />
+  );
+}
+
 interface ContentNodeTreeChildrenProps {
   depth: number;
   isRoundedBackground?: boolean;
@@ -142,15 +183,17 @@ function ContentNodeTreeChildren({
     isResourcesLoading,
     isResourcesError,
     resourcesError,
-    totalResourceCount,
     nextPageCursor,
     loadMore,
     isLoadingMore,
   } = useResourcesHook(parentId);
 
-  const filteredNodes = resources
-    .filter((n) => filter.trim().length === 0 || n.title.includes(filter))
-    .sort((a, b) => a.title.localeCompare(b.title));
+  const isFiltering = filter.trim().length > 0;
+  const filteredNodes = isFiltering
+    ? resources
+        .filter((n) => n.title.includes(filter))
+        .sort((a, b) => a.title.localeCompare(b.title))
+    : resources;
 
   const getCheckedState = useCallback(
     (node: ContentNode) => {
@@ -344,26 +387,13 @@ function ContentNodeTreeChildren({
           </div>
         </>
       )}
-      <div className="overflow-y-auto p-1">
+      <div className="p-1">
         {tree}
-        {nextPageCursor && (
-          <div className="mt-2 flex flex-col items-center py-2">
-            <div className="mb-2 text-center text-xs text-gray-500">
-              {`Showing ${filteredNodes.length} of ${totalResourceCount ?? filteredNodes.length} items`}
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              label={isLoadingMore ? "Loading..." : "Load More"}
-              disabled={isResourcesLoading || isLoadingMore}
-              onClick={() => {
-                if (loadMore) {
-                  loadMore();
-                }
-              }}
-            />
-          </div>
-        )}
+        <ContentNodeTreeInfiniteScroll
+          loadMore={loadMore}
+          hasMore={!!nextPageCursor}
+          isLoadingMore={!!isLoadingMore}
+        />
       </div>
     </>
   );

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -201,6 +201,36 @@ const updateSelection = ({
   };
 };
 
+const applySelectionConfigUpdate = ({
+  prevState,
+  dataSourceView,
+  update,
+  selectionMode,
+  keepOnlyOneSpaceIfApplicable,
+}: {
+  prevState: DataSourceViewSelectionConfigurations;
+  dataSourceView: DataSourceViewType;
+  update: Partial<DataSourceViewSelectionConfiguration>;
+  selectionMode: "checkbox" | "radio";
+  keepOnlyOneSpaceIfApplicable: (
+    config: DataSourceViewSelectionConfigurations
+  ) => DataSourceViewSelectionConfigurations;
+}): DataSourceViewSelectionConfigurations => {
+  const { sId } = dataSourceView;
+  const prevConfig =
+    prevState[sId] ?? defaultSelectionConfiguration(dataSourceView);
+  const updatedConfig = { ...prevConfig, ...update };
+
+  if (selectionMode === "radio") {
+    return { [sId]: updatedConfig };
+  }
+
+  return keepOnlyOneSpaceIfApplicable({
+    ...prevState,
+    [sId]: updatedConfig,
+  });
+};
+
 export type useCaseDataSourceViewsSelector =
   | "spaceDatasourceManagement"
   | "assistantBuilder"
@@ -734,36 +764,6 @@ export function DataSourceViewSelector({
     selectionConfiguration.selectedResources.length > 0 ||
     selectionConfiguration.isSelectAll;
 
-  const applySelectAll = useCallback(
-    (nodes: typeof rootNodes) => {
-      setSelectionConfigurations((prevState) => {
-        const { sId } = dataSourceView;
-        const defaultConfig = defaultSelectionConfiguration(dataSourceView);
-        const prevConfig = prevState[sId] ?? defaultConfig;
-        const updatedConfig = {
-          ...prevConfig,
-          selectedResources: nodes,
-          isSelectAll: false,
-        };
-
-        if (selectionMode === "radio") {
-          return { [sId]: updatedConfig };
-        }
-
-        return keepOnlyOneSpaceIfApplicable({
-          ...prevState,
-          [sId]: updatedConfig,
-        });
-      });
-    },
-    [
-      dataSourceView,
-      keepOnlyOneSpaceIfApplicable,
-      setSelectionConfigurations,
-      selectionMode,
-    ]
-  );
-
   const handleSelectAll = () => {
     if (hasActiveSelection) {
       setSelectionConfigurations((prevState) =>
@@ -774,25 +774,15 @@ export function DataSourceViewSelector({
     }
 
     if (isRootSelectable) {
-      setSelectionConfigurations((prevState) => {
-        const { sId } = dataSourceView;
-        const defaultConfig = defaultSelectionConfiguration(dataSourceView);
-        const prevConfig = prevState[sId] ?? defaultConfig;
-        const updatedConfig = {
-          ...prevConfig,
-          selectedResources: [],
-          isSelectAll: true,
-        };
-
-        if (selectionMode === "radio") {
-          return { [sId]: updatedConfig };
-        }
-
-        return keepOnlyOneSpaceIfApplicable({
-          ...prevState,
-          [sId]: updatedConfig,
-        });
-      });
+      setSelectionConfigurations((prevState) =>
+        applySelectionConfigUpdate({
+          prevState,
+          dataSourceView,
+          update: { selectedResources: [], isSelectAll: true },
+          selectionMode,
+          keepOnlyOneSpaceIfApplicable,
+        })
+      );
       return;
     }
 
@@ -903,27 +893,35 @@ export function DataSourceViewSelector({
   );
 
   useEffect(() => {
-    if (selectAllTriggered && hasNextPage && !isLoadingMore) {
-      void loadMore();
+    if (!selectAllTriggered) {
+      return;
     }
-  }, [selectAllTriggered, hasNextPage, isLoadingMore, loadMore]);
-
-  useEffect(() => {
-    if (
-      selectAllTriggered &&
-      rootNodes.length > 0 &&
-      !hasNextPage &&
-      !isLoadingMore
-    ) {
-      applySelectAll(rootNodes);
+    if (hasNextPage && !isLoadingMore) {
+      void loadMore();
+      return;
+    }
+    if (!hasNextPage && !isLoadingMore && rootNodes.length > 0) {
+      setSelectionConfigurations((prevState) =>
+        applySelectionConfigUpdate({
+          prevState,
+          dataSourceView,
+          update: { selectedResources: rootNodes, isSelectAll: false },
+          selectionMode,
+          keepOnlyOneSpaceIfApplicable,
+        })
+      );
       setSelectAllTriggered(false);
     }
   }, [
     selectAllTriggered,
-    rootNodes,
     hasNextPage,
     isLoadingMore,
-    applySelectAll,
+    loadMore,
+    rootNodes,
+    dataSourceView,
+    selectionMode,
+    keepOnlyOneSpaceIfApplicable,
+    setSelectionConfigurations,
   ]);
 
   return (

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -104,9 +104,55 @@ const getUseResourceHook =
       isResourcesTruncated: !totalNodesCountIsAccurate,
       nextPageCursor: hasNextPage ? nextPageCursor : null,
       loadMore,
-      isLoadingMore: !!isLoadingMore && !isNodesLoading,
+      isLoadingMore: isLoadingMore && !isNodesLoading,
     };
   };
+
+interface UseLazyLoadAllNodesOptions {
+  owner: LightWorkspaceType;
+  dataSourceView: DataSourceViewType;
+  viewType: ContentNodesViewType;
+  onComplete: (
+    nodes: ReturnType<typeof useInfiniteDataSourceViewContentNodes>["nodes"]
+  ) => void;
+}
+
+function useLazyLoadAllNodes({
+  owner,
+  dataSourceView,
+  viewType,
+  onComplete,
+}: UseLazyLoadAllNodesOptions) {
+  const [triggered, setTriggered] = useState(false);
+
+  const { nodes, hasNextPage, isLoadingMore, loadMore } =
+    useInfiniteDataSourceViewContentNodes({
+      owner,
+      dataSourceView: triggered ? dataSourceView : undefined,
+      viewType,
+      pagination: { cursor: null, limit: ITEMS_PER_PAGE },
+    });
+
+  useEffect(() => {
+    if (!triggered) {
+      return;
+    }
+    if (hasNextPage && !isLoadingMore) {
+      void loadMore();
+      return;
+    }
+    if (!hasNextPage && !isLoadingMore && nodes.length > 0) {
+      onComplete(nodes);
+      setTriggered(false);
+    }
+  }, [triggered, hasNextPage, isLoadingMore, loadMore, nodes, onComplete]);
+
+  return {
+    trigger: () => setTriggered(true),
+    reset: () => setTriggered(false),
+    isLoading: triggered,
+  };
+}
 
 const getNodesFromConfig = (
   selectionConfiguration: DataSourceViewSelectionConfiguration
@@ -746,18 +792,29 @@ export function DataSourceViewSelector({
     [dataSourceView]
   );
 
-  const [selectAllTriggered, setSelectAllTriggered] = useState(false);
-
-  const {
-    nodes: rootNodes,
-    hasNextPage,
-    isLoadingMore,
-    loadMore,
-  } = useInfiniteDataSourceViewContentNodes({
+  const selectAll = useLazyLoadAllNodes({
     owner,
-    dataSourceView: selectAllTriggered ? dataSourceView : undefined,
+    dataSourceView,
     viewType,
-    pagination: { limit: ITEMS_PER_PAGE, cursor: null },
+    onComplete: useCallback(
+      (nodes: DataSourceViewContentNode[]) => {
+        setSelectionConfigurations((prevState) =>
+          applySelectionConfigUpdate({
+            prevState,
+            dataSourceView,
+            update: { selectedResources: nodes, isSelectAll: false },
+            selectionMode,
+            keepOnlyOneSpaceIfApplicable,
+          })
+        );
+      },
+      [
+        dataSourceView,
+        selectionMode,
+        keepOnlyOneSpaceIfApplicable,
+        setSelectionConfigurations,
+      ]
+    ),
   });
 
   const hasActiveSelection =
@@ -769,7 +826,7 @@ export function DataSourceViewSelector({
       setSelectionConfigurations((prevState) =>
         _.omit(prevState, dataSourceView.sId)
       );
-      setSelectAllTriggered(false);
+      selectAll.reset();
       return;
     }
 
@@ -786,7 +843,7 @@ export function DataSourceViewSelector({
       return;
     }
 
-    setSelectAllTriggered(true);
+    selectAll.trigger();
   };
 
   const isChecked = selectionConfiguration.isSelectAll
@@ -892,38 +949,6 @@ export function DataSourceViewSelector({
     [searchResult, isExpanded]
   );
 
-  useEffect(() => {
-    if (!selectAllTriggered) {
-      return;
-    }
-    if (hasNextPage && !isLoadingMore) {
-      void loadMore();
-      return;
-    }
-    if (!hasNextPage && !isLoadingMore && rootNodes.length > 0) {
-      setSelectionConfigurations((prevState) =>
-        applySelectionConfigUpdate({
-          prevState,
-          dataSourceView,
-          update: { selectedResources: rootNodes, isSelectAll: false },
-          selectionMode,
-          keepOnlyOneSpaceIfApplicable,
-        })
-      );
-      setSelectAllTriggered(false);
-    }
-  }, [
-    selectAllTriggered,
-    hasNextPage,
-    isLoadingMore,
-    loadMore,
-    rootNodes,
-    dataSourceView,
-    selectionMode,
-    keepOnlyOneSpaceIfApplicable,
-    setSelectionConfigurations,
-  ]);
-
   return (
     <div id={`dataSourceViewsSelector-${dataSourceView.dataSource.sId}`}>
       <Tree.Item
@@ -953,10 +978,10 @@ export function DataSourceViewSelector({
             <Button
               variant="ghost"
               size="xs"
-              disabled={selectAllTriggered}
+              disabled={selectAll.isLoading}
               className="mr-4 text-xs"
               label={
-                selectAllTriggered
+                selectAll.isLoading
                   ? "Loading..."
                   : hasActiveSelection
                     ? "Unselect All"

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -28,12 +28,8 @@ import {
   isRemoteDatabase,
   isWebsite,
 } from "@app/lib/data_sources";
-import {
-  useDataSourceViewContentNodes,
-  useInfiniteDataSourceViewContentNodes,
-} from "@app/lib/swr/data_source_views";
+import { useInfiniteDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { useSpacesSearch } from "@app/lib/swr/spaces";
-import type { ContentNode } from "@app/types/connectors/connectors_api";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { SearchWarningCode } from "@app/types/core/core_api";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/core_api";
@@ -68,87 +64,47 @@ import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
-const ITEMS_PER_PAGE = 50;
-const PAGE_SIZE = 1000;
+const ITEMS_PER_PAGE = 100;
 
 const getUseResourceHook =
   (
     owner: LightWorkspaceType,
     dataSourceView: DataSourceViewType,
-    viewType: ContentNodesViewType,
-    useContentNodes: typeof useDataSourceViewContentNodes
+    viewType: ContentNodesViewType
   ) =>
   (parentId: string | null) => {
-    // State for accumulating nodes for "load more".
-    const [currentCursor, setCurrentCursor] = useState<string | null>(null);
-    const [accumulatedNodes, setAccumulatedNodes] = useState<ContentNode[]>([]);
-    const [isLoadingMore, setIsLoadingMore] = useState(false);
-
     const {
-      nodes: fetchedNodes,
-      isNodesLoading: isInitialNodesLoading,
-      isNodesError,
-      totalNodesCountIsAccurate,
+      nodes,
+      hasNextPage,
+      loadMore,
+      isNodesLoading,
+      nodesError,
       totalNodesCount,
+      totalNodesCountIsAccurate,
+      isLoadingMore,
       nextPageCursor,
-    } = useContentNodes({
+    } = useInfiniteDataSourceViewContentNodes({
       owner,
       dataSourceView,
       parentId: parentId ?? undefined,
       viewType,
-      pagination: { cursor: currentCursor, limit: ITEMS_PER_PAGE },
+      sorting: [{ field: "title", direction: "asc" }],
+      pagination: { cursor: null, limit: ITEMS_PER_PAGE },
+      swrOptions: {
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+      },
     });
 
-    useEffect(() => {
-      // Skip if no nodes were fetched yet
-      if (!fetchedNodes || fetchedNodes.length === 0) {
-        return;
-      }
-
-      if (currentCursor === null) {
-        // Initial load - just set the nodes directly
-        setAccumulatedNodes(fetchedNodes);
-        return;
-      }
-
-      if (isLoadingMore) {
-        // Load more case - append new nodes to existing ones
-        setAccumulatedNodes((prev) => {
-          // Dedup new nodes.
-          const existingIds = new Set(prev.map((node) => node.internalId));
-          const newNodes = fetchedNodes.filter(
-            (node) => !existingIds.has(node.internalId)
-          );
-          if (newNodes.length === 0) {
-            // Avoid re-rendering if no new nodes are added.
-            return prev;
-          }
-
-          return [...prev, ...newNodes];
-        });
-
-        setIsLoadingMore(false);
-      }
-    }, [fetchedNodes, currentCursor, isLoadingMore]);
-
-    // Function to load more items
-    const loadMore = useCallback(() => {
-      if (nextPageCursor && !isLoadingMore) {
-        setIsLoadingMore(true);
-        setCurrentCursor(nextPageCursor);
-      }
-    }, [nextPageCursor, isLoadingMore]);
-
     return {
-      resources: accumulatedNodes,
+      resources: nodes,
       totalResourceCount: totalNodesCount,
-      isResourcesLoading:
-        isInitialNodesLoading || (isLoadingMore && currentCursor === null),
-      isResourcesError: isNodesError,
+      isResourcesLoading: isNodesLoading,
+      isResourcesError: !!nodesError,
       isResourcesTruncated: !totalNodesCountIsAccurate,
-      nextPageCursor,
+      nextPageCursor: hasNextPage ? nextPageCursor : null,
       loadMore,
-      isLoadingMore,
+      isLoadingMore: !!isLoadingMore,
     };
   };
 
@@ -702,7 +658,6 @@ interface DataSourceViewSelectorProps {
   setSelectionConfigurations: Dispatch<
     SetStateAction<DataSourceViewSelectionConfigurations>
   >;
-  useContentNodes?: typeof useDataSourceViewContentNodes;
   viewType: ContentNodesViewType;
   isRootSelectable: boolean;
   defaultCollapsed?: boolean;
@@ -721,7 +676,6 @@ export function DataSourceViewSelector({
   readonly = false,
   selectionConfiguration,
   setSelectionConfigurations,
-  useContentNodes = useDataSourceViewContentNodes,
   viewType,
   isRootSelectable,
   defaultCollapsed = true,
@@ -762,6 +716,8 @@ export function DataSourceViewSelector({
     [dataSourceView]
   );
 
+  const [selectAllTriggered, setSelectAllTriggered] = useState(false);
+
   const {
     nodes: rootNodes,
     hasNextPage,
@@ -769,49 +725,78 @@ export function DataSourceViewSelector({
     loadMore,
   } = useInfiniteDataSourceViewContentNodes({
     owner,
-    dataSourceView,
+    dataSourceView: selectAllTriggered ? dataSourceView : undefined,
     viewType,
-    pagination: { limit: PAGE_SIZE, cursor: null },
+    pagination: { limit: ITEMS_PER_PAGE, cursor: null },
   });
 
   const hasActiveSelection =
     selectionConfiguration.selectedResources.length > 0 ||
     selectionConfiguration.isSelectAll;
 
-  const handleSelectAll = () => {
-    setSelectionConfigurations((prevState) => {
-      if (hasActiveSelection) {
-        // remove the whole dataSourceView from the list
-        return _.omit(prevState, dataSourceView.sId);
-      } else {
+  const applySelectAll = useCallback(
+    (nodes: typeof rootNodes) => {
+      setSelectionConfigurations((prevState) => {
         const { sId } = dataSourceView;
         const defaultConfig = defaultSelectionConfiguration(dataSourceView);
-        const prevConfig = prevState[sId] || defaultConfig;
-
-        const updatedConfig = isRootSelectable
-          ? {
-              ...prevConfig,
-              selectedResources: [],
-              isSelectAll: true,
-            }
-          : {
-              ...prevConfig,
-              selectedResources: rootNodes,
-              isSelectAll: false,
-            };
+        const prevConfig = prevState[sId] ?? defaultConfig;
+        const updatedConfig = {
+          ...prevConfig,
+          selectedResources: nodes,
+          isSelectAll: false,
+        };
 
         if (selectionMode === "radio") {
-          return {
-            [dataSourceView.sId]: updatedConfig,
-          };
+          return { [sId]: updatedConfig };
         }
 
         return keepOnlyOneSpaceIfApplicable({
           ...prevState,
-          [dataSourceView.sId]: updatedConfig,
+          [sId]: updatedConfig,
         });
-      }
-    });
+      });
+    },
+    [
+      dataSourceView,
+      keepOnlyOneSpaceIfApplicable,
+      setSelectionConfigurations,
+      selectionMode,
+    ]
+  );
+
+  const handleSelectAll = () => {
+    if (hasActiveSelection) {
+      setSelectionConfigurations((prevState) =>
+        _.omit(prevState, dataSourceView.sId)
+      );
+      setSelectAllTriggered(false);
+      return;
+    }
+
+    if (isRootSelectable) {
+      setSelectionConfigurations((prevState) => {
+        const { sId } = dataSourceView;
+        const defaultConfig = defaultSelectionConfiguration(dataSourceView);
+        const prevConfig = prevState[sId] ?? defaultConfig;
+        const updatedConfig = {
+          ...prevConfig,
+          selectedResources: [],
+          isSelectAll: true,
+        };
+
+        if (selectionMode === "radio") {
+          return { [sId]: updatedConfig };
+        }
+
+        return keepOnlyOneSpaceIfApplicable({
+          ...prevState,
+          [sId]: updatedConfig,
+        });
+      });
+      return;
+    }
+
+    setSelectAllTriggered(true);
   };
 
   const isChecked = selectionConfiguration.isSelectAll
@@ -894,13 +879,8 @@ export function DataSourceViewSelector({
 
   const useResourcesHook = useCallback(
     (parentId: string | null) =>
-      getUseResourceHook(
-        owner,
-        dataSourceView,
-        viewType,
-        useContentNodes
-      )(parentId),
-    [owner, dataSourceView, viewType, useContentNodes]
+      getUseResourceHook(owner, dataSourceView, viewType)(parentId),
+    [owner, dataSourceView, viewType]
   );
 
   const isExpanded = searchResult
@@ -923,14 +903,28 @@ export function DataSourceViewSelector({
   );
 
   useEffect(() => {
-    const handleLoadMore = async () => {
-      await loadMore();
-    };
-
-    if (hasNextPage && !isLoadingMore) {
-      void handleLoadMore();
+    if (selectAllTriggered && hasNextPage && !isLoadingMore) {
+      void loadMore();
     }
-  }, [hasNextPage, isLoadingMore, loadMore]);
+  }, [selectAllTriggered, hasNextPage, isLoadingMore, loadMore]);
+
+  useEffect(() => {
+    if (
+      selectAllTriggered &&
+      rootNodes.length > 0 &&
+      !hasNextPage &&
+      !isLoadingMore
+    ) {
+      applySelectAll(rootNodes);
+      setSelectAllTriggered(false);
+    }
+  }, [
+    selectAllTriggered,
+    rootNodes,
+    hasNextPage,
+    isLoadingMore,
+    applySelectAll,
+  ]);
 
   return (
     <div id={`dataSourceViewsSelector-${dataSourceView.dataSource.sId}`}>
@@ -961,7 +955,7 @@ export function DataSourceViewSelector({
             <Button
               variant="ghost"
               size="xs"
-              disabled={rootNodes.length === 0 || isLoadingMore}
+              disabled={selectAllTriggered && isLoadingMore}
               className="mr-4 text-xs"
               label={hasActiveSelection ? "Unselect All" : "Select All"}
               icon={ListCheckIcon}

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -104,7 +104,7 @@ const getUseResourceHook =
       isResourcesTruncated: !totalNodesCountIsAccurate,
       nextPageCursor: hasNextPage ? nextPageCursor : null,
       loadMore,
-      isLoadingMore: !!isLoadingMore,
+      isLoadingMore: !!isLoadingMore && !isNodesLoading,
     };
   };
 
@@ -953,9 +953,15 @@ export function DataSourceViewSelector({
             <Button
               variant="ghost"
               size="xs"
-              disabled={selectAllTriggered && isLoadingMore}
+              disabled={selectAllTriggered}
               className="mr-4 text-xs"
-              label={hasActiveSelection ? "Unselect All" : "Select All"}
+              label={
+                selectAllTriggered
+                  ? "Loading..."
+                  : hasActiveSelection
+                    ? "Unselect All"
+                    : "Select All"
+              }
               icon={ListCheckIcon}
               onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                 e.stopPropagation();

--- a/front/components/poke/pages/SpaceDataSourceViewPage.tsx
+++ b/front/components/poke/pages/SpaceDataSourceViewPage.tsx
@@ -5,8 +5,6 @@ import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeDataSourceViewDetails } from "@app/poke/swr/data_source_view_details";
-import type { DataSourceViewContentNodesProps } from "@app/poke/swr/data_source_views";
-import { usePokeDataSourceViewContentNodes } from "@app/poke/swr/data_source_views";
 import { defaultSelectionConfiguration } from "@app/types/data_source_view";
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
 
@@ -24,14 +22,6 @@ export function SpaceDataSourceViewPage() {
     dataSourceViewId: dsvId,
     disabled: false,
   });
-
-  const useContentNodes = (
-    contentNodesParams: DataSourceViewContentNodesProps
-  ) => {
-    return usePokeDataSourceViewContentNodes({
-      ...contentNodesParams,
-    });
-  };
 
   if (isLoading) {
     return (
@@ -91,7 +81,6 @@ export function SpaceDataSourceViewPage() {
                 dataSourceView
               )}
               setSelectionConfigurations={() => {}}
-              useContentNodes={useContentNodes}
               viewType="all"
               isRootSelectable={true}
             />

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -351,7 +351,11 @@ export function useInfiniteDataSourceViewContentNodes({
       async ([url, body]) => {
         return fetcherWithBody([url, body, "POST"]);
       },
-      swrOptions
+      {
+        revalidateAll: false,
+        revalidateFirstPage: false,
+        ...swrOptions,
+      }
     );
 
   const nodes = data?.flatMap((page) => page.nodes) ?? emptyArray();

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -3,6 +3,7 @@ import { FocusScope } from "@radix-ui/react-focus-scope";
 import { Button } from "@sparkle/components/Button";
 import { Icon } from "@sparkle/components/Icon";
 import { ScrollArea } from "@sparkle/components/ScrollArea";
+import { SheetViewportProvider } from "@sparkle/components/SheetViewportContext";
 import { XMarkIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
@@ -214,10 +215,24 @@ const ScrollContainer = ({
   className?: string;
   children: React.ReactNode;
 }) => {
+  const viewportRef = React.useRef<HTMLDivElement>(null);
+  const [viewport, setViewport] = React.useState<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    setViewport(viewportRef.current);
+  }, []);
+
   if (noScroll) {
     return <div className={className}>{children}</div>;
   }
-  return <ScrollArea className={className}>{children}</ScrollArea>;
+
+  const value = React.useMemo(() => viewport, [viewport]);
+
+  return (
+    <ScrollArea className={className} viewportRef={viewportRef}>
+      <SheetViewportProvider value={value}>{children}</SheetViewportProvider>
+    </ScrollArea>
+  );
 };
 
 const SheetContainer = ({
@@ -348,6 +363,7 @@ const SheetDescription = React.forwardRef<
 ));
 SheetDescription.displayName = SheetPrimitive.Description.displayName;
 
+export { useSheetViewport } from "@sparkle/components/SheetViewportContext";
 export {
   Sheet,
   SheetClose,

--- a/sparkle/src/components/SheetViewportContext.tsx
+++ b/sparkle/src/components/SheetViewportContext.tsx
@@ -1,0 +1,9 @@
+import { createContext, useContext } from "react";
+
+const SheetViewportContext = createContext<HTMLDivElement | null>(null);
+
+export const SheetViewportProvider = SheetViewportContext.Provider;
+
+export function useSheetViewport(): HTMLDivElement | null {
+  return useContext(SheetViewportContext);
+}

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -213,6 +213,7 @@ export {
   SheetPortal,
   SheetTitle,
   SheetTrigger,
+  useSheetViewport,
 } from "./Sheet";
 export type { SidebarLayoutProps, SidebarLayoutRef } from "./SidebarLayout";
 export { SidebarLayout } from "./SidebarLayout";


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7363

- Currently our content node tree uses an artisan-made accumulator useEffect that is a bit flaky when you have a lot of nodes.
- Replace this by the streamlined infinite scroll with sheetviewport for scroll area handling

## Tests

- Tested with 2 datasources containing both 700 slack channels (to test a lot of nodes, and two trees)

<details><summary>seed script (ai slope not added to git)</summary>
<p>

````
/**
 * Creates a fake Slack data source with ~700 channels for testing the
 * data source node selector pagination UI.
 *
 * Usage:
 *   npx tsx scripts/seed_slack_channels.ts --workspaceSId <SID> --execute
 *
 * Find your workspace sId:
 *   SELECT "sId", name FROM workspaces;
 */
import config from "@app/lib/api/config";
import { getLlmCredentials } from "@app/lib/api/provider_credentials";
import { Authenticator } from "@app/lib/auth";
import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
import { SpaceResource } from "@app/lib/resources/space_resource";
import { makeScript } from "@app/scripts/helpers";
import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
import { CoreAPI, EMBEDDING_CONFIGS } from "@app/types/core/core_api";
import { DEFAULT_QDRANT_CLUSTER } from "@app/types/core/data_source";

const CHANNEL_COUNT = 700;
const SLACK_CHANNEL_MIME_TYPE = "application/vnd.dust.slack.channel";

function generateChannelName(index: number): string {
  const prefixes = [
    "team",
    "proj",
    "eng",
    "sales",
    "marketing",
    "support",
    "design",
    "product",
    "ops",
    "hr",
    "finance",
    "legal",
    "data",
    "infra",
    "platform",
    "security",
    "qa",
    "devops",
    "mobile",
    "web",
    "backend",
    "frontend",
    "api",
    "ml",
    "analytics",
    "growth",
    "onboarding",
    "customer",
    "partner",
    "internal",
  ];
  const suffixes = [
    "general",
    "random",
    "standup",
    "alerts",
    "deploys",
    "incidents",
    "reviews",
    "planning",
    "retro",
    "announcements",
    "help",
    "feedback",
    "ideas",
    "watercooler",
    "social",
    "wins",
    "bugs",
    "releases",
    "metrics",
    "docs",
    "onboarding",
    "interviews",
    "demos",
    "experiments",
  ];

  const prefix = prefixes[index % prefixes.length];
  const suffix =
    suffixes[Math.floor(index / prefixes.length) % suffixes.length];
  const num = Math.floor(index / (prefixes.length * suffixes.length));

  return num > 0 ? `${prefix}-${suffix}-${num}` : `${prefix}-${suffix}`;
}

makeScript(
  {
    workspaceSId: {
      type: "string" as const,
      describe: "sId of the workspace",
      demandOption: true,
    },
    count: {
      type: "number" as const,
      describe: "Number of channels to create",
      default: CHANNEL_COUNT,
    },
  },
  async (args, logger) => {
    const auth = await Authenticator.internalAdminForWorkspace(
      args.workspaceSId
    );
    const owner = auth.getNonNullableWorkspace();

    if (!args.execute) {
      logger.info(
        {
          workspaceSId: args.workspaceSId,
          channelCount: args.count,
        },
        "Dry run — would create a Slack data source with channels. Pass --execute to run."
      );
      return;
    }

    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);

    // Step 1: Create a Core project.
    logger.info("Creating Core project...");
    const projectRes = await coreAPI.createProject();
    if (projectRes.isErr()) {
      throw new Error(`Failed to create project: ${projectRes.error.message}`);
    }
    const projectId = projectRes.value.project.project_id.toString();
    logger.info({ projectId }, "Core project created");

    // Step 2: Create a Core data source.
    logger.info("Creating Core data source...");
    const embedderConfig =
      EMBEDDING_CONFIGS[
        owner.defaultEmbeddingProvider ?? DEFAULT_EMBEDDING_PROVIDER_ID
      ];
    const credentials = await getLlmCredentials(auth);

    const dsRes = await coreAPI.createDataSource({
      projectId,
      config: {
        embedder_config: { embedder: embedderConfig },
        qdrant_config: {
          cluster: DEFAULT_QDRANT_CLUSTER,
          shadow_write_cluster: null,
        },
      },
      credentials,
      name: "managed-slack",
    });
    if (dsRes.isErr()) {
      throw new Error(
        `Failed to create Core data source: ${dsRes.error.message}`
      );
    }
    const coreDataSourceId = dsRes.value.data_source.data_source_id;
    logger.info({ coreDataSourceId }, "Core data source created");

    // Step 3: Create front DB records (DataSource + default DataSourceView in system space).
    logger.info("Creating front DB records...");
    const systemSpace =
      await SpaceResource.fetchWorkspaceSystemSpace(auth);

    const dsView =
      await DataSourceViewResource.createDataSourceAndDefaultView(
        {
          assistantDefaultSelected: true,
          connectorProvider: "slack",
          connectorId: "fake-connector-for-testing",
          description: "Fake Slack data source for testing pagination",
          dustAPIProjectId: projectId,
          dustAPIDataSourceId: coreDataSourceId,
          name: "managed-slack",
          workspaceId: owner.id,
        },
        systemSpace
      );
    logger.info(
      { dataSourceSId: dsView.dataSource.sId, viewSId: dsView.sId },
      "Front DB records created"
    );

    // Step 4: Create channel nodes.
    logger.info({ count: args.count }, "Creating channel nodes...");
    let created = 0;
    let errors = 0;

    for (let i = 0; i < args.count; i++) {
      const channelId = `C${String(i).padStart(9, "0")}`;
      const folderId = `slack-channel-${channelId}`;
      const title = generateChannelName(i);
      const isPrivate = i % 10 === 0;

      const res = await coreAPI.upsertDataSourceFolder({
        projectId,
        dataSourceId: coreDataSourceId,
        folderId,
        timestamp: Date.now(),
        parentId: null,
        parents: [folderId],
        title,
        mimeType: SLACK_CHANNEL_MIME_TYPE,
        sourceUrl: `https://workspace.slack.com/archives/${channelId}`,
        providerVisibility: isPrivate ? "private" : "public",
      });

      if (res.isErr()) {
        logger.error(
          { channelId, error: res.error.message },
          "Failed to create channel"
        );
        errors++;
      } else {
        created++;
        if (created % 100 === 0) {
          logger.info({ created, total: args.count }, "Progress");
        }
      }
    }

    logger.info(
      {
        created,
        errors,
        total: args.count,
        dataSourceSId: dsView.dataSource.sId,
      },
      "Done! Go to a non-system space -> 'Add data from connections' to test."
    );
  }
);

````
</p>
</details> 

## Risk

Low
Blast radius: Data selection in spaces + Permissions selection in spaces + a bunch of poke plugins
Also small risk of breaking sheet component in sparkle but did not see anything bad 🙈 (but don't trust me)

## Deploy Plan

- [ ] Deploy front