### PR TITLE
Add: mergedAt and createdAt to get_pull_request github tool.

### DIFF
--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -36,7 +36,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
   get_pull_request: {
     description:
       "Retrieve a pull request from a specified GitHub repository including" +
-      " its associated description, diff, comments and reviews.",
+      " its associated description, creation time (createdAt), merge time" +
+      " (mergedAt when merged), diff, comments and reviews.",
     schema: {
       owner: z
         .string()

--- a/front/lib/api/actions/servers/github/tools/index.ts
+++ b/front/lib/api/actions/servers/github/tools/index.ts
@@ -105,6 +105,8 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
               pullRequest(number: $pullNumber) {
                 title
                 body
+                createdAt
+                mergedAt
                 commits(last: ${GITHUB_GET_PULL_REQUEST_ACTION_MAX_COMMITS}) {
                   nodes {
                     commit {
@@ -157,6 +159,8 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
             pullRequest: {
               title: string;
               body: string;
+              createdAt: string;
+              mergedAt: string | null;
               commits: {
                 nodes: {
                   commit: {
@@ -202,6 +206,8 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
 
         const pullTitle = pull.repository.pullRequest.title;
         const pullBody = pull.repository.pullRequest.body;
+        const pullCreatedAt = pull.repository.pullRequest.createdAt;
+        const pullMergedAt = pull.repository.pullRequest.mergedAt;
         const pullCommits = pull.repository.pullRequest.commits.nodes.map(
           (n) => {
             return {
@@ -312,8 +318,16 @@ export function createGithubTools(auth: Authenticator): ToolDefinition[] {
         // their defauilt response type)
         const pullDiff = diffWithPositions(diff.data as string);
 
+        const createdAtLine = `CREATED_AT: ${new Date(pullCreatedAt).toISOString()}\n\n`;
+        const mergedAtLine =
+          pullMergedAt != null
+            ? `MERGED_AT: ${new Date(pullMergedAt).toISOString()}\n\n`
+            : `MERGED_AT: (not merged)\n\n`;
+
         const content =
           `TITLE: ${pullTitle}\n\n` +
+          createdAtLine +
+          mergedAtLine +
           `BODY:\n` +
           `${pullBody}\n\n` +
           `COMMITS:\n` +


### PR DESCRIPTION
## Description

Expose `createdAt` and `mergedAt` in the `get_pull_request` GitHub tool output.
- Add both fields to the GraphQL query and typed response
- Append `CREATED_AT` and `MERGED_AT` lines to the formatted content string (`(not merged)` when not yet merged)
- Update tool description to advertise the new fields

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`
