### PR TITLE
feat(api): allow marking conversation as unread

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1576,6 +1576,27 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return new Ok(updated);
   }
 
+  static async markAsUnreadForAuthUser(
+    auth: Authenticator,
+    {
+      conversation,
+    }: {
+      conversation: ConversationWithoutContentType;
+    }
+  ) {
+    if (!auth.user()) {
+      return new Err(new Error("user_not_authenticated"));
+    }
+    await UserConversationReadsModel.destroy({
+      where: {
+        conversationId: conversation.id,
+        userId: auth.getNonNullableUser().id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    return new Ok(undefined);
+  }
+
   static async getActionRequiredAndLastReadAtForUser(
     auth: Authenticator,
     id: number

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -64,8 +64,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
  *       500:
  *         description: Internal Server Error.
  *   patch:
- *     summary: Mark a conversation as read
- *     description: Mark a conversation as read in the workspace identified by {wId}.
+ *     summary: Update conversation read status
+ *     description: Mark a conversation as read or unread in the workspace identified by {wId}.
  *     tags:
  *       - Conversations
  *     security:
@@ -202,6 +202,10 @@ async function handler(
       const { read } = r.data;
       if (read) {
         await ConversationResource.markAsReadForAuthUser(auth, {
+          conversation: conversationRes.value,
+        });
+      } else {
+        await ConversationResource.markAsUnreadForAuthUser(auth, {
           conversation: conversationRes.value,
         });
       }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -96,7 +96,6 @@
  *                 properties:
  *                   read:
  *                     type: boolean
- *                     enum: [true]
  *               - type: object
  *                 required:
  *                   - spaceId
@@ -146,7 +145,7 @@ const PatchConversationsRequestBodySchema = t.union([
     title: t.string,
   }),
   t.type({
-    read: t.literal(true),
+    read: t.boolean,
   }),
   t.type({
     spaceId: t.string,
@@ -278,9 +277,15 @@ async function handler(
           }
           return res.status(200).json({ success: true });
         } else if ("read" in bodyValidation.right) {
-          await ConversationResource.markAsReadForAuthUser(auth, {
-            conversation,
-          });
+          if (bodyValidation.right.read) {
+            await ConversationResource.markAsReadForAuthUser(auth, {
+              conversation,
+            });
+          } else {
+            await ConversationResource.markAsUnreadForAuthUser(auth, {
+              conversation,
+            });
+          }
 
           return res.status(200).json({ success: true });
         } else if ("spaceId" in bodyValidation.right) {

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -1427,8 +1427,8 @@
         }
       },
       "patch": {
-        "summary": "Mark a conversation as read",
-        "description": "Mark a conversation as read in the workspace identified by {wId}.",
+        "summary": "Update conversation read status",
+        "description": "Mark a conversation as read or unread in the workspace identified by {wId}.",
         "tags": [
           "Conversations"
         ],
@@ -6355,10 +6355,7 @@
                     ],
                     "properties": {
                       "read": {
-                        "type": "boolean",
-                        "enum": [
-                          true
-                        ]
+                        "type": "boolean"
                       }
                     }
                   },

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2141,7 +2141,7 @@ export type GetConversationResponseType = z.infer<
 >;
 
 export const PatchConversationRequestSchema = z.object({
-  read: z.literal(true),
+  read: z.boolean(),
 });
 
 export type PatchConversationRequestType = z.infer<


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

 - Extend PATCH `/api/v1/w/{wId}/assistant/conversations/{cId}` to accept `{ "read": false }` to mark a conversation as unread (previously only {` "read": true }` was accepted)
- Add `ConversationResource.markAsUnreadForAuthUser()` which deletes the user's read record, causing the conversation to appear unread (since `lastReadAt === null` → unread)
- Apply the same change to both the public API (`/api/v1/`) and the private API (`/api/w/`)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front