### PR TITLE
Send gauge events only on billing day

### DIFF
--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -27,6 +27,7 @@ import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -389,7 +390,7 @@ export async function emitMetronomeUsageEventsActivity(
 export async function emitMetronomeGaugeEventsForAllWorkspacesActivity(): Promise<void> {
   // Only workspaces with a metronomeCustomerId.
   const allWorkspaces = await WorkspaceResource.listAll();
-  const workspaces = allWorkspaces.filter(
+  const metronomeWorkspaces = allWorkspaces.filter(
     (w) => w.metronomeCustomerId !== null
   );
 
@@ -400,10 +401,61 @@ export async function emitMetronomeGaugeEventsForAllWorkspacesActivity(): Promis
     ? now.toISOString().slice(0, 13) // YYYY-MM-DDTHH
     : now.toISOString().slice(0, 10); // YYYY-MM-DD
   const timestamp = now.toISOString();
+  const todayUTC = now.toISOString().slice(0, 10);
+
+  // In production, only emit gauge events for workspaces whose billing cycle
+  // ends today. In dev, emit for all workspaces (hourly schedule).
+  let workspaces: WorkspaceResource[];
+  if (isDevelopment()) {
+    workspaces = metronomeWorkspaces;
+  } else {
+    // Batch-fetch active subscriptions for all Metronome-enabled workspaces.
+    const subscriptionsByWorkspaceId =
+      await SubscriptionResource.fetchActiveByWorkspacesModelId(
+        metronomeWorkspaces.map((w) => w.id)
+      );
+
+    // Filter to workspaces whose billing cycle ends today.
+    workspaces = [];
+    await concurrentExecutor(
+      metronomeWorkspaces,
+      async (workspace) => {
+        const subscription = subscriptionsByWorkspaceId[workspace.id];
+        if (!subscription?.stripeSubscriptionId) {
+          return;
+        }
+        const stripeSubscription = await getStripeSubscription(
+          subscription.stripeSubscriptionId
+        );
+        if (!stripeSubscription) {
+          return;
+        }
+        // Check if today matches the billing cycle boundary.
+        // Before Stripe processes renewal: current_period_end == today.
+        // After Stripe processes renewal: current_period_start == today.
+        const periodStart = new Date(
+          stripeSubscription.current_period_start * 1000
+        )
+          .toISOString()
+          .slice(0, 10);
+        const periodEnd = new Date(stripeSubscription.current_period_end * 1000)
+          .toISOString()
+          .slice(0, 10);
+        if (periodStart === todayUTC || periodEnd === todayUTC) {
+          workspaces.push(workspace);
+        }
+      },
+      { concurrency: 10 }
+    );
+  }
 
   logger.info(
-    { workspaceCount: workspaces.length, dateKey },
-    "[Metronome] Emitting gauge events for Metronome-enabled workspaces"
+    {
+      totalMetronomeWorkspaces: metronomeWorkspaces.length,
+      workspaceCount: workspaces.length,
+      dateKey,
+    },
+    "[Metronome] Emitting gauge events for workspaces with billing cycle ending today"
   );
 
   // Process workspaces in chunks: build events concurrently, then ingest

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -401,10 +401,9 @@ export async function emitMetronomeGaugeEventsForAllWorkspacesActivity(): Promis
     ? now.toISOString().slice(0, 13) // YYYY-MM-DDTHH
     : now.toISOString().slice(0, 10); // YYYY-MM-DD
   const timestamp = now.toISOString();
-  const todayUTC = now.toISOString().slice(0, 10);
 
   // In production, only emit gauge events for workspaces whose billing cycle
-  // ends today. In dev, emit for all workspaces (hourly schedule).
+  // ends within the next 24h. In dev, emit for all workspaces (hourly schedule).
   let workspaces: WorkspaceResource[];
   if (isDevelopment()) {
     workspaces = metronomeWorkspaces;
@@ -415,7 +414,8 @@ export async function emitMetronomeGaugeEventsForAllWorkspacesActivity(): Promis
         metronomeWorkspaces.map((w) => w.id)
       );
 
-    // Filter to workspaces whose billing cycle ends today.
+    // Filter to workspaces whose billing cycle ends within the next 24 hours.
+    const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000);
     const results = await concurrentExecutor(
       metronomeWorkspaces,
       async (workspace): Promise<WorkspaceResource | null> => {
@@ -429,20 +429,10 @@ export async function emitMetronomeGaugeEventsForAllWorkspacesActivity(): Promis
         if (!stripeSubscription) {
           return null;
         }
-        // Check if today matches the billing cycle boundary.
-        // Before Stripe processes renewal: current_period_end == today.
-        // After Stripe processes renewal: current_period_start == today.
-        const periodStart = new Date(
-          stripeSubscription.current_period_start * 1000
-        )
-          .toISOString()
-          .slice(0, 10);
-        const periodEnd = new Date(stripeSubscription.current_period_end * 1000)
-          .toISOString()
-          .slice(0, 10);
-        return periodStart === todayUTC || periodEnd === todayUTC
-          ? workspace
-          : null;
+        const periodEnd = new Date(
+          stripeSubscription.current_period_end * 1000
+        );
+        return periodEnd >= now && periodEnd <= in24h ? workspace : null;
       },
       { concurrency: 10 }
     );

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -416,19 +416,18 @@ export async function emitMetronomeGaugeEventsForAllWorkspacesActivity(): Promis
       );
 
     // Filter to workspaces whose billing cycle ends today.
-    workspaces = [];
-    await concurrentExecutor(
+    const results = await concurrentExecutor(
       metronomeWorkspaces,
-      async (workspace) => {
+      async (workspace): Promise<WorkspaceResource | null> => {
         const subscription = subscriptionsByWorkspaceId[workspace.id];
         if (!subscription?.stripeSubscriptionId) {
-          return;
+          return null;
         }
         const stripeSubscription = await getStripeSubscription(
           subscription.stripeSubscriptionId
         );
         if (!stripeSubscription) {
-          return;
+          return null;
         }
         // Check if today matches the billing cycle boundary.
         // Before Stripe processes renewal: current_period_end == today.
@@ -441,12 +440,13 @@ export async function emitMetronomeGaugeEventsForAllWorkspacesActivity(): Promis
         const periodEnd = new Date(stripeSubscription.current_period_end * 1000)
           .toISOString()
           .slice(0, 10);
-        if (periodStart === todayUTC || periodEnd === todayUTC) {
-          workspaces.push(workspace);
-        }
+        return periodStart === todayUTC || periodEnd === todayUTC
+          ? workspace
+          : null;
       },
       { concurrency: 10 }
     );
+    workspaces = results.filter((w): w is WorkspaceResource => w !== null);
   }
 
   logger.info(

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -414,8 +414,11 @@ export async function emitMetronomeGaugeEventsForAllWorkspacesActivity(): Promis
         metronomeWorkspaces.map((w) => w.id)
       );
 
-    // Filter to workspaces whose billing cycle ends within the next 24 hours.
-    const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    // The cron runs at 2am UTC. We check for cycles ending between 3am today
+    // and 3am tomorrow to cover the full day with a 1h buffer after launch.
+    const todayAt3am = new Date(now);
+    todayAt3am.setUTCHours(3, 0, 0, 0);
+    const tomorrowAt3am = new Date(todayAt3am.getTime() + 24 * 60 * 60 * 1000);
     const results = await concurrentExecutor(
       metronomeWorkspaces,
       async (workspace): Promise<WorkspaceResource | null> => {
@@ -432,7 +435,9 @@ export async function emitMetronomeGaugeEventsForAllWorkspacesActivity(): Promis
         const periodEnd = new Date(
           stripeSubscription.current_period_end * 1000
         );
-        return periodEnd >= now && periodEnd <= in24h ? workspace : null;
+        return periodEnd >= todayAt3am && periodEnd <= tomorrowAt3am
+          ? workspace
+          : null;
       },
       { concurrency: 10 }
     );


### PR DESCRIPTION
## Description

Optimizes Metronome gauge event emission to only send events on billing cycle days instead of daily for all workspaces. In production, the activity now filters to workspaces whose Stripe billing cycle ends in the next 24 hours (checking `current_period_end`). In development, it continues to emit for all Metronome-enabled workspaces hourly for testing.

## Tests


## Risk

Low.

## Deploy Plan

Deploy front