### PR TITLE
[front] - fix(analytics): allow API keys to access analytics endpoints

### DIFF
--- a/front/pages/api/v1/w/[wId]/analytics/export.test.ts
+++ b/front/pages/api/v1/w/[wId]/analytics/export.test.ts
@@ -116,7 +116,7 @@ async function setupTest({
   endDate?: string;
   timezone?: string;
 } = {}) {
-  const result = await createPublicApiMockRequest({ systemKey: true });
+  const result = await createPublicApiMockRequest();
 
   const query: Record<string, string> = {
     wId: result.workspace.sId,
@@ -133,24 +133,16 @@ async function setupTest({
 }
 
 describe("GET /api/v1/w/[wId]/analytics/export", () => {
-  it("returns 403 for non-admin API key", async () => {
-    const { req, res } = await createPublicApiMockRequest();
+  it("returns 200 for regular (builder) API key", async () => {
+    const { req, res } = await setupTest();
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({
-      error: {
-        type: "workspace_auth_error",
-        message: "Only workspace admins can access workspace analytics.",
-      },
-    });
+    expect(res._getStatusCode()).toBe(200);
   });
 
   it("returns 400 for missing required query params", async () => {
-    const { req, res, workspace } = await createPublicApiMockRequest({
-      systemKey: true,
-    });
+    const { req, res, workspace } = await createPublicApiMockRequest();
     req.query = { wId: workspace.sId };
 
     await handler(req, res);
@@ -189,7 +181,6 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
     for (const method of ["POST", "PUT", "DELETE", "PATCH"] as const) {
       const result = await createPublicApiMockRequest({
         method,
-        systemKey: true,
       });
       result.req.query = {
         wId: result.workspace.sId,

--- a/front/pages/api/v1/w/[wId]/analytics/export.ts
+++ b/front/pages/api/v1/w/[wId]/analytics/export.ts
@@ -61,7 +61,7 @@
  *       400:
  *         description: Invalid request query parameters
  *       403:
- *         description: Only workspace admins can access workspace analytics
+ *         description: Requires an API key with at least builder role
  *       405:
  *         description: Method not supported
  */
@@ -79,12 +79,13 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<string>>,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isAdmin()) {
+  if (!auth.isKey() || !auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
-        message: "Only workspace admins can access workspace analytics.",
+        message:
+          "Requires an API key with at least builder role to access workspace analytics.",
       },
     });
   }

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -314,7 +314,7 @@
             "description": "Invalid request query parameters"
           },
           "403": {
-            "description": "Only workspace admins can access workspace analytics"
+            "description": "Requires an API key with at least builder role"
           },
           "405": {
             "description": "Method not supported"


### PR DESCRIPTION
## Description

Changes the `/api/v1/w/[wId]/analytics/export` endpoint authentication requirement from admin-only to builder-level API keys. This allows API keys with builder role (not just admin) to access workspace analytics data exports.

## Tests

- Updated test suite to verify builder API keys can access the endpoint
- Removed `systemKey: true` from test setup as builder keys are now sufficient
- Changed test assertion from expecting 403 to expecting 200 for regular API keys

## Risk

Medium. The endpoint remains restricted to authenticated API keys with at least builder role, and the change broadens access only slightly within the workspace.

## Deploy Plan

Deploy front