### PR TITLE
[front] fix: Handle missing transaction <> cache dependencies

### DIFF
--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -11,6 +11,7 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import {
   batchInvalidateCacheWithRedis,
   cacheWithRedis,
+  invalidateCacheAfterCommit,
   invalidateCacheWithRedis,
 } from "@app/lib/utils/cache";
 import type { KeyType } from "@app/types/key";
@@ -129,7 +130,9 @@ export class KeyResource extends BaseResource<KeyModel> {
   ): Promise<[affectedCount: number]> {
     const oldSecret = this.secret;
     const result = await super.update(blob, transaction);
-    await KeyResource.invalidateKeyCache(oldSecret);
+    invalidateCacheAfterCommit(transaction, () =>
+      KeyResource.invalidateKeyCache(oldSecret)
+    );
     return result;
   }
 

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -379,9 +379,11 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   private static async _getActiveRoleForUserInWorkspaceUncached({
     userModelId,
     workspaceModelId,
+    transaction,
   }: {
     userModelId: ModelId;
     workspaceModelId: ModelId;
+    transaction?: Transaction;
   }): Promise<MembershipRoleType | "none"> {
     const membership = await MembershipModel.findOne({
       attributes: ["role"],
@@ -395,6 +397,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
           [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: new Date() }],
         },
       },
+      transaction,
     });
     return membership?.role ?? "none";
   }
@@ -426,6 +429,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       return this._getActiveRoleForUserInWorkspaceUncached({
         userModelId: user.id,
         workspaceModelId: workspace.id,
+        transaction,
       });
     }
     return this.getActiveRoleForUserInWorkspaceCached({


### PR DESCRIPTION
## Description

1. In Key resource, we're invalidating cache before the (optional) transaction is allowed to commit. 
This is an incident waiting to happen.

2. In Membership resource, we read from a snapshot that is potentially different than the (optional) transaction snapshot.
We do this by not passing along the transaction to the uncached fetch (the actual sql query).

This PR fixes both

## Tests

- Unit tests

## Risk

- Low

## Deploy Plan

- [ ] Deploy front