### PR TITLE
Add providers in extension project page

### DIFF
--- a/extension/ui/components/ErrorFallback.tsx
+++ b/extension/ui/components/ErrorFallback.tsx
@@ -1,0 +1,30 @@
+import { Button, ExclamationCircleIcon, Icon } from "@dust-tt/sparkle";
+
+export function ErrorFallback() {
+  return (
+    <div className="flex h-dvh items-center justify-center">
+      <div className="flex flex-col gap-3 text-center mt-2">
+        <div className="flex flex-col items-center">
+          <Icon
+            visual={ExclamationCircleIcon}
+            size="lg"
+            className="text-warning-400"
+          />
+          <p className="heading-xl text-foreground dark:text-foreground-night">
+            Something went wrong
+          </p>
+          <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+            An unexpected error occurred. Please try again.
+          </p>
+        </div>
+        <div>
+          <Button
+            variant="outline"
+            label="Try again"
+            onClick={() => window.location.reload()}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/extension/ui/pages/ProjectMainPage.tsx
+++ b/extension/ui/pages/ProjectMainPage.tsx
@@ -1,3 +1,5 @@
+import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { SpaceConversationsPage } from "@app/components/pages/conversation/SpaceConversationsPage";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
@@ -16,9 +18,13 @@ export const ProjectMainPage = () => {
 
   return (
     <ConversationLayout title={spaceInfo?.name ?? ""}>
-      <ExtensionInputBarProvider workspace={workspace}>
-        <SpaceConversationsPage />
-      </ExtensionInputBarProvider>
+      <BlockedActionsProvider owner={workspace}>
+        <GenerationContextProvider>
+          <ExtensionInputBarProvider workspace={workspace}>
+            <SpaceConversationsPage />
+          </ExtensionInputBarProvider>
+        </GenerationContextProvider>
+      </BlockedActionsProvider>
     </ConversationLayout>
   );
 };

--- a/extension/ui/pages/routes.tsx
+++ b/extension/ui/pages/routes.tsx
@@ -1,4 +1,5 @@
 import { ProtectedRoute } from "@extension/ui/components/auth/ProtectedRoute";
+import { ErrorFallback } from "@extension/ui/components/ErrorFallback";
 import { LoginPage } from "@extension/ui/pages/LoginPage";
 import { MainPage } from "@extension/ui/pages/MainPage";
 import { ProjectMainPage } from "@extension/ui/pages/ProjectMainPage";
@@ -9,9 +10,11 @@ export const routes = [
   {
     path: "/login",
     element: <LoginPage />,
+    errorElement: <ErrorFallback />,
   },
   {
     element: <ProtectedRoute />,
+    errorElement: <ErrorFallback />,
     children: [
       {
         path: "/run",


### PR DESCRIPTION
## Description

Adds context providers and error handling to the extension's project page to align with the main conversation experience. The `BlockedActionsProvider` manages tool validation states for user approvals, while `GenerationContextProvider` tracks message generation status. Also introduces an `ErrorFallback` component and registers it as the `errorElement` in the extension's route configuration to gracefully handle routing errors.

## Tests

Manually tested the extension project page to verify conversation functionality works correctly with the providers.

## Risk

Low. These are established patterns from the main app being applied to the extension. The providers are already battle-tested in production conversations.

## Deploy Plan

Deploy extension