### PR TITLE
[Front] feat(metronome): end Metronome contract on subscription cancellation

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -289,15 +289,17 @@ export async function getMetronomeActiveContract(
 export async function endMetronomeContract({
   metronomeCustomerId,
   contractId,
+  endingBefore,
 }: {
   metronomeCustomerId: string;
   contractId: string;
+  endingBefore?: Date;
 }): Promise<Result<void, Error>> {
   try {
     await getMetronomeClient().v1.contracts.updateEndDate({
       customer_id: metronomeCustomerId,
       contract_id: contractId,
-      ending_before: ceilToHourISO(new Date()),
+      ending_before: ceilToHourISO(endingBefore ?? new Date()),
     });
 
     logger.info(

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -7,7 +7,10 @@ import {
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import { getMetronomeContractPackageAliases } from "@app/lib/metronome/client";
+import {
+  endMetronomeContract,
+  getMetronomeContractPackageAliases,
+} from "@app/lib/metronome/client";
 import {
   LEGACY_BUSINESS_PACKAGE_ALIAS,
   LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
@@ -48,6 +51,7 @@ import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import {
   cacheWithRedis,
   invalidateCacheAfterCommit,
@@ -123,6 +127,10 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   }
 
   get isBilled(): boolean {
+    if (this.status !== "active") {
+      return false;
+    }
+
     return (
       this.stripeSubscriptionId !== null || this.metronomeContractId !== null
     );
@@ -458,6 +466,27 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     );
   }
 
+  static async fetchByMetronomeContractId(
+    workspace: WorkspaceResource,
+    metronomeContractId: string
+  ): Promise<SubscriptionResource | null> {
+    const res = await this.model.findOne({
+      where: { workspaceId: workspace.id, metronomeContractId },
+      include: [PlanModel],
+      order: [["createdAt", "DESC"]],
+    });
+
+    if (!res) {
+      return null;
+    }
+
+    return new this(
+      SubscriptionModel,
+      res.get(),
+      renderPlanFromModel({ plan: res.plan })
+    );
+  }
+
   static async isStripeIdAlreadyUsed(
     stripeSubscriptionId: string
   ): Promise<boolean> {
@@ -587,9 +616,8 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     const now = new Date();
 
     // Find active subscription
-    const activeSubscription = await SubscriptionModel.findOne({
-      where: { workspaceId: workspace.id, status: "active" },
-    });
+    const activeSubscription =
+      await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
 
     // Prevent subscribing to the same plan
     if (activeSubscription && activeSubscription.planId === newPlan.id) {
@@ -613,20 +641,13 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     // Proceed to the termination of the active subscription (if any) and creation of the new one
     const newSubscription = await withTransaction(async (t) => {
       if (activeSubscription) {
-        const endedStatus = activeSubscription.stripeSubscriptionId
+        const endedStatus = activeSubscription.isBilled
           ? "ended_backend_only"
           : "ended";
-
-        await activeSubscription.update(
-          {
-            status: endedStatus,
-            endDate: now,
-          },
-          { transaction: t }
-        );
+        await activeSubscription.markAsEnded(endedStatus, t);
       }
 
-      return SubscriptionModel.create(
+      return SubscriptionResource.makeNew(
         {
           sId: generateRandomModelSId(),
           workspaceId: workspace.id,
@@ -636,7 +657,8 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
           stripeSubscriptionId: stripeSubscriptionId ?? null,
           endDate: endDate,
         },
-        { transaction: t }
+        renderPlanFromModel({ plan: newPlan }),
+        t
       );
     });
 
@@ -654,6 +676,28 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       });
     }
 
+    // End Metronome contract on the previous subscription.
+    if (
+      activeSubscription?.metronomeContractId &&
+      workspace.metronomeCustomerId
+    ) {
+      if (activeSubscription.stripeSubscriptionId) {
+        // Shadow mode: fire-and-forget.
+        void endMetronomeContract({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          contractId: activeSubscription.metronomeContractId,
+        });
+      } else {
+        const result = await endMetronomeContract({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          contractId: activeSubscription.metronomeContractId,
+        });
+        if (result.isErr()) {
+          throw result.error;
+        }
+      }
+    }
+
     // Clean up WorkOS config for features the new plan doesn't allow.
     if (!newPlan.isSSOAllowed || !newPlan.isSCIMAllowed) {
       await disableWorkOSSSOAndSCIM(workspace, {
@@ -664,11 +708,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
 
     await SubscriptionResource.invalidateSubscriptionCache(workspace.id);
 
-    return new SubscriptionResource(
-      SubscriptionModel,
-      newSubscription.get(),
-      renderPlanFromModel({ plan: newPlan })
-    );
+    return newSubscription;
   }
 
   static async pokeUpgradeWorkspaceToEnterprise(
@@ -1235,22 +1275,45 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     const activeSubscription =
       await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
 
-    if (activeSubscription) {
-      // End the subscription.
-      const endedStatus = activeSubscription.stripeSubscriptionId
-        ? "ended_backend_only"
-        : "ended";
-      await activeSubscription.markAsEnded(endedStatus);
-
-      // Notify Stripe that we ended the subscription if the subscription was a paid one.
-      if (activeSubscription.stripeSubscriptionId) {
-        await cancelSubscriptionImmediately({
-          stripeSubscriptionId: activeSubscription.stripeSubscriptionId,
-        });
-      }
+    if (!activeSubscription) {
+      return null;
     }
 
-    return activeSubscription;
+    // End the subscription. Billed subscriptions use "ended_backend_only" so the
+    // external webhook (Stripe or Metronome) performs the final "ended" transition.
+    const endedStatus = activeSubscription.isBilled
+      ? "ended_backend_only"
+      : "ended";
+    await activeSubscription.markAsEnded(endedStatus);
+
+    // Notify Stripe.
+    if (activeSubscription.stripeSubscriptionId) {
+      await cancelSubscriptionImmediately({
+        stripeSubscriptionId: activeSubscription.stripeSubscriptionId,
+      });
+    }
+
+    if (
+      !activeSubscription.metronomeContractId ||
+      !workspace.metronomeCustomerId
+    ) {
+      return activeSubscription;
+    }
+
+    const res = await endMetronomeContract({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      contractId: activeSubscription.metronomeContractId,
+    });
+    if (res.isOk()) {
+      return activeSubscription;
+    }
+
+    if (activeSubscription.stripeSubscriptionId) {
+      // Shadow mode: fire-and-forget.
+      return activeSubscription;
+    }
+
+    throw res.error;
   }
 
   private async isSubscriptionOnProOrBusinessPlan(

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -315,6 +315,15 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return workspace ? new this(this.model, workspace.get()) : null;
   }
 
+  static async fetchByMetronomeCustomerId(
+    metronomeCustomerId: string
+  ): Promise<WorkspaceResource | null> {
+    const workspace = await this.model.findOne({
+      where: { metronomeCustomerId },
+    });
+    return workspace ? new this(this.model, workspace.get()) : null;
+  }
+
   static async fetchByModelIds(ids: ModelId[]): Promise<WorkspaceResource[]> {
     const workspaces = await this.model.findAll({
       where: {

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -1,18 +1,29 @@
 /** @ignoreswagger */
 import apiConfig from "@app/lib/api/config";
 import { getMetronomeClient } from "@app/lib/metronome/client";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
+import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { pipeline, Writable } from "stream";
 import { promisify } from "util";
+import { z } from "zod";
 
 type ResponseBody = {
   success: boolean;
   message?: string;
 };
+
+const ContractEndEventSchema = z.object({
+  type: z.literal("contract.end"),
+  contract_id: z.string(),
+  customer_id: z.string(),
+});
 
 // Disable Next.js body parsing so we can read the raw body for signature verification.
 export const config = {
@@ -113,9 +124,100 @@ async function handler(
           logger.info({ event }, "[Metronome Webhook] Contract started");
           break;
 
-        case "contract.end":
-          logger.info({ event }, "[Metronome Webhook] Contract ended");
+        case "contract.end": {
+          const parsed = ContractEndEventSchema.safeParse(event);
+          if (!parsed.success) {
+            logger.error(
+              { event, error: parsed.error.message },
+              "[Metronome Webhook] Invalid contract.end event"
+            );
+            break;
+          }
+
+          const { contract_id: contractId, customer_id: customerId } =
+            parsed.data;
+
+          const workspace =
+            await WorkspaceResource.fetchByMetronomeCustomerId(customerId);
+          if (!workspace) {
+            logger.warn(
+              { contractId, customerId },
+              "[Metronome Webhook] contract.end: workspace not found"
+            );
+            break;
+          }
+
+          const subscription =
+            await SubscriptionResource.fetchByMetronomeContractId(
+              workspace,
+              contractId
+            );
+          if (!subscription) {
+            logger.warn(
+              { contractId, customerId, workspaceId: workspace.sId },
+              "[Metronome Webhook] contract.end: subscription not found"
+            );
+            break;
+          }
+
+          // Shadow mode: Stripe owns the subscription lifecycle.
+          if (subscription.stripeSubscriptionId) {
+            logger.info(
+              { contractId, workspaceId: workspace.sId },
+              "[Metronome Webhook] contract.end: shadow contract ended, Stripe handles subscription"
+            );
+            break;
+          }
+
+          switch (subscription.status) {
+            case "ended":
+              logger.info(
+                { contractId, workspaceId: workspace.sId },
+                "[Metronome Webhook] contract.end: subscription already ended"
+              );
+              break;
+
+            case "ended_backend_only":
+              logger.info(
+                { contractId, workspaceId: workspace.sId },
+                "[Metronome Webhook] contract.end: marking as ended (backend-initiated)"
+              );
+              await subscription.markAsEnded("ended");
+              break;
+
+            case "active":
+              await subscription.markAsEnded("ended");
+              logger.info(
+                { contractId, workspaceId: workspace.sId },
+                "[Metronome Webhook] contract.end: ending subscription and scrubbing workspace"
+              );
+              const scrubRes = await launchScheduleWorkspaceScrubWorkflow({
+                workspaceId: workspace.sId,
+              });
+              if (scrubRes.isErr()) {
+                logger.error(
+                  {
+                    workspaceId: workspace.sId,
+                    contractId,
+                    error: scrubRes.error,
+                  },
+                  "[Metronome Webhook] Error launching scrub workspace workflow"
+                );
+                return apiError(req, res, {
+                  status_code: 500,
+                  api_error: {
+                    type: "internal_server_error",
+                    message: `Error launching scrub workspace workflow: ${scrubRes.error.message}`,
+                  },
+                });
+              }
+              break;
+
+            default:
+              assertNever(subscription.status);
+          }
           break;
+        }
 
         case "invoice.finalized":
           logger.info({ event }, "[Metronome Webhook] Invoice finalized");

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -26,6 +26,7 @@ import {
 import { handleMetronomeSetupCheckout } from "@app/lib/metronome/checkout";
 import {
   createMetronomeCredit,
+  endMetronomeContract,
   getMetronomeActiveContract,
 } from "@app/lib/metronome/client";
 import { getFreeCreditProductId } from "@app/lib/metronome/constants";
@@ -1249,6 +1250,21 @@ async function handler(
               await subscription.markAsCanceled({
                 endDate,
               });
+
+              // Shadow mode: schedule the Metronome contract end at the same time.
+              if (subscription.metronomeContractId) {
+                const trialingWorkspace =
+                  await WorkspaceResource.fetchByModelId(
+                    subscription.workspaceId
+                  );
+                if (trialingWorkspace?.metronomeCustomerId) {
+                  void endMetronomeContract({
+                    metronomeCustomerId: trialingWorkspace.metronomeCustomerId,
+                    contractId: subscription.metronomeContractId,
+                    endingBefore: endDate,
+                  });
+                }
+              }
             }
           }
 
@@ -1290,10 +1306,26 @@ async function handler(
               "Workspace not found for subscription in customer.subscription.updated."
             );
 
+            // Shadow mode: schedule the Metronome contract end at the same time.
+            if (
+              endDate &&
+              subscription.metronomeContractId &&
+              workspace.metronomeCustomerId
+            ) {
+              void endMetronomeContract({
+                metronomeCustomerId: workspace.metronomeCustomerId,
+                contractId: subscription.metronomeContractId,
+                endingBefore: endDate,
+              });
+            }
+
             const auth = await Authenticator.internalAdminForWorkspace(
               workspace.sId
             );
             if (!endDate) {
+              // TODO(pricing): reactivate Metronome contract (remove scheduled end date)
+              // by calling updateEndDate without ending_before.
+
               // Subscription is re-activated, so we need to unpause the connectors and re-enable triggers.
               await restoreWorkspaceAfterSubscription(auth);
 

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -2,6 +2,7 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
+import { endMetronomeContract } from "@app/lib/metronome/client";
 import {
   cancelSubscriptionAtPeriodEnd,
   skipSubscriptionFreeTrial,
@@ -147,7 +148,7 @@ async function handler(
       const { action } = bodyValidation.right;
 
       switch (action) {
-        case "cancel_free_trial":
+        case "cancel_free_trial": {
           if (!subscription.trialing) {
             return apiError(req, res, {
               status_code: 400,
@@ -157,7 +158,14 @@ async function handler(
               },
             });
           }
-          if (!subscription.stripeSubscriptionId) {
+
+          const owner = auth.getNonNullableWorkspace();
+          const useMetronomeBilling = await hasFeatureFlag(
+            auth,
+            "metronome_billing"
+          );
+
+          if (!subscription.stripeSubscriptionId && !useMetronomeBilling) {
             return apiError(req, res, {
               status_code: 400,
               api_error: {
@@ -167,10 +175,40 @@ async function handler(
             });
           }
 
-          await cancelSubscriptionAtPeriodEnd({
-            stripeSubscriptionId: subscription.stripeSubscriptionId,
+          if (subscription.stripeSubscriptionId) {
+            await cancelSubscriptionAtPeriodEnd({
+              stripeSubscriptionId: subscription.stripeSubscriptionId,
+            });
+          }
+
+          if (!subscription.metronomeContractId || !owner.metronomeCustomerId) {
+            break;
+          }
+
+          if (!useMetronomeBilling) {
+            // Shadow mode: fire-and-forget.
+            void endMetronomeContract({
+              metronomeCustomerId: owner.metronomeCustomerId,
+              contractId: subscription.metronomeContractId,
+            });
+            break;
+          }
+
+          const result = await endMetronomeContract({
+            metronomeCustomerId: owner.metronomeCustomerId,
+            contractId: subscription.metronomeContractId,
           });
+          if (result.isErr()) {
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to end Metronome contract.",
+              },
+            });
+          }
           break;
+        }
         case "pay_now":
           {
             if (!subscription.trialing) {


### PR DESCRIPTION
## Description

When a subscription is cancelled, the associated Metronome contract is now also ended. Covers both shadow mode (Stripe + shadow contract) and full Metronome billing path.

Three cancellation entry points call `endMetronomeContract`:
- **`endActiveSubscription()`** — Poke, workspace scrubbing
- **`internalSubscribeWorkspaceToFreePlan()`** — plan changes
- **PATCH `cancel_free_trial`** — user cancels from billing page (feature flag distinguishes shadow vs full Metronome)

Stripe portal cancel is handled in `customer.subscription.updated` webhook: when `cancel_at` is set, the Metronome contract end is scheduled at the same date.

The Metronome `contract.end` webhook handles the final subscription status transition, mirroring the Stripe `customer.subscription.deleted` pattern with `ended` / `ended_backend_only` / `active` statuses. Shadow mode skips subscription lifecycle changes (Stripe owns it).

Billed subscriptions now use `ended_backend_only` for both Stripe and Metronome (was Stripe-only), so the external webhook performs the final `ended` transition.

Closes dust-tt/tasks#7503

## Risk

Shadow mode is fire-and-forget — failure to end a shadow contract doesn't affect Stripe billing. Full Metronome path awaits and returns errors.

Reactivation (removing scheduled end date when user re-subscribes from Stripe portal) is not yet handled — tracked as TODO(pricing).