### PR TITLE
[front] chore: deprecate `sidebar-all-actions` mode for message breakdown

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -97,12 +97,8 @@ import type { LightWorkspaceType } from "@app/types/user";
 import {
   ActionDocumentTextIcon,
   ClockIcon,
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
   ContentBlockWrapper,
   ContentMessage,
-  cn,
   GlobeAltIcon,
   MagnifyingGlassIcon,
   Markdown,
@@ -427,84 +423,31 @@ export function GenericActionDetails({
     >
       {displayContext !== "conversation" && (
         <div className="dd-privacy-mask flex flex-col gap-4 py-4 pl-6">
-          {displayContext === "sidebar-single-action" ? (
-            <>
-              <div>
-                <span className="font-medium text-foreground dark:text-foreground-night">
-                  Inputs
-                </span>
-                <RenderToolItemMarkdown text={inputs} type="input" />
+          <div>
+            <span className="font-medium text-foreground dark:text-foreground-night">
+              Inputs
+            </span>
+            <RenderToolItemMarkdown text={inputs} type="input" />
+          </div>
+          {action.output && (
+            <div>
+              <span className="font-medium text-foreground dark:text-foreground-night">
+                Output
+              </span>
+              <div className="my-2 flex flex-col gap-2">
+                {action.output
+                  .filter(
+                    (o) => isTextContent(o) || isResourceContentWithText(o)
+                  )
+                  .map((o, index) => (
+                    <RenderToolItemMarkdown
+                      key={index}
+                      text={getOutputText(o)}
+                      type="output"
+                    />
+                  ))}
               </div>
-              {action.output && (
-                <div>
-                  <span className="font-medium text-foreground dark:text-foreground-night">
-                    Output
-                  </span>
-                  <div className="my-2 flex flex-col gap-2">
-                    {action.output
-                      .filter(
-                        (o) => isTextContent(o) || isResourceContentWithText(o)
-                      )
-                      .map((o, index) => (
-                        <RenderToolItemMarkdown
-                          key={index}
-                          text={getOutputText(o)}
-                          type="output"
-                        />
-                      ))}
-                  </div>
-                </div>
-              )}
-            </>
-          ) : (
-            <>
-              <Collapsible defaultOpen={false}>
-                <CollapsibleTrigger>
-                  <div
-                    className={cn(
-                      "text-foreground dark:text-foreground-night",
-                      "flex flex-row items-center gap-x-2"
-                    )}
-                  >
-                    <span className="heading-base">Inputs</span>
-                  </div>
-                </CollapsibleTrigger>
-                <CollapsibleContent>
-                  <RenderToolItemMarkdown text={inputs} type="input" />
-                </CollapsibleContent>
-              </Collapsible>
-
-              {action.output && (
-                <Collapsible defaultOpen={false}>
-                  <CollapsibleTrigger>
-                    <div
-                      className={cn(
-                        "text-foreground dark:text-foreground-night",
-                        "flex flex-row items-center gap-x-2"
-                      )}
-                    >
-                      <span className="heading-base">Output</span>
-                    </div>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <div className="my-2 flex flex-col gap-2">
-                      {action.output
-                        .filter(
-                          (o) =>
-                            isTextContent(o) || isResourceContentWithText(o)
-                        )
-                        .map((o, index) => (
-                          <RenderToolItemMarkdown
-                            key={index}
-                            text={getOutputText(o)}
-                            type="output"
-                          />
-                        ))}
-                    </div>
-                  </CollapsibleContent>
-                </Collapsible>
-              )}
-            </>
+            </div>
           )}
 
           {action.generatedFiles.filter((f) => !f.hidden).length > 0 && (

--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -1,8 +1,5 @@
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type {
-  ActionDetailsDisplayContext,
-  ToolExecutionDetailsProps,
-} from "@app/components/actions/mcp/details/types";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import {
   isExtractQueryResourceType,
   isExtractResultResourceType,
@@ -13,9 +10,6 @@ import {
   CitationIcons,
   CitationTitle,
   CodeBlock,
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
   Icon,
   ScanIcon,
 } from "@dust-tt/sparkle";
@@ -41,7 +35,6 @@ interface MCPExtractActionResultsProps {
     contentType: string;
     snippet: string | null;
   };
-  displayContext: ActionDetailsDisplayContext;
 }
 
 export function MCPExtractActionDetails({
@@ -78,70 +71,28 @@ export function MCPExtractActionDetails({
           />
         </div>
 
-        {jsonSchema &&
-          (displayContext === "sidebar-single-action" ? (
-            <div>
-              <span className="font-medium text-foreground dark:text-foreground-night">
-                Schema
-              </span>
-              <div className="py-2">
-                <CodeBlock
-                  className="language-json max-h-60 overflow-y-auto"
-                  wrapLongLines={true}
-                >
-                  {JSON.stringify(jsonSchema, null, 2)}
-                </CodeBlock>
-              </div>
+        {jsonSchema && (
+          <div>
+            <span className="font-medium text-foreground dark:text-foreground-night">
+              Schema
+            </span>
+            <div className="py-2">
+              <CodeBlock
+                className="language-json max-h-60 overflow-y-auto"
+                wrapLongLines={true}
+              >
+                {JSON.stringify(jsonSchema, null, 2)}
+              </CodeBlock>
             </div>
-          ) : (
-            <div>
-              <Collapsible defaultOpen={false}>
-                <CollapsibleTrigger>
-                  <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                    Schema
-                  </span>
-                </CollapsibleTrigger>
-                <CollapsibleContent>
-                  <div className="py-2">
-                    <CodeBlock
-                      className="language-json max-h-60 overflow-y-auto"
-                      wrapLongLines={true}
-                    >
-                      {JSON.stringify(jsonSchema, null, 2)}
-                    </CodeBlock>
-                  </div>
-                </CollapsibleContent>
-              </Collapsible>
-            </div>
-          ))}
+          </div>
+        )}
 
         {displayContext !== "conversation" && (
           <div>
-            {displayContext === "sidebar-single-action" ? (
-              <>
-                <span className="font-medium text-foreground dark:text-foreground-night">
-                  Results
-                </span>
-                <MCPExtractActionResults
-                  resultResource={resultResource}
-                  displayContext={displayContext}
-                />
-              </>
-            ) : (
-              <Collapsible defaultOpen={false}>
-                <CollapsibleTrigger>
-                  <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                    Results
-                  </span>
-                </CollapsibleTrigger>
-                <CollapsibleContent>
-                  <MCPExtractActionResults
-                    resultResource={resultResource}
-                    displayContext={displayContext}
-                  />
-                </CollapsibleContent>
-              </Collapsible>
-            )}
+            <span className="font-medium text-foreground dark:text-foreground-night">
+              Results
+            </span>
+            <MCPExtractActionResults resultResource={resultResource} />
           </div>
         )}
       </div>
@@ -181,7 +132,6 @@ function MCPExtractActionQuery({
 
 function MCPExtractActionResults({
   resultResource,
-  displayContext,
 }: MCPExtractActionResultsProps) {
   const [isDownloading, setIsDownloading] = useState(false);
 
@@ -221,40 +171,21 @@ function MCPExtractActionResults({
         </Citation>
       </div>
 
-      {resultResource.snippet &&
-        (displayContext === "sidebar-single-action" ? (
-          <div>
-            <span className="font-medium text-foreground dark:text-foreground-night">
-              Preview
-            </span>
-            <div className="py-2">
-              <CodeBlock
-                className="language-json max-h-60 overflow-y-auto"
-                wrapLongLines={true}
-              >
-                {resultResource.snippet}
-              </CodeBlock>
-            </div>
+      {resultResource.snippet && (
+        <div>
+          <span className="font-medium text-foreground dark:text-foreground-night">
+            Preview
+          </span>
+          <div className="py-2">
+            <CodeBlock
+              className="language-json max-h-60 overflow-y-auto"
+              wrapLongLines={true}
+            >
+              {resultResource.snippet}
+            </CodeBlock>
           </div>
-        ) : (
-          <Collapsible defaultOpen={false}>
-            <CollapsibleTrigger>
-              <span className="text-sm font-semibold text-muted-foreground dark:text-muted-foreground-night">
-                Preview
-              </span>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <div className="py-2">
-                <CodeBlock
-                  className="language-json max-h-60 overflow-y-auto"
-                  wrapLongLines={true}
-                >
-                  {resultResource.snippet}
-                </CodeBlock>
-              </div>
-            </CollapsibleContent>
-          </Collapsible>
-        ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
@@ -4,9 +4,6 @@ import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_sche
 import {
   ActionDocumentTextIcon,
   Button,
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
   CommandLineIcon,
   cn,
   Markdown,
@@ -140,10 +137,7 @@ export function MCPSandboxActionDetails({
       {displayContext === "conversation" ? (
         <ConversationView {...viewProps} />
       ) : (
-        <SidebarView
-          {...viewProps}
-          useCollapsible={displayContext === "sidebar-all-actions"}
-        />
+        <SidebarView {...viewProps} />
       )}
     </ActionDetailsWrapper>
   );
@@ -245,10 +239,6 @@ function ConversationView({
   );
 }
 
-interface SidebarViewFullProps extends SandboxViewProps {
-  useCollapsible: boolean;
-}
-
 function SidebarView({
   command,
   summary,
@@ -256,8 +246,7 @@ function SidebarView({
   isRawMode,
   isRunning,
   exitCode,
-  useCollapsible,
-}: SidebarViewFullProps) {
+}: SandboxViewProps) {
   return (
     <div className="flex flex-col gap-4 py-4 pl-6">
       {!isRawMode && (
@@ -272,76 +261,31 @@ function SidebarView({
 
       {isRawMode && (
         <>
-          {command &&
-            (useCollapsible ? (
-              <Collapsible defaultOpen={true}>
-                <CollapsibleTrigger>
-                  <div
-                    className={cn(
-                      "text-foreground dark:text-foreground-night",
-                      "flex flex-row items-center gap-x-2"
-                    )}
-                  >
-                    <span className="heading-base">Command</span>
-                  </div>
-                </CollapsibleTrigger>
-                <CollapsibleContent>
-                  <div className="py-2">
-                    <Markdown content={`\`\`\`bash\n${command}\n\`\`\``} />
-                  </div>
-                </CollapsibleContent>
-              </Collapsible>
-            ) : (
-              <div>
-                <span className="font-medium text-foreground dark:text-foreground-night">
-                  Command
-                </span>
-                <div className="py-2">
-                  <Markdown content={`\`\`\`bash\n${command}\n\`\`\``} />
-                </div>
-              </div>
-            ))}
-
-          {useCollapsible ? (
-            <Collapsible defaultOpen={!!rawOutputText}>
-              <CollapsibleTrigger>
-                <div
-                  className={cn(
-                    "text-foreground dark:text-foreground-night",
-                    "flex flex-row items-center gap-x-2"
-                  )}
-                >
-                  <span className="heading-base">Output</span>
-                </div>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <div className="py-2">
-                  {rawOutputText ? (
-                    <Markdown content={`\`\`\`\n${rawOutputText}\n\`\`\``} />
-                  ) : (
-                    <p className="text-sm italic text-muted-foreground dark:text-muted-foreground-night">
-                      {isRunning ? "Waiting for output…" : "(no output)"}
-                    </p>
-                  )}
-                </div>
-              </CollapsibleContent>
-            </Collapsible>
-          ) : (
+          {command && (
             <div>
               <span className="font-medium text-foreground dark:text-foreground-night">
-                Output
+                Command
               </span>
               <div className="py-2">
-                {rawOutputText ? (
-                  <Markdown content={`\`\`\`\n${rawOutputText}\n\`\`\``} />
-                ) : (
-                  <p className="text-sm italic text-muted-foreground dark:text-muted-foreground-night">
-                    {isRunning ? "Waiting for output…" : "(no output)"}
-                  </p>
-                )}
+                <Markdown content={`\`\`\`bash\n${command}\n\`\`\``} />
               </div>
             </div>
           )}
+
+          <div>
+            <span className="font-medium text-foreground dark:text-foreground-night">
+              Output
+            </span>
+            <div className="py-2">
+              {rawOutputText ? (
+                <Markdown content={`\`\`\`\n${rawOutputText}\n\`\`\``} />
+              ) : (
+                <p className="text-sm italic text-muted-foreground dark:text-muted-foreground-night">
+                  {isRunning ? "Waiting for output…" : "(no output)"}
+                </p>
+              )}
+            </div>
+          </div>
 
           <ExitCodeBadge exitCode={exitCode} />
         </>

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -22,12 +22,8 @@ import type { LightWorkspaceType } from "@app/types/user";
 import {
   Chip,
   CodeBlock,
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
   ContentBlockWrapper,
   ContentMessage,
-  cn,
   FaviconIcon,
   InformationCircleIcon,
   Markdown,
@@ -204,22 +200,10 @@ export function SearchResultDetails({
       ) : (
         <div className="flex flex-col gap-4 pl-6 pt-4">
           <div className="flex flex-col gap-1">
-            <span
-              className={cn(
-                displayContext === "sidebar-single-action" ? "font-medium" : "",
-                "text-foreground dark:text-foreground-night"
-              )}
-            >
+            <span className="font-medium text-foreground dark:text-foreground-night">
               Query
             </span>
-            <div
-              className={cn(
-                displayContext === "sidebar-single-action"
-                  ? ""
-                  : "text-sm font-normal",
-                "text-muted-foreground dark:text-muted-foreground-night"
-              )}
-            >
+            <div className="text-muted-foreground dark:text-muted-foreground-night">
               {displayQuery}
             </div>
             {warning && (
@@ -229,44 +213,22 @@ export function SearchResultDetails({
               />
             )}
           </div>
-          {actionOutput &&
-            (displayContext === "sidebar-single-action" ? (
-              <div className="flex flex-col gap-2">
-                <span className="font-medium text-foreground dark:text-foreground-night">
-                  Results
-                </span>
-                {singleFileContentText && (
-                  <Markdown
-                    content={singleFileContentText}
-                    isStreaming={false}
-                    forcedTextSize="text-sm"
-                    textColor="text-muted-foreground dark:text-muted-foreground-night"
-                  />
-                )}
-                <PaginatedCitationsGrid items={citations} />
-              </div>
-            ) : (
-              <div>
-                <Collapsible defaultOpen={false}>
-                  <CollapsibleTrigger>
-                    <span className="text-sm font-bold text-foreground dark:text-foreground-night">
-                      Results
-                    </span>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    {singleFileContentText && (
-                      <Markdown
-                        content={singleFileContentText}
-                        isStreaming={false}
-                        forcedTextSize="text-sm"
-                        textColor="text-muted-foreground dark:text-muted-foreground-night"
-                      />
-                    )}
-                    <PaginatedCitationsGrid items={citations} />
-                  </CollapsibleContent>
-                </Collapsible>
-              </div>
-            ))}
+          {actionOutput && (
+            <div className="flex flex-col gap-2">
+              <span className="font-medium text-foreground dark:text-foreground-night">
+                Results
+              </span>
+              {singleFileContentText && (
+                <Markdown
+                  content={singleFileContentText}
+                  isStreaming={false}
+                  forcedTextSize="text-sm"
+                  textColor="text-muted-foreground dark:text-muted-foreground-night"
+                />
+              )}
+              <PaginatedCitationsGrid items={citations} />
+            </div>
+          )}
         </div>
       )}
     </ActionDetailsWrapper>

--- a/front/components/actions/mcp/details/types.ts
+++ b/front/components/actions/mcp/details/types.ts
@@ -4,8 +4,6 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 export type ActionDetailsDisplayContext =
   | "conversation"
-  // TODO(2026-04-07 inline activity): the "all actions" display will be deprecated with the ship of inline activity.
-  | "sidebar-all-actions"
   | "sidebar-single-action";
 
 // Generic interface for every component that displays details for a certain type of tool output.

--- a/front/components/assistant/conversation/actions/PanelAgentStep.tsx
+++ b/front/components/assistant/conversation/actions/PanelAgentStep.tsx
@@ -124,7 +124,7 @@ export function PanelAgentStep({
       {pendingToolCalls.map((pendingToolCall, index) => (
         <div key={getPendingToolCallKey(pendingToolCall, index)}>
           <PendingToolCallDetails
-            displayContext="sidebar-all-actions"
+            displayContext="sidebar-single-actions"
             functionCallName={pendingToolCall.toolName}
           />
         </div>

--- a/front/components/assistant/conversation/actions/PanelAgentStep.tsx
+++ b/front/components/assistant/conversation/actions/PanelAgentStep.tsx
@@ -124,7 +124,7 @@ export function PanelAgentStep({
       {pendingToolCalls.map((pendingToolCall, index) => (
         <div key={getPendingToolCallKey(pendingToolCall, index)}>
           <PendingToolCallDetails
-            displayContext="sidebar-single-actions"
+            displayContext="sidebar-single-action"
             functionCallName={pendingToolCall.toolName}
           />
         </div>

--- a/front/components/assistant/conversation/actions/PanelAgentStep.tsx
+++ b/front/components/assistant/conversation/actions/PanelAgentStep.tsx
@@ -87,7 +87,7 @@ export function PanelAgentStep({
         return (
           <div key={`action-${entry.action.id}`}>
             <MCPActionDetails
-              displayContext="sidebar-all-actions"
+              displayContext="sidebar-single-action"
               action={entry.action}
               lastNotification={streamProgress ?? null}
               owner={owner}
@@ -109,7 +109,7 @@ export function PanelAgentStep({
             return (
               <div key={`streaming-action-${action.id}`} className="mb-4">
                 <MCPActionDetails
-                  displayContext="sidebar-all-actions"
+                  displayContext="sidebar-single-action"
                   action={action}
                   lastNotification={lastNotification}
                   owner={owner}

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -80,8 +80,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Creating new Interactive Content file",
-      done: "Create new Interactive Content file",
+      running: "Creating new Frame",
+      done: "Create new Frame",
     },
   },
   [EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
@@ -138,8 +138,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Updating Interactive Content file",
-      done: "Update Interactive Content file",
+      running: "Updating Frame",
+      done: "Update Frame",
     },
   },
   [REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
@@ -156,8 +156,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Reverting Interactive Content file",
-      done: "Revert Interactive Content file",
+      running: "Reverting changes on Frame",
+      done: "Revert changes on Frame",
     },
   },
   [RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
@@ -178,8 +178,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Renaming Interactive Content file",
-      done: "Rename Interactive Content file",
+      running: "Renaming Frame",
+      done: "Rename Frame",
     },
   },
   [RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
@@ -198,8 +198,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Reading Interactive Content file",
-      done: "Read Interactive Content file",
+      running: "Reading Frame content",
+      done: "Read Frame content",
     },
   },
   [GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME]: {

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -80,8 +80,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Creating new Frame",
-      done: "Create new Frame",
+      running: "Creating new Interactive Content file",
+      done: "Create new Interactive Content file",
     },
   },
   [EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
@@ -138,8 +138,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Updating Frame",
-      done: "Update Frame",
+      running: "Updating Interactive Content file",
+      done: "Update Interactive Content file",
     },
   },
   [REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
@@ -156,8 +156,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Reverting changes on Frame",
-      done: "Revert changes on Frame",
+      running: "Reverting Interactive Content file",
+      done: "Revert Interactive Content file",
     },
   },
   [RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
@@ -178,8 +178,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Renaming Frame",
-      done: "Rename Frame",
+      running: "Renaming Interactive Content file",
+      done: "Rename Interactive Content file",
     },
   },
   [RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
@@ -198,8 +198,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Reading Frame content",
-      done: "Read Frame content",
+      running: "Reading Interactive Content file",
+      done: "Read Interactive Content file",
     },
   },
   [GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME]: {


### PR DESCRIPTION
## Description

- This PR deprecates the display mode of the message breakdown where we show all the actions at once.
- In this mode we typically show collapsible components for long inputs or outputs since we have many tool calls to show at once.
- With the ship of the inline activity the side panel opens only on one action at any time.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
