### PR TITLE
filter revoked/unused memberships in production check

### DIFF
--- a/front/lib/production_checks/checks/check_membership_active_users_consistency.ts
+++ b/front/lib/production_checks/checks/check_membership_active_users_consistency.ts
@@ -51,6 +51,10 @@ export const checkMembershipActiveUsersConsistency: CheckFunction = async (
           COUNT(DISTINCT um."userId")::int as "activeUsersByMessagesCount"
         FROM messages msg
         JOIN user_messages um ON msg."userMessageId" = um.id
+        JOIN memberships m ON m."userId" = um."userId"
+          AND m."workspaceId" = msg."workspaceId"
+          AND m."firstUsedAt" IS NOT NULL
+          AND m."endAt" IS NULL
         GROUP BY msg."workspaceId"
       )
       SELECT


### PR DESCRIPTION
## Description

The check_membership_active_users_consistency production check compares active membership count to the count of users who sent messages. The  users_with_messages CTE was missing a join on memberships, so it counted all users who ever sent a message regardless of whether their membership was revoked or unused. This caused large false mismatches for any workspace with member turnover (e.g. 4 active members vs 112 message senders).

Added a join on memberships with the same filters as the active_memberships CTE (endAt IS NULL and firstUsedAt IS NOT NULL), so both sides of the comparison use the same definition of "active member."

Note: the check still has a structural limitation where it flags workspaces where active members simply haven't sent messages yet. That's a separate  improvement.

## Tests / Risk / Deploy plan

Deploy and verify the production check no longer flags workspaces that only have mismatches due to revoked members.

