### PR TITLE
[sessions]: Fix agent selection from URL param and stale draft restoration

### DIFF
--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -141,7 +141,7 @@ export function useConversationDrafts({
   // Save draft for current conversation (debounced).
   const saveDraft = useCallback(
     (text: string, agentMention?: RichAgentMention | null) => {
-      if (!shouldUseDraft || !userId || !text.trim()) {
+      if (!shouldUseDraft || !userId) {
         return;
       }
 

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -143,6 +143,13 @@ const useHandleMentions = ({
         // @TODO we should handle this in each event handler and not inside the useEffect
         setSelectedSingleAgent(selectedAgent);
         externalAgentSetRef.current = true;
+        // If the restored draft contains @user mentions, clear the editor
+        // to prevent the user-mention handler from calling
+        // setSelectedSingleAgent(null) and overriding the URL agent.
+        const { mentions } = editorService.getMarkdownAndMentions();
+        if (mentions.some((m) => m.type === "user")) {
+          queueMicrotask(() => editorService.clearEditor());
+        }
         return;
       }
       if (!editorService.hasMention(selectedAgent)) {

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -49,6 +49,11 @@ const useHandleMentions = ({
   // Also resets when the conversation changes so stale state doesn't leak.
   const prevConversationIdRef = useRef(conversation?.sId ?? null);
 
+  // Tracks when an agent has been explicitly set via the URL ?agent= param.
+  // When set, the priority resolution effect must not override it with
+  // stickyMentions or the @Dust fallback.
+  const externalAgentSetRef = useRef(false);
+
   useEffect(() => {
     if (!singleAgentInput) {
       return;
@@ -57,7 +62,13 @@ const useHandleMentions = ({
     const currentId = conversation?.sId ?? null;
     if (currentId !== prevConversationIdRef.current) {
       prevConversationIdRef.current = currentId;
+      externalAgentSetRef.current = false;
       setSelectedSingleAgent(null);
+    }
+
+    // An external source (URL param) already set the agent — do not override.
+    if (externalAgentSetRef.current) {
+      return;
     }
 
     // Agent builder: wait for the draft agent to arrive via stickyMentions.
@@ -131,6 +142,7 @@ const useHandleMentions = ({
       if (singleAgentInput) {
         // @TODO we should handle this in each event handler and not inside the useEffect
         setSelectedSingleAgent(selectedAgent);
+        externalAgentSetRef.current = true;
         return;
       }
       if (!editorService.hasMention(selectedAgent)) {


### PR DESCRIPTION

## Description
Two fixes for "Start chat" from agent builder not selecting the created agent:

1. useHandleMentions: Add externalAgentSetRef to prevent the priority resolution effect from overriding a URL-selected agent with the draft agent or @Dust fallback.

2. useConversationDrafts: Remove !text.trim() guard from saveDraft so clearing the editor properly overwrites stale drafts instead of silently preserving old content. This was causing old content that I had deleted from the input box to be restored once I navigated back to the main page. But not sure if this will have other implications?

One edge case: if the draft contains a user mention, the agent selection gets clobbered. I added a commit to just remove the draft if it has a user mention, but maybe we should always remove it, or just try strip the mention? Wdyt?

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Test using link! Make a new agent by any means (scratch, duplicate, template), press "start chatting" and the agent should be pre-selected in the inputbox
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
