### PR TITLE
[front] chore: remove ambiguous `XXX_TOOL_NAME` variables

### DIFF
--- a/front/lib/api/actions/servers/agent_management/index.ts
+++ b/front/lib/api/actions/servers/agent_management/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { AGENT_MANAGEMENT_TOOL_NAME } from "@app/lib/api/actions/servers/agent_management/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/agent_management/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: AGENT_MANAGEMENT_TOOL_NAME,
+      monitoringName: "agent_management",
     });
   }
 

--- a/front/lib/api/actions/servers/agent_management/metadata.ts
+++ b/front/lib/api/actions/servers/agent_management/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const AGENT_MANAGEMENT_TOOL_NAME = "agent_management" as const;
-
 // Tools metadata with exhaustive keys
 export const AGENT_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
   create_agent: {

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { AGENT_SIDEKICK_AGENT_STATE_TOOL_NAME } from "@app/lib/api/actions/servers/agent_sidekick_agent_state/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/agent_sidekick_agent_state/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: AGENT_SIDEKICK_AGENT_STATE_TOOL_NAME,
+      monitoringName: "agent_sidekick_agent_state",
     });
   }
 

--- a/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_agent_state/metadata.ts
@@ -4,9 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const AGENT_SIDEKICK_AGENT_STATE_TOOL_NAME =
-  "agent_sidekick_agent_state" as const;
-
 export const AGENT_SIDEKICK_AGENT_STATE_TOOLS_METADATA = createToolsRecord({
   get_agent_info: {
     description:

--- a/front/lib/api/actions/servers/data_warehouses/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { DATA_WAREHOUSES_TOOL_NAME } from "@app/lib/api/actions/servers/data_warehouses/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/data_warehouses/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: DATA_WAREHOUSES_TOOL_NAME,
+      monitoringName: "data_warehouses",
     });
   }
 

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -6,8 +6,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const DATA_WAREHOUSES_TOOL_NAME = "data_warehouses" as const;
-
 // Constants
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;

--- a/front/lib/api/actions/servers/databricks/index.ts
+++ b/front/lib/api/actions/servers/databricks/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { DATABRICKS_TOOL_NAME } from "@app/lib/api/actions/servers/databricks/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/databricks/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: DATABRICKS_TOOL_NAME,
+      monitoringName: "databricks",
     });
   }
 

--- a/front/lib/api/actions/servers/databricks/metadata.ts
+++ b/front/lib/api/actions/servers/databricks/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const DATABRICKS_TOOL_NAME = "databricks" as const;
-
 export const DATABRICKS_TOOLS_METADATA = createToolsRecord({
   list_warehouses: {
     description:

--- a/front/lib/api/actions/servers/extract_data/index.ts
+++ b/front/lib/api/actions/servers/extract_data/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { EXTRACT_DATA_TOOL_NAME } from "@app/lib/api/actions/servers/extract_data/metadata";
 import { createExtractDataTools } from "@app/lib/api/actions/servers/extract_data/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -15,7 +14,7 @@ function createServer(
   const tools = createExtractDataTools(auth, agentLoopContext);
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: EXTRACT_DATA_TOOL_NAME,
+      monitoringName: "extract_data",
     });
   }
 

--- a/front/lib/api/actions/servers/extract_data/metadata.ts
+++ b/front/lib/api/actions/servers/extract_data/metadata.ts
@@ -11,7 +11,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const EXTRACT_DATA_TOOL_NAME = "extract_data" as const;
 export const EXTRACT_DATA_MAIN_TOOL_NAME =
   "extract_information_from_documents" as const;
 

--- a/front/lib/api/actions/servers/freshservice/index.ts
+++ b/front/lib/api/actions/servers/freshservice/index.ts
@@ -1,10 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import {
-  FRESHSERVICE_SERVER,
-  FRESHSERVICE_TOOL_NAME,
-} from "@app/lib/api/actions/servers/freshservice/metadata";
+import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/freshservice/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -17,7 +14,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: FRESHSERVICE_TOOL_NAME,
+      monitoringName: "freshservice",
     });
   }
 

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -6,8 +6,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const FRESHSERVICE_TOOL_NAME = "freshservice" as const;
-
 const ALLOWED_TICKET_INCLUDES = [
   "conversations",
   "requester",

--- a/front/lib/api/actions/servers/front/index.ts
+++ b/front/lib/api/actions/servers/front/index.ts
@@ -1,10 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import {
-  FRONT_SERVER,
-  FRONT_TOOL_NAME,
-} from "@app/lib/api/actions/servers/front/metadata";
+import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/front/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -17,7 +14,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: FRONT_TOOL_NAME,
+      monitoringName: "front",
     });
   }
 

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const FRONT_TOOL_NAME = "front" as const;
-
 export const FRONT_TOOLS_METADATA = createToolsRecord({
   search_conversations: {
     description:

--- a/front/lib/api/actions/servers/github/index.ts
+++ b/front/lib/api/actions/servers/github/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { GITHUB_TOOL_NAME } from "@app/lib/api/actions/servers/github/metadata";
 import { createGithubTools } from "@app/lib/api/actions/servers/github/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -15,7 +14,7 @@ function createServer(
   const tools = createGithubTools(auth);
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: GITHUB_TOOL_NAME,
+      monitoringName: "github",
     });
   }
 

--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const GITHUB_TOOL_NAME = "github" as const;
-
 export const GITHUB_TOOLS_METADATA = createToolsRecord({
   create_issue: {
     description: "Create a new issue on a specified GitHub repository.",

--- a/front/lib/api/actions/servers/gong/index.ts
+++ b/front/lib/api/actions/servers/gong/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { GONG_TOOL_NAME } from "@app/lib/api/actions/servers/gong/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/gong/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: GONG_TOOL_NAME,
+      monitoringName: "gong",
     });
   }
 

--- a/front/lib/api/actions/servers/gong/metadata.ts
+++ b/front/lib/api/actions/servers/gong/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const GONG_TOOL_NAME = "gong" as const;
-
 export const GONG_TOOLS_METADATA = createToolsRecord({
   list_calls: {
     description:

--- a/front/lib/api/actions/servers/google_calendar/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { GOOGLE_CALENDAR_TOOL_NAME } from "@app/lib/api/actions/servers/google_calendar/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/google_calendar/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: GOOGLE_CALENDAR_TOOL_NAME,
+      monitoringName: "google_calendar",
     });
   }
 

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const GOOGLE_CALENDAR_TOOL_NAME = "google_calendar" as const;
-
 export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
   list_calendars: {
     description:

--- a/front/lib/api/actions/servers/hubspot/index.ts
+++ b/front/lib/api/actions/servers/hubspot/index.ts
@@ -1,10 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import {
-  HUBSPOT_SERVER,
-  HUBSPOT_TOOL_NAME,
-} from "@app/lib/api/actions/servers/hubspot/metadata";
+import { HUBSPOT_SERVER } from "@app/lib/api/actions/servers/hubspot/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/hubspot/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -17,7 +14,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: HUBSPOT_TOOL_NAME,
+      monitoringName: "hubspot",
     });
   }
 

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -5,8 +5,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const HUBSPOT_TOOL_NAME = "hubspot" as const;
-
 const ALL_OBJECTS = ["contacts", "companies", "deals", "owners"] as const;
 const SIMPLE_OBJECTS = ["contacts", "companies", "deals"] as const;
 

--- a/front/lib/api/actions/servers/include_data/index.ts
+++ b/front/lib/api/actions/servers/include_data/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { INCLUDE_DATA_TOOL_NAME } from "@app/lib/api/actions/servers/include_data/metadata";
 import { createIncludeDataTools } from "@app/lib/api/actions/servers/include_data/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -15,7 +14,7 @@ function createServer(
   const tools = createIncludeDataTools(auth, agentLoopContext);
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: INCLUDE_DATA_TOOL_NAME,
+      monitoringName: "include_data",
     });
   }
 

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -12,8 +12,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const INCLUDE_DATA_TOOL_NAME = "include_data" as const;
-
 // Base tool without tags support
 export const INCLUDE_DATA_BASE_TOOLS_METADATA = createToolsRecord({
   retrieve_recent_documents: {

--- a/front/lib/api/actions/servers/jira/index.ts
+++ b/front/lib/api/actions/servers/jira/index.ts
@@ -1,10 +1,7 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import {
-  JIRA_SERVER,
-  JIRA_TOOL_NAME,
-} from "@app/lib/api/actions/servers/jira/metadata";
+import { JIRA_SERVER } from "@app/lib/api/actions/servers/jira/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/jira/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -17,7 +14,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: JIRA_TOOL_NAME,
+      monitoringName: "jira",
     });
   }
 

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -13,8 +13,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const JIRA_TOOL_NAME = "jira" as const;
-
 export const JIRA_TOOLS_METADATA = createToolsRecord({
   // Read operations
   get_issue_read_fields: {

--- a/front/lib/api/actions/servers/luma/index.ts
+++ b/front/lib/api/actions/servers/luma/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { LUMA_TOOL_NAME } from "@app/lib/api/actions/servers/luma/metadata";
 import { createLumaTools } from "@app/lib/api/actions/servers/luma/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -15,7 +14,7 @@ function createServer(
   const tools = createLumaTools(auth, agentLoopContext);
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: LUMA_TOOL_NAME,
+      monitoringName: "luma",
     });
   }
 

--- a/front/lib/api/actions/servers/luma/metadata.ts
+++ b/front/lib/api/actions/servers/luma/metadata.ts
@@ -9,8 +9,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const LUMA_TOOL_NAME = "luma" as const;
-
 export const LUMA_TOOLS_METADATA = createToolsRecord({
   get_authenticated_user: {
     description:

--- a/front/lib/api/actions/servers/missing_action_catcher/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { MISSING_ACTION_CATCHER_TOOL_NAME } from "@app/lib/api/actions/servers/missing_action_catcher/metadata";
 import { createMissingActionCatcherTools } from "@app/lib/api/actions/servers/missing_action_catcher/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -15,7 +14,7 @@ function createServer(
   const tools = createMissingActionCatcherTools(agentLoopContext);
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: MISSING_ACTION_CATCHER_TOOL_NAME,
+      monitoringName: "missing_action_catcher",
     });
   }
 

--- a/front/lib/api/actions/servers/missing_action_catcher/metadata.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/metadata.ts
@@ -1,8 +1,5 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
-export const MISSING_ACTION_CATCHER_TOOL_NAME =
-  "missing_action_catcher" as const;
-
 // This server has dynamically created tools based on the agentLoopContext,
 // so we don't have fixed tools metadata. The tools are created at runtime
 // in the createServer function.

--- a/front/lib/api/actions/servers/monday/index.ts
+++ b/front/lib/api/actions/servers/monday/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { MONDAY_TOOL_NAME } from "@app/lib/api/actions/servers/monday/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/monday/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: MONDAY_TOOL_NAME,
+      monitoringName: "monday",
     });
   }
 

--- a/front/lib/api/actions/servers/monday/metadata.ts
+++ b/front/lib/api/actions/servers/monday/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const MONDAY_TOOL_NAME = "monday" as const;
-
 export const MONDAY_TOOLS_METADATA = createToolsRecord({
   get_boards: {
     description:

--- a/front/lib/api/actions/servers/openai_usage/index.ts
+++ b/front/lib/api/actions/servers/openai_usage/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { OPENAI_USAGE_TOOL_NAME } from "@app/lib/api/actions/servers/openai_usage/metadata";
 import { createOpenAIUsageTools } from "@app/lib/api/actions/servers/openai_usage/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -15,7 +14,7 @@ function createServer(
   const tools = createOpenAIUsageTools(auth, agentLoopContext);
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: OPENAI_USAGE_TOOL_NAME,
+      monitoringName: "openai_usage",
     });
   }
 

--- a/front/lib/api/actions/servers/openai_usage/metadata.ts
+++ b/front/lib/api/actions/servers/openai_usage/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const OPENAI_USAGE_TOOL_NAME = "openai_usage" as const;
-
 export const OPENAI_USAGE_TOOLS_METADATA = createToolsRecord({
   get_completions_usage: {
     description:

--- a/front/lib/api/actions/servers/outlook/calendar_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const OUTLOOK_CALENDAR_TOOL_NAME = "outlook_calendar" as const;
-
 export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
   get_user_timezone: {
     description:

--- a/front/lib/api/actions/servers/outlook/calendar_server.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_server.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { OUTLOOK_CALENDAR_TOOL_NAME } from "@app/lib/api/actions/servers/outlook/calendar_metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/outlook/tools/calendar";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: OUTLOOK_CALENDAR_TOOL_NAME,
+      monitoringName: "outlook_calendar",
     });
   }
 

--- a/front/lib/api/actions/servers/poke/index.ts
+++ b/front/lib/api/actions/servers/poke/index.ts
@@ -9,7 +9,7 @@ function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer {
-  const server = makeInternalMCPServer(POKE_SERVER_NAME);
+  const server = makeInternalMCPServer("poke");
 
   // Gate at server creation: if the caller is not a Dust super user, register
   // a single error tool so the agent gets a clear message.

--- a/front/lib/api/actions/servers/poke/index.ts
+++ b/front/lib/api/actions/servers/poke/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { POKE_SERVER_NAME } from "@app/lib/api/actions/servers/poke/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/poke/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -34,7 +33,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: POKE_SERVER_NAME,
+      monitoringName: "poke",
     });
   }
 

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -261,7 +261,7 @@ export const POKE_TOOLS_METADATA = createToolsRecord({
 
 export const POKE_SERVER = {
   serverInfo: {
-    name: POKE_SERVER_NAME,
+    name: "poke",
     version: "1.0.0",
     description:
       "Dust-internal tools for cross-workspace data access (poke). Requires super user privileges.",

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const POKE_SERVER_NAME = "poke" as const;
-
 // ─── Workspace Context ───────────────────────────────────────────────────────
 
 export const GET_WORKSPACE_METADATA_TOOL_NAME = "get_workspace_metadata";

--- a/front/lib/api/actions/servers/primitive_types_debugger/index.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { PRIMITIVE_TYPES_DEBUGGER_TOOL_NAME } from "@app/lib/api/actions/servers/primitive_types_debugger/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/primitive_types_debugger/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: PRIMITIVE_TYPES_DEBUGGER_TOOL_NAME,
+      monitoringName: "primitive_types_debugger",
     });
   }
 

--- a/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
@@ -6,9 +6,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const PRIMITIVE_TYPES_DEBUGGER_TOOL_NAME =
-  "primitive_types_debugger" as const;
-
 // Schema for tool_without_user_config
 const toolWithoutUserConfigSchema = {
   query: z.string(),

--- a/front/lib/api/actions/servers/productboard/index.ts
+++ b/front/lib/api/actions/servers/productboard/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { PRODUCTBOARD_TOOL_NAME } from "@app/lib/api/actions/servers/productboard/metadata";
 import { createProductboardTools } from "@app/lib/api/actions/servers/productboard/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -15,7 +14,7 @@ function createServer(
   const tools = createProductboardTools();
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: PRODUCTBOARD_TOOL_NAME,
+      monitoringName: "productboard",
     });
   }
 

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const PRODUCTBOARD_TOOL_NAME = "productboard" as const;
-
 export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
   create_note: {
     description:

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -17,7 +17,6 @@ import {
   prepareParamsWithHistory,
   processDustFileOutput,
 } from "@app/lib/api/actions/servers/run_dust_app/helpers";
-import { RUN_DUST_APP_TOOL_NAME } from "@app/lib/api/actions/servers/run_dust_app/metadata";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { getApiKeyNameHeader, prodAPICredentialsForOwner } from "@app/lib/auth";
@@ -93,7 +92,7 @@ export default async function createServer(
     };
 
     registerTool(auth, agentLoopContext, server, toolDefinition, {
-      monitoringName: RUN_DUST_APP_TOOL_NAME,
+      monitoringName: "run_dust_app",
     });
   } else if (agentLoopContext?.runContext) {
     // Context: Running the Dust app
@@ -221,7 +220,7 @@ export default async function createServer(
     };
 
     registerTool(auth, agentLoopContext, server, toolDefinition, {
-      monitoringName: RUN_DUST_APP_TOOL_NAME,
+      monitoringName: "run_dust_app",
     });
   } else {
     // Context: Configuration - selecting which Dust app to use
@@ -249,7 +248,7 @@ export default async function createServer(
     };
 
     registerTool(auth, agentLoopContext, server, toolDefinition, {
-      monitoringName: RUN_DUST_APP_TOOL_NAME,
+      monitoringName: "run_dust_app",
     });
   }
 

--- a/front/lib/api/actions/servers/run_dust_app/metadata.ts
+++ b/front/lib/api/actions/servers/run_dust_app/metadata.ts
@@ -6,8 +6,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const RUN_DUST_APP_TOOL_NAME = "run_dust_app" as const;
-
 /**
  * Tools metadata for run_dust_app server.
  *

--- a/front/lib/api/actions/servers/salesforce/index.ts
+++ b/front/lib/api/actions/servers/salesforce/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { SALESFORCE_TOOL_NAME } from "@app/lib/api/actions/servers/salesforce/metadata";
 import { createSalesforceTools } from "@app/lib/api/actions/servers/salesforce/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -15,12 +14,11 @@ function createServer(
   const tools = createSalesforceTools(auth);
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: SALESFORCE_TOOL_NAME,
+      monitoringName: "salesforce",
     });
   }
 
   return server;
 }
 
-export { SALESFORCE_SERVER } from "./metadata";
 export default createServer;

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -5,8 +5,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SALESFORCE_TOOL_NAME = "salesforce" as const;
-
 export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
   execute_read_query: {
     description: "Execute a read query on Salesforce",

--- a/front/lib/api/actions/servers/salesloft/index.ts
+++ b/front/lib/api/actions/servers/salesloft/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { SALESLOFT_TOOL_NAME } from "@app/lib/api/actions/servers/salesloft/metadata";
 import { createSalesloftTools } from "@app/lib/api/actions/servers/salesloft/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -15,7 +14,7 @@ function createServer(
   const tools = createSalesloftTools(auth, agentLoopContext);
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: SALESLOFT_TOOL_NAME,
+      monitoringName: "salesloft",
     });
   }
 

--- a/front/lib/api/actions/servers/salesloft/metadata.ts
+++ b/front/lib/api/actions/servers/salesloft/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SALESLOFT_TOOL_NAME = "salesloft" as const;
-
 export const SALESLOFT_TOOLS_METADATA = createToolsRecord({
   get_actions: {
     description:

--- a/front/lib/api/actions/servers/schedules_management/index.ts
+++ b/front/lib/api/actions/servers/schedules_management/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { SCHEDULES_MANAGEMENT_TOOL_NAME } from "@app/lib/api/actions/servers/schedules_management/metadata";
 import { createSchedulesManagementTools } from "@app/lib/api/actions/servers/schedules_management/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -16,7 +15,7 @@ function createServer(
 
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: SCHEDULES_MANAGEMENT_TOOL_NAME,
+      monitoringName: "schedules_management",
     });
   }
 

--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SCHEDULES_MANAGEMENT_TOOL_NAME = "schedules_management" as const;
-
 export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
   create_schedule: {
     description: "Create a schedule that runs this agent at specified times.",

--- a/front/lib/api/actions/servers/skill_management/index.ts
+++ b/front/lib/api/actions/servers/skill_management/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { SKILL_MANAGEMENT_TOOL_NAME } from "@app/lib/api/actions/servers/skill_management/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/skill_management/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: SKILL_MANAGEMENT_TOOL_NAME,
+      monitoringName: "skill_management",
     });
   }
 

--- a/front/lib/api/actions/servers/skill_management/metadata.ts
+++ b/front/lib/api/actions/servers/skill_management/metadata.ts
@@ -5,8 +5,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SKILL_MANAGEMENT_TOOL_NAME = "skill_management" as const;
-
 export const SKILL_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
   [ENABLE_SKILL_TOOL_NAME]: {
     description:

--- a/front/lib/api/actions/servers/slab/index.ts
+++ b/front/lib/api/actions/servers/slab/index.ts
@@ -1,10 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import {
-  SLAB_SERVER,
-  SLAB_TOOL_NAME,
-} from "@app/lib/api/actions/servers/slab/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/slab/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -17,13 +13,11 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: SLAB_TOOL_NAME,
+      monitoringName: "slab",
     });
   }
 
   return server;
 }
-
-export { SLAB_SERVER };
 
 export default createServer;

--- a/front/lib/api/actions/servers/slab/metadata.ts
+++ b/front/lib/api/actions/servers/slab/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SLAB_TOOL_NAME = "slab" as const;
-
 const MAX_CONTENT_SIZE = 32000;
 
 export const SLAB_TOOLS_METADATA = createToolsRecord({

--- a/front/lib/api/actions/servers/slack_bot/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { SLACK_BOT_TOOL_NAME } from "@app/lib/api/actions/servers/slack_bot/metadata";
 import { createSlackBotTools } from "@app/lib/api/actions/servers/slack_bot/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -16,7 +15,7 @@ async function createServer(
   const tools = createSlackBotTools(auth, mcpServerId, agentLoopContext);
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: SLACK_BOT_TOOL_NAME,
+      monitoringName: "slack_bot",
     });
   }
 

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SLACK_BOT_TOOL_NAME = "slack_bot" as const;
-
 export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
   post_message: {
     description:

--- a/front/lib/api/actions/servers/snowflake/index.ts
+++ b/front/lib/api/actions/servers/snowflake/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { SNOWFLAKE_TOOL_NAME } from "@app/lib/api/actions/servers/snowflake/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/snowflake/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: SNOWFLAKE_TOOL_NAME,
+      monitoringName: "snowflake",
     });
   }
 

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -4,7 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SNOWFLAKE_TOOL_NAME = "snowflake" as const;
 export const MAX_QUERY_ROWS = 1000;
 
 export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({

--- a/front/lib/api/actions/servers/statuspage/index.ts
+++ b/front/lib/api/actions/servers/statuspage/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { STATUSPAGE_TOOL_NAME } from "@app/lib/api/actions/servers/statuspage/metadata";
 import { createStatuspageTools } from "@app/lib/api/actions/servers/statuspage/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -15,7 +14,7 @@ function createServer(
   const tools = createStatuspageTools(auth, agentLoopContext);
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: STATUSPAGE_TOOL_NAME,
+      monitoringName: "statuspage",
     });
   }
 

--- a/front/lib/api/actions/servers/statuspage/metadata.ts
+++ b/front/lib/api/actions/servers/statuspage/metadata.ts
@@ -9,8 +9,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const STATUSPAGE_TOOL_NAME = "statuspage" as const;
-
 export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
   list_pages: {
     description:

--- a/front/lib/api/actions/servers/toolsets/index.ts
+++ b/front/lib/api/actions/servers/toolsets/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { TOOLSETS_TOOL_NAME } from "@app/lib/api/actions/servers/toolsets/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/toolsets/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: TOOLSETS_TOOL_NAME,
+      monitoringName: "toolsets",
     });
   }
 

--- a/front/lib/api/actions/servers/toolsets/metadata.ts
+++ b/front/lib/api/actions/servers/toolsets/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const TOOLSETS_TOOL_NAME = "toolsets" as const;
-
 export const TOOLSETS_TOOLS_METADATA = createToolsRecord({
   list: {
     description:

--- a/front/lib/api/actions/servers/ukg_ready/index.ts
+++ b/front/lib/api/actions/servers/ukg_ready/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { UKG_READY_TOOL_NAME } from "@app/lib/api/actions/servers/ukg_ready/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/ukg_ready/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: UKG_READY_TOOL_NAME,
+      monitoringName: "ukg_ready",
     });
   }
 

--- a/front/lib/api/actions/servers/ukg_ready/metadata.ts
+++ b/front/lib/api/actions/servers/ukg_ready/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const UKG_READY_TOOL_NAME = "ukg_ready" as const;
-
 export const UKG_READY_TOOLS_METADATA = createToolsRecord({
   get_my_info: {
     description:

--- a/front/lib/api/actions/servers/val_town/index.ts
+++ b/front/lib/api/actions/servers/val_town/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { VAL_TOWN_TOOL_NAME } from "@app/lib/api/actions/servers/val_town/metadata";
 import { createValTownTools } from "@app/lib/api/actions/servers/val_town/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -16,7 +15,7 @@ function createServer(
 
   for (const tool of tools) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: VAL_TOWN_TOOL_NAME,
+      monitoringName: "val_town",
     });
   }
 

--- a/front/lib/api/actions/servers/val_town/metadata.ts
+++ b/front/lib/api/actions/servers/val_town/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const VAL_TOWN_TOOL_NAME = "val_town" as const;
-
 export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   create_val: {
     description:

--- a/front/lib/api/actions/servers/vanta/index.ts
+++ b/front/lib/api/actions/servers/vanta/index.ts
@@ -1,7 +1,6 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { VANTA_TOOL_NAME } from "@app/lib/api/actions/servers/vanta/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/vanta/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -14,7 +13,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: VANTA_TOOL_NAME,
+      monitoringName: "vanta",
     });
   }
 

--- a/front/lib/api/actions/servers/vanta/metadata.ts
+++ b/front/lib/api/actions/servers/vanta/metadata.ts
@@ -4,8 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const VANTA_TOOL_NAME = "vanta" as const;
-
 const PaginationSchema = {
   pageSize: z
     .number()

--- a/front/runbooks/NEW_MCP_SERVER.md
+++ b/front/runbooks/NEW_MCP_SERVER.md
@@ -98,8 +98,6 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
-export const YOUR_PROVIDER_TOOL_NAME = "your_provider" as const;
-
 // Tools metadata with exhaustive keys
 // Adding a tool here without implementing its handler will cause a type error
 export const YOUR_PROVIDER_TOOLS_METADATA = createToolsRecord({
@@ -267,7 +265,6 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { YOUR_PROVIDER_TOOL_NAME } from "@app/lib/api/actions/servers/your_provider/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/your_provider/tools";
 import type { Authenticator } from "@app/lib/auth";
 
@@ -279,7 +276,7 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: YOUR_PROVIDER_TOOL_NAME,
+      monitoringName: "your_provider",
     });
   }
 
@@ -470,7 +467,7 @@ export function createYourProviderTools(auth: Authenticator): ToolDefinition[] {
 const tools = createYourProviderTools(auth);
 for (const tool of tools) {
   registerTool(auth, agentLoopContext, server, tool, {
-    monitoringName: YOUR_PROVIDER_TOOL_NAME,
+    monitoringName: "your_provider",
   });
 }
 ```
@@ -497,7 +494,7 @@ your_provider: {
   isRestricted: ({ featureFlags }) => {
     return !featureFlags.includes("your_provider_tool");
   },
-  isPreview: true,
+    isPreview: true,
   // ...
 }
 ```
@@ -571,7 +568,7 @@ Always add `.describe()` to schema fields - this helps the LLM understand what v
 ```typescript
 schema: {
   query: z.string().describe("Search query to find items by name or description."),
-  limit: z.number().optional().describe("Maximum number of results (default: 50, max: 100)."),
+    limit: z.number().optional().describe("Maximum number of results (default: 50, max: 100)."),
 }
 ```
 
@@ -605,16 +602,16 @@ private async request<T extends z.Schema>(
 
   const parseResult = schema.safeParse(rawData);
   if (!parseResult.success) {
-    logger.error(
-      { endpoint, error: parseResult.error.message },
-      "[Provider] Invalid API response format"
-    );
-    return new Err(
-      new Error(`Invalid API response format: ${parseResult.error.message}`)
-    );
-  }
+  logger.error(
+    { endpoint, error: parseResult.error.message },
+    "[Provider] Invalid API response format"
+  );
+  return new Err(
+    new Error(`Invalid API response format: ${parseResult.error.message}`)
+  );
+}
 
-  return new Ok(parseResult.data);
+return new Ok(parseResult.data);
 }
 ```
 


### PR DESCRIPTION
## Description

- This PR cleans up exported variables named `XXX_TOOL_NAME` that are only used as monitoringName in `withToolLogging`.
- This name is ambiguous as it's actually relative to the MCP server.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
