### PR TITLE
[Session Branching] Add sessions_branching feature flag

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -243,6 +243,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable conversation branches",
     stage: "dust_only",
   },
+  sessions_branching: {
+    description: "Enable sessions branching",
+    stage: "dust_only",
+  },
   reinforced_agents: {
     description:
       "Enable reinforcement: background analysis of conversations to suggest improvements to skills.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -684,6 +684,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "claude_4_opus_feature"
   | "confluence_tool"
   | "conversation_branches"
+  | "sessions_branching"
   | "project_todo"
   | "projects"
   | "databricks_tool"


### PR DESCRIPTION
## Description
Adds `sessions_branching` to the shared front feature-flag registry and the JS SDK whitelistable feature schema so the flag can be enabled and returned through typed APIs.

## Risks
Blast radius: workspace feature-flag typing and flag management surfaces in front.
Risk: low

## Deploy Plan
- pmrr
- deploy front