### PR TITLE
Filter pending messages by branchId in conversation steering

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2616,18 +2616,11 @@ export async function updateAgentMessageWithFinalStatus(
       // invariant in which case we could have more than one running agent message and could pick
       // the wrong agent compared to user attempt. But should ~never happen so the simplicity is
       // worth it.
-      const pendingMessages = await MessageModel.findAll({
-        where: {
-          conversationId: conversation.id,
-          workspaceId: owner.id,
-          visibility: "pending",
-        },
-        include: [
-          { model: UserMessageModel, as: "userMessage", required: false },
-        ],
-        order: [["rank", "ASC"]],
-        transaction: t,
-      });
+      const pendingMessages =
+        await ConversationResource.getPendingUserMessagesInConversation(auth, {
+          conversation,
+          transaction: t,
+        });
 
       if (pendingMessages.length === 0) {
         return {

--- a/front/lib/reinforced_agent/signals.ts
+++ b/front/lib/reinforced_agent/signals.ts
@@ -148,7 +148,7 @@ export async function fetchReinforcementAutoTrackSignals(
         agentIds,
         lookbackWindowDays
       ),
-      ConversationResource.getConversationSIdsByAgent(auth, {
+      ConversationResource.getConversationIdsByAgent(auth, {
         agentIds,
         cutoffDate,
         excludeHumanOutOfTheLoop: true,

--- a/front/lib/reinforced_agent/utils.ts
+++ b/front/lib/reinforced_agent/utils.ts
@@ -81,7 +81,7 @@ export async function listRecentConversationsForAgent(
 ): Promise<string[]> {
   const auth = await getAuthForWorkspace(workspaceId);
 
-  const convSIdsByAgent = await ConversationResource.getConversationSIdsByAgent(
+  const convSIdsByAgent = await ConversationResource.getConversationIdsByAgent(
     auth,
     {
       agentIds: [agentConfigurationId],

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3430,6 +3430,285 @@ describe("Space Handling", () => {
     });
   });
 
+  describe("getPendingUserMessagesInConversation", () => {
+    let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+    let auth: Authenticator;
+    let conversation: ConversationWithoutContentType;
+    let agents: LightAgentConfigurationType[];
+
+    beforeEach(async () => {
+      workspace = await WorkspaceFactory.basic();
+      const user = await UserFactory.basic();
+      auth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+      agents = await setupTestAgents(workspace, user);
+
+      conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agents[0].sId,
+        messagesCreatedAt: [],
+      });
+    });
+
+    async function createPendingUserMessage(
+      conversationId: number,
+      rank: number,
+      branchId: number | null = null
+    ) {
+      const user = auth.getNonNullableUser();
+      const userMessageRow = await UserMessageModel.create({
+        userId: user.id,
+        workspaceId: workspace.id,
+        content: `Pending message rank ${rank}`,
+        userContextUsername: "testuser",
+        userContextTimezone: "UTC",
+        userContextFullName: "Test User",
+        userContextEmail: "test@example.com",
+        userContextProfilePictureUrl: null,
+        userContextOrigin: "web",
+        clientSideMCPServerIds: [],
+      });
+
+      return MessageModel.create({
+        sId: generateRandomModelSId(),
+        rank,
+        conversationId,
+        parentId: null,
+        userMessageId: userMessageRow.id,
+        workspaceId: workspace.id,
+        visibility: "pending",
+        branchId,
+      });
+    }
+
+    it("returns pending messages with null branchId when conversation has no branch", async () => {
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      assert(conversationResource, "Conversation resource not found");
+
+      const msg1 = await createPendingUserMessage(conversationResource.id, 10);
+      const msg2 = await createPendingUserMessage(conversationResource.id, 11);
+
+      const pending =
+        await ConversationResource.getPendingUserMessagesInConversation(auth, {
+          conversation,
+        });
+
+      expect(pending).toHaveLength(2);
+      expect(pending.map((m) => m.id)).toEqual([msg1.id, msg2.id]);
+    });
+
+    it("excludes pending messages that belong to a different branch", async () => {
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      assert(conversationResource, "Conversation resource not found");
+
+      const user = auth.getNonNullableUser();
+
+      // Create a main-thread message to anchor the branch.
+      const anchorUserMessageRow = await UserMessageModel.create({
+        userId: user.id,
+        workspaceId: workspace.id,
+        content: "Anchor message",
+        userContextUsername: "testuser",
+        userContextTimezone: "UTC",
+        userContextFullName: "Test User",
+        userContextEmail: "test@example.com",
+        userContextProfilePictureUrl: null,
+        userContextOrigin: "web",
+        clientSideMCPServerIds: [],
+      });
+      const anchorMessage = await MessageModel.create({
+        sId: generateRandomModelSId(),
+        rank: 0,
+        conversationId: conversationResource.id,
+        parentId: null,
+        userMessageId: anchorUserMessageRow.id,
+        workspaceId: workspace.id,
+      });
+
+      // Create two branches.
+      const branchA = await ConversationBranchResource.makeNew(auth, {
+        state: "open",
+        previousMessageId: anchorMessage.id,
+        conversationId: conversationResource.id,
+        userId: user.id,
+      });
+      const branchB = await ConversationBranchResource.makeNew(auth, {
+        state: "open",
+        previousMessageId: anchorMessage.id,
+        conversationId: conversationResource.id,
+        userId: user.id,
+      });
+
+      // Create a pending message on branchA.
+      const msgOnA = await createPendingUserMessage(
+        conversationResource.id,
+        10,
+        branchA.id
+      );
+      // Create a pending message on branchB.
+      await createPendingUserMessage(conversationResource.id, 11, branchB.id);
+      // Create a pending message with no branch.
+      const msgNoBranch = await createPendingUserMessage(
+        conversationResource.id,
+        12
+      );
+
+      // Query with conversation scoped to branchA.
+      const conversationOnBranchA: ConversationWithoutContentType = {
+        ...conversation,
+        branchId: branchA.sId,
+      };
+
+      const pending =
+        await ConversationResource.getPendingUserMessagesInConversation(auth, {
+          conversation: conversationOnBranchA,
+        });
+
+      // Should include the message on branchA and the one with null branchId,
+      // but NOT the message on branchB.
+      expect(pending).toHaveLength(2);
+      expect(pending.map((m) => m.id)).toEqual([msgOnA.id, msgNoBranch.id]);
+    });
+
+    it("excludes all branched pending messages when conversation has no branch", async () => {
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      assert(conversationResource, "Conversation resource not found");
+
+      const user = auth.getNonNullableUser();
+
+      // Create a main-thread anchor message.
+      const anchorUserMessageRow = await UserMessageModel.create({
+        userId: user.id,
+        workspaceId: workspace.id,
+        content: "Anchor",
+        userContextUsername: "testuser",
+        userContextTimezone: "UTC",
+        userContextFullName: "Test User",
+        userContextEmail: "test@example.com",
+        userContextProfilePictureUrl: null,
+        userContextOrigin: "web",
+        clientSideMCPServerIds: [],
+      });
+      const anchorMessage = await MessageModel.create({
+        sId: generateRandomModelSId(),
+        rank: 0,
+        conversationId: conversationResource.id,
+        parentId: null,
+        userMessageId: anchorUserMessageRow.id,
+        workspaceId: workspace.id,
+      });
+
+      const branch = await ConversationBranchResource.makeNew(auth, {
+        state: "open",
+        previousMessageId: anchorMessage.id,
+        conversationId: conversationResource.id,
+        userId: user.id,
+      });
+
+      // A pending message on the branch.
+      await createPendingUserMessage(conversationResource.id, 10, branch.id);
+      // A pending message with no branch.
+      const msgNoBranch = await createPendingUserMessage(
+        conversationResource.id,
+        11
+      );
+
+      // Query with the main conversation (branchId: null).
+      const pending =
+        await ConversationResource.getPendingUserMessagesInConversation(auth, {
+          conversation,
+        });
+
+      // Only the null-branch message is returned.
+      expect(pending).toHaveLength(1);
+      expect(pending[0].id).toBe(msgNoBranch.id);
+    });
+
+    it("returns pending messages ordered by rank", async () => {
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      assert(conversationResource, "Conversation resource not found");
+
+      const msg3 = await createPendingUserMessage(
+        conversationResource.id,
+        30
+      );
+      const msg1 = await createPendingUserMessage(
+        conversationResource.id,
+        10
+      );
+      const msg2 = await createPendingUserMessage(
+        conversationResource.id,
+        20
+      );
+
+      const pending =
+        await ConversationResource.getPendingUserMessagesInConversation(auth, {
+          conversation,
+        });
+
+      expect(pending.map((m) => m.id)).toEqual([msg1.id, msg2.id, msg3.id]);
+    });
+
+    it("does not return visible or deleted messages", async () => {
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      assert(conversationResource, "Conversation resource not found");
+
+      // Create one pending message.
+      const pendingMsg = await createPendingUserMessage(
+        conversationResource.id,
+        10
+      );
+
+      // Create a visible message (default visibility).
+      const user = auth.getNonNullableUser();
+      const visibleUserMessageRow = await UserMessageModel.create({
+        userId: user.id,
+        workspaceId: workspace.id,
+        content: "Visible message",
+        userContextUsername: "testuser",
+        userContextTimezone: "UTC",
+        userContextFullName: "Test User",
+        userContextEmail: "test@example.com",
+        userContextProfilePictureUrl: null,
+        userContextOrigin: "web",
+        clientSideMCPServerIds: [],
+      });
+      await MessageModel.create({
+        sId: generateRandomModelSId(),
+        rank: 11,
+        conversationId: conversationResource.id,
+        parentId: null,
+        userMessageId: visibleUserMessageRow.id,
+        workspaceId: workspace.id,
+        visibility: "visible",
+      });
+
+      const pending =
+        await ConversationResource.getPendingUserMessagesInConversation(auth, {
+          conversation,
+        });
+
+      expect(pending).toHaveLength(1);
+      expect(pending[0].id).toBe(pendingMsg.id);
+    });
+  });
+
   describe("fetchMessagesForPage", () => {
     let auth: Authenticator;
     let conversation: ConversationWithoutContentType;

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3452,7 +3452,7 @@ describe("Space Handling", () => {
     });
 
     async function createPendingUserMessage(
-      conversationId: number,
+      conversationModelId: number,
       rank: number,
       branchId: number | null = null
     ) {
@@ -3473,7 +3473,7 @@ describe("Space Handling", () => {
       return MessageModel.create({
         sId: generateRandomModelSId(),
         rank,
-        conversationId,
+        conversationId: conversationModelId,
         parentId: null,
         userMessageId: userMessageRow.id,
         workspaceId: workspace.id,
@@ -3641,18 +3641,9 @@ describe("Space Handling", () => {
       );
       assert(conversationResource, "Conversation resource not found");
 
-      const msg3 = await createPendingUserMessage(
-        conversationResource.id,
-        30
-      );
-      const msg1 = await createPendingUserMessage(
-        conversationResource.id,
-        10
-      );
-      const msg2 = await createPendingUserMessage(
-        conversationResource.id,
-        20
-      );
+      const msg3 = await createPendingUserMessage(conversationResource.id, 30);
+      const msg1 = await createPendingUserMessage(conversationResource.id, 10);
+      const msg2 = await createPendingUserMessage(conversationResource.id, 20);
 
       const pending =
         await ConversationResource.getPendingUserMessagesInConversation(auth, {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -725,7 +725,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
    * createdAt >= cutoffDate. With excludeHumanOutOfTheLoop, removes conversations where
    * triggerId IS NOT NULL and no user messages are present.
    */
-  static async getConversationSIdsByAgent(
+  static async getConversationIdsByAgent(
     auth: Authenticator,
     {
       agentIds,
@@ -1706,6 +1706,38 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       messageId,
       version
     );
+  }
+
+  static async getPendingUserMessagesInConversation(
+    auth: Authenticator,
+    {
+      conversation,
+      transaction,
+    }: {
+      conversation: ConversationWithoutContentType;
+      transaction?: Transaction;
+    }
+  ): Promise<MessageModel[]> {
+    const owner = auth.getNonNullableWorkspace();
+    const pendingMessages = await MessageModel.findAll({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: owner.id,
+        visibility: "pending",
+        branchId: conversation.branchId
+          ? {
+              [Op.or]: [getResourceIdFromSId(conversation.branchId), null],
+            }
+          : null,
+      },
+      include: [
+        { model: UserMessageModel, as: "userMessage", required: false },
+      ],
+      order: [["rank", "ASC"]],
+      transaction,
+    });
+
+    return pendingMessages;
   }
 
   static async getMessageByIdInConversation(


### PR DESCRIPTION
## Description

Addresses [@Fraggle 's review comment](https://github.com/dust-tt/dust/pull/23758#discussion_r2132505170) on #23758: the pending messages query was not filtering by `branchId`, which could promote messages from the wrong branch when steering is used with project branches.

- Moved pending message fetching to `ConversationResource.getPendingUserMessagesInConversation`
- Added `branchId` filter: when the conversation is on a branch, fetches pending messages from that branch OR with null branchId; when on the main thread, only fetches null-branchId messages
- Renamed `getConversationSIdsByAgent` → `getConversationIdsByAgent` for BACK10 consistency
- Added 5 tests covering branch filtering, ordering, and visibility

## Tests

New tests + tested locally

## Risk

Low: touches pending messages loading which is not released yet (`enable_steering`)

## Deploy Plan

- deploy `front`