### PR TITLE
Fixed script, remove logs

### DIFF
--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -974,7 +974,12 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     subscriptionModelId: ModelId,
     metronomeContractId: string
   ): Promise<void> {
-    const subscription = await SubscriptionModel.findByPk(subscriptionModelId);
+    const subscription = await SubscriptionResource.model.findOne({
+      where: { id: subscriptionModelId },
+      // subscription ID is already trusted.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
     if (!subscription) {
       throw new Error(`Subscription not found: ${subscriptionModelId}`);
     }

--- a/front/migrations/20260408_backfill_metronome_events.ts
+++ b/front/migrations/20260408_backfill_metronome_events.ts
@@ -392,7 +392,7 @@ makeScript(
           );
         }
       },
-      { wId: args.wId, fromWorkspaceId: args.fromWorkspaceId }
+      { wId: args.wId, fromWorkspaceId: args.fromWorkspaceId, concurrency: 5 }
     );
 
     logger.info(

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -220,18 +220,6 @@ export async function emitMetronomeUsageEventsActivity(
   const { agentMessageId, conversationId, userMessageId } = agentLoopArgs;
   const userMessageOrigin = agentLoopArgs.userMessageOrigin ?? "web";
 
-  logger.info(
-    {
-      workspaceId: workspace.sId,
-      agentMessageId,
-      conversationId,
-      messageModelId: agentLoopArgs.dustRunIds ? "with-dustRunIds" : "legacy",
-      dustRunIds: agentLoopArgs.dustRunIds,
-      startStep: agentLoopArgs.startStep,
-    },
-    "[Metronome] Processing usage events"
-  );
-
   // Query agent message with its run IDs.
   const agentMessageRow = await MessageModel.findOne({
     where: {


### PR DESCRIPTION
## Summary

Fixes for backfill script and Metronome event emission.

- **`subscription_resource.ts`**: `updateMetronomeContractId` uses `dangerouslyBypassWorkspaceIsolationSecurity` for the `findOne` lookup (admin operation, subscription ID already trusted)
- **`backfill script`**: workspace concurrency (5)
- **`activities.ts`**: Cleanup debug logs from usage events activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)