### PR TITLE
[front] - fix(ab): enhance member table with improved avatar rendering

### DIFF
--- a/front/components/members/MemberSelectionTable.tsx
+++ b/front/components/members/MemberSelectionTable.tsx
@@ -1,6 +1,7 @@
 import { useSearchMembers } from "@app/lib/swr/memberships";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import {
+  Avatar,
   createSelectionColumn,
   DataTable,
   SearchInput,
@@ -130,15 +131,22 @@ export function MemberSelectionTable({
         meta: {
           className: "w-full",
         },
-        cell: (info: CellContext<MemberRowData, unknown>) => (
-          <DataTable.CellContent
-            avatarUrl={info.row.original.image}
-            roundedAvatar
-            description={info.row.original.email}
-          >
-            {info.row.original.fullName}
-          </DataTable.CellContent>
-        ),
+        cell: (info: CellContext<MemberRowData, unknown>) => {
+          const { fullName, image, email } = info.row.original;
+          return (
+            <DataTable.CellContent description={email}>
+              <div className="flex items-center gap-2">
+                <Avatar
+                  name={fullName}
+                  visual={image || undefined}
+                  size="xs"
+                  isRounded
+                />
+                <span className="text-sm">{fullName}</span>
+              </div>
+            </DataTable.CellContent>
+          );
+        },
       },
       ...(extraColumns ?? []),
     ];


### PR DESCRIPTION

## Description

This PR replaces `DataTable` avatar rendering with Avatar component for consistency and ensures member avatars display properly even when an image is missing and improves the member row appearance

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
