### PR TITLE
[front] enh: add richer dynamic labels for various tools

### DIFF
--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -133,6 +133,13 @@ function getDynamicToolDisplayLabels({
           done: `Searched “${q}”`,
         };
       }
+      if (toolName === "cat" && isString(inputs.grep)) {
+        const g = truncateQuery(inputs.grep);
+        return {
+          running: `Searching for “${g}” in file`,
+          done: `Searched for “${g}” in file`,
+        };
+      }
       return null;
 
     case "image_generation":

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -141,10 +141,24 @@ function getDynamicToolDisplayLabels({
             done: `Searched for “${g}” in file`,
           };
         }
-        if (isNumber(inputs.offset) && inputs.offset > 0) {
+        const hasOffset = isNumber(inputs.offset) && inputs.offset > 0;
+        const hasLimit = isNumber(inputs.limit);
+        if (hasOffset && hasLimit) {
           return {
-            running: "Reading more of file",
-            done: "Read more of file",
+            running: "Reading a section of file",
+            done: "Read a section of file",
+          };
+        }
+        if (hasOffset) {
+          return {
+            running: "Continuing to read file",
+            done: "Continued reading file",
+          };
+        }
+        if (hasLimit) {
+          return {
+            running: "Reading the beginning of file",
+            done: "Read the beginning of file",
           };
         }
       }
@@ -227,10 +241,24 @@ function getDynamicToolDisplayLabels({
             done: `Searched for “${g}” in file`,
           };
         }
-        if (isNumber(inputs.offset) && inputs.offset > 0) {
+        const hasOffset = isNumber(inputs.offset) && inputs.offset > 0;
+        const hasLimit = isNumber(inputs.limit);
+        if (hasOffset && hasLimit) {
           return {
-            running: "Reading more of file",
-            done: "Read more of file",
+            running: "Reading a section of file",
+            done: "Read a section of file",
+          };
+        }
+        if (hasOffset) {
+          return {
+            running: "Continuing to read file",
+            done: "Continued reading file",
+          };
+        }
+        if (hasLimit) {
+          return {
+            running: "Reading the beginning of file",
+            done: "Read the beginning of file",
           };
         }
       }

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -272,7 +272,7 @@ function getDynamicToolDisplayLabels({
       if (
         toolName === "get_pull_request" &&
         base &&
-        typeof inputs.pullNumber === "number"
+        isNumber(inputs.pullNumber)
       ) {
         const url = `${base}/pull/${inputs.pullNumber}`;
         return {
@@ -283,7 +283,7 @@ function getDynamicToolDisplayLabels({
       if (
         toolName === "get_issue" &&
         base &&
-        typeof inputs.issueNumber === "number"
+        isNumber(inputs.issueNumber)
       ) {
         const url = `${base}/issues/${inputs.issueNumber}`;
         return {
@@ -301,7 +301,7 @@ function getDynamicToolDisplayLabels({
       if (
         toolName === "comment_on_issue" &&
         base &&
-        typeof inputs.issueNumber === "number"
+        isNumber(inputs.issueNumber)
       ) {
         const url = `${base}/issues/${inputs.issueNumber}`;
         return {
@@ -312,7 +312,7 @@ function getDynamicToolDisplayLabels({
       if (
         toolName === "create_pull_request_review" &&
         base &&
-        typeof inputs.pullNumber === "number"
+        isNumber(inputs.pullNumber)
       ) {
         const url = `${base}/pull/${inputs.pullNumber}`;
         return {

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -361,12 +361,81 @@ function getDynamicToolDisplayLabels({
         (toolName === "create_document" ||
           toolName === "create_spreadsheet" ||
           toolName === "create_presentation") &&
-        isString(inputs.title)
+        isString(inputs.description)
       ) {
-        const t = truncateQuery(inputs.title);
+        const t = truncateQuery(inputs.description);
         return {
           running: `Creating “${t}”`,
           done: `Created “${t}”`,
+        };
+      }
+      return null;
+
+    case "sandbox":
+      if (toolName === "bash" && isString(inputs.description)) {
+        const t = truncateQuery(inputs.description);
+        return { running: t, done: t };
+      }
+      return null;
+
+    case "query_tables_v2":
+      if (
+        toolName === "execute_database_query" &&
+        isString(inputs.description)
+      ) {
+        const t = truncateQuery(inputs.description);
+        return { running: t, done: t };
+      }
+      return null;
+
+    case "data_warehouses":
+      if (toolName === "query" && isString(inputs.description)) {
+        const t = truncateQuery(inputs.description);
+        return { running: t, done: t };
+      }
+      return null;
+
+    case "file_generation":
+      if (
+        (toolName === "generate_file" || toolName === "convert_file_format") &&
+        isString(inputs.file_name)
+      ) {
+        const name = truncateQuery(inputs.file_name);
+        const verb = toolName === "generate_file" ? "Generating" : "Converting";
+        const past = toolName === "generate_file" ? "Generated" : "Converted";
+        return {
+          running: `${verb} "${name}"`,
+          done: `${past} "${name}"`,
+        };
+      }
+      return null;
+
+    case "run_agent":
+      if (isString(inputs.description)) {
+        const d = truncateQuery(inputs.description);
+        return { running: d, done: d };
+      }
+      return null;
+
+    case "interactive_content":
+      if (
+        toolName === "create_interactive_content_file" &&
+        isString(inputs.file_name)
+      ) {
+        const name = truncateQuery(inputs.file_name);
+        return {
+          running: `Creating "${name}"`,
+          done: `Created "${name}"`,
+        };
+      }
+      if (
+        toolName === "rename_interactive_content_file" &&
+        isString(inputs.new_file_name)
+      ) {
+        const name = truncateQuery(inputs.new_file_name);
+        return {
+          running: `Renaming to "${name}"`,
+          done: `Renamed to "${name}"`,
         };
       }
       return null;
@@ -380,15 +449,12 @@ function getDynamicToolDisplayLabels({
     case "ashby":
     case "confluence":
     case "databricks":
-    case "data_warehouses":
-    case "file_generation":
     case "fathom":
     case "freshservice":
     case "gong":
     case "google_sheets":
     case "hubspot":
     case "include_data":
-    case "interactive_content":
     case "slideshow":
     case "jira":
     case "luma":
@@ -402,7 +468,6 @@ function getDynamicToolDisplayLabels({
     case "productboard":
     case "common_utilities":
     case "jit_testing":
-    case "run_agent":
     case "run_dust_app":
     case "salesforce":
     case "salesloft":
@@ -418,13 +483,11 @@ function getDynamicToolDisplayLabels({
     case "vanta":
     case "front":
     case "zendesk":
-    case "query_tables_v2":
     case "skill_management":
     case "schedules_management":
     case "project_manager":
     case "poke":
     case "project_conversation":
-    case "sandbox":
     case "ask_user_question":
     default:
       return null;

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -280,11 +280,7 @@ function getDynamicToolDisplayLabels({
           done: `Retrieved ${url}`,
         };
       }
-      if (
-        toolName === "get_issue" &&
-        base &&
-        isNumber(inputs.issueNumber)
-      ) {
+      if (toolName === "get_issue" && base && isNumber(inputs.issueNumber)) {
         const url = `${base}/issues/${inputs.issueNumber}`;
         return {
           running: `Retrieving ${url}`,

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -13,7 +13,7 @@ import {
   isWebsearchInputType,
 } from "@app/lib/actions/mcp_internal_actions/types";
 import type { ToolDisplayLabels } from "@app/lib/api/mcp";
-import { isString } from "@app/types/shared/utils/general";
+import { isNumber, isString } from "@app/types/shared/utils/general";
 import { asDisplayName, slugify } from "@app/types/shared/utils/string_utils";
 
 type ToolDisplayLabelsByTool = Record<string, ToolDisplayLabels>;
@@ -141,7 +141,7 @@ function getDynamicToolDisplayLabels({
             done: `Searched for “${g}” in file`,
           };
         }
-        if (typeof inputs.offset === "number" && inputs.offset > 0) {
+        if (isNumber(inputs.offset) && inputs.offset > 0) {
           return {
             running: "Reading more of file",
             done: "Read more of file",
@@ -227,7 +227,7 @@ function getDynamicToolDisplayLabels({
             done: `Searched for “${g}” in file`,
           };
         }
-        if (typeof inputs.offset === "number" && inputs.offset > 0) {
+        if (isNumber(inputs.offset) && inputs.offset > 0) {
           return {
             running: "Reading more of file",
             done: "Read more of file",

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -211,12 +211,20 @@ function getDynamicToolDisplayLabels({
           done: `Searched files “${q}”`,
         };
       }
-      if (toolName === "cat" && isString(inputs.grep)) {
-        const g = truncateQuery(inputs.grep);
-        return {
-          running: `Searching for “${g}” in file`,
-          done: `Searched for “${g}” in file`,
-        };
+      if (toolName === "cat") {
+        if (isString(inputs.grep)) {
+          const g = truncateQuery(inputs.grep);
+          return {
+            running: `Searching for “${g}” in file`,
+            done: `Searched for “${g}” in file`,
+          };
+        }
+        if (typeof inputs.offset === "number" && inputs.offset > 0) {
+          return {
+            running: "Reading more of file",
+            done: "Read more of file",
+          };
+        }
       }
       return null;
 

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -133,12 +133,20 @@ function getDynamicToolDisplayLabels({
           done: `Searched “${q}”`,
         };
       }
-      if (toolName === "cat" && isString(inputs.grep)) {
-        const g = truncateQuery(inputs.grep);
-        return {
-          running: `Searching for “${g}” in file`,
-          done: `Searched for “${g}” in file`,
-        };
+      if (toolName === "cat") {
+        if (isString(inputs.grep)) {
+          const g = truncateQuery(inputs.grep);
+          return {
+            running: `Searching for “${g}” in file`,
+            done: `Searched for “${g}” in file`,
+          };
+        }
+        if (typeof inputs.offset === "number" && inputs.offset > 0) {
+          return {
+            running: "Reading more of file",
+            done: "Read more of file",
+          };
+        }
       }
       return null;
 

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -263,8 +263,8 @@ function getDynamicToolDisplayLabels({
           done: `Retrieved ${url}`,
         };
       }
-      if (toolName === "create_issue" && base && isString(inputs.title)) {
-        const t = truncateQuery(inputs.title);
+      if (toolName === "create_issue" && base && isString(inputs.description)) {
+        const t = truncateQuery(inputs.description);
         return {
           running: `Creating issue on ${base}: “${t}”`,
           done: `Created issue on ${base}: “${t}”`,

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -291,8 +291,8 @@ function getDynamicToolDisplayLabels({
           done: `Retrieved ${url}`,
         };
       }
-      if (toolName === "create_issue" && base && isString(inputs.description)) {
-        const t = truncateQuery(inputs.description);
+      if (toolName === "create_issue" && base && isString(inputs.title)) {
+        const t = truncateQuery(inputs.title);
         return {
           running: `Creating issue on ${base}: “${t}”`,
           done: `Created issue on ${base}: “${t}”`,
@@ -389,9 +389,9 @@ function getDynamicToolDisplayLabels({
         (toolName === "create_document" ||
           toolName === "create_spreadsheet" ||
           toolName === "create_presentation") &&
-        isString(inputs.description)
+        isString(inputs.title)
       ) {
-        const t = truncateQuery(inputs.description);
+        const t = truncateQuery(inputs.title);
         return {
           running: `Creating “${t}”`,
           done: `Created “${t}”`,

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -140,8 +140,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
       description: z
         .string()
         .describe(
-          "A short, user-facing summary of what this query does, using infinitive verbs (e.g. " +
-            '"Compute monthly revenue by region", "Find top 10 customers by spend").'
+          "A short, high-level description of the goal, not the query itself. Use infinitive verbs (e.g. " +
+            '"Analyze revenue trends", "Identify top customers").'
         ),
       query: z
         .string()

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -137,6 +137,12 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
           "Array of table identifiers in the format 'table-<dataSourceId>-<nodeId>'. " +
             "All tables must be from the same warehouse (same dataSourceId)."
         ),
+      description: z
+        .string()
+        .describe(
+          "A short, user-facing summary of what this query does, using infinitive verbs (e.g. " +
+            '"Compute monthly revenue by region", "Find top 10 customers by spend").'
+        ),
       query: z
         .string()
         .describe(

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -140,7 +140,7 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
       description: z
         .string()
         .describe(
-          "A short, high-level description of the goal, not the query itself. Use infinitive verbs (e.g. " +
+          "The reason this query is being run and what it achieves, in a few words. Use infinitive verbs (e.g. " +
             '"Analyze revenue trends", "Identify top customers").'
         ),
       query: z

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -34,7 +34,7 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
       description: z
         .string()
         .describe(
-          "A short, high-level description of the goal, not the query itself. Use infinitive verbs (e.g. " +
+          "The reason this query is being run and what it achieves, in a few words. Use infinitive verbs (e.g. " +
             '"Analyze revenue trends", "Identify top customers").'
         ),
       query: z

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -34,8 +34,8 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
       description: z
         .string()
         .describe(
-          "A short, user-facing summary of what this query does, using infinitive verbs (e.g. " +
-            '"Compute monthly revenue by region", "Find top 10 customers by spend").'
+          "A short, high-level description of the goal, not the query itself. Use infinitive verbs (e.g. " +
+            '"Analyze revenue trends", "Identify top customers").'
         ),
       query: z
         .string()

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -31,6 +31,12 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
     schema: {
       tables:
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE],
+      description: z
+        .string()
+        .describe(
+          "A short, user-facing summary of what this query does, using infinitive verbs (e.g. " +
+            '"Compute monthly revenue by region", "Find top 10 customers by spend").'
+        ),
       query: z
         .string()
         .describe(

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -53,7 +53,7 @@ export const RUN_AGENT_TOOL_SCHEMA = {
   description: z
     .string()
     .describe(
-      "A short, high-level description of the goal, not the detailed instructions. Use infinitive verbs (e.g. " +
+      "The reason this agent is being called and what it achieves, in a few words. Use infinitive verbs (e.g. " +
         '"Review Q1 performance", "Assess support backlog").'
     ),
   query: z

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -50,6 +50,12 @@ export const RUN_AGENT_CONFIGURABLE_PROPERTIES = {
 };
 
 export const RUN_AGENT_TOOL_SCHEMA = {
+  description: z
+    .string()
+    .describe(
+      "A short summary of what the agent will do, using infinitive verbs (e.g. " +
+        '"Analyze Q1 revenue trends", "Summarize the latest support tickets").'
+    ),
   query: z
     .string()
     .describe(

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -53,8 +53,8 @@ export const RUN_AGENT_TOOL_SCHEMA = {
   description: z
     .string()
     .describe(
-      "A short summary of what the agent will do, using infinitive verbs (e.g. " +
-        '"Analyze Q1 revenue trends", "Summarize the latest support tickets").'
+      "A short, high-level description of the goal, not the detailed instructions. Use infinitive verbs (e.g. " +
+        '"Review Q1 performance", "Assess support backlog").'
     ),
   query: z
     .string()

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -14,6 +14,12 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       "Use this for running scripts, installing packages, or executing code. " +
       "The sandbox persists for the duration of the conversation.",
     schema: {
+      description: z
+        .string()
+        .describe(
+          "A short, user-facing summary of what this command does, using infinitive verbs (e.g. " +
+            '"Install dependencies", "Run test suite").'
+        ),
       command: z
         .string()
         .describe(

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -17,8 +17,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       description: z
         .string()
         .describe(
-          "A short, user-facing summary of what this command does, using infinitive verbs (e.g. " +
-            '"Install dependencies", "Run test suite").'
+          "A short, high-level description of the goal, not the implementation details. Use infinitive verbs (e.g. " +
+            '"Set up environment", "Generate the chart").'
         ),
       command: z
         .string()

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -17,7 +17,7 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       description: z
         .string()
         .describe(
-          "A short, high-level description of the goal, not the implementation details. Use infinitive verbs (e.g. " +
+          "The reason this command is being run and what it achieves, in a few words. Use infinitive verbs (e.g. " +
             '"Set up environment", "Generate the chart").'
         ),
       command: z

--- a/front/types/shared/utils/general.ts
+++ b/front/types/shared/utils/general.ts
@@ -10,7 +10,7 @@ export function isString(value: unknown): value is string {
 }
 
 export function isNumber(value: unknown): value is number {
-  return typeof value === "number";
+  return typeof value === "number" && !Number.isNaN(value);
 }
 
 export function isNumberOrBoolean(value: unknown): value is number | boolean {

--- a/front/types/shared/utils/general.ts
+++ b/front/types/shared/utils/general.ts
@@ -9,6 +9,10 @@ export function isString(value: unknown): value is string {
   return typeof value === "string";
 }
 
+export function isNumber(value: unknown): value is number {
+  return typeof value === "number";
+}
+
 export function isNumberOrBoolean(value: unknown): value is number | boolean {
   return typeof value === "number" || typeof value === "boolean";
 }


### PR DESCRIPTION
## Description

- Add a description input field to the bash, query_tables_v2, data_warehouses/query, and run_agent tools to have the model provide a human-readable label for opaque tool calls (code, SQL, agent delegation)
- Add a few more contextual labels (`cat` tool, file generation).

<img width="770" height="223" alt="Screenshot 2026-04-09 at 2 12 53 PM" src="https://github.com/user-attachments/assets/9c99cd2e-4b3c-44bb-bbbd-a0bce112a9e5" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.