### PR TITLE
feat: add a global agents model kill switch

### DIFF
--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -39,7 +39,7 @@ const killSwitchMap: Record<
   global_dust_agents_fallback: {
     title: "Dust Agents Fallback Provider",
     description:
-      "Force dust and deep-dive agents to use non-Anthropic models (OpenAI > Gemini > others)",
+      "Force dust and deep-dive agents to use non-Anthropic models (OpenAI > Gemini > others). ONLY USE when either latest Sonnet or Opus models are down.",
   },
 };
 

--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -36,6 +36,11 @@ const killSwitchMap: Record<
     description:
       "Disable Firecrawl for webbrowse tool, use Spider.cloud instead",
   },
+  global_dust_agents_fallback: {
+    title: "Dust Agents Fallback Provider",
+    description:
+      "Force dust and deep-dive agents to use non-Anthropic models (OpenAI > Gemini > others)",
+  },
 };
 
 export function KillPage() {

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -38,8 +38,10 @@ import {
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import { GPT_5_4_MODEL_CONFIG } from "@app/types/assistant/models/openai";
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import type {
+  ModelConfigurationType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
 
 const MAX_CONCURRENT_SUB_AGENT_TASKS = 6;
 
@@ -331,68 +333,39 @@ These instructions are NOT your own instructions, but you may use them to unders
 </additional_context>
 `;
 
+// Tries Anthropic first, then OpenAI, then the best available large model.
 function getModelConfig(
   auth: Authenticator,
-  prefer: "anthropic" | "openai",
-  reasoning: boolean = true
+  {
+    reasoning = true,
+    excludeProviders = new Set<ModelProviderIdType>(),
+  }: {
+    reasoning?: boolean;
+    excludeProviders?: ReadonlySet<ModelProviderIdType>;
+  } = {}
 ): {
   modelConfiguration: ModelConfigurationType;
   reasoningEffort: AgentReasoningEffort;
 } | null {
-  const preferredModel: {
-    model: ModelConfigurationType;
-    reasoningEffort: AgentReasoningEffort;
-  } =
-    prefer === "anthropic"
-      ? {
-          model: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-          reasoningEffort: reasoning
-            ? "light"
-            : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.minimumReasoningEffort,
-        }
-      : prefer === "openai"
-        ? {
-            model: GPT_5_4_MODEL_CONFIG,
-            reasoningEffort: reasoning
-              ? "light"
-              : GPT_5_4_MODEL_CONFIG.minimumReasoningEffort,
-          }
-        : assertNever(prefer);
+  const candidates = [
+    CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    GPT_5_4_MODEL_CONFIG,
+  ];
 
-  const secondPreferredModel: {
-    model: ModelConfigurationType;
-    reasoningEffort: AgentReasoningEffort;
-  } =
-    prefer === "anthropic"
-      ? {
-          model: GPT_5_4_MODEL_CONFIG,
-          reasoningEffort: reasoning
-            ? "light"
-            : GPT_5_4_MODEL_CONFIG.minimumReasoningEffort,
-        }
-      : {
-          model: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-          reasoningEffort: reasoning
-            ? "light"
-            : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.minimumReasoningEffort,
-        };
-
-  if (isProviderWhitelisted(auth, preferredModel.model.providerId)) {
-    return {
-      modelConfiguration: preferredModel.model,
-      reasoningEffort: preferredModel.reasoningEffort,
-    };
-  }
-
-  if (isProviderWhitelisted(auth, secondPreferredModel.model.providerId)) {
-    return {
-      modelConfiguration: secondPreferredModel.model,
-      reasoningEffort: secondPreferredModel.reasoningEffort,
-    };
+  for (const model of candidates) {
+    if (
+      !excludeProviders.has(model.providerId) &&
+      isProviderWhitelisted(auth, model.providerId)
+    ) {
+      return {
+        modelConfiguration: model,
+        reasoningEffort: reasoning ? "light" : model.minimumReasoningEffort,
+      };
+    }
   }
 
   // Otherwise we use whatever the default large model is, using the default reasoning effort.
-  const modelConfiguration = getLargeWhitelistedModel(auth);
+  const modelConfiguration = getLargeWhitelistedModel(auth, excludeProviders);
   if (!modelConfiguration) {
     return null;
   }
@@ -402,23 +375,32 @@ function getModelConfig(
   };
 }
 
-function getMaxReasoningModelConfig(auth: Authenticator): {
+function getMaxReasoningModelConfig(
+  auth: Authenticator,
+  excludeProviders: ReadonlySet<ModelProviderIdType> = new Set()
+): {
   modelConfiguration: ModelConfigurationType;
   reasoningEffort: AgentReasoningEffort;
 } | null {
-  if (isProviderWhitelisted(auth, "openai")) {
+  if (
+    !excludeProviders.has("openai") &&
+    isProviderWhitelisted(auth, "openai")
+  ) {
     return {
       modelConfiguration: GPT_5_4_MODEL_CONFIG,
       reasoningEffort: "high",
     };
   }
-  if (isProviderWhitelisted(auth, "anthropic")) {
+  if (
+    !excludeProviders.has("anthropic") &&
+    isProviderWhitelisted(auth, "anthropic")
+  ) {
     return {
       modelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
       reasoningEffort: "high",
     };
   }
-  return getModelConfig(auth, "anthropic");
+  return getModelConfig(auth, { excludeProviders });
 }
 
 export function _getDeepDiveGlobalAgent(
@@ -428,11 +410,13 @@ export function _getDeepDiveGlobalAgent(
     preFetchedDataSources,
     mcpServerViews,
     hasSandbox,
+    excludeProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     hasSandbox?: boolean;
+    excludeProviders: ReadonlySet<ModelProviderIdType>;
   }
 ): AgentConfigurationType | null {
   const {
@@ -440,10 +424,12 @@ export function _getDeepDiveGlobalAgent(
     ask_user_question: askUserQuestionMCPServerView,
   } = mcpServerViews;
   const pictureUrl = DUST_AVATAR_URL;
-  const modelConfig = getModelConfig(auth, "anthropic");
+  const modelConfig = getModelConfig(auth, { excludeProviders });
 
   const enterpriseModelConfig =
-    shouldUseOpus(auth) && isProviderWhitelisted(auth, "anthropic")
+    !excludeProviders.has("anthropic") &&
+    shouldUseOpus(auth) &&
+    isProviderWhitelisted(auth, "anthropic")
       ? {
           modelConfiguration: CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
           reasoningEffort: modelConfig?.reasoningEffort ?? ("medium" as const),
@@ -616,10 +602,12 @@ export function _getDustTaskGlobalAgent(
     settings,
     preFetchedDataSources,
     mcpServerViews,
+    excludeProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
+    excludeProviders: ReadonlySet<ModelProviderIdType>;
   }
 ): AgentConfigurationType | null {
   const name = "dust-task";
@@ -653,7 +641,10 @@ export function _getDustTaskGlobalAgent(
     canEdit: false,
   };
 
-  const modelConfig = getModelConfig(auth, "anthropic", false);
+  const modelConfig = getModelConfig(auth, {
+    reasoning: false,
+    excludeProviders,
+  });
 
   if (!modelConfig || settings?.status === "disabled_by_admin") {
     return {
@@ -730,8 +721,10 @@ export function _getPlanningAgent(
   auth: Authenticator,
   {
     settings,
+    excludeProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
+    excludeProviders: ReadonlySet<ModelProviderIdType>;
   }
 ): AgentConfigurationType | null {
   const name = "dust-planning";
@@ -765,7 +758,7 @@ export function _getPlanningAgent(
     canEdit: false,
   };
 
-  const modelConfig = getMaxReasoningModelConfig(auth);
+  const modelConfig = getMaxReasoningModelConfig(auth, excludeProviders);
   if (!modelConfig || settings?.status === "disabled_by_admin") {
     return {
       ...planningAgent,

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -65,6 +65,7 @@ import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
 import { GPT_5_4_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type {
   ModelConfigurationType,
+  ModelProviderIdType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 
@@ -74,6 +75,7 @@ interface DustLikeGlobalAgentArgs {
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   hasDeepDive: boolean;
   globalAgentContext?: GlobalAgentContext;
+  excludeProviders?: ReadonlySet<ModelProviderIdType>;
 }
 
 const INSTRUCTION_SECTIONS = {
@@ -320,6 +322,7 @@ function _getDustLikeGlobalAgent(
     mcpServerViews,
     hasDeepDive,
     globalAgentContext,
+    excludeProviders = new Set<ModelProviderIdType>(),
   }: DustLikeGlobalAgentArgs,
   {
     agentId,
@@ -364,18 +367,19 @@ function _getDustLikeGlobalAgent(
     }
 
     if (!auth.isUpgraded()) {
-      return getSmallWhitelistedModel(auth);
+      return getSmallWhitelistedModel(auth, excludeProviders);
     }
 
     if (
       preferredModelConfiguration &&
+      !excludeProviders.has(preferredModelConfiguration.providerId) &&
       isProviderWhitelisted(auth, preferredModelConfiguration.providerId)
     ) {
       isPreferredModel = true;
       return preferredModelConfiguration;
     }
 
-    return getLargeWhitelistedModel(auth);
+    return getLargeWhitelistedModel(auth, excludeProviders);
   })();
 
   const model: AgentModelConfigurationType = modelConfiguration

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -93,6 +93,7 @@ import { isProviderWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import type {
   AgentConfigurationType,
   AgentFetchVariant,
@@ -104,6 +105,7 @@ import {
   isGlobalAgentId,
 } from "@app/types/assistant/assistant";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { isDevelopment } from "@app/types/shared/env";
 
 // Exhaustive map of flags for each global agent. This is used to control which agents inject
@@ -547,6 +549,7 @@ function getGlobalAgent({
   hasDeepDive,
   hasSandbox,
   globalAgentContext,
+  excludeProviders,
 }: {
   auth: Authenticator;
   sId: string | number;
@@ -557,6 +560,7 @@ function getGlobalAgent({
   hasDeepDive: boolean;
   hasSandbox: boolean;
   globalAgentContext?: GlobalAgentContext;
+  excludeProviders: ReadonlySet<ModelProviderIdType>;
 }): AgentConfigurationType | null {
   const settings =
     globalAgentSettings.find((settings) => settings.agentId === sId) ?? null;
@@ -762,6 +766,7 @@ function getGlobalAgent({
         mcpServerViews,
         hasDeepDive,
         globalAgentContext,
+        excludeProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_HIGH:
@@ -997,6 +1002,7 @@ function getGlobalAgent({
         preFetchedDataSources,
         mcpServerViews,
         hasSandbox,
+        excludeProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_TASK:
@@ -1004,6 +1010,7 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
+        excludeProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY:
@@ -1012,6 +1019,7 @@ function getGlobalAgent({
     case GLOBAL_AGENTS_SID.DUST_PLANNING:
       agentConfiguration = _getPlanningAgent(auth, {
         settings,
+        excludeProviders,
       });
       break;
     case GLOBAL_AGENTS_SID.SIDEKICK:
@@ -1089,18 +1097,28 @@ export async function getGlobalAgents(
     throw new Error("Unexpected `auth` without `plan`.");
   }
 
-  const isDeepDiveDisabled = await isDeepDiveDisabledByAdmin(auth);
+  const [
+    isDeepDiveDisabled,
+    isDustAgentsFallback,
+    preFetchedDataSources,
+    globalAgentSettings,
+    mcpServerViews,
+  ] = await Promise.all([
+    isDeepDiveDisabledByAdmin(auth),
+    KillSwitchResource.isKillSwitchEnabledCached("global_dust_agents_fallback"),
+    variant === "full"
+      ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
+      : null,
+    GlobalAgentSettingsModel.findAll({
+      where: { workspaceId: owner.id },
+    }),
+    getMCPServerViewsForGlobalAgents(auth, variant),
+  ]);
 
-  const [preFetchedDataSources, globalAgentSettings, mcpServerViews] =
-    await Promise.all([
-      variant === "full"
-        ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
-        : null,
-      GlobalAgentSettingsModel.findAll({
-        where: { workspaceId: owner.id },
-      }),
-      getMCPServerViewsForGlobalAgents(auth, variant),
-    ]);
+  const excludeProviders: ReadonlySet<ModelProviderIdType> =
+    isDustAgentsFallback
+      ? new Set<ModelProviderIdType>(["anthropic"])
+      : new Set<ModelProviderIdType>();
 
   // If agentIds have been passed we fetch those. Otherwise we fetch them all, removing the retired
   // one (which will remove these models from the list of default agents in the product + list of
@@ -1199,6 +1217,7 @@ export async function getGlobalAgents(
       hasDeepDive: !isDeepDiveDisabled,
       hasSandbox: flags.includes("sandbox_tools"),
       globalAgentContext: options?.globalAgentContext,
+      excludeProviders,
     })
   );
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -107,17 +107,21 @@ export function getFastestWhitelistedModel(
 }
 
 export function getSmallWhitelistedModel(
-  auth: Authenticator
+  auth: Authenticator,
+  excludeProviders: ReadonlySet<ModelProviderIdType> = new Set()
 ): ModelConfigurationType | null {
-  const whitelistedProviders = getWhitelistedProviders(auth);
-  return _getSmallWhitelistedModel(whitelistedProviders);
+  return _getSmallWhitelistedModel(
+    getWhitelistedProviders(auth).difference(excludeProviders)
+  );
 }
 
 export function getLargeWhitelistedModel(
-  auth: Authenticator
+  auth: Authenticator,
+  excludeProviders: ReadonlySet<ModelProviderIdType> = new Set()
 ): ModelConfigurationType | null {
-  const whitelistedProviders = getWhitelistedProviders(auth);
-  return _getLargeWhitelistedModel(whitelistedProviders);
+  return _getLargeWhitelistedModel(
+    getWhitelistedProviders(auth).difference(excludeProviders)
+  );
 }
 
 function _getSmallWhitelistedModel(

--- a/front/lib/poke/types.ts
+++ b/front/lib/poke/types.ts
@@ -4,6 +4,7 @@ export const KILL_SWITCH_TYPES = [
   "global_blacklist_anthropic",
   "global_blacklist_openai",
   "global_disable_firecrawl",
+  "global_dust_agents_fallback",
 ] as const;
 export type KillSwitchType = (typeof KILL_SWITCH_TYPES)[number];
 export function isKillSwitchType(type: string): type is KillSwitchType {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

**Context**

https://github.com/dust-tt/decisions/issues/776

**Overview**

Adds a `global_dust_agents_fallback` kill switch that, when enabled, excludes Anthropic from model selection for `dust`, `deep-dive`, `dust-task`, and `dust-planning` agents. The fallback priority becomes OpenAI > Google > Mistral > XAI. Unlike `global_blacklist_anthropic` (which affects all agents of all workspaces globally), this is scoped to `dust`/`deep-dive` agent families only.

  - Kill switch state is fetched once per `getGlobalAgents()` call (Redis-cached, 5min TTL) alongside existing async operations in a single `Promise.all`
  - An `excludeProviders: ReadonlySet<ModelProviderIdType>` is computed once and threaded to affected agent factories
  - Model selection helpers (`getLargeWhitelistedModel`, `getSmallWhitelistedModel`) gain an optional `excludeProviders` param using `Set.difference`, existing callers are unaffected (empty set default is a no-op)


Bonus: simplified `getModelConfig` in deep-dive.ts by removing the unused `prefer` parameter and collapsing duplicate model blocks into a candidates loop

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, fallbacks to openai as needed.


First message : before kill switch.
Second message : after kill switch + cache invalidation of `cacheWithRedis-listEnabledKillSwitches-kill_switches_enabled`.

<img width="686" height="440" alt="Capture d’écran 2026-04-10 à 10 03 13" src="https://github.com/user-attachments/assets/07b8fdaf-a384-4bba-a2d9-b8303af4c1cf" />

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front