### PR TITLE
fix: project popover height

### DIFF
--- a/front/components/assistant/conversation/sidebar/ProjectsBrowsePopover.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsBrowsePopover.tsx
@@ -94,12 +94,16 @@ export function ProjectsBrowsePopover({ owner }: ProjectsBrowsePopoverProps) {
 
   return (
     <div className="hidden sm:block">
-      <PopoverRoot open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverRoot open={isOpen} onOpenChange={setIsOpen} modal>
         <PopoverTrigger asChild>
           <Button size="xs" icon={MoreIcon} variant="ghost" />
         </PopoverTrigger>
-        <PopoverContent className="w-80 p-0" align="start">
-          <div className="p-3 pb-2">
+        <PopoverContent
+          className="flex w-80 max-h-[--radix-popover-content-available-height] flex-col p-0"
+          align="start"
+          collisionPadding={16}
+        >
+          <div className="shrink-0 p-3 pb-2">
             <SearchInput
               name="browse-projects-search"
               placeholder="Search projects..."
@@ -107,7 +111,7 @@ export function ProjectsBrowsePopover({ owner }: ProjectsBrowsePopoverProps) {
               onChange={setSearchQuery}
             />
           </div>
-          <div className="max-h-[40rem] overflow-y-auto px-2 pb-2">
+          <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
             {isSearching && filteredProjects.length === 0 ? (
               <ProjectBrowseItemSkeleton count={5} />
             ) : filteredProjects.length === 0 ? (


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7015

This PR fixes the project browse popover height to properly adapt to available space.

- Added `modal` prop to `PopoverRoot` to avoid sidebar scrolling
- Updated `PopoverContent` to use Radix UI's `--radix-popover-content-available-height` CSS variable for dynamic height constraint
- Added `collisionPadding={16}` to prevent the popover from being cut off at screen edges
- Changed the search input container to `shrink-0` to prevent it from being compressed
- Converted the projects list container from fixed max-height to flexible layout

Before:

https://github.com/user-attachments/assets/2e1cc61b-89d9-4297-9df5-d66b33237619

After:


https://github.com/user-attachments/assets/7a33dcaa-24c6-4dd8-bfb4-f809b3cd82df



## Tests

Manually

## Risks

Low.

## Deploy Plan

Standard deployment - no special considerations needed.
