### PR TITLE
[front] - refactor(poke): support 4-hour window for metronome usage

### DIFF
--- a/front/components/poke/credits/PokeMetronomeUsageChart.tsx
+++ b/front/components/poke/credits/PokeMetronomeUsageChart.tsx
@@ -39,7 +39,7 @@ export function PokeMetronomeUsageChart({
       billingCycleStartDay,
       groupBy,
       groupByCount,
-      windowSize: displayMode === "cumulative" ? "HOUR" : "DAY",
+      windowSize: displayMode === "cumulative" ? "FOUR_HOURS" : "DAY",
     });
 
   return (

--- a/front/lib/api/analytics/metronome_usage.ts
+++ b/front/lib/api/analytics/metronome_usage.ts
@@ -1,3 +1,9 @@
+import type { WindowSize } from "@app/lib/api/analytics/time_utils";
+import {
+  DAY_MS,
+  FOUR_HOURS_MS,
+  getTimestampsForWindow,
+} from "@app/lib/api/analytics/time_utils";
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import {
@@ -31,7 +37,7 @@ const QuerySchema = z.object({
   groupByCount: z.coerce.number().optional().default(5),
   selectedPeriod: z.string().optional(),
   billingCycleStartDay: z.coerce.number().min(1).max(31),
-  windowSize: z.enum(["HOUR", "DAY"]).optional().default("DAY"),
+  windowSize: z.enum(["HOUR", "FOUR_HOURS", "DAY"]).optional().default("DAY"),
 });
 
 export interface MetronomeUsagePointGroup {
@@ -70,22 +76,29 @@ const GROUP_BY_TO_METRICS: Record<MetronomeUsageGroupByType, "llm" | "both"> = {
   origin: "both",
 };
 
-const HOUR_MS = 3_600_000;
-const DAY_MS = 24 * HOUR_MS;
+type MetronomeWindowSize = "HOUR" | "DAY";
 
-function getTimestampsForWindow(
-  start: Date,
-  end: Date,
-  windowSize: "HOUR" | "DAY"
-): number[] {
-  const timestamps: number[] = [];
-  const current = new Date(start);
-  const incrementMs = windowSize === "DAY" ? DAY_MS : HOUR_MS;
-  while (current < end) {
-    timestamps.push(current.getTime());
-    current.setTime(current.getTime() + incrementMs);
+function getMetronomeWindowSize(windowSize: WindowSize): MetronomeWindowSize {
+  switch (windowSize) {
+    case "FOUR_HOURS":
+    case "HOUR":
+      return "HOUR";
+    case "DAY":
+      return "DAY";
+    default:
+      assertNever(windowSize);
   }
-  return timestamps;
+}
+
+function aggregateToFourHourBuckets(
+  hourlyMap: Map<number, number>
+): Map<number, number> {
+  const aggregated = new Map<number, number>();
+  for (const [ts, value] of hourlyMap) {
+    const bucket = ts - (ts % FOUR_HOURS_MS);
+    aggregated.set(bucket, (aggregated.get(bucket) ?? 0) + value);
+  }
+  return aggregated;
 }
 
 interface ParsedBalance {
@@ -216,7 +229,7 @@ export async function handleMetronomeUsageRequest(
       const { cycleStart: periodStart, cycleEnd: periodEnd } =
         getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
 
-      const TEN_DAYS_MS = 10 * 24 * 60 * 60 * 1000;
+      const TEN_DAYS_MS = 10 * DAY_MS;
       const cappedEnd = new Date(
         Math.min(periodEnd.getTime(), Date.now() + TEN_DAYS_MS)
       );
@@ -237,13 +250,16 @@ export async function handleMetronomeUsageRequest(
       const groupValues: Record<string, Map<number, number>> = {};
       const availableGroups: MetronomeUsageAvailableGroup[] = [];
 
+      const metronomeApiWindowSize = getMetronomeWindowSize(windowSize);
+      const needsFourHourAggregation = windowSize === "FOUR_HOURS";
+
       if (!groupBy) {
         const result = await listMetronomeUsage({
           customerIds: [metronomeCustomerId],
           billableMetricIds: [llmMetricId, toolMetricId],
           startingOn,
           endingBefore,
-          windowSize,
+          windowSize: metronomeApiWindowSize,
         });
 
         if (result.isErr()) {
@@ -256,10 +272,13 @@ export async function handleMetronomeUsageRequest(
           });
         }
 
-        const totalMap = new Map<number, number>();
+        let totalMap = new Map<number, number>();
         for (const entry of result.value) {
           const ts = new Date(entry.startTimestamp).getTime();
           totalMap.set(ts, (totalMap.get(ts) ?? 0) + (entry.value ?? 0));
+        }
+        if (needsFourHourAggregation) {
+          totalMap = aggregateToFourHourBuckets(totalMap);
         }
         groupValues["total"] = totalMap;
 
@@ -275,7 +294,7 @@ export async function handleMetronomeUsageRequest(
           customerId: metronomeCustomerId,
           startingOn,
           endingBefore,
-          windowSize,
+          windowSize: metronomeApiWindowSize,
           groupKey: [eventProperty],
         };
 
@@ -334,6 +353,13 @@ export async function handleMetronomeUsageRequest(
               mergedGroupMap.set(key, keyMap);
             }
             keyMap.set(ts, (keyMap.get(ts) ?? 0) + (entry.value ?? 0));
+          }
+        }
+
+        if (needsFourHourAggregation) {
+          for (const key of [...mergedGroupMap.keys()]) {
+            const tsMap = mergedGroupMap.get(key)!;
+            mergedGroupMap.set(key, aggregateToFourHourBuckets(tsMap));
           }
         }
 

--- a/front/lib/api/analytics/programmatic_cost.ts
+++ b/front/lib/api/analytics/programmatic_cost.ts
@@ -1,3 +1,7 @@
+import {
+  DAY_MS,
+  getTimestampsForWindow,
+} from "@app/lib/api/analytics/time_utils";
 import type { MetricsBucket } from "@app/lib/api/assistant/observability/messages_metrics";
 import {
   buildMetricAggregates,
@@ -171,19 +175,6 @@ function calculateCreditTotalsPerTimestamp(
   return creditTotalsMap;
 }
 
-function getTimestampsInRange(startOfMonth: Date, endDate: Date): number[] {
-  const timestamps = [];
-  const current = new Date(startOfMonth);
-  for (
-    let timestamp = current;
-    timestamp < endDate;
-    timestamp.setUTCHours(timestamp.getUTCHours() + 4)
-  ) {
-    timestamps.push(timestamp.getTime());
-  }
-  return timestamps;
-}
-
 function getSelectedFilterClauses(
   filterParams: Partial<Record<GroupByType, string[]>> | undefined,
   excluded?: GroupByType
@@ -319,12 +310,16 @@ export async function handleProgrammaticCostRequest(
         getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
 
       // Cap periodEnd to 10 days in the future to avoid too big empty chart areas.
-      const TEN_DAYS_IN_MS = 10 * 24 * 60 * 60 * 1000;
+      const TEN_DAYS_MS = 10 * DAY_MS;
       const cappedPeriodEnd = new Date(
-        Math.min(periodEnd.getTime(), Date.now() + TEN_DAYS_IN_MS)
+        Math.min(periodEnd.getTime(), Date.now() + TEN_DAYS_MS)
       );
 
-      const timestamps = getTimestampsInRange(periodStart, cappedPeriodEnd);
+      const timestamps = getTimestampsForWindow(
+        periodStart,
+        cappedPeriodEnd,
+        "FOUR_HOURS"
+      );
 
       // Fetch all credits for the workspace (including free credits and fully consumed ones)
       // We'll filter them per timestamp in calculateCreditTotalsPerTimestamp

--- a/front/lib/api/analytics/time_utils.ts
+++ b/front/lib/api/analytics/time_utils.ts
@@ -1,0 +1,35 @@
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export const HOUR_MS = 3_600_000;
+export const FOUR_HOURS_MS = 4 * HOUR_MS;
+export const DAY_MS = 24 * HOUR_MS;
+
+export type WindowSize = "HOUR" | "FOUR_HOURS" | "DAY";
+
+function getWindowSizeMs(windowSize: WindowSize): number {
+  switch (windowSize) {
+    case "HOUR":
+      return HOUR_MS;
+    case "FOUR_HOURS":
+      return FOUR_HOURS_MS;
+    case "DAY":
+      return DAY_MS;
+    default:
+      assertNever(windowSize);
+  }
+}
+
+export function getTimestampsForWindow(
+  start: Date,
+  end: Date,
+  windowSize: WindowSize
+): number[] {
+  const incrementMs = getWindowSizeMs(windowSize);
+  const timestamps: number[] = [];
+  const current = new Date(start);
+  while (current < end) {
+    timestamps.push(current.getTime());
+    current.setTime(current.getTime() + incrementMs);
+  }
+  return timestamps;
+}

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -6,6 +6,7 @@ import type {
   GetWorkspaceProgrammaticCostResponse,
   GroupByType,
 } from "@app/lib/api/analytics/programmatic_cost";
+import type { WindowSize } from "@app/lib/api/analytics/time_utils";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListCreditsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
@@ -104,7 +105,7 @@ export function usePokeMetronomeUsage({
   groupByCount?: number;
   selectedPeriod?: string;
   billingCycleStartDay: number;
-  windowSize?: "HOUR" | "DAY";
+  windowSize?: WindowSize;
 }) {
   const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetMetronomeUsageResponse> = fetcher;


### PR DESCRIPTION
## Description

Adds support for 4-hour time windows in metronome usage charts to align with the existing programmatic cost chart implementation. The programmatic cost chart uses 4-hour buckets for its time aggregation (via Elasticsearch's `fixed_interval: "4h"`), while metronome cumulative charts were using hourly buckets.

## Tests

- [x] Locally

## Risk

Low. Only affects the metronome usage chart visualization when `displayMode` is "cumulative"

## Deploy Plan

Deploy front