### PR TITLE
Remove panic from Metronome seat errors and add [Metronome] prefix

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -133,12 +133,11 @@ export async function createAndTrackMembership({
   if (addSeatResult.isErr()) {
     logger.error(
       {
-        panic: true,
         workspaceId: workspace.sId,
         userId: user.sId,
         error: addSeatResult.error,
       },
-      "Failed to add seat for new member"
+      "[Metronome] Failed to add seat for new member"
     );
   }
 
@@ -211,12 +210,11 @@ export async function revokeAndTrackMembership(
     if (removeSeatResult.isErr()) {
       logger.error(
         {
-          panic: true,
           workspaceId: workspace.sId,
           userId: user.sId,
           error: removeSeatResult.error,
         },
-        "Failed to remove seat for revoked member"
+        "[Metronome] Failed to remove seat for revoked member"
       );
     }
   }
@@ -289,12 +287,11 @@ export async function updateMembershipRoleAndTrack({
       if (addSeatResult.isErr()) {
         logger.error(
           {
-            panic: true,
             workspaceId: workspace.sId,
             userId: user.sId,
             error: addSeatResult.error,
           },
-          "Failed to add seat for re-activated member"
+          "[Metronome] Failed to add seat for re-activated member"
         );
       }
       await launchUpdateUsageWorkflow({ workspaceId: workspace.sId });


### PR DESCRIPTION
## Description

Replace panic: true with a [Metronome] log prefix on seat add/remove errors in membership operations, so the team can build a Datadog dashboard  filtering on the prefix instead of triggering alerts, while it's in progress work 🙏🏻 


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
