### PR TITLE
[front] fix caching invalidation on kill switches

### DIFF
--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -116,7 +116,7 @@ async function handleWebbrowser(
     toolConfiguration.additionalConfiguration[USE_SUMMARY_SWITCH] === true;
 
   const isFirecrawlDisabled =
-    await KillSwitchResource.isKillSwitchEnabledCached(
+    await KillSwitchResource.isKillSwitchEnabled(
       "global_disable_firecrawl"
     );
   const browsingProvider = isFirecrawlDisabled ? "spider" : "firecrawl";

--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -115,10 +115,9 @@ async function handleWebbrowser(
     isLightServerSideMCPToolConfiguration(toolConfiguration) &&
     toolConfiguration.additionalConfiguration[USE_SUMMARY_SWITCH] === true;
 
-  const isFirecrawlDisabled =
-    await KillSwitchResource.isKillSwitchEnabled(
-      "global_disable_firecrawl"
-    );
+  const isFirecrawlDisabled = await KillSwitchResource.isKillSwitchEnabled(
+    "global_disable_firecrawl"
+  );
   const browsingProvider = isFirecrawlDisabled ? "spider" : "firecrawl";
 
   const results = await browseUrls(urls, 8, "markdown", {

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -35,9 +35,7 @@ async function importAgentConfiguration(
   agentConfigurationId?: string
 ): Promise<ImportResult> {
   const isSaveAgentConfigurationsEnabled =
-    await KillSwitchResource.isKillSwitchEnabled(
-      "save_agent_configurations"
-    );
+    await KillSwitchResource.isKillSwitchEnabled("save_agent_configurations");
   if (isSaveAgentConfigurationsEnabled) {
     return new Err({
       status_code: 400,

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -35,7 +35,7 @@ async function importAgentConfiguration(
   agentConfigurationId?: string
 ): Promise<ImportResult> {
   const isSaveAgentConfigurationsEnabled =
-    await KillSwitchResource.isKillSwitchEnabledCached(
+    await KillSwitchResource.isKillSwitchEnabled(
       "save_agent_configurations"
     );
   if (isSaveAgentConfigurationsEnabled) {

--- a/front/lib/resources/kill_switch_resource.ts
+++ b/front/lib/resources/kill_switch_resource.ts
@@ -75,9 +75,7 @@ export class KillSwitchResource extends BaseResource<KillSwitchModel> {
     return KillSwitchResource.listEnabledKillSwitchesCached();
   }
 
-  static async isKillSwitchEnabled(
-    type: KillSwitchType
-  ): Promise<boolean> {
+  static async isKillSwitchEnabled(type: KillSwitchType): Promise<boolean> {
     const enabledKillSwitches =
       await KillSwitchResource.listEnabledKillSwitches();
     return enabledKillSwitches.includes(type);

--- a/front/lib/resources/kill_switch_resource.ts
+++ b/front/lib/resources/kill_switch_resource.ts
@@ -28,6 +28,17 @@ export class KillSwitchResource extends BaseResource<KillSwitchModel> {
     super(KillSwitchModel, blob);
   }
 
+  private static listEnabledKillSwitchesCached = cacheWithRedis(
+    KillSwitchResource._listEnabledKillSwitchesUncached,
+    () => KILL_SWITCH_ENABLED_CACHE_KEY,
+    { ttlMs: KILL_SWITCH_ENABLED_CACHE_TTL_MS }
+  );
+
+  private static invalidateKillSwitchCache = invalidateCacheWithRedis(
+    KillSwitchResource._listEnabledKillSwitchesUncached,
+    () => KILL_SWITCH_ENABLED_CACHE_KEY
+  );
+
   static async enableKillSwitch(
     type: KillSwitchType
   ): Promise<KillSwitchResource> {
@@ -38,10 +49,7 @@ export class KillSwitchResource extends BaseResource<KillSwitchModel> {
         },
       })) ?? (await KillSwitchModel.create({ type }));
 
-    await invalidateCacheWithRedis(
-      KillSwitchResource.listEnabledKillSwitches,
-      () => KILL_SWITCH_ENABLED_CACHE_KEY
-    );
+    await KillSwitchResource.invalidateKillSwitchCache();
 
     return new KillSwitchResource(KillSwitchModel, ks.get());
   }
@@ -53,32 +61,25 @@ export class KillSwitchResource extends BaseResource<KillSwitchModel> {
       },
     });
 
-    await invalidateCacheWithRedis(
-      KillSwitchResource.listEnabledKillSwitches,
-      () => KILL_SWITCH_ENABLED_CACHE_KEY
-    );
+    await KillSwitchResource.invalidateKillSwitchCache();
   }
 
-  static async listEnabledKillSwitches(): Promise<KillSwitchType[]> {
+  private static async _listEnabledKillSwitchesUncached(): Promise<
+    KillSwitchType[]
+  > {
     const killSwitches = await KillSwitchModel.findAll();
     return killSwitches.map((ks) => ks.type);
   }
 
-  static async listEnabledKillSwitchesCached(): Promise<KillSwitchType[]> {
-    return cacheWithRedis(
-      KillSwitchResource.listEnabledKillSwitches,
-      () => KILL_SWITCH_ENABLED_CACHE_KEY,
-      {
-        ttlMs: KILL_SWITCH_ENABLED_CACHE_TTL_MS,
-      }
-    )();
+  static async listEnabledKillSwitches(): Promise<KillSwitchType[]> {
+    return KillSwitchResource.listEnabledKillSwitchesCached();
   }
 
-  static async isKillSwitchEnabledCached(
+  static async isKillSwitchEnabled(
     type: KillSwitchType
   ): Promise<boolean> {
     const enabledKillSwitches =
-      await KillSwitchResource.listEnabledKillSwitchesCached();
+      await KillSwitchResource.listEnabledKillSwitches();
     return enabledKillSwitches.includes(type);
   }
 

--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -74,9 +74,7 @@ vi.mock("@app/lib/api/workos/organization_primitives", async () => {
   };
 });
 
-const listEnabledKillSwitches = vi.hoisted(() =>
-  vi.fn().mockResolvedValue([])
-);
+const listEnabledKillSwitches = vi.hoisted(() => vi.fn().mockResolvedValue([]));
 vi.mock("@app/lib/resources/kill_switch_resource", () => ({
   KillSwitchResource: {
     listEnabledKillSwitches,
@@ -497,9 +495,7 @@ describe("WorkspaceResource", () => {
     });
 
     it("filters out anthropic when global_blacklist_anthropic is enabled", async () => {
-      listEnabledKillSwitches.mockResolvedValue([
-        "global_blacklist_anthropic",
-      ]);
+      listEnabledKillSwitches.mockResolvedValue(["global_blacklist_anthropic"]);
 
       const result =
         await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches([
@@ -512,9 +508,7 @@ describe("WorkspaceResource", () => {
     });
 
     it("filters out openai when global_blacklist_openai is enabled", async () => {
-      listEnabledKillSwitches.mockResolvedValue([
-        "global_blacklist_openai",
-      ]);
+      listEnabledKillSwitches.mockResolvedValue(["global_blacklist_openai"]);
 
       const result =
         await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches([
@@ -543,9 +537,7 @@ describe("WorkspaceResource", () => {
     });
 
     it("uses MODEL_PROVIDER_IDS and filters anthropic when whiteListedProviders is null and anthropic is blacklisted", async () => {
-      listEnabledKillSwitches.mockResolvedValue([
-        "global_blacklist_anthropic",
-      ]);
+      listEnabledKillSwitches.mockResolvedValue(["global_blacklist_anthropic"]);
 
       const result =
         await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches(
@@ -559,9 +551,7 @@ describe("WorkspaceResource", () => {
     });
 
     it("uses MODEL_PROVIDER_IDS and filters openai when whiteListedProviders is null and openai is blacklisted", async () => {
-      listEnabledKillSwitches.mockResolvedValue([
-        "global_blacklist_openai",
-      ]);
+      listEnabledKillSwitches.mockResolvedValue(["global_blacklist_openai"]);
 
       const result =
         await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches(

--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -74,12 +74,12 @@ vi.mock("@app/lib/api/workos/organization_primitives", async () => {
   };
 });
 
-const listEnabledKillSwitchesCached = vi.hoisted(() =>
+const listEnabledKillSwitches = vi.hoisted(() =>
   vi.fn().mockResolvedValue([])
 );
 vi.mock("@app/lib/resources/kill_switch_resource", () => ({
   KillSwitchResource: {
-    listEnabledKillSwitchesCached,
+    listEnabledKillSwitches,
   },
 }));
 
@@ -473,7 +473,7 @@ describe("WorkspaceResource", () => {
 
   describe("getWhiteListedProvidersFilteredByKillSwitches", () => {
     beforeEach(() => {
-      listEnabledKillSwitchesCached.mockResolvedValue([]);
+      listEnabledKillSwitches.mockResolvedValue([]);
     });
 
     it("returns whiteListedProviders when no kill switches are enabled", async () => {
@@ -497,7 +497,7 @@ describe("WorkspaceResource", () => {
     });
 
     it("filters out anthropic when global_blacklist_anthropic is enabled", async () => {
-      listEnabledKillSwitchesCached.mockResolvedValue([
+      listEnabledKillSwitches.mockResolvedValue([
         "global_blacklist_anthropic",
       ]);
 
@@ -512,7 +512,7 @@ describe("WorkspaceResource", () => {
     });
 
     it("filters out openai when global_blacklist_openai is enabled", async () => {
-      listEnabledKillSwitchesCached.mockResolvedValue([
+      listEnabledKillSwitches.mockResolvedValue([
         "global_blacklist_openai",
       ]);
 
@@ -527,7 +527,7 @@ describe("WorkspaceResource", () => {
     });
 
     it("filters out both anthropic and openai when both kill switches are enabled", async () => {
-      listEnabledKillSwitchesCached.mockResolvedValue([
+      listEnabledKillSwitches.mockResolvedValue([
         "global_blacklist_anthropic",
         "global_blacklist_openai",
       ]);
@@ -543,7 +543,7 @@ describe("WorkspaceResource", () => {
     });
 
     it("uses MODEL_PROVIDER_IDS and filters anthropic when whiteListedProviders is null and anthropic is blacklisted", async () => {
-      listEnabledKillSwitchesCached.mockResolvedValue([
+      listEnabledKillSwitches.mockResolvedValue([
         "global_blacklist_anthropic",
       ]);
 
@@ -559,7 +559,7 @@ describe("WorkspaceResource", () => {
     });
 
     it("uses MODEL_PROVIDER_IDS and filters openai when whiteListedProviders is null and openai is blacklisted", async () => {
-      listEnabledKillSwitchesCached.mockResolvedValue([
+      listEnabledKillSwitches.mockResolvedValue([
         "global_blacklist_openai",
       ]);
 

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -152,7 +152,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     whiteListedProviders: ModelProviderIdType[] | null
   ): Promise<ModelProviderIdType[] | null> {
     const enabledKillSwitches =
-      await KillSwitchResource.listEnabledKillSwitchesCached();
+      await KillSwitchResource.listEnabledKillSwitches();
 
     const isAnthropicBlacklisted = enabledKillSwitches.includes(
       "global_blacklist_anthropic"

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -322,7 +322,7 @@ async function handler(
       });
     case "POST":
       const isSaveAgentConfigurationsEnabled =
-        await KillSwitchResource.isKillSwitchEnabledCached(
+        await KillSwitchResource.isKillSwitchEnabled(
           "save_agent_configurations"
         );
       if (isSaveAgentConfigurationsEnabled) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -206,9 +206,7 @@ async function handler(
 
     case "PATCH": {
       const isSaveDataSourceViewsEnabled =
-        await KillSwitchResource.isKillSwitchEnabled(
-          "save_data_source_views"
-        );
+        await KillSwitchResource.isKillSwitchEnabled("save_data_source_views");
       if (isSaveDataSourceViewsEnabled) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -206,7 +206,7 @@ async function handler(
 
     case "PATCH": {
       const isSaveDataSourceViewsEnabled =
-        await KillSwitchResource.isKillSwitchEnabledCached(
+        await KillSwitchResource.isKillSwitchEnabled(
           "save_data_source_views"
         );
       if (isSaveDataSourceViewsEnabled) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -262,7 +262,7 @@ async function handler(
       }
 
       const isSaveDataSourceViewsEnabled =
-        await KillSwitchResource.isKillSwitchEnabledCached(
+        await KillSwitchResource.isKillSwitchEnabled(
           "save_data_source_views"
         );
       if (isSaveDataSourceViewsEnabled) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -262,9 +262,7 @@ async function handler(
       }
 
       const isSaveDataSourceViewsEnabled =
-        await KillSwitchResource.isKillSwitchEnabled(
-          "save_data_source_views"
-        );
+        await KillSwitchResource.isKillSwitchEnabled("save_data_source_views");
       if (isSaveDataSourceViewsEnabled) {
         return apiError(req, res, {
           status_code: 400,


### PR DESCRIPTION
## Description

- This PR fixes the caching invalidation in `KillSwitchResource` and refactors to align on existing patterns (`MembershipResource` notably).
- The initial issue comes from the fact that the callback returned by `invalidateCacheWithRedis` is never called, therefore the cache was actually never invalidated.
- The refactor makes the caching logic local to the resource, and does not expose it to callers.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
