### PR TITLE
Round periodEnd

### DIFF
--- a/front/lib/api/analytics/metronome_usage.ts
+++ b/front/lib/api/analytics/metronome_usage.ts
@@ -212,8 +212,10 @@ export async function handleMetronomeUsageRequest(
         getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
 
       const TEN_DAYS_MS = 10 * 24 * 60 * 60 * 1000;
+      const minDate = new Date(Date.now() + TEN_DAYS_MS);
+      minDate.setUTCHours(0, 0, 0, 0);
       const cappedPeriodEnd = new Date(
-        Math.min(periodEnd.getTime(), Date.now() + TEN_DAYS_MS)
+        Math.min(periodEnd.getTime(), minDate.getTime())
       );
 
       const startingOn = periodStart.toISOString();


### PR DESCRIPTION
## Summary

Fixes the `cappedPeriodEnd` calculation in the Metronome usage API. The cap (now + 10 days) is rounded down to midnight UTC to avoid passing a mid-day timestamp to Metronome's usage query, which expects day-boundary dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)