### PR TITLE
feat: add dedup of TODOs

### DIFF
--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -14,6 +14,7 @@ interface LLMTraceContextBase {
   operationType:
     | "agent_builder_description_suggestion"
     | "project_todo_analyze_conversation"
+    | "project_todo_deduplicate"
     | "agent_builder_emoji_suggestion"
     | "agent_builder_name_suggestion"
     | "agent_builder_tags_suggestion"

--- a/front/lib/project_todo/deduplicate_todos.ts
+++ b/front/lib/project_todo/deduplicate_todos.ts
@@ -1,0 +1,286 @@
+// This module provides LLM-assisted deduplication for project todo candidates
+// collected during the merge workflow. It is called after the per-conversation
+// fast-path source lookup to avoid creating duplicate ProjectTodo rows for
+// items that are semantically equivalent to existing todos created from other
+// conversations or manually entered by users.
+//
+// Algorithm — one LLM call per (userId, category) group:
+//   1. Fetch existing ProjectTodos for that userId+category in the space (up to
+//      MAX_EXISTING_FOR_DEDUP most-recent items).
+//   2. If no existing todos: skip — all candidates in the group are new.
+//   3. Otherwise: call the LLM with a forced `deduplicate_todos` tool call,
+//      passing the existing-todo list and the candidate list.
+//   4. Return a Map<candidateIndex, existing ProjectTodoResource | null>.
+//      - non-null  → the candidate duplicates that existing todo; caller links source only.
+//      - null      → the candidate is new; caller creates a new ProjectTodo.
+//
+// Failure policy: LLM errors are best-effort — if the call or parse fails,
+// all candidates in the affected group are treated as new (no false merges).
+
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { ProjectTodoCategory } from "@app/types/project_todo";
+import type { ModelId } from "@app/types/shared/model_id";
+import { z } from "zod";
+
+const DEDUPLICATE_TODOS_FUNCTION_NAME = "deduplicate_todos";
+
+// Cap the number of existing todos included in the prompt so that context size
+// stays bounded regardless of how many todos a user has accumulated.
+const MAX_EXISTING_FOR_DEDUP = 50;
+
+// A candidate todo that did not match any existing source via the fast-path
+// conversation-source lookup and therefore needs LLM-assisted deduplication.
+export type DeduplicationCandidate = {
+  index: number;
+  text: string;
+  category: ProjectTodoCategory;
+  userId: ModelId;
+};
+
+// Module-level constant — the spec object is immutable and identical across all calls.
+const DEDUPLICATE_SPEC: AgentActionSpecification = {
+  name: DEDUPLICATE_TODOS_FUNCTION_NAME,
+  description:
+    "For each new candidate item, identify the existing todo it duplicates, if any.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      matches: {
+        type: "array",
+        description:
+          "One entry per candidate item, in the same order as listed.",
+        items: {
+          type: "object",
+          properties: {
+            candidate_index: {
+              type: "number",
+              description: "The 0-based index of the candidate item.",
+            },
+            existing_sId: {
+              type: "string",
+              description:
+                "The sId of the existing todo this candidate duplicates, or the literal string 'none' if it is a distinct new item.",
+            },
+          },
+          required: ["candidate_index", "existing_sId"],
+        },
+      },
+    },
+    required: ["matches"],
+  },
+};
+
+const DeduplicateMatchSchema = z.object({
+  candidate_index: z.number().int(),
+  existing_sId: z.string(),
+});
+
+const DeduplicateResultSchema = z.object({
+  matches: z.array(DeduplicateMatchSchema),
+});
+
+// Calls the LLM with a forced deduplicate_todos tool call and returns a map
+// from candidate index to the matched existing todo's sId, or null for new items.
+// Returns null if the LLM call fails or the output cannot be parsed.
+async function callDeduplicateLLM(
+  auth: Authenticator,
+  {
+    candidates,
+    existingTodos,
+    model,
+    category,
+  }: {
+    candidates: DeduplicationCandidate[];
+    existingTodos: ProjectTodoResource[];
+    model: ModelConfigurationType;
+    category: ProjectTodoCategory;
+  }
+): Promise<Map<number, string | null> | null> {
+  const owner = auth.getNonNullableWorkspace();
+  const specification = DEDUPLICATE_SPEC;
+
+  const existingList = existingTodos
+    .map((t) => `- [${t.sId}] "${t.text}"`)
+    .join("\n");
+  const candidateList = candidates
+    .map((c) => `- [${c.index}] "${c.text}"`)
+    .join("\n");
+
+  const prompt = [
+    "You are reviewing a project todo list to avoid creating duplicates.",
+    `Category: ${category}`,
+    "",
+    "Existing project todos:",
+    existingList,
+    "",
+    "New items extracted from conversations:",
+    candidateList,
+    "",
+    "Two todos are duplicates if they refer to the same underlying task, decision, or" +
+      " fact — even if phrased differently.",
+    `Call the ${DEDUPLICATE_TODOS_FUNCTION_NAME} tool with one match entry per candidate item.`,
+  ].join("\n");
+
+  // Construct a minimal conversation containing only the prompt as a user message.
+  // The dedup call does not need a full conversation rendering — the todo lists
+  // themselves carry all the context the LLM needs.
+  const conv = {
+    messages: [
+      {
+        role: "user" as const,
+        name: "todo_deduplicator",
+        content: [{ type: "text" as const, text: prompt }],
+      },
+    ],
+  };
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      providerId: model.providerId,
+      modelId: model.modelId,
+      functionCall: specification.name,
+      useCache: false,
+    },
+    {
+      conversation: conv,
+      prompt,
+      specifications: [specification],
+      forceToolCall: specification.name,
+    },
+    {
+      context: {
+        operationType: "project_todo_deduplicate",
+        workspaceId: owner.sId,
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    logger.warn(
+      { error: res.error, workspaceId: owner.sId },
+      "Project todo dedup: LLM call failed"
+    );
+    return null;
+  }
+
+  const action = res.value.actions?.[0];
+  if (!action?.arguments) {
+    logger.warn(
+      { workspaceId: owner.sId },
+      "Project todo dedup: no tool call in LLM response"
+    );
+    return null;
+  }
+
+  const parsed = DeduplicateResultSchema.safeParse(action.arguments);
+  if (!parsed.success) {
+    logger.warn(
+      { error: parsed.error, workspaceId: owner.sId },
+      "Project todo dedup: failed to parse LLM response"
+    );
+    return null;
+  }
+
+  const result = new Map<number, string | null>();
+  for (const match of parsed.data.matches) {
+    result.set(
+      match.candidate_index,
+      match.existing_sId === "none" ? null : match.existing_sId
+    );
+  }
+  return result;
+}
+
+// Deduplicates a flat list of candidates against existing ProjectTodos in the
+// space by grouping them per (userId, category) and running one LLM call per
+// non-empty group.
+//
+// Returns a Map from each candidate's index to the matching existing
+// ProjectTodoResource (duplicate) or null (new item).
+export async function deduplicateTodoCandidates(
+  auth: Authenticator,
+  {
+    spaceModelId,
+    candidates,
+    model,
+  }: {
+    spaceModelId: ModelId;
+    candidates: DeduplicationCandidate[];
+    model: ModelConfigurationType;
+  }
+): Promise<Map<number, ProjectTodoResource | null>> {
+  const result = new Map<number, ProjectTodoResource | null>();
+
+  // Group candidates by (userId, category) so we make one LLM call per group.
+  const groups = new Map<string, DeduplicationCandidate[]>();
+  for (const candidate of candidates) {
+    const key = `${candidate.userId}:${candidate.category}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(candidate);
+    } else {
+      groups.set(key, [candidate]);
+    }
+  }
+
+  // Process groups concurrently — each group writes to disjoint candidate indices
+  // in `result`, so there is no cross-group data dependency.
+  await concurrentExecutor(
+    Array.from(groups.values()),
+    async (groupCandidates) => {
+      const { userId, category } = groupCandidates[0];
+
+      const existingTodos =
+        await ProjectTodoResource.fetchLatestByUserAndCategory(auth, {
+          spaceId: spaceModelId,
+          userId,
+          category,
+          limit: MAX_EXISTING_FOR_DEDUP,
+        });
+
+      if (existingTodos.length === 0) {
+        // Nothing to dedup against — all candidates are new.
+        for (const candidate of groupCandidates) {
+          result.set(candidate.index, null);
+        }
+        return;
+      }
+
+      const existingBySId = new Map(existingTodos.map((t) => [t.sId, t]));
+
+      const llmResult = await callDeduplicateLLM(auth, {
+        candidates: groupCandidates,
+        existingTodos,
+        model,
+        category,
+      });
+
+      for (const candidate of groupCandidates) {
+        if (!llmResult) {
+          // LLM failed: fall through to creation (best-effort dedup, no false merges).
+          result.set(candidate.index, null);
+          continue;
+        }
+
+        const matchedSId = llmResult.get(candidate.index);
+        if (matchedSId == null) {
+          result.set(candidate.index, null);
+        } else {
+          // Map the sId back to the resource; if the LLM hallucinated a non-existent
+          // sId, we treat it as new to avoid losing data.
+          result.set(candidate.index, existingBySId.get(matchedSId) ?? null);
+        }
+      }
+    },
+    { concurrency: 3 }
+  );
+
+  return result;
+}

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -5,21 +5,26 @@
 // mergeTodosForProjectActivity, which itself is invoked by the per-project
 // projectMergeWorkflow at most once per MERGE_THROTTLE_MS (1 hour by default).
 //
-// High-level algorithm (to be implemented):
+//   Pass 1 — per-source lookup (fast path):
+//     For each conversation's takeaway, for each item (actionItem / keyDecision /
+//     notableFact) and each target user:
+//       - Look up existing agent-created ProjectTodo via
+//         ProjectTodoResource.fetchBySourceId(auth, { sourceId: itemId, userId }).
+//       - found, unchanged → skip
+//       - found, changed   → existing.createVersion()
+//       - not found        → collect as a deduplication candidate
 //
-//   1. Fetch all takeaway snapshots (latest per conversation) for
-//      conversations that belong to the given spaceId.
-//   2. For each item (actionItem / keyDecision / notableFact):
-//        - Resolve target users (assigneeUserId, relevantUserIds, or conversation participants).
-//        - For each target user, look up existing agent-created ProjectTodo via
-//          ProjectTodoResource.fetchByConversationSource(auth, {
-//            sourceConversationModelId, conversationTodoItemSId, userId
-//          }).
-//        - not found  → ProjectTodoResource.makeNew() + addSource({ conversationTodoItemSId })
-//        - found, changed  → existing.createVersion()
-//        - found, unchanged → skip
-//   3. For each agent-created ProjectTodo whose conversationTodoItemSId is absent from
-//      the latest snapshot → createVersion({ status: "done", markedAsDoneByType: "agent" }).
+//   Pass 2 — LLM-assisted deduplication:
+//     Group candidates by (userId, category). For each group call
+//     deduplicateTodoCandidates(), which runs one LLM call against the user's
+//     existing todos in that category.
+//       - candidate matches existing todo → addSource({ sourceId: itemId }) on the existing todo
+//                                           (user-created todos: text is never
+//                                           updated — "user wins" policy)
+//       - candidate is new               → ProjectTodoResource.makeNew() + addSource({ sourceId: itemId })
+//
+//   LLM dedup is best-effort: if the call fails, all affected candidates are
+//   created as new todos (no false merges, at the cost of some duplicates).
 //
 // Category mapping:
 //   actionItems  (open)    → "follow_ups",      status: "todo"
@@ -28,11 +33,451 @@
 //   keyDecisions (decided) → "key_decisions",   status: "done"
 //   notableFacts           → "notable_updates", status: "todo"
 
-import type { Authenticator } from "@app/lib/auth";
+import {getFastestWhitelistedModel} from "@app/lib/assistant";
+import type {Authenticator} from "@app/lib/auth";
+import {
+  type DeduplicationCandidate,
+  deduplicateTodoCandidates,
+} from "@app/lib/project_todo/deduplicate_todos";
+import {ConversationResource} from "@app/lib/resources/conversation_resource";
+import {ProjectTodoResource} from "@app/lib/resources/project_todo_resource";
+import {getResourceIdFromSId} from "@app/lib/resources/string_ids";
+import {TakeawaysResource} from "@app/lib/resources/takeaways_resource";
+import {UserResource} from "@app/lib/resources/user_resource";
+import {concurrentExecutor} from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type {ModelId} from "@app/types/shared/model_id";
+import type {
+  TodoVersionedActionItem,
+  TodoVersionedKeyDecision,
+  TodoVersionedNotableFact,
+} from "@app/types/takeaways";
 
-export async function mergeTakeawaysIntoProject(
-  _auth: Authenticator,
-  { spaceId }: { spaceId: string }
+// Stable identifier used when recording the creating actor for butler-created
+// project todos. This is not an actual agent configuration sId but a sentinel
+// for the internal merge workflow.
+const BUTLER_AGENT_SID = "butler";
+
+type ConversationWithTakeaway = {
+  conversation: ConversationResource;
+  takeaway: TakeawaysResource;
+};
+
+// A candidate that passed the fast-path source lookup without a match and
+// needs LLM-assisted deduplication before a new todo is created.
+type CollectedCandidate = {
+  conversation: ConversationResource;
+  itemId: string;
+  userId: ModelId;
+  blob: TodoBlob;
+};
+
+export async function mergeConversationTodosIntoProject (
+  auth: Authenticator,
+  {spaceId}: { spaceId: string }
 ): Promise<void> {
-  void spaceId;
+  const spaceModelId = getResourceIdFromSId (spaceId);
+  if (spaceModelId === null) {
+    logger.error ({spaceId}, "Project todo merge: invalid space sId");
+    return;
+  }
+
+  const conversationTakeaways = await fetchConversationTakeaways (auth, {
+    spaceModelId,
+  });
+  if (conversationTakeaways.length === 0) {
+    return;
+  }
+
+  const usersById = await fetchUsersById (auth, conversationTakeaways);
+
+  // Pass 1: for each conversation takeaway, run the fast-path per-source lookup.
+  // Items already tracked from this conversation are updated in-place; items not
+  // yet tracked are collected as deduplication candidates.
+  const collectedCandidates: CollectedCandidate[] = [];
+  await concurrentExecutor (
+    conversationTakeaways,
+    async ({conversation, takeaway}) => {
+      const candidates = await collectCandidatesFromTakeaway (auth, {
+        conversation,
+        takeaway,
+        usersById,
+      });
+      collectedCandidates.push (...candidates);
+    },
+    {concurrency: 4}
+  );
+
+  if (collectedCandidates.length === 0) {
+    return;
+  }
+
+  // Pass 2: LLM-assisted deduplication.
+  await runDeduplicationPass (auth, {collectedCandidates, spaceModelId});
+}
+
+// Fetches all latest takeaway snapshots for the space and pairs each with its
+// source conversation. Because takeaways now carry a spaceId, no conversation
+// listing is required — only conversations that actually have takeaways are
+// returned.
+async function fetchConversationTakeaways (
+  auth: Authenticator,
+  {spaceModelId}: { spaceModelId: ModelId }
+): Promise<ConversationWithTakeaway[]> {
+  const takeawaysWithSource = await TakeawaysResource.fetchLatestBySpaceId (
+    auth,
+    {spaceModelId}
+  );
+
+  if (takeawaysWithSource.length === 0) {
+    return [];
+  }
+
+  // Batch-fetch conversations by sId — needed to pass ConversationResource
+  // objects to the candidate collector (for logging and future use).
+  const conversationSIds = [
+    ...new Set (
+      takeawaysWithSource.map (({conversationSId}) => conversationSId)
+    ),
+  ];
+  const conversations = await ConversationResource.fetchByIds (
+    auth,
+    conversationSIds
+  );
+  const conversationBySId = new Map<string, ConversationResource> (
+    conversations.map ((c) => [c.sId, c])
+  );
+
+  const result: ConversationWithTakeaway[] = [];
+  for (const {takeaway, conversationSId} of takeawaysWithSource) {
+    const conversation = conversationBySId.get (conversationSId);
+    if (!conversation) {
+      logger.warn (
+        {conversationSId},
+        "Project todo merge: conversation not found, skipping takeaway"
+      );
+      continue;
+    }
+    result.push ({conversation, takeaway});
+  }
+  return result;
+}
+
+// Collects all user sIds referenced across the takeaways (assignees, relevant
+// users) and batch-fetches the corresponding UserResources in a single query.
+async function fetchUsersById (
+  auth: Authenticator,
+  conversationTakeaways: ConversationWithTakeaway[]
+): Promise<Map<string, UserResource>> {
+  const allUserIds = new Set<string> ();
+  for (const {takeaway} of conversationTakeaways) {
+    for (const item of takeaway.actionItems) {
+      if (item.assigneeUserId) {
+        allUserIds.add (item.assigneeUserId);
+      }
+    }
+    for (const item of takeaway.keyDecisions) {
+      for (const userId of item.relevantUserIds) {
+        allUserIds.add (userId);
+      }
+    }
+    for (const item of takeaway.notableFacts) {
+      for (const userId of item.relevantUserIds) {
+        allUserIds.add (userId);
+      }
+    }
+  }
+
+  const users =
+    allUserIds.size > 0 ? await UserResource.fetchByIds ([...allUserIds]) : [];
+  return new Map (users.map ((u) => [u.sId, u]));
+}
+
+// Pass 2: assigns each candidate a stable index, calls deduplicateTodoCandidates,
+// then either links the source to a matched existing todo or creates a new one.
+async function runDeduplicationPass (
+  auth: Authenticator,
+  {
+    collectedCandidates,
+    spaceModelId,
+  }: {
+    collectedCandidates: CollectedCandidate[];
+    spaceModelId: ModelId;
+  }
+): Promise<void> {
+  const deduplicationCandidates: DeduplicationCandidate[] =
+    collectedCandidates.map ((c, i) => ({
+      index: i,
+      text: c.blob.text,
+      category: c.blob.category,
+      userId: c.userId,
+    }));
+
+  const model = getFastestWhitelistedModel (auth);
+  if (!model) {
+    logger.warn (
+      {workspaceId: auth.getNonNullableWorkspace ().sId},
+      "Project todo merge: no whitelisted model — skipping dedup, creating all candidates as new"
+    );
+    await createAllCandidates (auth, {
+      candidates: collectedCandidates,
+      spaceModelId,
+    });
+    return;
+  }
+
+  const deduplicationResult = await deduplicateTodoCandidates (auth, {
+    spaceModelId,
+    candidates: deduplicationCandidates,
+    model,
+  });
+
+  await concurrentExecutor (
+    collectedCandidates.map ((candidate, index) => ({candidate, index})),
+    async ({candidate, index}) => {
+      const existingTodo = deduplicationResult.get (index);
+
+      if (existingTodo) {
+        // Duplicate detected. Attach the source item as an additional source
+        // without modifying the todo's text or status ("user wins" policy:
+        // user-created todos are never updated; agent-created canonical todos
+        // are also left unchanged so the first source remains authoritative).
+        await existingTodo.addSource (auth, {
+          sourceType: "conversation",
+          sourceId: candidate.itemId,
+        });
+        logger.info (
+          {
+            existingTodoSId: existingTodo.sId,
+            conversationId: candidate.conversation.id,
+            itemId: candidate.itemId,
+            userId: candidate.userId,
+          },
+          "Project todo merge: linked duplicate candidate to existing todo"
+        );
+        return;
+      }
+
+      await createTodoFromCandidate (auth, {candidate, spaceModelId});
+    },
+    {concurrency: 4}
+  );
+}
+
+// ── Pass-1 helpers ────────────────────────────────────────────────────────────
+
+// Processes one conversation's takeaway snapshot. For each item+user pair,
+// performs the fast-path source lookup:
+//   - found, unchanged → skip
+//   - found, changed   → createVersion()
+//   - not found        → collect as a candidate for Pass 2
+async function collectCandidatesFromTakeaway (
+  auth: Authenticator,
+  {
+    conversation,
+    takeaway,
+    usersById,
+  }: {
+    conversation: ConversationResource;
+    takeaway: TakeawaysResource;
+    usersById: Map<string, UserResource>;
+  }
+): Promise<CollectedCandidate[]> {
+  const candidates: CollectedCandidate[] = [];
+
+  function resolveTargetUserIds (userIds: string[]): ModelId[] {
+    return userIds
+      .map ((sId) => usersById.get (sId)?.id)
+      .filter ((id): id is ModelId => id !== undefined);
+  }
+
+  async function collectForItem (
+    itemId: string,
+    targetUserIds: ModelId[],
+    makeBlob: () => TodoBlob
+  ): Promise<void> {
+    await concurrentExecutor (
+      targetUserIds,
+      async (userId) => {
+        const existing = await ProjectTodoResource.fetchBySourceId (auth, {
+          sourceId: itemId,
+          userId,
+        });
+
+        const blob = makeBlob ();
+
+        if (existing !== null) {
+          // The todo from this conversation already exists. Create a new version
+          // only if the wording or completion state has changed.
+          const textChanged = existing.text !== blob.text;
+          const statusChanged = existing.status !== blob.status;
+          const doneAtChanged =
+            existing.doneAt?.toISOString () !== blob.doneAt?.toISOString ();
+
+          if (textChanged || statusChanged || doneAtChanged) {
+            await existing.createVersion (auth, {
+              text: blob.text,
+              status: blob.status,
+              doneAt: blob.doneAt,
+            });
+          }
+          return;
+        }
+
+        // No existing todo for this conversation+item+user — hand off to Pass 2.
+        candidates.push ({conversation, itemId, userId, blob});
+      },
+      {concurrency: 4}
+    );
+  }
+
+  // Flatten all item types into a single list and process them concurrently.
+  // Items are independent — no item within a takeaway depends on another.
+  type ItemTask = {
+    itemId: string;
+    targetUserIds: ModelId[];
+    makeBlob: () => TodoBlob;
+  };
+
+  const itemTasks: ItemTask[] = [
+    ...takeaway.actionItems.map (
+      (item): ItemTask => ({
+        itemId: item.sId,
+        targetUserIds: resolveTargetUserIds (
+          item.assigneeUserId ? [item.assigneeUserId] : []
+        ),
+        makeBlob: () => actionItemBlob (item),
+      })
+    ),
+    ...takeaway.keyDecisions.map (
+      (item): ItemTask => ({
+        itemId: item.sId,
+        targetUserIds: resolveTargetUserIds (item.relevantUserIds),
+        makeBlob: () => keyDecisionBlob (item),
+      })
+    ),
+    ...takeaway.notableFacts.map (
+      (item): ItemTask => ({
+        itemId: item.sId,
+        targetUserIds: resolveTargetUserIds (item.relevantUserIds),
+        makeBlob: () => notableFactBlob (item),
+      })
+    ),
+  ];
+
+  await concurrentExecutor (
+    itemTasks,
+    ({itemId, targetUserIds, makeBlob}) =>
+      collectForItem (itemId, targetUserIds, makeBlob),
+    {concurrency: 4}
+  );
+
+  return candidates;
+}
+
+// ── Pass-2 helpers ────────────────────────────────────────────────────────────
+
+// Creates a new ProjectTodo and links it to its source conversation.
+async function createTodoFromCandidate (
+  auth: Authenticator,
+  {
+    candidate,
+    spaceModelId,
+  }: {
+    candidate: CollectedCandidate;
+    spaceModelId: ModelId;
+  }
+): Promise<void> {
+  const {conversation, itemId, userId, blob} = candidate;
+
+  const todo = await ProjectTodoResource.makeNew (auth, {
+    spaceId: spaceModelId,
+    userId,
+    createdByType: "agent",
+    createdByUserId: null,
+    createdByAgentConfigurationId: BUTLER_AGENT_SID,
+    category: blob.category,
+    text: blob.text,
+    status: blob.status,
+    doneAt: blob.doneAt,
+    actorRationale: null,
+    markedAsDoneByType: null,
+    markedAsDoneByUserId: null,
+    markedAsDoneByAgentConfigurationId: null,
+    version: 1,
+  });
+
+  await todo.addSource (auth, {
+    sourceType: "conversation",
+    sourceId: itemId,
+  });
+
+  logger.info (
+    {
+      todoSId: todo.sId,
+      conversationId: conversation.id,
+      itemId,
+      userId,
+    },
+    "Project todo merge: created new todo"
+  );
+}
+
+// Fallback: create all candidates as new todos without deduplication.
+// Used when no LLM model is available.
+async function createAllCandidates (
+  auth: Authenticator,
+  {
+    candidates,
+    spaceModelId,
+  }: {
+    candidates: CollectedCandidate[];
+    spaceModelId: ModelId;
+  }
+): Promise<void> {
+  await concurrentExecutor (
+    candidates,
+    async (candidate) =>
+      createTodoFromCandidate (auth, {candidate, spaceModelId}),
+    {concurrency: 4}
+  );
+}
+
+// ── Blob helpers ─────────────────────────────────────────────────────────────
+
+type TodoBlob = {
+  category: "follow_ups" | "key_decisions" | "notable_updates";
+  text: string;
+  status: "todo" | "done";
+  doneAt: Date | null;
+};
+
+function actionItemBlob (item: TodoVersionedActionItem): TodoBlob {
+  const isDone = item.status === "done";
+  return {
+    category: "follow_ups",
+    text: item.text,
+    status: isDone ? "done" : "todo",
+    doneAt:
+      isDone && item.detectedDoneAt ? new Date (item.detectedDoneAt) : null,
+  };
+}
+
+function keyDecisionBlob (item: TodoVersionedKeyDecision): TodoBlob {
+  return {
+    category: "key_decisions",
+    text: item.text,
+    status: item.status === "decided" ? "done" : "todo",
+    doneAt: null,
+  };
+}
+
+function notableFactBlob (item: TodoVersionedNotableFact): TodoBlob {
+  return {
+    category: "notable_updates",
+    text: item.text,
+    status: "todo",
+    doneAt: null,
+  };
+
 }

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -1,20 +1,21 @@
-import type { Authenticator } from "@app/lib/auth";
-import { BaseResource } from "@app/lib/resources/base_resource";
+import type {Authenticator} from "@app/lib/auth";
+import {BaseResource} from "@app/lib/resources/base_resource";
 import {
   ProjectTodoConversationModel,
   ProjectTodoModel,
   ProjectTodoSourceModel,
 } from "@app/lib/resources/storage/models/project_todo";
-import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
-import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type {ReadonlyAttributesType} from "@app/lib/resources/storage/types";
+import type {ModelStaticWorkspaceAware} from "@app/lib/resources/storage/wrappers/workspace_models";
+import {generateRandomModelSId} from "@app/lib/resources/string_ids_server";
+import type {ResourceFindOptions} from "@app/lib/resources/types";
 import type {
+  ProjectTodoCategory,
   ProjectTodoSourceType,
   ProjectTodoType,
 } from "@app/types/project_todo";
-import type { ModelId } from "@app/types/shared/model_id";
-import { Ok, type Result } from "@app/types/shared/result";
+import type {ModelId} from "@app/types/shared/model_id";
+import {Ok, type Result} from "@app/types/shared/result";
 import type {
   Attributes,
   CreationAttributes,
@@ -25,41 +26,42 @@ import type {
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ProjectTodoResource
-  extends ReadonlyAttributesType<ProjectTodoModel> {}
+  extends ReadonlyAttributesType<ProjectTodoModel> {
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
   static model: ModelStaticWorkspaceAware<ProjectTodoModel> = ProjectTodoModel;
 
-  constructor(
+  constructor (
     model: ModelStatic<ProjectTodoModel>,
     blob: Attributes<ProjectTodoModel>
   ) {
-    super(ProjectTodoModel, blob);
+    super (ProjectTodoModel, blob);
   }
 
   // ── Creation ────────────────────────────────────────────────────────────────
 
-  static async makeNew(
+  static async makeNew (
     auth: Authenticator,
     blob: Omit<CreationAttributes<ProjectTodoModel>, "workspaceId" | "sId">,
     transaction?: Transaction
   ): Promise<ProjectTodoResource> {
-    const todo = await ProjectTodoModel.create(
+    const todo = await ProjectTodoModel.create (
       {
         ...blob,
-        sId: generateRandomModelSId(),
-        workspaceId: auth.getNonNullableWorkspace().id,
+        sId: generateRandomModelSId (),
+        workspaceId: auth.getNonNullableWorkspace ().id,
       },
-      { transaction }
+      {transaction}
     );
 
-    return new this(ProjectTodoModel, todo.get());
+    return new this (ProjectTodoModel, todo.get ());
   }
 
   // Inserts a new version row for this logical todo, copying unchanged fields and
   // applying the supplied updates. Mirrors the AgentConfiguration update pattern.
-  async createVersion(
+  async createVersion (
     auth: Authenticator,
     updates: Partial<
       Omit<
@@ -69,9 +71,9 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     >,
     transaction?: Transaction
   ): Promise<ProjectTodoResource> {
-    const newRow = await ProjectTodoModel.create(
+    const newRow = await ProjectTodoModel.create (
       {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: auth.getNonNullableWorkspace ().id,
         sId: this.sId,
         version: this.version + 1,
         spaceId: this.spaceId,
@@ -91,25 +93,25 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
         actorRationale: this.actorRationale ?? null,
         ...updates,
       },
-      { transaction }
+      {transaction}
     );
 
-    return new ProjectTodoResource(ProjectTodoModel, newRow.get());
+    return new ProjectTodoResource (ProjectTodoModel, newRow.get ());
   }
 
   // ── Fetching ─────────────────────────────────────────────────────────────────
 
-  private static async baseFetch(
+  private static async baseFetch (
     auth: Authenticator,
     options?: ResourceFindOptions<ProjectTodoModel>,
     transaction?: Transaction
   ): Promise<ProjectTodoResource[]> {
-    const { where, ...otherOptions } = options ?? {};
+    const {where, ...otherOptions} = options ?? {};
 
-    const todos = await ProjectTodoModel.findAll({
+    const todos = await ProjectTodoModel.findAll ({
       where: {
         ...where,
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: auth.getNonNullableWorkspace ().id,
       },
       ...otherOptions,
       transaction,
@@ -119,18 +121,18 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       return [];
     }
 
-    return todos.map((t) => {
-      return new this(ProjectTodoModel, t.get());
+    return todos.map ((t) => {
+      return new this (ProjectTodoModel, t.get ());
     });
   }
 
   // Fetches the latest version of a todo by its stable sId.
-  static async fetchBySId(
+  static async fetchBySId (
     auth: Authenticator,
     sId: string
   ): Promise<ProjectTodoResource | null> {
-    const results = await this.baseFetch(auth, {
-      where: { sId },
+    const results = await this.baseFetch (auth, {
+      where: {sId},
       order: [["version", "DESC"]],
       limit: 1,
     });
@@ -138,12 +140,12 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     return results[0] ?? null;
   }
 
-  static async fetchBySpace(
+  static async fetchBySpace (
     auth: Authenticator,
-    { spaceId }: { spaceId: ModelId }
+    {spaceId}: { spaceId: ModelId }
   ): Promise<ProjectTodoResource[]> {
-    return this.baseFetch(auth, {
-      where: { spaceId },
+    return this.baseFetch (auth, {
+      where: {spaceId},
       order: [["createdAt", "DESC"]],
     });
   }
@@ -151,37 +153,29 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
   // Returns only the latest version of each logical todo for the given space.
   // Fetches all version rows ordered by (sId ASC, version DESC) then keeps
   // only the first occurrence per sId, which has the highest version number.
-  static async fetchLatestBySpace(
+  static async fetchLatestBySpace (
     auth: Authenticator,
-    { spaceId }: { spaceId: ModelId }
+    {spaceId}: { spaceId: ModelId }
   ): Promise<ProjectTodoResource[]> {
-    const all = await this.baseFetch(auth, {
-      where: { spaceId, userId: auth.getNonNullableUser().id },
+    const all = await this.baseFetch (auth, {
+      where: {spaceId, userId: auth.getNonNullableUser ().id},
       order: [
         ["sId", "ASC"],
         ["version", "DESC"],
       ],
     });
 
-    // O(n) deduplication — keep the first occurrence per sId (highest version).
-    const latestBySId = new Map<string, ProjectTodoResource>();
-    for (const todo of all) {
-      if (!latestBySId.has(todo.sId)) {
-        latestBySId.set(todo.sId, todo);
-      }
-    }
-
-    return Array.from(latestBySId.values());
+    return this.toLatestBySId (all);
   }
 
   // Returns every version row for (spaceId, userId), across all sIds. Used by the
   // diff algorithm to reconstruct snapshots at arbitrary cutoff dates.
-  static async fetchAllVersionsBySpace(
+  static async fetchAllVersionsBySpace (
     auth: Authenticator,
-    { spaceId }: { spaceId: ModelId }
+    {spaceId}: { spaceId: ModelId }
   ): Promise<ProjectTodoResource[]> {
-    return this.baseFetch(auth, {
-      where: { spaceId, userId: auth.getNonNullableUser().id },
+    return this.baseFetch (auth, {
+      where: {spaceId, userId: auth.getNonNullableUser ().id},
       order: [
         ["sId", "ASC"],
         ["version", "ASC"],
@@ -189,31 +183,120 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
   }
 
+  // Returns the latest version of each logical todo for the given user and
+  // category within a space, capped to `limit` most-recently-created items.
+  // Used by the deduplication pass in the merge workflow.
+  static async fetchLatestByUserAndCategory (
+    auth: Authenticator,
+    {
+      spaceId,
+      userId,
+      category,
+      limit,
+    }: {
+      spaceId: ModelId;
+      userId: ModelId;
+      category: ProjectTodoCategory;
+      limit: number;
+    }
+  ): Promise<ProjectTodoResource[]> {
+    const all = await this.baseFetch (auth, {
+      where: {spaceId, userId, category},
+      order: [
+        ["sId", "ASC"],
+        ["version", "DESC"],
+      ],
+    });
+
+    // Return the most recently created ones, up to `limit`.
+    return this.toLatestBySId (all)
+      .sort ((a, b) => b.createdAt.getTime () - a.createdAt.getTime ())
+      .slice (0, limit);
+  }
+
+  // O(n) deduplication over a list pre-sorted by (sId ASC, version DESC):
+  // keeps only the first row per sId, which is the highest version.
+  private static toLatestBySId (
+    todos: ProjectTodoResource[]
+  ): ProjectTodoResource[] {
+    const latestBySId = new Map<string, ProjectTodoResource> ();
+    for (const todo of todos) {
+      if (!latestBySId.has (todo.sId)) {
+        latestBySId.set (todo.sId, todo);
+      }
+    }
+    return Array.from (latestBySId.values ());
+  }
+
+  // Returns the latest version of an agent-created todo linked to the given
+  // source item for a specific user, or null if none exists.
+  // Used by the merge workflow to decide whether to create or update a todo.
+  static async fetchBySourceId (
+    auth: Authenticator,
+    {
+      sourceId,
+      userId,
+    }: {
+      sourceId: string;
+      userId: ModelId;
+    }
+  ): Promise<ProjectTodoResource | null> {
+    const workspaceId = auth.getNonNullableWorkspace ().id;
+
+    // Find source rows for this specific source item.
+    const sources = await ProjectTodoSourceModel.findAll ({
+      where: {
+        workspaceId,
+        sourceId,
+      },
+    });
+
+    if (sources.length === 0) {
+      return null;
+    }
+
+    const projectTodoModelIds = sources.map ((s) => s.projectTodoId);
+
+    // Among the matched todos, find the one owned by the target user. There
+    // should be at most one such row, but we pick the first for safety.
+    const matched = await this.baseFetch (auth, {
+      where: {id: {[Op.in]: projectTodoModelIds}, userId},
+      limit: 1,
+    });
+
+    if (matched.length === 0) {
+      return null;
+    }
+
+    // Return the latest version of the todo using its stable sId.
+    return this.fetchBySId (auth, matched[0].sId);
+  }
+
   // ── Output conversation links (todo => conversation) ────────────────────
 
-  async addOutputConversation(
+  async addOutputConversation (
     auth: Authenticator,
-    { conversationId }: { conversationId: ModelId },
+    {conversationId}: { conversationId: ModelId },
     transaction?: Transaction
   ): Promise<void> {
-    await ProjectTodoConversationModel.create(
+    await ProjectTodoConversationModel.create (
       {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: auth.getNonNullableWorkspace ().id,
         projectTodoId: this.id,
         conversationId,
       },
-      { transaction }
+      {transaction}
     );
   }
 
-  async removeOutputConversation(
+  async removeOutputConversation (
     auth: Authenticator,
-    { conversationId }: { conversationId: ModelId },
+    {conversationId}: { conversationId: ModelId },
     transaction?: Transaction
   ): Promise<void> {
-    await ProjectTodoConversationModel.destroy({
+    await ProjectTodoConversationModel.destroy ({
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: auth.getNonNullableWorkspace ().id,
         projectTodoId: this.id,
         conversationId,
       },
@@ -223,7 +306,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
 
   // ── Source links (* => todo) ─────────────────────────────────────────────
 
-  async addSource(
+  async addSource (
     auth: Authenticator,
     {
       sourceType,
@@ -234,18 +317,18 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     },
     transaction?: Transaction
   ): Promise<void> {
-    await ProjectTodoSourceModel.create(
+    await ProjectTodoSourceModel.create (
       {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: auth.getNonNullableWorkspace ().id,
         projectTodoId: this.id,
         sourceType,
         sourceId,
       },
-      { transaction }
+      {transaction}
     );
   }
 
-  async removeSource(
+  async removeSource (
     auth: Authenticator,
     {
       sourceType,
@@ -256,9 +339,9 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     },
     transaction?: Transaction
   ): Promise<void> {
-    await ProjectTodoSourceModel.destroy({
+    await ProjectTodoSourceModel.destroy ({
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: auth.getNonNullableWorkspace ().id,
         projectTodoId: this.id,
         sourceType,
         sourceId,
@@ -269,7 +352,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
 
   // ── Serialization ──────────────────────────────────────────────────────────
 
-  toJSON(): ProjectTodoType {
+  toJSON (): ProjectTodoType {
     return {
       id: this.id,
       sId: this.sId,
@@ -283,7 +366,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       createdByAgentConfigurationId: this.createdByAgentConfigurationId,
       markedAsDoneByType: this.markedAsDoneByType,
       markedAsDoneByAgentConfigurationId:
-        this.markedAsDoneByAgentConfigurationId,
+      this.markedAsDoneByAgentConfigurationId,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };
@@ -291,34 +374,34 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
 
   // ── Lifecycle ──────────────────────────────────────────────────────────────
 
-  async delete(
+  async delete (
     auth: Authenticator,
-    { transaction }: { transaction?: Transaction }
+    {transaction}: { transaction?: Transaction }
   ): Promise<Result<undefined, Error>> {
-    await ProjectTodoConversationModel.destroy({
+    await ProjectTodoConversationModel.destroy ({
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: auth.getNonNullableWorkspace ().id,
         projectTodoId: this.id,
       },
       transaction,
     });
 
-    await ProjectTodoSourceModel.destroy({
+    await ProjectTodoSourceModel.destroy ({
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: auth.getNonNullableWorkspace ().id,
         projectTodoId: this.id,
       },
       transaction,
     });
 
-    await this.model.destroy({
+    await this.model.destroy ({
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: auth.getNonNullableWorkspace ().id,
         id: this.id,
       },
       transaction,
     });
 
-    return new Ok(undefined);
+    return new Ok (undefined);
   }
 }

--- a/front/migrations/db/migration_573 1.sql
+++ b/front/migrations/db/migration_573 1.sql
@@ -1,0 +1,5 @@
+-- Migration created on Apr 09, 2026
+ALTER TABLE "public"."project_todo_sources"
+    ADD COLUMN "takeawayItemSId" VARCHAR(255);
+
+CREATE INDEX CONCURRENTLY "project_todo_sources_ws_takeaway_item_idx" ON "project_todo_sources" ("workspaceId", "sourceConversationId", "takeawayItemSId");

--- a/front/migrations/db/migration_575.sql
+++ b/front/migrations/db/migration_575.sql
@@ -18,3 +18,4 @@ ALTER TABLE "project_todo_sources"
 -- Step 3: Create index matching TakeawaySourcesModel pattern.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "project_todo_sources_sourceType_sourceId_idx"
   ON "project_todo_sources" ("sourceType", "sourceId");
+front/lib/project_todo/merge_into_project.ts

--- a/front/temporal/project_todo/activities.ts
+++ b/front/temporal/project_todo/activities.ts
@@ -1,7 +1,7 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
 import { analyzeConversationTodos } from "@app/lib/project_todo/analyze_conversation";
-import { mergeTakeawaysIntoProject } from "@app/lib/project_todo/merge_into_project";
+import { mergeConversationTodosIntoProject } from "@app/lib/project_todo/merge_into_project";
 import logger from "@app/logger/logger";
 import { signalOrStartProjectMergeWorkflow } from "@app/temporal/project_todo/client";
 
@@ -80,5 +80,5 @@ export async function mergeTodosForProjectActivity({
     "Project todo merge: activity invoked (not yet implemented)"
   );
 
-  await mergeTakeawaysIntoProject(auth, { spaceId });
+  await mergeConversationTodosIntoProject(auth, { spaceId });
 }


### PR DESCRIPTION
## Description

Adds dedup of TODOs.

We collect all potential new TODOs, and for each category x user, we run a LLM to dedup tasks. 

We always keep existing tasks first

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
