### PR TITLE
Update legacy seats from seat-based to manual count

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -242,9 +242,8 @@ export async function createMetronomeContract({
 }
 
 /**
- * Get the active contract and subscription IDs for a Metronome customer.
- * Returns the contract ID and a map of product_id -> subscription_id
- * for seat-based subscriptions.
+ * Get the active contract for a Metronome customer.
+ * Returns the contract ID if found.
  */
 export async function getMetronomeActiveContract(
   metronomeCustomerId: string
@@ -252,7 +251,6 @@ export async function getMetronomeActiveContract(
   Result<
     {
       contractId: string;
-      seatSubscriptions: Record<string, string>;
     } | null,
     Error
   >
@@ -268,17 +266,9 @@ export async function getMetronomeActiveContract(
 
     // Take the most recent contract.
     const contract = response.data[0];
-    const subscriptions = contract.subscriptions ?? [];
-    const seatSubscriptions: Record<string, string> = {};
-    for (const sub of subscriptions) {
-      if (sub.quantity_management_mode === "SEAT_BASED" && sub.id) {
-        seatSubscriptions[sub.subscription_rate.product.id] = sub.id;
-      }
-    }
 
     return new Ok({
       contractId: contract.id,
-      seatSubscriptions,
     });
   } catch (err) {
     const error = normalizeError(err);
@@ -370,74 +360,66 @@ export async function getMetronomeContractPackageAliases({
 // Seat management
 // ---------------------------------------------------------------------------
 
-interface SeatSubscriptionEdit {
-  subscriptionId: string;
-  addSeatIds?: string[];
-  removeSeatIds?: string[];
-  addUnassignedSeats?: number;
-}
-
 /**
- * Add or remove seat IDs on a Metronome contract subscription.
- * Used when members join/leave or change seat type.
+ * Update the quantity on a MANUAL subscription (delta or absolute).
+ * Used for seat count changes when members join/leave.
  */
-export async function editMetronomeContractSeats({
+export async function updateSubscriptionQuantity({
   metronomeCustomerId,
   contractId,
-  edits,
+  subscriptionId,
+  quantityDelta,
+  quantity,
   startingAt,
 }: {
   metronomeCustomerId: string;
   contractId: string;
-  edits: SeatSubscriptionEdit[];
+  subscriptionId: string;
+  /** Relative change (+1 for add, -1 for remove). Mutually exclusive with quantity. */
+  quantityDelta?: number;
+  /** Absolute quantity. Mutually exclusive with quantityDelta. */
+  quantity?: number;
   startingAt?: string;
 }): Promise<Result<void, Error>> {
-  // Metronome requires starting_at on an hour boundary — round down to current hour.
+  if (quantity !== undefined && quantityDelta !== undefined) {
+    return new Err(
+      new Error("quantity and quantityDelta are mutually exclusive")
+    );
+  }
+  if (quantity === undefined && quantityDelta === undefined) {
+    return new Err(
+      new Error("one of quantity or quantityDelta must be provided")
+    );
+  }
+
   const now = startingAt ?? floorToHourISO(new Date());
 
   try {
     await getMetronomeClient().v2.contracts.edit({
       customer_id: metronomeCustomerId,
       contract_id: contractId,
-      update_subscriptions: edits.map((edit) => ({
-        subscription_id: edit.subscriptionId,
-        seat_updates: {
-          ...(edit.addSeatIds
-            ? {
-                add_seat_ids: edit.addSeatIds.map((id) => ({
-                  seat_ids: [id],
-                  starting_at: now,
-                })),
-              }
-            : {}),
-          ...(edit.removeSeatIds
-            ? {
-                remove_seat_ids: edit.removeSeatIds.map((id) => ({
-                  seat_ids: [id],
-                  starting_at: now,
-                })),
-              }
-            : {}),
-          ...(edit.addUnassignedSeats !== undefined
-            ? {
-                add_unassigned_seats: [
-                  {
-                    quantity: edit.addUnassignedSeats,
-                    starting_at: now,
-                  },
-                ],
-              }
-            : {}),
+      update_subscriptions: [
+        {
+          subscription_id: subscriptionId,
+          quantity_updates: [
+            {
+              starting_at: now,
+              ...(quantity !== undefined ? { quantity } : {}),
+              ...(quantityDelta !== undefined
+                ? { quantity_delta: quantityDelta }
+                : {}),
+            },
+          ],
         },
-      })),
+      ],
     });
 
     return new Ok(undefined);
   } catch (err) {
     const error = normalizeError(err);
     logger.error(
-      { error, metronomeCustomerId, contractId },
-      "[Metronome] Failed to edit contract seats"
+      { error, metronomeCustomerId, contractId, subscriptionId },
+      "[Metronome] Failed to update subscription quantity"
     );
     return new Err(error);
   }

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1,7 +1,8 @@
 import {
-  editMetronomeContractSeats,
   getMetronomeClient,
+  updateSubscriptionQuantity,
 } from "@app/lib/metronome/client";
+import { getProductWorkspaceSeatId } from "@app/lib/metronome/constants";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -9,37 +10,39 @@ import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 
 /**
- * Find the default SEAT_BASED subscription on a contract.
- * For legacy packages there's only one; for new pricing, this returns the first
- * SEAT_BASED subscription (Guest/Pro/Max — caller decides which to use).
+ * Find the seat subscription ID on a contract by matching the Workspace Seat product ID.
  */
-export async function getDefaultSeatProductId(
+async function getSeatSubscriptionId(
   metronomeCustomerId: string,
   contractId: string
 ): Promise<string | undefined> {
   const client = getMetronomeClient();
+  const seatProductId = getProductWorkspaceSeatId();
+
   const response = await client.v2.contracts.list({
     customer_id: metronomeCustomerId,
   });
-  const contract = response.data.find((c) => c.id === contractId);
+  const contract = response.data.find(
+    (c: { id: string }) => c.id === contractId
+  );
   if (!contract?.subscriptions?.length) {
     return undefined;
   }
 
   const seatSub = contract.subscriptions.find(
-    (s) => s.quantity_management_mode === "SEAT_BASED"
+    (s: { subscription_rate: { product: { id: string } } }) =>
+      s.subscription_rate.product.id === seatProductId
   );
   return seatSub?.id ?? undefined;
 }
 
 /**
- * Add a single member as a seat on a contract's default seat subscription.
+ * Increment seat count by 1 when a member joins.
  * Called from membership create hook.
  */
 export async function addSeat({
   metronomeCustomerId,
   contractId,
-  userId,
   workspaceId,
 }: {
   metronomeCustomerId: string;
@@ -47,29 +50,29 @@ export async function addSeat({
   userId: string;
   workspaceId: string;
 }): Promise<Result<void, Error>> {
-  const seatProductId = await getDefaultSeatProductId(
+  const subscriptionId = await getSeatSubscriptionId(
     metronomeCustomerId,
     contractId
   );
-  if (!seatProductId) {
-    return new Err(new Error("No SEAT_BASED subscription found on contract"));
+  if (!subscriptionId) {
+    return new Err(new Error("No seat subscription found on contract"));
   }
 
-  return await editMetronomeContractSeats({
+  return await updateSubscriptionQuantity({
     metronomeCustomerId,
     contractId,
-    edits: [{ subscriptionId: seatProductId, addSeatIds: [userId] }],
+    subscriptionId,
+    quantityDelta: 1,
   });
 }
 
 /**
- * Remove a single member's seat from a contract.
+ * Decrement seat count by 1 when a member leaves.
  * Called from membership revoke hook.
  */
 export async function removeSeat({
   metronomeCustomerId,
   contractId,
-  userId,
   workspaceId,
 }: {
   metronomeCustomerId: string;
@@ -77,23 +80,24 @@ export async function removeSeat({
   userId: string;
   workspaceId: string;
 }): Promise<Result<void, Error>> {
-  const seatProductId = await getDefaultSeatProductId(
+  const subscriptionId = await getSeatSubscriptionId(
     metronomeCustomerId,
     contractId
   );
-  if (!seatProductId) {
-    return new Err(new Error("No SEAT_BASED subscription found on contract"));
+  if (!subscriptionId) {
+    return new Err(new Error("No seat subscription found on contract"));
   }
 
-  return await editMetronomeContractSeats({
+  return await updateSubscriptionQuantity({
     metronomeCustomerId,
     contractId,
-    edits: [{ subscriptionId: seatProductId, removeSeatIds: [userId] }],
+    subscriptionId,
+    quantityDelta: -1,
   });
 }
 
 /**
- * Add all active workspace members as seats on a contract's default seat subscription.
+ * Set absolute seat count to match the current workspace member count.
  * Called after contract creation (both new provisioning and migration).
  */
 export async function provisionSeatsForContract({
@@ -107,26 +111,24 @@ export async function provisionSeatsForContract({
   workspace: LightWorkspaceType;
   startingAt: string;
 }): Promise<Result<void, Error>> {
-  const subscriptionId = await getDefaultSeatProductId(
+  const subscriptionId = await getSeatSubscriptionId(
     metronomeCustomerId,
     contractId
   );
   if (!subscriptionId) {
     logger.warn(
       { workspaceId: workspace.sId, contractId },
-      "[Metronome] No SEAT_BASED subscription found on contract — cannot provision seats"
+      "[Metronome] No seat subscription found on contract — cannot provision seats"
     );
-    return new Err(new Error("No SEAT_BASED subscription found on contract"));
+    return new Err(new Error("No seat subscription found on contract"));
   }
 
   const { memberships } = await MembershipResource.getActiveMemberships({
     workspace,
   });
-  const memberIds = memberships
-    .map((m) => m.user?.sId)
-    .filter((s): s is string => !!s);
+  const memberCount = memberships.length;
 
-  if (memberIds.length === 0) {
+  if (memberCount === 0) {
     logger.info(
       { workspaceId: workspace.sId },
       "[Metronome] No active members — no seats to provision"
@@ -134,20 +136,11 @@ export async function provisionSeatsForContract({
     return new Ok(undefined);
   }
 
-  // Metronome limits to 500 seats per subscription edit. Batch if needed.
-  const SEAT_BATCH_SIZE = 500;
-  for (let i = 0; i < memberIds.length; i += SEAT_BATCH_SIZE) {
-    const batch = memberIds.slice(i, i + SEAT_BATCH_SIZE);
-    const result = await editMetronomeContractSeats({
-      metronomeCustomerId,
-      contractId,
-      edits: [{ subscriptionId, addSeatIds: batch }],
-      startingAt,
-    });
-    if (result.isErr()) {
-      return result;
-    }
-  }
-
-  return new Ok(undefined);
+  return await updateSubscriptionQuantity({
+    metronomeCustomerId,
+    contractId,
+    subscriptionId,
+    quantity: memberCount,
+    startingAt,
+  });
 }

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -116,8 +116,10 @@ interface PackageSubscription {
   product_name: string; // resolved to product ID at runtime
   billing_frequency: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
   collection_schedule: "ADVANCE" | "ARREARS";
-  quantity_management_mode: "SEAT_BASED" | "MANUAL";
+  quantity_management_mode: "SEAT_BASED" | "QUANTITY_ONLY";
   seat_config?: { seat_group_key: string };
+  /** Required for QUANTITY_ONLY mode — initial seat count (set at contract creation). */
+  initial_quantity?: number;
   proration?: {
     is_prorated: boolean;
     invoice_behavior?: "BILL_IMMEDIATELY" | "BILL_ON_NEXT_COLLECTION_DATE";
@@ -494,8 +496,8 @@ const LEGACY_SEAT_SUBSCRIPTION: PackageSubscription = {
   product_name: "Workspace Seat",
   billing_frequency: "MONTHLY",
   collection_schedule: "ADVANCE",
-  quantity_management_mode: "SEAT_BASED",
-  seat_config: { seat_group_key: "user_id" },
+  quantity_management_mode: "QUANTITY_ONLY",
+  initial_quantity: 1,
   proration: {
     is_prorated: true,
     invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
@@ -1208,6 +1210,9 @@ async function syncPackages(): Promise<void> {
             collection_schedule: sub.collection_schedule,
             quantity_management_mode: sub.quantity_management_mode,
             ...(sub.seat_config ? { seat_config: sub.seat_config } : {}),
+            ...(sub.initial_quantity !== undefined
+              ? { initial_quantity: sub.initial_quantity }
+              : {}),
             ...(sub.proration ? { proration: sub.proration } : {}),
           };
         });


### PR DESCRIPTION
## Description

Switch Metronome seat subscriptions from `SEAT_BASED` (per user_id tracking) to `MANUAL` (pure quantity count). This removes the 500-seat limit imposed by Metronome on SEAT_BASED subscriptions.

Per Metronome PM: the 500-seat limit exists because per-seat credit allocation is compute-intensive. Since we don't allocate credits per seat, pure quantity management is the recommended approach.

### metronome_setup.ts
- Package subscription: `SEAT_BASED` with `seat_config: { seat_group_key: "user_id" }` → `MANUAL` (no seat_config). This will create a new package version when setup runs.

### seats.ts
- `addSeat`: was `add_seat_ids: [userId]` → now `quantity_delta: +1`
- `removeSeat`: was `remove_seat_ids: [userId]` → now `quantity_delta: -1`
- `provisionSeatsForContract`: was batched individual seat ID adds (500 per batch) → now single call with absolute `quantity: memberCount`
- `getSeatSubscriptionId`: finds subscription by matching the Workspace Seat product ID from constants (instead of filtering by `quantity_management_mode`)

### client.ts
- Replaced `editMetronomeContractSeats` (seat ID-based adds/removes) with `updateSubscriptionQuantity` (delta or absolute quantity updates)
- Simplified `getMetronomeActiveContract` — removed `seatSubscriptions` map

### Backwards compatibility
- Old contracts on `SEAT_BASED` package: `getSeatSubscriptionId` still finds them (same product ID). The `quantity_updates` API call will fail on Metronome's side, but callers in `membership.ts` handle errors gracefully (log + continue, no crash). These contracts need migration to the new package version.
- New contracts on `MANUAL` package: work with quantity-based updates, no seat limit.

## Tests

Manual testing in sandbox.

## Risk

Low. Seat update failures on old SEAT_BASED contracts are logged but don't crash. New contracts work with MANUAL mode. Migration script (from base PR) handles contract recreation to the new package version.

## Deploy Plan

1. Merge base PR (dust-tt/dust#23978) first
2. Merge this PR
3. Run `metronome_setup.ts --execute` to create new package versions with MANUAL subscriptions
4. Run `migrate_metronome_contracts.ts --execute` to migrate existing contracts to the new package version