### PR TITLE
fix(google_drive): refresh OAuth token on expiry to prevent infinite retry loops

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -251,11 +251,14 @@ export async function getAuthObject(
     connectionId,
   });
 
+  // Do not set expiry_date: without it, googleapis will not attempt to
+  // auto-refresh the token (which fails because we don't set a refresh_token,
+  // by design). If a token expires mid-activity, the API returns a 401 and
+  // Temporal retries the activity with a fresh token.
   oauth2Client.setCredentials({
     access_token: token.access_token,
     scope: (token.scrubbed_raw_json as { scope: string }).scope,
     token_type: (token.scrubbed_raw_json as { token_type: string }).token_type,
-    expiry_date: token.access_token_expiry,
   });
 
   return oauth2Client;


### PR DESCRIPTION
## Description

- Google Drive's `getAuthObject` was setting `expiry_date` on the OAuth2Client. When the access token expired (~1h) during long-running activities, googleapis attempted to auto-refresh but failed with "No refresh token is set." (we don't set one, by design).  Temporal retried the activity forever. This affected 15+ connectors since ~March 24.
- Removed `expiry_date` from `setCredentials` so googleapis never attempts auto-refresh. This matches how every other connector (Notion, Slack, Confluence) handles tokens: fetch once per activity, no expiry tracking. If a token expires mid-activity, the API returns a 401 and Temporal retries with a fresh token.

[Error logs](https://app.datadoghq.eu/logs?query=%22Error%3A%20No%20refresh%20token%20is%20set.%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1775205172097&to_ts=1775809972097&live=true)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
