### PR TITLE
Add: support searching for project's files in AttachmentPicker.

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -44,7 +44,7 @@ interface ConversationSidePanelContextType {
   data: string | undefined;
 }
 
-const ConversationSidePanelContext = React.createContext<
+export const ConversationSidePanelContext = React.createContext<
   ConversationSidePanelContextType | undefined
 >(undefined);
 

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -4,7 +4,12 @@ import {
   isAudioContentType,
   isTextualContentType,
 } from "@app/components/assistant/conversation/attachment/utils";
-import { getFileFormat, isSupportedImageContentType } from "@app/types/files";
+import { ConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import {
+  getFileFormat,
+  isInteractiveContentType,
+  isSupportedImageContentType,
+} from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Citation,
@@ -18,7 +23,7 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import type React from "react";
-import { useState } from "react";
+import { useContext, useState } from "react";
 
 interface AttachmentCitationProps {
   owner: LightWorkspaceType;
@@ -33,6 +38,7 @@ export function AttachmentCitation({
   compact,
 }: AttachmentCitationProps) {
   const [viewerOpen, setViewerOpen] = useState(false);
+  const sidePanel = useContext(ConversationSidePanelContext);
 
   const tooltipContent =
     attachmentCitation.type === "file" ? (
@@ -63,18 +69,35 @@ export function AttachmentCitation({
     (isTextualContentType(attachmentCitation) ||
       isAudioContentType(attachmentCitation));
 
-  const dialogOrDownloadProps = canOpenInDialog
+  const canOpenInteractivePanel =
+    attachmentCitation.type === "file" &&
+    Boolean(attachmentCitation.fileId) &&
+    !attachmentCitation.isUploading &&
+    isInteractiveContentType(attachmentCitation.contentType) &&
+    sidePanel != null;
+
+  const dialogOrDownloadProps = canOpenInteractivePanel
     ? {
         onClick: (e: React.MouseEvent<HTMLDivElement>) => {
           e.preventDefault();
-          setViewerOpen(true);
+          sidePanel.openPanel({
+            type: "interactive_content",
+            fileId: attachmentCitation.fileId as string,
+          });
         },
       }
-    : isImage
-      ? {} // ImagePreview handles click with its own zoom dialog
-      : {
-          href: attachmentCitation.sourceUrl ?? undefined,
-        };
+    : canOpenInDialog
+      ? {
+          onClick: (e: React.MouseEvent<HTMLDivElement>) => {
+            e.preventDefault();
+            setViewerOpen(true);
+          },
+        }
+      : isImage
+        ? {} // ImagePreview handles click with its own zoom dialog
+        : {
+            href: attachmentCitation.sourceUrl ?? undefined,
+          };
 
   return (
     <>

--- a/front/components/assistant/conversation/attachment/utils.test.tsx
+++ b/front/components/assistant/conversation/attachment/utils.test.tsx
@@ -46,11 +46,24 @@ vi.mock("@app/components/resources/resources_icons", () => ({
   isInternalAllowedIcon: () => false,
 }));
 
+vi.mock("@app/lib/file_icon_utils", () => ({
+  getFileTypeIcon: (contentType: string, _fileName?: string) => {
+    if (
+      contentType === "application/vnd.dust.frame" ||
+      contentType === "application/vnd.dust.frame.slideshow"
+    ) {
+      return "ActionFrameIcon";
+    }
+    return "DocumentIcon";
+  },
+}));
+
 // Mock sparkle icon components and wrappers with light-weight test doubles.
 vi.mock("@dust-tt/sparkle", () => ({
   // Visual icon identifiers
   ActionAtomIcon: "ActionAtomIcon",
   ActionBrainIcon: "ActionBrainIcon",
+  ActionFrameIcon: "ActionFrameIcon",
   ActionIcons: "ActionIcons",
   ActionVolumeUpIcon: "ActionVolumeUpIcon",
   DocumentIcon: "DocumentIcon",
@@ -104,6 +117,7 @@ function TestIcon(props: {
   nodeType?: any; // keep it lax for the test environment
   contentType?: string;
   sourceUrl?: string;
+  fileName?: string;
 }) {
   return <>{IconForAttachmentCitation(props)}</>;
 }
@@ -184,6 +198,18 @@ describe("IconForAttachmentCitation", () => {
     const el = screen.getByTestId("icon");
     expect(el).toBeInTheDocument();
     expect(el).toHaveAttribute("data-visual", "DoubleQuotesIcon");
+  });
+
+  it("renders frame icon for Dust frame content type", () => {
+    render(
+      <TestIcon
+        contentType="application/vnd.dust.frame"
+        fileName="HelloWorld4.tsx"
+      />
+    );
+    const el = screen.getByTestId("icon");
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveAttribute("data-visual", "ActionFrameIcon");
   });
 
   it("renders default Document icon when nothing matches", () => {

--- a/front/components/assistant/conversation/attachment/utils.tsx
+++ b/front/components/assistant/conversation/attachment/utils.tsx
@@ -20,6 +20,7 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ToolGeneratedFileType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
+import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import {
   isContentNodeContentFragment,
@@ -72,6 +73,7 @@ export const IconForAttachmentCitation = ({
   contentType,
   sourceUrl,
   iconName,
+  fileName,
   size = "md",
 }: {
   provider?: string;
@@ -79,6 +81,8 @@ export const IconForAttachmentCitation = ({
   contentType?: string;
   sourceUrl?: string;
   iconName?: string;
+  /** Improves icons for some MIME types (e.g. extension → frame). */
+  fileName?: string;
   size?: "md" | "sm" | "lg";
 }): ReactNode => {
   const { isDark } = useTheme();
@@ -139,6 +143,11 @@ export const IconForAttachmentCitation = ({
     );
   }
 
+  if (contentType) {
+    const FileIcon = getFileTypeIcon(contentType, fileName);
+    return <Icon visual={FileIcon} size={size} />;
+  }
+
   return <Icon visual={DocumentIcon} size={size} />;
 };
 
@@ -152,7 +161,10 @@ export function contentFragmentToAttachmentCitation(
       id: contentFragment.sId,
       title: `${contentFragment.title} (no longer available)`,
       visual: (
-        <IconForAttachmentCitation contentType={contentFragment.contentType} />
+        <IconForAttachmentCitation
+          contentType={contentFragment.contentType}
+          fileName={contentFragment.title}
+        />
       ),
       fileId:
         contentFragment.contentFragmentType === "file"
@@ -178,6 +190,7 @@ export function contentFragmentToAttachmentCitation(
           provider={provider ?? undefined}
           nodeType={nodeType}
           contentType={contentFragment.contentType}
+          fileName={contentFragment.title}
           sourceUrl={contentFragment.sourceUrl ?? undefined}
         />
       ),
@@ -204,6 +217,7 @@ export function contentFragmentToAttachmentCitation(
       visual: (
         <IconForAttachmentCitation
           contentType={contentFragment.contentType}
+          fileName={contentFragment.title}
           iconName={contentFragment.sourceIcon ?? undefined}
         />
       ),
@@ -231,6 +245,7 @@ export function attachmentToAttachmentCitation(
       visual: (
         <IconForAttachmentCitation
           contentType={attachment.contentType}
+          fileName={attachment.title}
           iconName={attachment.iconName}
         />
       ),
@@ -293,7 +308,12 @@ export function toolGeneratedFileToAttachmentCitation(
     description: file.text,
     title: file.title,
     type: "file",
-    visual: <IconForAttachmentCitation contentType={file.contentType} />,
+    visual: (
+      <IconForAttachmentCitation
+        contentType={file.contentType}
+        fileName={file.title}
+      />
+    ),
     isUploading: false,
   };
 }

--- a/front/components/assistant/conversation/files_panel/FilesTab.tsx
+++ b/front/components/assistant/conversation/files_panel/FilesTab.tsx
@@ -88,14 +88,14 @@ export function FilesTab({ isLoading, owner, rows }: FilesTabProps) {
       )}
       <ScrollArea className="flex-1 p-4">
         <div className="flex flex-col gap-8">
-          {CATEGORY_CONFIG.map(({ value, label }) => {
+          {CATEGORY_CONFIG.map(({ value, plural }) => {
             const categoryRows = groupedByCategory.get(value);
             if (!categoryRows || categoryRows.length === 0) {
               return null;
             }
             return (
               <div key={value}>
-                <SectionLabel>{label}</SectionLabel>
+                <SectionLabel>{plural}</SectionLabel>
                 <FileCards rows={categoryRows} owner={owner} />
               </div>
             );

--- a/front/components/assistant/conversation/files_panel/SandboxTab.tsx
+++ b/front/components/assistant/conversation/files_panel/SandboxTab.tsx
@@ -198,7 +198,7 @@ export function SandboxTab({
       )}
       <ScrollArea className="flex-1 p-4">
         <div className="flex flex-col gap-8">
-          {CATEGORY_CONFIG.map(({ value, label }) => {
+          {CATEGORY_CONFIG.map(({ value, plural }) => {
             const categoryFiles = groupedByCategory.get(value);
             if (!categoryFiles || categoryFiles.length === 0) {
               return null;
@@ -206,7 +206,7 @@ export function SandboxTab({
             return (
               <div key={value}>
                 <div className="heading-sm pb-2 text-foreground dark:text-foreground-night">
-                  {label}
+                  {plural}
                 </div>
                 <CardGrid>
                   {categoryFiles.map((entry) => {

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -25,18 +25,35 @@ import type {
  */
 export const CATEGORY_CONFIG: {
   value: FilePanelCategory;
-  label: string;
+  singular: string;
+  plural: string;
 }[] = [
-  { value: "frame", label: "Frames" },
-  { value: "slideshow", label: "Slideshows" },
-  { value: "image", label: "Images" },
-  { value: "document", label: "Documents" },
-  { value: "pdf", label: "PDFs" },
-  { value: "table", label: "Tables" },
-  { value: "audio", label: "Audio" },
-  { value: "knowledge", label: "Knowledge" },
-  { value: "other", label: "Other" },
+  { value: "frame", singular: "Frame", plural: "Frames" },
+  { value: "slideshow", singular: "Slideshow", plural: "Slideshows" },
+  { value: "image", singular: "Image", plural: "Images" },
+  { value: "document", singular: "Document", plural: "Documents" },
+  { value: "pdf", singular: "PDF", plural: "PDFs" },
+  { value: "table", singular: "Table", plural: "Tables" },
+  { value: "audio", singular: "Audio", plural: "Audio" },
+  { value: "knowledge", singular: "Knowledge", plural: "Knowledge" },
+  { value: "other", singular: "File", plural: "Other" },
 ];
+
+/**
+ * Human-readable singular category for a file MIME type (Image, Frame, PDF, …).
+ * Aligns with {@link getFilePanelCategory} / {@link getCategoryFromContentType}.
+ */
+export function getSingularFileCategoryLabelForContentType(
+  contentType: string
+): string {
+  const category: FilePanelCategory = isInteractiveContentType(contentType)
+    ? contentType === frameSlideshowContentType
+      ? "slideshow"
+      : "frame"
+    : getCategoryFromContentType(contentType);
+  const config = CATEGORY_CONFIG.find((c) => c.value === category);
+  return config?.singular ?? "File";
+}
 
 /**
  * Categorize a file by its content type alone (used for sandbox/mounted files).

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -1,3 +1,4 @@
+import { getSingularFileCategoryLabelForContentType } from "@app/components/assistant/conversation/files_panel/utils";
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { NodePathTooltip } from "@app/components/NodePathTooltip";
 import { getIcon } from "@app/components/resources/resources_icons";
@@ -15,6 +16,7 @@ import {
   isFolder,
   isWebsite,
 } from "@app/lib/data_sources";
+import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import type {
   ToolSearchResult,
   ToolSearchServerResult,
@@ -48,22 +50,38 @@ import {
   DropdownMenuTrigger,
   Icon,
   Input,
+  LoadingBlock,
   MagnifyingGlassIcon,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ButtonVariantType } from "@dust-tt/sparkle/dist/esm/components/Button";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-const getKeyForDataSource = (dataSource: DataSourceType) => {
-  if (dataSource.connectorProvider === "webcrawler") {
+const SEARCH_RESULTS_PLACEHOLDER_COUNT = 5;
+
+const getKeyForConnectorProvider = ({
+  connectorProvider,
+  dataSourceSId,
+}: {
+  connectorProvider: DataSourceType["connectorProvider"];
+  dataSourceSId: string;
+}) => {
+  if (connectorProvider === "webcrawler") {
     return `ds-webcrawler`;
-  } else if (!dataSource.connectorProvider) {
+  } else if (!connectorProvider) {
     return `ds-folder`;
-  } else if (dataSource.connectorProvider === "dust_project") {
+  } else if (connectorProvider === "dust_project") {
     return `ds-project`;
   } else {
-    return `ds-${dataSource.sId}`;
+    return `ds-${dataSourceSId}`;
   }
+};
+
+const getKeyForDataSource = (dataSource: DataSourceType) => {
+  return getKeyForConnectorProvider({
+    connectorProvider: dataSource.connectorProvider,
+    dataSourceSId: dataSource.sId,
+  });
 };
 
 interface InputBarAttachmentsPickerProps {
@@ -91,6 +109,10 @@ interface InputBarAttachmentsPickerProps {
 }
 
 const PAGE_SIZE = 25;
+const PROJECT_FILTER_KEY = getKeyForConnectorProvider({
+  connectorProvider: "dust_project",
+  dataSourceSId: "project",
+});
 
 interface KnowledgeNodeCheckboxItemProps {
   item: DataSourceViewContentNode;
@@ -202,6 +224,39 @@ const ToolFileCheckboxItem = ({
   );
 };
 
+interface ProjectFileItemProps {
+  item: { fileId: string; title: string; contentType: string };
+  projectName: string;
+  isAttached: boolean;
+  isDisabled: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+const ProjectFileItem = ({
+  item,
+  projectName,
+  isAttached,
+  isDisabled,
+  onCheckedChange,
+}: ProjectFileItemProps) => {
+  const FileIcon = getFileTypeIcon(item.contentType, item.title);
+  const fileKind = getSingularFileCategoryLabelForContentType(item.contentType);
+  const description = projectName
+    ? `${fileKind} in "${projectName}" knowledge`
+    : `${fileKind} in project knowledge`;
+  return (
+    <DropdownMenuCheckboxItem
+      label={item.title}
+      icon={<Icon visual={FileIcon} size="md" />}
+      description={description}
+      checked={isAttached}
+      disabled={isDisabled}
+      onCheckedChange={onCheckedChange}
+      truncateText
+    />
+  );
+};
+
 export const InputBarAttachmentsPicker = ({
   owner,
   fileUploaderService,
@@ -265,9 +320,16 @@ export const InputBarAttachmentsPicker = ({
     }
   }, [spaces, spaceId]);
 
+  const projectId =
+    spaceId && spacesMap?.[spaceId]?.kind === "project" ? spaceId : undefined;
+  const projectName =
+    projectId && spacesMap[projectId]?.name ? spacesMap[projectId].name : "";
+
   const {
     knowledgeResults: searchResultNodes,
     toolResults: toolFileResults,
+    projectContextFiles,
+    isProjectContextFilesLoading,
     isSearchLoading,
     isLoadingNextPage,
     isSearchValidating,
@@ -279,14 +341,24 @@ export const InputBarAttachmentsPicker = ({
     pageSize: PAGE_SIZE,
     disabled: isSpacesLoading || !searchQuery,
     spaceIds,
-    projectId:
-      spaceId && spacesMap?.[spaceId]?.kind === "project" ? spaceId : undefined,
+    projectId,
     viewType: "all",
     includeDataSources: true,
     searchSourceUrls: true,
     includeTools: true,
     prioritizeSpaceAccess: true,
   });
+
+  const attachedFileIds = useMemo(() => {
+    return new Set(fileUploaderService.fileBlobs.map((b) => b.fileId ?? b.id));
+  }, [fileUploaderService.fileBlobs]);
+
+  const projectFilesWithResults = useMemo(() => {
+    if (!projectId) {
+      return [];
+    }
+    return projectContextFiles;
+  }, [projectContextFiles, projectId]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   useEffect(() => {
@@ -363,6 +435,7 @@ export const InputBarAttachmentsPicker = ({
   // Auto-select new datasources/tools as they appear
   useEffect(() => {
     const allKeys = [
+      ...(projectFilesWithResults.length > 0 ? [PROJECT_FILTER_KEY] : []),
       ...Object.keys(dataSourcesWithResults),
       ...Object.keys(serversWithResults),
     ];
@@ -381,7 +454,11 @@ export const InputBarAttachmentsPicker = ({
         return hasChanges ? updated : prev;
       });
     }
-  }, [dataSourcesWithResults, serversWithResults]);
+  }, [
+    dataSourcesWithResults,
+    serversWithResults,
+    projectFilesWithResults.length,
+  ]);
 
   const handleFilterClick = (key: string) => {
     setSelectedDataSourcesAndTools((prev) => ({
@@ -408,21 +485,50 @@ export const InputBarAttachmentsPicker = ({
   });
 
   const showLoader =
-    isSearchLoading || isLoadingNextPage || isSearchValidating || isDebouncing;
+    isSearchLoading ||
+    isLoadingNextPage ||
+    isSearchValidating ||
+    isDebouncing ||
+    isProjectContextFilesLoading;
 
-  const availableSources: DropdownMenuFilterOption[] = useMemo(
-    () => [
-      ...Object.entries(dataSourcesWithResults).map(([key, r]) => ({
+  const availableSources: DropdownMenuFilterOption[] = useMemo(() => {
+    const options = new Map<string, DropdownMenuFilterOption>();
+
+    for (const [key, r] of Object.entries(dataSourcesWithResults)) {
+      options.set(key, {
         value: key,
-        label: getDisplayNameForDataSource(r.dataSource, true),
-      })),
-      ...Object.entries(serversWithResults).map(([key, s]) => ({
+        label:
+          key === PROJECT_FILTER_KEY
+            ? "Projects"
+            : getDisplayNameForDataSource(r.dataSource, true),
+      });
+    }
+
+    for (const [key, s] of Object.entries(serversWithResults)) {
+      options.set(key, {
         value: key,
         label: asDisplayToolName(s.server.serverName),
-      })),
-    ],
-    [dataSourcesWithResults, serversWithResults]
-  );
+      });
+    }
+
+    // Ensure project files share the same filter chip as project knowledge.
+    if (projectFilesWithResults.length > 0) {
+      options.set(PROJECT_FILTER_KEY, {
+        value: PROJECT_FILTER_KEY,
+        label: "Projects",
+      });
+    }
+
+    return Array.from(options.values());
+  }, [
+    dataSourcesWithResults,
+    serversWithResults,
+    projectFilesWithResults.length,
+  ]);
+
+  // Chips only exist once at least one source has hits; paired with showLoader = still fetching.
+  const showSearchResultPlaceholders =
+    showLoader && availableSources.length === 0;
 
   const selectedFilterKeys = useMemo(
     () =>
@@ -433,6 +539,7 @@ export const InputBarAttachmentsPicker = ({
   );
 
   const allUnselected = selectedFilterKeys.length === 0;
+
   const Wrapper = type === "dropdown" ? DropdownMenu : DropdownMenuSub;
   const ContentWrapper =
     type === "dropdown" ? DropdownMenuContent : DropdownMenuSubContent;
@@ -523,7 +630,8 @@ export const InputBarAttachmentsPicker = ({
               placeholder="Search"
               value={search}
               onChange={setSearch}
-              disabled={isLoading}
+              disabled={false}
+              isLoading={showLoader}
               onKeyDown={(e) => {
                 if (e.key === "ArrowDown") {
                   e.preventDefault();
@@ -539,6 +647,7 @@ export const InputBarAttachmentsPicker = ({
                   icon={CloudArrowUpIcon}
                   label="Upload File"
                   onClick={() => fileInputRef.current?.click()}
+                  className="ml-4"
                 />
               }
             />
@@ -548,80 +657,124 @@ export const InputBarAttachmentsPicker = ({
       >
         {searchQuery ? (
           <div ref={itemsContainerRef}>
-            {(showLoader || availableSources.length > 1) && (
-              <div className="flex flex-wrap items-center">
-                {availableSources.length > 1 && (
-                  <DropdownMenuFilters
-                    filters={availableSources}
-                    selectedValues={selectedFilterKeys}
-                    onSelectFilter={handleFilterClick}
-                  />
-                )}
-                {showLoader && (
-                  <div className="flex items-center justify-center gap-0.5 p-2 grow">
-                    <Button size="xs" isLoading={true} variant="ghost" />
-                  </div>
+            <div className="flex flex-wrap items-center">
+              <DropdownMenuFilters
+                filters={availableSources}
+                selectedValues={selectedFilterKeys}
+                onSelectFilter={handleFilterClick}
+              />
+
+              {availableSources.length === 0 && showLoader && (
+                <LoadingBlock
+                  // LoadingBlock defaults to dark:bg-muted-background-night, same as the menu
+                  // surface, so skeletons read as invisible; match menu row hover contrast.
+                  className="h-7 w-20 bg-muted-background dark:!bg-muted-night p-2 mt-2"
+                />
+              )}
+            </div>
+
+            {showSearchResultPlaceholders ? (
+              <div className="flex flex-col gap-2 px-2 py-2">
+                {Array.from(
+                  { length: SEARCH_RESULTS_PLACEHOLDER_COUNT },
+                  (_, i) => (
+                    <LoadingBlock
+                      key={i}
+                      // LoadingBlock defaults to dark:bg-muted-background-night, same as the menu
+                      // surface, so skeletons read as invisible; match menu row hover contrast.
+                      className="h-11 w-full bg-muted-background dark:border-border-night dark:!bg-muted-night"
+                    />
+                  )
                 )}
               </div>
-            )}
-            {Object.keys(serversWithResults).length === 0 ? (
-              // No tools results, show knowledge nodes as returned by the search.
-              dataSourcesNodes
-                .filter(
-                  (item) =>
-                    allUnselected ||
-                    selectedDataSourcesAndTools[
-                      getKeyForDataSource(item.dataSource)
-                    ]
-                )
-                .map((item) => (
-                  <KnowledgeNodeCheckboxItem
-                    key={`knowledge-${item.dataSourceView.dataSource.sId}-${item.internalId}`}
-                    item={item}
-                    owner={owner}
-                    attachedNodes={attachedNodes}
-                    onNodeSelect={onNodeSelect}
-                    onNodeUnselect={onNodeUnselect}
-                    spacesMap={spacesMap}
-                  />
-                ))
             ) : (
-              // Show grouped results, first knowledge nodes, then tools.
               <>
-                {Object.entries(dataSourcesWithResults).map(([key, r]) => {
-                  const isSelected =
-                    allUnselected || selectedDataSourcesAndTools[key];
-                  return isSelected
-                    ? r.results.map((item) => (
-                        <KnowledgeNodeCheckboxItem
-                          key={`knowledge-${item.dataSourceView.dataSource.sId}-${item.internalId}`}
-                          item={item}
-                          owner={owner}
-                          attachedNodes={attachedNodes}
-                          onNodeSelect={onNodeSelect}
-                          onNodeUnselect={onNodeUnselect}
-                          spacesMap={spacesMap}
-                        />
-                      ))
-                    : null;
-                })}
-                {Object.entries(serversWithResults).map(([key, r]) => {
-                  const isSelected =
-                    allUnselected || selectedDataSourcesAndTools[key];
-                  return isSelected
-                    ? r.results.map((item) => (
-                        <ToolFileCheckboxItem
-                          key={`tool-${getToolFileKey(item)}`}
-                          item={item}
-                          isLoading={isLoading}
-                          isToolFileAttached={isToolFileAttached}
-                          isToolFileUploading={isToolFileUploading}
-                          uploadToolFile={uploadToolFile}
-                          removeToolFile={removeToolFile}
-                        />
-                      ))
-                    : null;
-                })}
+                {(allUnselected ||
+                  selectedDataSourcesAndTools[PROJECT_FILTER_KEY]) &&
+                  projectFilesWithResults.map((f) => (
+                    <ProjectFileItem
+                      key={`project-file-${f.fileId}`}
+                      item={f}
+                      projectName={projectName}
+                      isAttached={attachedFileIds.has(f.fileId)}
+                      isDisabled={isLoading || disabled}
+                      onCheckedChange={(checked) => {
+                        if (checked) {
+                          fileUploaderService.addUploadedFile({
+                            fileId: f.fileId,
+                            filename: f.title,
+                            // We only fetch `type=file` from the project context endpoint.
+                            contentType: f.contentType as any,
+                            size: 0,
+                            id: f.fileId,
+                          });
+                        } else {
+                          fileUploaderService.removeFile(f.fileId);
+                        }
+                        onFileChange?.();
+                      }}
+                    />
+                  ))}
+                {Object.keys(serversWithResults).length === 0 ? (
+                  // No tools results, show knowledge nodes as returned by the search.
+                  dataSourcesNodes
+                    .filter(
+                      (item) =>
+                        allUnselected ||
+                        selectedDataSourcesAndTools[
+                          getKeyForDataSource(item.dataSource)
+                        ]
+                    )
+                    .map((item) => (
+                      <KnowledgeNodeCheckboxItem
+                        key={`knowledge-${item.dataSourceView.dataSource.sId}-${item.internalId}`}
+                        item={item}
+                        owner={owner}
+                        attachedNodes={attachedNodes}
+                        onNodeSelect={onNodeSelect}
+                        onNodeUnselect={onNodeUnselect}
+                        spacesMap={spacesMap}
+                      />
+                    ))
+                ) : (
+                  // Show grouped knowledge nodes, then tools (project files are rendered above).
+                  <>
+                    {Object.entries(dataSourcesWithResults).map(([key, r]) => {
+                      const isSelected =
+                        allUnselected || selectedDataSourcesAndTools[key];
+                      return isSelected
+                        ? r.results.map((item) => (
+                            <KnowledgeNodeCheckboxItem
+                              key={`knowledge-${item.dataSourceView.dataSource.sId}-${item.internalId}`}
+                              item={item}
+                              owner={owner}
+                              attachedNodes={attachedNodes}
+                              onNodeSelect={onNodeSelect}
+                              onNodeUnselect={onNodeUnselect}
+                              spacesMap={spacesMap}
+                            />
+                          ))
+                        : null;
+                    })}
+                    {Object.entries(serversWithResults).map(([key, r]) => {
+                      const isSelected =
+                        allUnselected || selectedDataSourcesAndTools[key];
+                      return isSelected
+                        ? r.results.map((item) => (
+                            <ToolFileCheckboxItem
+                              key={`tool-${getToolFileKey(item)}`}
+                              item={item}
+                              isLoading={isLoading}
+                              isToolFileAttached={isToolFileAttached}
+                              isToolFileUploading={isToolFileUploading}
+                              uploadToolFile={uploadToolFile}
+                              removeToolFile={removeToolFile}
+                            />
+                          ))
+                        : null;
+                    })}
+                  </>
+                )}
               </>
             )}
             {availableSources.length === 0 && !showLoader && (

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -10,6 +10,8 @@ import {
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { publishAgentMessagesEvents } from "@app/lib/api/assistant/streaming/events";
+import * as attachmentsModule from "@app/lib/api/files/attachments";
+import { fetchLatestProjectContextFileContentFragment } from "@app/lib/api/projects";
 import { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
@@ -26,9 +28,13 @@ import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
+import type {
+  ContentFragmentInputWithContentNode,
+  ContentFragmentInputWithFileIdType,
+} from "@app/types/api/internal/assistant";
 import { isContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -3078,6 +3084,176 @@ describe("postNewContentFragment", () => {
       }
       // Verify getContentFragmentBlob was not called since the data source view check failed first
       expect(getContentFragmentBlob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("project-context file reuse in project conversations", () => {
+    it("reuses existing project content fragment and skips attachment upsert and blob fetch", async () => {
+      const user = auth.getNonNullableUser();
+      const projectFile = await ProjectFileFactory.create(
+        auth,
+        user,
+        projectSpace,
+        {
+          contentType: "text/plain",
+          fileName: "project-doc.txt",
+          fileSize: 12,
+          status: "ready",
+        }
+      );
+
+      const latestContext = await fetchLatestProjectContextFileContentFragment(
+        auth,
+        projectSpace,
+        projectFile.sId
+      );
+      expect(latestContext).not.toBeNull();
+
+      const conversationWithoutContent = await ConversationFactory.create(
+        auth,
+        {
+          agentConfigurationId: agentConfig.sId,
+          messagesCreatedAt: [],
+          spaceId: projectSpace.id,
+        }
+      );
+
+      const fetchedConversationResult = await getConversation(
+        auth,
+        conversationWithoutContent.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      conversation = fetchedConversationResult.value;
+
+      const maybeUpsertSpy = vi.spyOn(
+        attachmentsModule,
+        "maybeUpsertFileAttachment"
+      );
+
+      const input: ContentFragmentInputWithFileIdType = {
+        title: projectFile.fileName,
+        fileId: projectFile.sId,
+      };
+
+      const result = await postNewContentFragment(auth, conversation, input, {
+        username: user.username,
+        fullName: user.fullName(),
+        email: user.email,
+        profilePictureUrl: null,
+      });
+
+      maybeUpsertSpy.mockRestore();
+
+      expect(result.isOk()).toBe(true);
+      expect(maybeUpsertSpy).not.toHaveBeenCalled();
+      expect(getContentFragmentBlob).not.toHaveBeenCalled();
+
+      if (result.isOk()) {
+        expect(result.value.contentFragmentId).toBe(
+          latestContext!.fragment.sId
+        );
+        expect(result.value.contentFragmentType).toBe("file");
+        if (result.value.contentFragmentType === "file") {
+          expect(result.value.fileId).toBe(projectFile.sId);
+          expect(result.value.isInProjectContext).toBe(true);
+        }
+      }
+    });
+
+    it("does not create a second message row when the project fragment is already in the conversation", async () => {
+      const user = auth.getNonNullableUser();
+      const projectFile = await ProjectFileFactory.create(
+        auth,
+        user,
+        projectSpace,
+        {
+          contentType: "text/plain",
+          fileName: "project-doc-duplicate.txt",
+          fileSize: 12,
+          status: "ready",
+        }
+      );
+
+      const latestContext = await fetchLatestProjectContextFileContentFragment(
+        auth,
+        projectSpace,
+        projectFile.sId
+      );
+      expect(latestContext).not.toBeNull();
+      const fragmentModelId = latestContext!.fragment.id;
+
+      const conversationWithoutContent = await ConversationFactory.create(
+        auth,
+        {
+          agentConfigurationId: agentConfig.sId,
+          messagesCreatedAt: [],
+          spaceId: projectSpace.id,
+        }
+      );
+
+      let fetchedConversationResult = await getConversation(
+        auth,
+        conversationWithoutContent.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      conversation = fetchedConversationResult.value;
+
+      const context = {
+        username: user.username,
+        fullName: user.fullName(),
+        email: user.email,
+        profilePictureUrl: null,
+      };
+
+      const input: ContentFragmentInputWithFileIdType = {
+        title: projectFile.fileName,
+        fileId: projectFile.sId,
+      };
+
+      const first = await postNewContentFragment(
+        auth,
+        conversation,
+        input,
+        context
+      );
+      expect(first.isOk()).toBe(true);
+
+      const messageCountAfterFirst = await MessageModel.count({
+        where: {
+          conversationId: conversation.id,
+          contentFragmentId: fragmentModelId,
+        },
+      });
+      expect(messageCountAfterFirst).toBe(1);
+
+      fetchedConversationResult = await getConversation(
+        auth,
+        conversationWithoutContent.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      const conversationAfterFirst = fetchedConversationResult.value;
+
+      const second = await postNewContentFragment(
+        auth,
+        conversationAfterFirst,
+        input,
+        context
+      );
+      expect(second.isOk()).toBe(true);
+
+      const messageCountAfterSecond = await MessageModel.count({
+        where: {
+          conversationId: conversation.id,
+          contentFragmentId: fragmentModelId,
+        },
+      });
+      expect(messageCountAfterSecond).toBe(1);
     });
   });
 });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -49,6 +49,7 @@ import {
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
+import { fetchLatestProjectContextFileContentFragment } from "@app/lib/api/projects";
 import { isModelAvailable, isProviderWhitelisted } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
@@ -73,7 +74,6 @@ import { ConversationBranchResource } from "@app/lib/resources/conversation_bran
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -1914,6 +1914,71 @@ export async function postNewContentFragment(
           "Only content fragments from the project space or the global space are allowed in a project conversation"
         )
       );
+    }
+  }
+
+  // If the user attaches a project-context file to a project conversation, reuse the existing
+  // project content fragment and only create the message row at send time.
+  if (isProjectConversation(conversation) && "fileId" in cf) {
+    const project = await SpaceResource.fetchById(auth, conversation.spaceId);
+    if (project?.isProject()) {
+      const r = await fetchLatestProjectContextFileContentFragment(
+        auth,
+        project,
+        cf.fileId
+      );
+      if (r) {
+        const alreadyPresent = conversation.content.some((versions) => {
+          const latest = versions[versions.length - 1];
+          return (
+            isContentFragmentType(latest) &&
+            latest.contentFragmentVersion === "latest" &&
+            latest.contentFragmentId === r.fragment.sId
+          );
+        });
+
+        if (!alreadyPresent) {
+          await withTransaction(async (t) => {
+            await getConversationRankVersionLock(auth, conversation, t);
+
+            const nextMessageRank =
+              ((await MessageModel.max<number | null, MessageModel>("rank", {
+                where: {
+                  workspaceId: owner.id,
+                  conversationId: conversation.id,
+                  branchId: conversation.branchId
+                    ? getResourceIdFromSId(conversation.branchId)
+                    : null,
+                },
+                transaction: t,
+              })) ?? -1) + 1;
+
+            await MessageModel.create(
+              {
+                sId: generateRandomModelSId(),
+                rank: nextMessageRank,
+                conversationId: conversation.id,
+                branchId: conversation.branchId
+                  ? getResourceIdFromSId(conversation.branchId)
+                  : null,
+                contentFragmentId: r.fragment.id,
+                workspaceId: owner.id,
+              },
+              { transaction: t }
+            );
+
+            await ConversationResource.markAsUpdated(auth, { conversation, t });
+          });
+        }
+
+        const rendered =
+          await ContentFragmentResource.renderToContentFragmentType(
+            auth,
+            r.fragment,
+            { kind: "project_context", file: r.file }
+          );
+        return new Ok(rendered);
+      }
     }
   }
 

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -189,6 +189,50 @@ export async function listProjectContextAttachments(
 }
 
 /**
+ * Fetches the latest project-context `ContentFragmentResource` for a given file in a project space.
+ * Returns null when the file or fragment cannot be found (or is not in that project context).
+ */
+export async function fetchLatestProjectContextFileContentFragment(
+  auth: Authenticator,
+  space: SpaceResource,
+  fileId: string // file sId
+): Promise<{ file: FileResource; fragment: ContentFragmentResource } | null> {
+  const file = await FileResource.fetchById(auth, fileId);
+  if (!file) {
+    return null;
+  }
+
+  if (file.useCase !== "project_context") {
+    return null;
+  }
+  if (file.useCaseMetadata?.spaceId !== space.sId) {
+    return null;
+  }
+
+  const row = await ContentFragmentModel.findOne({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      spaceId: space.id,
+      fileId: file.id,
+      version: "latest",
+    },
+    order: [["createdAt", "DESC"]],
+  });
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    file,
+    fragment: new ContentFragmentResource(
+      ContentFragmentResource.model,
+      row.get()
+    ),
+  };
+}
+
+/**
  * Indexes a project context file in the project data source (when possible) and
  * ensures a latest `content_fragments` row for the file. Core upsert failures
  * are logged and do not block the content fragment sync (file may still be used raw).

--- a/front/lib/api/projects/index.ts
+++ b/front/lib/api/projects/index.ts
@@ -3,6 +3,7 @@ export { createDataSourceAndConnectorForProject } from "./connector";
 export {
   addContentNodeToProject,
   addFileToProject,
+  fetchLatestProjectContextFileContentFragment,
   listProjectContentFragments,
   listProjectContextAttachments,
   listProjectContextFiles,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.test.ts
@@ -125,6 +125,42 @@ describe("/api/w/[wId]/spaces/[spaceId]/project_context", () => {
       expect(titles).toEqual(["Budget 2026.txt"]);
     });
 
+    it("filters attachments by query (spacing/camelCase-style titles)", async () => {
+      const { auth, req, res, user, globalSpace } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "user",
+        });
+
+      const space = globalSpace;
+
+      await ProjectFileFactory.create(auth, user, space, {
+        contentType: "text/plain",
+        fileName: "Hello World 4.tsx",
+        fileSize: 100,
+        status: "ready",
+      });
+
+      await ProjectFileFactory.create(auth, user, space, {
+        contentType: "text/plain",
+        fileName: "Other.txt",
+        fileSize: 100,
+        status: "ready",
+      });
+
+      req.query.spaceId = space.sId;
+      req.query.query = "helloworld";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const responseData = res._getJSONData();
+      const titles = responseData.attachments.map(
+        (a: { title: string }) => a.title
+      );
+      expect(titles).toEqual(["Hello World 4.tsx"]);
+    });
+
     it("filters attachments by type=content-node", async () => {
       const { req, res, globalSpace } = await createPrivateApiMockRequest({
         method: "GET",

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.ts
@@ -49,6 +49,26 @@ const ProjectContextQuerySchema = z.object({
   type: z.enum(["file", "content-node"]).optional(),
 });
 
+/** Lowercase + strip separators so "Hello World 4" matches query "helloworld". */
+function normalizeAttachmentSearchKey(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function attachmentTitleMatchesQuery(title: string, q: string): boolean {
+  if (q.length === 0) {
+    return true;
+  }
+  const lowerTitle = title.toLowerCase();
+  if (lowerTitle.includes(q)) {
+    return true;
+  }
+  const normalizedQuery = normalizeAttachmentSearchKey(q);
+  if (normalizedQuery.length === 0) {
+    return false;
+  }
+  return normalizeAttachmentSearchKey(title).includes(normalizedQuery);
+}
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
@@ -100,7 +120,7 @@ async function handler(
           }
         }
 
-        if (q.length > 0 && !a.title.toLowerCase().includes(q)) {
+        if (!attachmentTitleMatchesQuery(a.title, q)) {
           return false;
         }
 

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -765,6 +765,7 @@ const DropdownMenuSearchbar = React.forwardRef<
       name,
       className,
       disabled = false,
+      isLoading = false,
       button,
       autoFocus,
     },
@@ -819,6 +820,7 @@ const DropdownMenuSearchbar = React.forwardRef<
           onChange={onChange}
           onKeyDown={handleKeyDown}
           disabled={disabled}
+          isLoading={isLoading}
         />
         {button}
       </div>


### PR DESCRIPTION
## Description

Support searching project files in the `AttachmentPicker` and improve attachment citation UX.
- In `AttachmentCitation`, open interactive content (Dust Frames) in the side panel when available, falling back to dialog or download
- Pass `fileName` to `IconForAttachmentCitation` and use `getFileTypeIcon` for better icon resolution (e.g. frame icon for `.tsx` Frames)
- Wire `projectId` into `InputBarAttachmentsPicker` to search project files when in a project space
- Use `plural` label for file categories in `FilesTab`
- Add tests for frame icon rendering

https://github.com/user-attachments/assets/4a4b0abc-1b69-4ad2-ab36-85d3a6b86500


## Tests

Local + green

## Risk

Low

## Deploy Plan

Deploy `front`
