### PR TITLE
 Enable React hooks lint rules for sparkle and fix pre-existing violations

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -96,7 +96,7 @@
       }
     },
     {
-      "includes": ["front-spa/**", "front/**"],
+      "includes": ["front-spa/**", "front/**", "sparkle/**"],
       "linter": {
         "rules": {
           "correctness": {

--- a/sparkle/src/components/CollapseButton.tsx
+++ b/sparkle/src/components/CollapseButton.tsx
@@ -142,7 +142,7 @@ const CollapseButton: React.FC<CollapseButtonProps> = ({
     const timeoutId = setTimeout(initializeAnimation, 100);
 
     return () => clearTimeout(timeoutId);
-  }, [direction]);
+  }, []);
 
   return (
     <div

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -210,6 +210,7 @@ export function DataTable<TData extends TBaseData>({
     getRowId,
   });
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: table is recreated every render, adding it would cause infinite re-runs
   useEffect(() => {
     if (filterColumn) {
       table.getColumn(filterColumn)?.setFilterValue(filter);

--- a/sparkle/src/components/DiffBlock.tsx
+++ b/sparkle/src/components/DiffBlock.tsx
@@ -44,9 +44,6 @@ export function DiffBlock({
   collapsedLines = DEFAULT_COLLAPSED_LINES,
 }: DiffBlockProps) {
   const hasContent = changes !== undefined || children !== undefined;
-  if (!hasContent) {
-    return null;
-  }
 
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -56,6 +53,7 @@ export function DiffBlock({
   const [collapsedHeight, setCollapsedHeight] = useState<number>();
   const [expandedHeight, setExpandedHeight] = useState<number>();
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: changes/children are props that trigger re-measurement when content changes
   useLayoutEffect(() => {
     const element = contentRef.current;
     const container = containerRef.current;
@@ -101,6 +99,10 @@ export function DiffBlock({
       resizeObserver.disconnect();
     };
   }, [changes, children, collapsedLines]);
+
+  if (!hasContent) {
+    return null;
+  }
 
   const shouldClamp = isCollapsible && !isExpanded;
 

--- a/sparkle/src/components/Hover3D.tsx
+++ b/sparkle/src/components/Hover3D.tsx
@@ -25,6 +25,20 @@ const isTouchDevice = () => {
   return "ontouchstart" in window || navigator.maxTouchPoints > 0;
 };
 
+const clamp = (value: number, min: number, max: number) => {
+  return Math.min(Math.max(value, min), max);
+};
+
+const map = (
+  value: number,
+  istart: number,
+  istop: number,
+  ostart: number,
+  ostop: number
+) => {
+  return ostart + (ostop - ostart) * ((value - istart) / (istop - istart));
+};
+
 interface Hover3DProps {
   children: React.ReactNode;
   xOffset?: number;
@@ -61,18 +75,6 @@ function Hover3D({
     }px)`
   );
   const [transition, setTransition] = useState("");
-  const clamp = (value: number, min: number, max: number) => {
-    return Math.min(Math.max(value, min), max);
-  };
-  const map = (
-    value: number,
-    istart: number,
-    istop: number,
-    ostart: number,
-    ostop: number
-  ) => {
-    return ostart + (ostop - ostart) * ((value - istart) / (istop - istart));
-  };
 
   // Detect touch device on mount
   useEffect(() => {

--- a/sparkle/src/components/ImageZoomDialog.tsx
+++ b/sparkle/src/components/ImageZoomDialog.tsx
@@ -56,7 +56,7 @@ function ImageZoomDialog({
     [image.downloadUrl, image.title]
   );
 
-  // Reset image loaded state when dialog closes or image changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: open and image.src are props that should trigger the reset
   React.useEffect(() => {
     setImageLoaded(false);
   }, [open, image.src]);

--- a/sparkle/src/components/Pagination.tsx
+++ b/sparkle/src/components/Pagination.tsx
@@ -52,7 +52,7 @@ export function Pagination({
     (pageIndex: number) => {
       setPagination({ pageSize, pageIndex });
     },
-    [pageIndex, setPagination]
+    [pageSize, setPagination]
   );
 
   const pageButtons: React.ReactNode[] = getPageButtons(

--- a/sparkle/src/components/ScrollArea.tsx
+++ b/sparkle/src/components/ScrollArea.tsx
@@ -50,6 +50,7 @@ const ScrollArea = React.forwardRef<
 
     const shouldHideDefaultScrollBar = hideScrollBar || hasCustomScrollBar;
 
+    // biome-ignore lint/correctness/useExhaustiveDependencies: ref.current is mutable and should not be in deps; callback reads current value at call time
     const handleScroll = React.useCallback(() => {
       if (viewportRef && viewportRef.current) {
         setIsScrolled(viewportRef.current.scrollTop > 0);

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -165,17 +165,22 @@ function BaseSearchInputWithPopover<T>(
   }: SearchInputWithPopoverBaseProps<T>,
   ref: Ref<HTMLInputElement>
 ) {
+  // biome-ignore lint/correctness/useHookAtTopLevel: this is a forwardRef render function, Biome can't trace the forwardRef call
   const [selectedIndex, setSelectedIndex] = useState(0);
+  // biome-ignore lint/correctness/useHookAtTopLevel: this is a forwardRef render function
   const itemRefs = useRef<(HTMLElement | null)[]>([]);
   const showHeader =
     Boolean(stickyTopContent) ||
     (items.length > 0 && (displayItemCount || onSelectAll));
   const showBottom = Boolean(stickyBottomContent);
 
+  // biome-ignore lint/correctness/useHookAtTopLevel: this is a forwardRef render function
   useEffect(() => {
     itemRefs.current = new Array(items.length).fill(null);
   }, [items.length]);
 
+  // biome-ignore lint/correctness/useHookAtTopLevel: this is a forwardRef render function
+  // biome-ignore lint/correctness/useExhaustiveDependencies: items is a prop, resetting index on change is intentional
   useEffect(() => {
     setSelectedIndex(0);
   }, [items]);

--- a/sparkle/src/components/TypingAnimation.tsx
+++ b/sparkle/src/components/TypingAnimation.tsx
@@ -23,7 +23,7 @@ export function TypingAnimation({ text, duration = 50 }: TypingAnimationProps) {
     return () => {
       clearInterval(typingEffect);
     };
-  }, [duration, i]);
+  }, [duration, i, text]);
 
   return <>{displayedText ? displayedText : text}</>;
 }


### PR DESCRIPTION
## Description

- Enable Biome's useHookAtTopLevel and useExhaustiveDependencies rules for sparkle/** so hooks violations (like the ScrollContainer crash fixed in #23905) get caught at lint time
- Fix all 26 pre-existing violations surfaced by the new rules across 8 files

## Changes

**Lint config**
- biome.json: Add sparkle/** to the hooks rules override so useHookAtTopLevel and useExhaustiveDependencies are enforced on sparkle, matching what we already have for front/** and front-spa/**

**Hooks ordering fixes**
- DiffBlock.tsx: Move all hooks before the if (!hasContent) early return (same class of bug as the ScrollContainer crash)

**Dependency array fixes**
- Hover3D.tsx: Move pure clamp/map utility functions outside the component body so the effect no longer captures them as changing dependencies
- Pagination.tsx: The callback parameter pageIndex was shadowing the outer prop, making the outer pageIndex an unused dependency. Removed it and added the actually-used pageSize
- CollapseButton.tsx: Remove direction from the effect dependency array since it is not referenced inside the effect body
- TypingAnimation.tsx: Add missing text prop to the effect dependency array so the animation restarts when the text changes

**False positives (biome-ignore)**
- DiffBlock.tsx and ImageZoomDialog.tsx: Biome flags changes, children, open, and image.src as "outer scope values that don't re-render the component." These are component props and they do trigger re-renders. Removing them from the dependency arrays would break the intended behavior (re-measuring content on change, resetting image loaded state on navigation). This is a known Biome limitation where it treats function parameters as non-reactive.
- DataTable.tsx: Biome asks to add table.getColumn to the dependency array, but the table object from useReactTable is recreated on every render. Adding it would cause the effect to fire on every render instead of only when filter or filterColumn change.
- ScrollArea.tsx: Biome asks to add viewportRef.current and viewportRef.current.scrollTop as dependencies. Ref .current values are mutable and should not be in dependency arrays per the React docs. The callback reads the current value at call time, which is the correct pattern.
- SearchInput.tsx: Biome reports hooks are "called from within a function that is not a component." The function is a forwardRef render function passed to forwardRef on a separate line (needed for generic <T> support), and Biome cannot trace this indirection.



## Tests

Before I rebase to get the fix on Sheets, this commit did became red as expected on that rule: https://github.com/dust-tt/dust/actions/runs/24192305209/job/70612563061

## Risk

Break those components. 
Can be rolled back. 

## Deploy Plan

Merge. 