### PR TITLE
[Front] feat(metronome): add upgrade/reactivation and fix annual billing

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -198,7 +198,7 @@ export async function createMetronomeContract({
 }: {
   metronomeCustomerId: string;
   packageAlias: string;
-  uniquenessKey: string;
+  uniquenessKey?: string;
 }): Promise<Result<{ contractId: string; startingAt: string }, Error>> {
   // Metronome requires starting_at on an hour boundary — round down to current hour.
   const startingAt = floorToHourISO(new Date());
@@ -208,7 +208,7 @@ export async function createMetronomeContract({
       customer_id: metronomeCustomerId,
       package_alias: packageAlias,
       starting_at: startingAt,
-      uniqueness_key: uniquenessKey,
+      ...(uniquenessKey ? { uniqueness_key: uniquenessKey } : {}),
     });
 
     logger.info(
@@ -281,11 +281,11 @@ export async function getMetronomeActiveContract(
 }
 
 /**
- * End (cancel) a Metronome contract at the next hour boundary.
+ * Schedule a Metronome contract to end at the given date (defaults to now).
  * Metronome requires ending_before on an hour boundary; we ceil to avoid
  * dropping usage in the current partial hour.
  */
-export async function endMetronomeContract({
+export async function scheduleMetronomeContractEnd({
   metronomeCustomerId,
   contractId,
   endingBefore,
@@ -294,23 +294,56 @@ export async function endMetronomeContract({
   contractId: string;
   endingBefore?: Date;
 }): Promise<Result<void, Error>> {
+  const endDate = ceilToHourISO(endingBefore ?? new Date());
   try {
     await getMetronomeClient().v1.contracts.updateEndDate({
       customer_id: metronomeCustomerId,
       contract_id: contractId,
-      ending_before: ceilToHourISO(endingBefore ?? new Date()),
+      ending_before: endDate,
+    });
+
+    logger.info(
+      { metronomeCustomerId, contractId, endingBefore: endDate },
+      "[Metronome] Contract end date scheduled"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, contractId, endingBefore: endDate },
+      "[Metronome] Failed to schedule contract end date"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Remove the scheduled end date on a Metronome contract, making it open-ended.
+ * Used when a subscription is reactivated after cancellation.
+ */
+export async function reactivateMetronomeContract({
+  metronomeCustomerId,
+  contractId,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+}): Promise<Result<void, Error>> {
+  try {
+    await getMetronomeClient().v1.contracts.updateEndDate({
+      customer_id: metronomeCustomerId,
+      contract_id: contractId,
     });
 
     logger.info(
       { metronomeCustomerId, contractId },
-      "[Metronome] Contract ended"
+      "[Metronome] Contract reactivated (end date removed)"
     );
     return new Ok(undefined);
   } catch (err) {
     const error = normalizeError(err);
     logger.error(
       { error, metronomeCustomerId, contractId },
-      "[Metronome] Failed to end contract"
+      "[Metronome] Failed to reactivate contract"
     );
     return new Err(error);
   }

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -195,13 +195,16 @@ export async function createMetronomeContract({
   metronomeCustomerId,
   packageAlias,
   uniquenessKey,
+  startingAt: startingAtOverride,
 }: {
   metronomeCustomerId: string;
   packageAlias: string;
   uniquenessKey?: string;
+  startingAt?: Date;
 }): Promise<Result<{ contractId: string; startingAt: string }, Error>> {
   // Metronome requires starting_at on an hour boundary — round down to current hour.
-  const startingAt = floorToHourISO(new Date());
+  // Callers may pass an explicit startingAt (e.g. to align with a contract end time).
+  const startingAt = floorToHourISO(startingAtOverride ?? new Date());
 
   try {
     const response = await getMetronomeClient().v1.contracts.create({

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -1,4 +1,5 @@
 import {
+  ceilToHourISO,
   createMetronomeContract,
   createMetronomeCustomer,
   findMetronomeCustomerByAlias,
@@ -24,9 +25,15 @@ export async function switchMetronomeContractPackage({
   workspace: LightWorkspaceType;
   packageAlias: string;
 }): Promise<Result<{ metronomeContractId: string }, Error>> {
+  // Pre-round to the next hour boundary so both functions (which apply ceil
+  // and floor respectively) resolve to the same timestamp, ensuring the new
+  // contract starts exactly when the old one ends.
+  const switchAt = new Date(ceilToHourISO(new Date()));
+
   const endResult = await scheduleMetronomeContractEnd({
     metronomeCustomerId,
     contractId: oldContractId,
+    endingBefore: switchAt,
   });
   if (endResult.isErr()) {
     return new Err(endResult.error);
@@ -35,6 +42,7 @@ export async function switchMetronomeContractPackage({
   const contractResult = await createMetronomeContract({
     metronomeCustomerId,
     packageAlias,
+    startingAt: switchAt,
   });
   if (contractResult.isErr()) {
     return new Err(contractResult.error);

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -2,11 +2,55 @@ import {
   createMetronomeContract,
   createMetronomeCustomer,
   findMetronomeCustomerByAlias,
+  scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
 import { provisionSeatsForContract } from "@app/lib/metronome/seats";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
+
+/**
+ * Switch a Metronome contract to a different package (end old + create new).
+ * Customer must already exist.
+ */
+export async function switchMetronomeContractPackage({
+  metronomeCustomerId,
+  oldContractId,
+  workspace,
+  packageAlias,
+}: {
+  metronomeCustomerId: string;
+  oldContractId: string;
+  workspace: LightWorkspaceType;
+  packageAlias: string;
+}): Promise<Result<{ metronomeContractId: string }, Error>> {
+  const endResult = await scheduleMetronomeContractEnd({
+    metronomeCustomerId,
+    contractId: oldContractId,
+  });
+  if (endResult.isErr()) {
+    return new Err(endResult.error);
+  }
+
+  const contractResult = await createMetronomeContract({
+    metronomeCustomerId,
+    packageAlias,
+  });
+  if (contractResult.isErr()) {
+    return new Err(contractResult.error);
+  }
+
+  const { contractId: metronomeContractId, startingAt } = contractResult.value;
+
+  await provisionSeatsForContract({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+    workspace,
+    startingAt,
+  });
+
+  return new Ok({ metronomeContractId });
+}
 
 /**
  * Ensure a Metronome customer and contract exist for a workspace.

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -17,6 +17,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
 import type { StripePricingData } from "@app/types/stripe/pricing";
 import type {
   LightWorkspaceType,
@@ -543,11 +544,10 @@ export async function cancelSubscriptionAtPeriodEnd({
 }
 
 /**
- * Upgrades a Pro subscription to Business by swapping the Stripe product/price.
- * Always uses monthly billing for Business plan regardless of the original billing period.
- * Also updates the subscription metadata to reflect the new plan code.
+ * Creates a new Stripe Business subscription for upgrading Pro → Business.
+ * The old subscription is cancelled separately after the DB flip.
  */
-export async function upgradeProSubscriptionToBusiness({
+export async function createStripeBusinessSubscription({
   stripeSubscriptionId,
   owner,
   planCode,
@@ -555,12 +555,13 @@ export async function upgradeProSubscriptionToBusiness({
   stripeSubscriptionId: string;
   owner: WorkspaceType;
   planCode: string;
-}): Promise<Result<Stripe.Subscription, Error>> {
+}): Promise<Result<{ stripeSubscriptionId: string }, Error>> {
   const stripe = getStripeClient();
 
-  const subscription = await getStripeSubscription(stripeSubscriptionId);
-  if (!subscription) {
-    return new Err(new Error("Subscription not found"));
+  const existingSubscription =
+    await getStripeSubscription(stripeSubscriptionId);
+  if (!existingSubscription) {
+    return new Err(new Error("Existing subscription not found"));
   }
 
   const businessProductId = getBusinessProPlanProductId();
@@ -568,36 +569,38 @@ export async function upgradeProSubscriptionToBusiness({
     businessProductId,
     "IS_DEFAULT_MONHTLY_PRICE"
   );
-
   if (!newPriceId) {
     return new Err(new Error("Business monthly price not found"));
   }
 
-  const currentItem = subscription.items.data[0];
-  if (!currentItem) {
-    return new Err(new Error("Subscription has no items"));
+  const defaultPaymentMethodId =
+    getDefaultPaymentMethodId(existingSubscription);
+
+  if (!defaultPaymentMethodId) {
+    return new Err(
+      new Error("Existing subscription has no default payment method")
+    );
   }
 
-  // Update the subscription with the new price and metadata.
-  // Proration will handle billing adjustment.
-  const updatedSubscription = await stripe.subscriptions.update(
-    stripeSubscriptionId,
-    {
-      items: [
-        {
-          id: currentItem.id,
-          price: newPriceId,
-        },
-      ],
-      proration_behavior: "create_prorations",
-      metadata: {
-        planCode,
-        workspaceId: owner.sId,
-      },
-    }
+  const quantity = await MembershipResource.countActiveSeatsInWorkspace(
+    owner.sId
   );
 
-  return new Ok(updatedSubscription);
+  const newSubscription = await stripe.subscriptions.create({
+    customer: getCustomerId(existingSubscription),
+    currency: existingSubscription.currency,
+    items: [{ price: newPriceId, quantity }],
+    default_payment_method: defaultPaymentMethodId,
+    automatic_tax: {
+      enabled: existingSubscription.automatic_tax.enabled,
+    },
+    metadata: {
+      planCode,
+      workspaceId: owner.sId,
+    },
+  });
+
+  return new Ok({ stripeSubscriptionId: newSubscription.id });
 }
 
 /**
@@ -658,6 +661,14 @@ export function getCustomerId(subscription: Stripe.Subscription): string {
   return typeof subscription.customer === "string"
     ? subscription.customer
     : subscription.customer.id;
+}
+
+export function getDefaultPaymentMethodId(
+  subscription: Stripe.Subscription
+): string | null {
+  return isString(subscription.default_payment_method)
+    ? subscription.default_payment_method
+    : (subscription.default_payment_method?.id ?? null);
 }
 
 /**

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -37,12 +37,12 @@ import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
   cancelSubscriptionImmediately,
   createMetronomeSetupCheckoutSession,
+  createStripeBusinessSubscription,
   createStripeSubscriptionCheckoutSession,
   getBusinessProPlanProductId,
   getProPlanProductId,
   getStripeSubscription,
   type SupportedPaymentMethod,
-  upgradeProSubscriptionToBusiness,
 } from "@app/lib/plans/stripe";
 import { getTrialVersionForPlan, isTrial } from "@app/lib/plans/trial/limits";
 import { REPORT_USAGE_METADATA_KEY } from "@app/lib/plans/usage/types";
@@ -830,7 +830,6 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
 
   /**
    * Upgrades a Pro subscription to Business plan.
-   * This updates both Stripe (swaps product/price to Business monthly) and the database plan.
    * Only allowed for workspaces that are whitelisted for Business (metadata.isBusiness = true).
    */
   async upgradeToBusinessPlan(
@@ -850,19 +849,22 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       PRO_PLAN_SEAT_39_CODE
     );
 
-    if (this.stripeSubscriptionId) {
-      const stripeResult = await upgradeProSubscriptionToBusiness({
-        stripeSubscriptionId: this.stripeSubscriptionId,
+    const oldStripeSubscriptionId = this.stripeSubscriptionId;
+    let newStripeSubscriptionId: string | null = null;
+    if (oldStripeSubscriptionId) {
+      const stripeResult = await createStripeBusinessSubscription({
+        stripeSubscriptionId: oldStripeSubscriptionId,
         owner,
         planCode: PRO_PLAN_SEAT_39_CODE,
       });
       if (stripeResult.isErr()) {
         return new Err(stripeResult.error);
       }
+      newStripeSubscriptionId = stripeResult.value.stripeSubscriptionId;
     }
 
     // Switch Metronome contract to Business package.
-    let metronomeContractId: string | undefined;
+    let newMetronomeContractId: string | null = null;
     if (this.metronomeContractId && owner.metronomeCustomerId) {
       const result = await switchMetronomeContractPackage({
         metronomeCustomerId: owner.metronomeCustomerId,
@@ -874,21 +876,35 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         return new Err(result.error);
       }
       if (result.isOk()) {
-        metronomeContractId = result.value.metronomeContractId;
+        newMetronomeContractId = result.value.metronomeContractId;
       }
     }
 
-    await this.model.update(
-      {
-        planId: businessPlan.id,
-        metronomeContractId,
-      },
-      {
-        where: {
-          sId: this.sId,
+    await withTransaction(async (t) => {
+      await this.markAsEnded("ended_backend_only", t);
+      await SubscriptionResource.makeNew(
+        {
+          sId: generateRandomModelSId(),
+          workspaceId: this.workspaceId,
+          planId: businessPlan.id,
+          status: "active",
+          trialing: false,
+          startDate: new Date(),
+          endDate: null,
+          stripeSubscriptionId: newStripeSubscriptionId,
+          metronomeContractId: newMetronomeContractId,
         },
-      }
-    );
+        renderPlanFromModel({ plan: businessPlan }),
+        t
+      );
+    });
+
+    // Cancel after DB flip so the webhook finds ended_backend_only and does not scrub.
+    if (oldStripeSubscriptionId) {
+      await cancelSubscriptionImmediately({
+        stripeSubscriptionId: oldStripeSubscriptionId,
+      });
+    }
 
     return new Ok(undefined);
   }

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -8,11 +8,13 @@ import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import {
-  endMetronomeContract,
   getMetronomeContractPackageAliases,
+  scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
+import { switchMetronomeContractPackage } from "@app/lib/metronome/contracts";
 import {
   LEGACY_BUSINESS_PACKAGE_ALIAS,
+  LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
   LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
   PRO_OR_BUSINESS_PACKAGE_ALIASES,
 } from "@app/lib/metronome/types";
@@ -133,6 +135,16 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
 
     return (
       this.stripeSubscriptionId !== null || this.metronomeContractId !== null
+    );
+  }
+
+  /**
+   * Shadow-billed: Stripe owns billing, Metronome runs in parallel for invoice comparison.
+   * Both stripeSubscriptionId and metronomeContractId are set.
+   */
+  get isMetronomeShadowBilled(): boolean {
+    return (
+      this.stripeSubscriptionId !== null && this.metronomeContractId !== null
     );
   }
 
@@ -681,20 +693,12 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       activeSubscription?.metronomeContractId &&
       workspace.metronomeCustomerId
     ) {
-      if (activeSubscription.stripeSubscriptionId) {
-        // Shadow mode: fire-and-forget.
-        void endMetronomeContract({
-          metronomeCustomerId: workspace.metronomeCustomerId,
-          contractId: activeSubscription.metronomeContractId,
-        });
-      } else {
-        const result = await endMetronomeContract({
-          metronomeCustomerId: workspace.metronomeCustomerId,
-          contractId: activeSubscription.metronomeContractId,
-        });
-        if (result.isErr()) {
-          throw result.error;
-        }
+      const result = await scheduleMetronomeContractEnd({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        contractId: activeSubscription.metronomeContractId,
+      });
+      if (result.isErr() && !activeSubscription.isMetronomeShadowBilled) {
+        throw result.error;
       }
     }
 
@@ -722,6 +726,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     }
 
     const plan = await this.findPlanOrThrow(enterpriseDetails.planCode);
+    // TODO(pricing): provision Metronome contract for enterprise plans.
     // End the current subscription if any.
     await this.internalSubscribeWorkspaceToFreePlan({
       workspaceId: owner.sId,
@@ -807,6 +812,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
           },
         }
       );
+
       await SubscriptionResource.invalidateSubscriptionCache(owner.id);
       return;
     }
@@ -857,16 +863,34 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       return new Err(stripeResult.error);
     }
 
-    await SubscriptionModel.update(
-      { planId: businessPlan.id },
+    // Switch Metronome contract to Business package.
+    let metronomeContractId: string | undefined;
+    if (this.metronomeContractId && owner.metronomeCustomerId) {
+      const result = await switchMetronomeContractPackage({
+        metronomeCustomerId: owner.metronomeCustomerId,
+        oldContractId: this.metronomeContractId,
+        workspace: owner,
+        packageAlias: LEGACY_BUSINESS_PACKAGE_ALIAS,
+      });
+      if (result.isErr() && !this.isMetronomeShadowBilled) {
+        return new Err(result.error);
+      }
+      if (result.isOk()) {
+        metronomeContractId = result.value.metronomeContractId;
+      }
+    }
+
+    await this.model.update(
+      {
+        planId: businessPlan.id,
+        metronomeContractId,
+      },
       {
         where: {
           sId: this.sId,
         },
       }
     );
-
-    await SubscriptionResource.invalidateSubscriptionCache(owner.id);
 
     return new Ok(undefined);
   }
@@ -953,7 +977,10 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         : {
             planCode: PRO_PLAN_SEAT_29_CODE,
             allowedPaymentMethods: ["card"] satisfies SupportedPaymentMethod[],
-            metronomePackageAlias: LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
+            metronomePackageAlias:
+              billingPeriod === "yearly"
+                ? LEGACY_PRO_ANNUAL_PACKAGE_ALIAS
+                : LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
           };
 
     const proPlan = await SubscriptionResource.findPlanOrThrow(planCode);
@@ -1311,26 +1338,21 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       return activeSubscription;
     }
 
-    const res = await endMetronomeContract({
+    const res = await scheduleMetronomeContractEnd({
       metronomeCustomerId: workspace.metronomeCustomerId,
       contractId: activeSubscription.metronomeContractId,
     });
-    if (res.isOk()) {
-      return activeSubscription;
+    if (res.isErr() && !activeSubscription.isMetronomeShadowBilled) {
+      throw res.error;
     }
 
-    if (activeSubscription.stripeSubscriptionId) {
-      // Shadow mode: fire-and-forget.
-      return activeSubscription;
-    }
-
-    throw res.error;
+    return activeSubscription;
   }
 
   private async isSubscriptionOnProOrBusinessPlan(
     owner: WorkspaceType
   ): Promise<boolean> {
-    // Check Stripe-billed subscription first (covers shadow mode where both IDs are set).
+    // Check Stripe first (shadow-billed subscriptions have both IDs).
     if (this.stripeSubscriptionId) {
       const stripeSubscription = await getStripeSubscription(
         this.stripeSubscriptionId

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -841,10 +841,6 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         new Error("Workspace is not whitelisted for Business plan")
       );
     }
-    if (!this.stripeSubscriptionId) {
-      return new Err(new Error("No active Stripe subscription to upgrade"));
-    }
-
     const isOnProPlan = await this.isSubscriptionOnProOrBusinessPlan(owner);
     if (!isOnProPlan) {
       return new Err(new Error("Workspace is not on a Pro plan"));
@@ -854,13 +850,15 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       PRO_PLAN_SEAT_39_CODE
     );
 
-    const stripeResult = await upgradeProSubscriptionToBusiness({
-      stripeSubscriptionId: this.stripeSubscriptionId,
-      owner,
-      planCode: PRO_PLAN_SEAT_39_CODE,
-    });
-    if (stripeResult.isErr()) {
-      return new Err(stripeResult.error);
+    if (this.stripeSubscriptionId) {
+      const stripeResult = await upgradeProSubscriptionToBusiness({
+        stripeSubscriptionId: this.stripeSubscriptionId,
+        owner,
+        planCode: PRO_PLAN_SEAT_39_CODE,
+      });
+      if (stripeResult.isErr()) {
+        return new Err(stripeResult.error);
+      }
     }
 
     // Switch Metronome contract to Business package.

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -160,8 +160,7 @@ async function handler(
             break;
           }
 
-          // Shadow mode: Stripe owns the subscription lifecycle.
-          if (subscription.stripeSubscriptionId) {
+          if (subscription.isMetronomeShadowBilled) {
             logger.info(
               { contractId, workspaceId: workspace.sId },
               "[Metronome Webhook] contract.end: shadow contract ended, Stripe handles subscription"

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -26,8 +26,9 @@ import {
 import { handleMetronomeSetupCheckout } from "@app/lib/metronome/checkout";
 import {
   createMetronomeCredit,
-  endMetronomeContract,
   getMetronomeActiveContract,
+  reactivateMetronomeContract,
+  scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
 import { getProductFreeMonthlyCreditId } from "@app/lib/metronome/constants";
 import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/contracts";
@@ -1251,14 +1252,14 @@ async function handler(
                 endDate,
               });
 
-              // Shadow mode: schedule the Metronome contract end at the same time.
+              // Schedule the Metronome contract end (always shadow-billed here).
               if (subscription.metronomeContractId) {
                 const trialingWorkspace =
                   await WorkspaceResource.fetchByModelId(
                     subscription.workspaceId
                   );
                 if (trialingWorkspace?.metronomeCustomerId) {
-                  void endMetronomeContract({
+                  void scheduleMetronomeContractEnd({
                     metronomeCustomerId: trialingWorkspace.metronomeCustomerId,
                     contractId: subscription.metronomeContractId,
                     endingBefore: endDate,
@@ -1306,13 +1307,13 @@ async function handler(
               "Workspace not found for subscription in customer.subscription.updated."
             );
 
-            // Shadow mode: schedule the Metronome contract end at the same time.
+            // Schedule the Metronome contract end (always shadow-billed here).
             if (
               endDate &&
               subscription.metronomeContractId &&
               workspace.metronomeCustomerId
             ) {
-              void endMetronomeContract({
+              void scheduleMetronomeContractEnd({
                 metronomeCustomerId: workspace.metronomeCustomerId,
                 contractId: subscription.metronomeContractId,
                 endingBefore: endDate,
@@ -1323,8 +1324,15 @@ async function handler(
               workspace.sId
             );
             if (!endDate) {
-              // TODO(pricing): reactivate Metronome contract (remove scheduled end date)
-              // by calling updateEndDate without ending_before.
+              if (
+                subscription.metronomeContractId &&
+                workspace.metronomeCustomerId
+              ) {
+                void reactivateMetronomeContract({
+                  metronomeCustomerId: workspace.metronomeCustomerId,
+                  contractId: subscription.metronomeContractId,
+                });
+              }
 
               // Subscription is re-activated, so we need to unpause the connectors and re-enable triggers.
               await restoreWorkspaceAfterSubscription(auth);

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -2,7 +2,7 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
-import { endMetronomeContract } from "@app/lib/metronome/client";
+import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
   cancelSubscriptionAtPeriodEnd,
   skipSubscriptionFreeTrial,
@@ -185,20 +185,11 @@ async function handler(
             break;
           }
 
-          if (!useMetronomeBilling) {
-            // Shadow mode: fire-and-forget.
-            void endMetronomeContract({
-              metronomeCustomerId: owner.metronomeCustomerId,
-              contractId: subscription.metronomeContractId,
-            });
-            break;
-          }
-
-          const result = await endMetronomeContract({
+          const result = await scheduleMetronomeContractEnd({
             metronomeCustomerId: owner.metronomeCustomerId,
             contractId: subscription.metronomeContractId,
           });
-          if (result.isErr()) {
+          if (result.isErr() && useMetronomeBilling) {
             return apiError(req, res, {
               status_code: 500,
               api_error: {

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -7,7 +7,7 @@ import { deleteWebhookSource } from "@app/lib/api/webhook_source";
 import { deleteWorksOSOrganizationWithWorkspace } from "@app/lib/api/workos/organization";
 import { areAllSubscriptionsCanceled } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
-import { endMetronomeContract } from "@app/lib/metronome/client";
+import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import {
   AgentChildAgentConfigurationModel,
@@ -729,7 +729,7 @@ export async function deleteWorkspaceActivity({
         )
       : null;
     if (subscription?.metronomeContractId) {
-      const endResult = await endMetronomeContract({
+      const endResult = await scheduleMetronomeContractEnd({
         metronomeCustomerId: workspace.metronomeCustomerId,
         contractId: subscription.metronomeContractId,
       });


### PR DESCRIPTION
## Description

Continues the Metronome billing integration (#23728, dust-tt/dust#23910) to cover remaining subscription lifecycle events: plan upgrades, reactivation after cancellation, and a bug fix for annual billing.

**Reactivation**: Stripe portal cancel schedules a Metronome contract end date. If the user reactivates before period end, we now remove that scheduled end date (Metronome's `updateEndDate` without `ending_before` makes the contract open-ended).

**Pro → Business upgrade**: ends old contract and creates a new one with the business package alias. Uses a new `switchMetronomeContractPackage` helper that handles end + create + seat provisioning atomically.

**Annual billing bug**: `getCheckoutUrlForUpgrade` was always passing `legacy-pro-monthly` alias regardless of billing period — yearly subscribers now correctly get `legacy-pro-annual`.

**Shadow mode cleanup**: replaced ad-hoc `stripeSubscriptionId` checks with an `isMetronomeShadowBilled` getter. Renamed `endMetronomeContract` → `scheduleMetronomeContractEnd` to clarify it schedules an end date rather than immediately terminating.

Closes dust-tt/tasks#7504

## Tests

E2E tested on a single workspace:
1. Subscribe Pro (yearly) → shadow Metronome contract created
2. Cancel from Stripe portal → contract end date scheduled
3. Reactivate from Stripe portal → end date removed
4. Upgrade to Business → old contract ended, new `legacy-business` contract created with seats
5. Poke downgrade → business contract ended