### PR TITLE
feat(sbx): allow adding dev network policy

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -493,8 +493,10 @@ const config = {
   getDatadogApiKey: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("DD_API_KEY");
   },
-  getSandboxDevFrontUrl: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable("SBX_DEV_FRONT_URL");
+  getSandboxDevFrontHostName: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "SBX_DEV_FRONT_URL"
+    )?.replace(/^https?:\/\//, "");
   },
   getSandboxGcpArtifactServiceAccountPath: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable(

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -493,6 +493,9 @@ const config = {
   getDatadogApiKey: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("DD_API_KEY");
   },
+  getSandboxDevFrontUrl: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("SBX_DEV_FRONT_URL");
+  },
   getSandboxGcpArtifactServiceAccountPath: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable(
       "SBX_GCP_ARTIFACT_SERVICE_ACCOUNT"

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import {
   getRegisteredImages,
   getSandboxImageFromRegistry,
@@ -6,6 +7,7 @@ import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import type { ToolEntry, ToolProfile } from "@app/lib/api/sandbox/image/types";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -49,7 +51,30 @@ export function getToolsForProvider(
 export function getSandboxImage(
   _auth?: Authenticator
 ): Result<SandboxImage, Error> {
-  return getSandboxImageFromRegistry({ name: "dust-base" });
+  const imageResult = getSandboxImageFromRegistry({ name: "dust-base" });
+  if (imageResult.isErr()) {
+    return imageResult;
+  }
+
+  if (!isDevelopment()) {
+    return imageResult;
+  }
+
+  const devFrontUrl = config.getSandboxDevFrontUrl();
+  if (!devFrontUrl) {
+    return imageResult;
+  }
+
+  // E2B allowOut expects hostnames, strip the scheme if present.
+  const devHost = devFrontUrl.replace(/^https?:\/\//, "");
+
+  const image = imageResult.value;
+  return new Ok(
+    image.withNetwork({
+      mode: image.network.mode,
+      allowlist: [...(image.network.allowlist ?? []), devHost],
+    })
+  );
 }
 
 export { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -60,13 +60,10 @@ export function getSandboxImage(
     return imageResult;
   }
 
-  const devFrontUrl = config.getSandboxDevFrontUrl();
-  if (!devFrontUrl) {
+  const devHost = config.getSandboxDevFrontHostName();
+  if (!devHost) {
     return imageResult;
   }
-
-  // E2B allowOut expects hostnames, strip the scheme if present.
-  const devHost = devFrontUrl.replace(/^https?:\/\//, "");
 
   const image = imageResult.value;
   return new Ok(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR allows overriding the sandbox's network policy in dev.
This works by adding a new env var, loading it, and overriding the image's network policy when creating the sandbox.

Add to your hive config (e.g. `~/.dust-hive/config.env`) `export SBX_DEV_FRONT_URL=https://your-url.com`

New sandboxes will automatically have your ngrok hostname added to the E2B network allowlist, alongside the standard production hosts (dust.tt, storage.googleapis.com, etc.).

- Only applies when `NODE_ENV=development` and `SBX_DEV_FRONT_URL` is set
- The scheme (`https://`) is stripped automatically — E2B allowlists work with hostnames
- The network policy is applied at sandbox creation time, so existing sandboxes won't pick it up, one should start a new conversation to get a fresh sandbox
- In production, nothing changes, `getSandboxImage()` returns the standard dust-base image with the default allowlist

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

<img width="1234" height="530" alt="Capture d’écran 2026-04-09 à 14 59 04" src="https://github.com/user-attachments/assets/f5eb2306-08c0-4b3a-833e-f634fa00148b" />

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Merge :)