### PR TITLE
[Connectors] feat(slack): implement ask_user_question tool support on Slack bot

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack_bot_interaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot_interaction.ts
@@ -1,4 +1,5 @@
 import {
+  botAnswerUserQuestion,
   botReplaceMention,
   botValidateToolExecution,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
@@ -7,6 +8,7 @@ import {
   getAuthResponseUrlRedisKey,
   SlackBlockIdStaticAgentConfigSchema,
   SlackBlockIdToolValidationSchema,
+  SlackUserQuestionActionValueSchema,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/slack/chat/stream_conversation_handler";
 // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
@@ -29,6 +31,13 @@ export const REJECT_TOOL_EXECUTION = "reject_tool_execution";
 export const AUTHENTICATE_TOOL = "authenticate_tool";
 export const LEAVE_FEEDBACK_UP = "leave_feedback_up";
 export const LEAVE_FEEDBACK_DOWN = "leave_feedback_down";
+export const ANSWER_USER_QUESTION_SUBMIT = "answer_user_question_submit";
+export const ANSWER_USER_QUESTION_SKIP = "answer_user_question_skip";
+// Block IDs / action IDs for reading state.values when Submit is clicked.
+export const USER_QUESTION_TEXT_BLOCK_ID = "question_text_input";
+export const USER_QUESTION_TEXT_ACTION_ID = "question_text_element";
+export const USER_QUESTION_OPTIONS_BLOCK_ID = "question_options";
+export const USER_QUESTION_OPTIONS_ACTION_ID = "question_checkboxes";
 
 const ToolValidationActionsCodec = t.union([
   t.literal(APPROVE_TOOL_EXECUTION),
@@ -81,41 +90,99 @@ const AuthenticateToolActionSchema = t.type({
   value: t.string,
 });
 
+const AnswerUserQuestionButtonSchema = t.type({
+  type: t.literal("button"),
+  action_id: t.union([
+    t.literal(ANSWER_USER_QUESTION_SUBMIT),
+    t.literal(ANSWER_USER_QUESTION_SKIP),
+  ]),
+  block_id: t.string,
+  action_ts: t.string,
+  value: t.string,
+});
+
 export type RequestToolPermissionActionValueParsed = {
   status: "approved" | "rejected";
   agentName: string;
   toolName: string;
 };
 
-const BlockActionsPayloadSchema = t.type({
-  type: t.literal("block_actions"),
-  team: t.type({
-    id: t.string,
-    domain: t.string,
-  }),
-  channel: t.type({
-    id: t.string,
-    name: t.string,
-  }),
-  container: t.type({
-    message_ts: t.string,
-    channel_id: t.string,
-    thread_ts: t.string,
-  }),
-  user: t.type({
-    id: t.string,
-  }),
-  actions: t.array(
-    t.union([
-      StaticAgentConfigSchema,
-      ToolValidationActionsSchema,
-      FeedbackActionSchema,
-      AuthenticateToolActionSchema,
-    ])
-  ),
-  trigger_id: t.union([t.string, t.undefined]),
-  response_url: t.string,
+const BlockActionsStateSchema = t.record(
+  t.string,
+  t.record(t.string, t.unknown)
+);
+
+type BlockActionsState = t.TypeOf<typeof BlockActionsStateSchema>;
+
+const RadioStateSchema = t.type({
+  selected_option: t.type({ value: t.string }),
 });
+
+const CheckboxStateSchema = t.type({
+  selected_options: t.array(t.type({ value: t.string })),
+});
+
+const TextInputStateSchema = t.type({
+  value: t.union([t.string, t.null]),
+});
+
+function getStateSelectedOptions(
+  state: { values: BlockActionsState } | undefined,
+  blockId: string,
+  actionId: string
+): number[] {
+  const el = state?.values?.[blockId]?.[actionId];
+  const radio = RadioStateSchema.decode(el);
+  if (!isLeft(radio)) {
+    return [parseInt(radio.right.selected_option.value)];
+  }
+  const checkboxes = CheckboxStateSchema.decode(el);
+  if (!isLeft(checkboxes)) {
+    return checkboxes.right.selected_options.map((o) => parseInt(o.value));
+  }
+  return [];
+}
+
+function getStateTextValue(
+  state: { values: BlockActionsState } | undefined,
+  blockId: string,
+  actionId: string
+): string | undefined {
+  const el = state?.values?.[blockId]?.[actionId];
+  const decoded = TextInputStateSchema.decode(el);
+  if (isLeft(decoded) || !decoded.right.value) {
+    return undefined;
+  }
+  return decoded.right.value;
+}
+
+const BlockActionsPayloadSchema = t.intersection([
+  t.type({
+    type: t.literal("block_actions"),
+    team: t.type({
+      id: t.string,
+      domain: t.string,
+    }),
+    channel: t.type({
+      id: t.string,
+      name: t.string,
+    }),
+    container: t.type({
+      message_ts: t.string,
+      channel_id: t.string,
+      thread_ts: t.string,
+    }),
+    user: t.type({
+      id: t.string,
+    }),
+    actions: t.array(t.unknown),
+    trigger_id: t.union([t.string, t.undefined]),
+    response_url: t.string,
+  }),
+  t.partial({
+    state: t.type({ values: BlockActionsStateSchema }),
+  }),
+]);
 
 const ViewSubmissionPayloadSchema = t.type({
   type: t.literal("view_submission"),
@@ -155,6 +222,14 @@ const ViewSubmissionPayloadSchema = t.type({
     }),
   }),
 });
+
+const KnownActionSchema = t.union([
+  StaticAgentConfigSchema,
+  ToolValidationActionsSchema,
+  FeedbackActionSchema,
+  AuthenticateToolActionSchema,
+  AnswerUserQuestionButtonSchema,
+]);
 
 export const SlackInteractionPayloadSchema = t.union([
   BlockActionsPayloadSchema,
@@ -203,7 +278,13 @@ const _webhookSlackBotInteractionsAPIHandler = async (
   if (payload.type === "block_actions") {
     const responseUrl = payload.response_url;
 
-    for (const action of payload.actions) {
+    for (const rawAction of payload.actions) {
+      const actionDecoded = KnownActionSchema.decode(rawAction);
+      if (isLeft(actionDecoded)) {
+        continue;
+      }
+      const action = actionDecoded.right;
+
       if (action.action_id === STATIC_AGENT_CONFIG) {
         const blockIdValidation = SlackBlockIdStaticAgentConfigSchema.decode(
           JSON.parse(action.block_id)
@@ -403,6 +484,81 @@ const _webhookSlackBotInteractionsAPIHandler = async (
         const redisKey = getAuthResponseUrlRedisKey(workspaceId, messageId);
         const redis = await redisClient({ origin: "slack_auth" });
         await redis.set(redisKey, responseUrl, { EX: 1800 });
+      } else if (
+        action.action_id === ANSWER_USER_QUESTION_SUBMIT ||
+        action.action_id === ANSWER_USER_QUESTION_SKIP
+      ) {
+        const valueValidation = SlackUserQuestionActionValueSchema.decode(
+          JSON.parse(action.value)
+        );
+
+        if (isLeft(valueValidation)) {
+          const pathError = reporter.formatValidationErrors(
+            valueValidation.left
+          );
+          logger.error(
+            {
+              error: pathError,
+              value: action.value,
+            },
+            "Invalid value format in user question answer"
+          );
+          return;
+        }
+
+        const {
+          workspaceId,
+          conversationId,
+          messageId,
+          actionId,
+          slackChatBotMessageId,
+        } = valueValidation.right;
+
+        let answer: { selectedOptions: number[]; customResponse?: string };
+
+        if (action.action_id === ANSWER_USER_QUESTION_SUBMIT) {
+          const selectedOptions = getStateSelectedOptions(
+            payload.state,
+            USER_QUESTION_OPTIONS_BLOCK_ID,
+            USER_QUESTION_OPTIONS_ACTION_ID
+          );
+          const customResponse =
+            selectedOptions.length === 0
+              ? getStateTextValue(
+                  payload.state,
+                  USER_QUESTION_TEXT_BLOCK_ID,
+                  USER_QUESTION_TEXT_ACTION_ID
+                )
+              : undefined;
+          answer = { selectedOptions, customResponse };
+        } else {
+          answer = { selectedOptions: [] };
+        }
+
+        const answerRes = await botAnswerUserQuestion({
+          actionId,
+          answer,
+          conversationId,
+          messageId,
+          slackChatBotMessageId,
+          responseUrl,
+          slackTeamId: payload.team.id,
+          slackChannel: payload.channel.id,
+          slackThreadTs: payload.container.thread_ts,
+        });
+
+        if (answerRes.isErr()) {
+          logger.error(
+            {
+              error: answerRes.error,
+              workspaceId,
+              conversationId,
+              messageId,
+              actionId,
+            },
+            "Failed to answer user question"
+          );
+        }
       }
     }
   }

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -55,6 +55,7 @@ import {
 } from "@connectors/types";
 import type {
   AgentMessageSuccessEvent,
+  AnswerUserQuestionResponseType,
   APIError,
   ConversationPublicType,
   LightAgentConfigurationType,
@@ -483,7 +484,7 @@ export async function botValidateToolExecution(
       channel: slackChannel,
       user: slackChatBotMessage.slackUserId,
       text,
-      thread_ts: slackMessageTs,
+      thread_ts: params.slackThreadTs ?? slackMessageTs,
     });
 
     return res;
@@ -522,6 +523,118 @@ export async function botValidateToolExecution(
       );
     }
 
+    return new Err(new Error("An unexpected error occurred"));
+  }
+}
+
+type UserQuestionAnswerParams = {
+  actionId: string;
+  answer: { selectedOptions: number[]; customResponse?: string };
+  conversationId: string;
+  messageId: string;
+  slackChatBotMessageId: number;
+  slackTeamId: string;
+  slackChannel: string;
+  slackThreadTs: string;
+  responseUrl: string | undefined;
+};
+
+export async function botAnswerUserQuestion({
+  actionId,
+  answer,
+  conversationId,
+  messageId,
+  slackChatBotMessageId,
+  slackTeamId,
+  slackChannel,
+  slackThreadTs,
+  responseUrl,
+}: UserQuestionAnswerParams): Promise<
+  Result<AnswerUserQuestionResponseType, Error | APIError>
+> {
+  const slackConfig =
+    await SlackConfigurationResource.fetchByActiveBot(slackTeamId);
+  if (!slackConfig) {
+    return new Err(
+      new Error(
+        `Failed to find a Slack configuration for which the bot is enabled. Slack team id: ${slackTeamId}.`
+      )
+    );
+  }
+  const connector = await ConnectorResource.fetchById(slackConfig.connectorId);
+  if (!connector) {
+    return new Err(new Error("Failed to find connector"));
+  }
+
+  const slackChatBotMessage = await SlackChatBotMessageModel.findOne({
+    where: { id: slackChatBotMessageId },
+  });
+  if (!slackChatBotMessage) {
+    return new Err(new Error("Missing Slack message"));
+  }
+
+  const userEmailHeader =
+    slackChatBotMessage.slackEmail !== "unknown"
+      ? slackChatBotMessage.slackEmail
+      : undefined;
+
+  const dustAPI = new DustAPI(
+    { url: apiConfig.getDustFrontAPIUrl() },
+    {
+      apiKey: connector.workspaceAPIKey,
+      extraHeaders: getHeaderFromUserEmail(userEmailHeader),
+      workspaceId: connector.workspaceId,
+    },
+    logger
+  );
+
+  try {
+    const res = await dustAPI.answerUserQuestion({
+      conversationId,
+      messageId,
+      actionId,
+      answer,
+    });
+
+    if (responseUrl) {
+      const proxyFetch = createProxyAwareFetch();
+      const response = await proxyFetch(responseUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ delete_original: true }),
+      });
+      if (!response.ok) {
+        logger.error(
+          { responseUrl, connectorId: connector.id },
+          "Failed to delete original message using response_url"
+        );
+      }
+    }
+
+    const slackClient = await getSlackClient(connector.id);
+    const confirmationText =
+      answer.selectedOptions.length === 0 && !answer.customResponse
+        ? "Question skipped ⏭️"
+        : "Your answer was submitted ✅";
+    reportSlackUsage({
+      connectorId: connector.id,
+      method: "chat.postEphemeral",
+      channelId: slackChannel,
+      useCase: "bot",
+    });
+    await slackClient.chat.postEphemeral({
+      channel: slackChannel,
+      user: slackChatBotMessage.slackUserId,
+      text: confirmationText,
+      thread_ts: slackThreadTs,
+    });
+
+    return res;
+  } catch (e) {
+    logger.error(
+      { error: e, connectorId: connector.id, slackTeamId },
+      "Unexpected exception answering user question"
+    );
     return new Err(new Error("An unexpected error occurred"));
   }
 }

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -1,18 +1,28 @@
 // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 import type { RequestToolPermissionActionValueParsed } from "@connectors/api/webhooks/webhook_slack_bot_interaction";
 import {
+  ANSWER_USER_QUESTION_SKIP,
+  ANSWER_USER_QUESTION_SUBMIT,
   APPROVE_TOOL_EXECUTION,
   AUTHENTICATE_TOOL,
   LEAVE_FEEDBACK_DOWN,
   LEAVE_FEEDBACK_UP,
   REJECT_TOOL_EXECUTION,
   STATIC_AGENT_CONFIG,
+  USER_QUESTION_OPTIONS_ACTION_ID,
+  USER_QUESTION_OPTIONS_BLOCK_ID,
+  USER_QUESTION_TEXT_ACTION_ID,
+  USER_QUESTION_TEXT_BLOCK_ID,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/api/webhooks/webhook_slack_bot_interaction";
 import type { MessageFootnotes } from "@connectors/lib/bot/citations";
 import { makeDustAppUrl } from "@connectors/lib/bot/conversation_utils";
 import { truncate } from "@connectors/types";
-import type { LightAgentConfigurationType } from "@dust-tt/client";
+import type {
+  LightAgentConfigurationType,
+  UserQuestionItemType,
+} from "@dust-tt/client";
+import type { KnownBlock } from "@slack/web-api";
 import slackifyMarkdown from "slackify-markdown";
 
 /*
@@ -527,6 +537,77 @@ export function makeToolAuthenticationBlock({
   ];
 }
 
+/**
+ * Creates Slack blocks for an agent question to the user.
+ * Single-select: buttons per option, submits immediately on click.
+ * Multi-select: checkboxes + Submit button reads state.values.
+ */
+export function makeUserQuestionBlock({
+  question,
+  value,
+}: {
+  question: UserQuestionItemType;
+  value: string;
+}) {
+  const blocks: KnownBlock[] = [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: question.question },
+    },
+  ];
+
+  if (question.options.length > 0) {
+    blocks.push({
+      type: "actions",
+      block_id: USER_QUESTION_OPTIONS_BLOCK_ID,
+      elements: [
+        {
+          type: question.multiSelect ? "checkboxes" : "radio_buttons",
+          action_id: USER_QUESTION_OPTIONS_ACTION_ID,
+          options: question.options.map((opt, index) => ({
+            text: { type: "plain_text", text: opt.label },
+            ...(opt.description
+              ? { description: { type: "plain_text", text: opt.description } }
+              : {}),
+            value: String(index),
+          })),
+        },
+      ],
+    });
+  }
+
+  blocks.push({
+    type: "input",
+    block_id: USER_QUESTION_TEXT_BLOCK_ID,
+    label: { type: "plain_text", text: " " },
+    element: {
+      type: "plain_text_input",
+      action_id: USER_QUESTION_TEXT_ACTION_ID,
+      placeholder: { type: "plain_text", text: "Type something else…" },
+    },
+  });
+
+  blocks.push({
+    type: "actions",
+    elements: [
+      {
+        type: "button",
+        text: { type: "plain_text", text: "Skip" },
+        action_id: ANSWER_USER_QUESTION_SKIP,
+        value,
+      },
+      {
+        type: "button",
+        text: { type: "plain_text", text: "Submit" },
+        action_id: ANSWER_USER_QUESTION_SUBMIT,
+        value,
+        style: "primary",
+      },
+    ],
+  });
+
+  return blocks;
+}
 export function makeToolFileAuthorizationBlock({
   agentName,
   fileName,

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -11,6 +11,7 @@ import {
   makeToolAuthenticationBlock,
   makeToolFileAuthorizationBlock,
   makeToolValidationBlock,
+  makeUserQuestionBlock,
   type SlackMessageUpdate,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/slack/chat/blocks";
@@ -71,6 +72,14 @@ export const SlackBlockIdToolValidationSchema = t.intersection([
     workspaceId: t.string,
   }),
 ]);
+
+export const SlackUserQuestionActionValueSchema = t.type({
+  workspaceId: t.string,
+  conversationId: t.string,
+  messageId: t.string,
+  actionId: t.string,
+  slackChatBotMessageId: t.number,
+});
 
 export function getAuthResponseUrlRedisKey(
   workspaceId: string,
@@ -737,12 +746,33 @@ async function streamAgentAnswerToSlack(
         return new Ok(undefined);
       }
 
+      case "tool_ask_user_question": {
+        const questionValue = JSON.stringify({
+          workspaceId: connector.workspaceId,
+          conversationId: event.conversationId,
+          messageId: event.messageId,
+          actionId: event.actionId,
+          slackChatBotMessageId: slackChatBotMessage.id,
+        });
+
+        if (slackUserId && !slackUserInfo.is_bot) {
+          await slackClient.chat.postEphemeral({
+            channel: slackChannelId,
+            user: slackUserId,
+            text: event.question.question,
+            blocks: makeUserQuestionBlock({
+              question: event.question,
+              value: questionValue,
+            }),
+            thread_ts: slackMessageTs,
+          });
+        }
+        break;
+      }
+
       case "agent_context_pruned":
       case "agent_message_done":
       case "tool_call_started":
-      // TODO(2026-04-02 ask-user-question): add support for the AskUserQuestion tool on Slack.
-      // Temporarily we will not add the tool for messages coming from Slack to avoid receiving this event at all here.
-      case "tool_ask_user_question":
         // No-op.
         break;
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
@@ -1,0 +1,199 @@
+import { UserQuestionAnswerSchema } from "@app/lib/actions/types";
+import { registerUserAnswer } from "@app/lib/api/assistant/conversation/answer_user_question";
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/assistant/conversations/{cId}/messages/{mId}/answer-question:
+ *   post:
+ *     summary: Answer a user question in a conversation message
+ *     description: Submits an answer to a question asked by an agent in a specific message
+ *     tags:
+ *       - Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Workspace ID
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Conversation ID
+ *       - in: path
+ *         name: mId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Message ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - actionId
+ *               - answer
+ *             properties:
+ *               actionId:
+ *                 type: string
+ *                 description: ID of the action to answer
+ *               answer:
+ *                 type: object
+ *                 required:
+ *                   - selectedOptions
+ *                 properties:
+ *                   selectedOptions:
+ *                     type: array
+ *                     items:
+ *                       type: integer
+ *                     description: Indices of selected options
+ *                   customResponse:
+ *                     type: string
+ *                     description: Optional free-text response
+ *     responses:
+ *       200:
+ *         description: Answer submitted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *       400:
+ *         description: Invalid request body or action not blocked
+ *       403:
+ *         description: User not authorized to answer this question
+ *       404:
+ *         description: Conversation, message, or action not found
+ *       405:
+ *         description: Method not allowed
+ *       500:
+ *         description: Internal server error
+ *     security:
+ *       - BearerAuth: []
+ */
+
+const AnswerQuestionRequestSchema = z.object({
+  actionId: z.string(),
+  answer: UserQuestionAnswerSchema,
+});
+
+interface AnswerQuestionResponse {
+  success: boolean;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<AnswerQuestionResponse>>,
+  auth: Authenticator
+): Promise<void> {
+  const { cId, mId } = req.query;
+  if (!isString(cId) || !isString(mId)) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation, message, or workspace not found.",
+      },
+    });
+  }
+
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const parseResult = AnswerQuestionRequestSchema.safeParse(req.body);
+  if (!parseResult.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${parseResult.error.message}`,
+      },
+    });
+  }
+
+  const conversation = await ConversationResource.fetchById(auth, cId);
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  const { actionId, answer } = parseResult.data;
+
+  const result = await registerUserAnswer(auth, conversation, {
+    actionId,
+    messageId: mId,
+    answer,
+  });
+
+  if (result.isErr()) {
+    switch (result.error.code) {
+      case "unauthorized":
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: result.error.message,
+          },
+        });
+      case "action_not_blocked":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "action_not_blocked",
+            message: result.error.message,
+          },
+        });
+      case "action_not_found":
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "action_not_found",
+            message: result.error.message,
+          },
+        });
+      default:
+        return apiError(
+          req,
+          res,
+          {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to answer question",
+            },
+          },
+          result.error
+        );
+    }
+  }
+
+  res.status(200).json({ success: true });
+}
+
+export default withPublicAPIAuthentication(handler);

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -1515,6 +1515,120 @@
         }
       }
     },
+    "/api/v1/w/{wId}/assistant/conversations/{cId}/messages/{mId}/answer-question": {
+      "post": {
+        "summary": "Answer a user question in a conversation message",
+        "description": "Submits an answer to a question asked by an agent in a specific message",
+        "tags": [
+          "Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Workspace ID"
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Conversation ID"
+          },
+          {
+            "in": "path",
+            "name": "mId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Message ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "actionId",
+                  "answer"
+                ],
+                "properties": {
+                  "actionId": {
+                    "type": "string",
+                    "description": "ID of the action to answer"
+                  },
+                  "answer": {
+                    "type": "object",
+                    "required": [
+                      "selectedOptions"
+                    ],
+                    "properties": {
+                      "selectedOptions": {
+                        "type": "array",
+                        "items": {
+                          "type": "integer"
+                        },
+                        "description": "Indices of selected options"
+                      },
+                      "customResponse": {
+                        "type": "string",
+                        "description": "Optional free-text response"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Answer submitted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or action not blocked"
+          },
+          "403": {
+            "description": "User not authorized to answer this question"
+          },
+          "404": {
+            "description": "Conversation, message, or action not found"
+          },
+          "405": {
+            "description": "Method not allowed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    },
     "/api/v1/w/{wId}/assistant/conversations/{cId}/messages/{mId}/edit": {
       "post": {
         "tags": [

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -72,7 +72,10 @@ import { getOutputFromLLMStream } from "@app/temporal/agent_loop/lib/get_output_
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import type { AgentActionsEvent } from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
-import type { AgentMessageType } from "@app/types/assistant/conversation";
+import type {
+  AgentMessageType,
+  UserMessageOrigin,
+} from "@app/types/assistant/conversation";
 import { isTextContent } from "@app/types/assistant/generation";
 import { isByokProviderId } from "@app/types/assistant/models/providers";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -307,11 +310,16 @@ export async function runModel(
     );
   }
 
-  // Filter out ask_user_question for non-web origins (e.g. Slack, API).
-  const filteredMcpActions =
-    userMessage.context.origin !== "web"
-      ? mcpActions.filter((s) => s.serverName !== "ask_user_question")
-      : mcpActions;
+  // Filter out ask_user_question for origins that don't support interactive questions.
+  const ASK_USER_QUESTION_ALLOWED_ORIGINS: UserMessageOrigin[] = [
+    "web",
+    "slack",
+  ];
+  const filteredMcpActions = !ASK_USER_QUESTION_ALLOWED_ORIGINS.includes(
+    userMessage.context.origin
+  )
+    ? mcpActions.filter((s) => s.serverName !== "ask_user_question")
+    : mcpActions;
 
   const isLastStep = step === agentConfiguration.maxStepsPerRun;
 

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -17,6 +17,8 @@ import type {
   AgentMessagePublicType,
   AgentMessageSuccessEvent,
   AgentToolCallStartedEvent,
+  AnswerUserQuestionRequestBodyType,
+  AnswerUserQuestionResponseType,
   APIError,
   AppsCheckRequestType,
   BlockedActionsResponseType,
@@ -62,6 +64,7 @@ import type {
   ValidateActionResponseType,
 } from "./types";
 import {
+  AnswerUserQuestionResponseSchema,
   APIErrorSchema,
   AppsCheckResponseSchema,
   BlockedActionsResponseSchema,
@@ -1998,6 +2001,30 @@ export class DustAPI {
     });
 
     return this._resultFromResponse(ValidateActionResponseSchema, res);
+  }
+
+  async answerUserQuestion({
+    conversationId,
+    messageId,
+    actionId,
+    answer,
+    signal,
+  }: AnswerUserQuestionRequestBodyType & {
+    conversationId: string;
+    messageId: string;
+    signal?: AbortSignal;
+  }): Promise<Result<AnswerUserQuestionResponseType, APIError>> {
+    const res = await this.request({
+      method: "POST",
+      path: `assistant/conversations/${conversationId}/messages/${messageId}/answer-question`,
+      body: {
+        actionId,
+        answer,
+      },
+      signal,
+    });
+
+    return this._resultFromResponse(AnswerUserQuestionResponseSchema, res);
   }
 
   async registerMCPServer({

--- a/sdks/js/src/output_schemas.ts
+++ b/sdks/js/src/output_schemas.ts
@@ -649,6 +649,8 @@ export const UserQuestionItemSchema = z.object({
   multiSelect: z.boolean(),
 });
 
+export type UserQuestionItemType = z.infer<typeof UserQuestionItemSchema>;
+
 export const UserAnswerRequiredOutputResourceSchema = z.object({
   mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT),
   type: z.literal("tool_user_answer_required"),

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3550,6 +3550,26 @@ export type ValidateActionRequestBodyType = z.infer<
   typeof ValidateActionRequestBodySchema
 >;
 
+export const AnswerUserQuestionResponseSchema = z.object({
+  success: z.boolean(),
+});
+
+export type AnswerUserQuestionResponseType = z.infer<
+  typeof AnswerUserQuestionResponseSchema
+>;
+
+export const AnswerUserQuestionRequestBodySchema = z.object({
+  actionId: z.string(),
+  answer: z.object({
+    selectedOptions: z.array(z.number()),
+    customResponse: z.string().optional(),
+  }),
+});
+
+export type AnswerUserQuestionRequestBodyType = z.infer<
+  typeof AnswerUserQuestionRequestBodySchema
+>;
+
 export const ClientSideMCPServerNameSchema = z.string().min(5).max(30);
 
 export const PublicRegisterMCPRequestBodySchema = z.object({


### PR DESCRIPTION
## What

Implements the `ask_user_question` internal MCP tool for the Slack bot, allowing agents to interactively ask users structured questions mid-conversation.

> [!TIP]
> The 4 commits map 1:1 to the sections below — easiest to review commit by commit.

## How

### SDK 
- Add `answerUserQuestion()` method to `DustAPI`, hitting the new public endpoint
- Export `UserQuestionItemType` and `AnswerUserQuestion*` types

### Public API 
- New endpoint `POST .../messages/[mId]/answer-question` — public counterpart of the existing private endpoint, delegates to `registerUserAnswer()`
- Allow `"slack"` origin in `run_model.ts` so the `ask_user_question` tool is available to Slack-originating messages (was previously filtered to `"web"` only)

### Slack bot 
- **Event handler**: `tool_ask_user_question` case in `streamConversationToSlack` posts an ephemeral with question text, options (radio buttons for single-select, checkboxes for multi-select), and Skip/Submit buttons
- **Webhook handler**: new `ANSWER_USER_QUESTION_SUBMIT` / `ANSWER_USER_QUESTION_SKIP` action constants; reads option selections and free-text from `state.values`; calls `botAnswerUserQuestion()`
- **`botAnswerUserQuestion()`**: simplified compared to `botValidateToolExecution` — no permission re-validation since the question was already shown to the user; just resolves the connector, builds DustAPI with email header, submits the answer, and posts a confirmation ephemeral
- **Block Kit**: options rendered as radio/checkboxes in `actions` block; unknown action types (spurious fires from interactive elements) are silently skipped via `KnownActionSchema` decode-and-continue pattern; state parsing uses typed io-ts schemas

## Notes

- For single select, answer is submitted only on clicking 'Submit' button, not upon clicking radio button (Slight drift from the behavior of front but submit button was required for the free input and the UX felt weird otherwise)
- If both an option and free text are submitted, the option takes priority
- Confirmation ephemeral: "Your answer was submitted ✅" or "Question skipped ⏭️"

## Tests

<details>

<summary>Test videos</summary>

### Checkboxes
![Screen Recording 2026-04-09 at 11 59 40](https://github.com/user-attachments/assets/83f2061f-d9a2-4cf4-b225-a81f303cbdce)
### Radio
![Screen Recording 2026-04-09 at 12 00 29](https://github.com/user-attachments/assets/11f297f9-e9cc-43dc-b9c1-1f8577d15d65)
### Free input
![Screen Recording 2026-04-09 at 12 01 03](https://github.com/user-attachments/assets/406374f8-c7a6-47c0-888c-66f6a1240665)
### Skip
![Screen Recording 2026-04-09 at 12 01 50](https://github.com/user-attachments/assets/e05df2a8-344f-4011-a3cd-038532f453fd)

</details>