### PR TITLE
Update scripts, add enterprise migration

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -219,6 +219,7 @@ export function WorkspacePage() {
               <TabsContent value="subscriptions">
                 <ActiveSubscriptionTable
                   owner={owner}
+                  metronomeCustomerId={metronomeCustomerId}
                   subscription={activeSubscription}
                   subscriptions={subscriptions}
                   programmaticUsageConfig={programmaticUsageConfig}

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -164,6 +164,7 @@ export function SubscriptionsDataTable({
 
 interface ActiveSubscriptionTableProps {
   owner: WorkspaceType;
+  metronomeCustomerId: string | null;
   subscription: SubscriptionType;
   subscriptions: SubscriptionType[];
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
@@ -171,6 +172,7 @@ interface ActiveSubscriptionTableProps {
 
 export function ActiveSubscriptionTable({
   owner,
+  metronomeCustomerId,
   subscription,
   subscriptions,
   programmaticUsageConfig,
@@ -240,7 +242,7 @@ export function ActiveSubscriptionTable({
                   <PokeTableCell>Metronome Contract</PokeTableCell>
                   <PokeTableCell>
                     <LinkWrapper
-                      href={`https://app.metronome.com/${isDevelopment() ? "sandbox/" : ""}contracts/${subscription.metronomeContractId}`}
+                      href={`https://app.metronome.com/${isDevelopment() ? "sandbox/" : ""}customers/${metronomeCustomerId}/contracts/${subscription.metronomeContractId}`}
                       target="_blank"
                       className="text-xs text-highlight-400"
                     >

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -7,43 +7,45 @@ import { isDevelopment } from "@app/types/shared/env";
 
 // Metrics
 const DEV_METRIC_LLM_PROVIDER_COST_PROGRAMMATIC =
-  "8bd72d3e-e338-46b9-bf9d-60f7ae6a8fa6";
+  "2251e7d7-0a02-45ee-8bc3-edc0961a97ac";
 const DEV_METRIC_LLM_PROVIDER_COST_USER =
-  "eab9a2d9-c76f-4647-a7fe-623790296f27";
+  "7c9d1949-f221-4c16-9810-de4ca34e9fc6";
 const DEV_METRIC_TOOL_INVOCATIONS_PROGRAMMATIC =
-  "23b1b4dd-1766-4974-88d9-aacbe22437be";
-const DEV_METRIC_TOOL_INVOCATIONS_USER = "96226d69-0f02-42bd-a2d1-9f5d0c4015cb";
+  "9266a43d-8615-4df4-9ff3-3501c474d889";
+const DEV_METRIC_TOOL_INVOCATIONS_USER = "c4558ec4-6d47-4246-aadc-9a0e74ca9393";
 const DEV_METRIC_REGISTERED_USERS = "85c130a1-afc2-4135-8dae-72427b173aef";
 const DEV_METRIC_MAU_1_MESSAGES = "5b6d92b6-6cf1-4348-809e-93dd751666d7";
 const DEV_METRIC_MAU_5_MESSAGES = "3c264b7d-5437-4f19-abcc-3a9e9a4204e1";
 const DEV_METRIC_MAU_10_MESSAGES = "152837b9-c662-4b86-bb4f-afabf18d4a40";
 
 // Products
-const DEV_PRODUCT_PROGRAMMATIC_USAGE = "61a2b400-04ca-4939-b706-5c6c9859b2c6";
-const DEV_PRODUCT_AI_USAGE_USER = "00418a5c-1053-423c-97da-1ba0ea2ec0cd";
+const DEV_PRODUCT_PROGRAMMATIC_USAGE = "8797d133-8301-4282-b3f2-fd811c9aa5b1";
+const DEV_PRODUCT_AI_USAGE_USER = "4804c415-ec80-4125-9cb1-e71b0f268ca3";
 const DEV_PRODUCT_AI_USAGE_PROGRAMMATIC =
-  "9c1cc7c6-2b59-4c49-ba6b-143c3930cdd7";
+  "80712396-3ffe-4471-901b-64730f8acf0f";
 const DEV_PRODUCT_TOOL_USAGE_PROGRAMMATIC =
-  "584fa254-0a31-47cf-8107-1ce50bce8586";
-const DEV_PRODUCT_TOOL_USAGE_USER = "0a90d9d4-453f-464d-9472-14993c93e292";
+  "715493fd-8480-4755-a0b6-6e3c6cb4e156";
+const DEV_PRODUCT_TOOL_USAGE_USER = "0a25bc30-4fb4-49f7-94e3-2b2a95c30bdd";
 const DEV_PRODUCT_WORKSPACE_SEAT = "e1532e1d-4964-4656-b6db-070fafafc44c";
-// const DEV_PRODUCT_MAU_BILLING_1 = "06868f2b-f519-48c6-95e9-e28579306b2d";
-// const DEV_PRODUCT_MAU_BILLING_5 = "7193add5-a895-4f40-aaa3-80e49603355c";
-// const DEV_PRODUCT_MAU_BILLING_10 = "972dcb2f-0909-4444-8f29-ac26e042dbbc";
+const DEV_PRODUCT_MAU_BILLING_1 = "06868f2b-f519-48c6-95e9-e28579306b2d";
+const DEV_PRODUCT_MAU_BILLING_5 = "7193add5-a895-4f40-aaa3-80e49603355c";
+const DEV_PRODUCT_MAU_BILLING_10 = "972dcb2f-0909-4444-8f29-ac26e042dbbc";
 const DEV_PRODUCT_FREE_MONTHLY_CREDITS = "04f41dd1-ba27-42e3-93d5-6121712a4b67";
 const DEV_PRODUCT_PREPAID_COMMIT = "5f4331b7-4bf6-488b-9a0c-51bd139ac91c";
 const DEV_PRODUCT_PAYG_OVERAGE = "f4583c77-d226-48bb-97a3-46a8087b97fe";
 
 // Rate Cards
-// const DEV_RATE_CARD_LEGACY_PRO_29 = "16e39785-9e74-4c01-bca0-e1d52dd77798";
-// const DEV_RATE_CARD_LEGACY_BUSINESS_45 = "89727fbf-ddea-40b4-bad7-46b6398dd201";
-// const DEV_RATE_CARD_LEGACY_PRO_27_ANNUAL =
-//   "6044555b-e223-40ab-ac30-e922d44fc9d6";
+const DEV_RATE_CARD_LEGACY_PRO_29 = "1da852d8-65d0-470b-a6c8-f3e7d95d727e";
+const DEV_RATE_CARD_LEGACY_BUSINESS_45 = "7e891ab9-21c0-4f83-b309-8a8841816609";
+const DEV_RATE_CARD_LEGACY_PRO_27_ANNUAL =
+  "aa256b1d-4c44-498b-964b-b23e7210222b";
+const DEV_RATE_CARD_LEGACY_ENTERPRISE = "c07a67ff-c26a-4550-9cf3-f98d2ddb4705";
 
 // Packages
-const DEV_PACKAGE_LEGACY_PRO_29 = "f55ceaeb-56c6-4007-b3bc-01cbb9a458b4";
-const DEV_PACKAGE_LEGACY_BUSINESS_45 = "bec4b726-252f-4ae1-bf2b-c848c2119648";
-const DEV_PACKAGE_LEGACY_PRO_27_ANNUAL = "1b458342-3f7f-4103-a08f-8ceeb68e23bd";
+const DEV_PACKAGE_LEGACY_PRO_29 = "1db8fc59-6fc1-4351-8806-549de566797d";
+const DEV_PACKAGE_LEGACY_BUSINESS_45 = "ee20fbc5-22f7-4e29-b14a-cb2fb6c9ae60";
+const DEV_PACKAGE_LEGACY_PRO_27_ANNUAL = "4886d12c-45bd-4551-bff3-306b24a5c83e";
+const DEV_PACKAGE_LEGACY_ENTERPRISE = "a01630e0-2f1f-4feb-9ae5-074db2292e63";
 
 // --- PROD (production) — TODO: update after running setup script in production ---
 
@@ -70,32 +72,53 @@ const PROD_PRODUCT_TOOL_USAGE_PROGRAMMATIC =
   "109097e2-ed2d-4848-ba53-c4cbfa94cbdc";
 const PROD_PRODUCT_TOOL_USAGE_USER = "0edd3afa-f89f-44c0-9e5d-dbace04cb133";
 const PROD_PRODUCT_WORKSPACE_SEAT = "5c2e2986-1305-4406-96a2-2296e66b5a25";
-// const PROD_PRODUCT_MAU_BILLING_1 = "4135a928-9447-42a5-9b66-bb35b57c7155";
-// const PROD_PRODUCT_MAU_BILLING_5 = "565bef07-0348-4da8-8d4e-22de0ce856fe";
-// const PROD_PRODUCT_MAU_BILLING_10 = "c34f8b46-68e0-43d3-833e-753e3150ff07";
+const PROD_PRODUCT_MAU_BILLING_1 = "4135a928-9447-42a5-9b66-bb35b57c7155";
+const PROD_PRODUCT_MAU_BILLING_5 = "565bef07-0348-4da8-8d4e-22de0ce856fe";
+const PROD_PRODUCT_MAU_BILLING_10 = "c34f8b46-68e0-43d3-833e-753e3150ff07";
 const PROD_PRODUCT_FREE_MONTHLY_CREDITS =
   "7379999c-5492-4e68-968f-345a26f6da63";
 const PROD_PRODUCT_PREPAID_COMMIT = "1408c9fc-dea1-4269-bd6d-1bc0aa1f1218";
 const PROD_PRODUCT_PAYG_OVERAGE = "f6b27a6e-86fc-4964-8076-371a912cee09";
 
 // Rate Cards
-// const PROD_RATE_CARD_LEGACY_PRO_29 = "ab1ecdac-67b0-4803-8d17-13e3415d3e1d";
-// const PROD_RATE_CARD_LEGACY_BUSINESS_45 =
-//   "db5cea19-6421-4912-8511-9f514fc0ece2";
-// const PROD_RATE_CARD_LEGACY_PRO_27_ANNUAL =
-//   "7042405c-c89e-4538-80e6-e42ead7087e8";
+const PROD_RATE_CARD_LEGACY_PRO_29 = "ab1ecdac-67b0-4803-8d17-13e3415d3e1d";
+const PROD_RATE_CARD_LEGACY_BUSINESS_45 =
+  "db5cea19-6421-4912-8511-9f514fc0ece2";
+const PROD_RATE_CARD_LEGACY_PRO_27_ANNUAL =
+  "7042405c-c89e-4538-80e6-e42ead7087e8";
+const PROD_RATE_CARD_LEGACY_ENTERPRISE = "df225bf4-3183-4d10-96aa-e9eb87bb6b0a";
 
 // Packages
 const PROD_PACKAGE_LEGACY_PRO_29 = "a8d782ea-b8e4-460d-99eb-393536254a01";
 const PROD_PACKAGE_LEGACY_BUSINESS_45 = "c362bd20-43a1-4c1f-957d-d889dfe34704";
 const PROD_PACKAGE_LEGACY_PRO_27_ANNUAL =
   "e52b9a0e-f151-4284-aa4a-87d0bddf23d0";
+const PROD_PACKAGE_LEGACY_ENTERPRISE = "7d1d8d4e-c488-4dfd-8c9a-e74529c1010e";
+
+// --- Credit type IDs (stable across envs unless noted) ---
+
+// USD and EUR are the same in sandbox and production.
+export const CREDIT_TYPE_USD_ID = "2714e483-4ff1-48e4-9e25-ac732e8f24f2";
+export const CREDIT_TYPE_EUR_ID = "58f0be15-cc47-4220-bdaf-072ab0e44f96";
+
+// AWU (Agentic Work Units) differs per environment.
+const DEV_CREDIT_TYPE_AWU_ID = "1ad632f0-4e5a-44d6-a1bf-aa6f6bc550d8";
+const PROD_CREDIT_TYPE_AWU_ID = "e53a841e-b741-4bc3-8148-f377c1fb2501";
+
+/** Map Stripe currency code to Metronome credit type ID. */
+export const CURRENCY_TO_CREDIT_TYPE_ID: Record<string, string> = {
+  usd: CREDIT_TYPE_USD_ID,
+  eur: CREDIT_TYPE_EUR_ID,
+};
 
 // --- Accessors ---
 
 function devOrProd<T>(dev: T, prod: T): T {
   return isDevelopment() ? dev : prod;
 }
+
+export const getCreditTypeAwuId = () =>
+  devOrProd(DEV_CREDIT_TYPE_AWU_ID, PROD_CREDIT_TYPE_AWU_ID);
 
 // Metrics
 export const getMetricLlmProviderCostProgrammaticId = () =>
@@ -155,6 +178,28 @@ export const getProductPrepaidCommitId = () =>
   devOrProd(DEV_PRODUCT_PREPAID_COMMIT, PROD_PRODUCT_PREPAID_COMMIT);
 export const getProductPaygOverageId = () =>
   devOrProd(DEV_PRODUCT_PAYG_OVERAGE, PROD_PRODUCT_PAYG_OVERAGE);
+export const getProductMauBilling1Id = () =>
+  devOrProd(DEV_PRODUCT_MAU_BILLING_1, PROD_PRODUCT_MAU_BILLING_1);
+export const getProductMauBilling5Id = () =>
+  devOrProd(DEV_PRODUCT_MAU_BILLING_5, PROD_PRODUCT_MAU_BILLING_5);
+export const getProductMauBilling10Id = () =>
+  devOrProd(DEV_PRODUCT_MAU_BILLING_10, PROD_PRODUCT_MAU_BILLING_10);
+
+// Rate Cards
+export const getRateCardLegacyPro29Id = () =>
+  devOrProd(DEV_RATE_CARD_LEGACY_PRO_29, PROD_RATE_CARD_LEGACY_PRO_29);
+export const getRateCardLegacyBusiness45Id = () =>
+  devOrProd(
+    DEV_RATE_CARD_LEGACY_BUSINESS_45,
+    PROD_RATE_CARD_LEGACY_BUSINESS_45
+  );
+export const getRateCardLegacyPro27AnnualId = () =>
+  devOrProd(
+    DEV_RATE_CARD_LEGACY_PRO_27_ANNUAL,
+    PROD_RATE_CARD_LEGACY_PRO_27_ANNUAL
+  );
+export const getRateCardLegacyEnterpriseId = () =>
+  devOrProd(DEV_RATE_CARD_LEGACY_ENTERPRISE, PROD_RATE_CARD_LEGACY_ENTERPRISE);
 
 // Packages
 export const getPackageLegacyPro29Id = () =>
@@ -166,3 +211,5 @@ export const getPackageLegacyPro27AnnualId = () =>
     DEV_PACKAGE_LEGACY_PRO_27_ANNUAL,
     PROD_PACKAGE_LEGACY_PRO_27_ANNUAL
   );
+export const getPackageLegacyEnterpriseId = () =>
+  devOrProd(DEV_PACKAGE_LEGACY_ENTERPRISE, PROD_PACKAGE_LEGACY_ENTERPRISE);

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -12,6 +12,7 @@ import type { Commit, Credit } from "@metronome/sdk/resources/shared";
 export const LEGACY_PRO_MONTHLY_PACKAGE_ALIAS = "legacy-pro-monthly";
 export const LEGACY_PRO_ANNUAL_PACKAGE_ALIAS = "legacy-pro-annual";
 export const LEGACY_BUSINESS_PACKAGE_ALIAS = "legacy-business";
+export const LEGACY_ENTERPRISE_PACKAGE_ALIAS = "legacy-enterprise";
 
 export const PRO_OR_BUSINESS_PACKAGE_ALIASES: ReadonlySet<string> = new Set([
   LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -1,41 +1,58 @@
 /**
- * Metronome Sandbox Setup — idempotent TypeScript script using the official SDK.
+ * Metronome Setup — idempotent TypeScript script using the official SDK.
  *
  * Fetches existing metrics/products/rate cards/packages from Metronome,
  * compares by name, archives stale ones, creates missing ones.
  * Cascading: if a metric is recreated, dependent products are also recreated,
  * which cascades to rate cards, then packages.
  *
- * Run with: npx tsx scripts/metronome_setup.ts
+ * Run with: npx tsx scripts/metronome_setup.ts [--execute]
+ *
+ * Without --execute, runs in dry-run mode (logs what would change, no mutations).
  * Requires: METRONOME_API_KEY env var
  */
 
 import { getMetronomeClient } from "@app/lib/metronome/client";
+import {
+  CREDIT_TYPE_USD_ID,
+  getCreditTypeAwuId,
+} from "@app/lib/metronome/constants";
 
 if (!process.env.METRONOME_API_KEY) {
   console.error("METRONOME_API_KEY env var required");
   process.exit(1);
 }
 
-const ENV =
-  process.env.METRONOME_ENV === "production" ? "production" : "sandbox";
+const EXECUTE = process.argv.includes("--execute");
 
 const client = getMetronomeClient();
 
-// Credit type IDs per environment (created via Metronome UI, not API-manageable).
-const CREDIT_TYPES = {
-  sandbox: {
-    USD: "2714e483-4ff1-48e4-9e25-ac732e8f24f2",
-    AWU: "1ad632f0-4e5a-44d6-a1bf-aa6f6bc550d8",
-  },
-  production: {
-    USD: "2714e483-4ff1-48e4-9e25-ac732e8f24f2",
-    AWU: "e53a841e-b741-4bc3-8148-f377c1fb2501",
-  },
-} as const;
+// Detect environment by listing pricing units and checking for the AWU credit type.
+// AWU has a different ID in sandbox vs production; USD/EUR are the same.
+const SANDBOX_AWU_ID = "1ad632f0-4e5a-44d6-a1bf-aa6f6bc550d8";
+const PRODUCTION_AWU_ID = "e53a841e-b741-4bc3-8148-f377c1fb2501";
 
-const USD_CREDIT_TYPE_ID = CREDIT_TYPES[ENV].USD;
-const AWU_CREDIT_TYPE_ID = CREDIT_TYPES[ENV].AWU;
+async function detectEnvironment(): Promise<"sandbox" | "production"> {
+  const creditTypeIds = new Set<string>();
+  for await (const pu of client.v1.pricingUnits.list()) {
+    if (pu.id) {
+      creditTypeIds.add(pu.id);
+    }
+  }
+  if (creditTypeIds.has(PRODUCTION_AWU_ID)) {
+    return "production";
+  }
+  if (creditTypeIds.has(SANDBOX_AWU_ID)) {
+    return "sandbox";
+  }
+  throw new Error(
+    "Cannot detect Metronome environment: AWU credit type not found. " +
+      `Expected sandbox=${SANDBOX_AWU_ID} or production=${PRODUCTION_AWU_ID}`
+  );
+}
+
+// Resolved in main() before anything else runs.
+let ENV: "sandbox" | "production" = "sandbox";
 
 // ---------------------------------------------------------------------------
 // Types for desired state definitions
@@ -293,137 +310,183 @@ const PRODUCTS: ProductDef[] = [
   },
 ];
 
-const RATE_CARDS: RateCardDef[] = [
-  {
-    name: "Legacy Pro $29",
-    description:
-      "Grandfathered Pro plan. $29/seat via seat subscription. AI usage 30% markup.",
-    aliases: [{ name: "legacy-pro-monthly" }],
-    fiat_credit_type_id: USD_CREDIT_TYPE_ID,
-    rates: [
-      {
-        product_name: "Workspace Seat",
-        starting_at: "2026-04-01T00:00:00.000Z",
-        entitled: true,
-        rate_type: "FLAT",
-        price: 2900,
-        billing_frequency: "MONTHLY",
-      },
-      {
-        product_name: "Programmatic Usage",
-        starting_at: "2026-04-01T00:00:00.000Z",
-        entitled: true,
-        rate_type: "FLAT",
-        price: 100,
-      },
-    ],
-  },
-  {
-    name: "Legacy Business $45",
-    description:
-      "Grandfathered Business plan. $45/seat via seat subscription. AI usage 30% markup.",
-    aliases: [{ name: "legacy-business" }],
-    fiat_credit_type_id: USD_CREDIT_TYPE_ID,
-    rates: [
-      {
-        product_name: "Workspace Seat",
-        starting_at: "2026-04-01T00:00:00.000Z",
-        entitled: true,
-        rate_type: "FLAT",
-        price: 4500,
-        billing_frequency: "MONTHLY",
-      },
-      {
-        product_name: "Programmatic Usage",
-        starting_at: "2026-04-01T00:00:00.000Z",
-        entitled: true,
-        rate_type: "FLAT",
-        price: 100,
-      },
-    ],
-  },
-  {
-    name: "Legacy Pro $27 Annual",
-    description:
-      "Grandfathered Pro plan (annual). $27/seat/month billed monthly. AI usage 30% markup.",
-    aliases: [{ name: "legacy-pro-annual" }],
-    fiat_credit_type_id: USD_CREDIT_TYPE_ID,
-    rates: [
-      {
-        product_name: "Workspace Seat",
-        starting_at: "2026-04-01T00:00:00.000Z",
-        entitled: true,
-        rate_type: "FLAT",
-        price: 2700,
-        billing_frequency: "MONTHLY",
-      },
-      {
-        product_name: "Programmatic Usage",
-        starting_at: "2026-04-01T00:00:00.000Z",
-        entitled: true,
-        rate_type: "FLAT",
-        price: 100,
-      },
-    ],
-  },
-  // --- Example: New Business plan with AWU-based usage pricing ---
-  // Seats in USD, AI/Tool usage in AWU (1 AWU = $0.01).
-  // This is a template — uncomment and adjust when new pricing goes live.
-  // {
-  //   name: "Business Plan",
-  //   description: "New Business plan. Pro/Max seats in USD, usage in AWU.",
-  //   aliases: [{ name: "business-plan" }],
-  //   fiat_credit_type_id: USD_CREDIT_TYPE_ID,
-  //   credit_type_conversions: [
-  //     { custom_credit_type_id: AWU_CREDIT_TYPE_ID, fiat_per_custom_credit: 0.01 },
-  //   ],
-  //   rates: [
-  //     // Pro Seat — $30/mo in USD
-  //     {
-  //       product_name: "Workspace Seat",
-  //       starting_at: "2026-04-01T00:00:00.000Z",
-  //       entitled: true,
-  //       rate_type: "FLAT",
-  //       price: 3000,
-  //       billing_frequency: "MONTHLY",
-  //     },
-  //     // AI Usage — 1 AWU per unit (quantity already converted from cost_micro_usd)
-  //     {
-  //       product_name: "AI Usage (User)",
-  //       starting_at: "2026-04-01T00:00:00.000Z",
-  //       entitled: true,
-  //       rate_type: "FLAT",
-  //       price: 1,
-  //       credit_type_id: AWU_CREDIT_TYPE_ID,
-  //     },
-  //     {
-  //       product_name: "AI Usage (Programmatic)",
-  //       starting_at: "2026-04-01T00:00:00.000Z",
-  //       entitled: true,
-  //       rate_type: "FLAT",
-  //       price: 1,
-  //       credit_type_id: AWU_CREDIT_TYPE_ID,
-  //     },
-  //     // Tool Usage — AWU per invocation (price = tool weight in AWU)
-  //     {
-  //       product_name: "Tool Usage (User)",
-  //       starting_at: "2026-04-01T00:00:00.000Z",
-  //       entitled: true,
-  //       rate_type: "FLAT",
-  //       price: 1,
-  //       credit_type_id: AWU_CREDIT_TYPE_ID,
-  //     },
-  //     {
-  //       product_name: "Tool Usage (Programmatic)",
-  //       starting_at: "2026-04-01T00:00:00.000Z",
-  //       entitled: true,
-  //       rate_type: "FLAT",
-  //       price: 1,
-  //       credit_type_id: AWU_CREDIT_TYPE_ID,
-  //     },
-  //   ],
-  // },
-];
+// Function — evaluated after detectEnvironment() resolves ENV.
+// Function — evaluated after detectEnvironment() resolves ENV (needed for AWU credit type).
+function getRateCards(): RateCardDef[] {
+  return [
+    {
+      name: "Legacy Pro $29",
+      description:
+        "Grandfathered Pro plan. $29/seat via seat subscription. AI usage 30% markup.",
+      aliases: [{ name: "legacy-pro-monthly" }],
+      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      rates: [
+        {
+          product_name: "Workspace Seat",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 2900,
+          billing_frequency: "MONTHLY",
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 100,
+        },
+      ],
+    },
+    {
+      name: "Legacy Business $45",
+      description:
+        "Grandfathered Business plan. $45/seat via seat subscription. AI usage 30% markup.",
+      aliases: [{ name: "legacy-business" }],
+      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      rates: [
+        {
+          product_name: "Workspace Seat",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 4500,
+          billing_frequency: "MONTHLY",
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 100,
+        },
+      ],
+    },
+    {
+      name: "Legacy Pro $27 Annual",
+      description:
+        "Grandfathered Pro plan (annual). $27/seat/month billed monthly. AI usage 30% markup.",
+      aliases: [{ name: "legacy-pro-annual" }],
+      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      rates: [
+        {
+          product_name: "Workspace Seat",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 2700,
+          billing_frequency: "MONTHLY",
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 100,
+        },
+      ],
+    },
+    // --- Enterprise plan: MAU-based billing + programmatic usage ---
+    // Default: MAU-1 at $45/MAU. MAU-5/MAU-10 not entitled by default but present
+    // on the rate card so they can be enabled per contract via overrides.
+    // Programmatic usage at $1 = $1 (30% markup baked into product).
+    {
+      name: "Legacy Enterprise",
+      description:
+        "Enterprise plan. Per-MAU billing + programmatic usage at cost with 30% markup.",
+      aliases: [{ name: "legacy-enterprise" }],
+      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      rates: [
+        {
+          product_name: "MAU Billing (1+)",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 4500,
+        },
+        // MAU-5 and MAU-10 not entitled by default — enabled per contract via overrides.
+        {
+          product_name: "MAU Billing (5+)",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: false,
+          rate_type: "FLAT",
+          price: 0,
+        },
+        {
+          product_name: "MAU Billing (10+)",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: false,
+          rate_type: "FLAT",
+          price: 0,
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 100,
+        },
+      ],
+    },
+    // --- Example: New Business plan with AWU-based usage pricing ---
+    // Seats in USD, AI/Tool usage in AWU (1 AWU = $0.01).
+    // This is a template — uncomment and adjust when new pricing goes live.
+    // {
+    //   name: "Business Plan",
+    //   description: "New Business plan. Pro/Max seats in USD, usage in AWU.",
+    //   aliases: [{ name: "business-plan" }],
+    //   fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+    //   credit_type_conversions: [
+    //     { custom_credit_type_id: getCreditTypeAwuId(), fiat_per_custom_credit: 0.01 },
+    //   ],
+    //   rates: [
+    //     // Pro Seat — $30/mo in USD
+    //     {
+    //       product_name: "Workspace Seat",
+    //       starting_at: "2026-04-01T00:00:00.000Z",
+    //       entitled: true,
+    //       rate_type: "FLAT",
+    //       price: 3000,
+    //       billing_frequency: "MONTHLY",
+    //     },
+    //     // AI Usage — 1 AWU per unit (quantity already converted from cost_micro_usd)
+    //     {
+    //       product_name: "AI Usage (User)",
+    //       starting_at: "2026-04-01T00:00:00.000Z",
+    //       entitled: true,
+    //       rate_type: "FLAT",
+    //       price: 1,
+    //       credit_type_id: getCreditTypeAwuId(),
+    //     },
+    //     {
+    //       product_name: "AI Usage (Programmatic)",
+    //       starting_at: "2026-04-01T00:00:00.000Z",
+    //       entitled: true,
+    //       rate_type: "FLAT",
+    //       price: 1,
+    //       credit_type_id: getCreditTypeAwuId(),
+    //     },
+    //     // Tool Usage — AWU per invocation (price = tool weight in AWU)
+    //     {
+    //       product_name: "Tool Usage (User)",
+    //       starting_at: "2026-04-01T00:00:00.000Z",
+    //       entitled: true,
+    //       rate_type: "FLAT",
+    //       price: 1,
+    //       credit_type_id: getCreditTypeAwuId(),
+    //     },
+    //     {
+    //       product_name: "Tool Usage (Programmatic)",
+    //       starting_at: "2026-04-01T00:00:00.000Z",
+    //       entitled: true,
+    //       rate_type: "FLAT",
+    //       price: 1,
+    //       credit_type_id: getCreditTypeAwuId(),
+    //     },
+    //   ],
+    // },
+  ];
+}
 
 // Seat subscription definition shared by all legacy packages.
 const LEGACY_SEAT_SUBSCRIPTION: PackageSubscription = {
@@ -479,6 +542,13 @@ const PACKAGES: PackageDef[] = [
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
     ...BILLING_CYCLE_CONFIG,
   },
+  // Enterprise: MAU-based billing, no seat subscriptions.
+  {
+    name: "Legacy Enterprise",
+    aliases: [{ name: "legacy-enterprise" }],
+    rate_card_name: "Legacy Enterprise",
+    ...BILLING_CYCLE_CONFIG,
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -532,8 +602,12 @@ async function syncMetrics(): Promise<void> {
 
   for (const m of existing) {
     if (!desiredNames.has(m.name) && !isTestObject(m.name)) {
-      console.log(`  ⚠ Archiving stale metric: ${m.name} (${m.id})`);
-      await client.v1.billableMetrics.archive({ id: m.id });
+      console.log(
+        `  ⚠ ${EXECUTE ? "Archiving" : "[DRYRUN] Would archive"} stale metric: ${m.name} (${m.id})`
+      );
+      if (EXECUTE) {
+        await client.v1.billableMetrics.archive({ id: m.id });
+      }
     }
   }
 
@@ -545,9 +619,16 @@ async function syncMetrics(): Promise<void> {
     const eventTypeMatch =
       JSON.stringify(ex?.event_type_filter?.in_values?.sort() ?? []) ===
       JSON.stringify([...desired.event_type_filter.in_values].sort());
+    const sortFilters = (
+      filters: Array<{
+        name: string;
+        exists?: boolean;
+        in_values?: string[];
+      }>
+    ) => [...filters].sort((a, b) => a.name.localeCompare(b.name));
     const propertyFiltersMatch =
-      JSON.stringify(ex?.property_filters ?? []) ===
-      JSON.stringify(desired.property_filters ?? []);
+      JSON.stringify(sortFilters(ex?.property_filters ?? [])) ===
+      JSON.stringify(sortFilters(desired.property_filters ?? []));
     const configMatch =
       ex &&
       ex.aggregation_key === desired.aggregation_key &&
@@ -562,16 +643,26 @@ async function syncMetrics(): Promise<void> {
       ids.metrics[desired.name] = ex.id;
     } else {
       if (ex) {
-        console.log(`  ↻ ${desired.name} — config changed, archiving ${ex.id}`);
-        await client.v1.billableMetrics.archive({ id: ex.id });
+        console.log(
+          `  ↻ ${desired.name} — config changed${EXECUTE ? ", archiving" : ""} ${ex.id}`
+        );
+        if (EXECUTE) {
+          await client.v1.billableMetrics.archive({ id: ex.id });
+        }
       }
-      console.log(`  + Creating: ${desired.name}`);
-      const created = await client.v1.billableMetrics.create(
-        desired as Parameters<typeof client.v1.billableMetrics.create>[0]
-      );
-      const id = (created as { data: { id: string } }).data.id;
-      console.log(`    → ${id}`);
-      ids.metrics[desired.name] = id;
+      if (EXECUTE) {
+        console.log(`  + Creating: ${desired.name}`);
+        const created = await client.v1.billableMetrics.create(
+          desired as Parameters<typeof client.v1.billableMetrics.create>[0]
+        );
+        const id = (created as { data: { id: string } }).data.id;
+        console.log(`    → ${id}`);
+        ids.metrics[desired.name] = id;
+      } else {
+        console.log(`  + [DRYRUN] Would create: ${desired.name}`);
+        // Use existing ID if available (for cascading checks), otherwise placeholder.
+        ids.metrics[desired.name] = ex?.id ?? `dryrun-${desired.name}`;
+      }
       recreated.metrics.add(desired.name);
     }
   }
@@ -723,11 +814,15 @@ async function syncProducts(): Promise<void> {
   for (const p of existing) {
     const name = p.current?.name ?? "";
     if (!desiredNames.has(name) && !isTestObject(name)) {
-      console.log(`  ⚠ Archiving stale product: ${name} (${p.id})`);
-      try {
-        await client.v1.contracts.products.archive({ product_id: p.id });
-      } catch {
-        console.log(`    (archive failed — may have active references)`);
+      console.log(
+        `  ⚠ ${EXECUTE ? "Archiving" : "[DRYRUN] Would archive"} stale product: ${name} (${p.id})`
+      );
+      if (EXECUTE) {
+        try {
+          await client.v1.contracts.products.archive({ product_id: p.id });
+        } catch {
+          console.log(`    (archive failed — may have active references)`);
+        }
       }
     }
   }
@@ -742,35 +837,44 @@ async function syncProducts(): Promise<void> {
       ids.products[desired.name] = ex.id;
     } else {
       if (ex) {
-        console.log(`  ↻ ${desired.name} — config changed, archiving ${ex.id}`);
-        try {
-          await client.v1.contracts.products.archive({ product_id: ex.id });
-        } catch {
-          console.log(`    (archive failed)`);
+        console.log(
+          `  ↻ ${desired.name} — config changed${EXECUTE ? ", archiving" : ""} ${ex.id}`
+        );
+        if (EXECUTE) {
+          try {
+            await client.v1.contracts.products.archive({ product_id: ex.id });
+          } catch {
+            console.log(`    (archive failed)`);
+          }
         }
       }
 
-      const metricId = desired.billable_metric_name
-        ? ids.metrics[desired.billable_metric_name]
-        : undefined;
-      if (desired.billable_metric_name && !metricId) {
-        throw new Error(`Metric not found: ${desired.billable_metric_name}`);
-      }
+      if (EXECUTE) {
+        const metricId = desired.billable_metric_name
+          ? ids.metrics[desired.billable_metric_name]
+          : undefined;
+        if (desired.billable_metric_name && !metricId) {
+          throw new Error(`Metric not found: ${desired.billable_metric_name}`);
+        }
 
-      console.log(`  + Creating: ${desired.name}`);
-      const created = await client.v1.contracts.products.create({
-        name: desired.name,
-        type: desired.type,
-        billable_metric_id: metricId,
-        quantity_conversion: desired.quantity_conversion ?? undefined,
-        quantity_rounding: desired.quantity_rounding ?? undefined,
-        pricing_group_key: desired.pricing_group_key,
-        presentation_group_key: desired.presentation_group_key,
-        tags: desired.tags,
-      });
-      const id = (created as { data: { id: string } }).data.id;
-      console.log(`    → ${id}`);
-      ids.products[desired.name] = id;
+        console.log(`  + Creating: ${desired.name}`);
+        const created = await client.v1.contracts.products.create({
+          name: desired.name,
+          type: desired.type,
+          billable_metric_id: metricId,
+          quantity_conversion: desired.quantity_conversion ?? undefined,
+          quantity_rounding: desired.quantity_rounding ?? undefined,
+          pricing_group_key: desired.pricing_group_key,
+          presentation_group_key: desired.presentation_group_key,
+          tags: desired.tags,
+        });
+        const id = (created as { data: { id: string } }).data.id;
+        console.log(`    → ${id}`);
+        ids.products[desired.name] = id;
+      } else {
+        console.log(`  + [DRYRUN] Would create: ${desired.name}`);
+        ids.products[desired.name] = ex?.id ?? `dryrun-${desired.name}`;
+      }
       recreated.products.add(desired.name);
     }
   }
@@ -829,26 +933,32 @@ interface ExistingRateCard {
 async function syncRateCards(): Promise<void> {
   console.log("\n=== Syncing Rate Cards ===");
 
+  const rateCards = getRateCards();
+
   const existing: ExistingRateCard[] = [];
   for await (const r of client.v1.contracts.rateCards.list({ body: {} })) {
     existing.push(r as ExistingRateCard);
   }
 
   const byName = new Map(existing.map((r) => [r.name, r]));
-  const desiredNames = new Set(RATE_CARDS.map((r) => r.name));
+  const desiredNames = new Set(rateCards.map((r) => r.name));
 
   for (const r of existing) {
     if (!desiredNames.has(r.name) && !isTestObject(r.name)) {
-      console.log(`  ⚠ Archiving stale rate card: ${r.name} (${r.id})`);
-      try {
-        await client.v1.contracts.rateCards.archive({ id: r.id });
-      } catch {
-        console.log(`    (archive failed)`);
+      console.log(
+        `  ⚠ ${EXECUTE ? "Archiving" : "[DRYRUN] Would archive"} stale rate card: ${r.name} (${r.id})`
+      );
+      if (EXECUTE) {
+        try {
+          await client.v1.contracts.rateCards.archive({ id: r.id });
+        } catch {
+          console.log(`    (archive failed)`);
+        }
       }
     }
   }
 
-  for (const desired of RATE_CARDS) {
+  for (const desired of rateCards) {
     const ex = byName.get(desired.name);
 
     if (ex && rateCardMatches(ex, desired)) {
@@ -856,49 +966,60 @@ async function syncRateCards(): Promise<void> {
       ids.rateCards[desired.name] = ex.id;
     } else {
       if (ex) {
-        console.log(`  ↻ ${desired.name} — config changed, archiving ${ex.id}`);
-        try {
-          await client.v1.contracts.rateCards.archive({ id: ex.id });
-        } catch {
-          console.log(`    (archive failed)`);
+        console.log(
+          `  ↻ ${desired.name} — config changed${EXECUTE ? ", archiving" : ""} ${ex.id}`
+        );
+        if (EXECUTE) {
+          try {
+            await client.v1.contracts.rateCards.archive({ id: ex.id });
+          } catch {
+            console.log(`    (archive failed)`);
+          }
         }
       }
 
-      console.log(`  + Creating: ${desired.name}`);
-      const created = await client.v1.contracts.rateCards.create({
-        name: desired.name,
-        description: desired.description,
-        aliases: desired.aliases,
-        fiat_credit_type_id: desired.fiat_credit_type_id,
-        credit_type_conversions: desired.credit_type_conversions,
-      });
-      const id = (created as { data: { id: string } }).data.id;
-      console.log(`    → ${id}`);
-      ids.rateCards[desired.name] = id;
-
-      // Add rates (one at a time — SDK takes a single rate per call)
-      console.log(`    Adding ${desired.rates.length} rates...`);
-      for (const r of desired.rates) {
-        const productId = ids.products[r.product_name];
-        if (!productId) {
-          throw new Error(`Product not found: ${r.product_name}`);
-        }
-        await client.v1.contracts.rateCards.rates.add({
-          rate_card_id: id,
-          product_id: productId,
-          starting_at: r.starting_at,
-          entitled: r.entitled,
-          rate_type: r.rate_type as "FLAT",
-          price: r.price,
-          credit_type_id: r.credit_type_id,
-          pricing_group_values: r.pricing_group_values,
-          billing_frequency: r.billing_frequency as
-            | "MONTHLY"
-            | "QUARTERLY"
-            | "ANNUAL"
-            | "WEEKLY"
-            | undefined,
+      if (EXECUTE) {
+        console.log(`  + Creating: ${desired.name}`);
+        const created = await client.v1.contracts.rateCards.create({
+          name: desired.name,
+          description: desired.description,
+          aliases: desired.aliases,
+          fiat_credit_type_id: desired.fiat_credit_type_id,
+          credit_type_conversions: desired.credit_type_conversions,
         });
+        const id = (created as { data: { id: string } }).data.id;
+        console.log(`    → ${id}`);
+        ids.rateCards[desired.name] = id;
+
+        // Add rates (one at a time — SDK takes a single rate per call)
+        console.log(`    Adding ${desired.rates.length} rates...`);
+        for (const r of desired.rates) {
+          const productId = ids.products[r.product_name];
+          if (!productId) {
+            throw new Error(`Product not found: ${r.product_name}`);
+          }
+          await client.v1.contracts.rateCards.rates.add({
+            rate_card_id: id,
+            product_id: productId,
+            starting_at: r.starting_at,
+            entitled: r.entitled,
+            rate_type: r.rate_type as "FLAT",
+            price: r.price,
+            credit_type_id: r.credit_type_id,
+            pricing_group_values: r.pricing_group_values,
+            billing_frequency: r.billing_frequency as
+              | "MONTHLY"
+              | "QUARTERLY"
+              | "ANNUAL"
+              | "WEEKLY"
+              | undefined,
+          });
+        }
+      } else {
+        console.log(
+          `  + [DRYRUN] Would create: ${desired.name} (${desired.rates.length} rates)`
+        );
+        ids.rateCards[desired.name] = ex?.id ?? `dryrun-${desired.name}`;
       }
 
       recreated.rateCards.add(desired.name);
@@ -1017,11 +1138,15 @@ async function syncPackages(): Promise<void> {
     const aliases = (p.aliases ?? []).map((a) => a.name);
     const isDesired = aliases.some((a) => desiredAliases.has(a));
     if (!isDesired && !isTestObject(p.name)) {
-      console.log(`  ⚠ Archiving stale package: ${p.name} (${p.id})`);
-      try {
-        await client.v1.packages.archive({ package_id: p.id });
-      } catch {
-        console.log(`    (archive failed — may have active contracts)`);
+      console.log(
+        `  ⚠ ${EXECUTE ? "Archiving" : "[DRYRUN] Would archive"} stale package: ${p.name} (${p.id})`
+      );
+      if (EXECUTE) {
+        try {
+          await client.v1.packages.archive({ package_id: p.id });
+        } catch {
+          console.log(`    (archive failed — may have active contracts)`);
+        }
       }
     }
   }
@@ -1048,56 +1173,63 @@ async function syncPackages(): Promise<void> {
 
       if (ex) {
         console.log(
-          `  ↻ ${versionedName} — config changed, archiving ${ex.name} (${ex.id})`
+          `  ↻ ${versionedName} — config changed${EXECUTE ? ", archiving" : ""} ${ex.name} (${ex.id})`
         );
-        try {
-          await client.v1.packages.archive({ package_id: ex.id });
-        } catch {
-          console.log(`    (archive failed)`);
+        if (EXECUTE) {
+          try {
+            await client.v1.packages.archive({ package_id: ex.id });
+          } catch {
+            console.log(`    (archive failed)`);
+          }
         }
       }
 
-      const rateCardId = ids.rateCards[desired.rate_card_name];
-      if (!rateCardId) {
-        throw new Error(`Rate card not found: ${desired.rate_card_name}`);
-      }
-
-      console.log(`  + Creating: ${versionedName}`);
-      // Resolve subscription product IDs
-      const subscriptions = (desired.subscriptions ?? []).map((sub) => {
-        const productId = ids.products[sub.product_name];
-        if (!productId) {
-          throw new Error(
-            `Product not found for subscription: ${sub.product_name}`
-          );
+      if (EXECUTE) {
+        const rateCardId = ids.rateCards[desired.rate_card_name];
+        if (!rateCardId) {
+          throw new Error(`Rate card not found: ${desired.rate_card_name}`);
         }
-        return {
-          temporary_id: sub.temporary_id,
-          subscription_rate: {
-            billing_frequency: sub.billing_frequency,
-            product_id: productId,
-          },
-          collection_schedule: sub.collection_schedule,
-          quantity_management_mode: sub.quantity_management_mode,
-          ...(sub.seat_config ? { seat_config: sub.seat_config } : {}),
-          ...(sub.proration ? { proration: sub.proration } : {}),
-        };
-      });
 
-      const created = await client.v1.packages.create({
-        name: versionedName,
-        contract_name: versionedName,
-        aliases: desired.aliases,
-        rate_card_id: rateCardId,
-        billing_anchor_date: desired.billing_anchor_date,
-        ...(desired.usage_statement_schedule
-          ? { usage_statement_schedule: desired.usage_statement_schedule }
-          : {}),
-        ...(subscriptions.length > 0 ? { subscriptions } : {}),
-      } as Parameters<typeof client.v1.packages.create>[0]);
-      const id = (created as { data: { id: string } }).data.id;
-      console.log(`    → ${id}`);
-      ids.packages[desired.name] = id;
+        console.log(`  + Creating: ${versionedName}`);
+        // Resolve subscription product IDs
+        const subscriptions = (desired.subscriptions ?? []).map((sub) => {
+          const productId = ids.products[sub.product_name];
+          if (!productId) {
+            throw new Error(
+              `Product not found for subscription: ${sub.product_name}`
+            );
+          }
+          return {
+            temporary_id: sub.temporary_id,
+            subscription_rate: {
+              billing_frequency: sub.billing_frequency,
+              product_id: productId,
+            },
+            collection_schedule: sub.collection_schedule,
+            quantity_management_mode: sub.quantity_management_mode,
+            ...(sub.seat_config ? { seat_config: sub.seat_config } : {}),
+            ...(sub.proration ? { proration: sub.proration } : {}),
+          };
+        });
+
+        const created = await client.v1.packages.create({
+          name: versionedName,
+          contract_name: versionedName,
+          aliases: desired.aliases,
+          rate_card_id: rateCardId,
+          billing_anchor_date: desired.billing_anchor_date,
+          ...(desired.usage_statement_schedule
+            ? { usage_statement_schedule: desired.usage_statement_schedule }
+            : {}),
+          ...(subscriptions.length > 0 ? { subscriptions } : {}),
+        } as Parameters<typeof client.v1.packages.create>[0]);
+        const id = (created as { data: { id: string } }).data.id;
+        console.log(`    → ${id}`);
+        ids.packages[desired.name] = id;
+      } else {
+        console.log(`  + [DRYRUN] Would create: ${versionedName}`);
+        ids.packages[desired.name] = ex?.id ?? `dryrun-${desired.name}`;
+      }
     }
   }
 }
@@ -1107,17 +1239,24 @@ async function syncPackages(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  console.log("Metronome Setup — syncing desired state to sandbox\n");
-
-  console.log(`Environment: ${ENV}`);
+  ENV = await detectEnvironment();
   console.log(
-    `Credit types: USD=${USD_CREDIT_TYPE_ID}, AWU=${AWU_CREDIT_TYPE_ID}`
+    `Metronome Setup — environment: ${ENV}, mode: ${EXECUTE ? "EXECUTE" : "DRY-RUN (pass --execute to apply)"}\n`
+  );
+
+  console.log(
+    `Credit types: USD=${CREDIT_TYPE_USD_ID}, AWU=${getCreditTypeAwuId()}`
   );
 
   await syncMetrics();
   await syncProducts();
   await syncRateCards();
   await syncPackages();
+
+  if (!EXECUTE) {
+    console.log("\n✓ Dry-run complete. Pass --execute to apply changes.");
+    return;
+  }
 
   console.log("\n=== ID Summary ===");
   for (const [category, map] of Object.entries(ids)) {

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -7,28 +7,43 @@
  * 3. If so, end the old contract and create a new one using the latest package alias
  * 4. Update metronomeContractId on the subscription
  *
+ * Enterprise plans: reads the Stripe subscription to extract tiered pricing
+ * (MAU price, floor/included seats) and creates a Metronome contract with
+ * rate overrides matching the Stripe pricing.
+ *
  * Run with: npx tsx scripts/migrate_metronome_contracts.ts [--execute] [-w workspaceId]
  *
  * Without --execute, runs in dry-run mode (logs what would happen, no changes).
  */
 
 import { getMetronomeClient } from "@app/lib/metronome/client";
+import {
+  CURRENCY_TO_CREDIT_TYPE_ID,
+  getProductMauBilling1Id,
+  getProductMauBilling5Id,
+  getProductMauBilling10Id,
+  getProductPrepaidCommitId,
+} from "@app/lib/metronome/constants";
 import { provisionSeatsForContract } from "@app/lib/metronome/seats";
 import {
   LEGACY_BUSINESS_PACKAGE_ALIAS,
+  LEGACY_ENTERPRISE_PACKAGE_ALIAS,
   LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
   LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
 } from "@app/lib/metronome/types";
 import {
+  isEntreprisePlanPrefix,
   PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
-import { getStripeSubscription } from "@app/lib/plans/stripe";
+import { getStripeClient, getStripeSubscription } from "@app/lib/plans/stripe";
+import { isMauReportUsage } from "@app/lib/plans/usage/types";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
 import type { LightWorkspaceType } from "@app/types/user";
+import type Stripe from "stripe";
 import { makeScript } from "./helpers";
 import { runOnAllWorkspaces } from "./workspace_helpers";
 
@@ -41,6 +56,232 @@ const ALIAS_MIGRATION: Record<string, string> = {
   "legacy-business-45": LEGACY_BUSINESS_PACKAGE_ALIAS,
   "legacy-pro-27-annual": LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
 };
+
+// ---------------------------------------------------------------------------
+// Enterprise Stripe pricing extraction
+// ---------------------------------------------------------------------------
+
+/** MAU threshold from Stripe metadata REPORT_USAGE (e.g. "MAU_1", "MAU_5", "MAU_10"). */
+type MauThreshold = "MAU_1" | "MAU_5" | "MAU_10";
+
+/**
+ * Enterprise pricing extracted from Stripe's tiered price.
+ * All amounts in cents (USD or EUR).
+ */
+interface EnterprisePricingCents {
+  /** Currency of the Stripe price (e.g. "usd", "eur"). */
+  currency: string;
+  /** Per-MAU overage price in cents (from the last tier's unit_amount). */
+  mauPriceCents: number;
+  /** Monthly floor amount in cents (flat_amount on the first tier, 0 if none). */
+  floorCents: number;
+  /** Number of included seats (up_to on the first tier). */
+  includedSeats: number;
+  /** Which MAU threshold this price uses (MAU_1, MAU_5, MAU_10). */
+  mauThreshold: MauThreshold;
+}
+
+function getMauProductId(threshold: MauThreshold): string {
+  switch (threshold) {
+    case "MAU_1":
+      return getProductMauBilling1Id();
+    case "MAU_5":
+      return getProductMauBilling5Id();
+    case "MAU_10":
+      return getProductMauBilling10Id();
+  }
+}
+
+/**
+ * Extract enterprise MAU pricing from a Stripe subscription.
+ *
+ * Enterprise subscriptions on prod_PsyrjK1wsV9vgW have a metered, tiered price
+ * with metadata REPORT_USAGE=MAU_1. The tiered structure is:
+ *   - Tier 1: up_to=N, flat_amount=floor, unit_amount=0 (included seats)
+ *   - Tier 2: up_to=inf, unit_amount=per_mau_price (overage)
+ *
+ * Returns undefined if the subscription has no MAU price item.
+ */
+async function extractEnterprisePricing(
+  stripeSubscription: Stripe.Subscription,
+  logger: Logger
+): Promise<EnterprisePricingCents | undefined> {
+  const stripe = getStripeClient();
+
+  for (const item of stripeSubscription.items.data) {
+    const reportUsage = item.price.metadata?.REPORT_USAGE;
+    if (!isMauReportUsage(reportUsage)) {
+      continue;
+    }
+
+    // Validate it's one of our known MAU thresholds.
+    if (
+      reportUsage !== "MAU_1" &&
+      reportUsage !== "MAU_5" &&
+      reportUsage !== "MAU_10"
+    ) {
+      logger.warn(
+        { reportUsage, priceId: item.price.id },
+        "Unknown MAU threshold — skipping"
+      );
+      continue;
+    }
+
+    // For tiered prices, Stripe doesn't include tiers in the subscription item
+    // by default. Retrieve the full price with tiers expanded.
+    const price = await stripe.prices.retrieve(item.price.id, {
+      expand: ["tiers"],
+    });
+
+    if (!price.tiers || price.tiers.length < 2) {
+      logger.warn(
+        { priceId: price.id, tiersCount: price.tiers?.length },
+        "Enterprise price missing expected tiers"
+      );
+      return undefined;
+    }
+
+    const firstTier = price.tiers[0];
+    const lastTier = price.tiers[price.tiers.length - 1];
+
+    return {
+      currency: price.currency,
+      mauPriceCents: lastTier.unit_amount ?? 0,
+      floorCents: firstTier.flat_amount ?? 0,
+      includedSeats: firstTier.up_to ?? 0,
+      mauThreshold: reportUsage,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Apply enterprise pricing on a Metronome contract to match Stripe's tiered pricing.
+ *
+ * Uses a recurring prepaid commit to model the floor + included seats:
+ * 1. A monthly recurring commit of `floorCents` with rate_type COMMIT_RATE.
+ *    Usage draws down the commit at the per-MAU commit rate, so the commit
+ *    covers `floor / mauPrice` MAUs (the included seats).
+ * 2. A commit-specific override sets the commit rate to the per-MAU price.
+ * 3. The list rate (overage beyond the commit) is set to the same per-MAU price.
+ *
+ * Result: single invoice per period with the floor as the minimum charge,
+ * included seats consumed from the commit, and overage billed at the list rate.
+ *
+ * If the customer uses MAU-5 or MAU-10 instead of MAU-1, disables the default
+ * MAU-1 product and enables the correct one.
+ */
+async function applyEnterpriseOverrides({
+  metronomeCustomerId,
+  contractId,
+  pricing,
+  startDate,
+  logger,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  pricing: EnterprisePricingCents;
+  startDate: string;
+  logger: Logger;
+  workspaceId: string;
+}): Promise<void> {
+  const client = getMetronomeClient();
+  const targetProductId = getMauProductId(pricing.mauThreshold);
+
+  const creditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[pricing.currency];
+  if (!creditTypeId) {
+    throw new Error(
+      `Unsupported currency "${pricing.currency}" for enterprise pricing — add it to CURRENCY_TO_CREDIT_TYPE_ID`
+    );
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      contractId,
+      mauThreshold: pricing.mauThreshold,
+      mauPriceCents: pricing.mauPriceCents,
+      floorCents: pricing.floorCents,
+      includedSeats: pricing.includedSeats,
+      currency: pricing.currency,
+    },
+    `Applying enterprise overrides for MAU Billing (${pricing.mauThreshold})`
+  );
+
+  // --- Build overrides ---
+  const overrides = [];
+
+  if (pricing.mauThreshold !== "MAU_1") {
+    // Disable the default MAU-1 product (base package includes it at $45).
+    overrides.push({
+      product_id: getProductMauBilling1Id(),
+      starting_at: startDate,
+      type: "OVERWRITE" as const,
+      entitled: false,
+      overwrite_rate: { rate_type: "FLAT" as const, price: 0 },
+    });
+  }
+
+  // List rate override: per-MAU price in the customer's currency.
+  // Also used by the recurring commit (rate_type: LIST_RATE) to determine
+  // drawdown rate, so floor / mauPrice = included seats.
+  overrides.push({
+    product_id: targetProductId,
+    starting_at: startDate,
+    type: "OVERWRITE" as const,
+    entitled: true,
+    overwrite_rate: {
+      rate_type: "FLAT" as const,
+      price: pricing.mauPriceCents,
+      credit_type_id: creditTypeId,
+    },
+  });
+
+  // --- Build recurring commit for the floor ---
+  const recurringCommits =
+    pricing.floorCents > 0
+      ? [
+          {
+            product_id: getProductPrepaidCommitId(),
+            name: "MAU Floor (monthly minimum)",
+            starting_at: startDate,
+            // LIST_RATE: drawdown uses the list rate override (per-MAU price),
+            // so floor / mauPrice = number of included MAUs.
+            rate_type: "LIST_RATE" as const,
+            priority: 100,
+            access_amount: {
+              credit_type_id: creditTypeId,
+              unit_price: pricing.floorCents,
+              quantity: 1,
+            },
+            commit_duration: { value: 1, unit: "PERIODS" as const },
+            recurrence_frequency: "MONTHLY" as const,
+            applicable_product_ids: [targetProductId],
+          },
+        ]
+      : [];
+
+  await client.v2.contracts.edit({
+    customer_id: metronomeCustomerId,
+    contract_id: contractId,
+    add_overrides: overrides,
+    ...(recurringCommits.length > 0
+      ? { add_recurring_commits: recurringCommits }
+      : {}),
+  });
+
+  logger.info(
+    {
+      workspaceId,
+      contractId,
+      mauThreshold: pricing.mauThreshold,
+      hasFloor: pricing.floorCents > 0,
+    },
+    "Enterprise overrides applied"
+  );
+}
 
 /**
  * Get the current package IDs for the latest versions (by listing packages and
@@ -115,12 +356,20 @@ async function getPackageInfo(): Promise<{
 /**
  * Get the package alias and contract start date from the workspace's active subscription.
  * Returns undefined if no active paid subscription.
+ *
+ * For enterprise plans, also extracts the per-MAU pricing from the Stripe subscription
+ * so it can be applied as a rate override on the Metronome contract.
  */
 async function getSubscriptionInfo(
   workspaceId: number,
   logger: Logger
 ): Promise<
-  | { packageAlias: string; startDate: string; subscriptionModelId: number }
+  | {
+      packageAlias: string;
+      startDate: string;
+      subscriptionModelId: number;
+      enterprisePricing?: EnterprisePricingCents;
+    }
   | undefined
 > {
   const subscription =
@@ -133,8 +382,9 @@ async function getSubscriptionInfo(
   // Get Stripe subscription start date, rounded to hour boundary (Metronome requirement).
   let startDate: string | undefined;
   let isAnnual = false;
+  let stripeSubscription: Stripe.Subscription | null = null;
   try {
-    const stripeSubscription = await getStripeSubscription(
+    stripeSubscription = await getStripeSubscription(
       subscription.stripeSubscriptionId
     );
     if (stripeSubscription) {
@@ -162,9 +412,37 @@ async function getSubscriptionInfo(
     return undefined;
   }
 
+  const planCode = subscription.getPlan().code;
+
+  // Enterprise plans: extract MAU pricing from Stripe tiers.
+  if (isEntreprisePlanPrefix(planCode)) {
+    if (!stripeSubscription) {
+      return undefined;
+    }
+
+    const enterprisePricing = await extractEnterprisePricing(
+      stripeSubscription,
+      logger
+    );
+    if (!enterprisePricing) {
+      logger.warn(
+        { workspaceId, planCode },
+        "Enterprise plan but no MAU pricing found in Stripe — skipping"
+      );
+      return undefined;
+    }
+
+    return {
+      packageAlias: LEGACY_ENTERPRISE_PACKAGE_ALIAS,
+      startDate,
+      subscriptionModelId: subscription.id,
+      enterprisePricing,
+    };
+  }
+
   // Determine alias from plan code + billing interval.
-  const isPro = subscription.getPlan().code === PRO_PLAN_SEAT_29_CODE;
-  const isBusiness = subscription.getPlan().code === PRO_PLAN_SEAT_39_CODE;
+  const isPro = planCode === PRO_PLAN_SEAT_29_CODE;
+  const isBusiness = planCode === PRO_PLAN_SEAT_39_CODE;
   let packageAlias: string;
   if (isBusiness) {
     packageAlias = LEGACY_BUSINESS_PACKAGE_ALIAS;
@@ -239,6 +517,8 @@ async function migrateWorkspace(
     }
 
     const targetPackageAlias = subInfo.packageAlias;
+    const isEnterprise = targetPackageAlias === LEGACY_ENTERPRISE_PACKAGE_ALIAS;
+
     logger.info(
       {
         workspaceId: workspace.sId,
@@ -248,6 +528,11 @@ async function migrateWorkspace(
         targetPackageId,
         startDate: subInfo.startDate,
         subscriptionModelId: subInfo.subscriptionModelId,
+        ...(isEnterprise && subInfo.enterprisePricing
+          ? {
+              enterprisePricing: subInfo.enterprisePricing,
+            }
+          : {}),
         action: "CREATE_NEW",
       },
       `${execute ? "" : "[DRYRUN] "}Creating new contract (no existing contract)`
@@ -275,22 +560,36 @@ async function migrateWorkspace(
       "New contract created (aligned to Stripe subscription start)"
     );
 
-    // Provision seats for all existing members.
-    const seatResult = await provisionSeatsForContract({
-      metronomeCustomerId,
-      contractId: newContractId,
-      workspace,
-      startingAt: subInfo.startDate,
-    });
-    if (seatResult.isErr()) {
-      logger.error(
-        {
-          workspaceId: workspace.sId,
-          contractId: newContractId,
-          error: seatResult.error.message,
-        },
-        "Failed to provision seats on new contract"
-      );
+    // For enterprise contracts, apply rate overrides to match Stripe pricing.
+    if (isEnterprise && subInfo.enterprisePricing) {
+      await applyEnterpriseOverrides({
+        metronomeCustomerId,
+        contractId: newContractId,
+        pricing: subInfo.enterprisePricing,
+        startDate: subInfo.startDate,
+        logger,
+        workspaceId: workspace.sId,
+      });
+    }
+
+    // Provision seats for all existing members (for seat-based plans).
+    if (!isEnterprise) {
+      const seatResult = await provisionSeatsForContract({
+        metronomeCustomerId,
+        contractId: newContractId,
+        workspace,
+        startingAt: subInfo.startDate,
+      });
+      if (seatResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            contractId: newContractId,
+            error: seatResult.error.message,
+          },
+          "Failed to provision seats on new contract"
+        );
+      }
     }
 
     // Update metronomeContractId on the subscription.
@@ -360,7 +659,6 @@ async function migrateWorkspace(
       continue;
     }
 
-    // Already on the latest version?
     if (contractPackageId === targetPackageId) {
       logger.info(
         {
@@ -368,9 +666,8 @@ async function migrateWorkspace(
           contractId: contract.id,
           targetAlias,
         },
-        "Contract already on target package — skipping"
+        "Contract already on target package — will recreate"
       );
-      continue;
     }
 
     logger.info(
@@ -436,25 +733,42 @@ async function migrateWorkspace(
       "New contract created (same starting_at as old)"
     );
 
-    // 3. Provision seats on the new contract.
-    const seatResult2 = await provisionSeatsForContract({
-      metronomeCustomerId,
-      contractId: newContractId,
-      workspace,
-      startingAt: contract.starting_at,
-    });
-    if (seatResult2.isErr()) {
-      logger.error(
-        {
-          workspaceId: workspace.sId,
+    // 3. For enterprise contracts migrating to the enterprise package, apply overrides.
+    if (targetAlias === LEGACY_ENTERPRISE_PACKAGE_ALIAS) {
+      const subInfo = await getSubscriptionInfo(workspace.id, logger);
+      if (subInfo?.enterprisePricing) {
+        await applyEnterpriseOverrides({
+          metronomeCustomerId,
           contractId: newContractId,
-          error: seatResult2.error.message,
-        },
-        "Failed to provision seats on new contract"
-      );
+          pricing: subInfo.enterprisePricing,
+          startDate: contract.starting_at,
+          logger,
+          workspaceId: workspace.sId,
+        });
+      }
     }
 
-    // 4. Update metronomeContractId on the active subscription.
+    // 4. Provision seats on the new contract (for seat-based plans).
+    if (targetAlias !== LEGACY_ENTERPRISE_PACKAGE_ALIAS) {
+      const seatResult2 = await provisionSeatsForContract({
+        metronomeCustomerId,
+        contractId: newContractId,
+        workspace,
+        startingAt: contract.starting_at,
+      });
+      if (seatResult2.isErr()) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            contractId: newContractId,
+            error: seatResult2.error.message,
+          },
+          "Failed to provision seats on new contract"
+        );
+      }
+    }
+
+    // 5. Update metronomeContractId on the active subscription.
     const activeSubscription =
       await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
 


### PR DESCRIPTION
## Description

Add Metronome billing support for enterprise plans and improve the setup/migration scripts.

### metronome_setup.ts
- **Legacy Enterprise rate card + package**: MAU-based billing (MAU-1 at $45/MAU default, MAU-5/MAU-10 disabled but overridable per contract) + programmatic usage at $1=$1 (30% markup baked into product).
- **Auto-detect environment**: probes Metronome pricing units (AWU credit type ID) to determine sandbox vs production — no longer relies on `METRONOME_ENV` env var.
- **Dry-run mode**: default is now dry-run; pass `--execute` to apply changes.
- **Fix metric recreation bug**: property_filters from Metronome API were returned in different order than defined, causing JSON.stringify comparison to always fail. Now sorted by name before comparing.
- **New product**: "MAU Floor" FIXED product removed — recurring commits use existing "Prepaid Commit" product instead.

### migrate_metronome_contracts.ts
- **Enterprise plan migration**: detects enterprise plans (`ENT_*` plan codes), reads Stripe subscription to extract tiered MAU pricing (per-MAU rate, floor, included seats, MAU threshold).
- **Pricing model**: uses a **recurring prepaid commit** (LIST_RATE) for the floor amount, tied to the MAU product via `applicable_product_ids`. A list rate **OVERWRITE override** sets the per-MAU price. Usage draws down from the commit at the list rate, so `floor / mauPrice = included MAUs`. Overage beyond the commit is billed at the same list rate.
- **MAU threshold support**: handles MAU-1, MAU-5, and MAU-10. For non-default thresholds, disables MAU-1 and enables the correct product via overrides.
- **Always recreate contracts**: contracts are always torn down and recreated (even if already on the target package) to ensure overrides are fresh.
- **No seat provisioning for enterprise**: enterprise contracts are MAU-based, not seat-based.

### constants.ts
- Uncommented MAU billing product IDs (1/5/10) for both dev and prod.
- Added rate card getters and enterprise package getter.

### types.ts
- Added `LEGACY_ENTERPRISE_PACKAGE_ALIAS = "legacy-enterprise"`.

### Poke UI
- Fixed Metronome contract link: now uses `/customers/{customerId}/contracts/{contractId}` instead of `/contracts/{contractId}`.

## Tests

- Ran `metronome_setup.ts` in sandbox + production (dry-run + execute). Environment auto-detection works. All resources sync idempotently after the property_filters sort fix.
- Ran `migrate_metronome_contracts.ts` on a production enterprise workspace. Verified:
  - Stripe tiered pricing correctly extracted (per-MAU rate, floor, included seats)
  - Contract created with correct list rate override
  - Recurring prepaid commit tied to MAU Billing (1+) product with correct floor amount
  - Commit drawdown at list rate produces correct included seat count

## Risk

Low — no changes to production billing flows. Setup script is idempotent and defaults to dry-run. Migration script requires `--execute`. Enterprise contracts have no `billing_provider_configuration` so invoices stay in Metronome (no Stripe charges).

## Deploy Plan

1. Merge PR
2. Run `metronome_setup.ts --execute` in production (already done — enterprise package created)
3. Run `migrate_metronome_contracts.ts -p legacy-enterprise` in dry-run to verify enterprise workspace detection
4. Run with `--execute` to create enterprise Metronome contracts with overrides