### PR TITLE
Eval framework for skill reinforcement

### DIFF
--- a/front/tests/reinforcement-evals/README.md
+++ b/front/tests/reinforcement-evals/README.md
@@ -1,0 +1,43 @@
+# Reinforced Skills Evaluation Tests
+
+End-to-end eval suite for the reinforced skills pipeline. Tests both phases:
+
+1. **Analyse conversation** — given a skill config and a conversation, does the model produce the expected synthetic suggestions?
+2. **Aggregate suggestions** — given a set of synthetic suggestions, does the model merge and prioritise them correctly?
+
+Each test case checks two things:
+
+- **Expected tool calls** — the right tools were invoked (e.g. `suggest_skill_instruction_edits`, `suggest_skill_tools`).
+- **LLM-as-judge** — a separate LLM scores the quality of the suggestions against scenario-specific criteria.
+
+## Quick start
+
+```bash
+# Run all tests (streaming / non-batch mode)
+NODE_ENV=test \
+  TEST_FRONT_DATABASE_URI="$FRONT_DATABASE_URI"_test \
+  RUN_REINFORCEMENT_EVAL=true \
+  npm run test -- tests/reinforcement-evals/reinforcement-eval.test.ts --config tests/reinforcement-evals/vite.config.mjs
+
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUN_REINFORCEMENT_EVAL` | `false` | Set to `true` to enable the tests (skipped otherwise). |
+| `USE_BATCH` | `false` | Set to `true` to submit all prompts via the LLM batch API instead of streaming each individually. |
+| `REINFORCEMENT_MODEL_ID` | `claude-sonnet-4-6` | Model used for the reinforced skills LLM calls. |
+| `JUDGE_RUNS` | `3` | Number of judge evaluations per test (majority vote). |
+| `PASS_THRESHOLD` | `2` | Minimum judge score (0-3) required to pass. |
+| `FILTER_CATEGORY` | _(all)_ | Run only tests in the given category (suite name). |
+| `FILTER_SCENARIO` | _(all)_ | Run only the test with the given scenario ID. |
+| `VERBOSE` | `false` | Set to `true` to log full tool call arguments and response text for each scenario. |
+| `DUST_MANAGED_ANTHROPIC_API_KEY` | — | Anthropic API key (required for Claude models). |
+| `DUST_MANAGED_OPENAI_API_KEY` | — | OpenAI API key (required for GPT judge model). |
+
+## Batch vs streaming mode
+
+**Streaming (default)** — each test case runs its LLM call concurrently via streaming. Fast feedback, good for development.
+
+**Batch** — all prompts are submitted as a single LLM batch request. The test suite polls until results are ready, then evaluates. Better cost efficiency, but slower turnaround.

--- a/front/tests/reinforcement-evals/lib/assertions.ts
+++ b/front/tests/reinforcement-evals/lib/assertions.ts
@@ -1,0 +1,131 @@
+import type {
+  ToolCall,
+  ToolCallAssertion,
+} from "@app/tests/reinforcement-evals/lib/types";
+
+type AssertionResult = { success: true } | { success: false; error: string };
+
+interface InstructionSuggestionItem {
+  skillId: string;
+}
+
+interface ToolSuggestionItem {
+  skillId: string;
+  toolId: string;
+  action: string;
+}
+
+function isInstructionSuggestionItem(
+  value: unknown
+): value is InstructionSuggestionItem {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "skillId" in value &&
+    typeof value.skillId === "string"
+  );
+}
+
+function isToolSuggestionItem(value: unknown): value is ToolSuggestionItem {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "skillId" in value &&
+    typeof value.skillId === "string" &&
+    "toolId" in value &&
+    typeof value.toolId === "string" &&
+    "action" in value &&
+    typeof value.action === "string"
+  );
+}
+
+function getSuggestions(args: Record<string, unknown>): unknown[] | undefined {
+  const suggestions = args.suggestions;
+  if (!Array.isArray(suggestions)) {
+    return undefined;
+  }
+  return suggestions;
+}
+
+function getInstructionSuggestions(
+  args: Record<string, unknown>
+): InstructionSuggestionItem[] {
+  return (getSuggestions(args) ?? []).filter(isInstructionSuggestionItem);
+}
+
+function getToolSuggestions(
+  args: Record<string, unknown>
+): ToolSuggestionItem[] {
+  return (getSuggestions(args) ?? []).filter(isToolSuggestionItem);
+}
+
+/**
+ * Validate a single assertion against the actual tool calls.
+ */
+export function validateToolCallAssertion(
+  assertion: ToolCallAssertion,
+  toolCalls: ToolCall[]
+): AssertionResult {
+  switch (assertion.type) {
+    case "instructionSuggestion": {
+      const call = toolCalls.find(
+        (tc) => tc.name === "suggest_skill_instruction_edits"
+      );
+      if (!call) {
+        return {
+          success: false,
+          error: `Expected suggest_skill_instruction_edits to be called with skillId "${assertion.skillId}", but suggest_skill_instruction_edits was not called`,
+        };
+      }
+      const suggestions = getInstructionSuggestions(call.arguments);
+      if (!suggestions.some((s) => s.skillId === assertion.skillId)) {
+        return {
+          success: false,
+          error: `Expected suggest_skill_instruction_edits to contain skillId "${assertion.skillId}", but got: ${JSON.stringify(suggestions)}`,
+        };
+      }
+      return { success: true };
+    }
+    case "toolSuggestion": {
+      const call = toolCalls.find((tc) => tc.name === "suggest_skill_tools");
+      if (!call) {
+        return {
+          success: false,
+          error: `Expected suggest_skill_tools to be called with skillId "${assertion.skillId}" and toolId "${assertion.toolId}", but suggest_skill_tools was not called`,
+        };
+      }
+      const suggestions = getToolSuggestions(call.arguments);
+      if (
+        !suggestions.some(
+          (s) =>
+            s.skillId === assertion.skillId && s.toolId === assertion.toolId
+        )
+      ) {
+        return {
+          success: false,
+          error: `Expected suggest_skill_tools to contain skillId "${assertion.skillId}" with toolId "${assertion.toolId}", but got: ${JSON.stringify(suggestions)}`,
+        };
+      }
+      return { success: true };
+    }
+    case "noSuggestion": {
+      const suggestionToolNames = new Set([
+        "suggest_skill_instruction_edits",
+        "suggest_skill_tools",
+      ]);
+      for (const tc of toolCalls) {
+        if (!suggestionToolNames.has(tc.name)) {
+          continue;
+        }
+        const suggestions = getSuggestions(tc.arguments);
+        if (suggestions && suggestions.length > 0) {
+          return {
+            success: false,
+            error: `Expected no suggestions, but ${tc.name} was called with ${suggestions.length} suggestion(s)`,
+          };
+        }
+      }
+      return { success: true };
+    }
+  }
+}

--- a/front/tests/reinforcement-evals/lib/config.ts
+++ b/front/tests/reinforcement-evals/lib/config.ts
@@ -1,0 +1,35 @@
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { isModelId } from "@app/types/assistant/models/models";
+import type { ModelIdType } from "@app/types/assistant/models/types";
+
+export const RUN_REINFORCEMENT_EVAL =
+  process.env.RUN_REINFORCEMENT_EVAL === "true";
+export const USE_BATCH = process.env.USE_BATCH === "true";
+export const JUDGE_RUNS = parseInt(process.env.JUDGE_RUNS ?? "3", 10);
+export const PASS_THRESHOLD = parseInt(process.env.PASS_THRESHOLD ?? "2", 10);
+export const FILTER_CATEGORY = process.env.FILTER_CATEGORY;
+export const FILTER_SCENARIO = process.env.FILTER_SCENARIO;
+export const VERBOSE = process.env.VERBOSE === "true";
+
+/** Model used for the reinforced skills LLM calls. */
+function resolveModelId(): ModelIdType {
+  const id = process.env.REINFORCEMENT_MODEL_ID || "claude-sonnet-4-6";
+  if (!isModelId(id)) {
+    throw new Error(
+      `Invalid REINFORCEMENT_MODEL_ID: "${id}". Must be a known model ID.`
+    );
+  }
+  return id;
+}
+
+export const MODEL_ID = resolveModelId();
+
+export const TIMEOUT_MS = 300_000;
+export const BATCH_TIMEOUT_MS = 1_800_000; // 30 minutes for batch polling
+export const BATCH_POLL_INTERVAL_MS = 10_000;
+
+export async function getReinforcementEvalAuth(): Promise<Authenticator> {
+  const workspace = await WorkspaceFactory.basic();
+  return Authenticator.internalAdminForWorkspace(workspace.sId);
+}

--- a/front/tests/reinforcement-evals/lib/judge.ts
+++ b/front/tests/reinforcement-evals/lib/judge.ts
@@ -1,0 +1,161 @@
+import { getLLM } from "@app/lib/api/llm";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  getTestCaseInputForDisplay,
+  type JudgeResult,
+  type TestCase,
+  type ToolCall,
+} from "@app/tests/reinforcement-evals/lib/types";
+
+const JUDGE_PROMPT = `You are evaluating the quality of a Reinforced Skills analyst's suggestions.
+
+The analyst reviews conversations that used skills and proposes improvements to skill configurations (instructions, tools).
+
+## Scoring Rubric
+
+- 0: Failed to produce relevant suggestions or major issues (wrong tool, irrelevant content)
+- 1: Partially addressed the issue, missing key elements or low quality suggestions
+- 2: Good suggestions with minor issues (slightly off-target, incomplete analysis)
+- 3: Excellent, well-targeted suggestions that clearly address the identified issues
+
+You MUST provide your response in this exact format:
+
+REASONING: <your detailed analysis>
+SCORE: <number>
+
+Where <number> is between 0 and 3.
+
+IMPORTANT: You must include both REASONING: and SCORE: labels. The score MUST appear at the end of your response.
+
+---
+
+## Test Input
+
+{{TEST_INPUT}}
+
+## Tool Calls Made
+
+{{TOOL_CALLS}}
+
+## Response Text (if any)
+
+{{RESPONSE_TEXT}}
+
+## Scenario-Specific Criteria
+
+{{JUDGE_CRITERIA}}
+
+---
+
+## General Evaluation Checklist (apply to all scenarios)
+
+1. **Correct Tool Usage**: Did the analyst call the right tool(s) for the situation?
+   - suggest_skill_instruction_edits for instruction improvements
+   - suggest_skill_tools for tool additions/removals
+2. **Suggestion Quality**: Are the suggestions specific, actionable, and well-reasoned?
+   - Does the analysis field explain WHY the change is needed?
+   - Is the suggested content appropriate and well-written?
+3. **Scope Appropriateness**: Did it avoid over-engineering?
+   - Focused on the actual issue rather than rewriting everything
+   - Suggestions preserve the skill's existing goals
+4. **If suggest_skill_instruction_edits was called**:
+   - Do the instructions directly address the identified issue?
+   - Are they in the same language as the existing instructions?
+   - Would they meaningfully improve the skill?
+5. **If suggest_skill_tools was called**:
+   - Is the correct tool/skill ID used?
+   - Is the action (add/remove) appropriate?
+   - Does the analysis explain the use case?
+
+Provide your evaluation using the REASONING: and SCORE: format described above.`;
+
+export async function evaluateWithJudge(
+  auth: Authenticator,
+  testCase: TestCase,
+  toolCalls: ToolCall[],
+  responseText: string,
+  numRuns: number = 1
+): Promise<JudgeResult> {
+  const prompt = JUDGE_PROMPT.replace(
+    "{{TEST_INPUT}}",
+    getTestCaseInputForDisplay(testCase)
+  )
+    .replace(
+      "{{TOOL_CALLS}}",
+      toolCalls.length > 0
+        ? toolCalls
+            .map(
+              (tc) => `- ${tc.name}(${JSON.stringify(tc.arguments, null, 2)})`
+            )
+            .join("\n\n")
+        : "(none)"
+    )
+    .replace("{{RESPONSE_TEXT}}", responseText || "(none)")
+    .replace("{{JUDGE_CRITERIA}}", testCase.judgeCriteria);
+
+  const scores: number[] = [];
+  let lastReasoning = "";
+
+  const credentials = await getLlmCredentials(auth, {
+    skipEmbeddingApiKeyRequirement: true,
+  });
+  const llm = await getLLM(auth, {
+    credentials,
+    modelId: "gpt-5-mini",
+    temperature: 0.2,
+    bypassFeatureFlag: true,
+  });
+  if (!llm) {
+    throw new Error("Failed to initialize LLM for judge evaluation");
+  }
+
+  for (let i = 0; i < numRuns; i++) {
+    const events = llm.stream({
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            name: "User",
+            content: [{ type: "text", text: prompt }],
+          },
+        ],
+      },
+      prompt:
+        "You are a careful evaluator. Analyze the reinforced skills output and provide a fair assessment.",
+      specifications: [],
+    });
+
+    let response = "";
+    for await (const event of events) {
+      if (event.type === "text_delta") {
+        response += event.content.delta;
+      }
+      if (event.type === "error") {
+        throw new Error(`Judge evaluation error: ${event.content.message}`);
+      }
+    }
+
+    const scoreMatch = response.match(/SCORE:\s*(\d)/i);
+    if (scoreMatch) {
+      const score = parseInt(scoreMatch[1], 10);
+      if (score >= 0 && score <= 3) {
+        scores.push(score);
+      }
+    }
+
+    const reasoningMatch = response.match(
+      /REASONING:\s*([\s\S]+?)(?=SCORE:|$)/i
+    );
+    if (reasoningMatch) {
+      lastReasoning = reasoningMatch[1].trim();
+    }
+  }
+
+  const finalScore =
+    scores.length > 0
+      ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length)
+      : 0;
+
+  return { finalScore, scores, reasoning: lastReasoning };
+}

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -1,0 +1,331 @@
+import { formatAvailableTools } from "@app/lib/api/assistant/global_agents/sidekick_context";
+import { getLLM } from "@app/lib/api/llm";
+import type { LLM } from "@app/lib/api/llm/llm";
+import type { BatchResultWithRunIds } from "@app/lib/api/llm/types/batch";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import type { Authenticator } from "@app/lib/auth";
+import type { ExploratoryToolCallInfo as AgentExploratoryToolCallInfo } from "@app/lib/reinforced_agent/types";
+import { buildContinuationMessages } from "@app/lib/reinforced_agent/utils";
+import { buildSkillAggregationPrompt } from "@app/lib/reinforcement/aggregate_suggestions";
+import { buildSkillAnalysisPrompt } from "@app/lib/reinforcement/analyze_conversation";
+import { MAX_REINFORCED_ANALYSIS_STEPS } from "@app/lib/reinforcement/constants";
+import {
+  buildReinforcedSkillsLLMParams,
+  classifySkillToolCalls,
+} from "@app/lib/reinforcement/run_reinforced_analysis";
+import {
+  BATCH_POLL_INTERVAL_MS,
+  MODEL_ID,
+} from "@app/tests/reinforcement-evals/lib/config";
+import {
+  buildConversationText,
+  type CategorizedTestCase,
+  type ExecutionResult,
+  isAnalysisTestCase,
+  type MockSkillConfig,
+  type TestCase,
+  type ToolCall,
+  type WorkspaceContext,
+} from "@app/tests/reinforcement-evals/lib/types";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+
+function makeSkillType(config: MockSkillConfig): SkillType {
+  return {
+    id: 0,
+    sId: config.sId,
+    createdAt: null,
+    updatedAt: null,
+    editedBy: null,
+    status: "active",
+    name: config.name,
+    agentFacingDescription: config.description ?? "",
+    userFacingDescription: config.description ?? "",
+    instructions: config.instructions ?? null,
+    icon: null,
+    source: null,
+    sourceMetadata: null,
+    requestedSpaceIds: [],
+    tools: (config.tools ?? []).map((t) => ({
+      id: 0,
+      sId: t.sId,
+      name: t.name,
+      description: null,
+      createdAt: 0,
+      updatedAt: 0,
+      spaceId: "space_eval",
+      serverType: "remote" as const,
+      server: {
+        name: t.name,
+        version: "1.0.0",
+        description: t.name,
+        sId: t.sId,
+        icon: "PuzzleIcon" as const,
+        authorization: null,
+        tools: [],
+        availability: "manual" as const,
+        allowMultipleInstances: false,
+        documentationUrl: null,
+      },
+      oAuthUseCase: null,
+      editedByUser: null,
+    })),
+    fileAttachments: [],
+    canWrite: false,
+    isExtendable: false,
+    isDefault: false,
+    extendedSkillId: null,
+  };
+}
+
+function buildPromptForTestCase(testCase: TestCase): {
+  systemPrompt: string;
+  userMessage: string;
+} {
+  if (isAnalysisTestCase(testCase)) {
+    const skillTypes = testCase.skillConfigs.map(makeSkillType);
+    const conversationText = buildConversationText(testCase.conversation);
+    return buildSkillAnalysisPrompt(conversationText, skillTypes);
+  }
+  const skillType = makeSkillType(testCase.skillConfig);
+  return buildSkillAggregationPrompt(
+    skillType,
+    testCase.syntheticSuggestions,
+    testCase.existingSuggestions ?? { pending: [], rejected: [] }
+  );
+}
+
+function extractFromEvents(events: LLMEvent[]): ExecutionResult {
+  const toolCalls: ToolCall[] = [];
+  let responseText = "";
+
+  for (const event of events) {
+    switch (event.type) {
+      case "text_delta":
+        responseText += event.content.delta;
+        break;
+      case "text_generated":
+        responseText = event.content.text;
+        break;
+      case "tool_call":
+        toolCalls.push({
+          name: event.content.name,
+          arguments: event.content.arguments,
+        });
+        break;
+      case "error":
+        throw new Error(
+          `Reinforced skills LLM error: ${event.content.message}`
+        );
+      default:
+        break;
+    }
+  }
+
+  return { toolCalls, responseText };
+}
+
+/**
+ * Simulate an exploratory tool call using the test case's workspace context.
+ */
+function simulateExploratoryTool(workspaceContext: WorkspaceContext): string {
+  // The skills pipeline only has one exploratory tool: get_available_tools.
+  return formatAvailableTools(workspaceContext.tools);
+}
+
+/**
+ * Run a multi-step LLM conversation. After each LLM call, if exploratory tools
+ * are called, simulate their responses from workspace context and continue.
+ * Returns accumulated tool calls from all steps.
+ */
+async function executeMultiStep(
+  llm: LLM,
+  initialParams: LLMStreamParameters,
+  workspaceContext: WorkspaceContext
+): Promise<ExecutionResult> {
+  const allToolCalls: ToolCall[] = [];
+  let lastResponseText = "";
+  let currentParams = initialParams;
+
+  for (let step = 0; step < MAX_REINFORCED_ANALYSIS_STEPS; step++) {
+    const events: LLMEvent[] = [];
+    for await (const event of llm.stream(currentParams)) {
+      events.push(event);
+    }
+
+    const stepResult = extractFromEvents(events);
+    allToolCalls.push(...stepResult.toolCalls);
+    lastResponseText = stepResult.responseText;
+
+    const { exploratoryToolCalls } = classifySkillToolCalls(events);
+
+    // If no exploratory tools were called, we're done.
+    if (exploratoryToolCalls.length === 0) {
+      return { toolCalls: allToolCalls, responseText: lastResponseText };
+    }
+
+    // Simulate exploratory tool responses from workspace context.
+    const toolResults: Record<string, string> = {};
+    for (const tc of exploratoryToolCalls) {
+      toolResults[tc.id] = simulateExploratoryTool(workspaceContext);
+    }
+
+    // Build continuation messages and extend conversation.
+    // The ExploratoryToolCallInfo shapes are compatible between the two modules.
+    // The skills ExploratoryToolCallInfo has the same shape as the agent one
+    // (name is a subset: "get_available_tools" vs "get_available_tools" | "get_available_skills").
+    const continuationMessages = buildContinuationMessages(
+      exploratoryToolCalls as AgentExploratoryToolCallInfo[],
+      toolResults
+    );
+
+    currentParams = {
+      ...currentParams,
+      conversation: {
+        messages: [
+          ...currentParams.conversation.messages,
+          ...continuationMessages,
+        ],
+      },
+    };
+  }
+
+  return { toolCalls: allToolCalls, responseText: lastResponseText };
+}
+
+async function getLLMInstance(auth: Authenticator): Promise<LLM> {
+  const credentials = await getLlmCredentials(auth, {
+    skipEmbeddingApiKeyRequirement: true,
+  });
+  const llm = await getLLM(auth, {
+    credentials,
+    modelId: MODEL_ID,
+    bypassFeatureFlag: true,
+  });
+  if (!llm) {
+    throw new Error(
+      `Failed to initialize LLM for reinforcement eval (model: ${MODEL_ID})`
+    );
+  }
+  return llm;
+}
+
+export async function executeReinforced(
+  auth: Authenticator,
+  testCase: TestCase
+): Promise<ExecutionResult> {
+  const llm = await getLLMInstance(auth);
+  const prompt = buildPromptForTestCase(testCase);
+  const params = buildReinforcedSkillsLLMParams(prompt);
+
+  return executeMultiStep(llm, params, testCase.workspaceContext);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function submitAndWaitForBatch(
+  llm: LLM,
+  batchMap: Map<string, LLMStreamParameters>
+): Promise<BatchResultWithRunIds> {
+  const batchId = await llm.sendBatchProcessing(batchMap);
+
+  let status = await llm.getBatchStatus(batchId);
+  while (status === "computing") {
+    await sleep(BATCH_POLL_INTERVAL_MS);
+    status = await llm.getBatchStatus(batchId);
+  }
+
+  if (status === "aborted") {
+    throw new Error(`LLM batch was aborted (batchId: ${batchId})`);
+  }
+
+  return llm.getBatchResult(batchId);
+}
+
+export async function executeBatch(
+  auth: Authenticator,
+  testCases: CategorizedTestCase[]
+): Promise<Map<string, ExecutionResult>> {
+  const llm = await getLLMInstance(auth);
+
+  const testCaseById = new Map<string, CategorizedTestCase>();
+  for (const tc of testCases) {
+    testCaseById.set(tc.scenarioId, tc);
+  }
+
+  // Build initial params for all test cases.
+  let pendingParams = new Map<string, LLMStreamParameters>();
+  for (const tc of testCases) {
+    const prompt = buildPromptForTestCase(tc);
+    pendingParams.set(tc.scenarioId, buildReinforcedSkillsLLMParams(prompt));
+  }
+
+  const results = new Map<string, ExecutionResult>();
+  // Accumulate tool calls across steps for each scenario.
+  const accumulatedToolCalls = new Map<string, ToolCall[]>();
+  let step = 0;
+
+  while (step < MAX_REINFORCED_ANALYSIS_STEPS && pendingParams.size > 0) {
+    const batchResult = await submitAndWaitForBatch(llm, pendingParams);
+
+    const nextPendingParams = new Map<string, LLMStreamParameters>();
+
+    for (const [scenarioId, { events }] of batchResult) {
+      const stepResult = extractFromEvents(events);
+      const prev = accumulatedToolCalls.get(scenarioId) ?? [];
+      const allToolCalls = [...prev, ...stepResult.toolCalls];
+      accumulatedToolCalls.set(scenarioId, allToolCalls);
+
+      const { exploratoryToolCalls } = classifySkillToolCalls(events);
+
+      if (exploratoryToolCalls.length === 0) {
+        // Terminal — done for this scenario.
+        results.set(scenarioId, {
+          toolCalls: allToolCalls,
+          responseText: stepResult.responseText,
+        });
+      } else {
+        // Simulate tool responses and prepare continuation params.
+        const tc = testCaseById.get(scenarioId)!;
+        const toolResultsMap: Record<string, string> = {};
+        for (const toolCall of exploratoryToolCalls) {
+          toolResultsMap[toolCall.id] = simulateExploratoryTool(
+            tc.workspaceContext
+          );
+        }
+
+        const continuationMessages = buildContinuationMessages(
+          exploratoryToolCalls as unknown as Parameters<
+            typeof buildContinuationMessages
+          >[0],
+          toolResultsMap
+        );
+
+        const currentParams = pendingParams.get(scenarioId)!;
+        nextPendingParams.set(scenarioId, {
+          ...currentParams,
+          conversation: {
+            messages: [
+              ...currentParams.conversation.messages,
+              ...continuationMessages,
+            ],
+          },
+        });
+      }
+    }
+
+    pendingParams = nextPendingParams;
+    step++;
+  }
+
+  // Any scenarios still pending after max steps — return what we have.
+  for (const [scenarioId] of pendingParams) {
+    const allToolCalls = accumulatedToolCalls.get(scenarioId) ?? [];
+    results.set(scenarioId, { toolCalls: allToolCalls, responseText: "" });
+  }
+
+  return results;
+}

--- a/front/tests/reinforcement-evals/lib/suite-loader.ts
+++ b/front/tests/reinforcement-evals/lib/suite-loader.ts
@@ -1,0 +1,36 @@
+import type {
+  CategorizedTestCase,
+  TestSuite,
+} from "@app/tests/reinforcement-evals/lib/types";
+
+/**
+ * Filter test cases from suites based on criteria.
+ * Automatically assigns category to each test case based on suite name.
+ */
+export function filterTestCases(
+  suites: TestSuite[],
+  options?: {
+    category?: string;
+    scenarioId?: string;
+  }
+): CategorizedTestCase[] {
+  let allTests: CategorizedTestCase[] = [];
+
+  for (const suite of suites) {
+    const categorizedCases = suite.testCases.map((tc) => ({
+      ...tc,
+      category: suite.name,
+    }));
+    allTests = allTests.concat(categorizedCases);
+  }
+
+  if (options?.category) {
+    allTests = allTests.filter((tc) => tc.category === options.category);
+  }
+
+  if (options?.scenarioId) {
+    allTests = allTests.filter((tc) => tc.scenarioId === options.scenarioId);
+  }
+
+  return allTests;
+}

--- a/front/tests/reinforcement-evals/lib/types.ts
+++ b/front/tests/reinforcement-evals/lib/types.ts
@@ -1,0 +1,220 @@
+import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
+import {
+  formatConversationForShrinkWrap,
+  type ShrinkWrapAction,
+} from "@app/lib/api/assistant/conversation/shrink_wrap";
+import type { AvailableTool } from "@app/lib/api/assistant/workspace_capabilities";
+import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+
+export interface WorkspaceContext {
+  tools: AvailableTool[];
+}
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, "_");
+}
+
+/** Create a mock AvailableTool. sId defaults to `mcp_<slugified name>`. */
+export function mockTool(
+  name: string,
+  description: string,
+  sId?: string
+): AvailableTool {
+  return {
+    sId: sId ?? `mcp_${slugify(name)}`,
+    name,
+    description,
+    serverType: "remote",
+    availability: "manual",
+  };
+}
+
+export interface MockFeedback {
+  direction: AgentMessageFeedbackDirection;
+  comment?: string;
+}
+
+/** Lightweight action descriptor for mock conversations. */
+export interface MockAction {
+  functionCallName: string;
+  status: "succeeded" | "failed";
+  params?: Record<string, unknown>;
+  output?: string | null;
+}
+
+export interface MockConversationMessage {
+  role: "user" | "agent";
+  content: string;
+  feedback?: MockFeedback;
+  actions?: MockAction[];
+}
+
+/**
+ * Build a shrink-wrapped conversation text from a compact message list,
+ * using the real `formatConversationForShrinkWrap`.
+ */
+export function buildConversationText(
+  messages: MockConversationMessage[],
+  agentConfigSId: string = "skill-under-test"
+): string {
+  const feedbackByMessageId = new Map<
+    string,
+    { thumbDirection: AgentMessageFeedbackDirection; content: string | null }[]
+  >();
+
+  const shrinkMessages = messages.map((msg, i) => {
+    const sId = `msg_${i}`;
+    const created = 1700000000 + i * 100;
+
+    if (msg.role === "user") {
+      return {
+        type: "user_message" as const,
+        sId,
+        created,
+        content: msg.content,
+        context: { username: "user" },
+        mentions: [{ configurationId: agentConfigSId }],
+      };
+    }
+
+    if (msg.feedback) {
+      feedbackByMessageId.set(sId, [
+        {
+          thumbDirection: msg.feedback.direction,
+          content: msg.feedback.comment ?? null,
+        },
+      ]);
+    }
+
+    const actions: ShrinkWrapAction[] = (msg.actions ?? []).map((a) => ({
+      functionCallName: a.functionCallName,
+      status: a.status,
+      internalMCPServerName: null,
+      params: a.params ?? {},
+      output: a.output ?? null,
+    }));
+
+    return {
+      type: "agent_message" as const,
+      sId,
+      created,
+      content: msg.content,
+      status: "succeeded",
+      configuration: { sId: agentConfigSId, name: "Agent" },
+      actions,
+      parentAgentMessageId: null,
+    };
+  });
+
+  return formatConversationForShrinkWrap(
+    { sId: "conv_eval", title: "Eval conversation", messages: shrinkMessages },
+    { feedbackByMessageId, includeActionDetails: true }
+  );
+}
+
+export interface MockSkillConfig {
+  name: string;
+  sId: string;
+  description?: string;
+  instructions?: string;
+  /** Tools already configured on the skill. */
+  tools?: Array<{ name: string; sId: string }>;
+}
+
+interface BaseTestCase {
+  scenarioId: string;
+  expectedToolCalls?: ToolCallAssertion[];
+  judgeCriteria: string;
+  workspaceContext: WorkspaceContext;
+}
+
+export interface AnalysisTestCase extends BaseTestCase {
+  type: "analysis";
+  skillConfigs: MockSkillConfig[];
+  conversation: MockConversationMessage[];
+}
+
+export interface AggregationTestCase extends BaseTestCase {
+  type: "aggregation";
+  skillConfig: MockSkillConfig;
+  syntheticSuggestions: SkillSuggestionType[];
+  existingSuggestions?: {
+    pending: SkillSuggestionType[];
+    rejected: SkillSuggestionType[];
+  };
+}
+
+export type TestCase = AnalysisTestCase | AggregationTestCase;
+
+export function isAnalysisTestCase(tc: TestCase): tc is AnalysisTestCase {
+  return tc.type === "analysis";
+}
+
+export function isAggregationTestCase(tc: TestCase): tc is AggregationTestCase {
+  return tc.type === "aggregation";
+}
+
+/** Returns a short description of the test case input for display/logging. */
+export function getTestCaseInputForDisplay(testCase: TestCase): string {
+  switch (testCase.type) {
+    case "analysis": {
+      const skillNames = testCase.skillConfigs.map((s) => s.name).join(", ");
+      const convSummary = testCase.conversation
+        .map((m) => `[${m.role}]: ${m.content.slice(0, 100)}`)
+        .join("\n");
+      return [`Skills: ${skillNames}`, `Conversation:\n${convSummary}`]
+        .filter(Boolean)
+        .join("\n");
+    }
+    case "aggregation":
+      return [
+        `Skill: ${testCase.skillConfig.name}`,
+        `Synthetic suggestions: ${testCase.syntheticSuggestions.length}`,
+      ].join("\n");
+  }
+}
+
+/** TestCase with category assigned by suite loader. */
+export type CategorizedTestCase = TestCase & { category: string };
+
+export interface TestSuite {
+  name: string;
+  description: string;
+  testCases: TestCase[];
+}
+
+export interface ToolCall {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export type ToolCallAssertion =
+  | { type: "instructionSuggestion"; skillId: string }
+  | { type: "toolSuggestion"; skillId: string; toolId: string }
+  | { type: "noSuggestion" };
+
+export function instructionSuggestion(skillId: string): ToolCallAssertion {
+  return { type: "instructionSuggestion", skillId };
+}
+
+export function toolSuggestion(
+  skillId: string,
+  toolId: string
+): ToolCallAssertion {
+  return { type: "toolSuggestion", skillId, toolId };
+}
+
+export function noSuggestion(): ToolCallAssertion {
+  return { type: "noSuggestion" };
+}
+
+export interface JudgeResult {
+  finalScore: number;
+  scores: number[];
+  reasoning: string;
+}
+
+export interface ExecutionResult {
+  responseText: string;
+  toolCalls: ToolCall[];
+}

--- a/front/tests/reinforcement-evals/reinforcement-eval.test.ts
+++ b/front/tests/reinforcement-evals/reinforcement-eval.test.ts
@@ -1,0 +1,186 @@
+import type { Authenticator } from "@app/lib/auth";
+import { validateToolCallAssertion } from "@app/tests/reinforcement-evals/lib/assertions";
+import {
+  BATCH_TIMEOUT_MS,
+  FILTER_CATEGORY,
+  FILTER_SCENARIO,
+  getReinforcementEvalAuth,
+  JUDGE_RUNS,
+  PASS_THRESHOLD,
+  RUN_REINFORCEMENT_EVAL,
+  TIMEOUT_MS,
+  USE_BATCH,
+  VERBOSE,
+} from "@app/tests/reinforcement-evals/lib/config";
+import { evaluateWithJudge } from "@app/tests/reinforcement-evals/lib/judge";
+import {
+  executeBatch,
+  executeReinforced,
+} from "@app/tests/reinforcement-evals/lib/reinforcement-executor";
+import { filterTestCases } from "@app/tests/reinforcement-evals/lib/suite-loader";
+import type {
+  CategorizedTestCase,
+  ExecutionResult,
+  ToolCall,
+} from "@app/tests/reinforcement-evals/lib/types";
+import { allTestSuites } from "@app/tests/reinforcement-evals/test-suites";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+function formatToolCallSummary(tc: ToolCall): string {
+  const args = tc.arguments as Record<string, unknown>;
+  switch (tc.name) {
+    case "suggest_skill_instruction_edits": {
+      const suggestions = args.suggestions as
+        | Array<{ skillId?: string }>
+        | undefined;
+      if (suggestions) {
+        const items = suggestions.map((s) => s.skillId ?? "?").join(", ");
+        return `suggest_skill_instruction_edits(${items})`;
+      }
+      return "suggest_skill_instruction_edits()";
+    }
+    case "suggest_skill_tools": {
+      const suggestions = args.suggestions as
+        | Array<{ skillId?: string; action?: string; toolId?: string }>
+        | undefined;
+      if (suggestions) {
+        const items = suggestions
+          .map(
+            (s) =>
+              `${s.action ?? "?"} ${s.toolId ?? "?"} on ${s.skillId ?? "?"}`
+          )
+          .join(", ");
+        return `suggest_skill_tools(${items})`;
+      }
+      return "suggest_skill_tools()";
+    }
+    default:
+      return tc.name;
+  }
+}
+
+function formatToolCalls(toolCalls: ToolCall[]): string {
+  return toolCalls.map(formatToolCallSummary).join(", ");
+}
+
+vi.mock("openai", async (importOriginal) => {
+  const actual = await importOriginal();
+  // @ts-expect-error actual is unknown
+  const OriginalOpenAI = actual.OpenAI;
+  class OpenAIWithBrowserSupport extends OriginalOpenAI {
+    constructor(config: ConstructorParameters<typeof OriginalOpenAI>[0]) {
+      super({ ...config, dangerouslyAllowBrowser: true });
+    }
+  }
+  return { ...(actual as object), OpenAI: OpenAIWithBrowserSupport };
+});
+
+vi.mock("@anthropic-ai/sdk", async (importOriginal) => {
+  const actual = await importOriginal();
+  // @ts-expect-error actual is unknown
+  const OriginalAnthropic = actual.default;
+  class AnthropicWithBrowserSupport extends OriginalAnthropic {
+    constructor(config: ConstructorParameters<typeof OriginalAnthropic>[0]) {
+      super({ ...config, dangerouslyAllowBrowser: true });
+    }
+  }
+  return { ...(actual as object), default: AnthropicWithBrowserSupport };
+});
+
+const testCases = RUN_REINFORCEMENT_EVAL
+  ? filterTestCases(allTestSuites, {
+      category: FILTER_CATEGORY,
+      scenarioId: FILTER_SCENARIO,
+    })
+  : [];
+
+const testGroups = new Map<string, Map<string, CategorizedTestCase>>();
+for (const testCase of testCases) {
+  if (!testGroups.has(testCase.category)) {
+    testGroups.set(testCase.category, new Map());
+  }
+  testGroups.get(testCase.category)!.set(testCase.scenarioId, testCase);
+}
+
+describe.skipIf(!RUN_REINFORCEMENT_EVAL)(
+  "Reinforced Skills Evaluation Tests",
+  () => {
+    let auth: Authenticator;
+
+    // In batch mode, all results are pre-computed in beforeAll.
+    let batchResults: Map<string, ExecutionResult> | null = null;
+
+    beforeAll(
+      async () => {
+        auth = await getReinforcementEvalAuth();
+
+        if (USE_BATCH) {
+          batchResults = await executeBatch(auth, testCases);
+        }
+      },
+      USE_BATCH ? BATCH_TIMEOUT_MS : TIMEOUT_MS
+    );
+
+    for (const [category, scenarios] of testGroups) {
+      describe(category, () => {
+        for (const [scenarioId, testCase] of scenarios) {
+          // In batch mode tests are sequential (results already computed).
+          // In non-batch mode tests run concurrently via streaming.
+          const testFn = USE_BATCH ? it : it.concurrent;
+
+          testFn(
+            scenarioId,
+            async () => {
+              const result: ExecutionResult = USE_BATCH
+                ? (() => {
+                    const r = batchResults!.get(scenarioId);
+                    if (!r) {
+                      throw new Error(
+                        `No batch result for scenario "${scenarioId}"`
+                      );
+                    }
+                    return r;
+                  })()
+                : await executeReinforced(auth, testCase);
+
+              const { responseText, toolCalls } = result;
+
+              if (VERBOSE) {
+                console.log(
+                  `[${scenarioId}] Tool calls:`,
+                  JSON.stringify(toolCalls, null, 2)
+                );
+                console.log(`[${scenarioId}] Response:`, responseText);
+              }
+
+              const judgeResult = await evaluateWithJudge(
+                auth,
+                testCase,
+                toolCalls,
+                responseText,
+                JUDGE_RUNS
+              );
+
+              const passedJudge = judgeResult.finalScore >= PASS_THRESHOLD;
+              const toolCallsSummary = formatToolCalls(toolCalls);
+
+              for (const assertion of testCase.expectedToolCalls ?? []) {
+                const result = validateToolCallAssertion(assertion, toolCalls);
+                expect(
+                  result.success,
+                  `${!result.success ? result.error : ""}\n\nTool calls: [${toolCallsSummary}]\nResponse:\n${responseText}`
+                ).toBe(true);
+              }
+
+              expect(
+                passedJudge,
+                `Judge score ${judgeResult.finalScore} < threshold ${PASS_THRESHOLD}\nReasoning: ${judgeResult.reasoning}\n\nTool calls: [${toolCallsSummary}]\nResponse:\n${responseText}`
+              ).toBe(true);
+            },
+            TIMEOUT_MS
+          );
+        }
+      });
+    }
+  }
+);

--- a/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
@@ -1,0 +1,280 @@
+import {
+  instructionSuggestion,
+  mockTool,
+  noSuggestion,
+  type TestSuite,
+  toolSuggestion,
+  type WorkspaceContext,
+} from "@app/tests/reinforcement-evals/lib/types";
+import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+
+const SKILL_SID = "skill_customer_support";
+
+function makeInstructionSuggestion(input: {
+  sId: string;
+  analysis: string;
+  instructions: string;
+  skillConfigurationId?: string;
+  source?: "reinforcement" | "synthetic";
+}): SkillSuggestionType {
+  return {
+    sId: input.sId,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    skillConfigurationId: input.skillConfigurationId ?? SKILL_SID,
+    analysis: input.analysis,
+    state: "pending",
+    source: input.source ?? "synthetic",
+    sourceConversationId: null,
+    kind: "edit_instructions",
+    suggestion: { instructions: input.instructions },
+  };
+}
+
+function makeToolSuggestion(input: {
+  sId: string;
+  analysis: string;
+  action: "add" | "remove";
+  toolId: string;
+  skillConfigurationId?: string;
+  source?: "reinforcement" | "synthetic";
+}): SkillSuggestionType {
+  return {
+    sId: input.sId,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    skillConfigurationId: input.skillConfigurationId ?? SKILL_SID,
+    analysis: input.analysis,
+    state: "pending",
+    source: input.source ?? "synthetic",
+    sourceConversationId: null,
+    kind: "tools",
+    suggestion: { action: input.action, toolId: input.toolId },
+  };
+}
+
+const WORKSPACE_CONTEXT: WorkspaceContext = {
+  tools: [
+    mockTool("Slack", "Read and send Slack messages"),
+    mockTool("Notion", "Search Notion workspace"),
+    mockTool("GitHub", "Access GitHub repositories"),
+    mockTool("JIRA", "Search and manage JIRA issues and projects"),
+    mockTool(
+      "Web Search",
+      "Search the web for current information and real-time data"
+    ),
+  ],
+};
+
+export const aggregateSuggestionsSuite: TestSuite = {
+  name: "aggregate-suggestions",
+  description:
+    "Aggregate multiple synthetic suggestions into merged, prioritised skill recommendations",
+  testCases: [
+    {
+      scenarioId: "merge-duplicate-instructions",
+      type: "aggregation",
+      skillConfig: {
+        name: "Customer Support",
+        sId: SKILL_SID,
+        description: "Handles customer support inquiries",
+        instructions: "Help customers with their questions. Be professional.",
+      },
+      syntheticSuggestions: [
+        makeInstructionSuggestion({
+          sId: "sug-1",
+          analysis:
+            "User complained that the skill's responses were too blunt and impersonal. The instructions should emphasize a warmer, more empathetic tone.",
+          instructions:
+            "Help customers with their questions. Be professional, warm, and empathetic. Acknowledge the customer's situation before providing solutions.",
+        }),
+        makeInstructionSuggestion({
+          sId: "sug-2",
+          analysis:
+            "User found the skill's language too robotic. The instructions should guide the skill to use more natural, conversational language.",
+          instructions:
+            "Help customers with their questions. Be professional and use natural, conversational language. Avoid formulaic or robotic phrasing.",
+        }),
+        makeInstructionSuggestion({
+          sId: "sug-3",
+          analysis:
+            "User reported the skill jumped straight to solutions without acknowledging the problem. Instructions should include empathy-first guidance.",
+          instructions:
+            "Help customers with their questions. Be professional. Always acknowledge the customer's frustration before jumping to a solution.",
+        }),
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [instructionSuggestion(SKILL_SID)],
+      judgeCriteria: `The analyst MUST call suggest_skill_instruction_edits with a single merged suggestion
+for skill "${SKILL_SID}". The merged suggestion should:
+- Combine all three themes: warmth/empathy, natural language, and acknowledge-first approach
+- Mention that 3 conversations support this suggestion
+- Provide well-structured instructions covering all three aspects
+- NOT create 3 separate suggestions — they must be merged into one
+
+Score 0 if no suggest_skill_instruction_edits call or if it creates 3 separate suggestions.
+Score 1 if merged but missing one or more key themes (warmth, natural language, acknowledge-first).
+Score 2 if all themes included but the merged instructions are disorganized or analysis is weak.
+Score 3 if well-merged with all themes, clear structure, and analysis referencing multiple conversations.`,
+    },
+    {
+      scenarioId: "merge-duplicate-tools",
+      type: "aggregation",
+      skillConfig: {
+        name: "Engineering Helper",
+        sId: "skill_engineering",
+        description: "Helps engineers with day-to-day tasks",
+        instructions:
+          "Help engineers with their daily work. Assist with task management and process questions.",
+      },
+      syntheticSuggestions: [
+        makeToolSuggestion({
+          sId: "sug-1",
+          skillConfigurationId: "skill_engineering",
+          analysis:
+            "User asked to create a JIRA ticket but the skill couldn't. Adding JIRA would enable direct ticket creation.",
+          action: "add",
+          toolId: "mcp_jira",
+        }),
+        makeToolSuggestion({
+          sId: "sug-2",
+          skillConfigurationId: "skill_engineering",
+          analysis:
+            "User wanted to check sprint status in JIRA. The skill had no way to query JIRA data.",
+          action: "add",
+          toolId: "mcp_jira",
+        }),
+        makeToolSuggestion({
+          sId: "sug-3",
+          skillConfigurationId: "skill_engineering",
+          analysis:
+            "User asked to assign a JIRA ticket to a teammate. Without the JIRA tool, the skill could only suggest doing it manually.",
+          action: "add",
+          toolId: "mcp_jira",
+        }),
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [toolSuggestion("skill_engineering", "mcp_jira")],
+      judgeCriteria: `The analyst MUST call suggest_skill_tools to suggest adding JIRA (mcp_jira)
+to skill "skill_engineering". The aggregated suggestion should:
+- Merge the 3 individual suggestions into a single recommendation
+- Mention that 3 conversations support this suggestion
+- Include a comprehensive analysis covering the different use cases (ticket creation, sprint status, assignment)
+- Use action "add" with toolId "mcp_jira"
+
+Score 0 if no suggest_skill_tools call or if it creates 3 separate suggestions.
+Score 1 if merged but analysis doesn't reference multiple conversations/use cases.
+Score 2 if properly merged with multi-conversation reference but analysis could be better.
+Score 3 if well-merged with clear analysis covering all use cases and conversation count.`,
+    },
+    {
+      scenarioId: "dedup-vs-pending",
+      type: "aggregation",
+      skillConfig: {
+        name: "Customer Support",
+        sId: SKILL_SID,
+        description: "Handles customer support inquiries",
+        instructions: "Help customers with their questions. Be professional.",
+      },
+      syntheticSuggestions: [
+        makeInstructionSuggestion({
+          sId: "sug-1",
+          analysis:
+            "User complained about the skill's tone being too cold. The skill should adopt a warmer communication style with more empathy.",
+          instructions:
+            "Help customers with their questions. Be professional, warm, and empathetic. Show care for the customer's needs.",
+        }),
+      ],
+      existingSuggestions: {
+        pending: [
+          makeInstructionSuggestion({
+            sId: "existing-pending-1",
+            source: "reinforcement",
+            analysis:
+              "Multiple users found responses impersonal. Adding warmth and a friendlier tone would improve satisfaction.",
+            instructions:
+              "Help customers with their questions. Be professional. Use a warm, conversational tone. Be friendly and approachable. Show genuine care for the user's needs.",
+          }),
+        ],
+        rejected: [],
+      },
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [noSuggestion()],
+      judgeCriteria: `The synthetic suggestion about tone/warmth is essentially the same as the existing pending
+suggestion. The analyst must not duplicate it.
+
+Score 0 if it creates a suggestion similar to the existing pending one (tone/warmth/friendliness).
+Score 1 if it creates an unrelated suggestion.
+Score 3 if no suggestion is created.`,
+    },
+    {
+      scenarioId: "dedup-vs-rejected",
+      type: "aggregation",
+      skillConfig: {
+        name: "Customer Support",
+        sId: SKILL_SID,
+        description: "Handles customer support inquiries",
+        instructions: "Help customers with their questions. Be professional.",
+      },
+      syntheticSuggestions: [
+        makeInstructionSuggestion({
+          sId: "sug-1",
+          analysis:
+            "User was frustrated that the skill didn't acknowledge their problem before jumping to solutions. The skill should show empathy first.",
+          instructions:
+            "Help customers with their questions. Be professional. When users report issues, always acknowledge their frustration and show understanding before providing a solution.",
+        }),
+      ],
+      existingSuggestions: {
+        pending: [],
+        rejected: [
+          makeInstructionSuggestion({
+            sId: "existing-rejected-1",
+            source: "reinforcement",
+            analysis:
+              "Users wanted more empathetic responses. The skill should acknowledge frustration and show understanding before jumping to solutions.",
+            instructions:
+              "Help customers with their questions. Be professional. When users report problems, first acknowledge their frustration. Show understanding and empathy before providing solutions.",
+          }),
+        ],
+      },
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [noSuggestion()],
+      judgeCriteria: `The synthetic suggestion about empathy/acknowledging frustration is essentially the same
+as a previously rejected suggestion. The analyst must not recreate it.
+
+Score 0 if it creates a suggestion similar to the rejected one (empathy/acknowledging frustration).
+Score 1 if it creates an unrelated suggestion.
+Score 3 if no suggestion is created.`,
+    },
+    {
+      scenarioId: "drop-minor-single",
+      type: "aggregation",
+      skillConfig: {
+        name: "Writing Assistant",
+        sId: "skill_writing",
+        description: "Helps with writing tasks",
+        instructions:
+          "Help users write and edit text. Focus on clarity and correctness.",
+      },
+      syntheticSuggestions: [
+        makeInstructionSuggestion({
+          sId: "sug-1",
+          skillConfigurationId: "skill_writing",
+          analysis:
+            "User found responses slightly long. The skill tends to include one or two unnecessary filler sentences at the end.",
+          instructions:
+            "Help users write and edit text. Focus on clarity and correctness. Keep responses concise. Avoid unnecessary filler sentences.",
+        }),
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [noSuggestion()],
+      judgeCriteria: `There is only one synthetic suggestion from a single conversation, and the issue is minor
+(slight verbosity / filler sentences — a style preference). According to prioritisation rules,
+low-severity issues from a single conversation should be dropped.
+
+Score 0 if it creates any suggestion based on this single minor synthetic input.
+Score 3 if no suggestion is created (correct: single low-severity conversation is insufficient evidence).`,
+    },
+  ],
+};

--- a/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
@@ -7,8 +7,6 @@ import {
   type WorkspaceContext,
 } from "@app/tests/reinforcement-evals/lib/types";
 
-const SKILL_SID = "skill_customer_support";
-
 const WORKSPACE_CONTEXT: WorkspaceContext = {
   tools: [
     mockTool("Slack", "Read and send Slack messages"),

--- a/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
@@ -1,0 +1,363 @@
+import {
+  instructionSuggestion,
+  mockTool,
+  noSuggestion,
+  type TestSuite,
+  toolSuggestion,
+  type WorkspaceContext,
+} from "@app/tests/reinforcement-evals/lib/types";
+
+const SKILL_SID = "skill_customer_support";
+
+const WORKSPACE_CONTEXT: WorkspaceContext = {
+  tools: [
+    mockTool("Slack", "Read and send Slack messages"),
+    mockTool("Notion", "Search Notion workspace"),
+    mockTool("GitHub", "Access GitHub repositories"),
+    mockTool("JIRA", "Search and manage JIRA issues and projects"),
+    mockTool(
+      "Web Search",
+      "Search the web for current information and real-time data"
+    ),
+    mockTool(
+      "Calendar",
+      "Manage calendar events, check availability, and schedule meetings"
+    ),
+  ],
+};
+
+export const analyzeConversationSuite: TestSuite = {
+  name: "analyze-conversation",
+  description:
+    "Analyze conversations to generate synthetic suggestions for skill improvements",
+  testCases: [
+    {
+      scenarioId: "unclear-instructions",
+      type: "analysis",
+      skillConfigs: [
+        {
+          name: "Meeting Scheduler",
+          sId: "skill_meeting_scheduler",
+          description: "Helps schedule meetings",
+          instructions: "Help with meetings.",
+          tools: [{ name: "Calendar", sId: "mcp_calendar" }],
+        },
+      ],
+      conversation: [
+        {
+          role: "user",
+          content: "Can you schedule a meeting with Sarah for tomorrow at 2pm?",
+        },
+        {
+          role: "agent",
+          content:
+            "I can help with meetings. What would you like me to do exactly?",
+        },
+        {
+          role: "user",
+          content:
+            "I just told you — schedule a meeting with Sarah tomorrow at 2pm. Why are you asking me again?",
+        },
+        {
+          role: "agent",
+          content:
+            "I apologize for the confusion. Let me check Sarah's availability for tomorrow at 2pm.",
+          actions: [
+            {
+              functionCallName: "calendar-check-availability",
+              status: "succeeded",
+              params: { user: "Sarah", date: "tomorrow", time: "2pm" },
+              output: '{"available": true}',
+            },
+            {
+              functionCallName: "calendar-create-event",
+              status: "succeeded",
+              params: {
+                title: "Meeting with Sarah",
+                date: "tomorrow",
+                time: "2pm",
+              },
+              output: '{"eventId": "evt_123"}',
+            },
+          ],
+        },
+        {
+          role: "user",
+          content:
+            "Finally. The instructions for this skill seem really vague.",
+          feedback: {
+            direction: "down",
+            comment:
+              "Skill instructions are too vague — it didn't know what to do with a straightforward scheduling request.",
+          },
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [instructionSuggestion("skill_meeting_scheduler")],
+      judgeCriteria: `The analyst MUST call suggest_skill_instruction_edits for skill "skill_meeting_scheduler".
+The suggestion should:
+- Provide clearer instructions that explain the skill should proactively schedule meetings when given enough information (attendee, date, time)
+- Reference that the current instructions ("Help with meetings.") are too vague
+- Include guidance on checking availability before scheduling
+- Have a meaningful analysis referencing the user's confusion
+
+Score 0 if no suggest_skill_instruction_edits call is made.
+Score 0-1 if the suggestion doesn't substantially improve the instructions' clarity.
+Score 2 if the suggestion improves clarity but misses key details (e.g., check availability first).
+Score 3 if the suggestion provides clear, actionable instructions that would prevent the observed confusion.`,
+    },
+    {
+      scenarioId: "missing-tool",
+      type: "analysis",
+      skillConfigs: [
+        {
+          name: "Research Assistant",
+          sId: "skill_research",
+          description:
+            "Helps users research topics and find current information",
+          instructions:
+            "Help users research topics thoroughly. Search for up-to-date information when needed. Cite sources when possible.",
+        },
+      ],
+      conversation: [
+        {
+          role: "user",
+          content:
+            "Can you find the latest news about the EU AI Act regulations?",
+        },
+        {
+          role: "agent",
+          content:
+            "I don't currently have the ability to search the web for real-time information. Based on what I know, the EU AI Act was adopted in 2024, but I may not have the most current developments. Would you like me to help with what I have?",
+        },
+        {
+          role: "user",
+          content:
+            "That's really frustrating. A research skill without web search is useless for finding current information.",
+          feedback: {
+            direction: "down",
+            comment:
+              "Research skill needs web search to be useful for current topics.",
+          },
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [toolSuggestion("skill_research", "mcp_web_search")],
+      judgeCriteria: `The analyst MUST call suggest_skill_tools to suggest adding the Web Search tool
+(mcp_web_search) to skill "skill_research". The suggestion should:
+- Recommend adding Web Search (toolId: mcp_web_search) with action "add"
+- Include an analysis explaining that the skill's purpose requires web search for current information
+- Reference that the agent couldn't fulfill the user's core request without this capability
+
+Score 0 if no suggest_skill_tools call is made.
+Score 0-1 if suggest_skill_tools is called but with the wrong tool ID or wrong skill ID.
+Score 2 if the correct tool is suggested but the analysis is weak.
+Score 3 if the correct tool is suggested with a clear, well-reasoned analysis.`,
+    },
+    {
+      scenarioId: "unused-tool",
+      type: "analysis",
+      skillConfigs: [
+        {
+          name: "Code Review Helper",
+          sId: "skill_code_review",
+          description: "Helps review code and suggest improvements",
+          instructions:
+            "Review code provided by the user. Focus on code quality, potential bugs, and best practices. Suggest improvements.",
+          tools: [
+            { name: "GitHub", sId: "mcp_github" },
+            { name: "Calendar", sId: "mcp_calendar" },
+          ],
+        },
+      ],
+      conversation: [
+        {
+          role: "user",
+          content:
+            "Can you review this function?\n\nfunction add(a, b) { return a + b; }",
+        },
+        {
+          role: "agent",
+          content:
+            "Here's my review of the function:\n\n1. **Type safety**: The function lacks type annotations. Consider using TypeScript.\n2. **Edge cases**: No input validation for non-numeric values.\n3. **Naming**: The function name is clear and concise.\n\nSuggested improvement:\n```typescript\nfunction add(a: number, b: number): number {\n  return a + b;\n}\n```",
+          actions: [
+            {
+              functionCallName: "calendar-list-events",
+              status: "failed",
+              params: {},
+              output: "Error: not relevant to the current task",
+            },
+          ],
+        },
+        {
+          role: "user",
+          content:
+            "Good review, but why did it try to access my calendar? That's weird for a code review.",
+          feedback: {
+            direction: "down",
+            comment:
+              "The Calendar tool has nothing to do with code review and caused a confusing error.",
+          },
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [toolSuggestion("skill_code_review", "mcp_calendar")],
+      judgeCriteria: `The analyst MUST call suggest_skill_tools to suggest removing the Calendar tool
+(mcp_calendar) from skill "skill_code_review". The suggestion should:
+- Recommend removing Calendar (toolId: mcp_calendar) with action "remove"
+- Include an analysis explaining that Calendar is irrelevant to code review and caused confusion
+- Reference the failed tool call and user complaint
+
+Score 0 if no suggest_skill_tools call is made.
+Score 0-1 if suggest_skill_tools is called but with the wrong action (add instead of remove).
+Score 2 if the correct tool removal is suggested but the analysis is weak.
+Score 3 if the correct removal is suggested with a clear analysis referencing the confusion it caused.`,
+    },
+    {
+      scenarioId: "instruction-and-tool-gap",
+      type: "analysis",
+      skillConfigs: [
+        {
+          name: "Bug Reporter",
+          sId: "skill_bug_reporter",
+          description: "Helps file bug reports from user descriptions",
+          instructions:
+            "When a user describes a bug, create a well-structured bug report with steps to reproduce, expected behavior, and actual behavior. File the bug report in the project tracker.",
+        },
+      ],
+      conversation: [
+        {
+          role: "user",
+          content:
+            "The login page crashes when I enter a special character in the password field. Can you file a bug for this?",
+        },
+        {
+          role: "agent",
+          content:
+            "I've prepared a bug report:\n\n**Title**: Login page crash on special characters in password\n**Steps to reproduce**: Enter a special character in the password field on the login page\n**Expected**: Password field accepts special characters\n**Actual**: Page crashes\n\nHowever, I don't have access to a project tracker to file this. You'll need to copy this into JIRA or your tracker manually.",
+        },
+        {
+          role: "user",
+          content:
+            "The instructions say to file it in the tracker but the skill can't actually do that. Pretty broken.",
+          feedback: {
+            direction: "down",
+            comment:
+              "Skill promises to file bugs but has no tool to do it. Instructions and tools are mismatched.",
+          },
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [
+        instructionSuggestion("skill_bug_reporter"),
+        toolSuggestion("skill_bug_reporter", "mcp_jira"),
+      ],
+      judgeCriteria: `The analyst MUST make BOTH types of suggestions for skill "skill_bug_reporter":
+1. suggest_skill_instruction_edits to update instructions to reference the JIRA tool for filing
+2. suggest_skill_tools to add JIRA (mcp_jira) so the skill can actually file bugs
+
+The suggestions should be co-dependent — the instructions should reference using JIRA,
+and the tool addition provides the capability.
+
+Score 0 if only one type of suggestion is made.
+Score 1 if both are made but the instructions don't reference the tool, or the analysis is weak.
+Score 2 if both are made with decent analysis but the instruction/tool connection isn't explicit.
+Score 3 if both are made with clear co-dependency: instructions reference JIRA, tool provides the capability, and analysis explains the mismatch.`,
+    },
+    {
+      scenarioId: "successful-conversation",
+      type: "analysis",
+      skillConfigs: [
+        {
+          name: "Data Lookup",
+          sId: "skill_data_lookup",
+          description: "Looks up data in Notion for the team",
+          instructions:
+            "Search Notion for the requested information. Present findings clearly with source references. If multiple results match, show the most relevant ones.",
+          tools: [{ name: "Notion", sId: "mcp_notion" }],
+        },
+      ],
+      conversation: [
+        {
+          role: "user",
+          content: "What's the Q1 revenue target for 2026?",
+        },
+        {
+          role: "agent",
+          content:
+            'According to the "2026 Revenue Targets" page in Notion, the Q1 target is **$2.5M**, representing 15% growth over Q4 2025.',
+          actions: [
+            {
+              functionCallName: "notion-search",
+              status: "succeeded",
+              params: { query: "Q1 2026 revenue target" },
+              output:
+                '{"results": [{"title": "2026 Revenue Targets", "content": "Q1: $2.5M (15% QoQ growth)"}]}',
+            },
+          ],
+          feedback: {
+            direction: "up",
+          },
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [noSuggestion()],
+      judgeCriteria: `This is a smooth, successful conversation. The skill searched Notion, found accurate data,
+cited the source, and presented it clearly. The user gave a thumbs up.
+
+There is nothing to improve — no negative feedback, no tool errors, no confusion.
+
+Score 0 if any substantive suggestion is made.
+Score 3 if no suggestion is created (empty suggestions arrays only).`,
+    },
+    {
+      scenarioId: "user-feedback-driven",
+      type: "analysis",
+      skillConfigs: [
+        {
+          name: "Email Drafter",
+          sId: "skill_email_drafter",
+          description: "Drafts professional emails",
+          instructions:
+            "Draft emails based on user requests. Keep them professional and concise.",
+          tools: [{ name: "Slack", sId: "mcp_slack" }],
+        },
+      ],
+      conversation: [
+        {
+          role: "user",
+          content:
+            "Draft an email to the client apologizing for the delayed shipment.",
+        },
+        {
+          role: "agent",
+          content:
+            "Subject: Shipment Delay Notification\n\nDear Customer,\n\nWe regret to inform you that your shipment has been delayed. We are working to resolve this.\n\nRegards,\nThe Team",
+        },
+        {
+          role: "user",
+          content:
+            "This is way too generic. I need it to sound empathetic and offer a specific remedy, like a discount or expedited shipping. The skill should know our company's tone — we're a premium brand.",
+          feedback: {
+            direction: "down",
+            comment:
+              "Email is generic and doesn't match our premium brand voice. Should include specific remedies for delays.",
+          },
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [instructionSuggestion("skill_email_drafter")],
+      judgeCriteria: `The analyst MUST call suggest_skill_instruction_edits for skill "skill_email_drafter".
+The suggestion should:
+- Add guidance about using a premium, empathetic brand voice
+- Include direction to offer specific remedies when addressing complaints
+- Reference the user's explicit feedback about generic tone and missing remedies
+- Preserve the existing instruction about being professional and concise
+
+Score 0 if no suggest_skill_instruction_edits call is made.
+Score 0-1 if the suggestion is generic and doesn't address the specific feedback points.
+Score 2 if the suggestion addresses tone but misses the remedy guidance (or vice versa).
+Score 3 if the suggestion addresses both brand voice and remedy guidance with a clear analysis.`,
+    },
+  ],
+};

--- a/front/tests/reinforcement-evals/test-suites/index.ts
+++ b/front/tests/reinforcement-evals/test-suites/index.ts
@@ -1,0 +1,8 @@
+import type { TestSuite } from "@app/tests/reinforcement-evals/lib/types";
+import { aggregateSuggestionsSuite } from "@app/tests/reinforcement-evals/test-suites/aggregate-suggestions";
+import { analyzeConversationSuite } from "@app/tests/reinforcement-evals/test-suites/analyze-conversation";
+
+export const allTestSuites: TestSuite[] = [
+  analyzeConversationSuite,
+  aggregateSuggestionsSuite,
+];

--- a/front/tests/reinforcement-evals/vite.config.mjs
+++ b/front/tests/reinforcement-evals/vite.config.mjs
@@ -1,0 +1,44 @@
+import { defineConfig } from "vite";
+import { mergeConfig } from "vite";
+
+import baseConfig from "../../vite.config.mjs";
+
+export default defineConfig(() => {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error(
+      `NODE_ENV must be set to "test" (value: ${process.env.NODE_ENV}). Action: make sure your have the correct environment variable set.`
+    );
+  }
+
+  const testConfig = defineConfig({
+    test: {
+      env: {
+        // Skip tests by default, unless explicitly enabled.
+        RUN_REINFORCEMENT_EVAL: process.env.RUN_REINFORCEMENT_EVAL ?? "false",
+        // Batch mode: "true" to submit all prompts via the LLM batch API.
+        USE_BATCH: process.env.USE_BATCH ?? "false",
+        // Filtering.
+        FILTER_CATEGORY: process.env.FILTER_CATEGORY ?? "",
+        FILTER_SCENARIO: process.env.FILTER_SCENARIO ?? "",
+        // Judge configuration.
+        JUDGE_RUNS: process.env.JUDGE_RUNS ?? "3",
+        PASS_THRESHOLD: process.env.PASS_THRESHOLD ?? "2",
+        // Model override for the reinforced skills LLM.
+        VERBOSE: process.env.VERBOSE ?? "false",
+        REINFORCEMENT_MODEL_ID: process.env.REINFORCEMENT_MODEL_ID ?? "",
+        // API keys forwarded from the shell environment.
+        DUST_MANAGED_ANTHROPIC_API_KEY:
+          process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
+        DUST_MANAGED_OPENAI_API_KEY:
+          process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+      },
+      testTimeout: 300000,
+    },
+  });
+
+  // Merge with base config and override globalSetup.
+  const merged = mergeConfig(baseConfig, testConfig);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  merged.test.globalSetup = [];
+  return merged;
+});


### PR DESCRIPTION
## Description

- Adds a new evaluation test suite at tests/reinforcement-evals/ for the reinforced skills pipeline (lib/reinforcement/), mirroring the architecture of the existing reinforced agent evals. Note that I stayed away from using any common code with reinforced agent, even though it's quite similar. Since the other one might just go away...
- Includes 6 conversation analysis scenarios (unclear instructions, missing tool, unused tool, instruction+tool gap, successful conversation, user feedback) and 5 aggregation scenarios (merge duplicate instructions, merge duplicate tools, dedup vs pending, dedup vs rejected, drop minor single)
- Uses dual validation: structural assertions on tool calls (suggest_skill_instruction_edits, suggest_skill_tools) plus LLM-as-judge quality scoring

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
