### PR TITLE
[front] GA `ask_user_question` tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1091,10 +1091,8 @@ export const INTERNAL_MCP_SERVERS = {
     id: 1028,
     availability: "auto",
     allowMultipleInstances: false,
-    isPreview: true,
-    isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("ask_user_question_tool");
-    },
+    isPreview: false,
+    isRestricted: undefined,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -13,11 +13,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Fallback to Vertex Anthropic for some Anthropic models",
     stage: "dust_only",
   },
-  ask_user_question_tool: {
-    description:
-      "Enable ask_user_question tool for agents to ask users questions",
-    stage: "dust_only",
-  },
   audit_logs: {
     description: "Enable audit log emission via WorkOS",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -680,7 +680,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "agent_management_tool"
   | "custom_model_feature"
   | "anthropic_vertex_fallback"
-  | "ask_user_question_tool"
   | "audit_logs"
   | "claude_4_5_opus_feature"
   | "claude_4_opus_feature"


### PR DESCRIPTION
## Description

- This PR removes the `ask_user_question_tool` feature flag.
- This tool allows agents to proactively ask questions to the user and collect their answer.
- It is automatically added to the dust and deep-dive global agents.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Run `ensure_all_auto_tools` script.
