### PR TITLE
feat(poke-mcp): add search_workspaces tool and external links to workspace metadata

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -454,6 +454,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_workspace_spaces": "high",
     "list_data_sources": "high",
     "list_workspace_groups": "high",
+    "search_workspaces": "high",
   },
   "primitive_types_debugger": {
     "pass_through": "high",

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -29,6 +29,10 @@ export const CHECK_SLACK_CHANNEL_TOOL_NAME = "check_slack_channel";
 export const GET_CONVERSATION_DETAILS_TOOL_NAME = "get_conversation_details";
 export const GET_MCP_SERVER_DETAILS_TOOL_NAME = "get_mcp_server_details";
 
+// ─── Search ──────────────────────────────────────────────────────────────────
+
+export const SEARCH_WORKSPACES_TOOL_NAME = "search_workspaces";
+
 // ─── Users & Cross-Reference ─────────────────────────────────────────────────
 
 export const LIST_WORKSPACE_GROUPS_TOOL_NAME = "list_workspace_groups";
@@ -205,6 +209,27 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Fetching MCP server details",
       done: "Fetched MCP server details",
+    },
+  },
+
+  // ── Search ───────────────────────────────────────────────────────────────
+
+  [SEARCH_WORKSPACES_TOOL_NAME]: {
+    description:
+      "Search workspaces by name (exact), verified domain, or member email. " +
+      "Returns matching workspaces with links to poke, WorkOS, Metronome, and health dashboards.",
+    schema: {
+      query: z
+        .string()
+        .describe(
+          "Search term: workspace name (e.g. 'Acme'), verified domain (e.g. 'acme.com'), " +
+            "or member email (e.g. 'alice@acme.com')."
+        ),
+    },
+    stake: "high" as const,
+    displayLabels: {
+      running: "Searching workspaces",
+      done: "Searched workspaces",
     },
   },
 

--- a/front/lib/api/actions/servers/poke/tools/index.test.ts
+++ b/front/lib/api/actions/servers/poke/tools/index.test.ts
@@ -142,6 +142,8 @@ describe("poke tools - security gates", () => {
 
       // Make isDustWorkspace return true.
       vi.stubEnv("PRODUCTION_DUST_WORKSPACE_ID", workspace.sId);
+      vi.stubEnv("WORKOS_ENVIRONMENT_ID", "123456789");
+      vi.stubEnv("POKE_APP_URL", "http://localhost:3000");
 
       // Mock getFeatureFlags to include poke_mcp.
       const authModule = await import("@app/lib/auth");

--- a/front/lib/api/actions/servers/poke/tools/index.ts
+++ b/front/lib/api/actions/servers/poke/tools/index.ts
@@ -10,9 +10,12 @@ import { userHandlers } from "@app/lib/api/actions/servers/poke/tools/users";
 import {
   enforcePokeSecurityGates,
   getTargetAuth,
+  jsonResponse,
 } from "@app/lib/api/actions/servers/poke/tools/utils";
 import { workspaceHandlers } from "@app/lib/api/actions/servers/poke/tools/workspace";
-import { Ok } from "@app/types/shared/result";
+import config from "@app/lib/api/config";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { isDevelopment } from "@app/types/shared/env";
 
 const handlers: ToolHandlers<typeof POKE_TOOLS_METADATA> = {
   [GET_WORKSPACE_METADATA_TOOL_NAME]: async ({ workspace_id }, extra) => {
@@ -34,30 +37,34 @@ const handlers: ToolHandlers<typeof POKE_TOOLS_METADATA> = {
     const targetWorkspace = targetAuth.getNonNullableWorkspace();
     const plan = targetAuth.plan();
 
-    return new Ok([
-      {
-        type: "text" as const,
-        text: JSON.stringify(
-          {
-            sId: targetWorkspace.sId,
-            name: targetWorkspace.name,
-            segmentation: targetWorkspace.segmentation,
-            ssoEnforced:
-              "ssoEnforced" in targetWorkspace
-                ? targetWorkspace.ssoEnforced
-                : undefined,
-            plan: plan
-              ? {
-                  code: plan.code,
-                  name: plan.name,
-                }
-              : null,
-          },
-          null,
-          2
-        ),
+    const workspaceResource = await WorkspaceResource.fetchById(workspace_id);
+    const workosEnvironmentId = config.getWorkOSEnvironmentId();
+
+    return jsonResponse({
+      sId: targetWorkspace.sId,
+      name: targetWorkspace.name,
+      segmentation: targetWorkspace.segmentation,
+      ssoEnforced:
+        "ssoEnforced" in targetWorkspace
+          ? targetWorkspace.ssoEnforced
+          : undefined,
+      plan: plan
+        ? {
+            code: plan.code,
+            name: plan.name,
+          }
+        : null,
+      links: {
+        poke: `${config.getPokeAppUrl()}/${targetWorkspace.sId}`,
+        workos: workspaceResource?.workOSOrganizationId
+          ? `https://dashboard.workos.com/${workosEnvironmentId}/organizations/${workspaceResource.workOSOrganizationId}`
+          : null,
+        metronome: workspaceResource?.metronomeCustomerId
+          ? `https://app.metronome.com/${isDevelopment() ? "sandbox/" : ""}customers/${workspaceResource.metronomeCustomerId}`
+          : null,
+        health: `https://metabase.dust.tt/dashboard/34-snowflake-workspace-health?end_date=2030-12-31&start_date=2024-01-01&tab=30-executive-summary&workspace_size_difference_margin=0.2&workspacesid=${targetWorkspace.sId}`,
       },
-    ]);
+    });
   },
 
   ...workspaceHandlers,

--- a/front/lib/api/actions/servers/poke/tools/workspace.ts
+++ b/front/lib/api/actions/servers/poke/tools/workspace.ts
@@ -7,6 +7,7 @@ import {
   GET_WORKSPACE_MEMBERS_TOOL_NAME,
   GET_WORKSPACE_PLAN_TOOL_NAME,
   GET_WORKSPACE_SPACES_TOOL_NAME,
+  SEARCH_WORKSPACES_TOOL_NAME,
 } from "@app/lib/api/actions/servers/poke/metadata";
 import {
   enforcePokeSecurityGates,
@@ -23,6 +24,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { isDomain, isEmailValid } from "@app/lib/utils";
 import { Err } from "@app/types/shared/result";
 import { format } from "date-fns/format";
 
@@ -35,6 +37,7 @@ type WorkspaceHandlers = Pick<
   | typeof GET_WORKSPACE_MEMBERS_TOOL_NAME
   | typeof GET_WORKSPACE_SPACES_TOOL_NAME
   | typeof GET_WORKSPACE_CREDITS_TOOL_NAME
+  | typeof SEARCH_WORKSPACES_TOOL_NAME
 >;
 
 export const workspaceHandlers: WorkspaceHandlers = {
@@ -230,5 +233,59 @@ export const workspaceHandlers: WorkspaceHandlers = {
       excessCreditsLast30DaysMicroUsd,
       poke_url: `${config.getPokeAppUrl()}/${workspace_id}`,
     });
+  },
+
+  [SEARCH_WORKSPACES_TOOL_NAME]: async ({ query }, extra) => {
+    const gateResult = await enforcePokeSecurityGates(
+      extra,
+      SEARCH_WORKSPACES_TOOL_NAME,
+      // No specific target workspace for a cross-workspace search.
+      "(global search)"
+    );
+    if (gateResult.isErr()) {
+      return gateResult;
+    }
+
+    let workspaces: WorkspaceResource[] = [];
+
+    if (isEmailValid(query)) {
+      // Search by member email: find user(s) → memberships → workspaces.
+      const users = await UserResource.listByEmail(query);
+      if (users.length) {
+        const { memberships } = await MembershipResource.getLatestMemberships({
+          users,
+        });
+        workspaces = await WorkspaceResource.fetchByModelIds(
+          memberships.map((m) => m.workspaceId)
+        );
+      }
+    } else if (isDomain(query)) {
+      // Search by verified domain.
+      const workspace = await WorkspaceResource.fetchByDomain(query);
+      if (workspace) {
+        workspaces = [workspace];
+      }
+    } else {
+      // Search by exact name or sId.
+      const [byName, bySId] = await Promise.all([
+        WorkspaceResource.fetchByName(query),
+        WorkspaceResource.fetchById(query),
+      ]);
+      // Deduplicate in case name and sId match the same workspace.
+      const seen = new Set<number>();
+      for (const w of [byName, bySId]) {
+        if (w && !seen.has(w.id)) {
+          seen.add(w.id);
+          workspaces.push(w);
+        }
+      }
+    }
+
+    const results = workspaces.map((w) => ({
+      sId: w.sId,
+      name: w.name,
+    }));
+
+    return jsonResponse({ count: results.length, workspaces: results });
   },
 };


### PR DESCRIPTION
## Description

Adds two improvements to the poke MCP server:

1. **New `search_workspaces` tool**: search workspaces by name (exact), verified domain, or member email. Returns matching workspaces with direct links to poke, WorkOS dashboard, Metronome, and the Metabase workspace health dashboard.

2. **External links in `get_workspace_metadata`**: the metadata response now includes a `links` block with poke, WorkOS, Metronome, and workspace health URLs, mirroring what the poke UI already shows on the workspace detail page.

## Tests


## Risk

