### PR TITLE
Fix Front extension Firebase source config

### DIFF
--- a/extension/platforms/front/firebase.json
+++ b/extension/platforms/front/firebase.json
@@ -4,7 +4,7 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
       {
-        "source": "**",
+        "source": "/**",
         "destination": "/index.html"
       }
     ]


### PR DESCRIPTION
## Description

Fixes the Firebase hosting rewrite pattern for the Front extension. Changes `"source": "**"` to `"source": "/**"` to match the standard Firebase hosting glob pattern used in other Firebase configs (`webhook-router`, `slack-webhook-router`). The leading slash is required for the catch-all pattern to properly route all requests to `index.html` for client-side routing.

## Tests

Configuration change only.

## Risk

None

## Deploy 
Deploy Frontapp extension