### PR TITLE
[front] - feat(poke): Metronome data

### DIFF
--- a/front/components/poke/credits/PokeMetronomeUsageChart.tsx
+++ b/front/components/poke/credits/PokeMetronomeUsageChart.tsx
@@ -1,0 +1,61 @@
+import { BaseMetronomeUsageChart } from "@app/components/workspace/MetronomeUsageChart";
+import { formatPeriod } from "@app/components/workspace/ProgrammaticCostChart";
+import type { MetronomeUsageGroupByType } from "@app/lib/api/analytics/metronome_usage";
+import { getBillingCycleFromDay } from "@app/lib/client/subscription";
+import { usePokeMetronomeUsage } from "@app/poke/swr/credits";
+import type { WorkspaceType } from "@app/types/user";
+import { useState } from "react";
+
+interface PokeMetronomeUsageChartProps {
+  owner: WorkspaceType;
+  billingCycleStartDay: number;
+}
+
+export function PokeMetronomeUsageChart({
+  owner,
+  billingCycleStartDay,
+}: PokeMetronomeUsageChartProps) {
+  const [groupBy, setGroupBy] = useState<MetronomeUsageGroupByType | undefined>(
+    undefined
+  );
+  const [groupByCount, setGroupByCount] = useState<number>(5);
+  const [displayMode, setDisplayMode] = useState<"cumulative" | "daily">(
+    "cumulative"
+  );
+
+  const [selectedPeriod, setSelectedPeriod] = useState<string>(() => {
+    const currentBillingCycle = getBillingCycleFromDay(
+      billingCycleStartDay,
+      new Date(),
+      true
+    );
+    return formatPeriod(currentBillingCycle.cycleStart);
+  });
+
+  const { metronomeUsageData, isMetronomeUsageLoading, isMetronomeUsageError } =
+    usePokeMetronomeUsage({
+      owner,
+      selectedPeriod,
+      billingCycleStartDay,
+      groupBy,
+      groupByCount,
+      windowSize: displayMode === "cumulative" ? "HOUR" : "DAY",
+    });
+
+  return (
+    <BaseMetronomeUsageChart
+      metronomeUsageData={metronomeUsageData}
+      isLoading={isMetronomeUsageLoading}
+      isError={!!isMetronomeUsageError}
+      groupBy={groupBy}
+      setGroupBy={setGroupBy}
+      groupByCount={groupByCount}
+      setGroupByCount={setGroupByCount}
+      selectedPeriod={selectedPeriod}
+      setSelectedPeriod={setSelectedPeriod}
+      billingCycleStartDay={billingCycleStartDay}
+      displayMode={displayMode}
+      setDisplayMode={setDisplayMode}
+    />
+  );
+}

--- a/front/components/poke/credits/columns.tsx
+++ b/front/components/poke/credits/columns.tsx
@@ -5,7 +5,7 @@ import { dateToHumanReadable } from "@app/types/shared/utils/date_utils";
 import { Chip } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
-function formatMicroUsdToUsd(microUsdAmount: number): string {
+export function formatMicroUsdToUsd(microUsdAmount: number): string {
   return `$${(microUsdAmount / 1_000_000).toFixed(2)}`;
 }
 

--- a/front/components/poke/credits/metronome_columns.tsx
+++ b/front/components/poke/credits/metronome_columns.tsx
@@ -1,0 +1,109 @@
+import { formatMicroUsdToUsd } from "@app/components/poke/credits/columns";
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import { TYPE_COLORS } from "@app/components/workspace/CreditsList";
+import type { CreditDisplayData } from "@app/types/credits";
+import { dateToHumanReadable } from "@app/types/shared/utils/date_utils";
+import { Chip } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+
+export function makeColumnsForMetronomeBalances(): ColumnDef<CreditDisplayData>[] {
+  return [
+    {
+      accessorKey: "sId",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="ID" />
+      ),
+      cell: ({ row }) => (
+        <span className="font-mono text-xs">
+          {row.original.sId.slice(0, 8)}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "type",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Type" />
+      ),
+      cell: ({ row }) => {
+        const { type } = row.original;
+        return (
+          <Chip color={TYPE_COLORS[type] ?? "highlight"} size="xs">
+            {type}
+          </Chip>
+        );
+      },
+    },
+    {
+      accessorKey: "initialAmountMicroUsd",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Initial" />
+      ),
+      cell: ({ row }) =>
+        formatMicroUsdToUsd(row.original.initialAmountMicroUsd),
+    },
+    {
+      accessorKey: "consumedAmountMicroUsd",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Consumed" />
+      ),
+      cell: ({ row }) =>
+        formatMicroUsdToUsd(row.original.consumedAmountMicroUsd),
+    },
+    {
+      accessorKey: "remainingAmountMicroUsd",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Remaining" />
+      ),
+      cell: ({ row }) => {
+        const remaining = row.original.remainingAmountMicroUsd;
+        const initial = row.original.initialAmountMicroUsd;
+        const percentUsed =
+          initial > 0 ? ((initial - remaining) / initial) * 100 : 0;
+        const color =
+          percentUsed > 90
+            ? "text-red-600"
+            : percentUsed > 70
+              ? "text-warning-500"
+              : "text-green-600";
+        return <span className={color}>{formatMicroUsdToUsd(remaining)}</span>;
+      },
+    },
+    {
+      accessorKey: "startDate",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Start date" />
+      ),
+      cell: ({ row }) => {
+        const { startDate } = row.original;
+        if (!startDate) {
+          return <span className="text-warning">Not started</span>;
+        }
+        return (
+          <span className="text-sm">
+            {dateToHumanReadable(new Date(startDate))}
+          </span>
+        );
+      },
+    },
+    {
+      accessorKey: "expirationDate",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Expiration" />
+      ),
+      cell: ({ row }) => {
+        const { expirationDate } = row.original;
+        if (!expirationDate) {
+          return <span className="text-warning">No expiration</span>;
+        }
+        const expDate = new Date(expirationDate);
+        const isExpired = expDate < new Date();
+        return (
+          <span className={`text-sm ${isExpired ? "text-warning" : ""}`}>
+            {dateToHumanReadable(expDate)}
+            {isExpired && " (Expired)"}
+          </span>
+        );
+      },
+    },
+  ];
+}

--- a/front/components/poke/credits/metronome_columns.tsx
+++ b/front/components/poke/credits/metronome_columns.tsx
@@ -1,5 +1,4 @@
 import { formatMicroUsdToUsd } from "@app/components/poke/credits/columns";
-import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { TYPE_COLORS } from "@app/components/workspace/CreditsList";
 import type { CreditDisplayData } from "@app/types/credits";
 import { dateToHumanReadable } from "@app/types/shared/utils/date_utils";
@@ -10,9 +9,7 @@ export function makeColumnsForMetronomeBalances(): ColumnDef<CreditDisplayData>[
   return [
     {
       accessorKey: "sId",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="ID" />
-      ),
+      header: "ID",
       cell: ({ row }) => (
         <span className="font-mono text-xs">
           {row.original.sId.slice(0, 8)}
@@ -21,9 +18,7 @@ export function makeColumnsForMetronomeBalances(): ColumnDef<CreditDisplayData>[
     },
     {
       accessorKey: "type",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Type" />
-      ),
+      header: "Type",
       cell: ({ row }) => {
         const { type } = row.original;
         return (
@@ -35,25 +30,19 @@ export function makeColumnsForMetronomeBalances(): ColumnDef<CreditDisplayData>[
     },
     {
       accessorKey: "initialAmountMicroUsd",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Initial" />
-      ),
+      header: "Initial",
       cell: ({ row }) =>
         formatMicroUsdToUsd(row.original.initialAmountMicroUsd),
     },
     {
       accessorKey: "consumedAmountMicroUsd",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Consumed" />
-      ),
+      header: "Consumed",
       cell: ({ row }) =>
         formatMicroUsdToUsd(row.original.consumedAmountMicroUsd),
     },
     {
       accessorKey: "remainingAmountMicroUsd",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Remaining" />
-      ),
+      header: "Remaining",
       cell: ({ row }) => {
         const remaining = row.original.remainingAmountMicroUsd;
         const initial = row.original.initialAmountMicroUsd;
@@ -70,9 +59,7 @@ export function makeColumnsForMetronomeBalances(): ColumnDef<CreditDisplayData>[
     },
     {
       accessorKey: "startDate",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Start date" />
-      ),
+      header: "Start date",
       cell: ({ row }) => {
         const { startDate } = row.original;
         if (!startDate) {
@@ -87,9 +74,7 @@ export function makeColumnsForMetronomeBalances(): ColumnDef<CreditDisplayData>[
     },
     {
       accessorKey: "expirationDate",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Expiration" />
-      ),
+      header: "Expiration",
       cell: ({ row }) => {
         const { expirationDate } = row.original;
         if (!expirationDate) {

--- a/front/components/poke/credits/table.tsx
+++ b/front/components/poke/credits/table.tsx
@@ -1,4 +1,8 @@
-import { makeColumnsForCredits } from "@app/components/poke/credits/columns";
+import {
+  formatMicroUsdToUsd,
+  makeColumnsForCredits,
+} from "@app/components/poke/credits/columns";
+import { makeColumnsForMetronomeBalances } from "@app/components/poke/credits/metronome_columns";
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { safeLazy, Tooltip } from "@dust-tt/sparkle";
 import { Suspense } from "react";
@@ -12,7 +16,15 @@ const PokeProgrammaticCostChart = safeLazy(() =>
   )
 );
 
-function PokeProgrammaticCostChartFallback() {
+const PokeMetronomeUsageChart = safeLazy(() =>
+  import("@app/components/poke/credits/PokeMetronomeUsageChart").then(
+    (mod) => ({
+      default: mod.PokeMetronomeUsageChart,
+    })
+  )
+);
+
+function PokeChartFallback() {
   return (
     <div className="h-96 animate-pulse rounded-lg bg-muted-background dark:bg-muted-background-night" />
   );
@@ -20,8 +32,14 @@ function PokeProgrammaticCostChartFallback() {
 
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { PokeCreditType } from "@app/pages/api/poke/workspaces/[wId]/credits";
-import type { PokeCreditsData } from "@app/poke/swr/credits";
-import { usePokeCredits } from "@app/poke/swr/credits";
+import type {
+  PokeCreditsData,
+  PokeMetronomeBalancesData,
+} from "@app/poke/swr/credits";
+import {
+  usePokeCredits,
+  usePokeMetronomeBalances,
+} from "@app/poke/swr/credits";
 import type { SubscriptionType } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
 
@@ -51,10 +69,6 @@ function sortByStartDateDescending(
     // Most recent first (descending order)
     return new Date(b.startDate).getTime() - new Date(a.startDate).getTime();
   });
-}
-
-function formatMicroUsdToUsd(microUsd: number): string {
-  return (microUsd / 1_000_000).toFixed(2);
 }
 
 export function CreditsDataTable({
@@ -91,7 +105,7 @@ export function CreditsDataTable({
                   label="Excess credits are created when programmatic usage exceeds available credits. This tracks over-consumption that needs to be billed."
                   trigger={
                     <p className="cursor-help text-sm font-medium text-warning-800 dark:text-warning-800-night">
-                      Excess credits (last 30 days): $
+                      Excess credits (last 30 days):{" "}
                       {formatMicroUsdToUsd(
                         data.excessCreditsLast30DaysMicroUsd
                       )}
@@ -109,13 +123,38 @@ export function CreditsDataTable({
         )}
       </PokeDataTableConditionalFetch>
 
-      {billingCycleStartDay && (
-        <Suspense fallback={<PokeProgrammaticCostChartFallback />}>
-          <PokeProgrammaticCostChart
-            owner={owner}
-            billingCycleStartDay={billingCycleStartDay}
+      <PokeDataTableConditionalFetch<
+        PokeMetronomeBalancesData,
+        PokeMetronomeBalancesData
+      >
+        header="Metronome Balances"
+        owner={owner}
+        useSWRHook={usePokeMetronomeBalances}
+      >
+        {(data) => (
+          <PokeDataTable
+            columns={makeColumnsForMetronomeBalances()}
+            data={data.credits}
+            defaultFilterColumn="type"
           />
-        </Suspense>
+        )}
+      </PokeDataTableConditionalFetch>
+
+      {billingCycleStartDay && (
+        <div className="flex flex-col gap-4">
+          <Suspense fallback={<PokeChartFallback />}>
+            <PokeProgrammaticCostChart
+              owner={owner}
+              billingCycleStartDay={billingCycleStartDay}
+            />
+          </Suspense>
+          <Suspense fallback={<PokeChartFallback />}>
+            <PokeMetronomeUsageChart
+              owner={owner}
+              billingCycleStartDay={billingCycleStartDay}
+            />
+          </Suspense>
+        </div>
       )}
     </>
   );

--- a/front/components/workspace/MetronomeUsageChart.tsx
+++ b/front/components/workspace/MetronomeUsageChart.tsx
@@ -160,7 +160,7 @@ function UsageTooltip(
   return <ChartTooltipCard title={date} rows={rows} />;
 }
 
-function BaseMetronomeUsageChart({
+export function BaseMetronomeUsageChart({
   metronomeUsageData,
   isLoading,
   isError,

--- a/front/lib/api/analytics/metronome_usage.ts
+++ b/front/lib/api/analytics/metronome_usage.ts
@@ -1,6 +1,8 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import {
+  ceilToMidnightUTC,
+  floorToMidnightUTC,
   listMetronomeBalances,
   listMetronomeUsage,
   listMetronomeUsageWithGroups,
@@ -70,20 +72,6 @@ const GROUP_BY_TO_METRICS: Record<MetronomeUsageGroupByType, "llm" | "both"> = {
 
 const HOUR_MS = 3_600_000;
 const DAY_MS = 24 * HOUR_MS;
-
-// Metronome usage APIs require dates at UTC midnight boundaries.
-function floorToMidnightUTC(d: Date): Date {
-  return new Date(
-    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
-  );
-}
-
-function ceilToMidnightUTC(d: Date): Date {
-  const floored = floorToMidnightUTC(d);
-  return floored.getTime() < d.getTime()
-    ? new Date(floored.getTime() + DAY_MS)
-    : floored;
-}
 
 function getTimestampsForWindow(
   start: Date,

--- a/front/lib/api/analytics/metronome_usage.ts
+++ b/front/lib/api/analytics/metronome_usage.ts
@@ -212,16 +212,28 @@ export async function handleMetronomeUsageRequest(
         getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
 
       const TEN_DAYS_MS = 10 * 24 * 60 * 60 * 1000;
-      const cappedPeriodEnd = new Date(
+      const cappedEnd = new Date(
         Math.min(periodEnd.getTime(), Date.now() + TEN_DAYS_MS)
       );
 
-      const startingOn = periodStart.toISOString();
-      const endingBefore = cappedPeriodEnd.toISOString();
+      // Metronome requires dates at UTC midnight boundaries.
+      const floorToMidnight = (d: Date) =>
+        new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+      const ceilToMidnight = (d: Date) => {
+        const floored = floorToMidnight(d);
+        return floored.getTime() < d.getTime()
+          ? new Date(floored.getTime() + 86_400_000)
+          : floored;
+      };
+
+      const rangeStart = floorToMidnight(periodStart);
+      const rangeEnd = ceilToMidnight(cappedEnd);
+      const startingOn = rangeStart.toISOString();
+      const endingBefore = rangeEnd.toISOString();
 
       const timestamps = getTimestampsForWindow(
-        periodStart,
-        cappedPeriodEnd,
+        rangeStart,
+        rangeEnd,
         windowSize
       );
 

--- a/front/lib/api/analytics/metronome_usage.ts
+++ b/front/lib/api/analytics/metronome_usage.ts
@@ -68,6 +68,23 @@ const GROUP_BY_TO_METRICS: Record<MetronomeUsageGroupByType, "llm" | "both"> = {
   origin: "both",
 };
 
+const HOUR_MS = 3_600_000;
+const DAY_MS = 24 * HOUR_MS;
+
+// Metronome usage APIs require dates at UTC midnight boundaries.
+function floorToMidnightUTC(d: Date): Date {
+  return new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+  );
+}
+
+function ceilToMidnightUTC(d: Date): Date {
+  const floored = floorToMidnightUTC(d);
+  return floored.getTime() < d.getTime()
+    ? new Date(floored.getTime() + DAY_MS)
+    : floored;
+}
+
 function getTimestampsForWindow(
   start: Date,
   end: Date,
@@ -75,7 +92,7 @@ function getTimestampsForWindow(
 ): number[] {
   const timestamps: number[] = [];
   const current = new Date(start);
-  const incrementMs = windowSize === "DAY" ? 86_400_000 : 3_600_000;
+  const incrementMs = windowSize === "DAY" ? DAY_MS : HOUR_MS;
   while (current < end) {
     timestamps.push(current.getTime());
     current.setTime(current.getTime() + incrementMs);
@@ -216,18 +233,8 @@ export async function handleMetronomeUsageRequest(
         Math.min(periodEnd.getTime(), Date.now() + TEN_DAYS_MS)
       );
 
-      // Metronome requires dates at UTC midnight boundaries.
-      const floorToMidnight = (d: Date) =>
-        new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
-      const ceilToMidnight = (d: Date) => {
-        const floored = floorToMidnight(d);
-        return floored.getTime() < d.getTime()
-          ? new Date(floored.getTime() + 86_400_000)
-          : floored;
-      };
-
-      const rangeStart = floorToMidnight(periodStart);
-      const rangeEnd = ceilToMidnight(cappedEnd);
+      const rangeStart = floorToMidnightUTC(periodStart);
+      const rangeEnd = ceilToMidnightUTC(cappedEnd);
       const startingOn = rangeStart.toISOString();
       const endingBefore = rangeEnd.toISOString();
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -25,20 +25,29 @@ export function getMetronomeClient(): Metronome {
   return cachedClient;
 }
 
-// ---------------------------------------------------------------------------
-// Metronome requires dates on hour boundaries.
-// ---------------------------------------------------------------------------
-const HOUR_IN_MS = 3_600_000;
-function floorToHourISO(date: Date): string {
-  return new Date(
-    Math.floor(date.getTime() / HOUR_IN_MS) * HOUR_IN_MS
-  ).toISOString();
+// Metronome requires dates on specific boundaries (hour for contracts, midnight for usage).
+const HOUR_MS = 3_600_000;
+const DAY_MS = 24 * HOUR_MS;
+
+export function floorToHourISO(date: Date): string {
+  return new Date(Math.floor(date.getTime() / HOUR_MS) * HOUR_MS).toISOString();
 }
 
-function ceilToHourISO(date: Date): string {
+export function ceilToHourISO(date: Date): string {
+  return new Date(Math.ceil(date.getTime() / HOUR_MS) * HOUR_MS).toISOString();
+}
+
+export function floorToMidnightUTC(d: Date): Date {
   return new Date(
-    Math.ceil(date.getTime() / HOUR_IN_MS) * HOUR_IN_MS
-  ).toISOString();
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+  );
+}
+
+export function ceilToMidnightUTC(d: Date): Date {
+  const floored = floorToMidnightUTC(d);
+  return floored.getTime() < d.getTime()
+    ? new Date(floored.getTime() + DAY_MS)
+    : floored;
 }
 
 // ---------------------------------------------------------------------------

--- a/front/pages/api/poke/workspaces/[wId]/analytics/metronome-usage.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/metronome-usage.ts
@@ -1,0 +1,45 @@
+/** @ignoreswagger */
+import type { GetMetronomeUsageResponse } from "@app/lib/api/analytics/metronome_usage";
+import { handleMetronomeUsageRequest } from "@app/lib/api/analytics/metronome_usage";
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetMetronomeUsageResponse>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId } = req.query;
+  if (!isString(wId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to access was not found.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Could not find the workspace.",
+      },
+    });
+  }
+
+  return handleMetronomeUsageRequest(req, res, auth);
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/credits/metronome-balances.ts
+++ b/front/pages/api/poke/workspaces/[wId]/credits/metronome-balances.ts
@@ -1,0 +1,46 @@
+/** @ignoreswagger */
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { handleMetronomeBalancesRequest } from "@app/lib/api/credits/metronome_balances";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+import type { GetCreditsResponseBody } from "@app/types/credits";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetCreditsResponseBody>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId } = req.query;
+  if (!isString(wId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to access was not found.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Could not find the workspace.",
+      },
+    });
+  }
+
+  return handleMetronomeBalancesRequest(req, res, auth);
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -1,10 +1,18 @@
 import type {
+  GetMetronomeUsageResponse,
+  MetronomeUsageGroupByType,
+} from "@app/lib/api/analytics/metronome_usage";
+import type {
   GetWorkspaceProgrammaticCostResponse,
   GroupByType,
 } from "@app/lib/api/analytics/programmatic_cost";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListCreditsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import type {
+  CreditDisplayData,
+  GetCreditsResponseBody,
+} from "@app/types/credits";
 import type { Fetcher } from "swr";
 
 export type PokeCreditsData = {
@@ -80,5 +88,82 @@ export function usePokeProgrammaticCost({
     isProgrammaticCostLoading: !error && !data && !disabled,
     isProgrammaticCostError: error,
     isProgrammaticCostValidating: isValidating,
+  };
+}
+
+export function usePokeMetronomeUsage({
+  owner,
+  groupBy,
+  groupByCount,
+  selectedPeriod,
+  billingCycleStartDay,
+  windowSize,
+  disabled,
+}: PokeConditionalFetchProps & {
+  groupBy?: MetronomeUsageGroupByType;
+  groupByCount?: number;
+  selectedPeriod?: string;
+  billingCycleStartDay: number;
+  windowSize?: "HOUR" | "DAY";
+}) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<GetMetronomeUsageResponse> = fetcher;
+
+  const queryParams = new URLSearchParams();
+  queryParams.set("billingCycleStartDay", billingCycleStartDay.toString());
+  if (selectedPeriod) {
+    queryParams.set("selectedPeriod", selectedPeriod);
+  }
+  if (groupBy) {
+    queryParams.set("groupBy", groupBy);
+  }
+  if (groupByCount !== undefined) {
+    queryParams.set("groupByCount", groupByCount.toString());
+  }
+  if (windowSize) {
+    queryParams.set("windowSize", windowSize);
+  }
+  const queryString = queryParams.toString();
+  const key = `/api/poke/workspaces/${owner.sId}/analytics/metronome-usage?${queryString}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    metronomeUsageData: data,
+    isMetronomeUsageLoading: !error && !data && !disabled,
+    isMetronomeUsageError: error,
+    isMetronomeUsageValidating: isValidating,
+  };
+}
+
+export type PokeMetronomeBalancesData = {
+  credits: CreditDisplayData[];
+};
+
+export function usePokeMetronomeBalances({
+  disabled,
+  owner,
+}: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<GetCreditsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/credits/metronome-balances`,
+    fetcherFn,
+    { disabled }
+  );
+
+  const balancesData: PokeMetronomeBalancesData = {
+    credits: data?.credits ?? emptyArray(),
+  };
+
+  return {
+    data: balancesData,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
   };
 }


### PR DESCRIPTION
## Description

This PR adds poke API endpoints to access Metronome usage analytics and credit balances for workspace troubleshooting by Dust super users. Introduces `/api/poke/workspaces/[wId]/analytics/metronome-usage` and `/api/poke/workspaces/[wId]/credits/metronome-balances` endpoints that mirror the existing workspace endpoints but with poke authentication. Also adds corresponding SWR hooks (`usePokeMetronomeUsage`, `usePokeMetronomeBalances`) and UI components (`PokeMetronomeUsageChart`, metronome balance columns) to display the data in the poke credits table. This enables internal access to Metronome billing data for debugging and customer support without requiring workspace-level authentication.

## Tests

- [x] Locally

## Risk

Low. Poke endpoints are only accessible to Dust super users and don't modify any existing workspace functionality.

## Deploy Plan

Deploy front