### PR TITLE
[Tool Calls] Match pending side panel to running tool UX

### DIFF
--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -1,20 +1,13 @@
-import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
 import { MCPImageGenerationGroupedDetails } from "@app/components/actions/mcp/details/MCPImageGenerationActionDetails";
+import { PendingToolCallDetails } from "@app/components/assistant/conversation/actions/PendingToolCallDetails";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import type {
   ActionProgressState,
   AgentStateClassification,
   PendingToolCall,
 } from "@app/components/assistant/conversation/types";
-import { InternalActionIcons } from "@app/components/resources/resources_icons";
-import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
-import {
-  GENERATE_IMAGE_TOOL_NAME,
-  getInternalMCPServerIconByName,
-  isInternalMCPServerName,
-} from "@app/lib/actions/mcp_internal_actions/constants";
-import { getToolCallDisplayLabel } from "@app/lib/actions/tool_display_labels";
+import { GENERATE_IMAGE_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   LightAgentMessageType,
   LightAgentMessageWithActionsType,
@@ -28,7 +21,6 @@ import {
   cn,
   Markdown,
   Spinner,
-  ToolsIcon,
 } from "@dust-tt/sparkle";
 import { useEffect, useRef } from "react";
 
@@ -38,32 +30,6 @@ interface AgentMessageActionsProps {
   actionProgress: ActionProgressState;
   pendingToolCalls: PendingToolCall[];
   owner: LightWorkspaceType;
-}
-
-function getPendingToolCallVisual(functionCallName: string) {
-  const separatorIndex = functionCallName.lastIndexOf(TOOL_NAME_SEPARATOR);
-
-  if (separatorIndex === -1) {
-    return ToolsIcon;
-  }
-
-  const serverName = functionCallName.slice(0, separatorIndex);
-  const candidates = [serverName];
-  const nestedSeparatorIndex = serverName.lastIndexOf(TOOL_NAME_SEPARATOR);
-
-  if (nestedSeparatorIndex !== -1) {
-    candidates.push(
-      serverName.slice(nestedSeparatorIndex + TOOL_NAME_SEPARATOR.length)
-    );
-  }
-
-  for (const candidate of candidates) {
-    if (isInternalMCPServerName(candidate)) {
-      return InternalActionIcons[getInternalMCPServerIconByName(candidate)];
-    }
-  }
-
-  return ToolsIcon;
 }
 
 export function AgentMessageActions({
@@ -156,13 +122,10 @@ export function AgentMessageActions({
         </Card>
       ) : latestPendingToolCall ? (
         <Card variant="secondary" className="max-w-xl">
-          <ActionDetailsWrapper
+          <PendingToolCallDetails
             displayContext="conversation"
-            actionName={getToolCallDisplayLabel(
-              latestPendingToolCall.toolName,
-              "running"
-            )}
-            visual={getPendingToolCallVisual(latestPendingToolCall.toolName)}
+            functionCallName={latestPendingToolCall.toolName}
+            labelContext="running"
           />
         </Card>
       ) : (

--- a/front/components/assistant/conversation/actions/PanelAgentStep.tsx
+++ b/front/components/assistant/conversation/actions/PanelAgentStep.tsx
@@ -1,13 +1,13 @@
 import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
+import { PendingToolCallDetails } from "@app/components/assistant/conversation/actions/PendingToolCallDetails";
 import {
   getPendingToolCallKey,
   type PendingToolCall,
 } from "@app/components/assistant/conversation/types";
-import { getToolCallDisplayLabel } from "@app/lib/actions/tool_display_labels";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type { ParsedContentItem } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
-import { ContentMessage, Markdown, Spinner } from "@dust-tt/sparkle";
+import { ContentMessage, Markdown } from "@dust-tt/sparkle";
 
 interface AgentStepProps {
   stepNumber: number;
@@ -121,30 +121,14 @@ export function PanelAgentStep({
         </div>
       )}
 
-      {pendingToolCalls.length > 0 && (
-        <ContentMessage variant="primary" className="min-h-fit p-3">
-          <div className="flex w-full flex-row">
-            <div className="flex flex-col gap-y-1">
-              {pendingToolCalls.map((pendingToolCall, index) => (
-                <span
-                  key={getPendingToolCallKey(pendingToolCall, index)}
-                  className="text-sm text-muted-foreground dark:text-muted-foreground-night"
-                >
-                  Preparing to{" "}
-                  <span className="font-medium text-foreground dark:text-foreground-night">
-                    {getToolCallDisplayLabel(pendingToolCall.toolName)}
-                  </span>
-                  ...
-                </span>
-              ))}
-            </div>
-            <span className="flex-grow"></span>
-            <div className="w-8 self-start pl-4 pt-0.5">
-              <Spinner size="xs" />
-            </div>
-          </div>
-        </ContentMessage>
-      )}
+      {pendingToolCalls.map((pendingToolCall, index) => (
+        <div key={getPendingToolCallKey(pendingToolCall, index)}>
+          <PendingToolCallDetails
+            displayContext="sidebar-all-actions"
+            functionCallName={pendingToolCall.toolName}
+          />
+        </div>
+      ))}
     </div>
   );
 }

--- a/front/components/assistant/conversation/actions/PendingToolCallDetails.tsx
+++ b/front/components/assistant/conversation/actions/PendingToolCallDetails.tsx
@@ -1,0 +1,56 @@
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ActionDetailsDisplayContext } from "@app/components/actions/mcp/details/types";
+import { InternalActionIcons } from "@app/components/resources/resources_icons";
+import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
+import {
+  getInternalMCPServerIconByName,
+  isInternalMCPServerName,
+} from "@app/lib/actions/mcp_internal_actions/constants";
+import { getToolCallDisplayLabel } from "@app/lib/actions/tool_display_labels";
+import { ToolsIcon } from "@dust-tt/sparkle";
+
+function getPendingToolCallVisual(functionCallName: string) {
+  const separatorIndex = functionCallName.lastIndexOf(TOOL_NAME_SEPARATOR);
+
+  if (separatorIndex === -1) {
+    return ToolsIcon;
+  }
+
+  const serverName = functionCallName.slice(0, separatorIndex);
+  const candidates = [serverName];
+  const nestedSeparatorIndex = serverName.lastIndexOf(TOOL_NAME_SEPARATOR);
+
+  if (nestedSeparatorIndex !== -1) {
+    candidates.push(
+      serverName.slice(nestedSeparatorIndex + TOOL_NAME_SEPARATOR.length)
+    );
+  }
+
+  for (const candidate of candidates) {
+    if (isInternalMCPServerName(candidate)) {
+      return InternalActionIcons[getInternalMCPServerIconByName(candidate)];
+    }
+  }
+
+  return ToolsIcon;
+}
+
+interface PendingToolCallDetailsProps {
+  displayContext: ActionDetailsDisplayContext;
+  functionCallName: string;
+  labelContext?: "running" | "done";
+}
+
+export function PendingToolCallDetails({
+  displayContext,
+  functionCallName,
+  labelContext = "done",
+}: PendingToolCallDetailsProps) {
+  return (
+    <ActionDetailsWrapper
+      displayContext={displayContext}
+      actionName={getToolCallDisplayLabel(functionCallName, labelContext)}
+      visual={getPendingToolCallVisual(functionCallName)}
+    />
+  );
+}


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/23775.

This makes pending tool calls in the breakdown panel reuse the same action header shell and icon/label resolution as real running tools, instead of showing the older "Preparing to …" placeholder box. The panel keeps its existing multi-item behavior, so pending calls still appear one row per tool when several are in flight.

## Risks
Blast radius: side panel rendering for pending tool calls in assistant conversations.
Risk: low

## Deploy Plan
- pmrr
- deploy front