### PR TITLE
[front] feat: add cli command to stop all labs transcripts for provider x workspace

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -37,6 +37,7 @@ import {
 } from "@app/temporal/labs/transcripts/client";
 import { REGISTERED_CHECKS } from "@app/temporal/production_checks/activities";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import { labsTranscriptsProviders } from "@app/types/labs";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { isRoleType } from "@app/types/user";
@@ -692,6 +693,46 @@ const transcripts = async (command: string, args: parseArgs.ParsedArgs) => {
         }
       }
       logger.info(`Restarted ${activeConfigSIds.length} workflows.`);
+      return;
+    }
+    case "stop-all": {
+      const provider = labsTranscriptsProviders.find(
+        (p) => p === args.provider
+      );
+      if (!provider) {
+        throw new Error(
+          `Missing or invalid --provider argument. Valid values: ${labsTranscriptsProviders.join(", ")}`
+        );
+      }
+
+      const providerConfigs =
+        await LabsTranscriptsConfigurationResource.listByWorkspaceAndProvider({
+          auth,
+          provider,
+        });
+
+      if (providerConfigs.length === 0) {
+        logger.info(
+          `No transcript configurations found for provider '${provider}' in workspace '${args.wId}'.`
+        );
+        return;
+      }
+
+      let stoppedCount = 0;
+      for (const config of providerConfigs) {
+        if (config.isActive()) {
+          await stopRetrieveTranscriptsWorkflow(config);
+          stoppedCount++;
+          logger.info(
+            { sId: config.sId },
+            `Stopped transcript workflow for config sId=${config.sId}.`
+          );
+        }
+      }
+
+      logger.info(
+        `Stopped ${stoppedCount}/${providerConfigs.length} workflows for provider '${provider}'.`
+      );
       return;
     }
   }

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -724,8 +724,8 @@ const transcripts = async (command: string, args: parseArgs.ParsedArgs) => {
           await stopRetrieveTranscriptsWorkflow(config);
           stoppedCount++;
           logger.info(
-            { sId: config.sId },
-            `Stopped transcript workflow for config sId=${config.sId}.`
+            { configId: config.sId },
+            `Stopped transcript workflow for config ${config.sId}.`
           );
         }
       }

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -137,11 +137,7 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     });
 
     return configurations.map(
-      (configuration) =>
-        new this(
-          this.model,
-          configuration.get()
-        )
+      (configuration) => new this(this.model, configuration.get())
     );
   }
 

--- a/front/lib/resources/labs_transcripts_resource.ts
+++ b/front/lib/resources/labs_transcripts_resource.ts
@@ -116,6 +116,35 @@ export class LabsTranscriptsConfigurationResource extends BaseResource<LabsTrans
     );
   }
 
+  static async listByWorkspaceAndProvider({
+    auth,
+    provider,
+  }: {
+    auth: Authenticator;
+    provider: LabsTranscriptsProviderType;
+  }): Promise<LabsTranscriptsConfigurationResource[]> {
+    const owner = auth.workspace();
+
+    if (!owner) {
+      return [];
+    }
+
+    const configurations = await this.model.findAll({
+      where: {
+        workspaceId: owner.id,
+        provider,
+      },
+    });
+
+    return configurations.map(
+      (configuration) =>
+        new this(
+          this.model,
+          configuration.get()
+        )
+    );
+  }
+
   static async findByWorkspaceAndProvider({
     auth,
     provider,


### PR DESCRIPTION
## Description

- This PR adds a CLI command that stops all labs transcript processing for a given provider (gong, google meet, modjo) and workspace.

## Tests

## Risk

- Low.

## Deploy Plan

- No deploy (will run from prodbox).
