### PR TITLE
[sparkle] fix hooks consistent rendering in Sheet component

### DIFF
--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -222,11 +222,11 @@ const ScrollContainer = ({
     setViewport(viewportRef.current);
   }, []);
 
+  const value = React.useMemo(() => viewport, [viewport]);
+
   if (noScroll) {
     return <div className={className}>{children}</div>;
   }
-
-  const value = React.useMemo(() => viewport, [viewport]);
 
   return (
     <ScrollArea className={className} viewportRef={viewportRef}>


### PR DESCRIPTION
## Description

- This PR fixes the error `Rendered more hooks than during the previous render.`
- Related [channel](https://dust4ai.slack.com/archives/C0ARM456HAP/p1775727037911209).
- This error can be seen when opening the knowledge sheet in Agent Builder.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.