### PR TITLE
[sessions]: Disable agent mentions in edit mode when single-agent input is enabled

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -187,13 +187,6 @@ export function UserMessage({
             originalAgentIds.has(agentId) ? _match : ""
           )
           .trim();
-
-        sendNotification({
-          type: "info",
-          title: "Agent mentions removed",
-          description:
-            "Tagging an agent in a sent message won't prompt re-evaluation.",
-        });
       }
     }
 
@@ -211,6 +204,8 @@ export function UserMessage({
     conversationId,
     onEnterKeyDown: handleSave,
     disableAutoFocus: false,
+    // This editor is only mounted in edit mode, so singleAgentInput
+    // alone is sufficient to disable agent mentions (edit mode is implied).
     disableAgentMentions: singleAgentInput,
   });
 

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -17,6 +17,7 @@ import { useEditUserMessage } from "@app/hooks/useEditUserMessage";
 import { useHover } from "@app/hooks/useHover";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
@@ -24,6 +25,10 @@ import type {
   UserMessageType,
   UserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
+import {
+  isAgentMention,
+  isRichAgentMention,
+} from "@app/types/assistant/mentions";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Avatar,
@@ -152,14 +157,37 @@ export function UserMessage({
     conversationId,
   });
   const confirm = useContext(ConfirmContext);
+  const sendNotification = useSendNotification();
+  const { hasFeature } = useFeatureFlags();
+  const singleAgentInput = hasFeature("enable_steering");
+
+  const originalAgentIds = new Set(
+    message.mentions.filter(isAgentMention).map((m) => m.configurationId)
+  );
 
   const handleSave = async () => {
     const { markdown, mentions } = editorService.getMarkdownAndMentions();
 
+    let filteredMentions = mentions;
+    if (singleAgentInput) {
+      filteredMentions = mentions.filter(
+        (m) => !isRichAgentMention(m) || originalAgentIds.has(m.id)
+      );
+
+      if (filteredMentions.length < mentions.length) {
+        sendNotification({
+          type: "info",
+          title: "Agent mentions removed",
+          description:
+            "Tagging an agent in a sent message won't prompt re-evaluation.",
+        });
+      }
+    }
+
     await editMessage({
       messageId: message.sId,
       content: markdown,
-      mentions,
+      mentions: filteredMentions,
     });
 
     setShouldShowEditor(false);
@@ -170,6 +198,7 @@ export function UserMessage({
     conversationId,
     onEnterKeyDown: handleSave,
     disableAutoFocus: false,
+    disableAgentMentions: singleAgentInput,
   });
 
   const renderName = useCallback(

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -18,6 +18,7 @@ import { useHover } from "@app/hooks/useHover";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { AGENT_MENTION_REGEX } from "@app/lib/mentions/format";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
@@ -57,7 +58,7 @@ import { BubbleMenu } from "@tiptap/react/menus";
 import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
 import { cva } from "class-variance-authority";
 import type React from "react";
-import { useCallback, useContext, useState } from "react";
+import { useCallback, useContext, useMemo, useState } from "react";
 
 interface UserMessageEditorProps {
   editor: Editor | null;
@@ -161,13 +162,18 @@ export function UserMessage({
   const { hasFeature } = useFeatureFlags();
   const singleAgentInput = hasFeature("enable_steering");
 
-  const originalAgentIds = new Set(
-    message.mentions.filter(isAgentMention).map((m) => m.configurationId)
+  const originalAgentIds = useMemo(
+    () =>
+      new Set(
+        message.mentions.filter(isAgentMention).map((m) => m.configurationId)
+      ),
+    [message.mentions]
   );
 
   const handleSave = async () => {
     const { markdown, mentions } = editorService.getMarkdownAndMentions();
 
+    let content = markdown;
     let filteredMentions = mentions;
     if (singleAgentInput) {
       filteredMentions = mentions.filter(
@@ -175,6 +181,13 @@ export function UserMessage({
       );
 
       if (filteredMentions.length < mentions.length) {
+        // Strip agent mention syntax from the markdown to match the filtered mentions array.
+        content = markdown
+          .replaceAll(AGENT_MENTION_REGEX, (_match, _label, agentId) =>
+            originalAgentIds.has(agentId) ? _match : ""
+          )
+          .trim();
+
         sendNotification({
           type: "info",
           title: "Agent mentions removed",
@@ -186,7 +199,7 @@ export function UserMessage({
 
     await editMessage({
       messageId: message.sId,
-      content: markdown,
+      content,
       mentions: filteredMentions,
     });
 

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -192,6 +192,8 @@ export interface CustomEditorProps {
   }) => void;
   longTextPasteCharsThreshold?: number;
   onInlineText?: (fileId: string, textContent: string) => void;
+  // When true, agent suggestions are fully disabled (e.g. edit mode).
+  disableAgentMentions?: boolean;
   // Ref that dynamically controls whether agent suggestions are shown for single agent mode.
   shouldSuggestAgentRef?: React.RefObject<boolean>;
   onFirstAgentMentionPasteRef?: React.RefObject<
@@ -207,6 +209,7 @@ export const buildEditorExtensions = ({
   conversationId,
   spaceId,
   disableUserMentions,
+  disableAgentMentions,
   onInlineText,
   onUrlDetected,
   onAgentSelect,
@@ -219,6 +222,7 @@ export const buildEditorExtensions = ({
   conversationId?: string | null;
   spaceId?: string;
   disableUserMentions?: boolean;
+  disableAgentMentions?: boolean;
   onInlineText?: (fileId: string, textContent: string) => void;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
   onAgentSelect?: (mention: RichMention) => void;
@@ -302,7 +306,7 @@ export const buildEditorExtensions = ({
         conversationId,
         spaceId,
         select: {
-          agents: true,
+          agents: !disableAgentMentions,
           users: !disableUserMentions,
         },
         shouldSuggestAgentRef,
@@ -350,6 +354,7 @@ const useCustomEditor = ({
   onLongTextPaste,
   longTextPasteCharsThreshold,
   onInlineText,
+  disableAgentMentions,
   shouldSuggestAgentRef,
   onFirstAgentMentionPasteRef,
   onAgentMentionsStrippedRef,
@@ -362,6 +367,7 @@ const useCustomEditor = ({
         conversationId,
         spaceId,
         disableUserMentions,
+        disableAgentMentions,
         onInlineText,
         onUrlDetected,
         onAgentSelect,


### PR DESCRIPTION
fix https://github.com/dust-tt/tasks/issues/7402
## Description
When editing an old message, you shouldn't be able to tag an agent
I maintained existing behavior when the FF is off, but when it's on we're not surfacing agents in the @ selector when editing messages, and strip any non-existing agent mentions on save (strip them in case they paste one in, and leave existing ones in case they're editing a message that was sent before the FF was enabled)
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Test via link
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, pretty edge case
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
