### PR TITLE
fix: use timingSafeEqual in webhook validation

### DIFF
--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from "node:crypto";
+
 import { Authenticator } from "@app/lib/auth";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
@@ -152,8 +154,10 @@ async function handler(
     });
   }
 
-  // Validate webhook url secret
-  if (webhookSourceUrlSecret !== webhookSource.urlSecret) {
+  // Validate webhook url secret using constant-time comparison to prevent timing attacks.
+  const a = Buffer.from(webhookSourceUrlSecret, "utf8");
+  const b = Buffer.from(webhookSource.urlSecret, "utf8");
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
     return apiError(req, res, {
       status_code: 401,
       api_error: {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

String comparison with !== is not constant-time. Webhook secret needs to be checked with timingSafeEqual check to prevent timing attacks on webhook secrets.

Really not likely to be usable because you already need to guess 2 sIds to reach that point, but better safe than sorry.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front