### PR TITLE
[Sessions] Add conversation fork lineage model

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -34,6 +34,7 @@ import {
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
+import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { TriggerSubscriberModel } from "@app/lib/models/agent/triggers/trigger_subscriber";
@@ -228,6 +229,7 @@ export function loadAllModels() {
     AcademyChapterVisitModel,
     SandboxModel,
     ConversationBranchModel,
+    ConversationForkModel,
     ProjectTodoModel,
     ProjectTodoConversationModel,
     ProjectTodoSourceModel,

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -10,6 +10,7 @@ import {
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
+import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import {
   AgentMessageSkillModel,
   ConversationSkillModel,
@@ -33,7 +34,7 @@ import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import chunk from "lodash/chunk";
-import type { WhereOptions } from "sequelize";
+import { Op, type WhereOptions } from "sequelize";
 
 const DESTROY_MESSAGE_BATCH = 50;
 
@@ -64,6 +65,13 @@ async function destroyMessageRelatedResources(
   messageIds: ModelId[]
 ) {
   const owner = auth.getNonNullableWorkspace();
+
+  await ConversationForkModel.destroy({
+    where: {
+      workspaceId: owner.id,
+      sourceMessageId: messageIds,
+    },
+  });
 
   await ConversationBranchModel.destroy({
     where: {
@@ -171,6 +179,16 @@ export async function destroyConversation(
   }
 ): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
+
+  await ConversationForkModel.destroy({
+    where: {
+      workspaceId: owner.id,
+      [Op.or]: [
+        { parentConversationId: conversation.id },
+        { childConversationId: conversation.id },
+      ],
+    },
+  });
 
   // Clean up all branches attached to this conversation before deleting messages.
   await ConversationBranchModel.destroy({

--- a/front/lib/models/agent/conversation_fork.ts
+++ b/front/lib/models/agent/conversation_fork.ts
@@ -1,0 +1,113 @@
+import {
+  ConversationModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
+
+export class ConversationForkModel extends WorkspaceAwareModel<ConversationForkModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare parentConversationId: ForeignKey<ConversationModel["id"]>;
+  declare childConversationId: ForeignKey<ConversationModel["id"]>;
+  declare createdByUserId: ForeignKey<UserModel["id"]>;
+  declare sourceMessageId: ForeignKey<MessageModel["id"]>;
+  declare branchedAt: Date;
+
+  declare parentConversation?: NonAttribute<ConversationModel>;
+  declare childConversation?: NonAttribute<ConversationModel>;
+  declare createdByUser?: NonAttribute<UserModel>;
+  declare sourceMessage?: NonAttribute<MessageModel>;
+}
+
+ConversationForkModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    branchedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "conversation_fork",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["workspaceId", "childConversationId"],
+        unique: true,
+      },
+      {
+        fields: ["workspaceId", "parentConversationId"],
+      },
+      {
+        fields: ["workspaceId", "sourceMessageId"],
+      },
+      {
+        fields: ["parentConversationId"],
+        concurrently: true,
+      },
+      {
+        fields: ["childConversationId"],
+        concurrently: true,
+      },
+      {
+        fields: ["createdByUserId"],
+        concurrently: true,
+      },
+      {
+        fields: ["sourceMessageId"],
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+ConversationModel.hasMany(ConversationForkModel, {
+  as: "forkedChildren",
+  foreignKey: { name: "parentConversationId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+ConversationForkModel.belongsTo(ConversationModel, {
+  as: "parentConversation",
+  foreignKey: { name: "parentConversationId", allowNull: false },
+});
+ConversationModel.hasOne(ConversationForkModel, {
+  as: "forkedFrom",
+  foreignKey: { name: "childConversationId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+ConversationForkModel.belongsTo(ConversationModel, {
+  as: "childConversation",
+  foreignKey: { name: "childConversationId", allowNull: false },
+});
+UserModel.hasMany(ConversationForkModel, {
+  as: "createdConversationForks",
+  foreignKey: { name: "createdByUserId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+ConversationForkModel.belongsTo(UserModel, {
+  as: "createdByUser",
+  foreignKey: { name: "createdByUserId", allowNull: false },
+});
+MessageModel.hasMany(ConversationForkModel, {
+  as: "conversationForks",
+  foreignKey: { name: "sourceMessageId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+ConversationForkModel.belongsTo(MessageModel, {
+  as: "sourceMessage",
+  foreignKey: { name: "sourceMessageId", allowNull: false },
+});

--- a/front/lib/models/agent/conversation_fork.ts
+++ b/front/lib/models/agent/conversation_fork.ts
@@ -46,7 +46,7 @@ ConversationForkModel.init(
     sequelize: frontSequelize,
     indexes: [
       {
-        fields: ["workspaceId", "childConversationId"],
+        fields: ["childConversationId"],
         unique: true,
       },
       {
@@ -57,10 +57,6 @@ ConversationForkModel.init(
       },
       {
         fields: ["parentConversationId"],
-        concurrently: true,
-      },
-      {
-        fields: ["childConversationId"],
         concurrently: true,
       },
       {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -5529,6 +5529,7 @@ const KNOWN_CONVERSATION_RELATED_MODELS = [
   "agent_message_feedback",
   "agent_suggestion",
   "conversation_branch",
+  "conversation_fork",
   "conversation_mcp_server_view",
   "conversation_participant",
   "conversation_skills",
@@ -5544,10 +5545,11 @@ const KNOWN_CONVERSATION_RELATED_MODELS = [
 
 const KNOWN_MESSAGE_RELATED_MODELS = [
   // Tables that have a foreign key to the `message` table.
+  "conversation_branch",
+  "conversation_fork",
   "message",
   "message_reaction",
   "mention",
-  "conversation_branch",
 ];
 
 describe("ConversationResource cleanup on delete", () => {

--- a/front/migrations/db/migration_574.sql
+++ b/front/migrations/db/migration_574.sql
@@ -1,0 +1,34 @@
+-- Migration created on Apr 10, 2026
+
+CREATE TABLE IF NOT EXISTS "conversation_forks" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "parentConversationId" BIGINT NOT NULL REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "childConversationId" BIGINT NOT NULL REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "createdByUserId" BIGINT NOT NULL REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "sourceMessageId" BIGINT NOT NULL REFERENCES "messages" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "branchedAt" TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_workspace_id_child_conversation_id"
+  ON "conversation_forks" ("workspaceId", "childConversationId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_workspace_id_parent_conversation_id"
+  ON "conversation_forks" ("workspaceId", "parentConversationId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_workspace_id_source_message_id"
+  ON "conversation_forks" ("workspaceId", "sourceMessageId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_parent_conversation_id"
+  ON "conversation_forks" ("parentConversationId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_child_conversation_id"
+  ON "conversation_forks" ("childConversationId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_created_by_user_id"
+  ON "conversation_forks" ("createdByUserId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_source_message_id"
+  ON "conversation_forks" ("sourceMessageId");

--- a/front/migrations/db/migration_574.sql
+++ b/front/migrations/db/migration_574.sql
@@ -12,8 +12,8 @@ CREATE TABLE IF NOT EXISTS "conversation_forks" (
   "branchedAt" TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
-CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_workspace_id_child_conversation_id"
-  ON "conversation_forks" ("workspaceId", "childConversationId");
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_child_conversation_id"
+  ON "conversation_forks" ("childConversationId");
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_workspace_id_parent_conversation_id"
   ON "conversation_forks" ("workspaceId", "parentConversationId");
@@ -23,9 +23,6 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_workspace_id_source_
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_parent_conversation_id"
   ON "conversation_forks" ("parentConversationId");
-
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_child_conversation_id"
-  ON "conversation_forks" ("childConversationId");
 
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_forks_created_by_user_id"
   ON "conversation_forks" ("createdByUserId");


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24018.

Adds the additive `conversation_forks` table migration and matching Sequelize model for conversation fork lineage. Registers the model in the front model loader and cleans fork lineage rows from the existing conversation destroy path so the restrictive FKs do not block later deletion flows. Resource, API, and creation flow work are intentionally left for later streams.

## Risks
Blast radius: front database schema, model loading, and hard-delete cleanup for conversation fork lineage.
Risk: low

## Deploy Plan
- pmrr
- run `front/migrations/db/migration_574.sql`
- deploy front
