### PR TITLE
[sessions] Block agent switch when a different agent has a pending blocked action

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -1,3 +1,4 @@
+import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { useFileDrop } from "@app/components/assistant/conversation/FileUploaderContext";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBarAttachments } from "@app/components/assistant/conversation/input_bar/InputBarAttachments";
@@ -133,35 +134,61 @@ export const InputBar = React.memo(function InputBar({
     [getAndClearPendingInputText]
   );
 
-  const { getConversationGeneratingMessages } = useGenerationContext();
+  const { generatingMessages, getConversationGeneratingMessages } =
+    useGenerationContext();
+  const { getFirstBlockedActionForMessage } = useBlockedActionsContext();
 
   // In single-agent mode, block submission when the selected agent differs from
   // the agent that is currently generating a response.
-  const blockedByGeneratingAgentName = useMemo(() => {
+  const agentSwitchBlockMessage = useMemo(() => {
     if (!singleAgentInput || !selectedSingleAgent) {
       return null;
     }
-    const generatingMessages = getConversationGeneratingMessages(
-      conversation?.sId ?? ""
-    );
-    const blockingAgentId = generatingMessages.find(
+    const conversationId = conversation?.sId ?? "";
+
+    // Check actively generating messages (excludes blocked-action messages).
+    const activeGenerating = getConversationGeneratingMessages(conversationId);
+    const activeBlockingId = activeGenerating.find(
       (gm) => gm.agentId && gm.agentId !== selectedSingleAgent.id
     )?.agentId;
-    if (!blockingAgentId) {
-      return null;
+    if (activeBlockingId) {
+      const name = agentConfigurations.find(
+        (a) => a.sId === activeBlockingId
+      )?.name;
+      return name
+        ? `Wait for @${name} to finish before switching agent`
+        : null;
     }
-    return (
-      agentConfigurations.find((a) => a.sId === blockingAgentId)?.name ?? null
+
+    // Check messages with a pending blocked action from a different agent.
+    const blockedActionMessage = generatingMessages.find(
+      (m) =>
+        m.conversationId === conversationId &&
+        m.agentId &&
+        m.agentId !== selectedSingleAgent.id &&
+        getFirstBlockedActionForMessage(m.messageId)
     );
+    if (blockedActionMessage) {
+      const name = agentConfigurations.find(
+        (a) => a.sId === blockedActionMessage.agentId
+      )?.name;
+      return name
+        ? `Resolve the pending action from @${name} before switching agents`
+        : null;
+    }
+
+    return null;
   }, [
     singleAgentInput,
     selectedSingleAgent,
     getConversationGeneratingMessages,
+    generatingMessages,
+    getFirstBlockedActionForMessage,
     conversation?.sId,
     agentConfigurations,
   ]);
 
-  const isBlockedByAgentSwitch = blockedByGeneratingAgentName !== null;
+  const isBlockedByAgentSwitch = agentSwitchBlockMessage !== null;
 
   // Tools selection
 
@@ -456,7 +483,7 @@ export const InputBar = React.memo(function InputBar({
             saveDraft={saveDraft}
             getDraft={getDraft}
             user={user}
-            blockedByGeneratingAgentName={blockedByGeneratingAgentName}
+            agentSwitchBlockMessage={agentSwitchBlockMessage}
             onShake={handleShake}
           />
         </div>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -155,9 +155,7 @@ export const InputBar = React.memo(function InputBar({
       const name = agentConfigurations.find(
         (a) => a.sId === activeBlockingId
       )?.name;
-      return name
-        ? `Wait for @${name} to finish before switching agent`
-        : null;
+      return name ? `Wait for @${name} to finish before switching agent` : null;
     }
 
     // Check messages with a pending blocked action from a different agent.

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -152,10 +152,10 @@ export const InputBar = React.memo(function InputBar({
       (gm) => gm.agentId && gm.agentId !== selectedSingleAgent.id
     )?.agentId;
     if (activeBlockingId) {
-      const name = agentConfigurations.find(
-        (a) => a.sId === activeBlockingId
-      )?.name;
-      return name ? `Wait for @${name} to finish before switching agent` : null;
+      const name =
+        agentConfigurations.find((a) => a.sId === activeBlockingId)?.name ??
+        "another agent";
+      return `Wait for @${name} to finish before switching agents`;
     }
 
     // Check messages with a pending blocked action from a different agent.
@@ -167,12 +167,10 @@ export const InputBar = React.memo(function InputBar({
         getFirstBlockedActionForMessage(m.messageId)
     );
     if (blockedActionMessage) {
-      const name = agentConfigurations.find(
-        (a) => a.sId === blockedActionMessage.agentId
-      )?.name;
-      return name
-        ? `Resolve the pending action from @${name} before switching agents`
-        : null;
+      const name =
+        agentConfigurations.find((a) => a.sId === blockedActionMessage.agentId)
+          ?.name ?? "another agent";
+      return `Resolve the pending action from @${name} before switching agents`;
     }
 
     return null;

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -131,7 +131,7 @@ export interface InputBarContainerProps {
   actions: InputBarAction[];
   allAgents: LightAgentConfigurationType[];
   attachedNodes: DataSourceViewContentNode[];
-  blockedByGeneratingAgentName: string | null;
+  agentSwitchBlockMessage: string | null;
   onShake: () => void;
   conversation?: ConversationWithoutContentType;
   space?: SpaceType;
@@ -192,10 +192,10 @@ const InputBarContainer = ({
   selectedSkills,
   saveDraft,
   user,
-  blockedByGeneratingAgentName,
+  agentSwitchBlockMessage,
   onShake,
 }: InputBarContainerProps) => {
-  const isBlockedByAgentSwitch = blockedByGeneratingAgentName !== null;
+  const isBlockedByAgentSwitch = agentSwitchBlockMessage !== null;
   const { subscription } = useAuth();
   const isMobile = useIsMobile();
   const { hasFeature } = useFeatureFlags();
@@ -1235,11 +1235,7 @@ const InputBarContainer = ({
             icon={ArrowUpIcon}
             variant={isBlockedByAgentSwitch ? "ghost-secondary" : "highlight"}
             disabled={isSubmitDisabled}
-            tooltip={
-              blockedByGeneratingAgentName
-                ? `Wait for @${blockedByGeneratingAgentName} to finish before switching agent`
-                : undefined
-            }
+            tooltip={agentSwitchBlockMessage ?? undefined}
             className={cn(
               isBlockedByAgentSwitch &&
                 "hover:s-bg-transparent dark:hover:s-bg-transparent hover:s-text-muted-foreground dark:hover:s-text-muted-foreground-night"


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/7445
## Description
The frontend allowed switching agents and submitting while another agent had a pending blocked action (e.g. tool call awaiting user validation), because getConversationGeneratingMessages filters out blocked-action messages. Use generatingMessages + getFirstBlockedActionForMessage directly to detect this case and block submission with an appropriate tooltip message.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Send a message to an agent that requires an action with explicit user approval
Before approving, try to send a message to a different agent. See that the same logic applies as trying to send a message while a different agent is thinking: enter button causes shake animation, send is disabled, tooltip over send button shows on hover with text relevant to the reason you can't send
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
