### PR TITLE
Add new tools for project conversations.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -472,7 +472,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "update_note": "low",
   },
   "project_conversation": {
+    "add_message_to_conversation": "low",
     "create_conversation": "low",
+    "list_conversations": "never_ask",
+    "search_conversations": "never_ask",
   },
   "project_manager": {
     "add_file": "low",

--- a/front/lib/api/actions/servers/project_conversation/metadata.ts
+++ b/front/lib/api/actions/servers/project_conversation/metadata.ts
@@ -32,11 +32,116 @@ export const PROJECT_CONVERSATION_TOOLS_METADATA = createToolsRecord({
       done: "Create conversation",
     },
   },
+  list_conversations: {
+    description:
+      "List conversations in the project updated on or after a given time (updatedSince). " +
+      "Use unreadOnly=true to return only conversations with unread messages (same as narrowing unread), " +
+      "or false to include all that match the time filter. " +
+      "When unreadOnly is false, results are paginated: pass pageCursor from nextPageCursor of the previous response to fetch the next page (efficient, one DB page per call). " +
+      "When unreadOnly is true, pagination cursors are not used; the tool scans conversations in the window up to the requested limit. " +
+      "By default, only conversation metadata is returned (no message bodies). Set includeMessages=true to load and format all messages (much heavier).",
+    schema: {
+      unreadOnly: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "If true, only conversations the user has not fully read. If false, all conversations matching updatedSince."
+        ),
+      updatedSince: z
+        .number()
+        .optional()
+        .describe(
+          "Unix timestamp in milliseconds; only conversations whose updated time is >= this value. If omitted, defaults to approximately 30 days before the tool runs."
+        ),
+      limit: z
+        .number()
+        .min(1)
+        .max(100)
+        .optional()
+        .default(20)
+        .describe(
+          "Maximum number of conversations to return per call (default: 20, max: 100)"
+        ),
+      pageCursor: z
+        .string()
+        .optional()
+        .describe(
+          "Opaque cursor from nextPageCursor of a prior list_conversations call. Only for unreadOnly=false."
+        ),
+      includeMessages: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "If true, fetch each conversation with messages and return formatted transcript text. If false (default), return metadata only (no getLightConversation calls)."
+        ),
+      dustProject:
+        ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+        ].optional(),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing project conversations",
+      done: "List conversations",
+    },
+  },
+  search_conversations: {
+    description:
+      "Semantic search over messages in this project's conversations. Returns the most relevant conversations for the given query.",
+    schema: {
+      query: z.string().min(1).describe("Natural-language search query"),
+      limit: z
+        .number()
+        .min(1)
+        .max(100)
+        .optional()
+        .default(10)
+        .describe("Maximum number of results (default: 10, max: 100)"),
+      dustProject:
+        ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+        ].optional(),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Searching project conversations",
+      done: "Search conversations",
+    },
+  },
+  add_message_to_conversation: {
+    description:
+      "Post a user message to an existing conversation in this project. The message is sent on behalf of the user executing the tool. " +
+      "The conversation must belong to the same project. If conversationId is omitted, the current agent conversation is used (when available).",
+    schema: {
+      conversationId: z
+        .string()
+        .optional()
+        .describe(
+          "Conversation sId to post to; defaults to the conversation this agent run is in when omitted"
+        ),
+      message: z.string().describe("The message content to post"),
+      agentId: z
+        .string()
+        .optional()
+        .describe("Optional agent ID to mention in the message"),
+      dustProject:
+        ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+        ].optional(),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Adding message to conversation",
+      done: "Add message to conversation",
+    },
+  },
 });
 
 const PROJECT_CONVERSATION_INSTRUCTIONS =
-  "Create new conversations within a project. " +
-  "Requires write permissions on the project space.";
+  "Create conversations, list or search conversations, and post messages within a project. " +
+  "Listing and search require read access; creating conversations and adding messages require write access on the project space.";
 
 export const PROJECT_CONVERSATION_SERVER = {
   // biome-ignore lint/plugin/noMcpServerInstructions: existing usage

--- a/front/lib/api/actions/servers/project_conversation/tools/index.ts
+++ b/front/lib/api/actions/servers/project_conversation/tools/index.ts
@@ -7,20 +7,59 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { PROJECT_CONVERSATION_TOOLS_METADATA } from "@app/lib/api/actions/servers/project_conversation/metadata";
 import {
+  getProjectSpace,
   getWritableProjectContext,
   makeSuccessResponse,
   withErrorHandling,
 } from "@app/lib/api/actions/servers/project_manager/helpers";
 import {
+  formatConversationForDisplay,
+  formatConversationsForDisplay,
+} from "@app/lib/api/actions/servers/project_manager/tools/conversation_formatting";
+import {
   createConversation,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
+import {
+  getConversation,
+  getLightConversation,
+} from "@app/lib/api/assistant/conversation/fetch";
 import config from "@app/lib/api/config";
+import { searchProjectConversations } from "@app/lib/api/projects";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { isUserMessageType } from "@app/types/assistant/conversation";
 import { Err, Ok } from "@app/types/shared/result";
+
+/** Matches space-scoped conversation semantic search API cutoff. */
+const SEMANTIC_SEARCH_SCORE_CUTOFF = 0.1;
+
+const LIST_CONVERSATIONS_DEFAULT_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
+
+function formatListedConversationWithoutMessages(
+  c: ConversationResource,
+  workspaceSId: string
+) {
+  const j = c.toJSON();
+  return {
+    sId: j.sId,
+    title: j.title ?? "Untitled Conversation",
+    created: new Date(j.created).toISOString(),
+    updated: new Date(j.updated).toISOString(),
+    unread: j.unread,
+    actionRequired: j.actionRequired,
+    hasError: j.hasError,
+    conversationUrl: getConversationRoute(
+      workspaceSId,
+      j.sId,
+      undefined,
+      config.getAppUrl()
+    ),
+  };
+}
 
 export function createProjectConversationTools(
   auth: Authenticator,
@@ -92,6 +131,7 @@ export function createProjectConversationTools(
           },
           skipToolsValidation: false,
           doNotAssociateUser: true,
+          skipDustAutoMention: true,
         });
 
         if (messageRes.isErr()) {
@@ -120,6 +160,353 @@ export function createProjectConversationTools(
           })
         );
       }, "Failed to create conversation");
+    },
+
+    list_conversations: async (params) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getProjectSpace(auth, {
+          agentLoopContext,
+          dustProject: params.dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const { space } = contextRes.value;
+        const {
+          unreadOnly = false,
+          limit = 20,
+          pageCursor,
+          includeMessages = false,
+        } = params;
+
+        const updatedSinceMs =
+          params.updatedSince ??
+          Date.now() - LIST_CONVERSATIONS_DEFAULT_LOOKBACK_MS;
+
+        const listOptions = {
+          updatedSince: updatedSinceMs,
+          excludeTest: true,
+        };
+
+        if (!unreadOnly) {
+          const {
+            conversations: resourcePage,
+            hasMore,
+            lastValue,
+          } = await ConversationResource.listConversationsInSpacePaginated(
+            auth,
+            {
+              spaceId: space.sId,
+              options: listOptions,
+              pagination: {
+                limit,
+                lastValue: pageCursor,
+              },
+            }
+          );
+
+          if (resourcePage.length === 0) {
+            return new Ok([
+              {
+                type: "text" as const,
+                text: `No conversations found in project "${space.name}" updated on or after ${new Date(updatedSinceMs).toISOString()}.`,
+              },
+            ]);
+          }
+
+          const owner = auth.getNonNullableWorkspace();
+          let conversationsPayload: unknown[];
+
+          if (includeMessages) {
+            const conversationResults = await concurrentExecutor(
+              resourcePage,
+              async (c) => getLightConversation(auth, c.sId, false),
+              { concurrency: 10 }
+            );
+            const conversationsForDisplay = conversationResults
+              .filter((r) => r.isOk())
+              .map((r) => r.value);
+            conversationsPayload = formatConversationsForDisplay(
+              conversationsForDisplay,
+              owner.sId
+            );
+          } else {
+            conversationsPayload = resourcePage.map((c) =>
+              formatListedConversationWithoutMessages(c, owner.sId)
+            );
+          }
+
+          const nextPageCursor = hasMore && lastValue ? lastValue : null;
+          return new Ok(
+            makeSuccessResponse({
+              success: true,
+              count: conversationsPayload.length,
+              unreadOnly: false,
+              includeMessages,
+              updatedSince: updatedSinceMs,
+              hasMore,
+              nextPageCursor,
+              conversations: conversationsPayload,
+              message: `Found ${conversationsPayload.length} conversation(s) in project "${space.name}" (page)${hasMore ? ". Pass nextPageCursor to fetch older updates in this window." : ""}.`,
+            })
+          );
+        }
+
+        const spaceConversations =
+          await ConversationResource.listConversationsInSpace(auth, {
+            spaceId: space.sId,
+            options: listOptions,
+          });
+
+        const unreadResources = spaceConversations.filter(
+          (c) => c.toJSON().unread
+        );
+        const pageResources = unreadResources.slice(0, limit);
+
+        if (pageResources.length === 0) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: `No unread conversations found in project "${space.name}" updated on or after ${new Date(updatedSinceMs).toISOString()}.`,
+            },
+          ]);
+        }
+
+        const owner = auth.getNonNullableWorkspace();
+        let conversationsPayload: unknown[];
+
+        if (includeMessages) {
+          const conversationResults = await concurrentExecutor(
+            pageResources,
+            async (c) => getLightConversation(auth, c.sId, false),
+            { concurrency: 10 }
+          );
+          const withContent = conversationResults
+            .filter((r) => r.isOk())
+            .map((r) => r.value);
+          conversationsPayload = formatConversationsForDisplay(
+            withContent,
+            owner.sId
+          );
+        } else {
+          conversationsPayload = pageResources.map((c) =>
+            formatListedConversationWithoutMessages(c, owner.sId)
+          );
+        }
+
+        return new Ok(
+          makeSuccessResponse({
+            success: true,
+            count: pageResources.length,
+            total: unreadResources.length,
+            unreadOnly: true,
+            includeMessages,
+            updatedSince: updatedSinceMs,
+            conversations: conversationsPayload,
+            message: `Found ${pageResources.length} unread conversation(s) in project "${space.name}"${unreadResources.length > limit ? ` (showing first ${limit} of ${unreadResources.length})` : ""}.`,
+          })
+        );
+      }, "Failed to list project conversations");
+    },
+
+    search_conversations: async (params) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getProjectSpace(auth, {
+          agentLoopContext,
+          dustProject: params.dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const { space } = contextRes.value;
+        const { query, limit: topK = 10 } = params;
+
+        const searchRes = await searchProjectConversations(auth, {
+          query,
+          spaceIds: [space.sId],
+          topK,
+        });
+
+        if (searchRes.isErr()) {
+          return new Err(
+            new MCPError(
+              `Failed to search conversations: ${searchRes.error.message}`,
+              { tracked: false }
+            )
+          );
+        }
+
+        const filteredResults = searchRes.value.filter(
+          (r) => r.score >= SEMANTIC_SEARCH_SCORE_CUTOFF
+        );
+
+        if (filteredResults.length === 0) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: `No matching conversations found in project "${space.name}" for this query.`,
+            },
+          ]);
+        }
+
+        const conversationResults = await concurrentExecutor(
+          filteredResults,
+          async (r) => getLightConversation(auth, r.conversationId, false),
+          { concurrency: 10 }
+        );
+
+        const owner = auth.getNonNullableWorkspace();
+        const conversationsWithScores: Array<{
+          formatted: ReturnType<typeof formatConversationForDisplay>;
+          score: number;
+        }> = [];
+
+        for (let i = 0; i < filteredResults.length; i++) {
+          const convRes = conversationResults[i];
+          if (convRes?.isOk()) {
+            conversationsWithScores.push({
+              formatted: formatConversationForDisplay(convRes.value, owner.sId),
+              score: filteredResults[i].score,
+            });
+          }
+        }
+
+        return new Ok(
+          makeSuccessResponse({
+            success: true,
+            count: conversationsWithScores.length,
+            query,
+            conversations: conversationsWithScores.map(
+              ({ formatted, score }) => ({
+                ...formatted,
+                relevanceScore: score,
+              })
+            ),
+            message: `Found ${conversationsWithScores.length} conversation(s) in project "${space.name}" matching the query.`,
+          })
+        );
+      }, "Failed to search project conversations");
+    },
+
+    add_message_to_conversation: async (params) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getWritableProjectContext(auth, {
+          agentLoopContext,
+          dustProject: params.dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const { space } = contextRes.value;
+        const user = auth.getNonNullableUser();
+        const owner = auth.getNonNullableWorkspace();
+
+        const conversationId =
+          params.conversationId ??
+          agentLoopContext?.runContext?.conversation?.sId;
+
+        if (!conversationId) {
+          return new Err(
+            new MCPError(
+              "No conversationId provided and no conversation in agent context; pass conversationId explicitly.",
+              { tracked: false }
+            )
+          );
+        }
+
+        const conversationRes = await getConversation(
+          auth,
+          conversationId,
+          false
+        );
+        if (conversationRes.isErr()) {
+          return new Err(
+            new MCPError(`Conversation not found: ${conversationId}`, {
+              tracked: false,
+            })
+          );
+        }
+
+        const conversation = conversationRes.value;
+        if (conversation.spaceId !== space.sId) {
+          return new Err(
+            new MCPError("Conversation is not in this project", {
+              tracked: false,
+            })
+          );
+        }
+
+        let origin: UserMessageOrigin = "web";
+        let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+        if (agentLoopContext?.runContext?.conversation?.content) {
+          const userMessage = agentLoopContext.runContext.conversation.content
+            .flat()
+            .findLast(isUserMessageType);
+          if (userMessage?.context) {
+            origin = userMessage.context.origin ?? origin;
+            timezone = userMessage.context.timezone ?? timezone;
+          }
+        }
+
+        const agentName =
+          agentLoopContext?.runContext?.agentConfiguration?.name ?? "Agent";
+        const agentProfilePictureUrl =
+          agentLoopContext?.runContext?.agentConfiguration?.pictureUrl ?? null;
+
+        const mentions = params.agentId
+          ? [{ configurationId: params.agentId }]
+          : [];
+
+        const messageRes = await postUserMessage(auth, {
+          conversation,
+          content: params.message,
+          mentions,
+          context: {
+            username: agentName,
+            fullName: `@${agentName} on behalf of ${user.fullName()}`,
+            email: null,
+            profilePictureUrl: agentProfilePictureUrl,
+            timezone,
+            origin,
+            clientSideMCPServerIds: [],
+            selectedMCPServerViewIds: [],
+            lastTriggerRunAt: null,
+          },
+          skipToolsValidation: false,
+          doNotAssociateUser: true,
+          skipDustAutoMention: true,
+        });
+
+        if (messageRes.isErr()) {
+          return new Err(
+            new MCPError(
+              `Failed to post message: ${messageRes.error.api_error.message}`,
+              { tracked: false }
+            )
+          );
+        }
+
+        const conversationUrl = getConversationRoute(
+          owner.sId,
+          conversation.sId,
+          undefined,
+          config.getAppUrl()
+        );
+
+        return new Ok(
+          makeSuccessResponse({
+            success: true,
+            conversationId: conversation.sId,
+            conversationUrl,
+            userMessageId: messageRes.value.userMessage.sId,
+            message: `Message posted to conversation in project "${space.name}".`,
+          })
+        );
+      }, "Failed to add message to conversation");
     },
   };
 

--- a/front/lib/api/actions/servers/project_manager/tools/conversation_formatting.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/conversation_formatting.ts
@@ -99,7 +99,7 @@ export function formatConversationForDisplay(
  * Formats multiple conversations for display.
  */
 export function formatConversationsForDisplay(
-  conversations: ConversationType[],
+  conversations: (ConversationType | LightConversationType)[],
   workspaceId: string
 ) {
   return conversations.map((conv) =>

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -5340,6 +5340,40 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
     expect(page1Sids.some((sId) => page2Sids.includes(sId))).toBe(false);
   });
 
+  it("should apply updatedSince on every page when using lastValue cursor", async () => {
+    const outsideWindow = await createConvoWithUpdatedAt(20);
+    const insideA = await createConvoWithUpdatedAt(5);
+    const insideB = await createConvoWithUpdatedAt(3);
+
+    const daysBack = 10;
+    const cutoffMs = Date.now() - daysBack * 24 * 60 * 60 * 1000;
+
+    const seen = new Set<string>();
+    let lastValue: string | undefined;
+    for (let i = 0; i < 10; i++) {
+      const page = await ConversationResource.listConversationsInSpacePaginated(
+        adminAuth,
+        {
+          spaceId: space.sId,
+          options: { updatedSince: cutoffMs, excludeTest: true },
+          pagination: { limit: 1, lastValue },
+        }
+      );
+
+      for (const c of page.conversations) {
+        seen.add(c.sId);
+      }
+      if (!page.hasMore) {
+        break;
+      }
+      lastValue = page.lastValue ?? undefined;
+    }
+
+    expect(seen.has(insideA.sId)).toBe(true);
+    expect(seen.has(insideB.sId)).toBe(true);
+    expect(seen.has(outsideWindow.sId)).toBe(false);
+  });
+
   it("should iterate through all pages and return all conversations", async () => {
     const convos = [];
     for (let i = 0; i < 5; i++) {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1247,7 +1247,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const orderDirection = pagination.orderDirection ?? "desc";
 
+    const { where: filterWhere } = this.getOptions(options);
     const whereClause: WhereOptions<InferAttributes<ConversationModel>> = {
+      ...filterWhere,
       spaceId: spaceModelId,
     };
 
@@ -1255,9 +1257,20 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       const timestampMs = parseInt(pagination.lastValue, 10);
       if (!Number.isNaN(timestampMs)) {
         const operator = orderDirection === "desc" ? Op.lt : Op.gt;
-        whereClause.updatedAt = {
-          [operator]: new Date(timestampMs),
-        };
+        const cursorConstraint = { [operator]: new Date(timestampMs) };
+        const existingUpdatedAt = whereClause.updatedAt;
+        if (
+          existingUpdatedAt &&
+          typeof existingUpdatedAt === "object" &&
+          !Array.isArray(existingUpdatedAt)
+        ) {
+          whereClause.updatedAt = {
+            ...existingUpdatedAt,
+            ...cursorConstraint,
+          };
+        } else {
+          whereClause.updatedAt = cursorConstraint;
+        }
       }
     }
 


### PR DESCRIPTION
## Description

Add three new tools to the project conversation MCP server.
- `list_conversations` — paginated listing of project conversations, with `unreadOnly`, `updatedSince`, `pageCursor`, and optional `includeMessages` to load full transcripts
- `search_conversations` — semantic search over project conversation messages
- `add_message_to_conversation` — post a user message to an existing project conversation, with optional agent mention
- Update server instructions to reflect the new read (list/search) vs write (create/add message) permission model

## Tests

Local + green

## Risk

Low

## Deploy Plan

Deploy `front`
