### PR TITLE
[front] enh: tie internal MCP tool names to server names in types

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -87,7 +87,7 @@ export type ClientSideMCPToolType = Omit<
   displayLabels?: ToolDisplayLabels;
 };
 
-type WithToolMetadata<
+type WithToolNameMetadata<
   T,
   TOriginalName extends string = string,
   TMCPServerName extends string = string,
@@ -113,13 +113,13 @@ type ExternalServerSideMCPToolType = Omit<
 
 export type InternalServerSideMCPToolConfigurationType<
   N extends InternalMCPServerNameType = InternalMCPServerNameType,
-> = WithToolMetadata<
+> = WithToolNameMetadata<
   InternalServerSideMCPToolType<N>,
   InternalMCPToolNameType<N>
 >;
 
 export type ExternalServerSideMCPToolConfigurationType =
-  WithToolMetadata<ExternalServerSideMCPToolType>;
+  WithToolNameMetadata<ExternalServerSideMCPToolType>;
 
 export type ServerSideMCPToolConfigurationType<
   N extends InternalMCPServerNameType | null = InternalMCPServerNameType | null,
@@ -128,7 +128,7 @@ export type ServerSideMCPToolConfigurationType<
   : ExternalServerSideMCPToolConfigurationType;
 
 export type ClientSideMCPToolConfigurationType =
-  WithToolMetadata<ClientSideMCPToolType>;
+  WithToolNameMetadata<ClientSideMCPToolType>;
 
 export type MCPToolConfigurationType =
   | ServerSideMCPToolConfigurationType

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -96,9 +96,10 @@ type WithToolMetadata<
   mcpServerName: TMCPServerName;
 };
 
-type InternalServerSideMCPToolType<
-  N extends InternalMCPServerNameType,
-> = Omit<ServerSideMCPToolType, "internalMCPServerId" | "name"> & {
+type InternalServerSideMCPToolType<N extends InternalMCPServerNameType> = Omit<
+  ServerSideMCPToolType,
+  "internalMCPServerId" | "name"
+> & {
   internalMCPServerId: string;
   name: InternalMCPToolNameType<N>;
 };
@@ -121,9 +122,7 @@ export type ExternalServerSideMCPToolConfigurationType =
   WithToolMetadata<ExternalServerSideMCPToolType>;
 
 export type ServerSideMCPToolConfigurationType<
-  N extends InternalMCPServerNameType | null =
-    | InternalMCPServerNameType
-    | null,
+  N extends InternalMCPServerNameType | null = InternalMCPServerNameType | null,
 > = N extends InternalMCPServerNameType
   ? InternalServerSideMCPToolConfigurationType<N>
   : ExternalServerSideMCPToolConfigurationType;
@@ -146,9 +145,7 @@ type LightMCPToolType<T> = Omit<
 >;
 
 export type LightServerSideMCPToolConfigurationType<
-  N extends InternalMCPServerNameType | null =
-    | InternalMCPServerNameType
-    | null,
+  N extends InternalMCPServerNameType | null = InternalMCPServerNameType | null,
 > = LightMCPToolType<ServerSideMCPToolConfigurationType<N>>;
 
 export type LightClientSideMCPToolConfigurationType =

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -2,7 +2,11 @@ import type {
   MCPToolStakeLevelType,
   MCPValidationMetadataType,
 } from "@app/lib/actions/constants";
-import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
+import type {
+  InternalMCPServerNameType,
+  InternalMCPToolNameType,
+  MCPServerAvailability,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   MCPApproveExecutionEvent,
   ToolAskUserQuestionEvent,
@@ -83,16 +87,49 @@ export type ClientSideMCPToolType = Omit<
   displayLabels?: ToolDisplayLabels;
 };
 
-type WithToolNameMetadata<T> = T & {
-  originalName: string;
-  mcpServerName: string;
+type WithToolMetadata<
+  T,
+  TOriginalName extends string = string,
+  TMCPServerName extends string = string,
+> = T & {
+  originalName: TOriginalName;
+  mcpServerName: TMCPServerName;
 };
 
-export type ServerSideMCPToolConfigurationType =
-  WithToolNameMetadata<ServerSideMCPToolType>;
+type InternalServerSideMCPToolType<
+  N extends InternalMCPServerNameType,
+> = Omit<ServerSideMCPToolType, "internalMCPServerId" | "name"> & {
+  internalMCPServerId: string;
+  name: InternalMCPToolNameType<N>;
+};
+
+type ExternalServerSideMCPToolType = Omit<
+  ServerSideMCPToolType,
+  "internalMCPServerId"
+> & {
+  internalMCPServerId: null;
+};
+
+export type InternalServerSideMCPToolConfigurationType<
+  N extends InternalMCPServerNameType = InternalMCPServerNameType,
+> = WithToolMetadata<
+  InternalServerSideMCPToolType<N>,
+  InternalMCPToolNameType<N>
+>;
+
+export type ExternalServerSideMCPToolConfigurationType =
+  WithToolMetadata<ExternalServerSideMCPToolType>;
+
+export type ServerSideMCPToolConfigurationType<
+  N extends InternalMCPServerNameType | null =
+    | InternalMCPServerNameType
+    | null,
+> = N extends InternalMCPServerNameType
+  ? InternalServerSideMCPToolConfigurationType<N>
+  : ExternalServerSideMCPToolConfigurationType;
 
 export type ClientSideMCPToolConfigurationType =
-  WithToolNameMetadata<ClientSideMCPToolType>;
+  WithToolMetadata<ClientSideMCPToolType>;
 
 export type MCPToolConfigurationType =
   | ServerSideMCPToolConfigurationType
@@ -108,8 +145,11 @@ type LightMCPToolType<T> = Omit<
   (typeof MCP_TOOL_CONFIGURATION_FIELDS_TO_OMIT)[number]
 >;
 
-export type LightServerSideMCPToolConfigurationType =
-  LightMCPToolType<ServerSideMCPToolConfigurationType>;
+export type LightServerSideMCPToolConfigurationType<
+  N extends InternalMCPServerNameType | null =
+    | InternalMCPServerNameType
+    | null,
+> = LightMCPToolType<ServerSideMCPToolConfigurationType<N>>;
 
 export type LightClientSideMCPToolConfigurationType =
   LightMCPToolType<ClientSideMCPToolConfigurationType>;

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1134,7 +1134,7 @@ type InternalMCPServerEntryCommon = {
 
 type InternalMCPServerEntryWithMetadata<K extends InternalMCPServerNameType> =
   InternalMCPServerEntryCommon & {
-    metadata: ServerMetadata;
+    metadata: ServerMetadata<K>;
     serverInfo?: InternalMCPServerDefinitionType & { name: K };
     tools_stakes?: Record<string, MCPToolStakeLevelType>;
   };
@@ -1156,6 +1156,24 @@ type InternalMCPServerEntry =
 
 export type InternalMCPServerNameType =
   (typeof AVAILABLE_INTERNAL_MCP_SERVER_NAMES)[number];
+
+type StaticInternalMCPToolNameType<N extends InternalMCPServerNameType> =
+  (typeof INTERNAL_MCP_SERVERS)[N]["metadata"]["tools"][number]["name"];
+
+type DynamicInternalMCPToolNameOverrides = {
+  data_sources_file_system: "find_tags";
+  extract_data: "find_tags";
+  include_data: "find_tags";
+  missing_action_catcher: string;
+  run_agent: string;
+  run_dust_app: string;
+  search: "find_tags";
+};
+
+export type InternalMCPToolNameType<N extends InternalMCPServerNameType> =
+  N extends keyof DynamicInternalMCPToolNameOverrides
+    ? StaticInternalMCPToolNameType<N> | DynamicInternalMCPToolNameOverrides[N]
+    : StaticInternalMCPToolNameType<N>;
 
 type AutoServerKeys<T> = {
   [K in keyof T]: T[K] extends { availability: "auto" | "auto_hidden_builder" }
@@ -1287,25 +1305,27 @@ export function getInternalMCPServerToolStakes(
   return server.metadata.tools_stakes;
 }
 
-// TODO(2026-01-27 MCP): improve typing once all servers are migrated to the metadata pattern.
-// Goal is to tie the tool name to the server name.
-export function getInternalMCPServerToolDisplayLabels(
-  name: InternalMCPServerNameType
+export function getInternalMCPServerToolDisplayLabels<
+  N extends InternalMCPServerNameType,
+>(
+  name: N
 ): Record<string, ToolDisplayLabels> | null {
   const server = INTERNAL_MCP_SERVERS[name];
+  const displayLabelsByTool: Record<string, ToolDisplayLabels> = {};
+  let hasDisplayLabels = false;
 
-  const entries = server.metadata.tools
-    .filter(
-      (tool): tool is typeof tool & { displayLabels: ToolDisplayLabels } =>
-        tool.displayLabels !== undefined
-    )
-    .map((tool) => [tool.name, tool.displayLabels] as const);
+  for (const tool of server.metadata.tools) {
+    if (tool.displayLabels) {
+      displayLabelsByTool[tool.name] = tool.displayLabels;
+      hasDisplayLabels = true;
+    }
+  }
 
-  if (entries.length === 0) {
+  if (!hasDisplayLabels) {
     return null;
   }
 
-  return Object.fromEntries(entries);
+  return displayLabelsByTool;
 }
 
 export function getInternalMCPServerInfo(
@@ -1352,10 +1372,10 @@ export function matchesInternalMCPServerName(
   return false;
 }
 
-export function getInternalMCPServerMetadata(
-  name: InternalMCPServerNameType
-): ServerMetadata {
-  const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
+export function getInternalMCPServerMetadata<N extends InternalMCPServerNameType>(
+  name: N
+): (typeof INTERNAL_MCP_SERVERS)[N]["metadata"] {
+  const server = INTERNAL_MCP_SERVERS[name];
 
   return server.metadata;
 }

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1307,9 +1307,7 @@ export function getInternalMCPServerToolStakes(
 
 export function getInternalMCPServerToolDisplayLabels<
   N extends InternalMCPServerNameType,
->(
-  name: N
-): Record<string, ToolDisplayLabels> | null {
+>(name: N): Record<string, ToolDisplayLabels> | null {
   const server = INTERNAL_MCP_SERVERS[name];
   const displayLabelsByTool: Record<string, ToolDisplayLabels> = {};
   let hasDisplayLabels = false;
@@ -1372,9 +1370,9 @@ export function matchesInternalMCPServerName(
   return false;
 }
 
-export function getInternalMCPServerMetadata<N extends InternalMCPServerNameType>(
-  name: N
-): (typeof INTERNAL_MCP_SERVERS)[N]["metadata"] {
+export function getInternalMCPServerMetadata<
+  N extends InternalMCPServerNameType,
+>(name: N): (typeof INTERNAL_MCP_SERVERS)[N]["metadata"] {
   const server = INTERNAL_MCP_SERVERS[name];
 
   return server.metadata;

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -144,8 +144,8 @@ type InternalMCPToolType<TName extends string = string> = Omit<
 };
 
 export type ServerMetadata<
-  TServerName extends InternalMCPServerDefinitionType["name"] =
-    InternalMCPServerDefinitionType["name"],
+  TServerName extends
+    InternalMCPServerDefinitionType["name"] = InternalMCPServerDefinitionType["name"],
   TToolName extends string = string,
 > = {
   serverInfo: InternalMCPServerDefinitionType & { name: TServerName };

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -135,12 +135,20 @@ export function buildTools<T extends Record<string, ToolMeta>>(
 }
 
 // Internal MCP server tools must have displayLabels (unlike remote servers).
-type InternalMCPToolType = MCPToolType & {
+type InternalMCPToolType<TName extends string = string> = Omit<
+  MCPToolType,
+  "name" | "displayLabels"
+> & {
+  name: TName;
   displayLabels: ToolDisplayLabels;
 };
 
-export type ServerMetadata = {
-  serverInfo: InternalMCPServerDefinitionType;
-  tools: InternalMCPToolType[];
-  tools_stakes: Record<string, MCPToolStakeLevelType>;
+export type ServerMetadata<
+  TServerName extends InternalMCPServerDefinitionType["name"] =
+    InternalMCPServerDefinitionType["name"],
+  TToolName extends string = string,
+> = {
+  serverInfo: InternalMCPServerDefinitionType & { name: TServerName };
+  tools: InternalMCPToolType<TToolName>[];
+  tools_stakes: Record<TToolName, MCPToolStakeLevelType>;
 };

--- a/front/lib/actions/types/guards.test.ts
+++ b/front/lib/actions/types/guards.test.ts
@@ -1,0 +1,46 @@
+import type {
+  LightServerSideMCPToolConfigurationType,
+  ServerSideMCPToolConfigurationType,
+} from "@app/lib/actions/mcp";
+import type { InternalMCPToolNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  isLightServerSideMCPToolConfigurationWithName,
+  isServerSideMCPToolConfigurationWithName,
+} from "@app/lib/actions/types/guards";
+import { describe, expectTypeOf, it } from "vitest";
+
+function assertServerSideToolNameNarrowing(
+  tool: ServerSideMCPToolConfigurationType
+) {
+  if (isServerSideMCPToolConfigurationWithName(tool, "gmail")) {
+    expectTypeOf(tool.name).toEqualTypeOf<InternalMCPToolNameType<"gmail">>();
+    expectTypeOf(tool.originalName).toEqualTypeOf<
+      InternalMCPToolNameType<"gmail">
+    >();
+  }
+
+  if (isServerSideMCPToolConfigurationWithName(tool, "search")) {
+    expectTypeOf(tool.name).toEqualTypeOf<InternalMCPToolNameType<"search">>();
+  }
+
+  if (isServerSideMCPToolConfigurationWithName(tool, "run_agent")) {
+    expectTypeOf(tool.name).toEqualTypeOf<
+      InternalMCPToolNameType<"run_agent">
+    >();
+  }
+}
+
+function assertLightServerSideToolNameNarrowing(
+  tool: LightServerSideMCPToolConfigurationType
+) {
+  if (isLightServerSideMCPToolConfigurationWithName(tool, "search")) {
+    expectTypeOf(tool.name).toEqualTypeOf<InternalMCPToolNameType<"search">>();
+  }
+}
+
+describe("MCP tool config guards", () => {
+  it("narrows internal tool names from the internal server name", () => {
+    expectTypeOf(assertServerSideToolNameNarrowing).toBeFunction();
+    expectTypeOf(assertLightServerSideToolNameNarrowing).toBeFunction();
+  });
+});

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -70,6 +70,18 @@ export function isLightServerSideMCPToolConfiguration(
   );
 }
 
+export function isLightServerSideMCPToolConfigurationWithName<
+  N extends InternalMCPServerNameType,
+>(
+  config: unknown,
+  name: N
+): config is LightServerSideMCPToolConfigurationType<N> {
+  return (
+    isLightServerSideMCPToolConfiguration(config) &&
+    matchesInternalMCPServerName(config.internalMCPServerId, name)
+  );
+}
+
 export function isLightClientSideMCPToolConfiguration(
   arg: unknown
 ): arg is LightClientSideMCPToolConfigurationType {
@@ -101,10 +113,12 @@ export function isServerSideMCPServerConfigurationWithName(
   );
 }
 
-export function isServerSideMCPToolConfigurationWithName(
+export function isServerSideMCPToolConfigurationWithName<
+  N extends InternalMCPServerNameType,
+>(
   config: MCPToolConfigurationType,
-  name: InternalMCPServerNameType
-): config is ServerSideMCPToolConfigurationType {
+  name: N
+): config is ServerSideMCPToolConfigurationType<N> {
   return (
     isServerSideMCPToolConfiguration(config) &&
     matchesInternalMCPServerName(config.internalMCPServerId, name)

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -607,7 +607,7 @@ const ALL_TOOLS_METADATA = {
 /**
  * Returns the Google Drive server metadata with all tools including write capabilities.
  */
-export function getGoogleDriveServerMetadata(): ServerMetadata {
+export function getGoogleDriveServerMetadata() {
   return {
     serverInfo: {
       name: "google_drive",

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -1,5 +1,4 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import { matchesInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ToolGeneratedFileType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -7,7 +6,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
-  isLightServerSideMCPToolConfiguration,
+  isLightServerSideMCPToolConfigurationWithName,
   isServerSideMCPServerConfigurationWithName,
 } from "@app/lib/actions/types/guards";
 import {
@@ -99,9 +98,8 @@ export default async function createServer(
     // Context: Running the Dust app
     const { toolConfiguration } = agentLoopContext.runContext;
     if (
-      !isLightServerSideMCPToolConfiguration(toolConfiguration) ||
-      !matchesInternalMCPServerName(
-        toolConfiguration.internalMCPServerId,
+      !isLightServerSideMCPToolConfigurationWithName(
+        toolConfiguration,
         "run_dust_app"
       )
     ) {


### PR DESCRIPTION
## Description

- Make ServerSideMCPToolConfigurationType generic for internal MCP servers.
- Derive internal tool-name unions from INTERNAL_MCP_SERVERS metadata.
- Update MCP guards so isServerSideMCPToolConfigurationWithName(...) narrows name and originalName to the right tool union for that server.
- Add coverage for dynamic/internal exceptions like run_agent, run_dust_app, missing_action_catcher, and tag-enabled find_tags tools.
- Add a type-level regression test for the guard narrowing behavior.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
