### PR TITLE
[sessions] fix sidekick default bug

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -146,7 +146,6 @@ function PreviewContent({
               }
               disableAutoFocus
               isFloating={false}
-              shouldUseDraft={false}
             />
           </div>
         )}

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -61,6 +61,8 @@ export const AgentInputBar = ({
     conversationId: context.conversation?.sId,
   });
 
+  const agentBuilderContext = context.agentBuilderContext;
+
   const isMobile = useIsMobile();
   const { hasFeature } = useFeatureFlags();
   const singleAgentInput = hasFeature("enable_steering");
@@ -96,7 +98,7 @@ export const AgentInputBar = ({
         ?.richMentions.find(isRichAgentMention) ?? null)
     : null;
 
-  const draftAgent = context.agentBuilderContext?.draftAgent;
+  const draftAgent = agentBuilderContext?.draftAgent;
 
   const autoMentions = useMemo(() => {
     // If we are in the agent builder, we show the draft agent as the sticky mention, all the time.
@@ -118,7 +120,7 @@ export const AgentInputBar = ({
       }
 
       // @sidekick is not available in accessibleAgentIds so we need to skip it
-      if (context.agentBuilderContext) {
+      if (agentBuilderContext) {
         return lastAgentMentionInConversation
           ? [lastAgentMentionInConversation]
           : [];
@@ -160,7 +162,7 @@ export const AgentInputBar = ({
     lastAgentMentionInConversation,
     accessibleAgentIds,
     agentConfigurations,
-    context.agentBuilderContext,
+    agentBuilderContext,
   ]);
 
   // Calculate positions and determine which user messages are navigable.
@@ -303,7 +305,7 @@ export const AgentInputBar = ({
     );
 
   const showStopButton = generatingMessages.length > 0;
-  const showMessageNavigation = !context.agentBuilderContext;
+  const showMessageNavigation = !agentBuilderContext;
   const showNavigationContainer = showStopButton || showMessageNavigation;
 
   const getStopButtonLabel = () => {
@@ -429,10 +431,10 @@ export const AgentInputBar = ({
         conversation={context.conversation}
         draftKey={context.draftKey}
         disableAutoFocus={isMobile}
-        disableUserMentions={!!context.agentBuilderContext}
-        actions={context.agentBuilderContext?.actionsToShow}
-        isSubmitting={context.agentBuilderContext?.isSubmitting === true}
-        isAgentBuilder={!!context.agentBuilderContext}
+        disableUserMentions={!!agentBuilderContext}
+        actions={agentBuilderContext?.actionsToShow}
+        isSubmitting={agentBuilderContext?.isSubmitting === true}
+        isAgentBuilder={!!agentBuilderContext}
       />
     </div>
   );

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -66,7 +66,6 @@ interface InputBarProps {
   isSubmitting?: boolean;
   disable?: boolean;
   isAgentBuilder?: boolean;
-  shouldUseDraft?: boolean;
 }
 
 export const InputBar = React.memo(function InputBar({
@@ -84,7 +83,6 @@ export const InputBar = React.memo(function InputBar({
   isFloating = true,
   isSubmitting = false,
   disable = false,
-  shouldUseDraft = true,
 }: InputBarProps) {
   const [isLocalSubmitting, setIsLocalSubmitting] = useState(isSubmitting);
   const { hasFeature } = useFeatureFlags();
@@ -113,7 +111,7 @@ export const InputBar = React.memo(function InputBar({
     workspaceId: owner.sId,
     userId: user?.sId ?? null,
     draftKey,
-    shouldUseDraft,
+    shouldUseDraft: !isAgentBuilder,
   });
 
   useEffect(() => {

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -72,7 +72,10 @@ const useHandleMentions = ({
     }
 
     // Agent builder: wait for the draft agent to arrive via stickyMentions.
+    // Clear any stale selectedSingleAgent from the previous page while waiting,
+    // so the old agent doesn't flash in the input bar.
     if (isAgentBuilder && (!stickyMentions || stickyMentions.length === 0)) {
+      setSelectedSingleAgent(null);
       return;
     }
 


### PR DESCRIPTION
## Description
This PR is to fix non sidekick agent is set as default agents in sidekick, according to claude this is what was happening: 
```
1. Stale state on mount: selectedSingleAgent lives in InputBarContext at the app root, so it persists across page
  navigations. When opening the sidekick, the old agent was still in context. useHandleMentions didn't clear it while
   waiting for stickyMentions — it just returned early, leaving the stale agent visible.
  2. Draft poisoning (the intermittent part): On mount, the saveDraft effect in InputBarContainer saw the stale
  selectedSingleAgent and queued a debounced write (500ms) to localStorage under the sidekick's new conversation
  draft key. If stickyMentions arrived after the debounce fired, useHandleMentions would read that poisoned draft —
  and since draft has higher priority than stickyMentions, it would set the old agent back. If stickyMentions arrived
   before the 500ms, the correct agent won. That's why it was random.
```
 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
