### PR TITLE
fix(inlinesteps): use AgentMessageMarkdown for content in inline steps

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1318,13 +1318,16 @@ function AgentMessageContent({
   return (
     <div className="flex flex-col gap-y-4">
       {isInlineActivityEnabled ? (
-        <InlineActivitySteps
-          agentMessage={agentMessage}
-          lastAgentStateClassification={agentMessage.streaming.agentState}
-          completedSteps={agentMessage.streaming.inlineActivitySteps}
-          pendingToolCalls={agentMessage.streaming.pendingToolCalls}
-          onOpenDetails={onOpenDetails}
-        />
+        <CitationsContext.Provider value={citationsContextValue}>
+          <InlineActivitySteps
+            agentMessage={agentMessage}
+            lastAgentStateClassification={agentMessage.streaming.agentState}
+            completedSteps={agentMessage.streaming.inlineActivitySteps}
+            pendingToolCalls={agentMessage.streaming.pendingToolCalls}
+            onOpenDetails={onOpenDetails}
+            owner={owner}
+          />
+        </CitationsContext.Provider>
       ) : (
         <AgentMessageActions
           agentMessage={agentMessage}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1316,9 +1316,9 @@ function AgentMessageContent({
   );
 
   return (
-    <div className="flex flex-col gap-y-4">
-      {isInlineActivityEnabled ? (
-        <CitationsContext.Provider value={citationsContextValue}>
+    <CitationsContext.Provider value={citationsContextValue}>
+      <div className="flex flex-col gap-y-4">
+        {isInlineActivityEnabled ? (
           <InlineActivitySteps
             agentMessage={agentMessage}
             lastAgentStateClassification={agentMessage.streaming.agentState}
@@ -1327,36 +1327,36 @@ function AgentMessageContent({
             onOpenDetails={onOpenDetails}
             owner={owner}
           />
-        </CitationsContext.Provider>
-      ) : (
-        <AgentMessageActions
-          agentMessage={agentMessage}
-          lastAgentStateClassification={agentMessage.streaming.agentState}
-          actionProgress={agentMessage.streaming.actionProgress}
-          pendingToolCalls={agentMessage.streaming.pendingToolCalls}
-          owner={owner}
+        ) : (
+          <AgentMessageActions
+            agentMessage={agentMessage}
+            lastAgentStateClassification={agentMessage.streaming.agentState}
+            actionProgress={agentMessage.streaming.actionProgress}
+            pendingToolCalls={agentMessage.streaming.pendingToolCalls}
+            owner={owner}
+          />
+        )}
+        <AgentMessageInteractiveContentGeneratedFiles
+          files={interactiveFiles}
         />
-      )}
-      <AgentMessageInteractiveContentGeneratedFiles files={interactiveFiles} />
-      {completedImages.length > 0 && (
-        <InteractiveImageGrid
-          images={completedImages.map((image) => ({
-            imageUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=view&version=processed`,
-            downloadUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=download`,
-            alt: image.title,
-            title: image.title,
-            isLoading: false,
-          }))}
-        />
-      )}
+        {completedImages.length > 0 && (
+          <InteractiveImageGrid
+            images={completedImages.map((image) => ({
+              imageUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=view&version=processed`,
+              downloadUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=download`,
+              alt: image.title,
+              title: image.title,
+              isLoading: false,
+            }))}
+          />
+        )}
 
-      {agentMessage.content !== null &&
-        !(
-          isInlineActivityEnabled &&
-          agentMessage.streaming.agentState !== "done"
-        ) && (
-          <div>
-            <CitationsContext.Provider value={citationsContextValue}>
+        {agentMessage.content !== null &&
+          !(
+            isInlineActivityEnabled &&
+            agentMessage.streaming.agentState !== "done"
+          ) && (
+            <div>
               <AgentMessageMarkdown
                 content={sanitizeVisualizationContent(agentMessage.content)}
                 owner={owner}
@@ -1369,60 +1369,60 @@ function AgentMessageContent({
                 additionalMarkdownComponents={additionalMarkdownComponents}
                 additionalMarkdownPlugins={additionalMarkdownPlugins}
               />
-            </CitationsContext.Provider>
+            </div>
+          )}
+        {generatedFiles.length > 0 && (
+          <div className="mt-2 grid grid-cols-5 gap-1">
+            {getCitations({
+              activeReferences: generatedFiles.map((file) => ({
+                index: -1,
+                document: {
+                  fileId: file.fileId,
+                  contentType: file.contentType,
+                  href: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`,
+                  title: file.title,
+                },
+              })),
+              owner,
+              conversationId,
+            })}
           </div>
         )}
-      {generatedFiles.length > 0 && (
-        <div className="mt-2 grid grid-cols-5 gap-1">
-          {getCitations({
-            activeReferences: generatedFiles.map((file) => ({
-              index: -1,
-              document: {
-                fileId: file.fileId,
-                contentType: file.contentType,
-                href: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`,
-                title: file.title,
-              },
-            })),
-            owner,
-            conversationId,
-          })}
-        </div>
-      )}
-      {agentMessage.status === "cancelled" && (
-        <div className="flex flex-col gap-2">
-          <div className="text-sm text-faint dark:text-faint-night">
-            Message generation was interrupted
-          </div>
-          <div>
-            <ButtonGroupDropdown
-              trigger={
-                <Button
-                  variant="outline"
-                  size="xs"
-                  icon={MoreIcon}
-                  className="text-muted-foreground"
-                />
-              }
-              items={[
-                {
-                  label: "Retry",
-                  icon: ArrowPathIcon,
-                  onSelect: () => {
-                    void retryHandler({
-                      conversationId,
-                      messageId: agentMessage.sId,
-                    });
+        {agentMessage.status === "cancelled" && (
+          <div className="flex flex-col gap-2">
+            <div className="text-sm text-faint dark:text-faint-night">
+              Message generation was interrupted
+            </div>
+            <div>
+              <ButtonGroupDropdown
+                trigger={
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    icon={MoreIcon}
+                    className="text-muted-foreground"
+                  />
+                }
+                items={[
+                  {
+                    label: "Retry",
+                    icon: ArrowPathIcon,
+                    onSelect: () => {
+                      void retryHandler({
+                        conversationId,
+                        messageId: agentMessage.sId,
+                      });
+                    },
+                    disabled: isRetryHandlerProcessing,
                   },
-                  disabled: isRetryHandlerProcessing,
-                },
-              ]}
-              align="end"
-            />
+                ]}
+                align="end"
+              />
+            </div>
           </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </CitationsContext.Provider>
   );
 }
 

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -1,3 +1,4 @@
+import { AgentMessageMarkdown } from "@app/components/assistant/AgentMessageMarkdown";
 import { ThinkingStep } from "@app/components/assistant/conversation/actions/inline/ThinkingStep";
 import { TimelineRow } from "@app/components/assistant/conversation/actions/inline/TimelineRow";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
@@ -17,13 +18,13 @@ import type {
 } from "@app/types/assistant/conversation";
 import { isLightAgentMessageWithActionsType } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { WorkspaceType } from "@app/types/user";
 import {
   AnimatedText,
   CheckIcon,
   ChevronRightIcon,
   cn,
   Icon,
-  Markdown,
   ToolsIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -34,6 +35,7 @@ interface InlineActivityStepsProps {
   completedSteps: InlineActivityStep[];
   pendingToolCalls: PendingToolCall[];
   onOpenDetails?: (messageId: string) => void;
+  owner: WorkspaceType;
 }
 
 function getCompletionLabel(
@@ -73,6 +75,7 @@ export function InlineActivitySteps({
   completedSteps,
   pendingToolCalls,
   onOpenDetails,
+  owner,
 }: InlineActivityStepsProps) {
   const isAgentMessageWithActions =
     isLightAgentMessageWithActionsType(agentMessage);
@@ -226,8 +229,9 @@ export function InlineActivitySteps({
                 case "content":
                   return (
                     <div key={step.id}>
-                      <Markdown
+                      <AgentMessageMarkdown
                         content={step.content}
+                        owner={owner}
                         isStreaming={false}
                         isLastMessage={false}
                       />
@@ -284,13 +288,11 @@ export function InlineActivitySteps({
             {/* Active writing (streaming content tokens) */}
             {showActiveWriting && agentMessage.content ? (
               <div>
-                <Markdown
+                <AgentMessageMarkdown
                   content={agentMessage.content}
+                  owner={owner}
                   isStreaming={false}
                   streamingState="streaming"
-                  enableAnimation
-                  animationDurationSeconds={0.3}
-                  delimiter=" "
                   isLastMessage={false}
                 />
               </div>


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7378
Citations are not properly displayed when using inline steps (enable_steering feature flag), see issue for details.

Comes from the fact that InlineActivityTasks used Markdown component to display content instead of the AgentMessageMarkdown component that handles the citations.

## Tests

Tested locally with steering enabled and a setup and question that generates citations in the agent response.

## Risk

Low
Impacts UX when steering is enabled (so for Dust only for the moment)

## Deploy Plan

Deploy front