### PR TITLE
Improve reinforced skill analyze conversation tool and prompt

### DIFF
--- a/front/lib/api/skills/apply_skill_instruction_edits.ts
+++ b/front/lib/api/skills/apply_skill_instruction_edits.ts
@@ -1,0 +1,30 @@
+import type { SkillInstructionEditItemType } from "@app/types/suggestions/skill_suggestion";
+
+function countSubstringOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) {
+    return 0;
+  }
+  let count = 0;
+  let pos = 0;
+  while ((pos = haystack.indexOf(needle, pos)) !== -1) {
+    count++;
+    pos += needle.length;
+  }
+  return count;
+}
+
+export function getSkillInstructionEditsValidationError(
+  instructions: string,
+  edits: SkillInstructionEditItemType[]
+): string | null {
+  let current = instructions;
+  for (let i = 0; i < edits.length; i++) {
+    const edit = edits[i];
+    const count = countSubstringOccurrences(current, edit.old_string);
+    if (count !== edit.expected_occurrences) {
+      return `Edit ${i + 1}: expected ${edit.expected_occurrences} occurrence(s) of old_string but found ${count}.`;
+    }
+    current = current.replaceAll(edit.old_string, edit.new_string);
+  }
+  return null;
+}

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -41,9 +41,15 @@ function makeInstructionSuggestion(
     state: "pending",
     source: "synthetic",
     sourceConversationId: null,
-    kind: "edit_instructions",
+    kind: "edit",
     suggestion: {
-      instructions: "Always verify data before responding.",
+      instructionEdits: [
+        {
+          old_string: "verify data",
+          new_string: "always verify data before responding",
+          expected_occurrences: 1,
+        },
+      ],
     },
     ...overrides,
   } as SkillSuggestionType;
@@ -61,10 +67,9 @@ function makeToolSuggestion(
     state: "pending",
     source: "synthetic",
     sourceConversationId: null,
-    kind: "tools",
+    kind: "edit",
     suggestion: {
-      action: "add",
-      toolId: "tool-search",
+      toolEdits: [{ action: "add", toolId: "tool-search" }],
     },
     ...overrides,
   } as SkillSuggestionType;
@@ -78,14 +83,20 @@ describe("buildSkillAggregationPrompt", () => {
       { pending: [], rejected: [] }
     );
 
-    expect(userMessage).toContain("Skill: DataLookup");
+    expect(userMessage).toContain('name="DataLookup"');
   });
 
-  it("formats instruction suggestions with skillId and instructions", () => {
+  it("formats instruction suggestions with skillId and edits", () => {
     const suggestion = makeInstructionSuggestion({
       skillConfigurationId: "skl_target",
       suggestion: {
-        instructions: "New improved instructions.",
+        instructionEdits: [
+          {
+            old_string: "old text",
+            new_string: "New improved instructions.",
+            expected_occurrences: 1,
+          },
+        ],
       },
     } as Partial<SkillSuggestionType>);
     const { userMessage } = buildSkillAggregationPrompt(
@@ -94,9 +105,9 @@ describe("buildSkillAggregationPrompt", () => {
       { pending: [], rejected: [] }
     );
 
-    expect(userMessage).toContain("kind: edit_instructions");
-    expect(userMessage).toContain("skillId: skl_target");
-    expect(userMessage).toContain("instructions: New improved instructions.");
+    expect(userMessage).toContain('kind="edit"');
+    expect(userMessage).toContain("<skillId>skl_target</skillId>");
+    expect(userMessage).toContain("New improved instructions.");
   });
 
   it("formats tool suggestions with action and toolId", () => {
@@ -106,9 +117,9 @@ describe("buildSkillAggregationPrompt", () => {
       { pending: [], rejected: [] }
     );
 
-    expect(userMessage).toContain("kind: tools");
-    expect(userMessage).toContain("action: add");
-    expect(userMessage).toContain("toolId: tool-search");
+    expect(userMessage).toContain('kind="edit"');
+    expect(userMessage).toContain('action="add"');
+    expect(userMessage).toContain('toolId="tool-search"');
   });
 
   it("shows N/A when analysis is null", () => {
@@ -119,7 +130,7 @@ describe("buildSkillAggregationPrompt", () => {
       { pending: [], rejected: [] }
     );
 
-    expect(userMessage).toContain("analysis: N/A");
+    expect(userMessage).toContain("<analysis>N/A</analysis>");
   });
 
   it("numbers multiple suggestions sequentially", () => {
@@ -177,15 +188,14 @@ describe("buildSkillAggregationPrompt", () => {
     expect(userMessage).not.toContain("Previously rejected suggestions");
   });
 
-  it("system prompt mentions the suggestion tools", () => {
+  it("system prompt mentions the suggestion tool", () => {
     const { systemPrompt } = buildSkillAggregationPrompt(
       makeSkill(),
       [makeInstructionSuggestion()],
       { pending: [], rejected: [] }
     );
 
-    expect(systemPrompt).toContain("suggest_skill_instruction_edits");
-    expect(systemPrompt).toContain("suggest_skill_tools");
+    expect(systemPrompt).toContain("edit_skill");
   });
 
   it("includes skill configured tools in user message", () => {
@@ -203,7 +213,8 @@ describe("buildSkillAggregationPrompt", () => {
       { pending: [], rejected: [] }
     );
 
-    expect(userMessage).toContain("### Configured tools");
-    expect(userMessage).toContain("web_search (ID: tool-ws)");
+    expect(userMessage).toContain("<tools>");
+    expect(userMessage).toContain('name="web_search"');
+    expect(userMessage).toContain('sId="tool-ws"');
   });
 });

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -6,6 +6,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import logger from "@app/logger/logger";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { escapeXml } from "@app/types/shared/utils/string_utils";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 
 const AGGREGATION_ASSEMBLY_ORDER = [
@@ -23,9 +24,8 @@ const REINFORCED_SKILL_AGGREGATION_SECTIONS: Record<
   primary: `You improve a skill's configuration by consolidating many draft suggestions. Each draft was produced from a single conversation that used the skill.
 Your job is to produce a subset of the highest quality suggestions for the skill builder to review.
 
-You have access to the following tools:
-- suggest_skill_instruction_edits: For suggesting instruction changes to the skill.
-- suggest_skill_tools: For suggesting tools to add or remove from the skill.
+You have access to the following tool:
+- edit_skill: For suggesting instruction edits and tool add/remove for one skill. The skill block above includes <agentFacingDescription> when set (for context only); you MUST NOT use edit_skill to change it.
 
 Your goal is to keep the most impactful suggestions. NEVER create more than 5 suggestions.
 You MUST follow <aggregation_rules> to determine the final set of suggestions.
@@ -66,21 +66,26 @@ export function buildSkillAggregationSystemPrompt(): string {
 
 function formatSuggestion(s: SkillSuggestionType): string {
   switch (s.kind) {
-    case "edit_instructions":
-      return `kind: edit_instructions
-skillId: ${s.skillConfigurationId}
-analysis: ${s.analysis ?? "N/A"}
-instructions: ${s.suggestion.instructions}`;
-    case "tools":
-      return `kind: tools
-skillId: ${s.skillConfigurationId}
-action: ${s.suggestion.action}
-toolId: ${s.suggestion.toolId}
-analysis: ${s.analysis ?? "N/A"}`;
-    case "create":
-      return `kind: create
-skillId: ${s.skillConfigurationId}
-analysis: ${s.analysis ?? "N/A"}`;
+    case "edit": {
+      let xml = `<suggestion kind="edit"><skillId>${escapeXml(s.skillConfigurationId)}</skillId><analysis>${escapeXml(s.analysis ?? "N/A")}</analysis>`;
+      if (s.suggestion.instructionEdits?.length) {
+        xml += "<instructionEdits>";
+        for (let i = 0; i < s.suggestion.instructionEdits.length; i++) {
+          const e = s.suggestion.instructionEdits[i];
+          xml += `<instructionEdit index="${i + 1}" expected_occurrences="${e.expected_occurrences}"><oldString>${escapeXml(e.old_string)}</oldString><newString>${escapeXml(e.new_string)}</newString></instructionEdit>`;
+        }
+        xml += "</instructionEdits>";
+      }
+      if (s.suggestion.toolEdits?.length) {
+        xml += "<toolEdits>";
+        for (const t of s.suggestion.toolEdits) {
+          xml += `<toolEdit action="${escapeXml(t.action)}" toolId="${escapeXml(t.toolId)}"/>`;
+        }
+        xml += "</toolEdits>";
+      }
+      xml += "</suggestion>";
+      return xml;
+    }
   }
 }
 

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -33,7 +33,8 @@ describe("buildSkillAnalysisPrompt", () => {
     const skill = makeSkill({ name: "DataLookup", sId: "skl_data" });
     const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
 
-    expect(userMessage).toContain("Skill: DataLookup (ID: skl_data)");
+    expect(userMessage).toContain('ID="skl_data"');
+    expect(userMessage).toContain('name="DataLookup"');
   });
 
   it("includes description when present", () => {
@@ -42,14 +43,17 @@ describe("buildSkillAnalysisPrompt", () => {
     });
     const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
 
-    expect(userMessage).toContain("Description: Searches internal databases");
+    expect(userMessage).toContain("<agentFacingDescription>");
+    expect(userMessage).toContain("Searches internal databases");
+    expect(userMessage).toContain("</agentFacingDescription>");
   });
 
-  it("omits description section when empty", () => {
+  it("omits description when empty", () => {
     const skill = makeSkill({ agentFacingDescription: "" });
     const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
 
-    expect(userMessage).not.toContain("Description:");
+    expect(userMessage).not.toContain("<agentFacingDescription>");
+    expect(userMessage).toMatch(/<skill[^>]+><\/skill>/);
   });
 
   it("includes instructions when present", () => {
@@ -58,15 +62,15 @@ describe("buildSkillAnalysisPrompt", () => {
     });
     const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
 
-    expect(userMessage).toContain("### Current instructions");
+    expect(userMessage).toContain("<instructions>");
     expect(userMessage).toContain("Always verify data before responding.");
   });
 
-  it("omits instructions section when null", () => {
+  it("omits instructions when null", () => {
     const skill = makeSkill({ instructions: null });
     const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
 
-    expect(userMessage).not.toContain("### Current instructions");
+    expect(userMessage).not.toContain("<instructions>");
   });
 
   it("wraps conversation text in <conversation> tags", () => {
@@ -94,8 +98,7 @@ describe("buildSkillAnalysisPrompt", () => {
       makeSkill(),
     ]);
 
-    expect(systemPrompt).toContain("suggest_skill_instruction_edits");
-    expect(systemPrompt).toContain("suggest_skill_tools");
+    expect(systemPrompt).toContain("edit_skill");
     expect(systemPrompt).toContain("get_available_tools");
   });
 
@@ -110,8 +113,9 @@ describe("buildSkillAnalysisPrompt", () => {
     });
     const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
 
-    expect(userMessage).toContain("### Configured tools");
-    expect(userMessage).toContain("web_search (ID: tool-ws)");
+    expect(userMessage).toContain("<tools>");
+    expect(userMessage).toContain('sId="tool-ws"');
+    expect(userMessage).toContain('name="web_search"');
   });
 
   it("includes multiple skills in user message", () => {
@@ -122,7 +126,9 @@ describe("buildSkillAnalysisPrompt", () => {
       skill2,
     ]);
 
-    expect(userMessage).toContain("Skill: SkillA (ID: skl_a)");
-    expect(userMessage).toContain("Skill: SkillB (ID: skl_b)");
+    expect(userMessage).toContain('ID="skl_a"');
+    expect(userMessage).toContain('name="SkillA"');
+    expect(userMessage).toContain('ID="skl_b"');
+    expect(userMessage).toContain('name="SkillB"');
   });
 });

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -8,7 +8,8 @@ import logger from "@app/logger/logger";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 const ASSEMBLY_ORDER = [
-  "primary",
+  "primary_goal",
+  "skill_usage_analysis",
   "analysis_workflow",
   "conversation_analysis",
   "instructions_guidance",
@@ -18,58 +19,70 @@ const ASSEMBLY_ORDER = [
 type SectionKey = (typeof ASSEMBLY_ORDER)[number];
 
 const REINFORCED_SKILL_ANALYSIS_SECTIONS: Record<SectionKey, string> = {
-  primary: `You are a skill improvement analyst. Your job is to analyze a conversation that used one or more skills and suggest concrete improvements to those skills.
+  primary_goal: `You are a Dust skill improvement analyst. Your job is to analyze a conversation that used one or more skills and suggest concrete improvements to those skills.
+A skill bundles tools and instructions that are used by a Dust agent to perform a specific task.
 
-You have access to the following tools:
+See <skill_usage_analysis> for guidance on how to analyze the relevance of a skill in the conversation.
 
-## Exploration tools (optional — use these first if you need more context)
+You MUST follow <analysis_workflow>. These steps are entirely focused on suggesting skill improvements.
+
+Users will not see your response. The user will ONLY see the content of the edit_skill tool calls.
+
+In most conversations, the correct outcome is no configuration change. This means the conversastion did not surface a clear, high-value gap in the skill configuration.
+Propose configuration changes only when <analysis_workflow> yields concrete evidence. If you are unsure, do not call edit_skill.
+
+## Exploration tools (optional — use these if you need more context)
 - get_available_tools: Lists all tools (MCP servers) available in the workspace. Use this to discover tools you could suggest adding or to verify that suggested tools exist.
+`,
 
-## Suggestion tools (terminal — the conversation ends after these)
-- suggest_skill_instruction_edits: For suggesting instruction changes to a skill.
-- suggest_skill_tools: For suggesting tools to add or remove from a skill.
-
-You can either:
-1. Call get_available_tools first to discover available tools, then make informed suggestions.
-2. Go straight to calling suggestion tools if you already have enough context.
-
-You MUST follow <analysis_workflow>. These steps are entirely focused on identifying potential skill improvements and calling the suggestion tools as an end result.
-In most conversations, the correct outcome is no configuration change: the thread does not surface a clear, high-value gap in how the skill is set up.
-Propose configuration changes only when <conversation_analysis> yields concrete evidence. If you are unsure, call suggest_skill_instruction_edits with an empty suggestions array.`,
+  skill_usage_analysis: `In <skill_context>, you have received all custom skills that were enabled in the conversation.
+Skills are injected into the agent's system prompt when enabled. This means that every subsequent agent action is influenced by each enabled skill in addition to the agent's system prompt.
+The only strong signal of skill influence on the agent behavior is when the agent calls a tool that the skill provides.
+You will need to infer the impact of the skill on the agent behavior by checking tool calls and agent messages.`,
 
   analysis_workflow: `Follow this process for every conversation you analyze:
 
-Step 1: Review the <skill_context> from the user message to understand each skill's purpose and configuration.
+Step 1: Determine which skills were relevant to the conversation.
+For each skill in <skill_context>, ask yourself these questions:
+- Were any of the skill's configured tools called in <conversation>? Match the skill's tool names/IDs against the functionCallName in actions.
+- Does the conversation topic match the skill's purpose and instructions? Use <agentFacingDescription> and <instructions> inside each <skill> in <skill_context>.
+- Was there an enable_skill tool call for the skill? If so, note when. This means the agent made an explicit decision to enable the skill for the rest of the conversation.
 
-Step 2: Analyze the conversation and identify improvement areas for the skill configurations.
-The conversation is in <conversation>. See <conversation_analysis> for guidance on how to analyze the conversation.
+At the end of this step, you should have a list of skills you think were relevant to this conversation and should be analyzed for improvements.
 
-Step 3: Build a plan. Based on the identified areas of improvement, determine specific suggestions to modify the skill configurations. Dimensions you MUST consider:
+Step 2: Go through every message in the conversation and identify areas where the agent behavior could be improved. See <conversation_analysis> for guidance.
+
+Step 3: For each of the areas that could be improved, determine if a skill could be improved to address the issue.
+Determine if any skill from Step 1 was relevant to this area of the conversation and could be improved.
+Be aware that one conversation is a small sample size. Before suggesting, ALWAYS look at systematic gaps in the skill instructions that could lead to this being a persistent issue.
+A key consideration is that conversations can be user-specific, but skills shared across agents and users. You MUST ensure that the suggestions are useful for all users of the skill.
+
+Step 4: For each skill improvement identified in Step 3, formulate a suggestion.
+ALWAYS ensure that the suggestion is inline with the skill's purpose and instructions. Skills SHOULD be single purpose and not be overloaded with multiple responsibilities.
+Consider the following improvements to a skill:
 - Review instructions to determine if the skill is meeting the user intent and properly utilizing the configured tools: <instructions_guidance>.
 - If the skill references or requires external actions or knowledge, then tools may need to be added or removed. See <tools_guidance>.
+All improvements that should be treated as a single atomic unit should be grouped together in a single suggestion.
+NEVER group things that are not related to each other.
 
-You can NOT suggest other types of skill configuration changes (e.g. knowledge). Only suggest instructions and tools.
+Step 5: For each skill, look for agent behavior that is directly aligned with the skill's purpose, but the behavior was not defined in the skill instructions.
+This is an opportunity to improve the skill instructions for all future agents and conversations.
+Evaluate if any suggestions could improve the behavior of ALL agents and users using that skill.
 
-Step 4: For each suggestion, you MUST include an "analysis" field explaining why this change would improve the skill.
+Step 6: Build a final plan for skill suggestions. You MUST include an "analysis" field explaining why this change would improve the skill.
 This MUST include the signal that was discovered in <conversation_analysis> that led to the suggestion.
 Subsequently, an aggregation workflow will use this analysis to determine which suggestions are most impactful.
 
-Step 5: Make suggestions.
+Step 7: Make suggestions.
 ONLY make suggestions that will affect the skill behavior. NEVER suggest cosmetic-only fixes.
 `,
 
-  conversation_analysis: `ALWAYS inspect the full conversation, which is a chronological timeline of messages. Each message has an index, sId, sender (user or agent name), actions, and content. Here are key signals for potential improvements in order of importance:
-
-1. If the user provided feedback, it will be included with each message in the form of thumbs up/down and comments.
-This is the MOST important signal as it is directly provided by the user and an explicit signal.
-
-2. User response to an agent message. Any user indication of confusion, disagreement, or correction is a signal of dissatisfaction. A user follow-up question or request could mean the skill response was useful, but the skill could be improved in terms of proactively providing that information or performing the action without user intervention.
-
-3. You should look for tool calls that indicate the skill is unsure how to perform an action (and is actively exploring options) or receiving unexpected results. A general principle is that you want to suggest improvements that increase the chances that the skill can replicate a successful workflow in the future.
-
-4. Missing capabilities the skill should have. Call get_available_tools to discover what tools are available in the workspace. Determine if more tools could have been added to the skill to improve satisfaction.
-
-A key consideration is that conversations can be user-specific, but skills are usually shared. You MUST ensure that the suggestions are useful for all users of the skill.`,
+  conversation_analysis: `ALWAYS inspect the full conversation, which is a chronological timeline of messages. Each message has an index, sId, sender (user or agent name), actions, and content. Here are key signals of areas where the agent behavior could be improved:
+1. Feedback - If the user provided feedback, it will be included with each message in the form of thumbs up/down and comments. This is the MOST important signal as it is directly provided by the user and an explicit signal.
+2. User reaction - Any user indication of confusion, disagreement, or correction is a signal of dissatisfaction. A user follow-up question or request could mean the skill response was useful, but a skill could be improved in terms of proactively providing that information or performing the action without user intervention.
+3. Tool calls - If the tool calls needed to be retried, could a skill's instructions be more clear on how to use that tool?
+4. Sequence - Did the agent call the tools in the correct order?
+`,
 
   instructions_guidance: `When suggesting instruction improvements for skills, follow these principles:
 

--- a/front/lib/reinforcement/format_skill_context.ts
+++ b/front/lib/reinforcement/format_skill_context.ts
@@ -1,26 +1,24 @@
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { escapeXml } from "@app/types/shared/utils/string_utils";
 
 export function formatSkillContext(skill: SkillType): string {
-  const sections: string[] = [];
+  const toolsBlock =
+    skill.tools.length > 0
+      ? `<tools>${skill.tools
+          .map(
+            (t) =>
+              `<tool sId="${escapeXml(t.sId)}" name="${escapeXml(t.name ?? "")}"/>`
+          )
+          .join("")}</tools>`
+      : "";
 
-  sections.push(`## Skill: ${skill.name} (ID: ${skill.sId})`);
+  const descBlock = skill.agentFacingDescription
+    ? `<agentFacingDescription>${escapeXml(skill.agentFacingDescription)}</agentFacingDescription>`
+    : "";
 
-  if (skill.agentFacingDescription) {
-    sections.push(`Description: ${skill.agentFacingDescription}`);
-  }
+  const instructionsBlock = skill.instructions
+    ? `<instructions>${escapeXml(skill.instructions)}</instructions>`
+    : "";
 
-  if (skill.instructions) {
-    sections.push(`### Current instructions\n${skill.instructions}`);
-  }
-
-  if (skill.tools.length > 0) {
-    const toolLines = skill.tools
-      .map((t) => `- ${t.name} (ID: ${t.sId})`)
-      .join("\n");
-    sections.push(
-      `### Configured tools\n${skill.tools.length} tools configured.\n\n${toolLines}`
-    );
-  }
-
-  return sections.join("\n\n");
+  return `<skill ID="${escapeXml(skill.sId)}" name="${escapeXml(skill.name)}">${toolsBlock}${descBlock}${instructionsBlock}</skill>`;
 }

--- a/front/lib/reinforcement/run_reinforced_analysis.test.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.test.ts
@@ -30,8 +30,7 @@ describe("buildReinforcedSkillsLLMParams", () => {
     });
 
     const toolNames = params.specifications?.map((s) => s.name) ?? [];
-    expect(toolNames).toContain("suggest_skill_instruction_edits");
-    expect(toolNames).toContain("suggest_skill_tools");
+    expect(toolNames).toContain("edit_skill");
     expect(toolNames).toContain("get_available_tools");
   });
 

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -5,6 +5,7 @@ import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import { getSkillInstructionEditsValidationError } from "@app/lib/api/skills/apply_skill_instruction_edits";
 import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -44,41 +45,56 @@ const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
       "Get the list of available tools (MCP servers) that can be added to skills.",
     schema: {},
   },
-  suggest_skill_instruction_edits: {
+  edit_skill: {
     description:
-      "Suggest instruction edits for one or more skills based on conversation analysis.",
+      "Suggest edits to a skill's instructions and/or configured tools.",
     schema: {
-      suggestions: z.array(
-        z.object({
-          skillId: z.string().describe("The sId of the skill to modify"),
-          instructions: z
-            .string()
-            .describe("Full replacement text for the skill instructions"),
-          analysis: z
-            .string()
-            .describe("Explanation of why this change improves the skill"),
-        })
-      ),
-    },
-  },
-  suggest_skill_tools: {
-    description:
-      "Suggest tools to add or remove from one or more skills based on conversation analysis.",
-    schema: {
-      suggestions: z.array(
-        z.object({
-          skillId: z.string().describe("The sId of the skill to modify"),
-          action: z
-            .enum(["add", "remove"])
-            .describe("Whether to add or remove the tool"),
-          toolId: z
-            .string()
-            .describe("The identifier of the tool to add or remove"),
-          analysis: z
-            .string()
-            .describe("Explanation of why this change improves the skill"),
-        })
-      ),
+      skillId: z.string().describe("The sId of the skill to modify"),
+      instructionEdits: z
+        .array(
+          z.object({
+            old_string: z
+              .string()
+              .min(1)
+              .describe(
+                "Exact text to find in the current skill instructions."
+              ),
+            new_string: z
+              .string()
+              .describe(
+                "Replacement text. Empty string deletes the matched span."
+              ),
+            expected_occurrences: z
+              .number()
+              .int()
+              .min(1)
+              .default(1)
+              .describe(
+                "How many times old_string is expected to appear. Used to validate the edit is still applicable."
+              ),
+          })
+        )
+        .optional()
+        .describe(
+          "Sequential search-and-replace operations applied to the skill instructions."
+        ),
+      toolEdits: z
+        .array(
+          z.object({
+            action: z
+              .enum(["add", "remove"])
+              .describe("Whether to add or remove the tool"),
+            toolId: z
+              .string()
+              .describe("The identifier of the tool to add or remove"),
+          })
+        )
+        .optional()
+        .describe("Tools to add or remove from the skill."),
+      analysis: z
+        .string()
+        .optional()
+        .describe("Why this change improves the skill"),
     },
   },
 };
@@ -349,9 +365,8 @@ async function createSkillSuggestionsFromToolCall({
   conversation?: ConversationResource;
 }): Promise<ToolCallResult> {
   switch (toolName) {
-    case "suggest_skill_instruction_edits": {
-      const parsed =
-        TOOL_SCHEMAS.suggest_skill_instruction_edits.safeParse(actionArguments);
+    case "edit_skill": {
+      const parsed = TOOL_SCHEMAS.edit_skill.safeParse(actionArguments);
       if (!parsed.success) {
         const errorMessage = `Invalid arguments for ${toolName}: ${parsed.error.message}`;
         logger.warn(
@@ -361,71 +376,78 @@ async function createSkillSuggestionsFromToolCall({
         return { suggestionsCreated: 0, error: errorMessage };
       }
 
-      let created = 0;
-      for (const suggestion of parsed.data.suggestions) {
-        const skill = await SkillResource.fetchById(auth, suggestion.skillId);
-        if (!skill) {
-          logger.warn(
-            { skillId: suggestion.skillId, contextId },
-            "ReinforcedSkills: skill not found for instruction suggestion"
-          );
-          continue;
-        }
-
-        await SkillSuggestionResource.createSuggestionForSkill(auth, skill, {
-          kind: "edit_instructions",
-          suggestion: { instructions: suggestion.instructions },
-          analysis: suggestion.analysis,
-          state: "pending",
-          source,
-          sourceConversationId: conversation?.id ?? null,
-          groupId: null,
-        });
-        created++;
-      }
-
-      return { suggestionsCreated: created };
-    }
-
-    case "suggest_skill_tools": {
-      const parsed =
-        TOOL_SCHEMAS.suggest_skill_tools.safeParse(actionArguments);
-      if (!parsed.success) {
-        const errorMessage = `Invalid arguments for ${toolName}: ${parsed.error.message}`;
+      const skill = await SkillResource.fetchById(auth, parsed.data.skillId);
+      if (!skill) {
         logger.warn(
-          { contextId, toolName, error: parsed.error },
-          `ReinforcedSkills: invalid LLM response shape for ${operationType}`
+          { skillId: parsed.data.skillId, contextId },
+          "ReinforcedSkills: skill not found for edit_skill"
         );
-        return { suggestionsCreated: 0, error: errorMessage };
+        return { suggestionsCreated: 0, error: "Skill not found" };
       }
 
-      let created = 0;
-      for (const suggestion of parsed.data.suggestions) {
-        const skill = await SkillResource.fetchById(auth, suggestion.skillId);
-        if (!skill) {
+      const hasInstructionEdits =
+        (parsed.data.instructionEdits?.length ?? 0) > 0;
+      const hasToolEdits = (parsed.data.toolEdits?.length ?? 0) > 0;
+      if (!hasInstructionEdits && !hasToolEdits) {
+        return {
+          suggestionsCreated: 0,
+          error:
+            "edit_skill requires at least one instruction edit or tool edit.",
+        };
+      }
+
+      if (
+        parsed.data.instructionEdits &&
+        parsed.data.instructionEdits.length > 0
+      ) {
+        const currentInstructions = skill.instructions ?? "";
+        const validationError = getSkillInstructionEditsValidationError(
+          currentInstructions,
+          parsed.data.instructionEdits
+        );
+        if (validationError) {
           logger.warn(
-            { skillId: suggestion.skillId, contextId },
-            "ReinforcedSkills: skill not found for tools suggestion"
+            { skillId: parsed.data.skillId, contextId, validationError },
+            "ReinforcedSkills: invalid instruction edits"
           );
-          continue;
+          return { suggestionsCreated: 0, error: validationError };
         }
-
-        await SkillSuggestionResource.createSuggestionForSkill(auth, skill, {
-          kind: "tools",
-          suggestion: {
-            action: suggestion.action,
-            toolId: suggestion.toolId,
-          },
-          analysis: suggestion.analysis,
-          state: "pending",
-          source,
-          sourceConversationId: conversation?.id ?? null,
-          groupId: null,
-        });
-        created++;
       }
 
-      return { suggestionsCreated: created };
+      // Mark any existing pending edit suggestions for this skill as outdated.
+      // This is not strictly necessary, but it is unclear if we want to allow multiple pending edit suggestions for the same skill.
+      const existingPending =
+        await SkillSuggestionResource.listBySkillConfigurationId(
+          auth,
+          skill.sId,
+          {
+            states: ["pending"],
+            kind: "edit",
+            sources: ["reinforcement", "synthetic"],
+          }
+        );
+      if (existingPending.length > 0) {
+        await SkillSuggestionResource.bulkUpdateState(
+          auth,
+          existingPending,
+          "outdated"
+        );
+      }
+
+      await SkillSuggestionResource.createSuggestionForSkill(auth, skill, {
+        kind: "edit",
+        suggestion: {
+          instructionEdits: parsed.data.instructionEdits,
+          toolEdits: parsed.data.toolEdits,
+        },
+        analysis: parsed.data.analysis ?? null,
+        state: "pending",
+        source,
+        sourceConversationId: conversation?.id ?? null,
+        groupId: null,
+      });
+
+      return { suggestionsCreated: 1 };
     }
 
     default:

--- a/front/lib/reinforcement/types.ts
+++ b/front/lib/reinforcement/types.ts
@@ -3,14 +3,9 @@ import { z } from "zod";
 
 export type ExploratoryToolName = "get_available_tools";
 
-export type TerminalToolName =
-  | "suggest_skill_instruction_edits"
-  | "suggest_skill_tools";
+export type TerminalToolName = "edit_skill";
 
-export const TERMINAL_TOOLS: TerminalToolName[] = [
-  "suggest_skill_instruction_edits",
-  "suggest_skill_tools",
-];
+export const TERMINAL_TOOLS: TerminalToolName[] = ["edit_skill"];
 
 export const EXPLORATORY_TOOLS: ExploratoryToolName[] = ["get_available_tools"];
 
@@ -29,28 +24,53 @@ export function isExploratoryToolName(
   return EXPLORATORY_TOOL_SET.has(name);
 }
 
+const SkillInstructionEditArgSchema = z.object({
+  old_string: z
+    .string()
+    .min(1)
+    .describe("Exact text to find in the current skill instructions."),
+  new_string: z
+    .string()
+    .describe("Replacement text. Empty string deletes the matched span."),
+  expected_occurrences: z
+    .number()
+    .int()
+    .min(1)
+    .default(1)
+    .describe(
+      "How many times old_string is expected to appear. Used to validate the edit is still applicable."
+    ),
+});
+
 export const TOOL_SCHEMAS: Record<
   TerminalToolName,
   z.ZodObject<z.ZodRawShape>
 > = {
-  suggest_skill_instruction_edits: z.object({
-    suggestions: z.array(
-      z.object({
-        skillId: z.string(),
-        instructions: z.string(),
-        analysis: z.string(),
-      })
-    ),
-  }),
-  suggest_skill_tools: z.object({
-    suggestions: z.array(
-      z.object({
-        skillId: z.string(),
-        action: z.enum(["add", "remove"]),
-        toolId: z.string(),
-        analysis: z.string(),
-      })
-    ),
+  edit_skill: z.object({
+    skillId: z.string().describe("The sId of the skill to modify"),
+    instructionEdits: z
+      .array(SkillInstructionEditArgSchema)
+      .optional()
+      .describe(
+        "Sequential search-and-replace operations applied to the skill instructions."
+      ),
+    toolEdits: z
+      .array(
+        z.object({
+          action: z
+            .enum(["add", "remove"])
+            .describe("Whether to add or remove the tool"),
+          toolId: z
+            .string()
+            .describe("The identifier of the tool to add or remove"),
+        })
+      )
+      .optional()
+      .describe("Tools to add or remove from the skill."),
+    analysis: z
+      .string()
+      .optional()
+      .describe("Why this change improves the skill"),
   }),
 };
 

--- a/front/lib/resources/skill_suggestion_resource.test.ts
+++ b/front/lib/resources/skill_suggestion_resource.test.ts
@@ -63,7 +63,15 @@ describe("SkillSuggestionResource", () => {
         authenticator,
         skill,
         {
-          suggestion: { instructions: "Be more detailed" },
+          suggestion: {
+            instructionEdits: [
+              {
+                old_string: "original",
+                new_string: "Be more detailed",
+                expected_occurrences: 1,
+              },
+            ],
+          },
           analysis: "Improving instructions",
           source: "reinforcement",
         }
@@ -73,7 +81,7 @@ describe("SkillSuggestionResource", () => {
       expect(suggestion.sId).toMatch(/^ssu_/);
       expect(suggestion.workspaceId).toBe(workspace.id);
       expect(suggestion.skillConfigurationId).toBe(skill.id);
-      expect(suggestion.kind).toBe("edit_instructions");
+      expect(suggestion.kind).toBe("edit");
       expect(suggestion.state).toBe("pending");
       expect(suggestion.source).toBe("reinforcement");
 
@@ -83,7 +91,7 @@ describe("SkillSuggestionResource", () => {
       );
       expect(fetched).toBeDefined();
       expect(fetched?.sId).toBe(suggestion.sId);
-      expect(fetched?.kind).toBe("edit_instructions");
+      expect(fetched?.kind).toBe("edit");
     });
 
     it("should fetch multiple suggestions by ids", async () => {
@@ -153,23 +161,17 @@ describe("SkillSuggestionResource", () => {
     });
 
     it("should filter by kind", async () => {
-      await SkillSuggestionFactory.create(authenticator, skill, {
-        kind: "edit_instructions",
-      });
-      await SkillSuggestionFactory.create(authenticator, skill, {
-        kind: "create",
-        suggestion: {},
-      });
+      await SkillSuggestionFactory.create(authenticator, skill);
 
       const editSuggestions =
         await SkillSuggestionResource.listBySkillConfigurationId(
           authenticator,
           skill.sId,
-          { kind: "edit_instructions" }
+          { kind: "edit" }
         );
 
       expect(editSuggestions).toHaveLength(1);
-      expect(editSuggestions[0].kind).toBe("edit_instructions");
+      expect(editSuggestions[0].kind).toBe("edit");
     });
 
     it("should exclude synthetic suggestions by default", async () => {
@@ -216,7 +218,15 @@ describe("SkillSuggestionResource", () => {
           authenticator,
           skill,
           {
-            suggestion: { instructions: `instruction-${i}` },
+            suggestion: {
+              instructionEdits: [
+                {
+                  old_string: "old",
+                  new_string: `instruction-${i}`,
+                  expected_occurrences: 1,
+                },
+              ],
+            },
           }
         );
         created.push(suggestion);
@@ -530,7 +540,15 @@ describe("SkillSuggestionResource", () => {
         authenticator,
         skill,
         {
-          suggestion: { instructions: "New instructions" },
+          suggestion: {
+            instructionEdits: [
+              {
+                old_string: "old text",
+                new_string: "New instructions",
+                expected_occurrences: 1,
+              },
+            ],
+          },
           analysis: "Improved clarity",
         }
       );
@@ -538,8 +556,16 @@ describe("SkillSuggestionResource", () => {
       const json = suggestion.toJSON();
 
       expect(json.sId).toBe(suggestion.sId);
-      expect(json.kind).toBe("edit_instructions");
-      expect(json.suggestion).toEqual({ instructions: "New instructions" });
+      expect(json.kind).toBe("edit");
+      expect(json.suggestion).toMatchObject({
+        instructionEdits: [
+          {
+            old_string: "old text",
+            new_string: "New instructions",
+            expected_occurrences: 1,
+          },
+        ],
+      });
       expect(json.analysis).toBe("Improved clarity");
       expect(json.state).toBe("pending");
       expect(json.source).toBe("reinforcement");

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions.test.ts
@@ -38,7 +38,7 @@ describe("GET /api/poke/workspaces/[wId]/skills/[sId]/suggestions", () => {
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
     expect(data.suggestions).toHaveLength(1);
-    expect(data.suggestions[0].kind).toBe("edit_instructions");
+    expect(data.suggestions[0].kind).toBe("edit");
   });
 
   it("returns empty array when skill has no suggestions", async () => {

--- a/front/tests/utils/SkillSuggestionFactory.ts
+++ b/front/tests/utils/SkillSuggestionFactory.ts
@@ -22,9 +22,15 @@ export class SkillSuggestionFactory {
     }> = {}
   ): Promise<SkillSuggestionResource> {
     return SkillSuggestionResource.createSuggestionForSkill(auth, skill, {
-      kind: overrides.kind ?? "edit_instructions",
+      kind: overrides.kind ?? "edit",
       suggestion: overrides.suggestion ?? {
-        instructions: "Updated skill instructions",
+        instructionEdits: [
+          {
+            old_string: "original text",
+            new_string: "updated skill instructions",
+            expected_occurrences: 1,
+          },
+        ],
       },
       analysis: overrides.analysis ?? "Improved instructions",
       state: overrides.state ?? "pending",
@@ -32,20 +38,33 @@ export class SkillSuggestionFactory {
     });
   }
 
-  static async createEditInstructions(
+  static async createEdit(
     auth: Authenticator,
     skill: SkillResource,
     overrides: Partial<{
-      suggestion: { instructions: string };
+      suggestion: {
+        instructionEdits?: {
+          old_string: string;
+          new_string: string;
+          expected_occurrences: number;
+        }[];
+        toolEdits?: { action: "add" | "remove"; toolId: string }[];
+      };
       analysis: string | null;
       state: SkillSuggestionState;
       source: SkillSuggestionSource;
     }> = {}
   ): Promise<SkillSuggestionResource> {
     return this.create(auth, skill, {
-      kind: "edit_instructions",
+      kind: "edit",
       suggestion: overrides.suggestion ?? {
-        instructions: "Updated skill instructions",
+        instructionEdits: [
+          {
+            old_string: "original text",
+            new_string: "updated skill instructions",
+            expected_occurrences: 1,
+          },
+        ],
       },
       analysis: overrides.analysis,
       state: overrides.state,

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -56,6 +56,15 @@ export function pluralize(count: number) {
   return count !== 1 ? "s" : "";
 }
 
+// Encode text for use in XML element bodies and double-quoted attributes
+export function escapeXml(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
 const HTML_ENTITIES: Record<string, string> = {
   "&nbsp;": " ",
   "&amp;": "&",

--- a/front/types/suggestions/skill_suggestion.ts
+++ b/front/types/suggestions/skill_suggestion.ts
@@ -31,70 +31,73 @@ export function isSkillSuggestionSource(
   );
 }
 
-export const SKILL_SUGGESTION_KINDS = [
-  "create",
-  "edit_instructions",
-  "tools",
-] as const;
+export const SKILL_SUGGESTION_KINDS = ["edit"] as const;
 
 export type SkillSuggestionKind = (typeof SKILL_SUGGESTION_KINDS)[number];
 
-export const SkillCreateSuggestionSchema = z.object({}).strict();
-
-export type SkillCreateSuggestionType = z.infer<
-  typeof SkillCreateSuggestionSchema
->;
-
-export function isSkillCreateSuggestion(
-  data: unknown
-): data is SkillCreateSuggestionType {
-  return SkillCreateSuggestionSchema.safeParse(data).success;
-}
-
-export const SkillEditInstructionsSuggestionSchema = z.object({
-  instructions: z
+export const SkillInstructionEditItemSchema = z.object({
+  old_string: z
     .string()
-    .describe("Full replacement text for the skill instructions."),
+    .min(1)
+    .describe("Exact text to find in the current skill instructions."),
+  new_string: z
+    .string()
+    .describe("Replacement text. Empty string deletes the matched span."),
+  expected_occurrences: z
+    .number()
+    .int()
+    .min(1)
+    .default(1)
+    .describe(
+      "How many times old_string is expected to appear. Validated before applying."
+    ),
 });
 
-export type SkillEditInstructionsSuggestionType = z.infer<
-  typeof SkillEditInstructionsSuggestionSchema
+export type SkillInstructionEditItemType = z.infer<
+  typeof SkillInstructionEditItemSchema
 >;
 
-export function isSkillEditInstructionsSuggestion(
-  data: unknown
-): data is SkillEditInstructionsSuggestionType {
-  return SkillEditInstructionsSuggestionSchema.safeParse(data).success;
-}
-
-export const SkillToolsSuggestionSchema = z.object({
+export const SkillToolEditItemSchema = z.object({
   action: z.enum(["add", "remove"]),
   toolId: z.string(),
 });
 
-export type SkillToolsSuggestionType = z.infer<
-  typeof SkillToolsSuggestionSchema
->;
+export type SkillToolEditItemType = z.infer<typeof SkillToolEditItemSchema>;
 
-export type SkillSuggestionPayload =
-  | SkillCreateSuggestionType
-  | SkillEditInstructionsSuggestionType
-  | SkillToolsSuggestionType;
+export const SkillEditSuggestionSchema = z
+  .object({
+    instructionEdits: z
+      .array(SkillInstructionEditItemSchema)
+      .optional()
+      .describe(
+        "Sequential search-and-replace edits to the skill instructions."
+      ),
+    toolEdits: z
+      .array(SkillToolEditItemSchema)
+      .optional()
+      .describe("Tools to add or remove from the skill."),
+  })
+  .refine(
+    (d) =>
+      (d.instructionEdits && d.instructionEdits.length > 0) ||
+      (d.toolEdits && d.toolEdits.length > 0),
+    "At least one of instructionEdits or toolEdits must be provided."
+  );
 
-export const SkillSuggestionDataSchema = z.discriminatedUnion("kind", [
-  z.object({
-    kind: z.literal("create"),
-    suggestion: SkillCreateSuggestionSchema,
-  }),
-  z.object({
-    kind: z.literal("edit_instructions"),
-    suggestion: SkillEditInstructionsSuggestionSchema,
-  }),
-  z.object({
-    kind: z.literal("tools"),
-    suggestion: SkillToolsSuggestionSchema,
-  }),
-]);
+export type SkillEditSuggestionType = z.infer<typeof SkillEditSuggestionSchema>;
+
+export function isSkillEditSuggestion(
+  data: unknown
+): data is SkillEditSuggestionType {
+  return SkillEditSuggestionSchema.safeParse(data).success;
+}
+
+export type SkillSuggestionPayload = SkillEditSuggestionType;
+
+export const SkillSuggestionDataSchema = z.object({
+  kind: z.literal("edit"),
+  suggestion: SkillEditSuggestionSchema,
+});
 
 export type SkillSuggestionData = z.infer<typeof SkillSuggestionDataSchema>;
 


### PR DESCRIPTION
## Description

* Iteration on the analyze_conversation prompt
* Allow single suggestion to batch multiple changes
* Using for new the string replacement approach for instruction suggestion. This seems to work well from a functionality perspective, but final decision on that will be based on UX discussions
 
## Tests

Many manual tests (evals are a separate GH issue)

<img width="965" height="600" alt="Screenshot 2026-04-08 at 6 33 00 PM" src="https://github.com/user-attachments/assets/1e856457-e0f5-441a-98ab-dfa8ba899c86" />

## Risk

* Low

## Deploy Plan

* Deploy front