### PR TITLE
[snowflake] Skip dropped databases instead of failing the entire sync

### DIFF
--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -440,6 +440,8 @@ export const fetchTree = async (
   const allSchemas: RemoteDBSchema[] = [];
   const allTables: RemoteDBTable[] = [];
 
+  const skippedDatabases: string[] = [];
+
   for (const db of databases) {
     const schemasRes = await fetchSchemas({
       credentials,
@@ -447,6 +449,14 @@ export const fetchTree = async (
       connection,
     });
     if (schemasRes.isErr()) {
+      if (isSnowflakeObjectNotFoundError(schemasRes.error)) {
+        localLogger.warn(
+          { database: db.name },
+          "Database no longer exists or is inaccessible, skipping."
+        );
+        skippedDatabases.push(db.name);
+        continue;
+      }
       return schemasRes;
     }
     allSchemas.push(...schemasRes.value);
@@ -457,10 +467,22 @@ export const fetchTree = async (
       connection,
     });
     if (tablesRes.isErr()) {
+      if (isSnowflakeObjectNotFoundError(tablesRes.error)) {
+        localLogger.warn(
+          { database: db.name },
+          "Database no longer exists or is inaccessible, skipping."
+        );
+        skippedDatabases.push(db.name);
+        continue;
+      }
       return tablesRes;
     }
     allTables.push(...tablesRes.value);
   }
+
+  const activeDatabases = databases.filter(
+    (db) => !skippedDatabases.includes(db.name)
+  );
 
   const schemas = allSchemas.filter((s) => !EXCLUDE_SCHEMAS.includes(s.name));
   localLogger.info(
@@ -479,7 +501,7 @@ export const fetchTree = async (
   );
 
   const tree = {
-    databases: databases.map((db) => ({
+    databases: activeDatabases.map((db) => ({
       ...db,
       schemas: schemas
         .filter((s) => s.database_name === db.name)
@@ -771,6 +793,16 @@ async function _closeConnection(
   } catch (error) {
     return new Err(normalizeError(error));
   }
+}
+
+/**
+ * Snowflake error code 002043: "Object does not exist, or operation cannot be
+ * performed." Raised when a database or schema has been dropped / made
+ * inaccessible after SHOW DATABASES returned it.
+ */
+function isSnowflakeObjectNotFoundError(err: Error): boolean {
+  const code = (err as { code?: string }).code;
+  return code === "002043";
 }
 
 /**

--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -481,9 +481,7 @@ export const fetchTree = async (
   }
 
   const skippedSet = new Set(skippedDatabases);
-  const activeDatabases = databases.filter(
-    (db) => !skippedSet.has(db.name)
-  );
+  const activeDatabases = databases.filter((db) => !skippedSet.has(db.name));
 
   const schemas = allSchemas.filter((s) => !EXCLUDE_SCHEMAS.includes(s.name));
   localLogger.info(

--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -480,8 +480,9 @@ export const fetchTree = async (
     allTables.push(...tablesRes.value);
   }
 
+  const skippedSet = new Set(skippedDatabases);
   const activeDatabases = databases.filter(
-    (db) => !skippedDatabases.includes(db.name)
+    (db) => !skippedSet.has(db.name)
   );
 
   const schemas = allSchemas.filter((s) => !EXCLUDE_SCHEMAS.includes(s.name));
@@ -801,8 +802,7 @@ async function _closeConnection(
  * inaccessible after SHOW DATABASES returned it.
  */
 function isSnowflakeObjectNotFoundError(err: Error): boolean {
-  const code = (err as { code?: string }).code;
-  return code === "002043";
+  return "code" in err && (err as Error & { code: string }).code === "002043";
 }
 
 /**


### PR DESCRIPTION
## Description

When a Snowflake database is dropped or becomes inaccessible between the initial `SHOW DATABASES` and the subsequent `SHOW SCHEMAS IN DATABASE` / `SHOW TABLES IN DATABASE` queries, `fetchTree()` fails with Snowflake error code `002043` ("Object does not exist, or operation cannot be performed"). Since this error isn't caught, the Temporal activity retries indefinitely.

This PR makes `fetchTree()` gracefully skip databases that return this error:
- Detects Snowflake error code `002043` on `fetchSchemas` / `fetchTables` calls
- Logs a warning and excludes the database from the returned tree
- The downstream `sync()` call then garbage-collects any previously synced records for the dropped database

Other errors still propagate and fail the activity as before.

## Risk

*Low.* Only affects the specific `002043` error code. All other errors continue to propagate unchanged. The skipped database is simply omitted from the tree, which causes the existing GC logic to clean up stale records — no new deletion path is introduced.

## Deploy Plan

Regular deploy. The fix will unstick any Snowflake sync workflow currently retrying on a dropped database.