### PR TITLE
fix(google_drive): skip spreadsheets with too many sheets

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -37,6 +37,7 @@ import type { GaxiosResponse, OAuth2Client } from "googleapis-common";
 import { GaxiosError } from "googleapis-common";
 
 const MAXIMUM_NUMBER_OF_GSHEET_ROWS = 50000;
+const MAXIMUM_NUMBER_OF_SHEETS_PER_SPREADSHEET = 50;
 
 export type Sheet = sheets_v4.Schema$ValueRange & {
   id: number;
@@ -536,6 +537,14 @@ export async function syncSpreadSheet(
           }
           throw err;
         }
+      }
+
+      if (sheets.length > MAXIMUM_NUMBER_OF_SHEETS_PER_SPREADSHEET) {
+        localLogger.info(
+          { sheetCount: sheets.length },
+          "[Spreadsheet] Spreadsheet has too many sheets, skipping."
+        );
+        return { isSupported: false, skipReason: "too_many_sheets" };
       }
 
       // List synced sheets.


### PR DESCRIPTION
## Description

Spreadsheets with a large number of sheets (150+) cause the sqlite worker to fail with a URL builder error. This happens because the transient database identifier is a raw concatenation of all table unique IDs joined with /, not an actual hash. When many sheets from the same spreadsheet are queried together, this identifier becomes too long to fit in an HTTP URL.

This PR adds a cap of 50 sheets per spreadsheet. Spreadsheets exceeding this limit are skipped during sync. The underlying issue in core (table_ids_hash not being a real hash) still needs a separate fix.

Full context here: https://dust4ai.slack.com/archives/C050SM8NSPK/p1775808182475319

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy connectors. 