### PR TITLE
Start persisting tool outputs to conversation GCS path

### DIFF
--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -6,6 +6,7 @@ import {
 import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { processToolResults } from "@app/lib/actions/mcp_execution";
 import { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
@@ -15,6 +16,7 @@ import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { assert, describe, expect, it, vi } from "vitest";
 
 // Mock file storage to avoid cloud storage interactions.
@@ -188,5 +190,114 @@ describe("processToolResults", () => {
     if (stored.type === "resource" && "text" in stored.resource) {
       expect(stored.resource.text).toBe(smallText);
     }
+  });
+
+  it("should persist DATA_SOURCE_NODE_CONTENT block to tool_outputs/", async () => {
+    const { auth, conversation, action, toolConfiguration } = await setupTest();
+
+    vi.mocked(getPrivateUploadBucket).mockClear();
+
+    await processToolResults(auth, {
+      action,
+      conversation,
+      localLogger: logger.child({ test: true }),
+      toolCallResultContent: [
+        {
+          type: "resource",
+          resource: {
+            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_NODE_CONTENT,
+            uri: "notion://page/abc123",
+            text: "# My Notion Page\n\nSome content here.",
+            metadata: {
+              nodeId: "abc123",
+              title: "My Notion Page",
+              path: "/workspace/My Notion Page",
+              parentTitle: null,
+              lastUpdatedAt: "2026-01-01T00:00:00Z",
+              sourceUrl: null,
+              mimeType: "application/vnd.notion.page",
+              hasChildren: false,
+              connectorProvider: null,
+            },
+          },
+        },
+      ],
+      toolConfiguration,
+    });
+
+    const uploadCalls = vi
+      .mocked(getPrivateUploadBucket)
+      .mock.results.flatMap((r) =>
+        r.type === "return"
+          ? vi.mocked(r.value.uploadRawContentToBucket).mock.calls
+          : []
+      );
+
+    const toolOutputWrite = uploadCalls.find((call) =>
+      call[0].filePath.includes("tool_outputs/")
+    );
+    expect(toolOutputWrite).toBeDefined();
+    expect(toolOutputWrite?.[0].filePath).toMatch(/tool_outputs\/\d+_my_notion_page\.md$/);
+    expect(toolOutputWrite?.[0].content).toBe("# My Notion Page\n\nSome content here.");
+  });
+
+  it("should persist large plain text block to tool_outputs/ as .txt", async () => {
+    const { auth, conversation, action, toolConfiguration } = await setupTest();
+
+    vi.mocked(getPrivateUploadBucket).mockClear();
+
+    const largeText = "hello world ".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES);
+
+    await processToolResults(auth, {
+      action,
+      conversation,
+      localLogger: logger.child({ test: true }),
+      toolCallResultContent: [{ type: "text", text: largeText }],
+      toolConfiguration,
+    });
+
+    const uploadCalls = vi
+      .mocked(getPrivateUploadBucket)
+      .mock.results.flatMap((r) =>
+        r.type === "return"
+          ? vi.mocked(r.value.uploadRawContentToBucket).mock.calls
+          : []
+      );
+
+    const toolOutputWrite = uploadCalls.find((call) =>
+      call[0].filePath.includes("tool_outputs/")
+    );
+    expect(toolOutputWrite).toBeDefined();
+    expect(toolOutputWrite?.[0].filePath).toMatch(/tool_outputs\/\d+_test_server\.txt$/);
+  });
+
+  it("should persist large JSON text block to tool_outputs/ as .json", async () => {
+    const { auth, conversation, action, toolConfiguration } = await setupTest();
+
+    vi.mocked(getPrivateUploadBucket).mockClear();
+
+    const largeJson = JSON.stringify({ data: "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES) });
+
+    await processToolResults(auth, {
+      action,
+      conversation,
+      localLogger: logger.child({ test: true }),
+      toolCallResultContent: [{ type: "text", text: largeJson }],
+      toolConfiguration,
+    });
+
+    const uploadCalls = vi
+      .mocked(getPrivateUploadBucket)
+      .mock.results.flatMap((r) =>
+        r.type === "return"
+          ? vi.mocked(r.value.uploadRawContentToBucket).mock.calls
+          : []
+      );
+
+    const toolOutputWrite = uploadCalls.find((call) =>
+      call[0].filePath.includes("tool_outputs/")
+    );
+    expect(toolOutputWrite).toBeDefined();
+    expect(toolOutputWrite?.[0].filePath).toMatch(/tool_outputs\/\d+_test_server\.json$/);
   });
 });

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/actions/action_output_limits";
 import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { processToolResults } from "@app/lib/actions/mcp_execution";
+import { DataSourceNodeContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -197,6 +198,23 @@ describe("processToolResults", () => {
 
     vi.mocked(getPrivateUploadBucket).mockClear();
 
+    const dataSourceNodeResult: DataSourceNodeContentType = {
+      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_NODE_CONTENT,
+      uri: "notion://page/abc123",
+      text: "# My Notion Page\n\nSome content here.",
+      metadata: {
+        nodeId: "abc123",
+        title: "My Notion Page",
+        path: "/workspace/My Notion Page",
+        parentTitle: null,
+        lastUpdatedAt: "2026-01-01T00:00:00Z",
+        sourceUrl: null,
+        mimeType: "application/vnd.notion.page",
+        hasChildren: false,
+        connectorProvider: null,
+      },
+    };
+
     await processToolResults(auth, {
       action,
       conversation,
@@ -204,22 +222,7 @@ describe("processToolResults", () => {
       toolCallResultContent: [
         {
           type: "resource",
-          resource: {
-            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_NODE_CONTENT,
-            uri: "notion://page/abc123",
-            text: "# My Notion Page\n\nSome content here.",
-            metadata: {
-              nodeId: "abc123",
-              title: "My Notion Page",
-              path: "/workspace/My Notion Page",
-              parentTitle: null,
-              lastUpdatedAt: "2026-01-01T00:00:00Z",
-              sourceUrl: null,
-              mimeType: "application/vnd.notion.page",
-              hasChildren: false,
-              connectorProvider: null,
-            },
-          },
+          resource: dataSourceNodeResult,
         },
       ],
       toolConfiguration,
@@ -237,8 +240,12 @@ describe("processToolResults", () => {
       call[0].filePath.includes("tool_outputs/")
     );
     expect(toolOutputWrite).toBeDefined();
-    expect(toolOutputWrite?.[0].filePath).toMatch(/tool_outputs\/\d+_my_notion_page\.md$/);
-    expect(toolOutputWrite?.[0].content).toBe("# My Notion Page\n\nSome content here.");
+    expect(toolOutputWrite?.[0].filePath).toMatch(
+      /tool_outputs\/\d+_my_notion_page\.md$/
+    );
+    expect(toolOutputWrite?.[0].content).toBe(
+      "# My Notion Page\n\nSome content here."
+    );
   });
 
   it("should persist large plain text block to tool_outputs/ as .txt", async () => {
@@ -268,7 +275,9 @@ describe("processToolResults", () => {
       call[0].filePath.includes("tool_outputs/")
     );
     expect(toolOutputWrite).toBeDefined();
-    expect(toolOutputWrite?.[0].filePath).toMatch(/tool_outputs\/\d+_test_server\.txt$/);
+    expect(toolOutputWrite?.[0].filePath).toMatch(
+      /tool_outputs\/\d+_test_server\.txt$/
+    );
   });
 
   it("should persist large JSON text block to tool_outputs/ as .json", async () => {
@@ -276,7 +285,9 @@ describe("processToolResults", () => {
 
     vi.mocked(getPrivateUploadBucket).mockClear();
 
-    const largeJson = JSON.stringify({ data: "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES) });
+    const largeJson = JSON.stringify({
+      data: "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES),
+    });
 
     await processToolResults(auth, {
       action,
@@ -298,6 +309,8 @@ describe("processToolResults", () => {
       call[0].filePath.includes("tool_outputs/")
     );
     expect(toolOutputWrite).toBeDefined();
-    expect(toolOutputWrite?.[0].filePath).toMatch(/tool_outputs\/\d+_test_server\.json$/);
+    expect(toolOutputWrite?.[0].filePath).toMatch(
+      /tool_outputs\/\d+_test_server\.json$/
+    );
   });
 });

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -13,11 +13,11 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { assert, describe, expect, it, vi } from "vitest";
 

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -5,7 +5,7 @@ import {
 } from "@app/lib/actions/action_output_limits";
 import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { processToolResults } from "@app/lib/actions/mcp_execution";
-import { DataSourceNodeContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { DataSourceNodeContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -17,6 +17,7 @@ import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { assert, describe, expect, it, vi } from "vitest";
 
@@ -195,6 +196,7 @@ describe("processToolResults", () => {
 
   it("should persist DATA_SOURCE_NODE_CONTENT block to tool_outputs/", async () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
     vi.mocked(getPrivateUploadBucket).mockClear();
 
@@ -250,6 +252,7 @@ describe("processToolResults", () => {
 
   it("should persist large plain text block to tool_outputs/ as .txt", async () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
     vi.mocked(getPrivateUploadBucket).mockClear();
 
@@ -282,6 +285,7 @@ describe("processToolResults", () => {
 
   it("should persist large JSON text block to tool_outputs/ as .json", async () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
     vi.mocked(getPrivateUploadBucket).mockClear();
 

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -27,6 +27,7 @@ import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import { persistToolOutput } from "@app/lib/api/files/action_output_fs";
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -160,6 +161,9 @@ export async function processToolResults(
     conversationId: conversation.sId,
   };
 
+  const flags = await getFeatureFlags(auth);
+  const hasSandbox = flags.includes("sandbox_tools");
+
   const timestamp = Date.now();
   const cleanContent: {
     content: CallToolResult["content"][number];
@@ -167,11 +171,11 @@ export async function processToolResults(
   }[] = await concurrentExecutor(
     toolCallResultContent,
     async (block, idx) => {
-      // Side effect: write qualifying blocks to tool_outputs/ in GCS.
-      // TODO(2026-04-08: SANDBOX): Make this the default path.
-      await persistToolOutput(auth, conversation, block, {
-        toolName: toolConfiguration.mcpServerName,
-      });
+      if (hasSandbox) {
+        await persistToolOutput(auth, conversation, block, {
+          toolName: toolConfiguration.mcpServerName,
+        });
+      }
 
       switch (block.type) {
         case "text": {

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -24,6 +24,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { handleBase64Upload } from "@app/lib/actions/mcp_utils";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
+import { persistToolOutput } from "@app/lib/api/files/action_output_fs";
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
@@ -166,6 +167,12 @@ export async function processToolResults(
   }[] = await concurrentExecutor(
     toolCallResultContent,
     async (block, idx) => {
+      // Side effect: write qualifying blocks to tool_outputs/ in GCS.
+      // TODO(2026-04-08: SANDBOX): Make this the default path.
+      await persistToolOutput(auth, conversation, block, {
+        toolName: toolConfiguration.mcpServerName,
+      });
+
       switch (block.type) {
         case "text": {
           // If the text is too large we create a file and return a resource block that references the file.

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -1,0 +1,105 @@
+import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
+import {
+  resolveResourceOutput,
+  shouldOffloadTextBlock,
+} from "@app/lib/api/files/action_output_fs/registry";
+import { getConversationToolOutputsBasePath } from "@app/lib/api/files/mount_path";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { AllSupportedFileContentType } from "@app/types/files";
+import { slugify } from "@app/types/shared/utils/string_utils";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+// Action output file system.
+//
+// Writes qualifying tool output blocks to the conversation's tool_outputs GCS path as a side effect
+// of processToolResults. Files are conversation-scoped and are not tracked in the database. They
+// are cleaned up when the conversation is scrubbed.
+//
+// Two cases are handled:
+//   1. Resource blocks whose mimeType is registered in resolveResourceOutput.
+//   2. Plain text blocks that exceed FILE_OFFLOAD_TEXT_SIZE_BYTES (with JSON sniffing for a better
+//      file extension).
+
+
+export interface PersistedToolOutput {
+  // Filename within tool_outputs/ — what the model and sandbox use.
+  fileName: string;
+}
+
+/**
+ * Attempts to persist a tool output block to the conversation's tool_outputs GCS path.
+ * Returns null if the block does not qualify for persistence.
+ *
+ * Call this as a side effect from processToolResults.
+ */
+export async function persistToolOutput(
+  auth: Authenticator,
+  conversation: ConversationType,
+  block: CallToolResult["content"][number],
+  { toolName }: { toolName: string }
+): Promise<PersistedToolOutput | null> {
+  const owner = auth.getNonNullableWorkspace();
+  const basePath = getConversationToolOutputsBasePath({
+    workspaceId: owner.sId,
+    conversationId: conversation.sId,
+  });
+
+  // Resource blocks (registered mimeTypes).
+  const resolved = resolveResourceOutput(block);
+  if (resolved) {
+    const { fileName: rawName, content, storageContentType } = resolved;
+    const ext = storageContentType === "application/json" ? ".json" : ".md";
+    const fileName = makeFileName({ name: rawName, ext });
+
+    await getPrivateUploadBucket().uploadRawContentToBucket({
+      content,
+      contentType: storageContentType,
+      filePath: `${basePath}${fileName}`,
+    });
+
+    return { fileName };
+  }
+
+  // Text blocks above the offload threshold.
+  if (shouldOffloadTextBlock(block)) {
+    const { fileName, contentType } = inferTextFileMetadata(block.text, toolName);
+
+    await getPrivateUploadBucket().uploadRawContentToBucket({
+      content: block.text,
+      contentType,
+      filePath: `${basePath}${fileName}`,
+    });
+
+    return { fileName };
+  }
+
+  return null;
+}
+
+/**
+ * Infers filename and content-type for a plain text block.
+ * Sniffs for JSON to assign a .json extension; falls back to .txt.
+ */
+function inferTextFileMetadata(
+  text: string,
+  toolName: string
+): { fileName: string; contentType: AllSupportedFileContentType } {
+  const trimmed = text.trimStart();
+  const isJson =
+    (trimmed.startsWith("{") || trimmed.startsWith("[")) &&
+    (() => {
+      try {
+        JSON.parse(text);
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+
+  const slug = slugify(toolName) || "output";
+  return isJson
+    ? { fileName: makeFileName({ name: slug, ext: ".json" }), contentType: "application/json" }
+    : { fileName: makeFileName({ name: slug, ext: ".txt" }), contentType: "text/plain" };
+}

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -22,7 +22,6 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 //   2. Plain text blocks that exceed FILE_OFFLOAD_TEXT_SIZE_BYTES (with JSON sniffing for a better
 //      file extension).
 
-
 export interface PersistedToolOutput {
   // Filename within tool_outputs/ — what the model and sandbox use.
   fileName: string;
@@ -64,7 +63,10 @@ export async function persistToolOutput(
 
   // Text blocks above the offload threshold.
   if (shouldOffloadTextBlock(block)) {
-    const { fileName, contentType } = inferTextFileMetadata(block.text, toolName);
+    const { fileName, contentType } = inferTextFileMetadata(
+      block.text,
+      toolName
+    );
 
     await getPrivateUploadBucket().uploadRawContentToBucket({
       content: block.text,
@@ -100,6 +102,12 @@ function inferTextFileMetadata(
 
   const slug = slugify(toolName) || "output";
   return isJson
-    ? { fileName: makeFileName({ name: slug, ext: ".json" }), contentType: "application/json" }
-    : { fileName: makeFileName({ name: slug, ext: ".txt" }), contentType: "text/plain" };
+    ? {
+        fileName: makeFileName({ name: slug, ext: ".json" }),
+        contentType: "application/json",
+      }
+    : {
+        fileName: makeFileName({ name: slug, ext: ".txt" }),
+        contentType: "text/plain",
+      };
 }

--- a/front/lib/api/files/action_output_fs/naming.ts
+++ b/front/lib/api/files/action_output_fs/naming.ts
@@ -1,0 +1,21 @@
+import { slugify } from "@app/types/shared/utils/string_utils";
+
+export function uriToSlug(uri: string): string {
+  try {
+    const url = new URL(uri);
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    const last = pathParts.at(-1) ?? url.hostname;
+    return slugify(last || url.hostname);
+  } catch {
+    // Not a valid URL, use as-is.
+    return slugify(uri.split("/").at(-1) ?? uri);
+  }
+}
+
+/**
+ * Builds a tool output filename. The timestamp prefix is mandatory so that files are naturally
+ * ordered when listing the tool_outputs/ folder and are never silently overwritten across runs.
+ */
+export function makeFileName({ ext, name }: { ext: string; name: string; }): string {
+  return `${Date.now()}_${slugify(name)}${ext}`;
+}

--- a/front/lib/api/files/action_output_fs/naming.ts
+++ b/front/lib/api/files/action_output_fs/naming.ts
@@ -16,6 +16,12 @@ export function uriToSlug(uri: string): string {
  * Builds a tool output filename. The timestamp prefix is mandatory so that files are naturally
  * ordered when listing the tool_outputs/ folder and are never silently overwritten across runs.
  */
-export function makeFileName({ ext, name }: { ext: string; name: string; }): string {
+export function makeFileName({
+  ext,
+  name,
+}: {
+  ext: string;
+  name: string;
+}): string {
   return `${Date.now()}_${slugify(name)}${ext}`;
 }

--- a/front/lib/api/files/action_output_fs/registry.ts
+++ b/front/lib/api/files/action_output_fs/registry.ts
@@ -1,0 +1,56 @@
+import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
+import {
+  isBrowseResultResourceType,
+  isDataSourceNodeContentType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { uriToSlug } from "@app/lib/api/files/action_output_fs/naming";
+import type { AllSupportedFileContentType } from "@app/types/files";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+// Registry mapping tool output blocks to GCS persistence descriptors.
+//
+// To add support for a new type: add one branch to resolveResourceOutput.
+// Reuse the typeguard and type already defined in output_schemas.ts.
+
+export interface ResolvedOutput {
+  fileName: string;
+  content: string;
+  storageContentType: AllSupportedFileContentType;
+}
+
+/**
+ * Maps a resource block to a GCS persistence descriptor.
+ * Returns null if the block type is not eligible for persistence.
+ */
+export function resolveResourceOutput(
+  block: CallToolResult["content"][number]
+): ResolvedOutput | null {
+  if (isDataSourceNodeContentType(block)) {
+    const r = block.resource;
+    return {
+      fileName: r.metadata.title,
+      content: r.text,
+      storageContentType: "text/plain",
+    };
+  }
+
+  if (isBrowseResultResourceType(block)) {
+    const r = block.resource;
+    return {
+      fileName: r.title ?? uriToSlug(r.uri),
+      content: r.text,
+      storageContentType: "text/plain",
+    };
+  }
+
+  return null;
+}
+
+export function shouldOffloadTextBlock(
+  block: CallToolResult["content"][number]
+): block is { type: "text"; text: string } {
+  return (
+    block.type === "text" &&
+    Buffer.byteLength(block.text, "utf8") > FILE_OFFLOAD_TEXT_SIZE_BYTES
+  );
+}

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -22,6 +22,16 @@ export function getConversationFilesBasePath({
   return `${getBaseMountPathForWorkspace({ workspaceId })}conversations/${conversationId}/files/`;
 }
 
+export function getConversationToolOutputsBasePath({
+  workspaceId,
+  conversationId,
+}: {
+  workspaceId: string;
+  conversationId: string;
+}): string {
+  return `${getConversationFilesBasePath({ workspaceId, conversationId })}tool_outputs/`;
+}
+
 export function getConversationFilePath({
   workspaceId,
   conversationId,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We're moving away from creating `FileResource` DB records for tool outputs. The goal is to write them as plain files directly under the conversation's GCS path (`tool_outputs/` subfolder). No DB record, conversation-scoped lifecycle, cleaned up at scrub time. This aligns with the broader effort to consolidate all conversation file I/O around the GCS mount path.

> [!WARNING]
> Some iteration around the file extension will be required. Material for follow up PRs.

This PR lays the groundwork. No existing behavior changes.

This first PR covers two use cases:
1. When retrieving the content of a data source node -> content is mounted in the conversation folder and made available in the sandbox
2. For text outputs which targets most external + internal (_for now_) MCP servers. If above a certain threshold (20KB) then it will be saved either as plain text or narrowed down if valid JSON.

What's coming next?
- We will cover lots of other resource mime types
- Refactor some internal MCP servers to be more specific on the return type

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
