### PR TITLE
[connectors] fix: add graceful stop event type to public event type

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -559,6 +559,7 @@ async function streamAgentAnswerToSlack(
         break;
       }
 
+      case "agent_message_gracefully_stopped":
       case "agent_message_success": {
         planHandler?.abortAllChildStreams();
         await planHandler?.deletePlanMessage();

--- a/sdks/js/src/high_level/stream.ts
+++ b/sdks/js/src/high_level/stream.ts
@@ -539,6 +539,7 @@ export class MessageStreamImpl implements MessageStream {
         return { type: "toolApprovalRequired", approval };
       }
 
+      case "agent_message_gracefully_stopped":
       case "agent_message_success": {
         this._response = {
           text: this._text,

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -14,6 +14,7 @@ import type {
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
   AgentMessageDoneEvent,
+  AgentMessageGracefullyStoppedEvent,
   AgentMessagePublicType,
   AgentMessageSuccessEvent,
   AgentToolCallStartedEvent,
@@ -167,6 +168,7 @@ export type AgentEvent =
   | AgentContextPrunedEvent
   | AgentErrorEvent
   | AgentGenerationCancelledEvent
+  | AgentMessageGracefullyStoppedEvent
   | AgentMessageSuccessEvent
   | AgentMessageDoneEvent
   | AgentToolCallStartedEvent
@@ -1061,6 +1063,7 @@ export class DustAPI {
 
     const terminalEventTypes: AgentEvent["type"][] = [
       "agent_message_success",
+      "agent_message_gracefully_stopped",
       "agent_error",
       "agent_generation_cancelled",
       "user_message_error",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1531,6 +1531,18 @@ export type AgentMessageSuccessEvent = z.infer<
   typeof AgentMessageSuccessEventSchema
 >;
 
+const AgentMessageGracefullyStoppedEventSchema = z.object({
+  type: z.literal("agent_message_gracefully_stopped"),
+  created: z.number(),
+  configurationId: z.string(),
+  messageId: z.string(),
+  message: AgentMessageTypeSchema,
+  runIds: z.array(z.string()),
+});
+export type AgentMessageGracefullyStoppedEvent = z.infer<
+  typeof AgentMessageGracefullyStoppedEventSchema
+>;
+
 const AgentMessageDoneEventSchema = z.object({
   type: z.literal("agent_message_done"),
   created: z.number(),


### PR DESCRIPTION
## Description

- This PR fixes errors in the slack bot ([logs](https://app.datadoghq.eu/logs?query=%22Unexpected%20exception%20answering%20to%20Slack%20Chat%20Bot%20message%22%20region%3Aus-central1%20%40connectorId%3A%2227115%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ1zss6_QtqxQAAAABhBWjF6c3RIYkFBRHhmNkRJTi1EbnRBRGoAAAAkMDE5ZDczYjQtMDc3Zi00ODVmLWJlY2EtZjc5ZTdmOTU1YjgwAAAC0Q&link_event_id=8575672701105827691&link_monitor_id=22042330&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1775678345522&to_ts=1775764745522&live=true)), failing (`assertNever`) when an event of type `agent_message_gracefully_stopped` is emitted and received in the conversation stream handler.
- Adds the event, processed the same way as an `agent_message_success`.
- Next step is to detect and prevent such type divergence on the events.

## Tests

- Typecheck

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
