### PR TITLE
[front] chore: enforce coding rule BACK10 on `userId`

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -81,7 +81,7 @@ const ConversationLayoutContent = ({
     return null;
   }, [router.query.agentDetails]);
 
-  const userSId = useMemo(() => {
+  const userId = useMemo(() => {
     const sid = router.query.userDetails ?? [];
     if (isString(sid)) {
       return sid;
@@ -133,7 +133,7 @@ const ConversationLayoutContent = ({
 
       <MemberDetails
         owner={owner}
-        userId={userSId}
+        userId={userId}
         onClose={() => onOpenChangeUserModal(false)}
       />
 

--- a/front/lib/api/actions/servers/poke/tools/utils.ts
+++ b/front/lib/api/actions/servers/poke/tools/utils.ts
@@ -65,7 +65,7 @@ export async function enforcePokeSecurityGates(
   logger.info(
     {
       action: "poke_cross_workspace_access",
-      callerUserSId: callerUser?.sId,
+      callerUserId: callerUser?.sId,
       callerUserEmail: callerUser?.email,
       callerWorkspaceId: callerWorkspace.sId,
       targetWorkspaceId,

--- a/front/lib/api/analytics/users_export.ts
+++ b/front/lib/api/analytics/users_export.ts
@@ -127,12 +127,12 @@ export async function fetchUserExportRows({
 
   const rows: UserExportRow[] = memberships.map((membership) => {
     const user = membership.user;
-    const userSid = user.sId;
-    const metrics = esMetrics.get(userSid);
-    const userId = String(user.id);
+    const userId = user.sId;
+    const metrics = esMetrics.get(userId);
+    const userModelId = String(user.id);
 
     return {
-      userId: userSid,
+      userId,
       userName:
         [user.firstName, user.lastName].filter(Boolean).join(" ") ||
         user.email ||
@@ -141,7 +141,7 @@ export async function fetchUserExportRows({
       messageCount: metrics?.messageCount ?? 0,
       lastMessageSent: metrics?.lastMessageSent ?? "",
       activeDaysCount: metrics?.activeDaysCount ?? 0,
-      groups: groupsMap[userId] ?? "",
+      groups: groupsMap[userModelId] ?? "",
     };
   });
 

--- a/front/lib/api/assistant/project_kickoff.test.ts
+++ b/front/lib/api/assistant/project_kickoff.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 
 describe("buildProjectKickoffPrompt", () => {
   const userFullName = "Test User";
-  const userSId = "user_123";
+  const userId = "user_123";
 
   const prompt = buildProjectKickoffPrompt({
     projectName: "Test Kickstart",
@@ -21,7 +21,7 @@ describe("buildProjectKickoffPrompt", () => {
     );
     expect(prompt).toContain(`Do NOT use plain \`@${userFullName}\``);
     expect(prompt).not.toContain(
-      `:mention_user[${userFullName}]{sId=${userSId}}`
+      `:mention_user[${userFullName}]{sId=${userId}}`
     );
     expect(prompt).toContain(
       "Do not claim that you already searched anything in this first message."

--- a/front/lib/api/poke/plugins/workspaces/send_onboarding_conversation.ts
+++ b/front/lib/api/poke/plugins/workspaces/send_onboarding_conversation.ts
@@ -16,9 +16,9 @@ export const sendOnboardingConversationPlugin = createPlugin({
       "This overwrites the user's onboarding metadata and may recreate the conversation even if one exists.",
     resourceTypes: ["workspaces"],
     args: {
-      userSId: {
+      userId: {
         type: "string",
-        label: "User sId",
+        label: "User ID",
         description:
           "Target user stable id (e.g., usr_xxx) belonging to this workspace.",
       },
@@ -36,7 +36,7 @@ export const sendOnboardingConversationPlugin = createPlugin({
       return new Err(new Error("Workspace not found in auth context."));
     }
 
-    const targetUser = await UserResource.fetchById(args.userSId);
+    const targetUser = await UserResource.fetchById(args.userId);
     if (!targetUser) {
       return new Err(new Error("User not found."));
     }

--- a/front/lib/mentions/markdown/plugin.tsx
+++ b/front/lib/mentions/markdown/plugin.tsx
@@ -85,7 +85,7 @@ export function userMentionDirective() {
         const data = node.data || (node.data = {});
         data.hName = "mention_user";
         data.hProperties = {
-          userSId: node.attributes.sId,
+          userId: node.attributes.sId,
           userName: node.children[0].value,
         };
       }
@@ -105,15 +105,15 @@ export function userMentionDirective() {
 export function getUserMentionPlugin(owner: WorkspaceType) {
   const UserMentionPlugin = ({
     userName,
-    userSId,
+    userId,
   }: {
     userName: string;
-    userSId: string;
+    userId: string;
   }) => {
     return (
       <MentionDisplay
         mention={{
-          id: userSId,
+          id: userId,
           label: userName,
           type: "user",
           pictureUrl: "",

--- a/front/lib/notifications/index.ts
+++ b/front/lib/notifications/index.ts
@@ -88,8 +88,8 @@ export const getUserNotificationDelay = async ({
     : DEFAULT_NOTIFICATION_DELAY;
 };
 
-export const getSlackConnectionIdentifier = (userSId: string): string => {
-  return `slack_connection_${userSId}`;
+export const getSlackConnectionIdentifier = (userId: string): string => {
+  return `slack_connection_${userId}`;
 };
 
 const isSlackNotificationsFeatureEnabled = async (

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -412,7 +412,7 @@ export class UserResource extends BaseResource<UserModel> {
       logger.error(
         {
           workspaceId: owner.sId,
-          missingUserSIds: missingUserIds,
+          missingUserIds,
           owner: "spolu",
         },
         // This log is expected as user search queries may happen before the index update completes

--- a/front/migrations/20260402_backfill_project_content_fragments.ts
+++ b/front/migrations/20260402_backfill_project_content_fragments.ts
@@ -75,7 +75,7 @@ async function backfillProjectContentFragmentsForWorkspace(
           : [];
       const creatorByModelId = new Map(creators.map((u) => [u.id, u]));
 
-      const fragmentAuthByUserSId = new Map<string, Authenticator>();
+      const fragmentAuthByUserId = new Map<string, Authenticator>();
 
       async function fragmentAuthForFile(
         file: FileResource
@@ -87,14 +87,14 @@ async function backfillProjectContentFragmentsForWorkspace(
         if (!creator) {
           return baseAuth;
         }
-        let cached = fragmentAuthByUserSId.get(creator.sId);
+        let cached = fragmentAuthByUserId.get(creator.sId);
         if (!cached) {
           const auth = await Authenticator.fromUserIdAndWorkspaceId(
             creator.sId,
             workspace.sId
           );
           cached = auth.user() ? auth : baseAuth;
-          fragmentAuthByUserSId.set(creator.sId, cached);
+          fragmentAuthByUserId.set(creator.sId, cached);
         }
         return cached;
       }

--- a/front/migrations/20260407_reconcile_trigger_editors.ts
+++ b/front/migrations/20260407_reconcile_trigger_editors.ts
@@ -14,11 +14,11 @@ interface AffectedTrigger {
   triggerName: string;
   workspaceModelId: ModelId;
   workspaceId: string;
-  currentEditorId: ModelId;
-  currentEditorSId: string;
+  currentEditorModelId: ModelId;
+  currentEditorId: string;
   currentEditorEmail: string;
-  originalUserId: ModelId;
-  originalUserSId: string;
+  originalUserModelId: ModelId;
+  originalUserId: string;
   originalUserEmail: string;
 }
 
@@ -33,11 +33,11 @@ async function findAffectedTriggers(): Promise<AffectedTrigger[]> {
       t.name AS "triggerName",
       t."workspaceId",
       w."sId" AS "workspaceId",
-      t.editor AS "currentEditorId",
-      curr_u."sId" AS "currentEditorSId",
+      t.editor AS "currentEditorModelId",
+      curr_u."sId" AS "currentEditorId",
       curr_u.email AS "currentEditorEmail",
-      um."userId" AS "originalUserId",
-      orig_u."sId" AS "originalUserSId",
+      um."userId" AS "originalUserModelId",
+      orig_u."sId" AS "originalUserId",
       orig_u.email AS "originalUserEmail"
     FROM triggers t
     JOIN users curr_u ON curr_u.id = t.editor
@@ -104,19 +104,19 @@ makeScript({}, async ({ execute }, logger) => {
       continue;
     }
 
-    const triggerSId = TriggerResource.modelIdToSId({
+    const triggerId = TriggerResource.modelIdToSId({
       id: row.triggerId,
       workspaceId: row.workspaceModelId,
     });
 
     // Auth as the current (admin) editor to pass the permission check.
     const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      row.currentEditorSId,
+      row.currentEditorId,
       row.workspaceId
     );
 
-    const result = await TriggerResource.update(adminAuth, triggerSId, {
-      editor: row.originalUserId,
+    const result = await TriggerResource.update(adminAuth, triggerId, {
+      editor: row.originalUserModelId,
     });
 
     if (result.isErr()) {
@@ -129,13 +129,13 @@ makeScript({}, async ({ execute }, logger) => {
 
     // Re-upsert the Temporal workflow under the original user's identity.
     const originalUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      row.originalUserSId,
+      row.originalUserId,
       row.workspaceId
     );
 
     const trigger = await TriggerResource.fetchById(
       originalUserAuth,
-      triggerSId
+      triggerId
     );
     if (trigger && trigger.status === "enabled") {
       const upsertResult =

--- a/front/scripts/seed/factories/seedConversations.ts
+++ b/front/scripts/seed/factories/seedConversations.ts
@@ -57,13 +57,13 @@ export async function seedConversations(
 
     // Determine which user to use for this conversation
     let conversationUser = user;
-    if (conv.userSId) {
-      const specifiedUser = additionalUsers.get(conv.userSId);
+    if (conv.userId) {
+      const specifiedUser = additionalUsers.get(conv.userId);
       if (specifiedUser) {
         conversationUser = specifiedUser;
       } else {
         logger.warn(
-          { userSId: conv.userSId },
+          { userId: requestedUserId },
           "Specified user not found in additionalUsers, using default user"
         );
       }

--- a/front/scripts/seed/factories/seedConversations.ts
+++ b/front/scripts/seed/factories/seedConversations.ts
@@ -63,7 +63,7 @@ export async function seedConversations(
         conversationUser = specifiedUser;
       } else {
         logger.warn(
-          { userId: requestedUserId },
+          { userId: conv.userId },
           "Specified user not found in additionalUsers, using default user"
         );
       }

--- a/front/scripts/seed/factories/types.ts
+++ b/front/scripts/seed/factories/types.ts
@@ -60,7 +60,7 @@ export interface ConversationAsset {
   sId: string;
   title: string;
   agentName?: string;
-  userSId?: string;
+  userId: string;
   exchanges: Exchange[];
 }
 

--- a/front/scripts/seed/sidekick/assets/conversations.json
+++ b/front/scripts/seed/sidekick/assets/conversations.json
@@ -30,7 +30,7 @@
     "sId": "SidekickConv02",
     "title": "Quantum computing updates",
     "agentName": "TechNewsDigest",
-    "userSId": "SeedUserJohn",
+    "userId": "SeedUserJohn",
     "exchanges": [
       {
         "user": {

--- a/x/henry/dust-hive/src/commands/seed-config.ts
+++ b/x/henry/dust-hive/src/commands/seed-config.ts
@@ -106,13 +106,13 @@ async function extractUsers(postgresUri: string): Promise<Result<UserRow[], Comm
 
 async function extractWorkspace(
   postgresUri: string,
-  userSId: string
+  userId: string
 ): Promise<Result<{ sId: string; name: string } | null, CommandError>> {
   const query = `
     SELECT w."sId", w.name FROM workspaces w
     JOIN memberships m ON m."workspaceId" = w.id
     JOIN users u ON u.id = m."userId"
-    WHERE u."sId" = '${userSId}' AND m.role = 'admin'
+    WHERE u."sId" = '${userId}' AND m.role = 'admin'
       AND (m."endAt" IS NULL OR m."endAt" > NOW())
     ORDER BY w."createdAt" ASC LIMIT 1;
   `;
@@ -132,7 +132,7 @@ async function extractWorkspace(
 
 function resolveWorkspace(
   result: { sId: string; name: string } | null,
-  userSId: string,
+  userId: string,
   firstName: string
 ): { sId: string; name: string } {
   if (result) {
@@ -140,7 +140,7 @@ function resolveWorkspace(
     return result;
   }
   logger.warn("No workspace found for user, will create a new one during seed");
-  return { sId: `dev-${userSId.slice(0, 6)}`, name: `${firstName}'s Dev Workspace` };
+  return { sId: `dev-${userId.slice(0, 6)}`, name: `${firstName}'s Dev Workspace` };
 }
 
 export async function seedConfigCommand(postgresUri?: string): Promise<Result<void>> {


### PR DESCRIPTION
## Description

- This PR enforces the coding rule BACK10 relative to naming of string IDs/model IDs variables.
- Focuses on `userSId` references throughout the codebase.
- The changes are retro-compatible, with the exception of a poke plugin.

## Tests

- Typecheck.

## Risk

- Low, mostly local changes.

## Deploy Plan

- Deploy front.