### PR TITLE
Add poke view to skills to list suggestions

### DIFF
--- a/front/components/poke/pages/SkillDetailsPage.tsx
+++ b/front/components/poke/pages/SkillDetailsPage.tsx
@@ -1,4 +1,5 @@
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { SkillSuggestionDataTable } from "@app/components/poke/skill_suggestions/table";
 import { SkillOverviewTable } from "@app/components/poke/skills/SkillOverviewTable";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
@@ -139,6 +140,8 @@ export function SkillDetailsPage() {
           ))}
         </div>
       </div>
+
+      <SkillSuggestionDataTable owner={owner} skillId={sId} />
 
       <div className="mt-4">
         <div className="border-material-200 rounded-lg border p-4">

--- a/front/components/poke/skill_suggestions/columns.tsx
+++ b/front/components/poke/skill_suggestions/columns.tsx
@@ -1,0 +1,221 @@
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import { clientFetch } from "@app/lib/egress/client";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Chip, IconButton, TrashIcon } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+
+const MAX_ANALYSIS_LENGTH = 80;
+const MAX_CONTENT_LENGTH = 80;
+
+function truncate(text: string | null, maxLength: number): string {
+  if (!text) {
+    return "-";
+  }
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return text.slice(0, maxLength) + "...";
+}
+
+function ClickableCell({
+  text,
+  maxLength,
+  onClick,
+}: {
+  text: string | null;
+  maxLength: number;
+  onClick: () => void;
+}) {
+  const truncated = truncate(text, maxLength);
+  const isTruncated = text && text.length > maxLength;
+  return (
+    <span
+      onClick={isTruncated ? onClick : undefined}
+      className={isTruncated ? "cursor-pointer hover:underline" : ""}
+      title={isTruncated ? "Click to see full content" : undefined}
+    >
+      {truncated}
+    </span>
+  );
+}
+
+async function deleteSuggestion(
+  owner: LightWorkspaceType,
+  skillId: string,
+  suggestion: SkillSuggestionType,
+  onSuggestionDeleted: () => Promise<void>
+) {
+  if (
+    !window.confirm(
+      `Are you sure you want to delete suggestion "${suggestion.sId}"?`
+    )
+  ) {
+    return;
+  }
+
+  try {
+    const r = await clientFetch(
+      `/api/poke/workspaces/${owner.sId}/skills/${skillId}/suggestions?suggestionSId=${suggestion.sId}`,
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+    if (!r.ok) {
+      throw new Error("Failed to delete suggestion.");
+    }
+    await onSuggestionDeleted();
+  } catch (_e) {
+    window.alert("An error occurred while deleting the suggestion.");
+  }
+}
+
+export function makeColumnsForSkillSuggestions(
+  owner: LightWorkspaceType,
+  skillId: string,
+  onSuggestionDeleted: () => Promise<void>,
+  onSuggestionClick: (suggestion: SkillSuggestionType) => void
+): ColumnDef<SkillSuggestionType>[] {
+  return [
+    {
+      accessorKey: "sId",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
+    },
+    {
+      accessorKey: "kind",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Kind" />
+      ),
+      cell: ({ row }) => {
+        return (
+          <Chip color="info" size="xs">
+            {row.original.kind}
+          </Chip>
+        );
+      },
+      filterFn: (row, id, value) => {
+        return value.includes(row.getValue(id));
+      },
+    },
+    {
+      accessorKey: "state",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="State" />
+      ),
+      cell: ({ row }) => {
+        const state = row.original.state;
+        const colorMap: Record<
+          string,
+          "info" | "primary" | "warning" | "rose"
+        > = {
+          pending: "warning",
+          approved: "primary",
+          rejected: "rose",
+          outdated: "info",
+        };
+        return (
+          <Chip color={colorMap[state] ?? "info"} size="xs">
+            {state}
+          </Chip>
+        );
+      },
+      filterFn: (row, id, value) => {
+        return value.includes(row.getValue(id));
+      },
+    },
+    {
+      accessorKey: "source",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Source" />
+      ),
+      filterFn: (row, id, value) => {
+        return value.includes(row.getValue(id));
+      },
+    },
+    {
+      accessorKey: "sourceConversationId",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Conversation" />
+      ),
+      cell: ({ row }) => {
+        const conversationId = row.original.sourceConversationId;
+        if (!conversationId) {
+          return "-";
+        }
+        return (
+          <a
+            href={`/${owner.sId}/conversation/${conversationId}`}
+            className="text-action-500 hover:underline"
+          >
+            {conversationId}
+          </a>
+        );
+      },
+    },
+    {
+      accessorKey: "analysis",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Analysis" />
+      ),
+      cell: ({ row }) => {
+        return (
+          <ClickableCell
+            text={row.original.analysis}
+            maxLength={MAX_ANALYSIS_LENGTH}
+            onClick={() => onSuggestionClick(row.original)}
+          />
+        );
+      },
+    },
+    {
+      accessorKey: "createdAt",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Created at" />
+      ),
+      cell: ({ row }) => {
+        return formatTimestampToFriendlyDate(row.original.createdAt);
+      },
+    },
+    {
+      id: "content",
+      header: "Content",
+      cell: ({ row }) => {
+        const content = JSON.stringify(row.original.suggestion);
+        return (
+          <ClickableCell
+            text={content}
+            maxLength={MAX_CONTENT_LENGTH}
+            onClick={() => onSuggestionClick(row.original)}
+          />
+        );
+      },
+    },
+    {
+      id: "actions",
+      cell: ({ row }) => {
+        const suggestion = row.original;
+        return (
+          <IconButton
+            icon={TrashIcon}
+            size="xs"
+            variant="outline"
+            onClick={async () => {
+              await deleteSuggestion(
+                owner,
+                skillId,
+                suggestion,
+                onSuggestionDeleted
+              );
+            }}
+          />
+        );
+      },
+    },
+  ];
+}

--- a/front/components/poke/skill_suggestions/table.tsx
+++ b/front/components/poke/skill_suggestions/table.tsx
@@ -1,0 +1,139 @@
+import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { makeColumnsForSkillSuggestions } from "@app/components/poke/skill_suggestions/columns";
+import { usePokeSkillSuggestions } from "@app/poke/swr/skill_suggestions";
+import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import { asDisplayName } from "@app/types/shared/utils/string_utils";
+import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+import {
+  SKILL_SUGGESTION_KINDS,
+  SKILL_SUGGESTION_SOURCES,
+  SKILL_SUGGESTION_STATES,
+} from "@app/types/suggestions/skill_suggestion";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface SkillSuggestionDetailsDialogProps {
+  onClose: () => void;
+  suggestion: SkillSuggestionType;
+}
+
+function SkillSuggestionDetailsDialog({
+  suggestion,
+  onClose,
+}: SkillSuggestionDetailsDialogProps) {
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-h-[80vh] max-w-4xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Suggestion Details - {suggestion.sId}</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="space-y-6">
+            <div>
+              <h3 className="mb-2 text-sm font-semibold">Analysis</h3>
+              <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
+                <pre className="overflow-x-auto whitespace-pre-wrap text-sm">
+                  {suggestion.analysis ?? "No analysis"}
+                </pre>
+              </div>
+            </div>
+            <div>
+              <h3 className="mb-2 text-sm font-semibold">Content</h3>
+              <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
+                <pre className="overflow-x-auto whitespace-pre-wrap text-sm">
+                  {JSON.stringify(suggestion.suggestion, null, 2)}
+                </pre>
+              </div>
+            </div>
+          </div>
+        </DialogContainer>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface SkillSuggestionDataTableProps {
+  owner: LightWorkspaceType;
+  skillId: string;
+}
+
+export function SkillSuggestionDataTable({
+  owner,
+  skillId,
+}: SkillSuggestionDataTableProps) {
+  const [selectedSuggestion, setSelectedSuggestion] =
+    useState<SkillSuggestionType | null>(null);
+
+  const useSuggestionsWithSkill = (props: PokeConditionalFetchProps) =>
+    usePokeSkillSuggestions({ ...props, skillId });
+
+  const facets = [
+    {
+      columnId: "kind",
+      title: "Kind",
+      options: SKILL_SUGGESTION_KINDS.map((kind) => ({
+        label: asDisplayName(kind),
+        value: kind,
+      })),
+    },
+    {
+      columnId: "state",
+      title: "State",
+      options: SKILL_SUGGESTION_STATES.map((state) => ({
+        label: asDisplayName(state),
+        value: state,
+      })),
+    },
+    {
+      columnId: "source",
+      title: "Source",
+      options: SKILL_SUGGESTION_SOURCES.map((source) => ({
+        label: asDisplayName(source),
+        value: source,
+      })),
+    },
+  ];
+
+  return (
+    <>
+      {selectedSuggestion && (
+        <SkillSuggestionDetailsDialog
+          suggestion={selectedSuggestion}
+          onClose={() => setSelectedSuggestion(null)}
+        />
+      )}
+      <PokeDataTableConditionalFetch
+        header="Suggestions"
+        owner={owner}
+        useSWRHook={useSuggestionsWithSkill}
+      >
+        {(suggestions, mutate) => {
+          const columns = makeColumnsForSkillSuggestions(
+            owner,
+            skillId,
+            async () => {
+              await mutate();
+            },
+            setSelectedSuggestion
+          );
+
+          return (
+            <PokeDataTable<SkillSuggestionType, unknown>
+              columns={columns}
+              data={suggestions}
+              facets={facets}
+            />
+          );
+        }}
+      </PokeDataTableConditionalFetch>
+    </>
+  );
+}

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions.test.ts
@@ -1,0 +1,125 @@
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { describe, expect, it } from "vitest";
+
+import handler from "./suggestions";
+
+describe("GET /api/poke/workspaces/[wId]/skills/[sId]/suggestions", () => {
+  it("returns 404 for non super users", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: false,
+      role: "admin",
+    });
+
+    req.query = { wId: workspace.sId, sId: "some-skill-id" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+  });
+
+  it("returns suggestions for a given skill", async () => {
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const skill = await SkillFactory.create(auth);
+    await SkillSuggestionFactory.create(auth, skill);
+
+    req.query = { wId: workspace.sId, sId: skill.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.suggestions).toHaveLength(1);
+    expect(data.suggestions[0].kind).toBe("edit_instructions");
+  });
+
+  it("returns empty array when skill has no suggestions", async () => {
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const skill = await SkillFactory.create(auth);
+
+    req.query = { wId: workspace.sId, sId: skill.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.suggestions).toHaveLength(0);
+  });
+});
+
+describe("DELETE /api/poke/workspaces/[wId]/skills/[sId]/suggestions", () => {
+  it("returns 400 when suggestionSId query param is missing", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    req.query = { wId: workspace.sId, sId: "some-skill-id" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 404 when suggestion does not exist", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    req.query = {
+      wId: workspace.sId,
+      sId: "some-skill-id",
+      suggestionSId: "non-existent-suggestion-id",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("skill_not_found");
+  });
+
+  it("deletes the suggestion and returns 204", async () => {
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const skill = await SkillFactory.create(auth);
+    const suggestion = await SkillSuggestionFactory.create(auth, skill);
+
+    req.query = {
+      wId: workspace.sId,
+      sId: skill.sId,
+      suggestionSId: suggestion.sId,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(204);
+
+    // Verify the suggestion is actually deleted.
+    const deleted = await SkillSuggestionResource.fetchById(
+      auth,
+      suggestion.sId
+    );
+    expect(deleted).toBeNull();
+  });
+});

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions.test.ts
@@ -1,7 +1,7 @@
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { describe, expect, it } from "vitest";
 
 import handler from "./suggestions";

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
@@ -1,0 +1,110 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+import { SKILL_SUGGESTION_SOURCES } from "@app/types/suggestions/skill_suggestion";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type PokeListSkillSuggestions = {
+  suggestions: SkillSuggestionType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeListSkillSuggestions>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, sId } = req.query;
+  if (!isString(wId) || !isString(sId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or skill ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+
+  const owner = auth.workspace();
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const suggestions =
+        await SkillSuggestionResource.listBySkillConfigurationId(auth, sId, {
+          sources: [...SKILL_SUGGESTION_SOURCES],
+        });
+
+      return res.status(200).json({
+        suggestions: suggestions.map((s) => s.toJSON()),
+      });
+    }
+
+    case "DELETE": {
+      const { suggestionSId } = req.query;
+      if (!isString(suggestionSId)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The suggestion ID is required.",
+          },
+        });
+      }
+
+      const suggestion = await SkillSuggestionResource.fetchById(
+        auth,
+        suggestionSId
+      );
+      if (!suggestion) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "skill_not_found",
+            message: "The suggestion was not found.",
+          },
+        });
+      }
+
+      const deleteResult = await suggestion.delete(auth);
+      if (deleteResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to delete suggestion.",
+          },
+        });
+      }
+
+      res.status(204).end();
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method is not supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/poke/swr/skill_suggestions.ts
+++ b/front/poke/swr/skill_suggestions.ts
@@ -1,0 +1,31 @@
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeListSkillSuggestions } from "@app/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions";
+import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import type { Fetcher } from "swr";
+
+export interface PokeSkillSuggestionsFetchProps
+  extends PokeConditionalFetchProps {
+  skillId: string;
+}
+
+export function usePokeSkillSuggestions({
+  disabled,
+  owner,
+  skillId,
+}: PokeSkillSuggestionsFetchProps) {
+  const { fetcher } = useFetcher();
+  const suggestionsFetcher: Fetcher<PokeListSkillSuggestions> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/skills/${skillId}/suggestions`,
+    suggestionsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data?.suggestions ?? emptyArray(),
+    isLoading: !error && !data && !disabled,
+    isError: !!error,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/7382

 - Add suggestions view so we can debug mor easily the reinforcement workflow results 

<img width="3350" height="554" alt="image" src="https://github.com/user-attachments/assets/b25b15fc-2b46-4f0d-b3a3-17d3b13038a5" />

## Tests

Tested locally + unit test for poke endpoint

## Risk

low, it's poke

## Deploy Plan

deploy front 
