### PR TITLE
[front] fix: add submit button for custom answer in `ask_user_question`

### DIFF
--- a/front/components/assistant/conversation/UserQuestionRequired.tsx
+++ b/front/components/assistant/conversation/UserQuestionRequired.tsx
@@ -179,13 +179,17 @@ export function UserQuestionRequired({
             disabled={selectedOptions.length === 0}
             onClick={handleMultiSelectSubmit}
           />
-        ): <Button
-          icon={ArrowUpIcon}
-          variant="highlight"
-          size="icon"
-          disabled={selectedOptions.length === 0 && isCustomResponseEmpty}
-          onClick={handleMultiSelectSubmit}
-        />}
+        ) : (
+          <Button
+            icon={ArrowUpIcon}
+            variant="highlight"
+            size="xs"
+            className="ml-auto"
+            disabled={isCustomResponseEmpty}
+            onClick={handleCustomResponseSubmit}
+            aria-label="Send custom response"
+          />
+        )}
       </div>
     </Card>
   );

--- a/front/components/assistant/conversation/UserQuestionRequired.tsx
+++ b/front/components/assistant/conversation/UserQuestionRequired.tsx
@@ -4,7 +4,14 @@ import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import type { UserQuestionAnswer } from "@app/lib/actions/types";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { Button, Card, Checkbox, Input, Spinner } from "@dust-tt/sparkle";
+import {
+  ArrowUpIcon,
+  Button,
+  Card,
+  Checkbox,
+  Input,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { useCallback, useState } from "react";
 
 interface UserQuestionRequiredProps {
@@ -35,6 +42,7 @@ export function UserQuestionRequired({
 
   const { question } = blockedAction;
   const isTriggeredByCurrentUser = blockedAction.userId === user?.sId;
+  const isCustomResponseEmpty = customResponse.trim().length === 0;
 
   const submitAnswer = useCallback(
     async (answer: UserQuestionAnswer) => {
@@ -74,13 +82,13 @@ export function UserQuestionRequired({
   );
 
   const handleCustomResponseSubmit = useCallback(() => {
-    if (customResponse.trim()) {
+    if (!isCustomResponseEmpty) {
       void submitAnswer({
         selectedOptions: [],
         customResponse: customResponse.trim(),
       });
     }
-  }, [customResponse, submitAnswer]);
+  }, [customResponse, isCustomResponseEmpty, submitAnswer]);
 
   const handleMultiSelectSubmit = useCallback(() => {
     if (selectedOptions.length === 0) {
@@ -163,7 +171,7 @@ export function UserQuestionRequired({
       )}
       <div className="flex gap-2">
         <Button label="Skip" variant="outline" size="xs" onClick={handleSkip} />
-        {question.multiSelect && (
+        {question.multiSelect ? (
           <Button
             label="Submit"
             variant="primary"
@@ -171,7 +179,13 @@ export function UserQuestionRequired({
             disabled={selectedOptions.length === 0}
             onClick={handleMultiSelectSubmit}
           />
-        )}
+        ): <Button
+          icon={ArrowUpIcon}
+          variant="highlight"
+          size="icon"
+          disabled={selectedOptions.length === 0 && isCustomResponseEmpty}
+          onClick={handleMultiSelectSubmit}
+        />}
       </div>
     </Card>
   );

--- a/front/components/assistant/conversation/UserQuestionRequired.tsx
+++ b/front/components/assistant/conversation/UserQuestionRequired.tsx
@@ -170,12 +170,12 @@ export function UserQuestionRequired({
         </div>
       )}
       <div className="flex gap-2">
-        <Button label="Skip" variant="outline" size="xs" onClick={handleSkip} />
+        <Button label="Skip" variant="outline" size="sm" onClick={handleSkip} />
         {question.multiSelect ? (
           <Button
             label="Submit"
             variant="primary"
-            size="xs"
+            size="sm"
             disabled={selectedOptions.length === 0}
             onClick={handleMultiSelectSubmit}
           />
@@ -183,7 +183,7 @@ export function UserQuestionRequired({
           <Button
             icon={ArrowUpIcon}
             variant="highlight"
-            size="xs"
+            size="sm"
             className="ml-auto"
             disabled={isCustomResponseEmpty}
             onClick={handleCustomResponseSubmit}


### PR DESCRIPTION
## Description

- This PR adds a submit button for the free text answer.
- The button is disabled when the text is empty.
- Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=4390-100649&t=alZvLDQWXkfIJ4nj-0).

<img width="749" height="421" alt="Screenshot 2026-04-08 at 4 02 18 PM" src="https://github.com/user-attachments/assets/f838e4f4-9108-432c-89cb-b2f0e1ee13ae" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
