### PR TITLE
Handle EUR contracts

### DIFF
--- a/front/components/paywall/TrialPricingCard.tsx
+++ b/front/components/paywall/TrialPricingCard.tsx
@@ -1,7 +1,7 @@
 import {
-  getPriceWithCurrency,
   PRO_PLAN_COST_MONTHLY,
   PRO_PLAN_COST_YEARLY,
+  usePriceWithCurrency,
 } from "@app/lib/client/subscription";
 import type { BillingPeriod } from "@app/types/plan";
 import {
@@ -33,10 +33,9 @@ export function TrialPricingCard({
   onSubscribe,
   isSubmitting,
 }: TrialPricingCardProps) {
-  const price =
-    billingPeriod === "monthly"
-      ? getPriceWithCurrency(PRO_PLAN_COST_MONTHLY)
-      : getPriceWithCurrency(PRO_PLAN_COST_YEARLY);
+  const rawPrice =
+    billingPeriod === "monthly" ? PRO_PLAN_COST_MONTHLY : PRO_PLAN_COST_YEARLY;
+  const price = usePriceWithCurrency(rawPrice);
 
   return (
     <div className="flex flex-col gap-6">

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -1,9 +1,9 @@
 import { FairUsageModal } from "@app/components/FairUsageModal";
 import {
   BUSINESS_PLAN_COST_MONTHLY,
-  getPriceWithCurrency,
   PRO_PLAN_COST_MONTHLY,
   PRO_PLAN_COST_YEARLY,
+  usePriceWithCurrency,
 } from "@app/lib/client/subscription";
 import {
   isProOrBusinessPlanCode,
@@ -311,6 +311,10 @@ export function ProPriceTable({
   plan,
   size,
 }: PriceTableProps) {
+  const rawPrice =
+    billingPeriod === "monthly" ? PRO_PLAN_COST_MONTHLY : PRO_PLAN_COST_YEARLY;
+  const price = usePriceWithCurrency(rawPrice);
+
   if (isWhitelistedBusinessPlan(owner)) {
     return (
       <BusinessPriceTable
@@ -322,11 +326,6 @@ export function ProPriceTable({
       />
     );
   }
-
-  const price =
-    billingPeriod === "monthly"
-      ? getPriceWithCurrency(PRO_PLAN_COST_MONTHLY)
-      : getPriceWithCurrency(PRO_PLAN_COST_YEARLY);
 
   return (
     <SeatBasedPriceTable
@@ -350,12 +349,13 @@ export function BusinessPriceTable({
   plan,
   size,
 }: PriceTableProps) {
+  const price = usePriceWithCurrency(BUSINESS_PLAN_COST_MONTHLY);
   return (
     <SeatBasedPriceTable
       plan="business"
       title="Enterprise (Seat-based)"
       color="blue"
-      price={getPriceWithCurrency(BUSINESS_PLAN_COST_MONTHLY)}
+      price={price}
       showButton={!plan || !isProPlan(plan)}
       display={display}
       isProcessing={isProcessing}

--- a/front/components/plans/SubscriptionPlanCards.tsx
+++ b/front/components/plans/SubscriptionPlanCards.tsx
@@ -1,9 +1,9 @@
 import config from "@app/lib/api/config";
 import {
   BUSINESS_PLAN_COST_MONTHLY,
-  getPriceWithCurrency,
   PRO_PLAN_COST_MONTHLY,
   PRO_PLAN_COST_YEARLY,
+  usePriceWithCurrency,
 } from "@app/lib/client/subscription";
 import { isWhitelistedBusinessPlan } from "@app/lib/plans/plan_codes";
 import type { BillingPeriod } from "@app/types/plan";
@@ -54,11 +54,12 @@ export function SubscriptionPlanCards({
   owner,
 }: SubscriptionPlanCardsProps) {
   const isBusiness = isWhitelistedBusinessPlan(owner);
-  const price = isBusiness
-    ? getPriceWithCurrency(BUSINESS_PLAN_COST_MONTHLY)
+  const rawPrice = isBusiness
+    ? BUSINESS_PLAN_COST_MONTHLY
     : billingPeriod === "monthly"
-      ? getPriceWithCurrency(PRO_PLAN_COST_MONTHLY)
-      : getPriceWithCurrency(PRO_PLAN_COST_YEARLY);
+      ? PRO_PLAN_COST_MONTHLY
+      : PRO_PLAN_COST_YEARLY;
+  const price = usePriceWithCurrency(rawPrice);
 
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2">

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -1,3 +1,8 @@
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
+import { useGeolocation } from "@app/lib/swr/geo";
+import type { SupportedCurrency } from "@app/types/currency";
+
 // If mention the price of the PRO plan in a few different places in the code base,
 // so this is just a way to have that value hardcoded in one place.
 // Changing this value only changes the value displayed on the webapp and the website,
@@ -6,11 +11,42 @@ export const PRO_PLAN_COST_MONTHLY = 29;
 export const PRO_PLAN_COST_YEARLY = 27;
 export const BUSINESS_PLAN_COST_MONTHLY = 45;
 
-export const getPriceWithCurrency = (price: number): string => {
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const isLikelyInUS = timeZone.startsWith("America");
-  return isLikelyInUS ? `$${price}` : `${price}€`;
-};
+export function formatPriceWithCurrency(
+  price: number,
+  currency: SupportedCurrency
+): string {
+  return currency === "usd" ? `$${price}` : `${price}€`;
+}
+
+/**
+ * Hook that resolves the user's billing currency from IP geolocation.
+ *
+ * When the workspace has the metronome_billing feature flag:
+ *   EU/EEA/CH → EUR, rest of world → USD.
+ * Without the flag (Stripe billing, or no workspace):
+ *   US → USD, rest of world → EUR (matches Stripe adaptive pricing).
+ *
+ * Falls back to Stripe behaviour while loading or on error.
+ */
+export function useUserBillingCurrency(): SupportedCurrency {
+  const { geoData } = useGeolocation();
+  const { hasFeature } = useFeatureFlags();
+  const metronomeBilled = hasFeature("metronome_billing");
+
+  if (geoData?.countryCode) {
+    return getBillingCurrencyForCountry(geoData.countryCode, metronomeBilled);
+  }
+  // No geo data yet — Stripe default (EUR base, USD for US only).
+  return "eur";
+}
+
+/**
+ * Hook: format a price with the user's billing currency.
+ */
+export function usePriceWithCurrency(price: number): string {
+  const currency = useUserBillingCurrency();
+  return formatPriceWithCurrency(price, currency);
+}
 
 export interface BillingCycle {
   cycleStart: Date;

--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -3,6 +3,10 @@ import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
+import {
+  getBillingCurrencyForCountry,
+  resolvePackageAliasForCurrency,
+} from "@app/lib/plans/billing_currency";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -14,7 +18,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import type Stripe from "stripe";
 import { z } from "zod";
 
-const MetronomeSetupSessionSchema = z.object({
+const StripeSetupSessionSchema = z.object({
   id: z.string(),
   client_reference_id: z.string(),
   metadata: z.object({
@@ -23,6 +27,17 @@ const MetronomeSetupSessionSchema = z.object({
     metronomePackageAlias: z.string(),
   }),
   customer: z.string(),
+  customer_details: z
+    .object({
+      address: z
+        .object({
+          country: z.string().nullable().optional(),
+        })
+        .nullable()
+        .optional(),
+    })
+    .nullable()
+    .optional(),
 });
 
 export async function handleMetronomeSetupCheckout({
@@ -32,7 +47,7 @@ export async function handleMetronomeSetupCheckout({
   session: Stripe.Checkout.Session;
   now: Date;
 }): Promise<Result<void, DustError>> {
-  const parsed = MetronomeSetupSessionSchema.safeParse(session);
+  const parsed = StripeSetupSessionSchema.safeParse(session);
   if (!parsed.success) {
     return new Err(
       new DustError(
@@ -47,7 +62,19 @@ export async function handleMetronomeSetupCheckout({
     client_reference_id: workspaceId,
     metadata: { planCode, userId, metronomePackageAlias },
     customer: stripeCustomerId,
+    customer_details: customerDetails,
   } = parsed.data;
+
+  // Resolve the package alias based on the customer's billing country.
+  // Stripe populates customer_details.address.country from billing_address_collection.
+  const customerCountry = customerDetails?.address?.country;
+  const billingCurrency = customerCountry
+    ? getBillingCurrencyForCountry(customerCountry, true)
+    : "usd";
+  const resolvedPackageAlias = resolvePackageAliasForCurrency(
+    metronomePackageAlias,
+    billingCurrency
+  );
 
   const workspace = await WorkspaceResource.fetchById(workspaceId);
   if (!workspace) {
@@ -69,7 +96,7 @@ export async function handleMetronomeSetupCheckout({
   const provisionResult = await provisionMetronomeCustomerAndContract({
     workspace: renderLightWorkspaceType({ workspace }),
     stripeCustomerId,
-    packageAlias: metronomePackageAlias,
+    packageAlias: resolvedPackageAlias,
     uniquenessKey: sessionId,
   });
   if (provisionResult.isErr()) {

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -34,19 +34,6 @@ const DEV_PRODUCT_FREE_MONTHLY_CREDITS = "04f41dd1-ba27-42e3-93d5-6121712a4b67";
 const DEV_PRODUCT_PREPAID_COMMIT = "5f4331b7-4bf6-488b-9a0c-51bd139ac91c";
 const DEV_PRODUCT_PAYG_OVERAGE = "f4583c77-d226-48bb-97a3-46a8087b97fe";
 
-// Rate Cards
-const DEV_RATE_CARD_LEGACY_PRO_29 = "1da852d8-65d0-470b-a6c8-f3e7d95d727e";
-const DEV_RATE_CARD_LEGACY_BUSINESS_45 = "7e891ab9-21c0-4f83-b309-8a8841816609";
-const DEV_RATE_CARD_LEGACY_PRO_27_ANNUAL =
-  "aa256b1d-4c44-498b-964b-b23e7210222b";
-const DEV_RATE_CARD_LEGACY_ENTERPRISE = "c07a67ff-c26a-4550-9cf3-f98d2ddb4705";
-
-// Packages
-const DEV_PACKAGE_LEGACY_PRO_29 = "1db8fc59-6fc1-4351-8806-549de566797d";
-const DEV_PACKAGE_LEGACY_BUSINESS_45 = "ee20fbc5-22f7-4e29-b14a-cb2fb6c9ae60";
-const DEV_PACKAGE_LEGACY_PRO_27_ANNUAL = "4886d12c-45bd-4551-bff3-306b24a5c83e";
-const DEV_PACKAGE_LEGACY_ENTERPRISE = "a01630e0-2f1f-4feb-9ae5-074db2292e63";
-
 // --- PROD (production) — TODO: update after running setup script in production ---
 
 // Metrics
@@ -79,21 +66,6 @@ const PROD_PRODUCT_FREE_MONTHLY_CREDITS =
   "7379999c-5492-4e68-968f-345a26f6da63";
 const PROD_PRODUCT_PREPAID_COMMIT = "1408c9fc-dea1-4269-bd6d-1bc0aa1f1218";
 const PROD_PRODUCT_PAYG_OVERAGE = "f6b27a6e-86fc-4964-8076-371a912cee09";
-
-// Rate Cards
-const PROD_RATE_CARD_LEGACY_PRO_29 = "ab1ecdac-67b0-4803-8d17-13e3415d3e1d";
-const PROD_RATE_CARD_LEGACY_BUSINESS_45 =
-  "db5cea19-6421-4912-8511-9f514fc0ece2";
-const PROD_RATE_CARD_LEGACY_PRO_27_ANNUAL =
-  "7042405c-c89e-4538-80e6-e42ead7087e8";
-const PROD_RATE_CARD_LEGACY_ENTERPRISE = "df225bf4-3183-4d10-96aa-e9eb87bb6b0a";
-
-// Packages
-const PROD_PACKAGE_LEGACY_PRO_29 = "a8d782ea-b8e4-460d-99eb-393536254a01";
-const PROD_PACKAGE_LEGACY_BUSINESS_45 = "c362bd20-43a1-4c1f-957d-d889dfe34704";
-const PROD_PACKAGE_LEGACY_PRO_27_ANNUAL =
-  "e52b9a0e-f151-4284-aa4a-87d0bddf23d0";
-const PROD_PACKAGE_LEGACY_ENTERPRISE = "7d1d8d4e-c488-4dfd-8c9a-e74529c1010e";
 
 // --- Credit type IDs (stable across envs unless noted) ---
 
@@ -184,32 +156,3 @@ export const getProductMauBilling5Id = () =>
   devOrProd(DEV_PRODUCT_MAU_BILLING_5, PROD_PRODUCT_MAU_BILLING_5);
 export const getProductMauBilling10Id = () =>
   devOrProd(DEV_PRODUCT_MAU_BILLING_10, PROD_PRODUCT_MAU_BILLING_10);
-
-// Rate Cards
-export const getRateCardLegacyPro29Id = () =>
-  devOrProd(DEV_RATE_CARD_LEGACY_PRO_29, PROD_RATE_CARD_LEGACY_PRO_29);
-export const getRateCardLegacyBusiness45Id = () =>
-  devOrProd(
-    DEV_RATE_CARD_LEGACY_BUSINESS_45,
-    PROD_RATE_CARD_LEGACY_BUSINESS_45
-  );
-export const getRateCardLegacyPro27AnnualId = () =>
-  devOrProd(
-    DEV_RATE_CARD_LEGACY_PRO_27_ANNUAL,
-    PROD_RATE_CARD_LEGACY_PRO_27_ANNUAL
-  );
-export const getRateCardLegacyEnterpriseId = () =>
-  devOrProd(DEV_RATE_CARD_LEGACY_ENTERPRISE, PROD_RATE_CARD_LEGACY_ENTERPRISE);
-
-// Packages
-export const getPackageLegacyPro29Id = () =>
-  devOrProd(DEV_PACKAGE_LEGACY_PRO_29, PROD_PACKAGE_LEGACY_PRO_29);
-export const getPackageLegacyBusiness45Id = () =>
-  devOrProd(DEV_PACKAGE_LEGACY_BUSINESS_45, PROD_PACKAGE_LEGACY_BUSINESS_45);
-export const getPackageLegacyPro27AnnualId = () =>
-  devOrProd(
-    DEV_PACKAGE_LEGACY_PRO_27_ANNUAL,
-    PROD_PACKAGE_LEGACY_PRO_27_ANNUAL
-  );
-export const getPackageLegacyEnterpriseId = () =>
-  devOrProd(DEV_PACKAGE_LEGACY_ENTERPRISE, PROD_PACKAGE_LEGACY_ENTERPRISE);

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -14,10 +14,19 @@ export const LEGACY_PRO_ANNUAL_PACKAGE_ALIAS = "legacy-pro-annual";
 export const LEGACY_BUSINESS_PACKAGE_ALIAS = "legacy-business";
 export const LEGACY_ENTERPRISE_PACKAGE_ALIAS = "legacy-enterprise";
 
+// EUR variants — same plans, billed in EUR for Eurozone/EEA/Switzerland customers.
+export const LEGACY_PRO_MONTHLY_EUR_PACKAGE_ALIAS = "legacy-pro-monthly-eur";
+export const LEGACY_PRO_ANNUAL_EUR_PACKAGE_ALIAS = "legacy-pro-annual-eur";
+export const LEGACY_BUSINESS_EUR_PACKAGE_ALIAS = "legacy-business-eur";
+export const LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS = "legacy-enterprise-eur";
+
 export const PRO_OR_BUSINESS_PACKAGE_ALIASES: ReadonlySet<string> = new Set([
   LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
   LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
   LEGACY_BUSINESS_PACKAGE_ALIAS,
+  LEGACY_PRO_MONTHLY_EUR_PACKAGE_ALIAS,
+  LEGACY_PRO_ANNUAL_EUR_PACKAGE_ALIAS,
+  LEGACY_BUSINESS_EUR_PACKAGE_ALIAS,
 ]);
 
 export interface MetronomeEvent {

--- a/front/lib/plans/billing_currency.ts
+++ b/front/lib/plans/billing_currency.ts
@@ -1,0 +1,95 @@
+import type { SupportedCurrency } from "@app/types/currency";
+
+/**
+ * ISO 3166-1 alpha-2 country codes that map to EUR billing.
+ *
+ * Includes:
+ * - Eurozone (20): AT, BE, CY, EE, FI, FR, DE, GR, IE, IT, LV, LT, LU, MT, NL, PT, SK, SI, ES, HR
+ * - Non-euro EU in EEA: BG, CZ, DK, HU, PL, RO, SE
+ * - EEA non-EU: IS, LI, NO
+ * - Switzerland: CH
+ */
+const EUR_COUNTRY_CODES: ReadonlySet<string> = new Set([
+  // Eurozone
+  "AT",
+  "BE",
+  "CY",
+  "EE",
+  "FI",
+  "FR",
+  "DE",
+  "GR",
+  "IE",
+  "IT",
+  "LV",
+  "LT",
+  "LU",
+  "MT",
+  "NL",
+  "PT",
+  "SK",
+  "SI",
+  "ES",
+  "HR",
+  // Non-euro EU in EEA
+  "BG",
+  "CZ",
+  "DK",
+  "HU",
+  "PL",
+  "RO",
+  "SE",
+  // EEA non-EU
+  "IS",
+  "LI",
+  "NO",
+  // Switzerland
+  "CH",
+]);
+
+/** Countries where Stripe prices have a USD currency_option. */
+const USD_COUNTRY_CODES: ReadonlySet<string> = new Set(["US"]);
+
+/**
+ * Determine billing currency from a country code.
+ *
+ * Two modes depending on whether the workspace uses Metronome billing:
+ * - Metronome (metronomeBilled=true): EU/EEA/CH → EUR, rest of world → USD.
+ *   We control the currency via Metronome rate cards.
+ * - Stripe (metronomeBilled=false, default): US → USD, rest of world → EUR.
+ *   Matches Stripe's adaptive pricing where EUR is the base currency
+ *   and USD is the only currency_option.
+ */
+export function getBillingCurrencyForCountry(
+  countryCode: string,
+  metronomeBilled = false
+): SupportedCurrency {
+  const upper = countryCode.toUpperCase();
+  if (metronomeBilled) {
+    return EUR_COUNTRY_CODES.has(upper) ? "eur" : "usd";
+  }
+  // Stripe mode: USD only for US, EUR for everyone else (Stripe base currency).
+  return USD_COUNTRY_CODES.has(upper) ? "usd" : "eur";
+}
+
+/**
+ * Map from a base (USD) Metronome package alias to its EUR variant.
+ * Returns the original alias if no EUR variant exists or currency is USD.
+ */
+export function resolvePackageAliasForCurrency(
+  baseAlias: string,
+  currency: SupportedCurrency
+): string {
+  if (currency === "usd") {
+    return baseAlias;
+  }
+
+  const eurAliases: Record<string, string> = {
+    "legacy-pro-monthly": "legacy-pro-monthly-eur",
+    "legacy-business": "legacy-business-eur",
+    "legacy-pro-annual": "legacy-pro-annual-eur",
+    "legacy-enterprise": "legacy-enterprise-eur",
+  };
+
+  return eurAliases[baseAlias] ?? baseAlias;
+}

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -32,6 +32,7 @@ import {
 import { getProductFreeMonthlyCreditId } from "@app/lib/metronome/constants";
 import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
+import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
   assertStripeSubscriptionIsValid,
@@ -511,10 +512,17 @@ async function handler(
               newSubscription &&
               isString(checkoutStripeSubscription.customer)
             ) {
+              // Resolve EUR variant based on Stripe subscription currency.
+              const subscriptionCurrency =
+                checkoutStripeSubscription.currency === "eur" ? "eur" : "usd";
+              const resolvedAlias = resolvePackageAliasForCurrency(
+                metronomePackageAlias,
+                subscriptionCurrency
+              );
               void shadowProvisionMetronome({
                 workspace,
                 stripeCustomerId: checkoutStripeSubscription.customer,
-                metronomePackageAlias,
+                metronomePackageAlias: resolvedAlias,
                 sessionId: session.id,
                 subscriptionModelId: newSubscription.id,
               });

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -14,6 +14,7 @@
 
 import { getMetronomeClient } from "@app/lib/metronome/client";
 import {
+  CREDIT_TYPE_EUR_ID,
   CREDIT_TYPE_USD_ID,
   getCreditTypeAwuId,
 } from "@app/lib/metronome/constants";
@@ -317,7 +318,7 @@ const PRODUCTS: ProductDef[] = [
 function getRateCards(): RateCardDef[] {
   return [
     {
-      name: "Legacy Pro $29",
+      name: "Legacy Pro USD",
       description:
         "Grandfathered Pro plan. $29/seat via seat subscription. AI usage 30% markup.",
       aliases: [{ name: "legacy-pro-monthly" }],
@@ -341,7 +342,7 @@ function getRateCards(): RateCardDef[] {
       ],
     },
     {
-      name: "Legacy Business $45",
+      name: "Legacy Business USD",
       description:
         "Grandfathered Business plan. $45/seat via seat subscription. AI usage 30% markup.",
       aliases: [{ name: "legacy-business" }],
@@ -365,7 +366,7 @@ function getRateCards(): RateCardDef[] {
       ],
     },
     {
-      name: "Legacy Pro $27 Annual",
+      name: "Legacy Pro Annual USD",
       description:
         "Grandfathered Pro plan (annual). $27/seat/month billed monthly. AI usage 30% markup.",
       aliases: [{ name: "legacy-pro-annual" }],
@@ -393,7 +394,7 @@ function getRateCards(): RateCardDef[] {
     // on the rate card so they can be enabled per contract via overrides.
     // Programmatic usage at $1 = $1 (30% markup baked into product).
     {
-      name: "Legacy Enterprise",
+      name: "Legacy Enterprise USD",
       description:
         "Enterprise plan. Per-MAU billing + programmatic usage at cost with 30% markup.",
       aliases: [{ name: "legacy-enterprise" }],
@@ -427,6 +428,130 @@ function getRateCards(): RateCardDef[] {
           entitled: true,
           rate_type: "FLAT",
           price: 100,
+        },
+      ],
+    },
+    // --- EUR variants: same seat prices, billed in EUR ---
+    // For Eurozone/EEA/Switzerland customers.
+    // Programmatic usage: same product (quantity_conversion converts cost_micro_usd to units),
+    // but priced at 87 (€0.87/unit) instead of 100 ($1.00/unit) to apply the USD→EUR FX rate.
+    // EUR prices are in whole euros (not cents) — Metronome EUR pricing unit is "EUR".
+    {
+      name: "Legacy Pro EUR",
+      description:
+        "Grandfathered Pro plan (EUR). 29€/seat via seat subscription. AI usage 30% markup.",
+      aliases: [{ name: "legacy-pro-monthly-eur" }],
+      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      rates: [
+        {
+          product_name: "Workspace Seat",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 29,
+          billing_frequency: "MONTHLY",
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 0.87,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+      ],
+    },
+    {
+      name: "Legacy Business EUR",
+      description:
+        "Grandfathered Business plan (EUR). 45€/seat via seat subscription. AI usage 30% markup.",
+      aliases: [{ name: "legacy-business-eur" }],
+      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      rates: [
+        {
+          product_name: "Workspace Seat",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 45,
+          billing_frequency: "MONTHLY",
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 0.87,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+      ],
+    },
+    {
+      name: "Legacy Pro Annual EUR",
+      description:
+        "Grandfathered Pro plan (EUR, annual). 27€/seat/month billed monthly. AI usage 30% markup.",
+      aliases: [{ name: "legacy-pro-annual-eur" }],
+      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      rates: [
+        {
+          product_name: "Workspace Seat",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 27,
+          billing_frequency: "MONTHLY",
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 0.87,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+      ],
+    },
+    {
+      name: "Legacy Enterprise EUR",
+      description:
+        "Enterprise plan (EUR). Per-MAU billing + programmatic usage at cost with 30% markup.",
+      aliases: [{ name: "legacy-enterprise-eur" }],
+      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      rates: [
+        {
+          product_name: "MAU Billing (1+)",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 45,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: "MAU Billing (5+)",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: false,
+          rate_type: "FLAT",
+          price: 0,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: "MAU Billing (10+)",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: false,
+          rate_type: "FLAT",
+          price: 0,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 0.87,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
         },
       ],
     },
@@ -519,36 +644,64 @@ const BILLING_CYCLE_CONFIG = {
 // Package names are versioned (v1, v2, ...) to track pricing changes.
 // Aliases stay stable — code always references the alias, which points to the latest version.
 // Old versions are archived automatically when a new version is created with the same alias.
-// Package names and contract_name are auto-versioned at sync time (e.g., "Legacy Pro $29 v3").
+// Package names and contract_name are auto-versioned at sync time (e.g., "Legacy Pro USD v3").
 // The version is derived from existing packages in Metronome: if the current package matches,
 // keep its version; if it needs recreation, increment by 1.
 const PACKAGES: PackageDef[] = [
   {
-    name: "Legacy Pro $29",
+    name: "Legacy Pro USD",
     aliases: [{ name: "legacy-pro-monthly" }],
-    rate_card_name: "Legacy Pro $29",
+    rate_card_name: "Legacy Pro USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
     ...BILLING_CYCLE_CONFIG,
   },
   {
-    name: "Legacy Business $45",
+    name: "Legacy Business USD",
     aliases: [{ name: "legacy-business" }],
-    rate_card_name: "Legacy Business $45",
+    rate_card_name: "Legacy Business USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
     ...BILLING_CYCLE_CONFIG,
   },
   {
-    name: "Legacy Pro $27 Annual",
+    name: "Legacy Pro Annual USD",
     aliases: [{ name: "legacy-pro-annual" }],
-    rate_card_name: "Legacy Pro $27 Annual",
+    rate_card_name: "Legacy Pro Annual USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
     ...BILLING_CYCLE_CONFIG,
   },
   // Enterprise: MAU-based billing, no seat subscriptions.
   {
-    name: "Legacy Enterprise",
+    name: "Legacy Enterprise USD",
     aliases: [{ name: "legacy-enterprise" }],
-    rate_card_name: "Legacy Enterprise",
+    rate_card_name: "Legacy Enterprise USD",
+    ...BILLING_CYCLE_CONFIG,
+  },
+  // EUR variants
+  {
+    name: "Legacy Pro EUR",
+    aliases: [{ name: "legacy-pro-monthly-eur" }],
+    rate_card_name: "Legacy Pro EUR",
+    subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+    ...BILLING_CYCLE_CONFIG,
+  },
+  {
+    name: "Legacy Business EUR",
+    aliases: [{ name: "legacy-business-eur" }],
+    rate_card_name: "Legacy Business EUR",
+    subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+    ...BILLING_CYCLE_CONFIG,
+  },
+  {
+    name: "Legacy Pro Annual EUR",
+    aliases: [{ name: "legacy-pro-annual-eur" }],
+    rate_card_name: "Legacy Pro Annual EUR",
+    subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+    ...BILLING_CYCLE_CONFIG,
+  },
+  {
+    name: "Legacy Enterprise EUR",
+    aliases: [{ name: "legacy-enterprise-eur" }],
+    rate_card_name: "Legacy Enterprise EUR",
     ...BILLING_CYCLE_CONFIG,
   },
 ];
@@ -886,11 +1039,18 @@ async function syncProducts(): Promise<void> {
 // Sync: Rate Cards
 // ---------------------------------------------------------------------------
 
-function rateCardMatches(ex: ExistingRateCard, desired: RateCardDef): boolean {
+async function rateCardMatches(
+  ex: ExistingRateCard,
+  desired: RateCardDef
+): Promise<boolean> {
   if (ex.description !== desired.description) {
+    console.log(`    [diff] ${ex.name}: description changed`);
     return false;
   }
   if (ex.fiat_credit_type?.id !== desired.fiat_credit_type_id) {
+    console.log(
+      `    [diff] ${ex.name}: fiat_credit_type ${ex.fiat_credit_type?.id} → ${desired.fiat_credit_type_id}`
+    );
     return false;
   }
 
@@ -898,6 +1058,9 @@ function rateCardMatches(ex: ExistingRateCard, desired: RateCardDef): boolean {
   const exAliases = (ex.aliases ?? []).map((a) => a.name).sort();
   const desiredAliases = desired.aliases.map((a) => a.name).sort();
   if (!arraysEqual(exAliases, desiredAliases)) {
+    console.log(
+      `    [diff] ${ex.name}: aliases [${exAliases}] → [${desiredAliases}]`
+    );
     return false;
   }
 
@@ -909,12 +1072,86 @@ function rateCardMatches(ex: ExistingRateCard, desired: RateCardDef): boolean {
     .map((c) => `${c.custom_credit_type_id}:${c.fiat_per_custom_credit}`)
     .sort();
   if (!arraysEqual(exConvs, desiredConvs)) {
+    console.log(
+      `    [diff] ${ex.name}: credit_type_conversions [${exConvs}] → [${desiredConvs}]`
+    );
     return false;
   }
 
   // Check if any referenced product was recreated
   if (desired.rates.some((r) => recreated.products.has(r.product_name))) {
+    const recreatedProducts = desired.rates
+      .filter((r) => recreated.products.has(r.product_name))
+      .map((r) => r.product_name);
+    console.log(
+      `    [diff] ${ex.name}: products recreated: ${recreatedProducts.join(", ")}`
+    );
     return false;
+  }
+
+  // Compare actual rates on the rate card.
+  const existingRates: Array<{
+    product_id?: string;
+    entitled?: boolean;
+    billing_frequency?: string;
+    rate?: {
+      price?: number;
+      credit_type?: { id: string };
+    };
+  }> = [];
+  for await (const rate of client.v1.contracts.rateCards.rates.list({
+    rate_card_id: ex.id,
+    at: new Date().toISOString(),
+  })) {
+    existingRates.push(rate as (typeof existingRates)[number]);
+  }
+
+  if (existingRates.length !== desired.rates.length) {
+    console.log(
+      `    [diff] ${ex.name}: rate count ${existingRates.length} → ${desired.rates.length}`
+    );
+    return false;
+  }
+
+  for (const desiredRate of desired.rates) {
+    const productId = ids.products[desiredRate.product_name];
+    const match = existingRates.find((r) => r.product_id === productId);
+    if (!match) {
+      console.log(
+        `    [diff] ${ex.name}: product ${desiredRate.product_name} (${productId}) not found in existing rates`
+      );
+      return false;
+    }
+    if (match.rate?.price !== desiredRate.price) {
+      console.log(
+        `    [diff] ${ex.name}: ${desiredRate.product_name} price ${match.rate?.price} → ${desiredRate.price}`
+      );
+      return false;
+    }
+    if (match.entitled !== desiredRate.entitled) {
+      console.log(
+        `    [diff] ${ex.name}: ${desiredRate.product_name} entitled ${match.entitled} → ${desiredRate.entitled}`
+      );
+      return false;
+    }
+    if (
+      desiredRate.credit_type_id &&
+      match.rate?.credit_type?.id !== desiredRate.credit_type_id
+    ) {
+      console.log(
+        `    [diff] ${ex.name}: ${desiredRate.product_name} credit_type ${match.rate?.credit_type?.id} → ${desiredRate.credit_type_id}`
+      );
+      return false;
+    }
+    if (
+      desiredRate.billing_frequency &&
+      match.billing_frequency !== desiredRate.billing_frequency
+    ) {
+      console.log(
+        `    [diff] ${ex.name}: ${desiredRate.product_name} billing_frequency ${match.billing_frequency} → ${desiredRate.billing_frequency}`
+      );
+      return false;
+    }
   }
 
   return true;
@@ -963,7 +1200,7 @@ async function syncRateCards(): Promise<void> {
   for (const desired of rateCards) {
     const ex = byName.get(desired.name);
 
-    if (ex && rateCardMatches(ex, desired)) {
+    if (ex && (await rateCardMatches(ex, desired))) {
       console.log(`  ✓ ${desired.name} — up to date (${ex.id})`);
       ids.rateCards[desired.name] = ex.id;
     } else {
@@ -1158,7 +1395,7 @@ async function syncPackages(): Promise<void> {
     const primaryAlias = desired.aliases[0]?.name;
     const ex = primaryAlias ? byAlias.get(primaryAlias) : undefined;
 
-    // Extract current version from existing package name (e.g., "Legacy Pro $29 v3" → 3).
+    // Extract current version from existing package name (e.g., "Legacy Pro USD v3" → 3).
     const existingVersion = ex?.name
       ? parseInt(ex.name.match(/\sv(\d+)$/)?.[1] ?? "0", 10)
       : 0;
@@ -1293,20 +1530,6 @@ async function main(): Promise<void> {
   for (const [name, id] of Object.entries(ids.products)) {
     console.log(
       `const ${toConstName(envPrefix + "_PRODUCT", name)} = "${id}";`
-    );
-  }
-
-  console.log("\n// Rate Cards");
-  for (const [name, id] of Object.entries(ids.rateCards)) {
-    console.log(
-      `const ${toConstName(envPrefix + "_RATE_CARD", name)} = "${id}";`
-    );
-  }
-
-  console.log("\n// Packages");
-  for (const [name, id] of Object.entries(ids.packages)) {
-    console.log(
-      `const ${toConstName(envPrefix + "_PACKAGE", name)} = "${id}";`
     );
   }
 

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -27,10 +27,12 @@ import {
 import { provisionSeatsForContract } from "@app/lib/metronome/seats";
 import {
   LEGACY_BUSINESS_PACKAGE_ALIAS,
+  LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS,
   LEGACY_ENTERPRISE_PACKAGE_ALIAS,
   LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
   LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
 } from "@app/lib/metronome/types";
+import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
 import {
   isEntreprisePlanPrefix,
   PRO_PLAN_SEAT_29_CODE,
@@ -42,6 +44,7 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
+import { isSupportedCurrency } from "@app/types/currency";
 import type { LightWorkspaceType } from "@app/types/user";
 import type Stripe from "stripe";
 import { makeScript } from "./helpers";
@@ -380,37 +383,26 @@ async function getSubscriptionInfo(
   }
 
   // Get Stripe subscription start date, rounded to hour boundary (Metronome requirement).
-  let startDate: string | undefined;
-  let isAnnual = false;
-  let stripeSubscription: Stripe.Subscription | null = null;
-  try {
-    stripeSubscription = await getStripeSubscription(
-      subscription.stripeSubscriptionId
-    );
-    if (stripeSubscription) {
-      // Use current billing period start — not the original subscription start date.
-      // This ensures the Metronome contract aligns with the current billing cycle.
-      const startTimestamp = stripeSubscription.current_period_start;
-      // Round to hour boundary (Metronome requirement).
-      const rounded = Math.floor(startTimestamp / 3600) * 3600;
-      startDate = new Date(rounded * 1000).toISOString();
+  let stripeSubscription = await getStripeSubscription(
+    subscription.stripeSubscriptionId
+  );
 
-      // Detect annual billing from the Stripe price interval.
-      const interval =
-        stripeSubscription.items?.data[0]?.price?.recurring?.interval;
-      isAnnual = interval === "year";
-    }
-  } catch (err) {
-    logger.warn(
-      { workspaceId, error: String(err) },
-      "Failed to fetch Stripe subscription — skipping"
-    );
+  if (!stripeSubscription) {
     return undefined;
   }
 
-  if (!startDate) {
-    return undefined;
-  }
+  // Use current billing period start — not the original subscription start date.
+  // This ensures the Metronome contract aligns with the current billing cycle.
+  const startTimestamp = stripeSubscription.current_period_start;
+  // Round to hour boundary (Metronome requirement).
+  const rounded = Math.floor(startTimestamp / 3600) * 3600;
+  const startDate = new Date(rounded * 1000).toISOString();
+  const stripeCurrency = stripeSubscription.currency;
+
+  // Detect annual billing from the Stripe price interval.
+  const firstItem = stripeSubscription.items?.data[0];
+  const interval = firstItem?.price?.recurring?.interval;
+  const isAnnual = interval === "year";
 
   const planCode = subscription.getPlan().code;
 
@@ -433,26 +425,36 @@ async function getSubscriptionInfo(
     }
 
     return {
-      packageAlias: LEGACY_ENTERPRISE_PACKAGE_ALIAS,
+      packageAlias: resolvePackageAliasForCurrency(
+        LEGACY_ENTERPRISE_PACKAGE_ALIAS,
+        isSupportedCurrency(enterprisePricing.currency)
+          ? enterprisePricing.currency
+          : "usd"
+      ),
       startDate,
       subscriptionModelId: subscription.id,
       enterprisePricing,
     };
   }
 
-  // Determine alias from plan code + billing interval.
+  // Determine alias from plan code + billing interval + currency.
   const isPro = planCode === PRO_PLAN_SEAT_29_CODE;
   const isBusiness = planCode === PRO_PLAN_SEAT_39_CODE;
-  let packageAlias: string;
+  let baseAlias: string;
   if (isBusiness) {
-    packageAlias = LEGACY_BUSINESS_PACKAGE_ALIAS;
+    baseAlias = LEGACY_BUSINESS_PACKAGE_ALIAS;
   } else if (isPro) {
-    packageAlias = isAnnual
+    baseAlias = isAnnual
       ? LEGACY_PRO_ANNUAL_PACKAGE_ALIAS
       : LEGACY_PRO_MONTHLY_PACKAGE_ALIAS;
   } else {
     return undefined;
   }
+
+  const packageAlias = resolvePackageAliasForCurrency(
+    baseAlias,
+    isSupportedCurrency(stripeCurrency) ? stripeCurrency : "usd"
+  );
 
   return {
     packageAlias,
@@ -517,7 +519,9 @@ async function migrateWorkspace(
     }
 
     const targetPackageAlias = subInfo.packageAlias;
-    const isEnterprise = targetPackageAlias === LEGACY_ENTERPRISE_PACKAGE_ALIAS;
+    const isEnterprise =
+      targetPackageAlias === LEGACY_ENTERPRISE_PACKAGE_ALIAS ||
+      targetPackageAlias === LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS;
 
     logger.info(
       {
@@ -734,7 +738,10 @@ async function migrateWorkspace(
     );
 
     // 3. For enterprise contracts migrating to the enterprise package, apply overrides.
-    if (targetAlias === LEGACY_ENTERPRISE_PACKAGE_ALIAS) {
+    if (
+      targetAlias === LEGACY_ENTERPRISE_PACKAGE_ALIAS ||
+      targetAlias === LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS
+    ) {
       const subInfo = await getSubscriptionInfo(workspace.id, logger);
       if (subInfo?.enterprisePricing) {
         await applyEnterpriseOverrides({
@@ -749,7 +756,10 @@ async function migrateWorkspace(
     }
 
     // 4. Provision seats on the new contract (for seat-based plans).
-    if (targetAlias !== LEGACY_ENTERPRISE_PACKAGE_ALIAS) {
+    if (
+      targetAlias !== LEGACY_ENTERPRISE_PACKAGE_ALIAS &&
+      targetAlias !== LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS
+    ) {
       const seatResult2 = await provisionSeatsForContract({
         metronomeCustomerId,
         contractId: newContractId,


### PR DESCRIPTION
## Description

Add EUR billing support for Metronome contracts. EUR customers (EU/EEA/Switzerland) get EUR-denominated rate cards and packages, while the rest of the world stays on USD.

### Metronome Setup (`metronome_setup.ts`)
- **EUR rate cards + packages**: Legacy Pro EUR, Legacy Business EUR, Legacy Pro Annual EUR, Legacy Enterprise EUR — mirror the USD variants but with EUR fiat credit type.
- **EUR pricing**: Seats in whole euros (EUR pricing unit uses whole euros, not cents like USD). Programmatic usage at €0.0087/unit (applies 0.87 USD→EUR FX rate to the $0.01/unit base, matching Stripe's credit purchase conversion).
- **Rate card comparison**: now fetches actual rates from the API (`rateCards.rates.list`) and compares prices, entitled, credit_type, billing_frequency — detects rate changes that the old metadata-only check missed. Shows `[diff]` logs for what changed.
- **Renamed rate cards/packages**: removed prices from names (e.g. "Legacy Pro $29" → "Legacy Pro USD"), added currency suffix.
- **Cleaned up constants**: removed rate card and package IDs from `constants.ts` (unused — code references aliases, not IDs). Setup script no longer outputs them.

### Billing Currency Resolution (`billing_currency.ts`)
- **Two modes** via `metronomeBilled` flag:
  - Metronome (`metronome_billing` feature flag on): EU/EEA/CH → EUR, rest of world → USD
  - Stripe (no flag, default): US → USD, rest of world → EUR (matches Stripe's adaptive pricing where EUR is base currency and USD is the only currency_option)
- **`resolvePackageAliasForCurrency`**: maps base aliases to EUR variants (including `legacy-enterprise` → `legacy-enterprise-eur`)

### Client-side Currency Detection (`subscription.ts`)
- **Replaced timezone heuristic** (`guessUserBillingCurrency`) with IP geolocation via `useGeolocation` hook (calls `/api/geo/location` → IPinfo API, cached in localStorage)
- **`useUserBillingCurrency` hook**: checks `metronome_billing` feature flag via `useFeatureFlags()` to select the right currency mode. Falls back to Stripe behaviour (EUR default) when no workspace context.
- **`usePriceWithCurrency` hook**: replaces the old synchronous `getPriceWithCurrency` function. Updated all call sites (`SubscriptionPlanCards`, `PlansTables`, `TrialPricingCard`).

### Migration Script (`migrate_metronome_contracts.ts`)
- **Currency-aware package resolution**: reads Stripe subscription currency, uses `resolvePackageAliasForCurrency` to pick EUR variant when applicable.
- **Enterprise EUR**: `LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS` added, enterprise alias checks match both USD and EUR variants.

### Checkout (`checkout.ts`)
- **Metronome checkout**: passes `metronomeBilled: true` to `getBillingCurrencyForCountry` — resolves package alias to EUR variant based on customer's billing country.
- **Renamed** `MetronomeSetupSessionSchema` → `StripeSetupSessionSchema`.

### Metronome types
- Added `LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS`, `LEGACY_PRO_MONTHLY_EUR_PACKAGE_ALIAS`, `LEGACY_PRO_ANNUAL_EUR_PACKAGE_ALIAS`, `LEGACY_BUSINESS_EUR_PACKAGE_ALIAS`.

### Constants cleanup
- Removed all rate card and package ID constants + getters (unused — only metrics and products are referenced by code).

## Tests

- Ran `metronome_setup.ts --execute` in sandbox. EUR rate cards created with correct prices (€29/seat, €0.0087/unit programmatic). Rate comparison correctly detects changes and shows diffs.
- Verified `useUserBillingCurrency` hook returns EUR for EU countries and USD for US via feature flag check.

## Risk

Low. EUR rate cards are new (no existing contracts). Currency detection fallback is safe (Stripe behaviour = EUR default for non-US). Feature flag gates the Metronome currency logic.

## Deploy Plan

1. Merge PR
2. Run `metronome_setup.ts --execute` in production to create EUR rate cards + packages
3. Enable `metronome_billing` feature flag on test workspaces to verify EUR checkout flow