### PR TITLE
fix(migrations): apply stashed changes after switching back to branch

### DIFF
--- a/connectors/create_db_migration_file.sh
+++ b/connectors/create_db_migration_file.sh
@@ -39,19 +39,20 @@ NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_
 echo "Second run: Capturing stable production state..."
 NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_output.txt
 
-# Checkout original branch and run command.
+# Checkout original branch.
 echo "Checking out $original_branch branch..."
 git checkout $original_branch --quiet
-echo "Running command on $original_branch branch..."
-NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > current_output.txt
-
 # Determine if there were any stashed changes and apply them.
 stash_list=$(git stash list)
 if [[ $stash_list == *"$stash_commit_message"* ]]; then
   # Pop the stash if it exists.
-  echo "Restoring original changes..."
+  echo "Restoring uncommited changes..."
   git stash pop --quiet
 fi
+
+# Run the command on original branch.
+echo "Running command on $original_branch branch..."
+NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > current_output.txt
 
 # Run diff.
 echo "Running diff..."

--- a/connectors/create_db_migration_file.sh
+++ b/connectors/create_db_migration_file.sh
@@ -39,19 +39,19 @@ NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_
 echo "Second run: Capturing stable production state..."
 NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_output.txt
 
-# Determine if there were any stashed changes.
+# Checkout original branch and run command.
+echo "Checking out $original_branch branch..."
+git checkout $original_branch --quiet
+echo "Running command on $original_branch branch..."
+NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > current_output.txt
+
+# Determine if there were any stashed changes and apply them.
 stash_list=$(git stash list)
 if [[ $stash_list == *"$stash_commit_message"* ]]; then
   # Pop the stash if it exists.
   echo "Restoring original changes..."
   git stash pop --quiet
 fi
-
-# Checkout original branch and run command.
-echo "Checking out $original_branch branch..."
-git checkout $original_branch --quiet
-echo "Running command on $original_branch branch..."
-NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > current_output.txt
 
 # Run diff.
 echo "Running diff..."

--- a/front/create_db_migration_file.sh
+++ b/front/create_db_migration_file.sh
@@ -39,19 +39,20 @@ NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_
 echo "Second run: Capturing stable production state..."
 NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_output.txt
 
-# Checkout original branch and run command.
+# Checkout original branch
 echo "Checking out $original_branch branch..."
 git checkout $original_branch --quiet
-echo "Running command on $original_branch branch..."
-NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > current_output.txt
-
 # Determine if there were any stashed changes and apply them.
 stash_list=$(git stash list)
 if [[ $stash_list == *"$stash_commit_message"* ]]; then
   # Pop the stash if it exists.
-  echo "Restoring original changes..."
+  echo "Restoring uncommited changes..."
   git stash pop --quiet
 fi
+
+# Run the command on original branch.
+echo "Running command on $original_branch branch..."
+NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > current_output.txt
 
 # Run diff.
 echo "Running diff..."

--- a/front/create_db_migration_file.sh
+++ b/front/create_db_migration_file.sh
@@ -39,19 +39,19 @@ NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_
 echo "Second run: Capturing stable production state..."
 NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_output.txt
 
-# Determine if there were any stashed changes.
+# Checkout original branch and run command.
+echo "Checking out $original_branch branch..."
+git checkout $original_branch --quiet
+echo "Running command on $original_branch branch..."
+NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > current_output.txt
+
+# Determine if there were any stashed changes and apply them.
 stash_list=$(git stash list)
 if [[ $stash_list == *"$stash_commit_message"* ]]; then
   # Pop the stash if it exists.
   echo "Restoring original changes..."
   git stash pop --quiet
 fi
-
-# Checkout original branch and run command.
-echo "Checking out $original_branch branch..."
-git checkout $original_branch --quiet
-echo "Running command on $original_branch branch..."
-NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > current_output.txt
 
 # Run diff.
 echo "Running diff..."


### PR DESCRIPTION
## Description

The `create_db_migration_file.sh` scripts weirdly applied the stashed changes before switching back the original branch, that could lead to script execution failures if we have not commited changes that could not be applied on main
=> fixing by applying the stash after branch switch

## Tests

Locally tested to have not commited changes and apply the migration creation script
=> fails without the fix
=> works with the fix

## Risk

None

## Deploy Plan

No deploy needed as it is for dev tools only