### PR TITLE
[front] fix: Strip null unicode characters generated by gpt5

### DIFF
--- a/front/lib/api/llm/utils/tool_arguments.test.ts
+++ b/front/lib/api/llm/utils/tool_arguments.test.ts
@@ -285,4 +285,29 @@ describe("parseToolArguments", () => {
       });
     });
   });
+
+  describe("standalone null characters (not caught by Latin-1 fix)", () => {
+    it("should strip \\u0000 followed by 1 hex digit then non-hex", () => {
+      const result = parseToolArguments('{"query":"caf\\u0000e"}', "test");
+      expect(result).toEqual({ query: "cafe" });
+    });
+
+    it("should strip \\u0000 followed by non-hex character", () => {
+      const result = parseToolArguments('{"query":"he\\u0000llo"}', "test");
+      expect(result).toEqual({ query: "hello" });
+    });
+
+    it("should strip multiple standalone nulls in one string", () => {
+      const result = parseToolArguments(
+        '{"query":"h\\u0000e\\u0000llo"}',
+        "test"
+      );
+      expect(result).toEqual({ query: "hello" });
+    });
+
+    it("should strip standalone \\u0000 with no trailing hex", () => {
+      const result = parseToolArguments('{"query":"test\\u0000"}', "test");
+      expect(result).toEqual({ query: "test" });
+    });
+  });
 });

--- a/front/lib/api/llm/utils/tool_arguments.ts
+++ b/front/lib/api/llm/utils/tool_arguments.ts
@@ -16,15 +16,21 @@ import isObject from "lodash/isObject";
  */
 function fixCorruptedUnicodeInJSON(jsonString: string): string {
   // Match the JSON escape sequence \u0000 followed by two hex digits
-  return jsonString.replace(/\\u0000([0-9a-fA-F]{2})/g, (_match, hex) => {
-    const codePoint = parseInt(hex, 16);
-    // Only fix if it maps to a Latin-1 Supplement character (0x80-0xFF)
-    // This avoids false positives with ASCII range (0x00-0x7F)
-    if (codePoint >= 0x80 && codePoint <= 0xff) {
-      return `\\u00${hex}`;
+  const fixed = jsonString.replace(
+    /\\u0000([0-9a-fA-F]{2})/g,
+    (_match, hex) => {
+      const codePoint = parseInt(hex, 16);
+      // Only fix if it maps to a Latin-1 Supplement character (0x80-0xFF)
+      // This avoids false positives with ASCII range (0x00-0x7F)
+      if (codePoint >= 0x80 && codePoint <= 0xff) {
+        return `\\u00${hex}`;
+      }
+      return _match; // Leave unchanged if outside target range
     }
-    return _match; // Leave unchanged if outside target range
-  });
+  );
+
+  // Strip remaining standalone \u0000 not followed by two hex digits (those are handled above).
+  return fixed.replace(/\\u0000(?![0-9a-fA-F]{2})/g, "");
 }
 
 export const parseToolArguments = (


### PR DESCRIPTION
## Description

Currently, gpt5 can output null unicode characters (eg `honor\u0000e`) which currently do not get sanitized.
This cause the agent-loops to crash.
This PR strips them completely, while keeping the rest of the corrupted sanitization correct.

Fix https://github.com/dust-tt/tasks/issues/7431

[Trace example](https://eu.langfuse.dust.tt/project/cmmkhrrsl0002xw07p611xnfp/traces?filter=outputCost%3Bnumber%3B%3B%3E%3D%3B0%2CoutputCost%3Bnumber%3B%3B%3C%3D%3B100%2Cmetadata%3BstringObject%3BagentConfigurationId%3Bcontains%3BVcP2Gu4fzs%2Cmetadata%3BstringObject%3BconversationId%3B%3D%3BRU5WABpij3&peek=664c4515e133543f024c890ae8fb7a17&timestamp=2026-04-09T00%3A15%3A54.513Z&observation=aded08b9d2d29b35)

## Tests

Unit tests

## Risk

Low
Blast radius: Every gpt5 conversation not in english

## Deploy Plan

- deploy front