### PR TITLE
[front] spacing adjustment for messages

### DIFF
--- a/front/components/academy/AcademyQuiz.tsx
+++ b/front/components/academy/AcademyQuiz.tsx
@@ -341,7 +341,11 @@ export function AcademyQuiz({
                 );
               })}
               {isLoading && messages[messages.length - 1]?.role === "user" && (
-                <ConversationMessageContainer messageType="agent" type="agent">
+                <ConversationMessageContainer
+                  messageType="agent"
+                  type="agent"
+                  className="py-2"
+                >
                   <ConversationMessageAvatar name={AGENT_NAME} type="agent" />
                   <div className="flex min-w-0 flex-col gap-1">
                     <ConversationMessageTitle

--- a/front/components/academy/AcademyQuiz.tsx
+++ b/front/components/academy/AcademyQuiz.tsx
@@ -297,6 +297,7 @@ export function AcademyQuiz({
                       key={index}
                       messageType="agent"
                       type="agent"
+                      className="py-4"
                     >
                       <ConversationMessageAvatar
                         name={AGENT_NAME}
@@ -344,7 +345,7 @@ export function AcademyQuiz({
                 <ConversationMessageContainer
                   messageType="agent"
                   type="agent"
-                  className="py-2"
+                  className="py-4"
                 >
                   <ConversationMessageAvatar name={AGENT_NAME} type="agent" />
                   <div className="flex min-w-0 flex-col gap-1">

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -168,7 +168,6 @@ interface AgentMessageProps {
   conversationId: string;
   hideHeader: boolean;
   isLastMessage: boolean;
-  isSteered: boolean;
   agentMessage: AgentMessageWithStreaming;
   messageFeedback: FeedbackSelectorBaseProps;
   owner: WorkspaceType;
@@ -189,7 +188,6 @@ export function AgentMessage({
   conversationId,
   hideHeader,
   isLastMessage,
-  isSteered,
   agentMessage,
   messageFeedback,
   owner,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1351,7 +1351,8 @@ function AgentMessageContent({
           />
         )}
 
-      {agentMessage.content &&
+      {agentMessage.content !== null &&
+        agentMessage.content !== "" &&
         !(
           isInlineActivityEnabled &&
           agentMessage.streaming.agentState !== "done"

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -168,6 +168,7 @@ interface AgentMessageProps {
   conversationId: string;
   hideHeader: boolean;
   isLastMessage: boolean;
+  isSteered: boolean;
   agentMessage: AgentMessageWithStreaming;
   messageFeedback: FeedbackSelectorBaseProps;
   owner: WorkspaceType;
@@ -188,6 +189,7 @@ export function AgentMessage({
   conversationId,
   hideHeader,
   isLastMessage,
+  isSteered,
   agentMessage,
   messageFeedback,
   owner,
@@ -1351,12 +1353,13 @@ function AgentMessageContent({
           />
         )}
 
-        {agentMessage.content !== null &&
-          !(
-            isInlineActivityEnabled &&
-            agentMessage.streaming.agentState !== "done"
-          ) && (
-            <div>
+      {agentMessage.content &&
+        !(
+          isInlineActivityEnabled &&
+          agentMessage.streaming.agentState !== "done"
+        ) && (
+          <div>
+            <CitationsContext.Provider value={citationsContextValue}>
               <AgentMessageMarkdown
                 content={sanitizeVisualizationContent(agentMessage.content)}
                 owner={owner}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1351,14 +1351,13 @@ function AgentMessageContent({
           />
         )}
 
-      {agentMessage.content !== null &&
-        agentMessage.content !== "" &&
-        !(
-          isInlineActivityEnabled &&
-          agentMessage.streaming.agentState !== "done"
-        ) && (
-          <div>
-            <CitationsContext.Provider value={citationsContextValue}>
+        {agentMessage.content !== null &&
+          agentMessage.content !== "" &&
+          !(
+            isInlineActivityEnabled &&
+            agentMessage.streaming.agentState !== "done"
+          ) && (
+            <div>
               <AgentMessageMarkdown
                 content={sanitizeVisualizationContent(agentMessage.content)}
                 owner={owner}

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -29,17 +29,20 @@ import React, { useMemo } from "react";
 // conversation-level context (who sent the message, steering flow, grouping).
 // Sparkle message components only handle padding inside the bubble.
 // The last message also gets a margin-bottom for breathing space (see MessageItem).
+//
+// - No margin: consecutive messages from the same user
+// - mt-2: steered flow (steering user message or steered agent response)
+// - mt-4: default gap between messages
+// - mt-8: previous message has reactions (extra space to clear them)
 function getMessageTopMargin({
   data,
   prevData,
-  currentUserId,
   isPreviousMessageSameSender,
   isSteeredAgentMessage,
   isPreviousAgentMessageSteered,
 }: {
   data: VirtuosoMessage;
   prevData: VirtuosoMessage | null;
-  currentUserId: string;
   isPreviousMessageSameSender: boolean | null;
   isSteeredAgentMessage: boolean;
   isPreviousAgentMessageSteered: boolean;
@@ -49,27 +52,18 @@ function getMessageTopMargin({
     return "mt-8";
   }
 
-  // No margin when visually grouped with the previous message.
-  if (
-    isPreviousMessageSameSender ||
-    isSteeredAgentMessage ||
-    isPreviousAgentMessageSteered
-  ) {
-    return undefined;
+  // Smaller margin when visually grouped (consecutive messages from the same user).
+  if (isPreviousMessageSameSender) {
+    return "mt-1";
   }
 
-  // Other users' messages get extra spacing.
-  if (isUserMessage(data) && data.user?.sId !== currentUserId) {
-    return "mt-3";
+  // Steered flow: reduced margin to keep the steering user message and
+  // steered agent response visually connected.
+  if (isPreviousAgentMessageSteered || isSteeredAgentMessage) {
+    return "mt-2";
   }
 
-  // Agent messages have no visible bubble background, so they need
-  // more top margin to compensate for the lack of internal padding.
-  if (isAgentMessageWithStreaming(data)) {
-    return "mt-4";
-  }
-
-  return "mt-1";
+  return "mt-4";
 }
 
 interface MessageItemProps {
@@ -255,7 +249,6 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
     const topMargin = getMessageTopMargin({
       data,
       prevData,
-      currentUserId: context.user.sId,
       isPreviousMessageSameSender,
       isSteeredAgentMessage,
       isPreviousAgentMessageSteered,

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -19,11 +19,57 @@ import { UserMessage } from "@app/components/assistant/conversation/UserMessage"
 import { useMessageFeedback } from "@app/hooks/useMessageFeedback";
 import { useReaction } from "@app/hooks/useReaction";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { classNames } from "@app/lib/utils";
-import { isSupportedImageContentType } from "@app/types/files";
 import type { UserType } from "@app/types/user";
+import { cn } from "@dust-tt/sparkle";
 import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
 import React, { useMemo } from "react";
+
+// Inter-message spacing lives here (not in Sparkle) because it depends on
+// conversation-level context (who sent the message, steering flow, grouping).
+// Sparkle message components only handle padding inside the bubble.
+// The last message also gets a margin-bottom for breathing space (see MessageItem).
+function getMessageTopMargin({
+  data,
+  prevData,
+  currentUserId,
+  isPreviousMessageSameSender,
+  isSteeredAgentMessage,
+  isPreviousAgentMessageSteered,
+}: {
+  data: VirtuosoMessage;
+  prevData: VirtuosoMessage | null;
+  currentUserId: string;
+  isPreviousMessageSameSender: boolean | null;
+  isSteeredAgentMessage: boolean;
+  isPreviousAgentMessageSteered: boolean;
+}): string | undefined {
+  // Previous message has reactions — add extra space to clear them.
+  if (prevData && prevData.reactions.length > 0) {
+    return "mt-8";
+  }
+
+  // No margin when visually grouped with the previous message.
+  if (
+    isPreviousMessageSameSender ||
+    isSteeredAgentMessage ||
+    isPreviousAgentMessageSteered
+  ) {
+    return undefined;
+  }
+
+  // Other users' messages get extra spacing.
+  if (isUserMessage(data) && data.user?.sId !== currentUserId) {
+    return "mt-3";
+  }
+
+  // Agent messages have no visible bubble background, so they need
+  // more top margin to compensate for the lack of internal padding.
+  if (isAgentMessageWithStreaming(data)) {
+    return "mt-4";
+  }
+
+  return "mt-1";
+}
 
 interface MessageItemProps {
   allowBranchMessages?: boolean;
@@ -135,13 +181,6 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       getMessageDate(prevData).toDateString() ===
         getMessageDate(data).toDateString();
 
-    const isNextMessageSameSender =
-      nextData &&
-      isUserMessage(data) &&
-      isUserMessage(nextData) &&
-      data.user?.sId !== undefined &&
-      data.user.sId === nextData.user?.sId;
-
     const isPreviousMessageSameSender =
       prevData &&
       isUserMessage(data) &&
@@ -212,16 +251,22 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       return null;
     }
 
+    const topMargin = getMessageTopMargin({
+      data,
+      prevData,
+      currentUserId: context.user.sId,
+      isPreviousMessageSameSender,
+      isSteeredAgentMessage,
+      isPreviousAgentMessageSteered,
+    });
+
     return (
       <>
         {!areSameDate && <MessageDateIndicator message={data} />}
         <div
           key={`message-id-${sId}`}
           ref={ref}
-          className={classNames(
-            "mx-auto max-w-conversation",
-            !isNextMessageSameSender && "mb-4"
-          )}
+          className={cn("mx-auto max-w-conversation", topMargin, !nextData && "mb-4")}
         >
           {isUserMessage(data) && (
             <UserMessage
@@ -244,6 +289,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               conversationId={context.conversation.sId}
               hideHeader={isSteeredAgentMessage}
               isLastMessage={!nextData}
+              isSteered={isSteeredAgentMessage}
               agentMessage={data}
               messageFeedback={messageFeedbackWithSubmit}
               owner={context.owner}

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -63,7 +63,7 @@ function getMessageTopMargin({
     return "mt-2";
   }
 
-  return "mt-4";
+  return "mt-8";
 }
 
 interface MessageItemProps {

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -19,6 +19,7 @@ import { UserMessage } from "@app/components/assistant/conversation/UserMessage"
 import { useMessageFeedback } from "@app/hooks/useMessageFeedback";
 import { useReaction } from "@app/hooks/useReaction";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { isSupportedImageContentType } from "@app/types/files";
 import type { UserType } from "@app/types/user";
 import { cn } from "@dust-tt/sparkle";
 import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
@@ -289,7 +290,6 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               conversationId={context.conversation.sId}
               hideHeader={isSteeredAgentMessage}
               isLastMessage={!nextData}
-              isSteered={isSteeredAgentMessage}
               agentMessage={data}
               messageFeedback={messageFeedbackWithSubmit}
               owner={context.owner}

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -263,7 +263,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
           className={cn(
             "mx-auto max-w-conversation",
             topMargin,
-            !nextData && "mb-4"
+            !nextData && "mb-8"
           )}
         >
           {isUserMessage(data) && (

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -267,7 +267,11 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
         <div
           key={`message-id-${sId}`}
           ref={ref}
-          className={cn("mx-auto max-w-conversation", topMargin, !nextData && "mb-4")}
+          className={cn(
+            "mx-auto max-w-conversation",
+            topMargin,
+            !nextData && "mb-4"
+          )}
         >
           {isUserMessage(data) && (
             <UserMessage

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -246,13 +246,6 @@ export function UserMessage({
   // Otherwise, show it to the side of the message.
   const showBottomActionMenu = !isDeleted && (hasReactions || isMobile);
   const showSideActionMenu = !isDeleted && !hasReactions && !isMobile;
-  // With reactions the button is always below; without, CSS container query floats it to the side.
-  // Deleted messages have no action menu → tight spacing.
-  const actionMenuBottomMargin = isDeleted
-    ? "mb-1"
-    : hasReactions
-      ? "mb-8"
-      : "mb-8 @sm/conversation:mb-1";
 
   const displayChip =
     message.version > 0 || isTriggeredOrigin(message.context.origin);
@@ -341,8 +334,7 @@ export function UserMessage({
             type="user"
             className={cn(
               isCurrentUser ? "ml-auto" : undefined,
-              "relative max-w-conversation @xxxs/conversation:max-w-[95%] @xxs/conversation:max-w-[80%] @xs/conversation:max-w-[85%]",
-              actionMenuBottomMargin
+              "relative max-w-conversation @xxxs/conversation:max-w-[95%] @xxs/conversation:max-w-[80%] @xs/conversation:max-w-[85%]"
             )}
             ref={userMessageHoveredRef}
           >

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -19,6 +19,7 @@ import type {
 import { isLightAgentMessageWithActionsType } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
+import type { WorkspaceType } from "@app/types/user";
 import {
   AnimatedText,
   CheckIcon,

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -206,7 +206,7 @@ export function InlineActivitySteps({
         style={getCollapseAnimationStyle(isCollapsed)}
       >
         <div className="overflow-hidden">
-          <div className="mt-4 flex flex-col gap-3">
+          <div className="mt-3 flex flex-col gap-3">
             {completedSteps.map((step, index) => {
               const isLast =
                 index === completedSteps.length - 1 &&
@@ -227,6 +227,9 @@ export function InlineActivitySteps({
                     />
                   );
                 case "content":
+                  if (!step.content.trim()) {
+                    return null;
+                  }
                   return (
                     <div key={step.id}>
                       <AgentMessageMarkdown

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -18,7 +18,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import { isLightAgentMessageWithActionsType } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { WorkspaceType } from "@app/types/user";
+import { isString } from "@app/types/shared/utils/general";
 import {
   AnimatedText,
   CheckIcon,
@@ -227,7 +227,10 @@ export function InlineActivitySteps({
                     />
                   );
                 case "content":
-                  if (!step.content.trim()) {
+                  if (
+                    !isString(step.content) ||
+                    step.content.trim().length === 0
+                  ) {
                     return null;
                   }
                   return (

--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -22,7 +22,7 @@ const wrapperVariants = cva("s-flex s-flex-col s-@container @xs:s-flex-row", {
 const messageVariants = cva("s-flex s-rounded-2xl s-max-w-full", {
   variants: {
     type: {
-      user: "s-bg-muted-background dark:s-bg-muted-background-night s-px-4 s-py-3 s-gap-2 s-w-fit",
+      user: "s-gap-2 s-w-fit",
       agent: "s-w-full s-gap-3 s-flex-col",
     },
   },

--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -22,8 +22,8 @@ const wrapperVariants = cva("s-flex s-flex-col s-@container @xs:s-flex-row", {
 const messageVariants = cva("s-flex s-rounded-2xl s-max-w-full", {
   variants: {
     type: {
-      user: "s-gap-2 s-w-fit",
-      agent: "s-w-full s-gap-3 s-py-4 s-flex-col",
+      user: "s-bg-muted-background dark:s-bg-muted-background-night s-px-4 s-py-3 s-gap-2 s-w-fit",
+      agent: "s-w-full s-gap-3 s-flex-col",
     },
   },
   defaultVariants: {
@@ -37,6 +37,8 @@ interface ConversationMessageContainerProps
   type: ConversationMessageType;
 }
 
+// This component should only contain padding (inside the bubble).
+// Any margin (inter-message spacing) should live outside of Sparkle.
 export const ConversationMessageContainer = React.forwardRef<
   HTMLDivElement,
   ConversationMessageContainerProps

--- a/sparkle/src/components/TruncatedContent.tsx
+++ b/sparkle/src/components/TruncatedContent.tsx
@@ -82,25 +82,29 @@ export function TruncatedContent({
           <div className="s-pointer-events-none s-absolute s-bottom-0 s-left-0 s-right-0 s-h-24 s-bg-gradient-to-t s-from-background dark:s-from-background-night" />
         )}
       </div>
-      <div className="s-flex s-items-center s-gap-3">
-        {shouldShowToggle && (
-          <Button
-            variant={variant === "light" ? "ghost-secondary" : "outline"}
-            size="xs"
-            label={isCollapsed ? expandLabel : collapseLabel}
-            icon={
-              variant === "light"
-                ? undefined
-                : isCollapsed
-                  ? ChevronDownIcon
-                  : ChevronUpIcon
-            }
-            onClick={handleToggle}
-            className={buttonClassName}
-          />
-        )}
-        {footer}
-      </div>
+      {(shouldShowToggle || footer) && (
+        <div
+          className={cn("s-flex s-items-center", shouldShowToggle && "s-gap-3")}
+        >
+          {shouldShowToggle && (
+            <Button
+              variant={variant === "light" ? "ghost-secondary" : "outline"}
+              size="xs"
+              label={isCollapsed ? expandLabel : collapseLabel}
+              icon={
+                variant === "light"
+                  ? undefined
+                  : isCollapsed
+                    ? ChevronDownIcon
+                    : ChevronUpIcon
+              }
+              onClick={handleToggle}
+              className={buttonClassName}
+            />
+          )}
+          {footer}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description
This PR is to adjust the spacing between messages based on various different scenario. Initially I was hacking around but it was really inefficient so I refactored the components, sparkle message component should only care about spacing inside the bubble, and never adjust spacing between each messages. To make everything easier, spacing is controlled by margin top (except the last message which needs to have margin bottom since there is nothing underneath). In the future it should be much easier to adjust spacing between messages.

We still have one more empty div rendering somewhere messing up spacing, I will fix it in a follow up PR:
<img width="1680" height="638" alt="CleanShot 2026-04-10 at 10 13 21@2x" src="https://github.com/user-attachments/assets/a17e8736-1d5d-40a2-9615-295b09d441ce" />


 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
