### PR TITLE
Add `workspace_only` to Frame Sharing Option

### DIFF
--- a/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
+++ b/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
@@ -74,7 +74,7 @@ const ALLOWED_SCOPES_BY_POLICY: Record<
   WorkspaceSharingPolicy,
   FileShareScope[]
 > = {
-  emails_only: ["emails_only"],
+  workspace_only: ["workspace_and_emails"],
   workspace_and_emails: ["emails_only", "workspace_and_emails"],
   all_scopes: ["emails_only", "workspace_and_emails", "public"],
 };
@@ -151,7 +151,8 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
   );
 
   const showEmailSection =
-    currentScope === "emails_only" || currentScope === "workspace_and_emails";
+    owner.sharingPolicy !== "workspace_only" &&
+    (currentScope === "emails_only" || currentScope === "workspace_and_emails");
 
   const onInviteSubmit = async (data: InviteFormValues) => {
     const emails = data.emailsRaw

--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -29,9 +29,9 @@ const SHARING_POLICY_OPTIONS: {
 }[] = [
   {
     icon: LockIcon,
-    label: "Email invites only",
-    description: "Frames can only be shared via email invite",
-    value: "emails_only",
+    label: "Workspace members only",
+    description: "Frames can only be viewed by workspace members",
+    value: "workspace_only",
   },
   {
     icon: UserGroupIcon,

--- a/front/lib/api/share/frame_sharing.ts
+++ b/front/lib/api/share/frame_sharing.ts
@@ -15,8 +15,9 @@ export function getDefaultFrameShareScope(
   sharingPolicy: WorkspaceSharingPolicy
 ): FileShareScope {
   switch (sharingPolicy) {
-    case "emails_only":
-      return "emails_only";
+    // TODO(2026-04-08 FRAME SHARING): Rework logic here.
+    case "workspace_only":
+      return "workspace_and_emails";
     case "workspace_and_emails":
     case "all_scopes":
       return "workspace_and_emails";

--- a/front/lib/misc.test.ts
+++ b/front/lib/misc.test.ts
@@ -14,7 +14,7 @@ function makeWorkspace(sId: string): LightWorkspaceType {
     whiteListedProviders: null,
     defaultEmbeddingProvider: null,
     metronomeCustomerId: null,
-    sharingPolicy: "emails_only",
+    sharingPolicy: "workspace_only",
   };
 }
 

--- a/front/migrations/db/migration_568.sql
+++ b/front/migrations/db/migration_568.sql
@@ -1,0 +1,5 @@
+UPDATE workspaces
+SET
+  "sharingPolicy" = 'workspace_only'
+WHERE
+  metadata->>'allowContentCreationFileSharing' = 'false';

--- a/front/pages/api/v1/public/frames/[token]/index.test.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.test.ts
@@ -6,6 +6,7 @@ import {
   ExternalViewerSessionModel,
   SharingGrantModel,
 } from "@app/lib/resources/storage/models/files";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -426,6 +427,53 @@ describe("GET /api/v1/public/frames/[token]", () => {
 
       expect(res._getStatusCode()).toBe(200);
       expect(res._getJSONData()).toHaveProperty("accessToken");
+    });
+  });
+
+  describe("workspace_only policy", () => {
+    beforeEach(async () => {
+      await WorkspaceModel.update(
+        { sharingPolicy: "workspace_only" },
+        { where: { sId: workspace.sId } }
+      );
+    });
+
+    it("blocks external user with a valid email grant", async () => {
+      const { file, token } = await createFrameWithScope("emails_only");
+      vi.mocked(getAuthForSharedEndpointWorkspaceMembersOnly).mockResolvedValue(
+        null
+      );
+
+      const sessionToken = await createGrantAndSession(
+        file,
+        "viewer@example.com"
+      );
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { token },
+      });
+      req.cookies = { dust_frame_session: sessionToken };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+    });
+
+    it("still allows authenticated workspace member", async () => {
+      const { token } = await createFrameWithScope("workspace_and_emails");
+      vi.mocked(getAuthForSharedEndpointWorkspaceMembersOnly).mockResolvedValue(
+        auth
+      );
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { token },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
     });
   });
 

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -125,6 +125,17 @@ async function handler(
     workspace.sId
   );
 
+  // If workspace policy restricts to members only, block all non-member access.
+  if (workspace.sharingPolicy === "workspace_only" && !auth) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "file_not_found",
+        message: "File not found.",
+      },
+    });
+  }
+
   // Handle email-based share scopes (treat legacy "workspace" as "workspace_and_emails").
   if (
     shareScope === "emails_only" ||

--- a/front/pages/api/w/[wId]/auth-context.ts
+++ b/front/pages/api/w/[wId]/auth-context.ts
@@ -1,6 +1,5 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import config from "@app/lib/api/config";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -97,7 +96,7 @@ async function handler(
     isBuilder: auth.isBuilder(),
     featureFlags,
     ...(isEligibleForTrial !== undefined && { isEligibleForTrial }),
-    vizUrl: config.getVizPublicUrl(),
+    vizUrl: "http://localhost:3007",
     providersHealth: auth.providersHealth(),
   });
 }

--- a/front/pages/api/w/[wId]/auth-context.ts
+++ b/front/pages/api/w/[wId]/auth-context.ts
@@ -1,5 +1,6 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -96,7 +97,7 @@ async function handler(
     isBuilder: auth.isBuilder(),
     featureFlags,
     ...(isEligibleForTrial !== undefined && { isEligibleForTrial }),
-    vizUrl: "http://localhost:3007",
+    vizUrl: config.getVizPublicUrl(),
     providersHealth: auth.providersHealth(),
   });
 }

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -62,7 +62,7 @@ const WorkspaceInteractiveContentSharingUpdateBodySchema = t.type({
 const WorkspaceSharingPolicyUpdateBodySchema = t.type({
   sharingPolicy: t.union([
     t.literal("all_scopes"),
-    t.literal("emails_only"),
+    t.literal("workspace_only"),
     t.literal("workspace_and_emails"),
   ]),
 });

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -42,7 +42,7 @@ export function isActiveRoleType(role: string): role is ActiveRoleType {
 }
 
 export type WorkspaceSharingPolicy =
-  | "emails_only"
+  | "workspace_only"
   | "workspace_and_emails"
   | "all_scopes";
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR renames the most restrictive frame sharing policy from `emails_only` to `workspace_only` in the admin settings, replacing the "Email invites only" label with "Workspace members only". This gives admins an explicit control to prevent any external sharing across the workspace.

When `workspace_only` is set, the email invite form is hidden in the sharing sheet. Enforcing the ceiling at the UI level without leaking policy logic into the per-frame sharing experience.

This introduces a deliberate split: workspace-level sharing policies (admin concern, low frequency) vs. the per-frame sharing sheet (user concern, high frequency). The sharing sheet UI will be revisited separately once usage patterns around `emails_only` as a per-frame scope become clearer.

<img width="439" height="264" alt="image" src="https://github.com/user-attachments/assets/b5397e20-f39b-4073-9b2c-ffd4f11e44fe" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] Once deploy apply migration in both regions
