### PR TITLE
Upg: allow mcp servers with no required input configurations to be used as JIT servers.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -3,7 +3,6 @@ import {
   getInternalMCPServerInfo,
   matchesInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type {
   AuthRequiredOutputResourceType,
   EarlyExitOutputResourceType,
@@ -11,6 +10,7 @@ import type {
   SingleResourceToolOutput,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { hasNoRequiredProperties } from "@app/lib/utils/json_schemas";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -103,7 +103,7 @@ export function isJITMCPServerView(view: MCPServerViewType): boolean {
   return (
     !matchesInternalMCPServerName(view.server.sId, "agent_memory") &&
     // Only tools that do not require any configuration can be enabled directly in a conversation.
-    getMCPServerRequirements(view).noRequirement
+    hasNoRequiredProperties(view)
   );
 }
 

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -3,9 +3,9 @@ import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
 } from "@app/lib/actions/mcp_helper";
-import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { TOOLSETS_TOOLS_METADATA } from "@app/lib/api/actions/servers/toolsets/metadata";
 import apiConfig from "@app/lib/api/config";
@@ -52,9 +52,7 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
         (mcpServerView) =>
           !mcpServerViewIdsFromAgentConfiguration.includes(mcpServerView.sId)
       )
-      .filter(
-        (mcpServerView) => getMCPServerRequirements(mcpServerView).noRequirement
-      )
+      .filter(isJITMCPServerView)
       .filter(
         (mcpServerView) =>
           mcpServerView.server.availability !== "auto_hidden_builder"

--- a/front/lib/resources/skill/global/discover_tools.ts
+++ b/front/lib/resources/skill/global/discover_tools.ts
@@ -1,4 +1,4 @@
-import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import { buildToolsetsContext } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -25,7 +25,7 @@ export const discoverToolsSkill = {
     const availableToolsets = allToolsets.filter((toolset) => {
       const mcpServerView = toolset.toJSON();
       return (
-        getMCPServerRequirements(mcpServerView).noRequirement &&
+        isJITMCPServerView(mcpServerView) &&
         mcpServerView.server.availability !== "auto_hidden_builder"
       );
     });

--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -2,8 +2,11 @@
 
 import { findMatchingSubSchemas } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import { ConfigurableToolInputJSONSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   ensurePathExists,
+  hasNoRequiredProperties,
+  jsonSchemaHasRequiredDustToolInput,
   setValueAtPath,
   validateJsonSchema,
 } from "@app/lib/utils/json_schemas";
@@ -514,5 +517,444 @@ describe("validateJsonSchema", () => {
       { enforceRequiredFields: true }
     );
     expect(result.isValid).toBe(true);
+  });
+});
+
+const DUST_DS_MIME = "application/vnd.dust.tool-input.data-source";
+
+function dustDataSourceItemSchema(): JSONSchema {
+  return {
+    type: "object",
+    properties: {
+      uri: { type: "string" },
+      mimeType: { const: DUST_DS_MIME },
+    },
+    required: ["uri", "mimeType"],
+    additionalProperties: false,
+  };
+}
+
+function minimalView(
+  inputSchemas: Array<JSONSchema | undefined>
+): MCPServerViewType {
+  return {
+    server: {
+      tools: inputSchemas.map((inputSchema, i) => ({
+        name: `tool_${i}`,
+        description: "",
+        inputSchema,
+      })),
+    },
+  } as MCPServerViewType;
+}
+
+describe("jsonSchemaHasRequiredDustToolInput", () => {
+  const fromRoot = true;
+
+  it("returns false for null, undefined, and non-objects", () => {
+    expect(jsonSchemaHasRequiredDustToolInput(null, fromRoot)).toBe(false);
+    expect(jsonSchemaHasRequiredDustToolInput(undefined, fromRoot)).toBe(false);
+    expect(jsonSchemaHasRequiredDustToolInput(1, fromRoot)).toBe(false);
+    expect(jsonSchemaHasRequiredDustToolInput("x", fromRoot)).toBe(false);
+  });
+
+  it("returns false when path is not all-required even if schema is a Dust object", () => {
+    const dustObject: JSONSchema = {
+      type: "object",
+      properties: {
+        uri: { type: "string" },
+        mimeType: { const: DUST_DS_MIME },
+      },
+      required: ["uri", "mimeType"],
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(dustObject, false)).toBe(false);
+  });
+
+  it("returns true when the root schema is a Dust object and path is all-required", () => {
+    const dustObject: JSONSchema = {
+      type: "object",
+      properties: {
+        uri: { type: "string" },
+        mimeType: { const: DUST_DS_MIME },
+      },
+      required: ["uri", "mimeType"],
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(dustObject, true)).toBe(true);
+  });
+
+  it("detects required array property whose items are Dust objects (dataSources pattern)", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: {
+        dataSources: {
+          type: "array",
+          items: dustDataSourceItemSchema(),
+        },
+        objective: { type: "string" },
+      },
+      required: ["dataSources", "objective"],
+      additionalProperties: false,
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(schema, true)).toBe(true);
+  });
+
+  it("returns false when Dust-like items sit under an optional array property", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: {
+        dataSources: {
+          type: "array",
+          items: dustDataSourceItemSchema(),
+        },
+      },
+      required: [],
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(schema, true)).toBe(false);
+  });
+
+  it("returns false when Dust project field is optional at root", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: {
+        message: { type: "string" },
+        dustProject: {
+          type: "object",
+          properties: {
+            uri: { type: "string" },
+            mimeType: { const: "application/vnd.dust.tool-input.dust-project" },
+          },
+          required: ["uri", "mimeType"],
+        },
+      },
+      required: ["message"],
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(schema, true)).toBe(false);
+  });
+
+  it("returns true when Dust project field is required at root", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: {
+        dustProject: {
+          type: "object",
+          properties: {
+            uri: { type: "string" },
+            mimeType: { const: "application/vnd.dust.tool-input.dust-project" },
+          },
+          required: ["uri", "mimeType"],
+        },
+      },
+      required: ["dustProject"],
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(schema, true)).toBe(true);
+  });
+
+  it("returns false when optional wrapper contains required Dust child", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: {
+        wrapper: {
+          type: "object",
+          properties: {
+            dustProject: {
+              type: "object",
+              properties: {
+                uri: { type: "string" },
+                mimeType: {
+                  const: "application/vnd.dust.tool-input.dust-project",
+                },
+              },
+              required: ["uri", "mimeType"],
+            },
+          },
+          required: ["dustProject"],
+        },
+      },
+      required: [],
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(schema, true)).toBe(false);
+  });
+
+  it("detects mimeType via enum strings under the Dust prefix", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: {
+        cfg: {
+          type: "object",
+          properties: {
+            uri: { type: "string" },
+            mimeType: {
+              type: "string",
+              enum: [
+                "application/vnd.dust.tool-input.data-source",
+                "application/vnd.dust.tool-input.folder",
+              ],
+            },
+          },
+        },
+      },
+      required: ["cfg"],
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(schema, true)).toBe(true);
+  });
+
+  it("returns false when mimeType const is not a Dust tool-input type", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: {
+        x: {
+          type: "object",
+          properties: {
+            mimeType: { const: "application/json" },
+          },
+        },
+      },
+      required: ["x"],
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(schema, true)).toBe(false);
+  });
+
+  it("treats top-level schema array like oneOf: bad only if every branch requires Dust", () => {
+    const onlyStrings: JSONSchema = {
+      type: "object",
+      properties: { a: { type: "string" } },
+      required: ["a"],
+    };
+    expect(
+      jsonSchemaHasRequiredDustToolInput([onlyStrings, onlyStrings], true)
+    ).toBe(false);
+
+    const withDust: JSONSchema = {
+      type: "object",
+      properties: {
+        p: {
+          type: "object",
+          properties: {
+            uri: { type: "string" },
+            mimeType: { const: DUST_DS_MIME },
+          },
+          required: ["uri", "mimeType"],
+        },
+      },
+      required: ["p"],
+    };
+    expect(
+      jsonSchemaHasRequiredDustToolInput([onlyStrings, withDust], true)
+    ).toBe(false);
+    expect(jsonSchemaHasRequiredDustToolInput([withDust, withDust], true)).toBe(
+      true
+    );
+  });
+
+  it("oneOf: false when at least one branch has no required Dust path", () => {
+    const clean: JSONSchema = {
+      type: "object",
+      properties: { x: { type: "string" } },
+      required: ["x"],
+    };
+    const dustRequired: JSONSchema = {
+      type: "object",
+      properties: {
+        p: {
+          type: "object",
+          properties: {
+            uri: { type: "string" },
+            mimeType: { const: DUST_DS_MIME },
+          },
+          required: ["uri", "mimeType"],
+        },
+      },
+      required: ["p"],
+    };
+    expect(
+      jsonSchemaHasRequiredDustToolInput({ oneOf: [clean, dustRequired] }, true)
+    ).toBe(false);
+  });
+
+  it("anyOf: behaves like oneOf for required Dust (any clean branch is enough)", () => {
+    const clean: JSONSchema = {
+      type: "object",
+      properties: { x: { type: "string" } },
+      required: ["x"],
+    };
+    const dustRequired: JSONSchema = {
+      type: "object",
+      properties: {
+        p: {
+          type: "object",
+          properties: {
+            uri: { type: "string" },
+            mimeType: { const: DUST_DS_MIME },
+          },
+          required: ["uri", "mimeType"],
+        },
+      },
+      required: ["p"],
+    };
+    expect(
+      jsonSchemaHasRequiredDustToolInput({ anyOf: [clean, dustRequired] }, true)
+    ).toBe(false);
+    expect(
+      jsonSchemaHasRequiredDustToolInput(
+        { anyOf: [dustRequired, dustRequired] },
+        true
+      )
+    ).toBe(true);
+  });
+
+  it("oneOf: true when every branch forces required Dust", () => {
+    const a: JSONSchema = {
+      type: "object",
+      properties: {
+        p: {
+          type: "object",
+          properties: {
+            uri: { type: "string" },
+            mimeType: { const: DUST_DS_MIME },
+          },
+          required: ["uri", "mimeType"],
+        },
+      },
+      required: ["p"],
+    };
+    expect(jsonSchemaHasRequiredDustToolInput({ oneOf: [a, a] }, true)).toBe(
+      true
+    );
+  });
+
+  it("allOf: true when any combined branch introduces required Dust", () => {
+    const base: JSONSchema = {
+      type: "object",
+      properties: { x: { type: "string" } },
+    };
+    const extra: JSONSchema = {
+      type: "object",
+      properties: {
+        p: {
+          type: "object",
+          properties: {
+            uri: { type: "string" },
+            mimeType: { const: DUST_DS_MIME },
+          },
+          required: ["uri", "mimeType"],
+        },
+      },
+      required: ["p"],
+    };
+    expect(
+      jsonSchemaHasRequiredDustToolInput({ allOf: [base, extra] }, true)
+    ).toBe(true);
+    expect(
+      jsonSchemaHasRequiredDustToolInput({ allOf: [base, base] }, true)
+    ).toBe(false);
+  });
+
+  it("accepts object-like schema without explicit type: object when properties carry Dust", () => {
+    const schema = {
+      properties: {
+        dustProject: {
+          type: "object",
+          properties: {
+            uri: { type: "string" },
+            mimeType: { const: "application/vnd.dust.tool-input.dust-project" },
+          },
+          required: ["uri", "mimeType"],
+        },
+      },
+      required: ["dustProject"],
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(schema, true)).toBe(true);
+  });
+
+  it("detects Dust object when type is a tuple including object", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: {
+        v: {
+          type: ["object", "null"] as unknown as JSONSchema["type"],
+          properties: {
+            uri: { type: "string" },
+            mimeType: { const: DUST_DS_MIME },
+          },
+          required: ["uri", "mimeType"],
+        },
+      },
+      required: ["v"],
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(schema, true)).toBe(true);
+  });
+
+  it("root-level array schema passes path flag to items", () => {
+    const schema: JSONSchema = {
+      type: "array",
+      items: dustDataSourceItemSchema(),
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(schema, true)).toBe(true);
+    expect(jsonSchemaHasRequiredDustToolInput(schema, false)).toBe(false);
+  });
+
+  it("tuple items array on property: any item schema with required Dust triggers", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      properties: {
+        pair: {
+          type: "array",
+          items: [
+            { type: "string" },
+            {
+              type: "object",
+              properties: {
+                uri: { type: "string" },
+                mimeType: { const: DUST_DS_MIME },
+              },
+              required: ["uri", "mimeType"],
+            },
+          ],
+        },
+      },
+      required: ["pair"],
+    };
+    expect(jsonSchemaHasRequiredDustToolInput(schema, true)).toBe(true);
+  });
+});
+
+describe("hasNoRequiredProperties (MCP view)", () => {
+  it("returns true when there are no input schemas", () => {
+    expect(hasNoRequiredProperties(minimalView([]))).toBe(true);
+  });
+
+  it("returns true when every tool inputSchema is undefined", () => {
+    expect(hasNoRequiredProperties(minimalView([undefined, undefined]))).toBe(
+      true
+    );
+  });
+
+  it("returns true when no tool requires Dust on a mandatory path", () => {
+    const clean: JSONSchema = {
+      type: "object",
+      properties: { q: { type: "string" } },
+      required: ["q"],
+    };
+    expect(hasNoRequiredProperties(minimalView([clean]))).toBe(true);
+  });
+
+  it("returns false when any tool has required Dust path", () => {
+    const clean: JSONSchema = {
+      type: "object",
+      properties: { q: { type: "string" } },
+      required: ["q"],
+    };
+    const bad: JSONSchema = {
+      type: "object",
+      properties: {
+        dataSources: {
+          type: "array",
+          items: dustDataSourceItemSchema(),
+        },
+      },
+      required: ["dataSources"],
+    };
+    expect(hasNoRequiredProperties(minimalView([clean, bad]))).toBe(false);
+    expect(hasNoRequiredProperties(minimalView([bad]))).toBe(false);
   });
 });

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -1,4 +1,5 @@
 import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import logger from "@app/logger/logger";
 import { isRecord } from "@app/types/shared/utils/general";
 import Ajv from "ajv";
@@ -374,4 +375,212 @@ export function iterateOverSchemaPropertiesRecursive(
       }
     }
   }
+}
+
+const DUST_TOOL_INPUT_MIME_PREFIX = "application/vnd.dust.tool-input.";
+
+/** Hot path: most property schemas are not Dust tool-input mime markers. */
+function mimeSchemaIndicatesDustToolInput(mimeSchema: unknown): boolean {
+  if (!mimeSchema || typeof mimeSchema !== "object") {
+    return false;
+  }
+  const m = mimeSchema as Record<string, unknown>;
+  const c = m.const;
+  if (typeof c === "string" && c.startsWith(DUST_TOOL_INPUT_MIME_PREFIX)) {
+    return true;
+  }
+  const en = m.enum;
+  if (!Array.isArray(en)) {
+    return false;
+  }
+  for (let i = 0; i < en.length; i++) {
+    const v = en[i];
+    if (typeof v === "string" && v.startsWith(DUST_TOOL_INPUT_MIME_PREFIX)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True when this schema describes an object that carries a Dust tool-input mime marker
+ * (uri + mimeType pattern used for configurable tool inputs).
+ */
+function isDustToolInputObjectSchema(schema: unknown): boolean {
+  if (!schema || typeof schema !== "object") {
+    return false;
+  }
+  const s = schema as Record<string, unknown>;
+  const props = s.properties;
+  if (!props || typeof props !== "object") {
+    return false;
+  }
+  if (
+    !mimeSchemaIndicatesDustToolInput(
+      (props as Record<string, unknown>).mimeType
+    )
+  ) {
+    return false;
+  }
+  const t = s.type;
+  if (t === undefined || t === "object") {
+    return true;
+  }
+  return Array.isArray(t) && t.includes("object");
+}
+
+/**
+ * True if somewhere under this schema a Dust tool-input object is reachable via a path
+ * where every object property on the path is listed in that object's `required` array
+ * (starting from the tool root with the same rule).
+ *
+ * Performance: optional branches (`pathFromRootAllRequired === false`) return immediately — no
+ * nested walk, since descendants cannot sit on an all-required path from the tool root.
+ */
+export function jsonSchemaHasRequiredDustToolInput(
+  schema: unknown,
+  pathFromRootAllRequired: boolean
+): boolean {
+  if (schema === null || schema === undefined) {
+    return false;
+  }
+
+  if (Array.isArray(schema)) {
+    const subs = schema;
+    for (let i = 0; i < subs.length; i++) {
+      if (
+        !jsonSchemaHasRequiredDustToolInput(subs[i], pathFromRootAllRequired)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (typeof schema !== "object") {
+    return false;
+  }
+
+  // Optional JSON subtree: cannot contain a mandatory Dust input from the tool root.
+  if (!pathFromRootAllRequired) {
+    return false;
+  }
+
+  const s = schema as Record<string, unknown> & JSONSchema;
+
+  if (isDustToolInputObjectSchema(s)) {
+    return true;
+  }
+
+  const allOf = s.allOf;
+  if (Array.isArray(allOf)) {
+    for (let i = 0; i < allOf.length; i++) {
+      if (jsonSchemaHasRequiredDustToolInput(allOf[i], true)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  const oneOf = s.oneOf;
+  if (Array.isArray(oneOf)) {
+    for (let i = 0; i < oneOf.length; i++) {
+      if (!jsonSchemaHasRequiredDustToolInput(oneOf[i], true)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  const anyOf = s.anyOf;
+  if (Array.isArray(anyOf)) {
+    for (let i = 0; i < anyOf.length; i++) {
+      if (!jsonSchemaHasRequiredDustToolInput(anyOf[i], true)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  const rawProps = s.properties;
+  if (rawProps && typeof rawProps === "object") {
+    const props = rawProps as Record<string, unknown>;
+    let requiredNames: Set<string> | undefined;
+    const req = s.required;
+    if (Array.isArray(req)) {
+      requiredNames = new Set<string>();
+      for (let i = 0; i < req.length; i++) {
+        const name = req[i];
+        if (typeof name === "string") {
+          requiredNames.add(name);
+        }
+      }
+    }
+
+    for (const propName in props) {
+      if (!Object.prototype.hasOwnProperty.call(props, propName)) {
+        continue;
+      }
+      const propSchema = props[propName];
+      if (!propSchema || typeof propSchema !== "object") {
+        continue;
+      }
+      if (!(requiredNames?.has(propName) === true)) {
+        continue;
+      }
+
+      const ps = propSchema as Record<string, unknown>;
+      if (ps.type === "array" && ps.items !== undefined) {
+        const items = ps.items;
+        if (Array.isArray(items)) {
+          for (let j = 0; j < items.length; j++) {
+            if (jsonSchemaHasRequiredDustToolInput(items[j], true)) {
+              return true;
+            }
+          }
+        } else if (jsonSchemaHasRequiredDustToolInput(items, true)) {
+          return true;
+        }
+        continue;
+      }
+
+      if (jsonSchemaHasRequiredDustToolInput(propSchema, true)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  if (s.type === "array" && s.items !== undefined) {
+    const items = s.items;
+    if (Array.isArray(items)) {
+      for (let i = 0; i < items.length; i++) {
+        if (jsonSchemaHasRequiredDustToolInput(items[i], true)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return jsonSchemaHasRequiredDustToolInput(items, true);
+  }
+
+  return false;
+}
+
+/**
+ * True when no tool input schema forces a Dust configurable input on an all-required path
+ * from the root (see {@link jsonSchemaHasRequiredDustToolInput}).
+ */
+export function hasNoRequiredProperties(view: MCPServerViewType): boolean {
+  const tools = view.server.tools;
+  for (let t = 0; t < tools.length; t++) {
+    const sch = tools[t].inputSchema;
+    if (sch !== undefined && sch !== null) {
+      if (jsonSchemaHasRequiredDustToolInput(sch, true)) {
+        return false;
+      }
+    }
+  }
+  return true;
 }

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -2,7 +2,7 @@ import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import { buildToolSpecification } from "@app/lib/actions/mcp";
 import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { isServerSideMCPServerConfigurationWithName } from "@app/lib/actions/types/guards";
@@ -375,7 +375,7 @@ export async function runModel(
     const filteredToolsets = allToolsets.filter((toolset) => {
       const mcpServerView = toolset.toJSON();
       return (
-        getMCPServerRequirements(mcpServerView).noRequirement &&
+        isJITMCPServerView(mcpServerView) &&
         mcpServerView.server.availability !== "auto_hidden_builder"
       );
     });


### PR DESCRIPTION
## Description

### Why

MCP servers that can be enabled "on the fly" (JIT) must not require any manual configuration in agent builder.
RIght now we rely on the same code path that agent builder uses to detect the requirements (optional or not).
However, getRequirements does not handle `.optional()` on arg schema definition correctly (it returns a "noRequirements" flag but it does not really work with optional())

This PR aim to focus only on detecting if ANY dust's internal configuration args is required in a very generic (and hopefully fast) way.

The new method is ONLY uses for isJITServer so the blast radius is very limited.

Exmaple:
Project's tools for example, allow you to pass a projectId, BUT fallback to the conversation's project if available.

### How

Allow MCP servers whose Dust tool inputs are all optional to be used as JIT servers.
- Replace `getMCPServerRequirements(view).noRequirement` with a new `hasNoRequiredProperties(view)` utility in `isJITMCPServerView` — servers like `project_conversation` that have only optional `dustProject` inputs are now eligible for JIT use
- Extract `jsonSchemaHasRequiredDustToolInput` helper to detect whether a JSON schema contains any required Dust-typed input
- Add comprehensive tests for both helpers

## Tests

Local + green (new tests added)

## Risk

Limited as it's a user manual action to pick the server for JIT.

## Deploy Plan

Deploy `front`
