### PR TITLE
[front] enh: improve loading state UI for `UserQuestionRequired`

### DIFF
--- a/front/components/assistant/conversation/UserQuestionRequired.tsx
+++ b/front/components/assistant/conversation/UserQuestionRequired.tsx
@@ -11,6 +11,7 @@ import {
   Counter,
   cn,
   Input,
+  Spinner,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -44,6 +45,7 @@ export function UserQuestionRequired({
   const { question } = blockedAction;
   const isTriggeredByCurrentUser = blockedAction.userId === user?.sId;
   const trimmedCustomResponse = customResponse.trim();
+  const isAnswerSubmitting = isSubmitting && !isSkipPending;
   const isCustomResponseSelected =
     trimmedCustomResponse.length > 0 && selectedOptions.length === 0;
 
@@ -127,111 +129,117 @@ export function UserQuestionRequired({
       <div className="text-base font-medium leading-tight text-foreground dark:text-foreground-night">
         {question.question}
       </div>
-      <div className="flex flex-col gap-2">
-        {question.options.map((option, index) => {
-          const isSelected = selectedOptions.includes(index);
+      {isAnswerSubmitting ? (
+        <div className="flex min-h-64 items-center justify-center">
+          <Spinner size="lg" />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {question.options.map((option, index) => {
+            const isSelected = selectedOptions.includes(index);
 
-          return (
-            <Card
-              key={index}
-              variant="tertiary"
-              className={cn(
-                "flex w-full cursor-pointer items-center gap-2 rounded-2xl p-3 text-left transition-colors",
-                isSelected
-                  ? question.multiSelect
-                    ? [
-                        "border-border bg-muted-background",
-                        "dark:border-border-night dark:bg-muted-background-night",
+            return (
+              <Card
+                key={index}
+                variant="tertiary"
+                className={cn(
+                  "flex w-full cursor-pointer items-center gap-2 rounded-2xl p-3 text-left transition-colors",
+                  isSelected
+                    ? question.multiSelect
+                      ? [
+                          "border-border bg-muted-background",
+                          "dark:border-border-night dark:bg-muted-background-night",
+                        ]
+                      : "bg-muted-background dark:bg-muted-background-night"
+                    : [
+                        "bg-background hover:bg-muted-background/60",
+                        "dark:bg-background-night",
+                        "dark:hover:bg-muted-background-night/60",
                       ]
-                    : "bg-muted-background dark:bg-muted-background-night"
-                  : [
-                      "bg-background hover:bg-muted-background/60",
-                      "dark:bg-background-night",
-                      "dark:hover:bg-muted-background-night/60",
-                    ]
+                )}
+                onClick={() => handleOptionClick(index)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleOptionClick(index);
+                  }
+                }}
+                role="button"
+                tabIndex={isSubmitting ? -1 : 0}
+                aria-pressed={isSelected}
+              >
+                <Counter
+                  value={index + 1}
+                  size="sm"
+                  variant="ghost"
+                  className={cn(
+                    "shrink-0 bg-border-dark text-muted-foreground",
+                    "dark:bg-border-dark-night dark:text-muted-foreground-night"
+                  )}
+                />
+                <div className="flex flex-col">
+                  <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                    {option.label}
+                  </span>
+                  {option.description && (
+                    <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                      {option.description}
+                    </span>
+                  )}
+                </div>
+              </Card>
+            );
+          })}
+          <Card
+            variant="tertiary"
+            className={cn(
+              "flex w-full items-center gap-2 rounded-2xl p-3 transition-colors",
+              isCustomResponseSelected &&
+                "border-border dark:border-border-night",
+              isCustomResponseSelected
+                ? "bg-muted-background dark:bg-muted-background-night"
+                : [
+                    "bg-background hover:bg-muted-background/60",
+                    "dark:bg-background-night",
+                    "dark:hover:bg-muted-background-night/60",
+                  ]
+            )}
+          >
+            <Counter
+              value={question.options.length + 1}
+              size="sm"
+              variant="ghost"
+              className={cn(
+                "shrink-0 bg-border-dark text-muted-foreground",
+                "dark:bg-border-dark-night dark:text-muted-foreground-night"
               )}
-              onClick={() => handleOptionClick(index)}
+            />
+            <Input
+              id={`custom-response-${blockedAction.actionId}`}
+              containerClassName="flex-1"
+              className={cn(
+                "h-auto w-full rounded-none border-transparent bg-transparent",
+                "px-0 py-0 text-sm shadow-none",
+                "focus-visible:border-transparent focus-visible:ring-0"
+              )}
+              placeholder="Type something else"
+              value={customResponse}
+              onFocus={() => {
+                setSelectedOptions([]);
+              }}
+              onChange={(e) => setCustomResponse(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
+                if (e.key === "Enter") {
                   e.preventDefault();
-                  handleOptionClick(index);
+                  handleSubmit();
                 }
               }}
-              role="button"
-              tabIndex={isSubmitting ? -1 : 0}
-              aria-pressed={isSelected}
-            >
-              <Counter
-                value={index + 1}
-                size="sm"
-                variant="ghost"
-                className={cn(
-                  "shrink-0 bg-border-dark text-muted-foreground",
-                  "dark:bg-border-dark-night dark:text-muted-foreground-night"
-                )}
-              />
-              <div className="flex flex-col">
-                <span className="text-sm font-medium text-foreground dark:text-foreground-night">
-                  {option.label}
-                </span>
-                {option.description && (
-                  <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                    {option.description}
-                  </span>
-                )}
-              </div>
-            </Card>
-          );
-        })}
-        <Card
-          variant="tertiary"
-          className={cn(
-            "flex w-full items-center gap-2 rounded-2xl p-3 transition-colors",
-            isCustomResponseSelected &&
-              "border-border dark:border-border-night",
-            isCustomResponseSelected
-              ? "bg-muted-background dark:bg-muted-background-night"
-              : [
-                  "bg-background hover:bg-muted-background/60",
-                  "dark:bg-background-night",
-                  "dark:hover:bg-muted-background-night/60",
-                ]
-          )}
-        >
-          <Counter
-            value={question.options.length + 1}
-            size="sm"
-            variant="ghost"
-            className={cn(
-              "shrink-0 bg-border-dark text-muted-foreground",
-              "dark:bg-border-dark-night dark:text-muted-foreground-night"
-            )}
-          />
-          <Input
-            id={`custom-response-${blockedAction.actionId}`}
-            containerClassName="flex-1"
-            className={cn(
-              "h-auto w-full rounded-none border-transparent bg-transparent",
-              "px-0 py-0 text-sm shadow-none",
-              "focus-visible:border-transparent focus-visible:ring-0"
-            )}
-            placeholder="Type something else"
-            value={customResponse}
-            onFocus={() => {
-              setSelectedOptions([]);
-            }}
-            onChange={(e) => setCustomResponse(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                handleSubmit();
-              }
-            }}
-            name="custom-response"
-            disabled={isSubmitting}
-          />
-        </Card>
-      </div>
+              name="custom-response"
+              disabled={isSubmitting}
+            />
+          </Card>
+        </div>
+      )}
       {errorMessage && (
         <div className="text-sm font-medium text-warning-800 dark:text-warning-800-night">
           {errorMessage}

--- a/front/components/assistant/conversation/UserQuestionRequired.tsx
+++ b/front/components/assistant/conversation/UserQuestionRequired.tsx
@@ -40,6 +40,7 @@ export function UserQuestionRequired({
 
   const [selectedOptions, setSelectedOptions] = useState<number[]>([]);
   const [customResponse, setCustomResponse] = useState("");
+  const [isSkipPending, setIsSkipPending] = useState(false);
 
   const { question } = blockedAction;
   const isTriggeredByCurrentUser = blockedAction.userId === user?.sId;
@@ -47,7 +48,8 @@ export function UserQuestionRequired({
   const isCustomResponseSelected =
     trimmedCustomResponse.length > 0 && selectedOptions.length === 0;
 
-  async function submitAnswer(answer: UserQuestionAnswer) {
+  async function submitAnswer(answer: UserQuestionAnswer, isSkip = false) {
+    setIsSkipPending(isSkip);
     const result = await answerQuestion({
       conversationId,
       messageId,
@@ -57,10 +59,16 @@ export function UserQuestionRequired({
 
     if (result.success) {
       removeCompletedAction(blockedAction.actionId);
+      return;
     }
-  }
 
+    setIsSkipPending(false);
+  }
   function handleOptionClick(index: number) {
+    if (isSubmitting) {
+      return;
+    }
+
     if (question.multiSelect) {
       setSelectedOptions((prev) =>
         prev.includes(index)
@@ -75,6 +83,10 @@ export function UserQuestionRequired({
   }
 
   function handleSubmit() {
+    if (isSubmitting) {
+      return;
+    }
+
     if (!isCustomResponseSelected && selectedOptions.length === 0) {
       return;
     }
@@ -87,15 +99,11 @@ export function UserQuestionRequired({
   }
 
   function handleSkip() {
-    void submitAnswer({ selectedOptions: [] });
-  }
+    if (isSubmitting) {
+      return;
+    }
 
-  if (isSubmitting) {
-    return (
-      <div className="flex justify-center py-4">
-        <Spinner size="sm" />
-      </div>
-    );
+    void submitAnswer({ selectedOptions: [] }, true);
   }
 
   if (!isTriggeredByCurrentUser) {
@@ -123,6 +131,8 @@ export function UserQuestionRequired({
       <div className="flex flex-col gap-2">
         {question.options.map((option, index) => {
           const isSelected = selectedOptions.includes(index);
+          const isSubmittingOption =
+            isSubmitting && !isSkipPending && isSelected;
 
           return (
             <Card
@@ -151,28 +161,36 @@ export function UserQuestionRequired({
                 }
               }}
               role="button"
-              tabIndex={0}
+              tabIndex={isSubmitting ? -1 : 0}
               aria-pressed={isSelected}
             >
-              <Counter
-                value={index + 1}
-                size="sm"
-                variant="ghost"
-                className={cn(
-                  "shrink-0 bg-border-dark text-muted-foreground",
-                  "dark:bg-border-dark-night dark:text-muted-foreground-night"
-                )}
-              />
-              <div className="flex flex-col">
-                <span className="text-sm font-medium text-foreground dark:text-foreground-night">
-                  {option.label}
-                </span>
-                {option.description && (
-                  <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                    {option.description}
-                  </span>
-                )}
-              </div>
+              {isSubmittingOption ? (
+                <div className="flex w-full items-center justify-center py-1">
+                  <Spinner size="sm" />
+                </div>
+              ) : (
+                <>
+                  <Counter
+                    value={index + 1}
+                    size="sm"
+                    variant="ghost"
+                    className={cn(
+                      "shrink-0 bg-border-dark text-muted-foreground",
+                      "dark:bg-border-dark-night dark:text-muted-foreground-night"
+                    )}
+                  />
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                      {option.label}
+                    </span>
+                    {option.description && (
+                      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                        {option.description}
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
             </Card>
           );
         })}
@@ -191,37 +209,46 @@ export function UserQuestionRequired({
                 ]
           )}
         >
-          <Counter
-            value={question.options.length + 1}
-            size="sm"
-            variant="ghost"
-            className={cn(
-              "shrink-0 bg-border-dark text-muted-foreground",
-              "dark:bg-border-dark-night dark:text-muted-foreground-night"
-            )}
-          />
-          <Input
-            id={`custom-response-${blockedAction.actionId}`}
-            containerClassName="flex-1"
-            className={cn(
-              "h-auto w-full rounded-none border-transparent bg-transparent",
-              "px-0 py-0 text-sm shadow-none",
-              "focus-visible:border-transparent focus-visible:ring-0"
-            )}
-            placeholder="Type something else"
-            value={customResponse}
-            onFocus={() => {
-              setSelectedOptions([]);
-            }}
-            onChange={(e) => setCustomResponse(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                handleSubmit();
-              }
-            }}
-            name="custom-response"
-          />
+          {isSubmitting && !isSkipPending && isCustomResponseSelected ? (
+            <div className="flex w-full items-center justify-center py-1">
+              <Spinner size="sm" />
+            </div>
+          ) : (
+            <>
+              <Counter
+                value={question.options.length + 1}
+                size="sm"
+                variant="ghost"
+                className={cn(
+                  "shrink-0 bg-border-dark text-muted-foreground",
+                  "dark:bg-border-dark-night dark:text-muted-foreground-night"
+                )}
+              />
+              <Input
+                id={`custom-response-${blockedAction.actionId}`}
+                containerClassName="flex-1"
+                className={cn(
+                  "h-auto w-full rounded-none border-transparent bg-transparent",
+                  "px-0 py-0 text-sm shadow-none",
+                  "focus-visible:border-transparent focus-visible:ring-0"
+                )}
+                placeholder="Type something else"
+                value={customResponse}
+                onFocus={() => {
+                  setSelectedOptions([]);
+                }}
+                onChange={(e) => setCustomResponse(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    handleSubmit();
+                  }
+                }}
+                name="custom-response"
+                disabled={isSubmitting}
+              />
+            </>
+          )}
         </Card>
       </div>
       {errorMessage && (
@@ -230,11 +257,18 @@ export function UserQuestionRequired({
         </div>
       )}
       <div className="flex items-center justify-between gap-3">
-        <Button label="Skip" variant="outline" size="sm" onClick={handleSkip} />
+        <Button
+          label="Skip"
+          variant="outline"
+          size="sm"
+          onClick={handleSkip}
+          isLoading={isSubmitting && isSkipPending}
+        />
         <Button
           icon={ArrowUpIcon}
           variant="highlight"
           size="sm"
+          isLoading={isSubmitting && !isSkipPending}
           disabled={
             trimmedCustomResponse.length === 0 && selectedOptions.length === 0
           }

--- a/front/components/assistant/conversation/UserQuestionRequired.tsx
+++ b/front/components/assistant/conversation/UserQuestionRequired.tsx
@@ -44,6 +44,8 @@ export function UserQuestionRequired({
   const { question } = blockedAction;
   const isTriggeredByCurrentUser = blockedAction.userId === user?.sId;
   const trimmedCustomResponse = customResponse.trim();
+  const isCustomResponseSelected =
+    trimmedCustomResponse.length > 0 && selectedOptions.length === 0;
 
   async function submitAnswer(answer: UserQuestionAnswer) {
     const result = await answerQuestion({
@@ -73,22 +75,15 @@ export function UserQuestionRequired({
   }
 
   function handleSubmit() {
-    if (trimmedCustomResponse.length === 0 && selectedOptions.length === 0) {
+    if (!isCustomResponseSelected && selectedOptions.length === 0) {
       return;
     }
 
-    if (!question.multiSelect && selectedOptions.length > 0) {
-      void submitAnswer({ selectedOptions });
-      return;
-    }
-
-    void submitAnswer({
-      selectedOptions,
-      // The selected options take precedence.
-      ...(selectedOptions.length === 0
-        ? { customResponse: trimmedCustomResponse }
-        : {}),
-    });
+    void submitAnswer(
+      selectedOptions.length > 0
+        ? { selectedOptions }
+        : { selectedOptions, customResponse: trimmedCustomResponse }
+    );
   }
 
   function handleSkip() {
@@ -185,10 +180,9 @@ export function UserQuestionRequired({
           variant="tertiary"
           className={cn(
             "flex w-full items-center gap-2 rounded-2xl p-3 transition-colors",
-            trimmedCustomResponse.length > 0 &&
-              selectedOptions.length === 0 &&
+            isCustomResponseSelected &&
               "border-border dark:border-border-night",
-            trimmedCustomResponse.length > 0 && selectedOptions.length === 0
+            isCustomResponseSelected
               ? "bg-muted-background dark:bg-muted-background-night"
               : [
                   "bg-background hover:bg-muted-background/60",

--- a/front/components/assistant/conversation/UserQuestionRequired.tsx
+++ b/front/components/assistant/conversation/UserQuestionRequired.tsx
@@ -44,12 +44,18 @@ export function UserQuestionRequired({
 
   const { question } = blockedAction;
   const isTriggeredByCurrentUser = blockedAction.userId === user?.sId;
+
   const trimmedCustomResponse = customResponse.trim();
-  const isAnswerSubmitting = isSubmitting && !isSkipPending;
   const isCustomResponseSelected =
     trimmedCustomResponse.length > 0 && selectedOptions.length === 0;
 
-  async function submitAnswer(answer: UserQuestionAnswer, isSkip = false) {
+  const isAnswerSubmitting = isSubmitting && !isSkipPending;
+  const isSkipSubmitting = isSubmitting && isSkipPending;
+
+  async function submitAnswer(
+    answer: UserQuestionAnswer,
+    { isSkip = false }: { isSkip?: boolean } = {}
+  ) {
     setIsSkipPending(isSkip);
     const result = await answerQuestion({
       conversationId,
@@ -104,7 +110,7 @@ export function UserQuestionRequired({
       return;
     }
 
-    void submitAnswer({ selectedOptions: [] }, true);
+    void submitAnswer({ selectedOptions: [] }, { isSkip: true });
   }
 
   if (!isTriggeredByCurrentUser) {
@@ -251,13 +257,13 @@ export function UserQuestionRequired({
           variant="outline"
           size="sm"
           onClick={handleSkip}
-          isLoading={isSubmitting && isSkipPending}
+          isLoading={isSkipSubmitting}
         />
         <Button
           icon={ArrowUpIcon}
           variant="highlight"
           size="sm"
-          isLoading={isSubmitting && !isSkipPending}
+          isLoading={isAnswerSubmitting}
           disabled={
             trimmedCustomResponse.length === 0 && selectedOptions.length === 0
           }

--- a/front/components/assistant/conversation/UserQuestionRequired.tsx
+++ b/front/components/assistant/conversation/UserQuestionRequired.tsx
@@ -11,7 +11,6 @@ import {
   Counter,
   cn,
   Input,
-  Spinner,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -131,8 +130,6 @@ export function UserQuestionRequired({
       <div className="flex flex-col gap-2">
         {question.options.map((option, index) => {
           const isSelected = selectedOptions.includes(index);
-          const isSubmittingOption =
-            isSubmitting && !isSkipPending && isSelected;
 
           return (
             <Card
@@ -164,33 +161,25 @@ export function UserQuestionRequired({
               tabIndex={isSubmitting ? -1 : 0}
               aria-pressed={isSelected}
             >
-              {isSubmittingOption ? (
-                <div className="flex w-full items-center justify-center py-1">
-                  <Spinner size="sm" />
-                </div>
-              ) : (
-                <>
-                  <Counter
-                    value={index + 1}
-                    size="sm"
-                    variant="ghost"
-                    className={cn(
-                      "shrink-0 bg-border-dark text-muted-foreground",
-                      "dark:bg-border-dark-night dark:text-muted-foreground-night"
-                    )}
-                  />
-                  <div className="flex flex-col">
-                    <span className="text-sm font-medium text-foreground dark:text-foreground-night">
-                      {option.label}
-                    </span>
-                    {option.description && (
-                      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                        {option.description}
-                      </span>
-                    )}
-                  </div>
-                </>
-              )}
+              <Counter
+                value={index + 1}
+                size="sm"
+                variant="ghost"
+                className={cn(
+                  "shrink-0 bg-border-dark text-muted-foreground",
+                  "dark:bg-border-dark-night dark:text-muted-foreground-night"
+                )}
+              />
+              <div className="flex flex-col">
+                <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                  {option.label}
+                </span>
+                {option.description && (
+                  <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                    {option.description}
+                  </span>
+                )}
+              </div>
             </Card>
           );
         })}
@@ -209,46 +198,38 @@ export function UserQuestionRequired({
                 ]
           )}
         >
-          {isSubmitting && !isSkipPending && isCustomResponseSelected ? (
-            <div className="flex w-full items-center justify-center py-1">
-              <Spinner size="sm" />
-            </div>
-          ) : (
-            <>
-              <Counter
-                value={question.options.length + 1}
-                size="sm"
-                variant="ghost"
-                className={cn(
-                  "shrink-0 bg-border-dark text-muted-foreground",
-                  "dark:bg-border-dark-night dark:text-muted-foreground-night"
-                )}
-              />
-              <Input
-                id={`custom-response-${blockedAction.actionId}`}
-                containerClassName="flex-1"
-                className={cn(
-                  "h-auto w-full rounded-none border-transparent bg-transparent",
-                  "px-0 py-0 text-sm shadow-none",
-                  "focus-visible:border-transparent focus-visible:ring-0"
-                )}
-                placeholder="Type something else"
-                value={customResponse}
-                onFocus={() => {
-                  setSelectedOptions([]);
-                }}
-                onChange={(e) => setCustomResponse(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    handleSubmit();
-                  }
-                }}
-                name="custom-response"
-                disabled={isSubmitting}
-              />
-            </>
-          )}
+          <Counter
+            value={question.options.length + 1}
+            size="sm"
+            variant="ghost"
+            className={cn(
+              "shrink-0 bg-border-dark text-muted-foreground",
+              "dark:bg-border-dark-night dark:text-muted-foreground-night"
+            )}
+          />
+          <Input
+            id={`custom-response-${blockedAction.actionId}`}
+            containerClassName="flex-1"
+            className={cn(
+              "h-auto w-full rounded-none border-transparent bg-transparent",
+              "px-0 py-0 text-sm shadow-none",
+              "focus-visible:border-transparent focus-visible:ring-0"
+            )}
+            placeholder="Type something else"
+            value={customResponse}
+            onFocus={() => {
+              setSelectedOptions([]);
+            }}
+            onChange={(e) => setCustomResponse(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleSubmit();
+              }
+            }}
+            name="custom-response"
+            disabled={isSubmitting}
+          />
         </Card>
       </div>
       {errorMessage && (

--- a/front/components/assistant/conversation/UserQuestionRequired.tsx
+++ b/front/components/assistant/conversation/UserQuestionRequired.tsx
@@ -66,7 +66,6 @@ export function UserQuestionRequired({
 
     if (result.success) {
       removeCompletedAction(blockedAction.actionId);
-      return;
     }
 
     setIsSkipPending(false);


### PR DESCRIPTION
## Description

- This PR improves the display of the `UserQuestionRequired` component while the answer is being sent to the backend.
- Currently we stop rendering anything and show a spinner instead, which causes a blink: component disappears, then we see the inline activity again.
- This PR keeps showing the container with the title but only replaces the cards with a spinner to avoid a blink.
- The buttons also show spinner when loading: skip when the user did skip, submit otherwise.
- When the user skips, we don't show the spinner where the cards where, 2 reasons: the only way to skip is to click on the skip button, and this is an indication the content is still left there but has not been interacted with.

Before

![Apr-10-2026 8-26-40 AM](https://github.com/user-attachments/assets/ec5b03b5-0c16-4710-99d7-fa7b759ac287)

After

![Apr-10-2026 8-26-34 AM](https://github.com/user-attachments/assets/45859bfe-eb35-4410-a6a1-0c608c0b7db6)

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
