### PR TITLE
Metronome fixes

### DIFF
--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -138,9 +138,9 @@ async function getSubscriptionInfo(
       subscription.stripeSubscriptionId
     );
     if (stripeSubscription) {
-      const startTimestamp =
-        stripeSubscription.start_date ??
-        stripeSubscription.current_period_start;
+      // Use current billing period start — not the original subscription start date.
+      // This ensures the Metronome contract aligns with the current billing cycle.
+      const startTimestamp = stripeSubscription.current_period_start;
       // Round to hour boundary (Metronome requirement).
       const rounded = Math.floor(startTimestamp / 3600) * 3600;
       startDate = new Date(rounded * 1000).toISOString();

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -281,9 +281,10 @@ export async function emitMetronomeUsageEventsActivity(
   // Resolve API key name from the stored numeric FK.
   let apiKeyName: string | null = null;
   if (userMessage?.userContextApiKeyId) {
-    const key = await KeyResource.fetchByModelId(
-      userMessage.userContextApiKeyId
-    );
+    const key = await KeyResource.fetchByWorkspaceAndId({
+      workspace,
+      id: userMessage.userContextApiKeyId,
+    });
     apiKeyName = key?.name ?? null;
   }
 


### PR DESCRIPTION
## Summary

Two fixes for Metronome integration.

### 1. Use current billing period for contract start date

The migration script was using `stripeSubscription.start_date` (original subscription creation date, potentially years ago) as the Metronome contract `starting_at`. Now uses `current_period_start` so the contract aligns with the current Stripe billing cycle.

### 2. Fix workspace isolation violation in usage events activity

`KeyResource.fetchByModelId` uses `findByPk` which doesn't pass `workspaceId` — this throws in dev (`NODE_ENV !== "production"`) due to workspace isolation enforcement. Replaced with `KeyResource.fetchByWorkspaceAndId` which queries with both `id` and `workspaceId`.

## Test plan

- [ ] Migration script creates contracts starting at current billing period, not original subscription date
- [ ] `emitMetronomeUsageEventsActivity` resolves API key name without workspace isolation error in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)