### PR TITLE
[sessions]: Enforce mutual exclusion between user and agent mentions on paste

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -5,6 +5,7 @@ import {
   getPastedFileName,
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
+import type { MentionsStrippedPayload } from "@app/components/editor/extensions/MentionExtension";
 import type { CustomEditorProps } from "@app/components/editor/input_bar/useCustomEditor";
 import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import useHandleMentions from "@app/components/editor/input_bar/useHandleMentions";
@@ -229,7 +230,7 @@ const InputBarContainer = ({
     ((agentId: string) => void) | undefined
   >(undefined);
   const onAgentMentionsStrippedRef = useRef<
-    ((count: number) => void) | undefined
+    ((payload: MentionsStrippedPayload) => void) | undefined
   >(undefined);
   const [isCaptureDropdownOpen, setIsCaptureDropdownOpen] = useState(false);
   const [showKnowledgePicker, setShowKnowledgePicker] = useState(false);
@@ -417,14 +418,30 @@ const InputBarContainer = ({
     : undefined;
 
   onAgentMentionsStrippedRef.current = singleAgentInput
-    ? (count: number) => {
+    ? (payload: MentionsStrippedPayload) => {
+        let title: string;
+        let description: string;
+        switch (payload.reason) {
+          case "extra-agents":
+            title = "Agent mentions removed";
+            description = `${payload.count} ${payload.count === 1 ? "agent mention was" : "agent mentions were"} removed. Only one agent can be used at a time.`;
+            break;
+          case "user-conflict":
+          case "mixed-conflict":
+            title = "Agent mentions removed";
+            description =
+              "You can't mention both users and agents in the same message.";
+            break;
+          case "users-stripped-for-agent":
+            title = "User mentions removed";
+            description =
+              "You can't mention both users and agents in the same message.";
+            break;
+        }
         sendNotification({
           type: "info",
-          title: "Agent mentions removed",
-          description:
-            count === 1
-              ? "1 agent mention was removed. Only one agent can be used at a time."
-              : `${count} agent mentions were removed. Only one agent can be used at a time.`,
+          title,
+          description,
         });
       }
     : undefined;

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -426,17 +426,19 @@ const InputBarContainer = ({
             title = "Agent mentions removed";
             description = `${payload.count} ${payload.count === 1 ? "agent mention was" : "agent mentions were"} removed. Only one agent can be used at a time.`;
             break;
+          case "users-stripped-for-agent":
+            title = "User mentions removed";
+            description =
+              "You can't mention both users and agents in the same message.";
+            break;
           case "user-conflict":
           case "mixed-conflict":
             title = "Agent mentions removed";
             description =
               "You can't mention both users and agents in the same message.";
             break;
-          case "users-stripped-for-agent":
-            title = "User mentions removed";
-            description =
-              "You can't mention both users and agents in the same message.";
-            break;
+          default:
+            assertNever(payload);
         }
         sendNotification({
           type: "info",

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -429,13 +429,13 @@ const InputBarContainer = ({
           case "users-stripped-for-agent":
             title = "User mentions removed";
             description =
-              "You can't mention both users and agents in the same message.";
+              "You can’t mention both users and agents in the same message.";
             break;
           case "user-conflict":
           case "mixed-conflict":
             title = "Agent mentions removed";
             description =
-              "You can't mention both users and agents in the same message.";
+              "You can’t mention both users and agents in the same message.";
             break;
           default:
             assertNever(payload);

--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -3,6 +3,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import {
   AGENT_MENTION_REGEX,
   AGENT_MENTION_REGEX_BEGINNING,
+  USER_MENTION_REGEX,
   USER_MENTION_REGEX_BEGINNING,
 } from "@app/lib/mentions/format";
 import logger from "@app/logger/logger";
@@ -21,12 +22,107 @@ const MENTION_PICTURE_URL_ATTRIBUTE = "data-picture-url";
 // Legacy attribute written by older versions of the extension. Kept for backward compat in parseHTML.
 const LEGACY_TYPE_ATTRIBUTE = "data-type";
 
+export type MentionsStrippedPayload =
+  | { reason: "extra-agents"; count: number }
+  | { reason: "user-conflict" }
+  | { reason: "mixed-conflict" }
+  | { reason: "users-stripped-for-agent" };
+
+/**
+ * In single-agent mode, enforce mutual exclusion between agent and user
+ * mentions in pasted markdown. Whichever type is established first wins.
+ */
+function stripConflictingMentions(
+  processedMarkdown: string,
+  {
+    editorHasUserMentions,
+    richHtmlAgentId,
+  }: {
+    editorHasUserMentions: boolean;
+    richHtmlAgentId: string | null;
+  }
+): {
+  content: string;
+  agentIdToRoute: string | null;
+  notification: MentionsStrippedPayload | null;
+} {
+  AGENT_MENTION_REGEX.lastIndex = 0;
+  USER_MENTION_REGEX.lastIndex = 0;
+  const firstAgentMatch = AGENT_MENTION_REGEX.exec(processedMarkdown);
+  const firstUserMatch = USER_MENTION_REGEX.exec(processedMarkdown);
+  AGENT_MENTION_REGEX.lastIndex = 0;
+  USER_MENTION_REGEX.lastIndex = 0;
+
+  const agentFirst =
+    firstAgentMatch !== null &&
+    (firstUserMatch === null || firstAgentMatch.index < firstUserMatch.index);
+
+  // User mentions win: editor already has them, or user mention appears first.
+  if (editorHasUserMentions || (!agentFirst && firstUserMatch !== null)) {
+    const content = processedMarkdown
+      .replaceAll(AGENT_MENTION_REGEX, "")
+      .trim();
+    AGENT_MENTION_REGEX.lastIndex = 0;
+    const notification: MentionsStrippedPayload | null =
+      firstAgentMatch !== null
+        ? {
+            reason:
+              firstUserMatch !== null ? "mixed-conflict" : "user-conflict",
+          }
+        : null;
+    return { content, agentIdToRoute: null, notification };
+  }
+
+  // Agent mentions win: route first agent to picker, strip the rest + all user mentions.
+  if (firstAgentMatch !== null) {
+    let markdownAgentId: string | null = null;
+    let agentStrippedCount = 0;
+    const content = processedMarkdown
+      .replaceAll(AGENT_MENTION_REGEX, (_match, _label, agentId) => {
+        if (!markdownAgentId) {
+          markdownAgentId = agentId;
+        }
+        agentStrippedCount++;
+        return "";
+      })
+      .replaceAll(USER_MENTION_REGEX, "")
+      .trim();
+    AGENT_MENTION_REGEX.lastIndex = 0;
+    USER_MENTION_REGEX.lastIndex = 0;
+
+    const agentIdToRoute = richHtmlAgentId ?? markdownAgentId;
+    // If richHtmlAgentId already claimed the first agent, all
+    // markdown-stripped mentions are extras; otherwise subtract one.
+    const extraAgents = richHtmlAgentId
+      ? agentStrippedCount
+      : agentStrippedCount - 1;
+
+    let notification: MentionsStrippedPayload | null = null;
+    if (firstUserMatch !== null) {
+      notification = { reason: "users-stripped-for-agent" };
+    } else if (extraAgents > 0) {
+      notification = { reason: "extra-agents", count: extraAgents };
+    }
+
+    return { content, agentIdToRoute, notification };
+  }
+
+  // No mentions to strip.
+  return {
+    content: processedMarkdown,
+    agentIdToRoute: null,
+    notification: null,
+  };
+}
+
 interface MentionExtensionOptions extends MentionOptions {
   owner: WorkspaceType;
   onFirstAgentMentionPasteRef?: RefObject<
     ((agentId: string) => void) | undefined
   >;
-  onAgentMentionsStrippedRef?: RefObject<((count: number) => void) | undefined>;
+  onAgentMentionsStrippedRef?: RefObject<
+    ((payload: MentionsStrippedPayload) => void) | undefined
+  >;
 }
 
 export const MentionExtension = Mention.extend<MentionExtensionOptions>({
@@ -179,10 +275,8 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
           // Get text from the slice after TipTap processing.
           const text = slice.content.textBetween(0, slice.content.size, "\n");
 
-          // In single-agent mode, check if the slice has agent mention nodes
-          // (rich HTML paste). If so, route the first to the picker — then fall
-          // through to parseMentionsOnBackend which will strip them from the
-          // serialized markdown before inserting.
+          // In single-agent mode, scan the slice for rich-HTML agent mention
+          // nodes so we know whether any exist before the backend call.
           let richHtmlAgentId: string | null = null;
           if (onFirstAgentMentionPasteRef?.current) {
             slice.content.descendants((node) => {
@@ -194,14 +288,22 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
                 richHtmlAgentId = node.attrs.id;
               }
             });
-            if (richHtmlAgentId) {
-              onFirstAgentMentionPasteRef?.current(richHtmlAgentId);
-            }
           }
 
           // Only process if text contains @ or we have agent mention nodes to strip.
           if (!text.includes("@") && !richHtmlAgentId) {
             return false;
+          }
+
+          // Check pre-existing editor state for user mentions.
+          let editorHasUserMentions = false;
+          if (onFirstAgentMentionPasteRef?.current) {
+            editor.state.doc.descendants((node) => {
+              if (node.type.name === "mention" && node.attrs.type === "user") {
+                editorHasUserMentions = true;
+                return false;
+              }
+            });
           }
 
           const { state } = view;
@@ -244,34 +346,20 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
             .then((processedMarkdown: string) => {
               let contentToInsert = processedMarkdown;
 
-              // In single-agent mode, strip all agent mentions from the pasted
-              // content and route the first one to the picker (unless we already
-              // routed it from the rich-HTML slice check above).
+              // In single-agent mode, enforce mutual exclusion between agent
+              // and user mentions. Whichever type is established first wins.
               if (onFirstAgentMentionPasteRef?.current) {
-                let markdownAgentId: string | null = null;
-                let strippedCount = 0;
-                contentToInsert = processedMarkdown
-                  .replaceAll(
-                    AGENT_MENTION_REGEX,
-                    (_match, _label, agentId) => {
-                      if (!markdownAgentId) {
-                        markdownAgentId = agentId;
-                      }
-                      strippedCount++;
-                      return "";
-                    }
-                  )
-                  .trim();
-                if (markdownAgentId && !richHtmlAgentId) {
-                  onFirstAgentMentionPasteRef?.current(markdownAgentId);
+                const { content, agentIdToRoute, notification } =
+                  stripConflictingMentions(processedMarkdown, {
+                    editorHasUserMentions,
+                    richHtmlAgentId,
+                  });
+                contentToInsert = content;
+                if (agentIdToRoute) {
+                  onFirstAgentMentionPasteRef.current(agentIdToRoute);
                 }
-                // If richHtmlAgentId already claimed the first agent, all
-                // markdown-stripped mentions are extras; otherwise subtract one.
-                const extraStripped = richHtmlAgentId
-                  ? strippedCount
-                  : strippedCount - 1;
-                if (extraStripped > 0) {
-                  onAgentMentionsStrippedRef?.current?.(extraStripped);
+                if (notification) {
+                  onAgentMentionsStrippedRef?.current?.(notification);
                 }
               }
 

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -5,7 +5,10 @@ import { KeyboardShortcutsExtension } from "@app/components/editor/extensions/in
 import { PastedAttachmentExtension } from "@app/components/editor/extensions/input_bar/PastedAttachmentExtension";
 import { URLDetectionExtension } from "@app/components/editor/extensions/input_bar/URLDetectionExtension";
 import { URLStorageExtension } from "@app/components/editor/extensions/input_bar/URLStorageExtension";
-import { MentionExtension } from "@app/components/editor/extensions/MentionExtension";
+import {
+  MentionExtension,
+  type MentionsStrippedPayload,
+} from "@app/components/editor/extensions/MentionExtension";
 import { BlockquoteExtension } from "@app/components/editor/input_bar/BlockquoteExtension";
 import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import { emojiPluginKey } from "@app/components/editor/input_bar/emojiSuggestion";
@@ -195,7 +198,7 @@ export interface CustomEditorProps {
     ((agentId: string) => void) | undefined
   >;
   onAgentMentionsStrippedRef?: React.RefObject<
-    ((count: number) => void) | undefined
+    ((payload: MentionsStrippedPayload) => void) | undefined
   >;
 }
 
@@ -225,7 +228,7 @@ export const buildEditorExtensions = ({
     ((agentId: string) => void) | undefined
   >;
   onAgentMentionsStrippedRef?: React.RefObject<
-    ((count: number) => void) | undefined
+    ((payload: MentionsStrippedPayload) => void) | undefined
   >;
 }) => {
   const extensions = [


### PR DESCRIPTION
## Description
This expands on the PR I put up to strip excess agent mentions on paste, also taking into account user mentions. It respects whichever is pasted first (user or first agent) and strips the rest of the mentions. Populates notification text based on what we stripped out and why 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Test via link! Testing no regression on the behavior already merged (agent only paste removal) as well as new user paste scenarios
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, these are all edge case 
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front 

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
