### PR TITLE
fix: upgrade actions/checkout from v3 to v4 to fix Node.js 20 deprecation warning

### DIFF
--- a/.github/workflows/build-and-test-connectors.yml
+++ b/.github/workflows/build-and-test-connectors.yml
@@ -16,7 +16,7 @@ jobs:
   tsgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -32,7 +32,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -33,7 +33,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -71,7 +71,7 @@ jobs:
   tsgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -88,7 +88,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-canary-image.yml
+++ b/.github/workflows/build-canary-image.yml
@@ -50,7 +50,7 @@ jobs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
       long_sha: ${{ steps.short_sha.outputs.long_sha }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get short sha
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -64,7 +64,7 @@ jobs:
     outputs:
       thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Notify Build And Deploy Start
         id: build_message
@@ -102,7 +102,7 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50 # Fetch last 50 commits for commit diff functionality
 

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install build dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -18,7 +18,7 @@ jobs:
   tsgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-spa.yaml
+++ b/.github/workflows/build-spa.yaml
@@ -17,7 +17,7 @@ jobs:
   tsgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-sparkle.yml
+++ b/.github/workflows/build-sparkle.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-viz.yml
+++ b/.github/workflows/build-viz.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/deploy-docs-openapi.yml
+++ b/.github/workflows/deploy-docs-openapi.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run `openapi` command 🚀
         uses: readmeio/rdme@v8

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,7 +88,7 @@ jobs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
       long_sha: ${{ steps.short_sha.outputs.long_sha }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get short sha
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -102,7 +102,7 @@ jobs:
     outputs:
       thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Notify Build And Deploy Start
         id: build_message
@@ -149,7 +149,7 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 50 # Fetch last 50 commits for commit diff functionality
 
@@ -214,7 +214,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && (needs.ensure-sandbox-images.result == 'success' || needs.ensure-sandbox-images.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Generate token
         id: generate-token

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -28,7 +28,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22.22.0

--- a/.github/workflows/node24-compat.yml
+++ b/.github/workflows/node24-compat.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -47,7 +47,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -18,7 +18,7 @@ jobs:
     # This ensures the workflow only runs on main branch
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22.22.0"

--- a/.github/workflows/publish-sdk-client.yml
+++ b/.github/workflows/publish-sdk-client.yml
@@ -18,7 +18,7 @@ jobs:
     # This ensures the workflow only runs on main branch
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22.22.0"

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -65,7 +65,7 @@ jobs:
     outputs:
       thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Notify Start
         id: build_message
@@ -103,7 +103,7 @@ jobs:
         region: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
       fail-fast: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set project ID
         id: project
@@ -160,7 +160,7 @@ jobs:
     needs: [notify-start, validate-image]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Generate token
         id: generate-token

--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Description

Upgrades all `actions/checkout@v3` references to `@v4` across GitHub Actions workflow files.

`actions/checkout@v3` runs on Node.js 20 which GitHub is deprecating starting June 2nd, 2026, with Node.js 20 runners removed on September 16th, 2026..
