### PR TITLE
display reinforcement conversations related to one skill in poke

### DIFF
--- a/front/components/poke/conversation/reinforcement_skills_table.tsx
+++ b/front/components/poke/conversation/reinforcement_skills_table.tsx
@@ -1,0 +1,148 @@
+import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { REINFORCED_SKILLS_METADATA_KEYS } from "@app/lib/reinforcement/types";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { PokeConversationsFetchProps } from "@app/poke/swr/conversation";
+import { usePokeConversations } from "@app/poke/swr/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { LightWorkspaceType } from "@app/types/user";
+import { IconButton, LinkWrapper } from "@dust-tt/sparkle";
+import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import type { ColumnDef } from "@tanstack/react-table";
+
+interface ReinforcementSkillsConversationDataTableProps {
+  owner: LightWorkspaceType;
+  skillId: string;
+}
+
+function getOperationTypeLabel(metadata: Record<string, unknown>): string {
+  const operationType =
+    metadata[REINFORCED_SKILLS_METADATA_KEYS.reinforcedOperationType];
+
+  switch (operationType) {
+    case "reinforcement_analyze_conversation":
+      return "Analysis";
+    case "reinforcement_aggregate_suggestions":
+      return "Aggregation";
+    default:
+      return "Unknown";
+  }
+}
+
+const makeColumnsForReinforcementSkillsConversations = (
+  owner: LightWorkspaceType
+): ColumnDef<ConversationWithoutContentType>[] => {
+  return [
+    {
+      accessorKey: "sId",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Id</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+      cell: ({ row }) => {
+        const conversation = row.original;
+        return (
+          <LinkWrapper
+            href={`/poke/${owner.sId}/conversation/${conversation.sId}`}
+          >
+            {conversation.sId}
+          </LinkWrapper>
+        );
+      },
+    },
+    {
+      accessorKey: "created",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Created at</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+      cell: ({ row }) => {
+        return formatTimestampToFriendlyDate(row.original.created);
+      },
+    },
+    {
+      accessorKey: "title",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Title</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+    },
+    {
+      id: "operationType",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Type</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+      accessorFn: (row) => getOperationTypeLabel(row.metadata),
+    },
+  ];
+};
+
+export function ReinforcementSkillsConversationDataTable({
+  owner,
+  skillId,
+}: ReinforcementSkillsConversationDataTableProps) {
+  const useReinforcementSkillsConversations = (
+    props: PokeConversationsFetchProps
+  ) => usePokeConversations({ ...props, reinforcedSkillId: skillId });
+
+  return (
+    <PokeDataTableConditionalFetch
+      header="Reinforcement conversations"
+      owner={owner}
+      showSensitiveDataWarning={true}
+      useSWRHook={useReinforcementSkillsConversations}
+    >
+      {(conversations) => {
+        const columns = makeColumnsForReinforcementSkillsConversations(owner);
+
+        return (
+          <PokeDataTable<ConversationWithoutContentType, unknown>
+            columns={columns}
+            data={conversations}
+          />
+        );
+      }}
+    </PokeDataTableConditionalFetch>
+  );
+}

--- a/front/components/poke/pages/SkillDetailsPage.tsx
+++ b/front/components/poke/pages/SkillDetailsPage.tsx
@@ -1,3 +1,4 @@
+import { ReinforcementSkillsConversationDataTable } from "@app/components/poke/conversation/reinforcement_skills_table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { SkillSuggestionDataTable } from "@app/components/poke/skill_suggestions/table";
 import { SkillOverviewTable } from "@app/components/poke/skills/SkillOverviewTable";
@@ -139,6 +140,10 @@ export function SkillDetailsPage() {
             </div>
           ))}
         </div>
+      </div>
+
+      <div className="mt-4">
+        <ReinforcementSkillsConversationDataTable owner={owner} skillId={sId} />
       </div>
 
       <SkillSuggestionDataTable owner={owner} skillId={sId} />

--- a/front/lib/reinforced_agent/tool_execution.ts
+++ b/front/lib/reinforced_agent/tool_execution.ts
@@ -134,7 +134,7 @@ async function createReinforcedAction(
       secretName: null,
       dustProject: null,
       availability: "auto",
-      permission: meta.stake,
+      permission: meta?.stake ?? "never_ask",
       toolServerId: "agent_sidekick_context",
       retryPolicy: "no_retry",
     },

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -32,7 +32,7 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const REINFORCEMENT_SKILLS_AGENT_ID = "reinforcement_skills";
+export const REINFORCEMENT_SKILLS_AGENT_ID = "reinforcement";
 
 // Tool schemas for reinforced skills (exploration + terminal).
 const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
@@ -128,11 +128,11 @@ export function classifySkillToolCalls(
 
 export function getReinforcedSkillsDefaultOptions(
   operationType: ReinforcedSkillsOperationType,
-  contextId: string
+  skillIds: string[]
 ) {
   return {
     visibility: "test" as const,
-    metadata: getReinforcedSkillsMetadata(operationType, contextId),
+    metadata: getReinforcedSkillsMetadata(operationType, skillIds),
     userContextUsername: "reinforcement",
     userContextOrigin: "reinforcement" as const,
     agentConfigurationId: REINFORCEMENT_SKILLS_AGENT_ID,
@@ -191,10 +191,12 @@ export async function createReinforcedSkillsConversation(
     prompt,
     operationType,
     contextId,
+    skillIds,
   }: {
     prompt: { systemPrompt: string; userMessage: string };
     operationType: ReinforcedSkillsOperationType;
     contextId: string;
+    skillIds: string[];
   }
 ): Promise<string> {
   const llmParams = buildReinforcedSkillsLLMParams(prompt);
@@ -204,7 +206,7 @@ export async function createReinforcedSkillsConversation(
     newMessages: llmConversation.messages,
     title: reinforcedSkillsConversationTitle(operationType, contextId),
     ...llmParamsWithoutConversation,
-    ...getReinforcedSkillsDefaultOptions(operationType, contextId),
+    ...getReinforcedSkillsDefaultOptions(operationType, skillIds),
   });
   if (writeResult.isErr()) {
     throw writeResult.error;

--- a/front/lib/reinforcement/types.ts
+++ b/front/lib/reinforcement/types.ts
@@ -97,17 +97,17 @@ export type ReinforcedSkillsOperationType =
 export const REINFORCED_SKILLS_METADATA_KEYS = {
   reinforcedSkills: "reinforcedSkills",
   reinforcedOperationType: "reinforcedOperationType",
-  reinforcedSkillId: "reinforcedSkillId",
+  reinforcedSkillIds: "reinforcedSkillIds",
 } as const;
 
 export function getReinforcedSkillsMetadata(
   reinforcedOperationType: ReinforcedSkillsOperationType,
-  reinforcedSkillId: string
+  reinforcedSkillIds: string[]
 ) {
   return {
     [REINFORCED_SKILLS_METADATA_KEYS.reinforcedSkills]: true,
     [REINFORCED_SKILLS_METADATA_KEYS.reinforcedOperationType]:
       reinforcedOperationType,
-    [REINFORCED_SKILLS_METADATA_KEYS.reinforcedSkillId]: reinforcedSkillId,
+    [REINFORCED_SKILLS_METADATA_KEYS.reinforcedSkillIds]: reinforcedSkillIds,
   };
 }

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -11,6 +11,7 @@ import {
   getReinforcementMetadata,
   REINFORCEMENT_METADATA_KEYS,
 } from "@app/lib/reinforced_agent/types";
+import { getReinforcedSkillsMetadata } from "@app/lib/reinforcement/types";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -405,6 +406,185 @@ describe("listReinforcementConversations", () => {
       [REINFORCEMENT_METADATA_KEYS.reinforcedAgent]: true,
       [REINFORCEMENT_METADATA_KEYS.reinforcedAgentConfigurationId]: "agent-1",
     });
+  });
+});
+
+describe("listSkillReinforcementConversations", () => {
+  let auth: Authenticator;
+  let anotherAuth: Authenticator;
+
+  beforeEach(async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const anotherWorkspace = await WorkspaceFactory.basic();
+    const anotherUser = await UserFactory.basic();
+    await MembershipFactory.associate(anotherWorkspace, anotherUser, {
+      role: "admin",
+    });
+    anotherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      anotherUser.sId,
+      anotherWorkspace.sId
+    );
+  });
+
+  it("should return conversations matching the given skill in reinforcedSkillIds", async () => {
+    // Create aggregation conversation for skill-1.
+    const aggregationConvo = await ConversationResource.makeNew(
+      auth,
+      {
+        sId: generateRandomModelSId(),
+        title: "Aggregation for skill-1",
+        visibility: "test",
+        requestedSpaceIds: [],
+        metadata: getReinforcedSkillsMetadata(
+          "reinforcement_aggregate_suggestions",
+          ["skill-1"]
+        ),
+      },
+      null
+    );
+
+    // Create analysis conversation with skill-1 in the array.
+    const analysisConvo = await ConversationResource.makeNew(
+      auth,
+      {
+        sId: generateRandomModelSId(),
+        title: "Analysis with skill-1",
+        visibility: "test",
+        requestedSpaceIds: [],
+        metadata: getReinforcedSkillsMetadata(
+          "reinforcement_analyze_conversation",
+          ["skill-1", "skill-3"]
+        ),
+      },
+      null
+    );
+
+    // Create aggregation conversation for skill-2 (should be excluded).
+    await ConversationResource.makeNew(
+      auth,
+      {
+        sId: generateRandomModelSId(),
+        title: "Aggregation for skill-2",
+        visibility: "test",
+        requestedSpaceIds: [],
+        metadata: getReinforcedSkillsMetadata(
+          "reinforcement_aggregate_suggestions",
+          ["skill-2"]
+        ),
+      },
+      null
+    );
+
+    // Create a regular (non-reinforcement) conversation (should be excluded).
+    await ConversationResource.makeNew(
+      auth,
+      {
+        sId: generateRandomModelSId(),
+        title: "Regular conversation",
+        visibility: "unlisted",
+        requestedSpaceIds: [],
+        metadata: {},
+      },
+      null
+    );
+
+    // Create aggregation conversation in another workspace (should be excluded).
+    await ConversationResource.makeNew(
+      anotherAuth,
+      {
+        sId: generateRandomModelSId(),
+        title: "Other workspace aggregation",
+        visibility: "test",
+        requestedSpaceIds: [],
+        metadata: getReinforcedSkillsMetadata(
+          "reinforcement_aggregate_suggestions",
+          ["skill-1"]
+        ),
+      },
+      null
+    );
+
+    const results =
+      await ConversationResource.listSkillReinforcementConversations(
+        auth,
+        "skill-1"
+      );
+
+    expect(results).toHaveLength(2);
+    const resultSIds = results.map((r) => r.sId).sort();
+    const expectedSIds = [aggregationConvo.sId, analysisConvo.sId].sort();
+    expect(resultSIds).toEqual(expectedSIds);
+  });
+
+  it("should filter conversations by after date when provided", async () => {
+    // Create an old conversation (2 weeks ago).
+    const twoWeeksAgo = new Date();
+    twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
+
+    const oldConvo = await ConversationResource.makeNew(
+      auth,
+      {
+        sId: generateRandomModelSId(),
+        title: "Old aggregation",
+        visibility: "test",
+        requestedSpaceIds: [],
+        metadata: getReinforcedSkillsMetadata(
+          "reinforcement_aggregate_suggestions",
+          ["skill-1"]
+        ),
+      },
+      null
+    );
+
+    // Manually backdate the conversation.
+    await ConversationModel.update(
+      { createdAt: twoWeeksAgo },
+      { where: { sId: oldConvo.sId } }
+    );
+
+    // Create a recent conversation.
+    const recentConvo = await ConversationResource.makeNew(
+      auth,
+      {
+        sId: generateRandomModelSId(),
+        title: "Recent aggregation",
+        visibility: "test",
+        requestedSpaceIds: [],
+        metadata: getReinforcedSkillsMetadata(
+          "reinforcement_aggregate_suggestions",
+          ["skill-1"]
+        ),
+      },
+      null
+    );
+
+    // Without after filter: both returned.
+    const allResults =
+      await ConversationResource.listSkillReinforcementConversations(
+        auth,
+        "skill-1"
+      );
+    expect(allResults).toHaveLength(2);
+
+    // With after filter (1 week ago): only the recent one.
+    const oneWeekAgo = new Date();
+    oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+
+    const filteredResults =
+      await ConversationResource.listSkillReinforcementConversations(
+        auth,
+        "skill-1",
+        { after: oneWeekAgo }
+      );
+    expect(filteredResults).toHaveLength(1);
+    expect(filteredResults[0].sId).toBe(recentConvo.sId);
   });
 });
 

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -528,25 +528,20 @@ describe("listSkillReinforcementConversations", () => {
     const twoWeeksAgo = new Date();
     twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
 
-    const oldConvo = await ConversationResource.makeNew(
+    await ConversationResource.makeNew(
       auth,
       {
         sId: generateRandomModelSId(),
         title: "Old aggregation",
         visibility: "test",
         requestedSpaceIds: [],
+        createdAt: twoWeeksAgo,
         metadata: getReinforcedSkillsMetadata(
           "reinforcement_aggregate_suggestions",
           ["skill-1"]
         ),
       },
       null
-    );
-
-    // Manually backdate the conversation.
-    await ConversationModel.update(
-      { createdAt: twoWeeksAgo },
-      { where: { sId: oldConvo.sId } }
     );
 
     // Create a recent conversation.

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -10,6 +10,7 @@ import {
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { REINFORCEMENT_METADATA_KEYS } from "@app/lib/reinforced_agent/types";
+import { REINFORCED_SKILLS_METADATA_KEYS } from "@app/lib/reinforcement/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -1392,6 +1393,66 @@ export class ConversationResource extends BaseResource<ConversationModel> {
             agentConfigurationId
           ),
         ],
+      },
+      order: [["createdAt", "DESC"]],
+    });
+
+    return conversations.map((c) => ({
+      id: c.id,
+      created: c.createdAt.getTime(),
+      updated: c.updatedAt.getTime(),
+      sId: c.sId,
+      title: c.title,
+      triggerId: ConversationResource.triggerIdToSId(c.triggerId, workspace.id),
+      actionRequired: false,
+      unread: false,
+      lastReadMs: Date.now(),
+      hasError: c.hasError,
+      requestedSpaceIds: c.requestedSpaceIds.map(String),
+      spaceId: null,
+      depth: c.depth,
+      metadata: c.metadata,
+      branchId: null,
+    }));
+  }
+
+  static async listSkillReinforcementConversations(
+    auth: Authenticator,
+    skillId: string,
+    { after }: { after?: Date } = {}
+  ): Promise<ConversationWithoutContentType[]> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    // The reinforcedSkillIds metadata field is a JSON array of skill sIds.
+    // We use jsonb_exists to check if the skill sId is present in the array.
+    const conditions: WhereOptions[] = [
+      where(
+        fn(
+          "jsonb_extract_path_text",
+          col("metadata"),
+          REINFORCED_SKILLS_METADATA_KEYS.reinforcedSkills
+        ),
+        "true"
+      ),
+      where(
+        fn(
+          "jsonb_exists",
+          fn(
+            "jsonb_extract_path",
+            col("metadata"),
+            REINFORCED_SKILLS_METADATA_KEYS.reinforcedSkillIds
+          ),
+          skillId
+        ),
+        true
+      ),
+    ];
+
+    const conversations = await ConversationModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        ...(after ? { createdAt: { [Op.gte]: after } } : {}),
+        [Op.and]: conditions,
       },
       order: [["createdAt", "DESC"]],
     });

--- a/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
@@ -23,7 +23,8 @@ async function handler(
     req.query.wId as string
   );
 
-  const { agentId, triggerId, reinforcedAgentId } = req.query;
+  const { agentId, triggerId, reinforcedAgentId, reinforcedSkillId } =
+    req.query;
 
   if (!auth.isDustSuperUser()) {
     return apiError(req, res, {
@@ -50,6 +51,16 @@ async function handler(
           await ConversationResource.listReinforcementConversations(
             auth,
             reinforcedAgentId
+          );
+      } else if (isString(reinforcedSkillId)) {
+        const oneWeekAgo = new Date();
+        oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+
+        conversations =
+          await ConversationResource.listSkillReinforcementConversations(
+            auth,
+            reinforcedSkillId,
+            { after: oneWeekAgo }
           );
       } else if (isString(agentId)) {
         // Get conversation IDs for this agent
@@ -92,7 +103,7 @@ async function handler(
           api_error: {
             type: "invalid_request_error",
             message:
-              "Either agent ID, reinforcedAgent ID or trigger ID is required.",
+              "Either agent ID, reinforcedAgent ID, reinforcedSkill ID or trigger ID is required.",
           },
         });
       }

--- a/front/poke/swr/conversation.ts
+++ b/front/poke/swr/conversation.ts
@@ -7,6 +7,7 @@ export interface PokeConversationsFetchProps extends PokeConditionalFetchProps {
   agentId?: string;
   triggerId?: string;
   reinforcedAgentId?: string;
+  reinforcedSkillId?: string;
 }
 
 export function usePokeConversations({
@@ -15,6 +16,7 @@ export function usePokeConversations({
   agentId,
   triggerId,
   reinforcedAgentId,
+  reinforcedSkillId,
 }: PokeConversationsFetchProps) {
   const { fetcher } = useFetcher();
   const conversationsFetcher: Fetcher<PokeListConversations> = fetcher;
@@ -22,6 +24,8 @@ export function usePokeConversations({
   let url: string | null = null;
   if (reinforcedAgentId) {
     url = `/api/poke/workspaces/${owner.sId}/conversations?reinforcedAgentId=${reinforcedAgentId}`;
+  } else if (reinforcedSkillId) {
+    url = `/api/poke/workspaces/${owner.sId}/conversations?reinforcedSkillId=${reinforcedSkillId}`;
   } else if (agentId) {
     url = `/api/poke/workspaces/${owner.sId}/conversations?agentId=${agentId}`;
   } else if (triggerId) {

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -333,6 +333,7 @@ export async function analyzeConversationStepActivity({
         prompt,
         operationType: "reinforcement_analyze_conversation",
         contextId: conversationId,
+        skillIds: skillSIds,
       }
     );
   }
@@ -430,6 +431,7 @@ export async function aggregateSuggestionsForSkillStepActivity({
         prompt: ctx.prompt,
         operationType: "reinforcement_aggregate_suggestions",
         contextId: skillId,
+        skillIds: [skillId],
       }
     );
   }
@@ -566,7 +568,7 @@ export async function startSkillConversationAnalysisBatchActivity({
   const batchConversations: LlmConversationOptions[] = [];
   const orderedAnalysedConversationIds: string[] = [];
 
-  for (const { conversationSId } of conversationsWithSkills) {
+  for (const { conversationSId, skillSIds } of conversationsWithSkills) {
     const existingReinforcementConvId =
       existingReinforcementConversationMap?.[conversationSId];
 
@@ -596,7 +598,7 @@ export async function startSkillConversationAnalysisBatchActivity({
         ...llmParamsWithoutConversation,
         ...getReinforcedSkillsDefaultOptions(
           "reinforcement_analyze_conversation",
-          conversationSId
+          skillSIds
         ),
       });
       orderedAnalysedConversationIds.push(conversationSId);
@@ -838,7 +840,7 @@ export async function startSkillAggregationBatchActivity({
         ...llmParamsWithoutConversation,
         ...getReinforcedSkillsDefaultOptions(
           "reinforcement_aggregate_suggestions",
-          skillId
+          [skillId]
         ),
       });
     }


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/7410

 - Update agent name to be "reinforcement" because we need an actual agent to display the conv
 - Add the skills used in the conv in the metadata so we can match a skill to all the analysis convs.
 - Add the poke table to show the reinforcement conversations for one skill

<img width="1600" height="550" alt="image" src="https://github.com/user-attachments/assets/ae564fff-6017-4b31-a763-6ad512993d4c" />


## Tests

 - Unit test for resource function
 - tested locally

## Risk

low

## Deploy Plan

deploy front
