### PR TITLE
[front] feat: add input-aware tool display labels

### DIFF
--- a/front/lib/actions/tool_display_labels.test.ts
+++ b/front/lib/actions/tool_display_labels.test.ts
@@ -1,6 +1,6 @@
 import {
-  getToolDisplayLabels,
   getStaticToolDisplayLabelsFromFunctionCallName,
+  getToolDisplayLabels,
   getToolNameFromFunctionCallName,
 } from "@app/lib/actions/tool_display_labels";
 import { describe, expect, it } from "vitest";

--- a/front/lib/actions/tool_display_labels.test.ts
+++ b/front/lib/actions/tool_display_labels.test.ts
@@ -25,6 +25,7 @@ describe("getStaticToolDisplayLabels", () => {
       getStaticToolDisplayLabels({
         internalMCPServerName: "common_utilities",
         toolName: "wait",
+        inputs: {},
       })
     ).toEqual({
       running: "Waiting",
@@ -37,6 +38,7 @@ describe("getStaticToolDisplayLabels", () => {
       getStaticToolDisplayLabels({
         mcpServerName: "Linear",
         toolName: "list_issues",
+        inputs: {},
       })
     ).toEqual({
       running: "Listing issues on Linear",

--- a/front/lib/actions/tool_display_labels.test.ts
+++ b/front/lib/actions/tool_display_labels.test.ts
@@ -1,5 +1,5 @@
 import {
-  getStaticToolDisplayLabels,
+  getToolDisplayLabels,
   getStaticToolDisplayLabelsFromFunctionCallName,
   getToolNameFromFunctionCallName,
 } from "@app/lib/actions/tool_display_labels";
@@ -19,10 +19,10 @@ describe("getToolNameFromFunctionCallName", () => {
   });
 });
 
-describe("getStaticToolDisplayLabels", () => {
+describe("getToolDisplayLabels", () => {
   it("resolves labels for internal tools", () => {
     expect(
-      getStaticToolDisplayLabels({
+      getToolDisplayLabels({
         internalMCPServerName: "common_utilities",
         toolName: "wait",
         inputs: {},
@@ -35,7 +35,7 @@ describe("getStaticToolDisplayLabels", () => {
 
   it("resolves labels for default remote tools", () => {
     expect(
-      getStaticToolDisplayLabels({
+      getToolDisplayLabels({
         mcpServerName: "Linear",
         toolName: "list_issues",
         inputs: {},

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -397,10 +397,8 @@ function getDynamicToolDisplayLabels({
     case "project_conversation":
     case "sandbox":
     case "ask_user_question":
-      return null;
-
     default:
-      assertNever(internalMCPServerName);
+      return null;
   }
 }
 

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -5,10 +5,31 @@ import {
   type InternalMCPServerNameType,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { DEFAULT_REMOTE_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/remote_servers";
+import {
+  isDataSourceFilesystemFindInputType,
+  isGenerateImageInputType,
+  isSearchInputType,
+  isWebbrowseInputType,
+  isWebsearchInputType,
+} from "@app/lib/actions/mcp_internal_actions/types";
 import type { ToolDisplayLabels } from "@app/lib/api/mcp";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
 import { asDisplayName, slugify } from "@app/types/shared/utils/string_utils";
 
 type ToolDisplayLabelsByTool = Record<string, ToolDisplayLabels>;
+
+const MAX_QUERY_DISPLAY_LENGTH = 60;
+
+function truncateQuery(query: string): string {
+  return query.length > MAX_QUERY_DISPLAY_LENGTH
+    ? query.slice(0, MAX_QUERY_DISPLAY_LENGTH) + "…"
+    : query;
+}
+
+function shortenUrl(url: string): string {
+  return truncateQuery(url.replace(/^https?:\/\//, ""));
+}
 
 const INTERNAL_TOOL_DISPLAY_LABELS_BY_SERVER = Object.fromEntries(
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES.flatMap((serverName) => {
@@ -83,12 +104,23 @@ export function getStaticToolDisplayLabels({
   internalMCPServerName,
   mcpServerName,
   toolName,
+  inputs,
 }: {
   internalMCPServerName?: InternalMCPServerNameType | null;
   mcpServerName?: string | null;
   toolName: string;
+  inputs: Record<string, unknown>;
 }): ToolDisplayLabels | null {
   if (internalMCPServerName) {
+    const dynamicLabels = getDynamicToolDisplayLabels({
+      internalMCPServerName,
+      toolName,
+      inputs,
+    });
+    if (dynamicLabels) {
+      return dynamicLabels;
+    }
+
     return getStaticToolDisplayLabelsForServerName(
       internalMCPServerName,
       toolName

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -147,10 +147,7 @@ function getDynamicToolDisplayLabels({
       return null;
 
     case "gmail":
-      if (
-        toolName === "create_draft" &&
-        isString(inputs.subject)
-      ) {
+      if (toolName === "create_draft" && isString(inputs.subject)) {
         const s = truncateQuery(inputs.subject);
         return {
           running: `Drafting “${s}”`,
@@ -187,16 +184,6 @@ function getDynamicToolDisplayLabels({
       }
       return null;
 
-    case "google_drive":
-      if (toolName === "search_files" && isString(inputs.q)) {
-        const q = truncateQuery(inputs.q);
-        return {
-          running: `Searching Drive “${q}”`,
-          done: `Searched Drive “${q}”`,
-        };
-      }
-      return null;
-
     case "extract_data":
       if (
         toolName === "extract_information_from_documents" &&
@@ -211,9 +198,146 @@ function getDynamicToolDisplayLabels({
       return null;
 
     case "conversation_files":
+      if (toolName === "semantic_search" && isString(inputs.query)) {
+        const q = truncateQuery(inputs.query);
         return {
           running: `Searching files “${q}”`,
           done: `Searched files “${q}”`,
+        };
+      }
+      return null;
+
+    case "github": {
+      const base =
+        isString(inputs.owner) && isString(inputs.repo)
+          ? `github.com/${inputs.owner}/${inputs.repo}`
+          : null;
+      if (
+        toolName === "get_pull_request" &&
+        base &&
+        typeof inputs.pullNumber === "number"
+      ) {
+        const url = `${base}/pull/${inputs.pullNumber}`;
+        return {
+          running: `Retrieving ${url}`,
+          done: `Retrieved ${url}`,
+        };
+      }
+      if (
+        toolName === "get_issue" &&
+        base &&
+        typeof inputs.issueNumber === "number"
+      ) {
+        const url = `${base}/issues/${inputs.issueNumber}`;
+        return {
+          running: `Retrieving ${url}`,
+          done: `Retrieved ${url}`,
+        };
+      }
+      if (toolName === "create_issue" && base && isString(inputs.title)) {
+        const t = truncateQuery(inputs.title);
+        return {
+          running: `Creating issue on ${base}: “${t}”`,
+          done: `Created issue on ${base}: “${t}”`,
+        };
+      }
+      if (
+        toolName === "comment_on_issue" &&
+        base &&
+        typeof inputs.issueNumber === "number"
+      ) {
+        const url = `${base}/issues/${inputs.issueNumber}`;
+        return {
+          running: `Commenting on ${url}`,
+          done: `Commented on ${url}`,
+        };
+      }
+      if (
+        toolName === "create_pull_request_review" &&
+        base &&
+        typeof inputs.pullNumber === "number"
+      ) {
+        const url = `${base}/pull/${inputs.pullNumber}`;
+        return {
+          running: `Reviewing ${url}`,
+          done: `Reviewed ${url}`,
+        };
+      }
+      if (toolName === "list_issues" && base) {
+        return {
+          running: `Listing issues on ${base}`,
+          done: `Listed issues on ${base}`,
+        };
+      }
+      if (toolName === "list_pull_requests" && base) {
+        return {
+          running: `Listing PRs on ${base}`,
+          done: `Listed PRs on ${base}`,
+        };
+      }
+      return null;
+    }
+
+    case "google_calendar":
+      if (toolName === "create_event" && isString(inputs.summary)) {
+        const s = truncateQuery(inputs.summary);
+        return {
+          running: `Creating event “${s}”`,
+          done: `Created event “${s}”`,
+        };
+      }
+      if (toolName === "update_event" && isString(inputs.summary)) {
+        const s = truncateQuery(inputs.summary);
+        return {
+          running: `Updating event “${s}”`,
+          done: `Updated event “${s}”`,
+        };
+      }
+      return null;
+
+    case "outlook_calendar":
+      if (
+        (toolName === "create_event" || toolName === "update_event") &&
+        isString(inputs.subject)
+      ) {
+        const s = truncateQuery(inputs.subject);
+        const verb = toolName === "create_event" ? "Creating" : "Updating";
+        const past = toolName === "create_event" ? "Created" : "Updated";
+        return {
+          running: `${verb} event “${s}”`,
+          done: `${past} event “${s}”`,
+        };
+      }
+      return null;
+
+    case "outlook":
+      if (toolName === "create_draft" && isString(inputs.subject)) {
+        const s = truncateQuery(inputs.subject);
+        return {
+          running: `Drafting “${s}”`,
+          done: `Drafted “${s}”`,
+        };
+      }
+      return null;
+
+    case "google_drive":
+      if (toolName === "search_files" && isString(inputs.q)) {
+        const q = truncateQuery(inputs.q);
+        return {
+          running: `Searching Drive “${q}”`,
+          done: `Searched Drive “${q}”`,
+        };
+      }
+      if (
+        (toolName === "create_document" ||
+          toolName === "create_spreadsheet" ||
+          toolName === "create_presentation") &&
+        isString(inputs.title)
+      ) {
+        const t = truncateQuery(inputs.title);
+        return {
+          running: `Creating “${t}”`,
+          done: `Created “${t}”`,
         };
       }
       return null;
@@ -231,9 +355,7 @@ function getDynamicToolDisplayLabels({
     case "file_generation":
     case "fathom":
     case "freshservice":
-    case "github":
     case "gong":
-    case "google_calendar":
     case "google_sheets":
     case "hubspot":
     case "include_data":
@@ -247,8 +369,6 @@ function getDynamicToolDisplayLabels({
     case "missing_action_catcher":
     case "monday":
     case "openai_usage":
-    case "outlook_calendar":
-    case "outlook":
     case "primitive_types_debugger":
     case "productboard":
     case "common_utilities":

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -205,6 +205,13 @@ function getDynamicToolDisplayLabels({
           done: `Searched files “${q}”`,
         };
       }
+      if (toolName === "cat" && isString(inputs.grep)) {
+        const g = truncateQuery(inputs.grep);
+        return {
+          running: `Searching for “${g}” in file`,
+          done: `Searched for “${g}” in file`,
+        };
+      }
       return null;
 
     case "github": {

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -68,6 +68,222 @@ function getToolCallNameParts(functionCallName: string) {
   };
 }
 
+/**
+ * Generate input-aware dynamic labels for internal MCP server tools.
+ */
+function getDynamicToolDisplayLabels({
+  internalMCPServerName,
+  toolName,
+  inputs,
+}: {
+  internalMCPServerName: InternalMCPServerNameType;
+  toolName: string;
+  inputs: Record<string, unknown>;
+}): ToolDisplayLabels | null {
+  switch (internalMCPServerName) {
+    case "web_search_&_browse":
+    case "http_client":
+      if (toolName === "websearch" && isWebsearchInputType(inputs)) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Searching “${q}”`,
+          done: `Searched “${q}”`,
+        };
+      }
+      if (toolName === "webbrowser" && isWebbrowseInputType(inputs)) {
+        if (inputs.urls.length === 1) {
+          const url = shortenUrl(inputs.urls[0]);
+          return {
+            running: `Browsing “${url}”`,
+            done: `Browsed “${url}”`,
+          };
+        }
+        return {
+          running: `Browsing ${inputs.urls.length} web pages`,
+          done: `Browsed ${inputs.urls.length} web pages`,
+        };
+      }
+      return null;
+
+    case "search":
+      if (toolName === "semantic_search" && isSearchInputType(inputs)) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Searching “${q}”`,
+          done: `Searched “${q}”`,
+        };
+      }
+      return null;
+
+    case "data_sources_file_system":
+      if (
+        toolName === "find" &&
+        isDataSourceFilesystemFindInputType(inputs) &&
+        inputs.query
+      ) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Finding “${q}”`,
+          done: `Found “${q}”`,
+        };
+      }
+      if (toolName === "semantic_search" && isSearchInputType(inputs)) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Searching “${q}”`,
+          done: `Searched “${q}”`,
+        };
+      }
+      return null;
+
+    case "image_generation":
+      if (toolName === "generate_image" && isGenerateImageInputType(inputs)) {
+        const name = truncateQuery(inputs.outputName);
+        return {
+          running: `Generating “${name}”`,
+          done: `Generated “${name}”`,
+        };
+      }
+      return null;
+
+    case "gmail":
+      if (
+        toolName === "create_draft" &&
+        isString(inputs.subject)
+      ) {
+        const s = truncateQuery(inputs.subject);
+        return {
+          running: `Drafting “${s}”`,
+          done: `Drafted “${s}”`,
+        };
+      }
+      if (toolName === "send_mail" && isString(inputs.subject)) {
+        const s = truncateQuery(inputs.subject);
+        return {
+          running: `Sending “${s}”`,
+          done: `Sent “${s}”`,
+        };
+      }
+      return null;
+
+    case "slack":
+    case "slack_bot":
+      if (toolName === "post_message" && isString(inputs.to)) {
+        const to = truncateQuery(inputs.to);
+        return {
+          running: `Posting to channel ${to}`,
+          done: `Posted to channel ${to}`,
+        };
+      }
+      return null;
+
+    case "notion":
+      if (toolName === "search" && isString(inputs.query)) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Searching Notion “${q}”`,
+          done: `Searched Notion “${q}”`,
+        };
+      }
+      return null;
+
+    case "google_drive":
+      if (toolName === "search_files" && isString(inputs.q)) {
+        const q = truncateQuery(inputs.q);
+        return {
+          running: `Searching Drive “${q}”`,
+          done: `Searched Drive “${q}”`,
+        };
+      }
+      return null;
+
+    case "extract_data":
+      if (
+        toolName === "extract_information_from_documents" &&
+        isString(inputs.objective)
+      ) {
+        const o = truncateQuery(inputs.objective);
+        return {
+          running: `Extracting “${o}”`,
+          done: `Extracted “${o}”`,
+        };
+      }
+      return null;
+
+    case "conversation_files":
+        return {
+          running: `Searching files “${q}”`,
+          done: `Searched files “${q}”`,
+        };
+      }
+      return null;
+
+    // All other servers: no dynamic labels.
+    case "agent_sidekick_agent_state":
+    case "agent_sidekick_context":
+    case "agent_management":
+    case "agent_memory":
+    case "agent_router":
+    case "ashby":
+    case "confluence":
+    case "databricks":
+    case "data_warehouses":
+    case "file_generation":
+    case "fathom":
+    case "freshservice":
+    case "github":
+    case "gong":
+    case "google_calendar":
+    case "google_sheets":
+    case "hubspot":
+    case "include_data":
+    case "interactive_content":
+    case "slideshow":
+    case "jira":
+    case "luma":
+    case "microsoft_drive":
+    case "microsoft_excel":
+    case "microsoft_teams":
+    case "missing_action_catcher":
+    case "monday":
+    case "openai_usage":
+    case "outlook_calendar":
+    case "outlook":
+    case "primitive_types_debugger":
+    case "productboard":
+    case "common_utilities":
+    case "jit_testing":
+    case "run_agent":
+    case "run_dust_app":
+    case "salesforce":
+    case "salesloft":
+    case "slab":
+    case "snowflake":
+    case "sound_studio":
+    case "speech_generator":
+    case "statuspage":
+    case "toolsets":
+    case "ukg_ready":
+    case "user_mentions":
+    case "val_town":
+    case "vanta":
+    case "front":
+    case "zendesk":
+    case "query_tables_v2":
+    case "skill_management":
+    case "schedules_management":
+    case "project_manager":
+    case "poke":
+    case "project_conversation":
+    case "sandbox":
+    case "ask_user_question":
+      return null;
+
+    default:
+      assertNever(internalMCPServerName);
+  }
+}
+
 function getStaticToolDisplayLabelsForServerName(
   serverName: string,
   toolName: string

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -436,7 +436,7 @@ export function getToolNameFromFunctionCallName(functionCallName: string) {
   return functionCallName.split(TOOL_NAME_SEPARATOR).at(-1) ?? functionCallName;
 }
 
-export function getStaticToolDisplayLabels({
+export function getToolDisplayLabels({
   internalMCPServerName,
   mcpServerName,
   toolName,

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -13,7 +13,6 @@ import {
   isWebsearchInputType,
 } from "@app/lib/actions/mcp_internal_actions/types";
 import type { ToolDisplayLabels } from "@app/lib/api/mcp";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import { asDisplayName, slugify } from "@app/types/shared/utils/string_utils";
 

--- a/front/lib/api/assistant/activity_steps.ts
+++ b/front/lib/api/assistant/activity_steps.ts
@@ -1,8 +1,4 @@
 import {
-  isSearchInputType,
-  isWebsearchInputType,
-} from "@app/lib/actions/mcp_internal_actions/types";
-import {
   AgentMessageContentParser,
   getCoTDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
@@ -17,36 +13,6 @@ import {
 import type { InlineActivityStep } from "@app/types/assistant/conversation";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 
-const MAX_QUERY_DISPLAY_LENGTH = 60;
-
-function truncateQuery(query: string): string {
-  return query.length > MAX_QUERY_DISPLAY_LENGTH
-    ? query.slice(0, MAX_QUERY_DISPLAY_LENGTH) + "\u2026"
-    : query;
-}
-
-function getToolInlineLabel(
-  action: AgentMCPActionWithOutputType,
-  context: "running" | "done"
-): string | null {
-  if (action.toolName === "websearch" && isWebsearchInputType(action.params)) {
-    const q = truncateQuery(action.params.query);
-    return context === "running"
-      ? `Searching \u201c${q}\u201d`
-      : `Searched \u201c${q}\u201d`;
-  }
-  if (
-    action.toolName === "semantic_search" &&
-    isSearchInputType(action.params)
-  ) {
-    const q = truncateQuery(action.params.query);
-    return context === "running"
-      ? `Searching \u201c${q}\u201d`
-      : `Searched \u201c${q}\u201d`;
-  }
-  return null;
-}
-
 /**
  * Compute the display label for an action (one-line summary).
  * Pure function with no browser dependencies — usable server-side and client-side.
@@ -56,7 +22,6 @@ export function getActionOneLineLabel(
   context: "running" | "done" = "done"
 ): string {
   return (
-    getToolInlineLabel(action, context) ??
     action.displayLabels?.[context] ??
     (action.functionCallName ? asDisplayName(action.functionCallName) : "Tool")
   );

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1022,24 +1022,20 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   }
 
   /**
-   * Resolve displayLabels for this action. Checks the persisted toolConfiguration
-   * first (handles dynamic tool names), then falls back to static metadata for
-   * older DB records or remote server defaults.
+   * Resolve displayLabels for this action. Tries dynamic input-aware labels
+   * first (e.g. Searching "query"), then persisted toolConfiguration labels,
+   * then falls back to static metadata for older DB records or remote server defaults.
    */
   private resolveDisplayLabels(
     internalMCPServerName: InternalMCPServerNameType | null,
     toolName: string
   ): ToolDisplayLabels | null {
-    if (this.toolConfiguration.displayLabels) {
-      return this.toolConfiguration.displayLabels;
-    }
-
     return getStaticToolDisplayLabels({
       internalMCPServerName,
       mcpServerName: this.toolConfiguration.mcpServerName,
       toolName,
       inputs: this.augmentedInputs,
-    });
+    }) ?? this.toolConfiguration.displayLabels ?? null;
   }
 
   async updateStatus(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1030,12 +1030,16 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     internalMCPServerName: InternalMCPServerNameType | null,
     toolName: string
   ): ToolDisplayLabels | null {
-    return getStaticToolDisplayLabels({
-      internalMCPServerName,
-      mcpServerName: this.toolConfiguration.mcpServerName,
-      toolName,
-      inputs: this.augmentedInputs,
-    }) ?? this.toolConfiguration.displayLabels ?? null;
+    return (
+      getStaticToolDisplayLabels({
+        internalMCPServerName,
+        mcpServerName: this.toolConfiguration.mcpServerName,
+        toolName,
+        inputs: this.augmentedInputs,
+      }) ??
+      this.toolConfiguration.displayLabels ??
+      null
+    );
   }
 
   async updateStatus(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1038,6 +1038,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       internalMCPServerName,
       mcpServerName: this.toolConfiguration.mcpServerName,
       toolName,
+      inputs: this.augmentedInputs,
     });
   }
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -11,7 +11,7 @@ import {
   TOOL_EXECUTION_BLOCKED_STATUSES,
 } from "@app/lib/actions/statuses";
 import {
-  getStaticToolDisplayLabels,
+  getToolDisplayLabels,
   getToolNameFromFunctionCallName,
 } from "@app/lib/actions/tool_display_labels";
 import type { StepContext } from "@app/lib/actions/types";
@@ -1031,7 +1031,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     toolName: string
   ): ToolDisplayLabels | null {
     return (
-      getStaticToolDisplayLabels({
+      getToolDisplayLabels({
         internalMCPServerName,
         mcpServerName: this.toolConfiguration.mcpServerName,
         toolName,


### PR DESCRIPTION
## Description

- This PR introduces a logic to make the display labels (Searching the web, Search the web) input-aware, meaning that for a tool we can define a callback that takes the input parameters to generate the display labels.
- Moves the existing logic for web search and semantic search to the backend.
- Only applies to internal MCP tools.
- This is a pragmatic but working implementation: ideally we'd define these callbacks near the tools and avoid the zod schema check with a stronger typing between the tool input schema and the parameters of this callback.
- A next PR will add a `title` or `label` parameter to bash tool (and maybe a few others, such as query tables) to let the model explain what it's doing and use that as a display label.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
