### PR TITLE
[Tool Calls] Emit tool_call_started in Anthropic batch

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -550,7 +550,7 @@ async function succeededMessageToEvents(
   const toolCalls: ToolCallEvent[] = [];
   let reasoningGeneratedEvent: ReasoningGeneratedEvent | undefined = undefined;
 
-  for (const block of message.content) {
+  for (const [index, block] of message.content.entries()) {
     switch (block.type) {
       case "text":
         textBlocks.push(block.text);
@@ -571,6 +571,11 @@ async function succeededMessageToEvents(
           isRecord(block.input)
             ? block.input
             : {};
+        events.push({
+          type: "tool_call_started",
+          content: { id: block.id, index, name: block.name },
+          metadata,
+        });
         const toolCallEvent: ToolCallEvent = {
           type: "tool_call",
           content: { id: block.id, name: block.name, arguments: input },

--- a/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
@@ -1,4 +1,8 @@
-import { streamLLMEvents } from "@app/lib/api/llm/clients/anthropic/utils/anthropic_to_events";
+import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches.mjs";
+import {
+  batchResultToLLMEvents,
+  streamLLMEvents,
+} from "@app/lib/api/llm/clients/anthropic/utils/anthropic_to_events";
 import { emptyToolCallLLMEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call";
 import { reasoningLLMEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning";
 import { toolUseLLMEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use";
@@ -54,5 +58,65 @@ describe("streamLLMEvents", () => {
     expect(result).toEqual(
       emptyToolCallLLMEvents.map((e) => ({ ...e, metadata }))
     );
+  });
+});
+
+describe("batchResultToLLMEvents", () => {
+  it("should emit tool_call_started before tool_call for tool use blocks", async () => {
+    const batchResult = {
+      type: "succeeded",
+      message: {
+        id: "msg_batch_123",
+        type: "message",
+        role: "assistant",
+        model: CLAUDE_4_SONNET_20250514_MODEL_ID,
+        content: [
+          { type: "text", text: "Hello, how are you ?" },
+          {
+            type: "tool_use",
+            id: "DdHr7L197",
+            name: "web_search_browse__websearch",
+            input: { query: "Paris France weather forecast October 23 2025" },
+          },
+        ],
+        stop_reason: "tool_use",
+        stop_sequence: null,
+        usage: {
+          input_tokens: 1766,
+          output_tokens: 128,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+    } as MessageBatchResult;
+
+    const result = await batchResultToLLMEvents(batchResult, metadata);
+
+    expect(result.map((event) => event.type)).toEqual([
+      "interaction_id",
+      "text_generated",
+      "tool_call_started",
+      "tool_call",
+      "token_usage",
+      "success",
+    ]);
+    expect(result[2]).toEqual({
+      type: "tool_call_started",
+      content: {
+        id: "DdHr7L197",
+        index: 1,
+        name: "web_search_browse__websearch",
+      },
+      metadata,
+    });
+    expect(result[3]).toEqual({
+      type: "tool_call",
+      content: {
+        id: "DdHr7L197",
+        name: "web_search_browse__websearch",
+        arguments: { query: "Paris France weather forecast October 23 2025" },
+      },
+      metadata,
+    });
   });
 });


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/23695

Anthropic live streaming already emits `tool_call_started` when a `tool_use` block begins, but Anthropic batch normalization still jumped straight to `tool_call`.

This makes `batchResultToLLMEvents()` emit the same start event before the final tool call, and adds a focused regression test for that normalized sequence.

## Risks
Blast radius: Anthropic batch LLM event normalization only.
Risk: low

## Deploy Plan
- pmrr
- deploy front