### PR TITLE
[front] fix: add missing field in skill type mock for tests

### DIFF
--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -43,6 +43,7 @@ function makeSkillType(config: MockSkillConfig): SkillType {
     agentFacingDescription: config.description ?? "",
     userFacingDescription: config.description ?? "",
     instructions: config.instructions ?? null,
+    instructionsHtml: null,
     icon: null,
     source: null,
     sourceMetadata: null,


### PR DESCRIPTION
## Description

- This PR fixes lint on main by adding a missing field in `makeSkillType` (util used in tests).

## Tests

## Risk

- Low. No runtime change.

## Deploy Plan

- No deploy.
