### PR TITLE
useUnifiedSearch optionnally look for project files.

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -283,14 +283,14 @@ export const AgentInputBar = ({
 
   if (
     context.isProjectMember === false &&
-    context.projectSpaceId &&
+    context.projectId &&
     context.projectSpaceName
   ) {
     return (
       <div className="relative z-20 mx-auto flex max-h-dvh w-full flex-col py-4 sm:w-full sm:max-w-conversation">
         <ProjectJoinCTA
           owner={context.owner}
-          spaceId={context.projectSpaceId}
+          spaceId={context.projectId}
           spaceName={context.projectSpaceName}
           isRestricted={context.isProjectRestricted ?? false}
           userName={context.user.fullName}

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -852,7 +852,7 @@ export const ConversationViewer = ({
       additionalMarkdownPlugins,
       isProjectMember,
       isProjectRestricted: spaceInfo?.isRestricted,
-      projectSpaceId: conversation?.spaceId ?? undefined,
+      projectId: conversation?.spaceId ?? undefined,
       projectSpaceName: spaceInfo?.name,
       branchIdToApprove: branchIdToApprove ?? undefined,
       setBranchIdToApprove,

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -248,6 +248,11 @@ export const InputBarAttachmentsPicker = ({
     disabled: !isOpen,
   });
 
+  const spacesMap = useMemo(
+    () => Object.fromEntries(spaces.map((space) => [space.sId, space])),
+    [spaces]
+  );
+
   const spaceIds = useMemo(() => {
     // We are having a conversation within a specific space, so we only allow datasources/tools from that space and the global space.
     // This is a project v1 limitation.
@@ -274,17 +279,14 @@ export const InputBarAttachmentsPicker = ({
     pageSize: PAGE_SIZE,
     disabled: isSpacesLoading || !searchQuery,
     spaceIds,
+    projectId:
+      spaceId && spacesMap?.[spaceId]?.kind === "project" ? spaceId : undefined,
     viewType: "all",
     includeDataSources: true,
     searchSourceUrls: true,
     includeTools: true,
     prioritizeSpaceAccess: true,
   });
-
-  const spacesMap = useMemo(
-    () => Object.fromEntries(spaces.map((space) => [space.sId, space])),
-    [spaces]
-  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   useEffect(() => {

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -106,7 +106,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     sId: string;
     fileName: string;
     contentType: string;
-    projectSpaceId?: string | null;
+    projectId?: string | null;
   } | null>(null);
   const [showPreviewSheet, setShowPreviewSheet] = useState(false);
   const confirm = useContext(ConfirmContext);
@@ -226,7 +226,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
           sId: item.fileId,
           fileName: item.title,
           contentType: item.contentType,
-          projectSpaceId: space.sId,
+          projectId: space.sId,
         });
         setShowPreviewSheet(true);
         return;

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -114,7 +114,7 @@ export type VirtuosoMessageListContext = {
   // Project membership fields (undefined for non-project conversations)
   isProjectMember?: boolean;
   isProjectRestricted?: boolean;
-  projectSpaceId?: string;
+  projectId?: string;
   projectSpaceName?: string;
   branchIdToApprove?: string;
   setBranchIdToApprove?: (branchId: string | null) => void;

--- a/front/components/spaces/FilePreviewSheet.tsx
+++ b/front/components/spaces/FilePreviewSheet.tsx
@@ -23,7 +23,7 @@ export type MinimalFileForPreview = {
   fileName: string;
   contentType: string;
   /** When set (e.g. project knowledge tab), interactive frames resolve in this project space. */
-  projectSpaceId?: string | null;
+  projectId?: string | null;
 };
 
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -255,7 +255,7 @@ function FileContentRenderer({
       return (
         <FrameRenderer
           fileId={file.sId}
-          projectId={file.projectSpaceId ?? null}
+          projectId={file.projectId ?? null}
           owner={owner}
           lastEditedByAgentConfigurationId={undefined}
           contentHash={undefined}

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -32,17 +32,36 @@ import type { Fetcher } from "swr";
 export function useProjectContextAttachments({
   owner,
   spaceId,
+  query,
+  type,
   disabled,
 }: {
   owner: LightWorkspaceType;
   spaceId: string;
+  query?: string;
+  type?: "file" | "content-node";
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const projectContextFetcher: Fetcher<GetProjectContextResponseBody> = fetcher;
 
+  const key = useMemo(() => {
+    if (disabled) {
+      return null;
+    }
+    const params = new URLSearchParams();
+    if (query && query.trim().length > 0) {
+      params.set("query", query);
+    }
+    if (type) {
+      params.set("type", type);
+    }
+    const qs = params.toString();
+    return `/api/w/${owner.sId}/spaces/${spaceId}/project_context${qs ? `?${qs}` : ""}`;
+  }, [disabled, owner.sId, spaceId, query, type]);
+
   const { data, error, mutate } = useSWRWithDefaults(
-    disabled ? null : `/api/w/${owner.sId}/spaces/${spaceId}/project_context`,
+    key,
     projectContextFetcher
   );
 

--- a/front/lib/swr/search.ts
+++ b/front/lib/swr/search.ts
@@ -1,5 +1,7 @@
+import type { FileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { clientEventSource } from "@app/lib/egress/client";
 import type { ToolSearchResult } from "@app/lib/search/tools/types";
+import { useProjectContextAttachments } from "@app/lib/swr/projects";
 import { emptyArray } from "@app/lib/swr/swr";
 import type { ContentNodeWithParent } from "@app/types/connectors/connectors_api";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
@@ -8,7 +10,7 @@ import type { DataSourceViewType } from "@app/types/data_source_view";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { EventSourcePolyfill } from "event-source-polyfill";
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 export type DataSourceViewContentNode = ContentNodeWithParent & {
   dataSource: DataSourceType;
@@ -31,6 +33,7 @@ export function useUnifiedSearch({
   pageSize = 25,
   disabled = false,
   spaceIds,
+  projectId,
   viewType = "all",
   excludeNonRemoteDatabaseTables = false,
   includeDataSources = true,
@@ -43,6 +46,7 @@ export function useUnifiedSearch({
   pageSize?: number;
   disabled?: boolean;
   spaceIds?: string[];
+  projectId?: string;
   viewType?: Exclude<ContentNodesViewType, "data_warehouse">;
   excludeNonRemoteDatabaseTables?: boolean;
   includeDataSources?: boolean;
@@ -50,7 +54,7 @@ export function useUnifiedSearch({
   includeTools?: boolean;
   prioritizeSpaceAccess?: boolean;
 }) {
-  const [knowledgeResults, setKnowledgeResults] = useState<
+  const [rawKnowledgeResults, setRawKnowledgeResults] = useState<
     DataSourceViewContentNode[]
   >([]);
   const [toolResults, setToolResults] = useState<ToolSearchResult[]>([]);
@@ -61,6 +65,41 @@ export function useUnifiedSearch({
   const [nextPageCursor, setNextPageCursor] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const eventSourceRef = useRef<EventSourcePolyfill | null>(null);
+
+  const {
+    attachments: projectContextAttachments,
+    isProjectContextAttachmentsLoading,
+  } = useProjectContextAttachments({
+    owner,
+    spaceId: projectId ?? "",
+    query,
+    type: "file",
+    disabled: disabled || !projectId,
+  });
+
+  const projectContextFiles = useMemo((): FileAttachmentType[] => {
+    // Server-side filtering (`type=file`) ensures the endpoint returns only file attachments.
+    return projectContextAttachments as FileAttachmentType[];
+  }, [projectContextAttachments]);
+
+  const projectContextFileIds = useMemo(() => {
+    return new Set(projectContextFiles.map((f) => f.fileId));
+  }, [projectContextFiles]);
+
+  const knowledgeResults = useMemo(() => {
+    if (!projectId || projectContextFileIds.size === 0) {
+      return rawKnowledgeResults;
+    }
+
+    // If a project file also exists as a `dust_project` knowledge node (Core),
+    // we only keep the file representation.
+    return rawKnowledgeResults.filter((n) => {
+      if (n.dataSource.connectorProvider !== "dust_project") {
+        return true;
+      }
+      return !projectContextFileIds.has(n.internalId);
+    });
+  }, [projectId, projectContextFileIds, rawKnowledgeResults]);
 
   const loadPage = useCallback(
     async (cursor?: string | null, appendResults = false) => {
@@ -116,12 +155,12 @@ export function useUnifiedSearch({
           if (chunk.knowledgeResults) {
             const { knowledgeResults } = chunk;
             if (appendResults) {
-              setKnowledgeResults((prev) => [
+              setRawKnowledgeResults((prev) => [
                 ...prev,
                 ...knowledgeResults.nodes,
               ]);
             } else {
-              setKnowledgeResults(knowledgeResults.nodes);
+              setRawKnowledgeResults(knowledgeResults.nodes);
             }
             setNextPageCursor(knowledgeResults.nextPageCursor);
             setHasMore(!!knowledgeResults.nextPageCursor);
@@ -168,7 +207,7 @@ export function useUnifiedSearch({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   useLayoutEffect(() => {
-    setKnowledgeResults([]);
+    setRawKnowledgeResults([]);
     setToolResults([]);
     setNextPageCursor(null);
     setHasMore(false);
@@ -220,6 +259,12 @@ export function useUnifiedSearch({
         : emptyArray<DataSourceViewContentNode>(),
     toolResults:
       toolResults.length > 0 ? toolResults : emptyArray<ToolSearchResult>(),
+    projectContextFiles:
+      projectContextFiles.length > 0
+        ? projectContextFiles
+        : emptyArray<FileAttachmentType>(),
+    isProjectContextFilesLoading:
+      !!projectId && isProjectContextAttachmentsLoading,
     isSearchLoading,
     isLoadingNextPage,
     isSearchValidating,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.test.ts
@@ -17,11 +17,20 @@ const addContentNodeToProjectSpy = vi.spyOn(
   projectsApi,
   "addContentNodeToProject"
 );
+let listProjectContextAttachmentsSpy = vi.spyOn(
+  projectsApi,
+  "listProjectContextAttachments"
+);
 
 describe("/api/w/[wId]/spaces/[spaceId]/project_context", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     addContentNodeToProjectSpy.mockClear();
+    listProjectContextAttachmentsSpy.mockRestore();
+    listProjectContextAttachmentsSpy = vi.spyOn(
+      projectsApi,
+      "listProjectContextAttachments"
+    );
     addContentNodeToProjectSpy.mockImplementation(async (...args) =>
       (
         await vi.importActual<typeof projectsApi>("@app/lib/api/projects")
@@ -78,6 +87,97 @@ describe("/api/w/[wId]/spaces/[spaceId]/project_context", () => {
         expect(withCreator.creator?.type).toBe("user");
         expect(withCreator.creator?.name).toBeDefined();
       }
+    });
+
+    it("filters attachments by query (case-insensitive)", async () => {
+      const { auth, req, res, user, globalSpace } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "user",
+        });
+
+      const space = globalSpace;
+
+      await ProjectFileFactory.create(auth, user, space, {
+        contentType: "text/plain",
+        fileName: "Budget 2026.txt",
+        fileSize: 100,
+        status: "ready",
+      });
+
+      await ProjectFileFactory.create(auth, user, space, {
+        contentType: "text/plain",
+        fileName: "Roadmap.txt",
+        fileSize: 100,
+        status: "ready",
+      });
+
+      req.query.spaceId = space.sId;
+      req.query.query = "budget";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const responseData = res._getJSONData();
+      const titles = responseData.attachments.map(
+        (a: { title: string }) => a.title
+      );
+      expect(titles).toEqual(["Budget 2026.txt"]);
+    });
+
+    it("filters attachments by type=content-node", async () => {
+      const { req, res, globalSpace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+
+      // Mock the list function so we can focus on filtering behavior.
+      listProjectContextAttachmentsSpy.mockResolvedValue([
+        {
+          title: "notes.txt",
+          contentType: "text/plain",
+          contentFragmentVersion: "latest",
+          snippet: null,
+          generatedTables: [],
+          isIncludable: true,
+          isSearchable: false,
+          isQueryable: false,
+          isInProjectContext: true,
+          creator: null,
+          hidden: false,
+          fileId: "file_1",
+          source: "user",
+          createdAt: Date.now(),
+        } as any,
+        {
+          title: "Spec doc",
+          contentType: "text/plain",
+          contentFragmentVersion: "latest",
+          snippet: null,
+          generatedTables: [],
+          isIncludable: true,
+          isSearchable: false,
+          isQueryable: false,
+          isInProjectContext: true,
+          creator: null,
+          hidden: false,
+          contentFragmentId: "cf_1",
+          nodeId: "core-node",
+          nodeDataSourceViewId: "dsv_1",
+          nodeType: "document",
+          sourceUrl: null,
+        } as any,
+      ]);
+
+      req.query.spaceId = globalSpace.sId;
+      req.query.type = "content-node";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const responseData = res._getJSONData();
+      expect(responseData.attachments).toHaveLength(1);
+      expect(responseData.attachments[0].title).toBe("Spec doc");
     });
 
     it("should return empty array when space has no files", async () => {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.ts
@@ -1,5 +1,9 @@
 /** @ignoreswagger */
-import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import {
+  type ConversationAttachmentType,
+  isContentNodeAttachmentType,
+  isFileAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   addContentNodeToProject,
@@ -12,7 +16,6 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { ContentNodeType } from "@app/types/core/content_node";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
@@ -40,6 +43,12 @@ export type PostProjectContextContentNodeResponseBody = {
   };
 };
 
+const ProjectContextQuerySchema = z.object({
+  spaceId: z.string(),
+  query: z.string().optional(),
+  type: z.enum(["file", "content-node"]).optional(),
+});
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
@@ -49,16 +58,19 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const { spaceId } = req.query;
-  if (!isString(spaceId)) {
+  const queryValidation = ProjectContextQuerySchema.safeParse(req.query);
+  if (!queryValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Invalid spaceId query parameter.",
+        message:
+          "Invalid query parameters. Expected `spaceId` (string), optional `query` (string), optional `type` (`file` | `content-node`).",
       },
     });
   }
+
+  const { spaceId, query, type } = queryValidation.data;
 
   const space = await SpaceResource.fetchById(auth, spaceId);
   if (!space || !space.canRead(auth)) {
@@ -74,7 +86,28 @@ async function handler(
   switch (req.method) {
     case "GET": {
       const attachments = await listProjectContextAttachments(auth, space);
-      res.status(200).json({ attachments });
+
+      const q = query?.trim().toLowerCase() ?? "";
+      const t = type ?? "";
+
+      const filtered = attachments.filter((a) => {
+        if (t) {
+          if (t === "file" && !isFileAttachmentType(a)) {
+            return false;
+          }
+          if (t === "content-node" && !isContentNodeAttachmentType(a)) {
+            return false;
+          }
+        }
+
+        if (q.length > 0 && !a.title.toLowerCase().includes(q)) {
+          return false;
+        }
+
+        return true;
+      });
+
+      res.status(200).json({ attachments: filtered });
       return;
     }
 


### PR DESCRIPTION
## Description

Extend `useUnifiedSearch` to optionally scope results to project files.
- Rename `projectSpaceId` → `projectId` across types and components for clarity
- Add `query` and `type` params to `useProjectContextAttachments`
- Move `spacesMap` memo before `spaceIds` (required dependency order)
- Pass `projectId` to `useUnifiedSearch` when the current space is a project, so search covers project-uploaded files

## Tests

Local + green

## Risk

Low

## Deploy Plan

Deploy `front`
