### PR TITLE
[sessions]: Remove @user mentions when selecting an agent in single-agent mode

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -578,27 +578,50 @@ const InputBarContainer = ({
   const selectedSingleAgentRef = useRef(selectedSingleAgent);
   selectedSingleAgentRef.current = selectedSingleAgent;
 
-  // When a user is mentioned in single-agent mode, deselect the agent and clear capabilities.
-  // Uses a ref so the editor listener (registered once in the useEffect below) always calls
-  // the latest closure without re-registering the listener on every render.
+  // When a user mention is *newly added* in single-agent mode, deselect the agent
+  // and clear capabilities. Only triggers on the transition from no-user-mention to
+  // user-mention so that re-selecting an agent (via card click or URL param) isn't
+  // immediately clobbered by the existing @user mention on the next editor update.
+  // Uses a ref so the editor listener (registered once in the useEffect below) always
+  // calls the latest closure without re-registering the listener on every render.
+  const prevUserMentionedRef = useRef(false);
   const onEditorMentionsChangedRef = useRef((_userMentioned: boolean) => {});
 
   onEditorMentionsChangedRef.current = (userMentioned: boolean) => {
     shouldSuggestAgentRef.current = !(singleAgentInput && userMentioned);
-    if (singleAgentInput && userMentioned) {
+    const wasUserMentioned = prevUserMentionedRef.current;
+    prevUserMentionedRef.current = userMentioned;
+    if (singleAgentInput && userMentioned && !wasUserMentioned) {
       setSelectedSingleAgent(null);
       onResetSelections();
       fileUploaderService.resetUpload();
     }
   };
 
-  // Persist the selected agent to the draft whenever it changes.
+  // When the selected agent changes, remove any @user mentions (which are
+  // incompatible with single-agent mode), notify the user, and persist the draft.
   useEffect(() => {
     if (singleAgentInput && selectedSingleAgent) {
+      const hadUserMentions = editorService.removeUserMentions();
+      if (hadUserMentions) {
+        sendNotification({
+          type: "info",
+          title: "User mentions removed",
+          description:
+            "You can't mention both users and agents in the same message.",
+        });
+      }
+      editorService.focusEnd();
       const { markdown } = editorService.getMarkdownAndMentions();
       saveDraft(markdown, selectedSingleAgent);
     }
-  }, [singleAgentInput, selectedSingleAgent, editorService, saveDraft]);
+  }, [
+    singleAgentInput,
+    selectedSingleAgent,
+    editorService,
+    saveDraft,
+    sendNotification,
+  ]);
 
   // Update the editor ref when the editor is created and listen for updates to the editor.
   useEffect(() => {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -608,7 +608,7 @@ const InputBarContainer = ({
           type: "info",
           title: "User mentions removed",
           description:
-            "You can't mention both users and agents in the same message.",
+            "You can’t mention both users and agents in the same message.",
         });
       }
       editorService.focusEnd();

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -153,6 +153,24 @@ const useEditorService = (editor: Editor | null) => {
         return editor?.commands.clearContent();
       },
 
+      removeUserMentions(): boolean {
+        if (!editor) {
+          return false;
+        }
+        const { tr } = editor.state;
+        let modified = false;
+        editor.state.doc.descendants((node, pos) => {
+          if (node.type.name === "mention" && node.attrs.type === "user") {
+            tr.delete(tr.mapping.map(pos), tr.mapping.map(pos + node.nodeSize));
+            modified = true;
+          }
+        });
+        if (modified) {
+          editor.view.dispatch(tr);
+        }
+        return modified;
+      },
+
       setLoading(loading: boolean) {
         if (loading) {
           editor?.view.dom.classList.add("loading-text");

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -146,13 +146,6 @@ const useHandleMentions = ({
         // @TODO we should handle this in each event handler and not inside the useEffect
         setSelectedSingleAgent(selectedAgent);
         externalAgentSetRef.current = true;
-        // If the restored draft contains @user mentions, clear the editor
-        // to prevent the user-mention handler from calling
-        // setSelectedSingleAgent(null) and overriding the URL agent.
-        const { mentions } = editorService.getMarkdownAndMentions();
-        if (mentions.some((m) => m.type === "user")) {
-          queueMicrotask(() => editorService.clearEditor());
-        }
         return;
       }
       if (!editorService.hasMention(selectedAgent)) {


### PR DESCRIPTION
## Description
Noticed an issue where if you had a user mention in the inputbar and select one of the agent cards, it won't set the agent. This is a more robust fix than I implemented in https://github.com/dust-tt/dust/pull/23949 and ensures that when an agent is set outside of the input bar selector (it will be hidden at this point) either by clicking an agent card or by query param, the user mention is stripped and notification is popped informing the user of this.
Simultaneously fixed https://github.com/dust-tt/tasks/issues/7436 since I was in there! 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
With a user @ in the input bar, click one of the agent cards and ensure the user mention is stripped properly but rest of the draft is maintained
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Should be low, could reintroduce bugs I fixed previously but I don't think it does!
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
