### PR TITLE
Add conference data (meeting links) to Google Calendar tool output

### DIFF
--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -280,6 +280,18 @@ export function formatEventAsText(event: EnrichedGoogleCalendarEvent): string {
     lines.push(`Location: ${event.location}`);
   }
 
+  if (event.conferenceData?.entryPoints) {
+    const meetingLinks = event.conferenceData.entryPoints
+      .filter((ep) => ep.uri)
+      .map((ep) => {
+        const type = ep.entryPointType ?? "Meeting";
+        return `${ep.uri}${ep.label ? ` (${ep.label})` : ` (${type})`}`;
+      });
+    if (meetingLinks.length > 0) {
+      lines.push(`Meeting Link${meetingLinks.length > 1 ? "s" : ""}: ${meetingLinks.join(", ")}`);
+    }
+  }
+
   if (event.description) {
     lines.push(`Description: ${event.description}`);
   }

--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -288,7 +288,9 @@ export function formatEventAsText(event: EnrichedGoogleCalendarEvent): string {
         return `${ep.uri}${ep.label ? ` (${ep.label})` : ` (${type})`}`;
       });
     if (meetingLinks.length > 0) {
-      lines.push(`Meeting Link${meetingLinks.length > 1 ? "s" : ""}: ${meetingLinks.join(", ")}`);
+      lines.push(
+        `Meeting Link${meetingLinks.length > 1 ? "s" : ""}: ${meetingLinks.join(", ")}`
+      );
     }
   }
 

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -43,6 +43,7 @@ function makeSkillType(config: MockSkillConfig): SkillType {
     agentFacingDescription: config.description ?? "",
     userFacingDescription: config.description ?? "",
     instructions: config.instructions ?? null,
+    instructionsHtml: null,
     icon: null,
     source: null,
     sourceMetadata: null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR adds support for displaying conference data (meeting links like Google Meet URLs) in the Google Calendar tool output. Previously, the `formatEventAsText` helper was dropping the `conferenceData.entryPoints[].uri` field even though the Google Calendar API returns it.

This addresses the feature request from @vince in #product_ideas-and-feedback where he noted that meeting links were being silently discarded before reaching the agent.

**Changes:**
- Modified `formatEventAsText` in `helpers.ts` to extract and display meeting links from `conferenceData.entryPoints`
- Meeting links are displayed after the Location field and before Description
- Supports multiple entry points with labels or types
- The field already exists in the `GoogleCalendarEvent` TypeScript interface (lines 72-99), so no schema changes needed

## Tests

The change is straightforward and doesn't require new dependencies or API calls:
- The Google Calendar API already returns `conferenceData` in the event response
- The TypeScript types already define the `conferenceData` structure
- The implementation safely handles optional fields using optional chaining (`?.`)
- Manually verified the logic matches the existing pattern used for other optional fields

Due to the environment not having dependencies installed, I was unable to run automated tests. However, the change follows the exact same pattern as the existing code for optional fields like `location`, `description`, and `attendees`.

## Risk

**Low risk:**
- Read-only change - only affects how data is formatted for display
- Uses optional chaining to safely handle missing fields
- No API changes, no database changes, no breaking changes
- The field is already part of the API response, we're just surfacing it
- Gracefully handles cases where conferenceData is undefined or empty

## Deploy Plan

Standard deployment - no special steps required:
1. Merge to main
2. Deploy normally
3. The change will immediately apply to both `get_event` and `list_events` tools since they both use the `formatEventAsText` helper
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dust4ai.slack.com/archives/C066R3PMUAU/p1775675276583079?thread_ts=1775675276.583079&cid=C066R3PMUAU)

<div><a href="https://cursor.com/agents/bc-7c6b1cbc-d139-5010-b41a-36e115b4bbe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c6b1cbc-d139-5010-b41a-36e115b4bbe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

