### PR TITLE
Add CompactionMessageType and handle in all exhaustive switches

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -66,6 +66,7 @@ import {
   isGlobalAgentId,
   isGlobalAgentWithFeedback,
 } from "@app/types/assistant/assistant";
+import { isLightAgentMessageType } from "@app/types/assistant/conversation";
 import type {
   RichAgentMention,
   RichMention,
@@ -677,8 +678,8 @@ export function AgentMessage({
         // Update the message state from the backend
         methods.data.map((m) => {
           if (
-            m.sId === msg.message.sId &&
-            msg.message.type === "agent_message"
+            isLightAgentMessageType(msg.message) &&
+            m.sId === msg.message.sId
           ) {
             return makeInitialMessageStreamState(msg.message);
           }

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -66,7 +66,6 @@ import {
   isGlobalAgentId,
   isGlobalAgentWithFeedback,
 } from "@app/types/assistant/assistant";
-import { isUserMessageType } from "@app/types/assistant/conversation";
 import type {
   RichAgentMention,
   RichMention,
@@ -677,7 +676,10 @@ export function AgentMessage({
           await response.json();
         // Update the message state from the backend
         methods.data.map((m) => {
-          if (m.sId === msg.message.sId && !isUserMessageType(msg.message)) {
+          if (
+            m.sId === msg.message.sId &&
+            msg.message.type === "agent_message"
+          ) {
             return makeInitialMessageStreamState(msg.message);
           }
           return m;

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -5,6 +5,7 @@ import {
   isCompactionMessageType,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { stripMarkdown } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import type { Avatar } from "@dust-tt/sparkle";
@@ -12,7 +13,6 @@ import { ConversationListItem, ReplySection } from "@dust-tt/sparkle";
 import uniqBy from "lodash/uniqBy";
 import moment from "moment";
 import { useMemo } from "react";
-
 import { isHiddenMessage } from "../../types";
 import { isMessageUnread } from "../../utils";
 
@@ -69,12 +69,14 @@ export function SpaceConversationListItem({
         });
       } else if (isCompactionMessageType(message)) {
         // Nothing to do unless we want to show that the conversation was compacted.
-      } else {
+      } else if (message.type === "agent_message") {
         avatars.push({
           isRounded: false,
           name: "@" + (message.configuration.name ?? ""),
           visual: message.configuration.pictureUrl ?? "",
         });
+      } else {
+        assertNever(message);
       }
     }
     return uniqBy(avatars.reverse(), "visual");
@@ -112,9 +114,11 @@ export function SpaceConversationListItem({
       firstVisibleMessage.user?.image ??
       firstVisibleMessage.context?.profilePictureUrl ??
       undefined;
-  } else {
+  } else if (firstVisibleMessage.type === "agent_message") {
     creatorName = `@${firstVisibleMessage.configuration.name}`;
     creatorVisual = firstVisibleMessage.configuration.pictureUrl || undefined;
+  } else {
+    assertNever(firstVisibleMessage);
   }
 
   return (

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -27,8 +27,8 @@ function isVisibleMessage(
   return (
     m.visibility !== "deleted" &&
     !(isUserMessageTypeWithContentFragments(m) && isHiddenMessage(m)) &&
-    // Compaction messages are not "visible" in the sense of how it is used here (can never be the
-    // first message of a conversation).
+    // Compaction message will possibly be first messages of a conversation (forking) but they are
+    // not "visible" per se. `firstVisibleMessage` should null until a first user message is posted.
     !isCompactionMessageType(m)
   );
 }

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -6,7 +6,7 @@ import {
   isLightAgentMessageType,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { stripMarkdown } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import type { Avatar } from "@dust-tt/sparkle";
@@ -77,7 +77,7 @@ export function SpaceConversationListItem({
           visual: message.configuration.pictureUrl ?? "",
         });
       } else {
-        assertNever(message);
+        assertNeverAndIgnore(message);
       }
     }
     return uniqBy(avatars.reverse(), "visual");
@@ -119,7 +119,7 @@ export function SpaceConversationListItem({
     creatorName = `@${firstVisibleMessage.configuration.name}`;
     creatorVisual = firstVisibleMessage.configuration.pictureUrl || undefined;
   } else {
-    assertNever(firstVisibleMessage);
+    assertNeverAndIgnore(firstVisibleMessage);
   }
 
   return (

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -1,7 +1,10 @@
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { LightConversationType } from "@app/types/assistant/conversation";
-import { isUserMessageTypeWithContentFragments } from "@app/types/assistant/conversation";
+import {
+  isCompactionMessageType,
+  isUserMessageTypeWithContentFragments,
+} from "@app/types/assistant/conversation";
 import { stripMarkdown } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import type { Avatar } from "@dust-tt/sparkle";
@@ -23,7 +26,10 @@ function isVisibleMessage(
 ): boolean {
   return (
     m.visibility !== "deleted" &&
-    !(isUserMessageTypeWithContentFragments(m) && isHiddenMessage(m))
+    !(isUserMessageTypeWithContentFragments(m) && isHiddenMessage(m)) &&
+    // Compaction messages are not "visible" in the sense of how it is used here (can never be the
+    // first message of a conversation).
+    !isCompactionMessageType(m)
   );
 }
 
@@ -34,6 +40,9 @@ export function SpaceConversationListItem({
   const router = useAppRouter();
 
   const validMessages = conversation.content.filter((message) => {
+    if (isCompactionMessageType(message)) {
+      return false;
+    }
     return (
       (isUserMessageTypeWithContentFragments(message) &&
         message.visibility === "visible" &&
@@ -58,6 +67,8 @@ export function SpaceConversationListItem({
           visual:
             message.user?.image ?? message.context?.profilePictureUrl ?? "",
         });
+      } else if (isCompactionMessageType(message)) {
+        // Nothing to do unless we want to show that the conversation was compacted.
       } else {
         avatars.push({
           isRounded: false,
@@ -75,7 +86,7 @@ export function SpaceConversationListItem({
     }).length;
   }, [validMessages, conversation.lastReadMs]);
 
-  if (!firstVisibleMessage) {
+  if (!firstVisibleMessage || isCompactionMessageType(firstVisibleMessage)) {
     return null;
   }
 

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -3,6 +3,7 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import type { LightConversationType } from "@app/types/assistant/conversation";
 import {
   isCompactionMessageType,
+  isLightAgentMessageType,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -69,7 +70,7 @@ export function SpaceConversationListItem({
         });
       } else if (isCompactionMessageType(message)) {
         // Nothing to do unless we want to show that the conversation was compacted.
-      } else if (message.type === "agent_message") {
+      } else if (isLightAgentMessageType(message)) {
         avatars.push({
           isRounded: false,
           name: "@" + (message.configuration.name ?? ""),
@@ -114,7 +115,7 @@ export function SpaceConversationListItem({
       firstVisibleMessage.user?.image ??
       firstVisibleMessage.context?.profilePictureUrl ??
       undefined;
-  } else if (firstVisibleMessage.type === "agent_message") {
+  } else if (isLightAgentMessageType(firstVisibleMessage)) {
     creatorName = `@${firstVisibleMessage.configuration.name}`;
     creatorVisual = firstVisibleMessage.configuration.pictureUrl || undefined;
   } else {

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -163,7 +163,8 @@ export const isHandoverUserMessage = (msg: VirtuosoMessage): boolean =>
 
 export const isAgentMessageWithStreaming = (
   msg: VirtuosoMessage
-): msg is AgentMessageWithStreaming => "streaming" in msg;
+): msg is AgentMessageWithStreaming =>
+  "streaming" in msg && msg.type === "agent_message";
 
 export const getMessageDate = (msg: VirtuosoMessage): Date =>
   new Date(msg.created);

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -16,6 +16,7 @@ import type {
   UserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
 import {
+  isCompactionMessageType,
   isLightAgentMessageWithActionsType,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
@@ -194,8 +195,11 @@ export const isSidekickBootstrapMessage = (
 export const convertLightMessageTypeToVirtuosoMessages = (
   messages: LightMessageType[]
 ) =>
-  messages.map((message) =>
-    isUserMessageTypeWithContentFragments(message)
-      ? message
-      : makeInitialMessageStreamState(message)
-  );
+  messages
+    // TODO(compaction): Add support for compaction messages in the UI instead of filtering.
+    .filter((message) => !isCompactionMessageType(message))
+    .map((message) =>
+      isUserMessageTypeWithContentFragments(message)
+        ? message
+        : makeInitialMessageStreamState(message)
+    );

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -1,6 +1,7 @@
 import { removeDiacritics, subFilter } from "@app/lib/utils";
 import type {
   AgentMessageType,
+  CompactionMessageType,
   ConversationWithoutContentType,
   LightAgentMessageType,
   UserMessageType,
@@ -146,7 +147,8 @@ export function isMessageUnread(
     | AgentMessageType
     | ContentFragmentType
     | LightAgentMessageType
-    | UserMessageTypeWithContentFragments,
+    | UserMessageTypeWithContentFragments
+    | CompactionMessageType,
   lastReadMs: number | null
 ): boolean {
   if (lastReadMs === null) {

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -6,7 +6,10 @@ import { classNames } from "@app/lib/utils";
 import { usePokeConversation } from "@app/poke/swr";
 import { usePokeAgentConfigurations } from "@app/poke/swr/agent_configurations";
 import { usePokeConversationConfig } from "@app/poke/swr/conversation_config";
-import type { UserMessageType } from "@app/types/assistant/conversation";
+import type {
+  CompactionMessageType,
+  UserMessageType,
+} from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isFileContentFragment } from "@app/types/content_fragment";
 import type { PokeAgentMessageType } from "@app/types/poke";
@@ -278,7 +281,7 @@ const ContentFragmentView = ({ message }: ContentFragmentViewProps) => {
     <div className="w-full text-sm">
       <div className="font-bold">[content_fragment] {message.title}</div>
       <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        date : {new Date(message.created).toLocaleString()}
+        date : {new Date(message.created).toLocaleString()} {" • "}
         version :{message.version} {" • "}
         textBytes :{isFileContentFragment(message) ? message.textBytes : "N/A"}
       </div>
@@ -301,6 +304,23 @@ const ContentFragmentView = ({ message }: ContentFragmentViewProps) => {
       >
         [textUrl]
       </a>
+    </div>
+  );
+};
+
+interface CompactionMessageViewProps {
+  message: CompactionMessageType;
+}
+
+const CompactionMessageView = ({ message }: CompactionMessageViewProps) => {
+  return (
+    <div className="w-full text-sm">
+      <div className="font-bold">[compaction]</div>
+      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        date : {new Date(message.created).toLocaleString()} {" • "}
+        version :{message.version}
+      </div>
+      <Markdown content={message.content || ""} />
     </div>
   );
 };
@@ -633,6 +653,14 @@ export function ConversationPage() {
                       case "content_fragment": {
                         return (
                           <ContentFragmentView
+                            message={m}
+                            key={`message-${i}-${j}`}
+                          />
+                        );
+                      }
+                      case "compaction_message": {
+                        return (
+                          <CompactionMessageView
                             message={m}
                             key={`message-${i}-${j}`}
                           />

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -50,6 +50,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import {
   isAgentMessageType,
+  isCompactionMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
 import { isAgentMention } from "@app/types/assistant/mentions";
@@ -1562,6 +1563,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
         continue;
       }
       const lastVersion = messageVersions[messageVersions.length - 1];
+      if (isCompactionMessageType(lastVersion)) {
+        continue;
+      }
       flatMessages.push(lastVersion);
     }
 

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -1,8 +1,8 @@
-import type {ServerSideMCPServerConfigurationType} from "@app/lib/actions/mcp";
-import {MCPError} from "@app/lib/actions/mcp_errors";
-import {isToolWithKnowledge} from "@app/lib/actions/mcp_helper";
-import type {ToolHandlers} from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import {buildTools} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { isToolWithKnowledge } from "@app/lib/actions/mcp_helper";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   MAX_PENDING_INSTRUCTIONS_SUGGESTIONS,
   MAX_PENDING_KNOWLEDGE_SUGGESTIONS,
@@ -16,34 +16,34 @@ import {
   type SkillsSuggestionSchema,
   type ToolsSuggestionSchema,
 } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
-import {getAgentConfigurationIdFromContext} from "@app/lib/api/actions/servers/agent_sidekick_helpers";
-import {pruneConflictingInstructionSuggestions} from "@app/lib/api/assistant/agent_suggestion_pruning";
-import {getAgentConfiguration} from "@app/lib/api/assistant/configuration/agent";
-import {getAgentConfigurationsForView} from "@app/lib/api/assistant/configuration/views";
-import {getConversation} from "@app/lib/api/assistant/conversation/fetch";
-import {getShrinkWrappedConversation} from "@app/lib/api/assistant/conversation/shrink_wrap";
-import type {AgentMessageFeedbackWithMetadataType} from "@app/lib/api/assistant/feedback";
-import {getAgentFeedbacks} from "@app/lib/api/assistant/feedback";
-import {fetchAgentOverview} from "@app/lib/api/assistant/observability/overview";
-import {buildAgentAnalyticsBaseQuery} from "@app/lib/api/assistant/observability/utils";
+import { getAgentConfigurationIdFromContext } from "@app/lib/api/actions/servers/agent_sidekick_helpers";
+import { pruneConflictingInstructionSuggestions } from "@app/lib/api/assistant/agent_suggestion_pruning";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
+import type { AgentMessageFeedbackWithMetadataType } from "@app/lib/api/assistant/feedback";
+import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
+import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import {
   formatTemplatesAsText,
   getTemplatesForSidekick,
 } from "@app/lib/api/assistant/sidekick_templates";
 import config from "@app/lib/api/config";
-import {getLlmCredentials} from "@app/lib/api/provider_credentials";
-import type {Authenticator} from "@app/lib/auth";
-import {getDisplayNameForDataSource} from "@app/lib/data_sources";
-import {AgentSuggestionResource} from "@app/lib/resources/agent_suggestion_resource";
-import type {ConversationResource} from "@app/lib/resources/conversation_resource";
-import {DataSourceViewResource} from "@app/lib/resources/data_source_view_resource";
-import {MCPServerViewResource} from "@app/lib/resources/mcp_server_view_resource";
-import {SkillResource} from "@app/lib/resources/skill/skill_resource";
-import {SpaceResource} from "@app/lib/resources/space_resource";
-import {TemplateResource} from "@app/lib/resources/template_resource";
-import {concurrentExecutor} from "@app/lib/utils/async_utils";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import type { Authenticator } from "@app/lib/auth";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { TemplateResource } from "@app/lib/resources/template_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type {DataSourceViewCategory} from "@app/types/api/public/spaces";
+import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
 import type {
   AgentMessageType,
   CompactionMessageType,
@@ -54,18 +54,18 @@ import {
   isCompactionMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
-import {isAgentMention} from "@app/types/assistant/mentions";
-import {isModelProviderId} from "@app/types/assistant/models/providers";
-import type {ContentFragmentType} from "@app/types/content_fragment";
-import {isContentFragmentType} from "@app/types/content_fragment";
-import {DATA_SOURCE_NODE_ID} from "@app/types/core/content_node";
-import {CoreAPI} from "@app/types/core/core_api";
-import {isJobType} from "@app/types/job_type";
-import type {Result} from "@app/types/shared/result";
-import {Err, Ok} from "@app/types/shared/result";
-import {normalizeError} from "@app/types/shared/utils/error_utils";
-import {isString, removeNulls} from "@app/types/shared/utils/general";
-import type {SpaceType} from "@app/types/space";
+import { isAgentMention } from "@app/types/assistant/mentions";
+import { isModelProviderId } from "@app/types/assistant/models/providers";
+import type { ContentFragmentType } from "@app/types/content_fragment";
+import { isContentFragmentType } from "@app/types/content_fragment";
+import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
+import { CoreAPI } from "@app/types/core/core_api";
+import { isJobType } from "@app/types/job_type";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString, removeNulls } from "@app/types/shared/utils/general";
+import type { SpaceType } from "@app/types/space";
 import type {
   AgentSuggestionSource,
   AgentSuggestionState,
@@ -80,7 +80,7 @@ import {
   isSubAgentSuggestion,
   isToolsSuggestion,
 } from "@app/types/suggestions/agent_suggestion";
-import {JSDOM} from "jsdom";
+import { JSDOM } from "jsdom";
 
 const SIDEKICK_KNOWLEDGE_CATEGORIES: DataSourceViewCategory[] = [
   "managed",
@@ -141,7 +141,7 @@ function canAddPendingSuggestions({
   kind: LimitedSuggestionKind;
   newPendingCount: number;
   currentPendingCount: number;
-}): {allowed: true} | {allowed: false; errorMessage: string} {
+}): { allowed: true } | { allowed: false; errorMessage: string } {
   const maxAllowed = getMaxPendingSuggestions(kind);
 
   const totalAfterAddition = currentPendingCount + newPendingCount;
@@ -159,7 +159,7 @@ function canAddPendingSuggestions({
     };
   }
 
-  return {allowed: true};
+  return { allowed: true };
 }
 
 /**
@@ -216,7 +216,7 @@ export async function createInstructionSuggestions({
   source: AgentSuggestionSource;
   conversation?: ConversationResource;
 }): Promise<
-  Result<{sId: string; kind: string; targetBlockId: string}[], string>
+  Result<{ sId: string; kind: string; targetBlockId: string }[], string>
 > {
   // Reject batches where multiple suggestions target the same block.
   const targetBlockIds = suggestions.map((s) => s.targetBlockId);
@@ -224,7 +224,7 @@ export async function createInstructionSuggestions({
   if (uniqueTargetBlockIds.size !== targetBlockIds.length) {
     return new Err(
       "Multiple suggestions target the same block ID. Use a single suggestion per block." +
-      `For full rewrites, target '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' instead.`
+        `For full rewrites, target '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' instead.`
     );
   }
 
@@ -233,7 +233,7 @@ export async function createInstructionSuggestions({
     await AgentSuggestionResource.listByAgentConfigurationId(
       auth,
       agentConfigurationId,
-      {states: ["pending"], kind: "instructions"}
+      { states: ["pending"], kind: "instructions" }
     );
 
   const limitCheck = canAddPendingSuggestions({
@@ -263,7 +263,7 @@ export async function createInstructionSuggestions({
       if (blockCount > 1) {
         return new Err(
           `Suggestion for block "${suggestion.targetBlockId}" contains ${blockCount} top-level elements but replace only supports 1. ` +
-          `Keep it within a single tag, or use targetBlockId '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' if the change requires multiple blocks.`
+            `Keep it within a single tag, or use targetBlockId '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' if the change requires multiple blocks.`
         );
       }
     }
@@ -276,7 +276,7 @@ export async function createInstructionSuggestions({
   }[] = [];
 
   for (const suggestion of suggestions) {
-    const {analysis, ...suggestionData} = suggestion;
+    const { analysis, ...suggestionData } = suggestion;
     const created = await AgentSuggestionResource.createSuggestionForAgent(
       auth,
       agentConfiguration,
@@ -326,7 +326,7 @@ export async function createToolsSuggestions({
   suggestions: ToolsSuggestionInput[];
   source: AgentSuggestionSource;
   conversation?: ConversationResource;
-}): Promise<Result<{sId: string; kind: string}[], string>> {
+}): Promise<Result<{ sId: string; kind: string }[], string>> {
   // Reject batches where multiple suggestions target the same tool.
   const suggestionToolIds = suggestions.map((s) => s.toolId);
   const uniqueToolIds = new Set(suggestionToolIds);
@@ -350,7 +350,7 @@ export async function createToolsSuggestions({
   if (missingToolIds.length > 0) {
     return new Err(
       `The following tool ID(s) are invalid or not accessible: ${missingToolIds.join(", ")}. ` +
-      `Check <workspace_context> for valid tool IDs.`
+        `Check <workspace_context> for valid tool IDs.`
     );
   }
 
@@ -365,7 +365,7 @@ export async function createToolsSuggestions({
       .join(", ");
     return new Err(
       `The following ID(s) are knowledge tools, not regular tools: ${knowledgeToolNames}. ` +
-      `Use \`suggest_knowledge\` instead of \`suggest_tools\` for data source, table, or data warehouse tools.`
+        `Use \`suggest_knowledge\` instead of \`suggest_tools\` for data source, table, or data warehouse tools.`
     );
   }
 
@@ -374,7 +374,7 @@ export async function createToolsSuggestions({
     await AgentSuggestionResource.listByAgentConfigurationId(
       auth,
       agentConfigurationId,
-      {states: ["pending"], kind: "tools"}
+      { states: ["pending"], kind: "tools" }
     );
 
   const remainingPending = await markDuplicateSuggestionsAsOutdated(
@@ -402,10 +402,10 @@ export async function createToolsSuggestions({
     return new Err(`Agent configuration not found: ${agentConfigurationId}`);
   }
 
-  const createdSuggestions: {sId: string; kind: string}[] = [];
+  const createdSuggestions: { sId: string; kind: string }[] = [];
 
-  for (const {action, toolId, analysis} of suggestions) {
-    const suggestion: ToolsSuggestionType = {action, toolId};
+  for (const { action, toolId, analysis } of suggestions) {
+    const suggestion: ToolsSuggestionType = { action, toolId };
     const created = await AgentSuggestionResource.createSuggestionForAgent(
       auth,
       agentConfiguration,
@@ -419,7 +419,7 @@ export async function createToolsSuggestions({
       }
     );
 
-    createdSuggestions.push({sId: created.sId, kind: created.kind});
+    createdSuggestions.push({ sId: created.sId, kind: created.kind });
   }
 
   return new Ok(createdSuggestions);
@@ -445,7 +445,7 @@ export async function createSkillsSuggestions({
   suggestions: SkillsSuggestionInput[];
   source: AgentSuggestionSource;
   conversation?: ConversationResource;
-}): Promise<Result<{sId: string; kind: string}[], string>> {
+}): Promise<Result<{ sId: string; kind: string }[], string>> {
   // Reject batches where multiple suggestions target the same skill.
   const suggestionSkillIds = suggestions.map((s) => s.skillId);
   const uniqueSkillIds = new Set(suggestionSkillIds);
@@ -471,7 +471,7 @@ export async function createSkillsSuggestions({
   if (missingSkillIds.length > 0) {
     return new Err(
       `The following skill ID(s) are invalid or not accessible: ${missingSkillIds.join(", ")}. ` +
-      `Check <workspace_context> for valid skill IDs.`
+        `Check <workspace_context> for valid skill IDs.`
     );
   }
 
@@ -480,7 +480,7 @@ export async function createSkillsSuggestions({
     await AgentSuggestionResource.listByAgentConfigurationId(
       auth,
       agentConfigurationId,
-      {states: ["pending"], kind: "skills"}
+      { states: ["pending"], kind: "skills" }
     );
 
   const remainingPending = await markDuplicateSuggestionsAsOutdated(
@@ -509,15 +509,15 @@ export async function createSkillsSuggestions({
     return new Err(`Agent configuration not found: ${agentConfigurationId}`);
   }
 
-  const createdSuggestions: {sId: string; kind: string}[] = [];
+  const createdSuggestions: { sId: string; kind: string }[] = [];
 
-  for (const {action, skillId, analysis} of suggestions) {
+  for (const { action, skillId, analysis } of suggestions) {
     const created = await AgentSuggestionResource.createSuggestionForAgent(
       auth,
       agentConfiguration,
       {
         kind: "skills",
-        suggestion: {action, skillId},
+        suggestion: { action, skillId },
         analysis: analysis ?? null,
         state: "pending",
         source,
@@ -525,7 +525,7 @@ export async function createSkillsSuggestions({
       }
     );
 
-    createdSuggestions.push({sId: created.sId, kind: created.kind});
+    createdSuggestions.push({ sId: created.sId, kind: created.kind });
   }
 
   return new Ok(createdSuggestions);
@@ -541,7 +541,7 @@ import {
   listAvailableSkills,
   listAvailableTools,
 } from "@app/lib/api/assistant/workspace_capabilities";
-import type {z} from "zod";
+import type { z } from "zod";
 
 /**
  * Lists all knowledge data source views across all spaces the user has access to.
@@ -559,7 +559,7 @@ async function listAllKnowledgeDataSourceViews(
 }
 
 const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
-  get_available_knowledge: async ({spaceId, category}, {auth}) => {
+  get_available_knowledge: async ({ spaceId, category }, { auth }) => {
     // Get all spaces the user is a member of.
     let spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
 
@@ -627,7 +627,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
           categories: categoriesData,
         } satisfies KnowledgeSpace;
       },
-      {concurrency: 8}
+      { concurrency: 8 }
     );
 
     // Filter out null results (spaces with no data sources).
@@ -659,7 +659,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_models: async ({providerId}, {auth}) => {
+  get_available_models: async ({ providerId }, { auth }) => {
     let models = await getAvailableModelsForWorkspace(auth);
 
     if (providerId) {
@@ -681,7 +681,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_skills: async (_, {auth}) => {
+  get_available_skills: async (_, { auth }) => {
     const [skillList, toolList] = await Promise.all([
       listAvailableSkills(auth),
       listAvailableTools(auth),
@@ -695,7 +695,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_tools: async (_, {auth}) => {
+  get_available_tools: async (_, { auth }) => {
     const toolList = await listAvailableTools(auth);
 
     return new Ok([
@@ -706,7 +706,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_agents: async ({limit, agentPrefix}, {auth}) => {
+  get_available_agents: async ({ limit, agentPrefix }, { auth }) => {
     const agents = await getAgentConfigurationsForView({
       auth,
       agentsGetView: "list",
@@ -737,7 +737,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  inspect_available_agent: async ({agentId}, {auth}) => {
+  inspect_available_agent: async ({ agentId }, { auth }) => {
     const agentConfiguration = await getAgentConfiguration(auth, {
       agentId,
       variant: "full",
@@ -782,8 +782,8 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
   },
 
   get_agent_feedback: async (
-    {limit, filter, latestVersionOnly},
-    {auth, agentLoopContext}
+    { limit, filter, latestVersionOnly },
+    { auth, agentLoopContext }
   ) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
@@ -792,7 +792,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -825,7 +825,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
         orderDirection: "desc",
       },
       filter: filter ?? "active",
-      ...(latestVersionOnlyWithDefault ? {version: currentVersion} : {}),
+      ...(latestVersionOnlyWithDefault ? { version: currentVersion } : {}),
     });
 
     if (feedbacksRes.isErr()) {
@@ -876,7 +876,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
             current_version_feedback: currentVersionFeedbackList,
             ...(latestVersionOnlyWithDefault
               ? {}
-              : {previous_versions_feedback: previousVersionsFeedbackList}),
+              : { previous_versions_feedback: previousVersionsFeedbackList }),
           },
           null,
           2
@@ -885,7 +885,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_agent_insights: async ({days}, {auth, agentLoopContext}) => {
+  get_agent_insights: async ({ days }, { auth, agentLoopContext }) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -893,7 +893,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -927,7 +927,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to fetch agent insights: ${overviewResult.error.message}`,
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -961,7 +961,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
   },
 
   // Suggestion handlers
-  suggest_prompt_edits: async (params, {auth, agentLoopContext}) => {
+  suggest_prompt_edits: async (params, { auth, agentLoopContext }) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -969,7 +969,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -983,7 +983,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       });
 
       if (result.isErr()) {
-        return new Err(new MCPError(result.error, {tracked: false}));
+        return new Err(new MCPError(result.error, { tracked: false }));
       }
 
       const directives = result.value.map(
@@ -1000,13 +1000,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create suggestion: ${normalizeError(error).message}`,
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
   },
 
-  suggest_tools: async (params, {auth, agentLoopContext}) => {
+  suggest_tools: async (params, { auth, agentLoopContext }) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -1014,7 +1014,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -1028,7 +1028,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       });
 
       if (result.isErr()) {
-        return new Err(new MCPError(result.error, {tracked: false}));
+        return new Err(new MCPError(result.error, { tracked: false }));
       }
 
       const directives = result.value.map(
@@ -1045,13 +1045,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create suggestion: ${normalizeError(error).message}`,
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
   },
 
-  suggest_sub_agent: async (params, {auth, agentLoopContext}) => {
+  suggest_sub_agent: async (params, { auth, agentLoopContext }) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -1059,13 +1059,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
 
     // Validate that the sub-agent exists and is accessible.
-    const {action, subAgentId} = params;
+    const { action, subAgentId } = params;
     const subAgentConfiguration = await getAgentConfiguration(auth, {
       agentId: subAgentId,
       variant: "light",
@@ -1075,7 +1075,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `The sub-agent ID "${subAgentId}" is invalid or not accessible.`,
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -1091,7 +1091,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "The run_agent server is not available in this workspace.",
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -1101,7 +1101,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       await AgentSuggestionResource.listByAgentConfigurationId(
         auth,
         agentConfigurationId,
-        {states: ["pending"], kind: "sub_agent"}
+        { states: ["pending"], kind: "sub_agent" }
       );
 
     const remainingPending = await markDuplicateSuggestionsAsOutdated(
@@ -1119,7 +1119,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       currentPendingCount: remainingPending.length,
     });
     if (!limitCheck.allowed) {
-      return new Err(new MCPError(limitCheck.errorMessage, {tracked: false}));
+      return new Err(new MCPError(limitCheck.errorMessage, { tracked: false }));
     }
 
     // Fetch the latest version of the agent configuration.
@@ -1167,13 +1167,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create suggestion: ${normalizeError(error).message}`,
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
   },
 
-  suggest_skills: async (params, {auth, agentLoopContext}) => {
+  suggest_skills: async (params, { auth, agentLoopContext }) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -1181,7 +1181,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -1195,7 +1195,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       });
 
       if (result.isErr()) {
-        return new Err(new MCPError(result.error, {tracked: false}));
+        return new Err(new MCPError(result.error, { tracked: false }));
       }
 
       const directives = result.value.map(
@@ -1212,22 +1212,22 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create suggestion: ${normalizeError(error).message}`,
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
   },
 
-  suggest_model: async (params, {auth, agentLoopContext}) => {
+  suggest_model: async (params, { auth, agentLoopContext }) => {
     const availableModels = await getAvailableModelsForWorkspace(auth);
     const availableModelIds = availableModels.map((m) => m.modelId);
 
-    const {modelId} = params.suggestion;
+    const { modelId } = params.suggestion;
     if (!availableModelIds.includes(modelId)) {
       return new Err(
         new MCPError(
           `Invalid model ID: ${modelId}. Check <workspace_context> for valid model IDs.`,
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -1239,7 +1239,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -1281,13 +1281,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create suggestion: ${normalizeError(error).message}`,
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
   },
 
-  search_knowledge: async ({query, topK}, {auth}) => {
+  search_knowledge: async ({ query, topK }, { auth }) => {
     const dataSourceViews = await listAllKnowledgeDataSourceViews(auth);
 
     if (dataSourceViews.length === 0) {
@@ -1359,12 +1359,12 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: JSON.stringify({matches}, null, 2),
+        text: JSON.stringify({ matches }, null, 2),
       },
     ]);
   },
 
-  suggest_knowledge: async (params, {auth, agentLoopContext}) => {
+  suggest_knowledge: async (params, { auth, agentLoopContext }) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -1372,21 +1372,21 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
 
     // Validate that the data source view exists and is accessible.
-    const {action, method, dataSourceViewId, description} = params.suggestion;
+    const { action, method, dataSourceViewId, description } = params.suggestion;
     const view = await DataSourceViewResource.fetchById(auth, dataSourceViewId);
 
     if (!view) {
       return new Err(
         new MCPError(
           `The data source view ID "${dataSourceViewId}" is invalid or not accessible. ` +
-          `Use get_available_knowledge or search_knowledge to find valid data source views.`,
-          {tracked: false}
+            `Use get_available_knowledge or search_knowledge to find valid data source views.`,
+          { tracked: false }
         )
       );
     }
@@ -1396,7 +1396,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       await AgentSuggestionResource.listByAgentConfigurationId(
         auth,
         agentConfigurationId,
-        {states: ["pending"], kind: "knowledge"}
+        { states: ["pending"], kind: "knowledge" }
       );
 
     const remainingPending = await markDuplicateSuggestionsAsOutdated(
@@ -1414,7 +1414,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       currentPendingCount: remainingPending.length,
     });
     if (!limitCheck.allowed) {
-      return new Err(new MCPError(limitCheck.errorMessage, {tracked: false}));
+      return new Err(new MCPError(limitCheck.errorMessage, { tracked: false }));
     }
 
     // Fetch the latest version of the agent configuration.
@@ -1462,13 +1462,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create suggestion: ${normalizeError(error).message}`,
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
   },
 
-  list_suggestions: async (params, {auth, agentLoopContext}) => {
+  list_suggestions: async (params, { auth, agentLoopContext }) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -1476,7 +1476,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -1511,8 +1511,8 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
   },
 
   inspect_conversation: async (
-    {conversationId, fromMessageIndex, toMessageIndex},
-    {auth}
+    { conversationId, fromMessageIndex, toMessageIndex },
+    { auth }
   ) => {
     const conversationRes = await getShrinkWrappedConversation(auth, {
       conversationId,
@@ -1524,7 +1524,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Conversation not found or not accessible: ${conversationId}`,
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -1532,7 +1532,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     return new Ok([conversationRes.value]);
   },
 
-  inspect_message: async ({conversationId, messageId}, extra) => {
+  inspect_message: async ({ conversationId, messageId }, extra) => {
     const auth = extra.auth;
     if (!auth) {
       return new Err(new MCPError("Authentication required"));
@@ -1543,7 +1543,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Conversation not found or not accessible: ${conversationId}`,
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -1551,7 +1551,11 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     const conversation = conversationRes.value;
 
     // Flatten to last version of each message, find the target by sId.
-    let foundMessage: UserMessageType | AgentMessageType | CompactionMessageType | null = null;
+    let foundMessage:
+      | UserMessageType
+      | AgentMessageType
+      | CompactionMessageType
+      | null = null;
     let foundIndex = -1;
     const flatMessages: (
       | UserMessageType
@@ -1571,7 +1575,9 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     for (let i = 0; i < flatMessages.length; i++) {
       const msg = flatMessages[i];
       if (
-        (isUserMessageType(msg) || isAgentMessageType(msg) || isCompactionMessageType(msg)) &&
+        (isUserMessageType(msg) ||
+          isAgentMessageType(msg) ||
+          isCompactionMessageType(msg)) &&
         msg.sId === messageId
       ) {
         foundMessage = msg;
@@ -1606,7 +1612,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Message not found: ${messageId} in conversation ${conversationId}`,
-          {tracked: false}
+          { tracked: false }
         )
       );
     }
@@ -1724,7 +1730,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
 
     // Find agents that this message handed off to.
-    const handoffTargets: {agentId: string; agentName: string}[] = [];
+    const handoffTargets: { agentId: string; agentName: string }[] = [];
     for (const msg of flatMessages) {
       if (
         isAgentMessageType(msg) &&
@@ -1761,8 +1767,8 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  update_suggestions_state: async (params, {auth}) => {
-    const {suggestions: suggestionUpdates} = params;
+  update_suggestions_state: async (params, { auth }) => {
+    const { suggestions: suggestionUpdates } = params;
 
     const suggestionIds = suggestionUpdates.map((s) => s.suggestionId);
     const suggestions = await AgentSuggestionResource.fetchByIds(
@@ -1783,7 +1789,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       AgentSuggestionResource[]
     >();
 
-    for (const {suggestionId, state} of suggestionUpdates) {
+    for (const { suggestionId, state } of suggestionUpdates) {
       const suggestion = suggestionsById.get(suggestionId);
       if (!suggestion) {
         results.push({
@@ -1804,7 +1810,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       try {
         await AgentSuggestionResource.bulkUpdateState(auth, group, state);
         results.push(
-          ...group.map((s) => ({success: true, suggestionId: s.sId}))
+          ...group.map((s) => ({ success: true, suggestionId: s.sId }))
         );
       } catch (error) {
         const msg = normalizeError(error).message;
@@ -1821,12 +1827,12 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: JSON.stringify({results}, null, 2),
+        text: JSON.stringify({ results }, null, 2),
       },
     ]);
   },
 
-  search_agent_templates: async ({jobType, query}, {auth}) => {
+  search_agent_templates: async ({ jobType, query }, { auth }) => {
     const res = await getTemplatesForSidekick({
       auth,
       jobType: jobType && isJobType(jobType) ? jobType : undefined,
@@ -1834,7 +1840,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       limit: 10,
     });
     if (res.isErr()) {
-      return new Err(new MCPError(res.error.message, {tracked: false}));
+      return new Err(new MCPError(res.error.message, { tracked: false }));
     }
     return new Ok([
       {
@@ -1844,7 +1850,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_agent_template: async ({templateId}, _extra) => {
+  get_agent_template: async ({ templateId }, _extra) => {
     const template = await TemplateResource.fetchByExternalId(templateId);
 
     if (!template) {

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -1,8 +1,8 @@
-import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
-import { MCPError } from "@app/lib/actions/mcp_errors";
-import { isToolWithKnowledge } from "@app/lib/actions/mcp_helper";
-import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {ServerSideMCPServerConfigurationType} from "@app/lib/actions/mcp";
+import {MCPError} from "@app/lib/actions/mcp_errors";
+import {isToolWithKnowledge} from "@app/lib/actions/mcp_helper";
+import type {ToolHandlers} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {buildTools} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   MAX_PENDING_INSTRUCTIONS_SUGGESTIONS,
   MAX_PENDING_KNOWLEDGE_SUGGESTIONS,
@@ -16,36 +16,37 @@ import {
   type SkillsSuggestionSchema,
   type ToolsSuggestionSchema,
 } from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
-import { getAgentConfigurationIdFromContext } from "@app/lib/api/actions/servers/agent_sidekick_helpers";
-import { pruneConflictingInstructionSuggestions } from "@app/lib/api/assistant/agent_suggestion_pruning";
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { getShrinkWrappedConversation } from "@app/lib/api/assistant/conversation/shrink_wrap";
-import type { AgentMessageFeedbackWithMetadataType } from "@app/lib/api/assistant/feedback";
-import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
-import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import {getAgentConfigurationIdFromContext} from "@app/lib/api/actions/servers/agent_sidekick_helpers";
+import {pruneConflictingInstructionSuggestions} from "@app/lib/api/assistant/agent_suggestion_pruning";
+import {getAgentConfiguration} from "@app/lib/api/assistant/configuration/agent";
+import {getAgentConfigurationsForView} from "@app/lib/api/assistant/configuration/views";
+import {getConversation} from "@app/lib/api/assistant/conversation/fetch";
+import {getShrinkWrappedConversation} from "@app/lib/api/assistant/conversation/shrink_wrap";
+import type {AgentMessageFeedbackWithMetadataType} from "@app/lib/api/assistant/feedback";
+import {getAgentFeedbacks} from "@app/lib/api/assistant/feedback";
+import {fetchAgentOverview} from "@app/lib/api/assistant/observability/overview";
+import {buildAgentAnalyticsBaseQuery} from "@app/lib/api/assistant/observability/utils";
 import {
   formatTemplatesAsText,
   getTemplatesForSidekick,
 } from "@app/lib/api/assistant/sidekick_templates";
 import config from "@app/lib/api/config";
-import { getLlmCredentials } from "@app/lib/api/provider_credentials";
-import type { Authenticator } from "@app/lib/auth";
-import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
-import type { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
-import { TemplateResource } from "@app/lib/resources/template_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import {getLlmCredentials} from "@app/lib/api/provider_credentials";
+import type {Authenticator} from "@app/lib/auth";
+import {getDisplayNameForDataSource} from "@app/lib/data_sources";
+import {AgentSuggestionResource} from "@app/lib/resources/agent_suggestion_resource";
+import type {ConversationResource} from "@app/lib/resources/conversation_resource";
+import {DataSourceViewResource} from "@app/lib/resources/data_source_view_resource";
+import {MCPServerViewResource} from "@app/lib/resources/mcp_server_view_resource";
+import {SkillResource} from "@app/lib/resources/skill/skill_resource";
+import {SpaceResource} from "@app/lib/resources/space_resource";
+import {TemplateResource} from "@app/lib/resources/template_resource";
+import {concurrentExecutor} from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
+import type {DataSourceViewCategory} from "@app/types/api/public/spaces";
 import type {
   AgentMessageType,
+  CompactionMessageType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
 import {
@@ -53,18 +54,18 @@ import {
   isCompactionMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
-import { isAgentMention } from "@app/types/assistant/mentions";
-import { isModelProviderId } from "@app/types/assistant/models/providers";
-import type { ContentFragmentType } from "@app/types/content_fragment";
-import { isContentFragmentType } from "@app/types/content_fragment";
-import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
-import { CoreAPI } from "@app/types/core/core_api";
-import { isJobType } from "@app/types/job_type";
-import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { isString, removeNulls } from "@app/types/shared/utils/general";
-import type { SpaceType } from "@app/types/space";
+import {isAgentMention} from "@app/types/assistant/mentions";
+import {isModelProviderId} from "@app/types/assistant/models/providers";
+import type {ContentFragmentType} from "@app/types/content_fragment";
+import {isContentFragmentType} from "@app/types/content_fragment";
+import {DATA_SOURCE_NODE_ID} from "@app/types/core/content_node";
+import {CoreAPI} from "@app/types/core/core_api";
+import {isJobType} from "@app/types/job_type";
+import type {Result} from "@app/types/shared/result";
+import {Err, Ok} from "@app/types/shared/result";
+import {normalizeError} from "@app/types/shared/utils/error_utils";
+import {isString, removeNulls} from "@app/types/shared/utils/general";
+import type {SpaceType} from "@app/types/space";
 import type {
   AgentSuggestionSource,
   AgentSuggestionState,
@@ -79,7 +80,7 @@ import {
   isSubAgentSuggestion,
   isToolsSuggestion,
 } from "@app/types/suggestions/agent_suggestion";
-import { JSDOM } from "jsdom";
+import {JSDOM} from "jsdom";
 
 const SIDEKICK_KNOWLEDGE_CATEGORIES: DataSourceViewCategory[] = [
   "managed",
@@ -140,7 +141,7 @@ function canAddPendingSuggestions({
   kind: LimitedSuggestionKind;
   newPendingCount: number;
   currentPendingCount: number;
-}): { allowed: true } | { allowed: false; errorMessage: string } {
+}): {allowed: true} | {allowed: false; errorMessage: string} {
   const maxAllowed = getMaxPendingSuggestions(kind);
 
   const totalAfterAddition = currentPendingCount + newPendingCount;
@@ -158,7 +159,7 @@ function canAddPendingSuggestions({
     };
   }
 
-  return { allowed: true };
+  return {allowed: true};
 }
 
 /**
@@ -215,7 +216,7 @@ export async function createInstructionSuggestions({
   source: AgentSuggestionSource;
   conversation?: ConversationResource;
 }): Promise<
-  Result<{ sId: string; kind: string; targetBlockId: string }[], string>
+  Result<{sId: string; kind: string; targetBlockId: string}[], string>
 > {
   // Reject batches where multiple suggestions target the same block.
   const targetBlockIds = suggestions.map((s) => s.targetBlockId);
@@ -223,7 +224,7 @@ export async function createInstructionSuggestions({
   if (uniqueTargetBlockIds.size !== targetBlockIds.length) {
     return new Err(
       "Multiple suggestions target the same block ID. Use a single suggestion per block." +
-        `For full rewrites, target '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' instead.`
+      `For full rewrites, target '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' instead.`
     );
   }
 
@@ -232,7 +233,7 @@ export async function createInstructionSuggestions({
     await AgentSuggestionResource.listByAgentConfigurationId(
       auth,
       agentConfigurationId,
-      { states: ["pending"], kind: "instructions" }
+      {states: ["pending"], kind: "instructions"}
     );
 
   const limitCheck = canAddPendingSuggestions({
@@ -262,7 +263,7 @@ export async function createInstructionSuggestions({
       if (blockCount > 1) {
         return new Err(
           `Suggestion for block "${suggestion.targetBlockId}" contains ${blockCount} top-level elements but replace only supports 1. ` +
-            `Keep it within a single tag, or use targetBlockId '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' if the change requires multiple blocks.`
+          `Keep it within a single tag, or use targetBlockId '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' if the change requires multiple blocks.`
         );
       }
     }
@@ -275,7 +276,7 @@ export async function createInstructionSuggestions({
   }[] = [];
 
   for (const suggestion of suggestions) {
-    const { analysis, ...suggestionData } = suggestion;
+    const {analysis, ...suggestionData} = suggestion;
     const created = await AgentSuggestionResource.createSuggestionForAgent(
       auth,
       agentConfiguration,
@@ -325,7 +326,7 @@ export async function createToolsSuggestions({
   suggestions: ToolsSuggestionInput[];
   source: AgentSuggestionSource;
   conversation?: ConversationResource;
-}): Promise<Result<{ sId: string; kind: string }[], string>> {
+}): Promise<Result<{sId: string; kind: string}[], string>> {
   // Reject batches where multiple suggestions target the same tool.
   const suggestionToolIds = suggestions.map((s) => s.toolId);
   const uniqueToolIds = new Set(suggestionToolIds);
@@ -349,7 +350,7 @@ export async function createToolsSuggestions({
   if (missingToolIds.length > 0) {
     return new Err(
       `The following tool ID(s) are invalid or not accessible: ${missingToolIds.join(", ")}. ` +
-        `Check <workspace_context> for valid tool IDs.`
+      `Check <workspace_context> for valid tool IDs.`
     );
   }
 
@@ -364,7 +365,7 @@ export async function createToolsSuggestions({
       .join(", ");
     return new Err(
       `The following ID(s) are knowledge tools, not regular tools: ${knowledgeToolNames}. ` +
-        `Use \`suggest_knowledge\` instead of \`suggest_tools\` for data source, table, or data warehouse tools.`
+      `Use \`suggest_knowledge\` instead of \`suggest_tools\` for data source, table, or data warehouse tools.`
     );
   }
 
@@ -373,7 +374,7 @@ export async function createToolsSuggestions({
     await AgentSuggestionResource.listByAgentConfigurationId(
       auth,
       agentConfigurationId,
-      { states: ["pending"], kind: "tools" }
+      {states: ["pending"], kind: "tools"}
     );
 
   const remainingPending = await markDuplicateSuggestionsAsOutdated(
@@ -401,10 +402,10 @@ export async function createToolsSuggestions({
     return new Err(`Agent configuration not found: ${agentConfigurationId}`);
   }
 
-  const createdSuggestions: { sId: string; kind: string }[] = [];
+  const createdSuggestions: {sId: string; kind: string}[] = [];
 
-  for (const { action, toolId, analysis } of suggestions) {
-    const suggestion: ToolsSuggestionType = { action, toolId };
+  for (const {action, toolId, analysis} of suggestions) {
+    const suggestion: ToolsSuggestionType = {action, toolId};
     const created = await AgentSuggestionResource.createSuggestionForAgent(
       auth,
       agentConfiguration,
@@ -418,7 +419,7 @@ export async function createToolsSuggestions({
       }
     );
 
-    createdSuggestions.push({ sId: created.sId, kind: created.kind });
+    createdSuggestions.push({sId: created.sId, kind: created.kind});
   }
 
   return new Ok(createdSuggestions);
@@ -444,7 +445,7 @@ export async function createSkillsSuggestions({
   suggestions: SkillsSuggestionInput[];
   source: AgentSuggestionSource;
   conversation?: ConversationResource;
-}): Promise<Result<{ sId: string; kind: string }[], string>> {
+}): Promise<Result<{sId: string; kind: string}[], string>> {
   // Reject batches where multiple suggestions target the same skill.
   const suggestionSkillIds = suggestions.map((s) => s.skillId);
   const uniqueSkillIds = new Set(suggestionSkillIds);
@@ -470,7 +471,7 @@ export async function createSkillsSuggestions({
   if (missingSkillIds.length > 0) {
     return new Err(
       `The following skill ID(s) are invalid or not accessible: ${missingSkillIds.join(", ")}. ` +
-        `Check <workspace_context> for valid skill IDs.`
+      `Check <workspace_context> for valid skill IDs.`
     );
   }
 
@@ -479,7 +480,7 @@ export async function createSkillsSuggestions({
     await AgentSuggestionResource.listByAgentConfigurationId(
       auth,
       agentConfigurationId,
-      { states: ["pending"], kind: "skills" }
+      {states: ["pending"], kind: "skills"}
     );
 
   const remainingPending = await markDuplicateSuggestionsAsOutdated(
@@ -508,15 +509,15 @@ export async function createSkillsSuggestions({
     return new Err(`Agent configuration not found: ${agentConfigurationId}`);
   }
 
-  const createdSuggestions: { sId: string; kind: string }[] = [];
+  const createdSuggestions: {sId: string; kind: string}[] = [];
 
-  for (const { action, skillId, analysis } of suggestions) {
+  for (const {action, skillId, analysis} of suggestions) {
     const created = await AgentSuggestionResource.createSuggestionForAgent(
       auth,
       agentConfiguration,
       {
         kind: "skills",
-        suggestion: { action, skillId },
+        suggestion: {action, skillId},
         analysis: analysis ?? null,
         state: "pending",
         source,
@@ -524,7 +525,7 @@ export async function createSkillsSuggestions({
       }
     );
 
-    createdSuggestions.push({ sId: created.sId, kind: created.kind });
+    createdSuggestions.push({sId: created.sId, kind: created.kind});
   }
 
   return new Ok(createdSuggestions);
@@ -540,7 +541,7 @@ import {
   listAvailableSkills,
   listAvailableTools,
 } from "@app/lib/api/assistant/workspace_capabilities";
-import type { z } from "zod";
+import type {z} from "zod";
 
 /**
  * Lists all knowledge data source views across all spaces the user has access to.
@@ -558,7 +559,7 @@ async function listAllKnowledgeDataSourceViews(
 }
 
 const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
-  get_available_knowledge: async ({ spaceId, category }, { auth }) => {
+  get_available_knowledge: async ({spaceId, category}, {auth}) => {
     // Get all spaces the user is a member of.
     let spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
 
@@ -626,7 +627,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
           categories: categoriesData,
         } satisfies KnowledgeSpace;
       },
-      { concurrency: 8 }
+      {concurrency: 8}
     );
 
     // Filter out null results (spaces with no data sources).
@@ -658,7 +659,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_models: async ({ providerId }, { auth }) => {
+  get_available_models: async ({providerId}, {auth}) => {
     let models = await getAvailableModelsForWorkspace(auth);
 
     if (providerId) {
@@ -680,7 +681,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_skills: async (_, { auth }) => {
+  get_available_skills: async (_, {auth}) => {
     const [skillList, toolList] = await Promise.all([
       listAvailableSkills(auth),
       listAvailableTools(auth),
@@ -694,7 +695,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_tools: async (_, { auth }) => {
+  get_available_tools: async (_, {auth}) => {
     const toolList = await listAvailableTools(auth);
 
     return new Ok([
@@ -705,7 +706,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_agents: async ({ limit, agentPrefix }, { auth }) => {
+  get_available_agents: async ({limit, agentPrefix}, {auth}) => {
     const agents = await getAgentConfigurationsForView({
       auth,
       agentsGetView: "list",
@@ -736,7 +737,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  inspect_available_agent: async ({ agentId }, { auth }) => {
+  inspect_available_agent: async ({agentId}, {auth}) => {
     const agentConfiguration = await getAgentConfiguration(auth, {
       agentId,
       variant: "full",
@@ -781,8 +782,8 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
   },
 
   get_agent_feedback: async (
-    { limit, filter, latestVersionOnly },
-    { auth, agentLoopContext }
+    {limit, filter, latestVersionOnly},
+    {auth, agentLoopContext}
   ) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
@@ -791,7 +792,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -824,7 +825,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
         orderDirection: "desc",
       },
       filter: filter ?? "active",
-      ...(latestVersionOnlyWithDefault ? { version: currentVersion } : {}),
+      ...(latestVersionOnlyWithDefault ? {version: currentVersion} : {}),
     });
 
     if (feedbacksRes.isErr()) {
@@ -875,7 +876,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
             current_version_feedback: currentVersionFeedbackList,
             ...(latestVersionOnlyWithDefault
               ? {}
-              : { previous_versions_feedback: previousVersionsFeedbackList }),
+              : {previous_versions_feedback: previousVersionsFeedbackList}),
           },
           null,
           2
@@ -884,7 +885,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_agent_insights: async ({ days }, { auth, agentLoopContext }) => {
+  get_agent_insights: async ({days}, {auth, agentLoopContext}) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -892,7 +893,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -926,7 +927,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to fetch agent insights: ${overviewResult.error.message}`,
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -960,7 +961,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
   },
 
   // Suggestion handlers
-  suggest_prompt_edits: async (params, { auth, agentLoopContext }) => {
+  suggest_prompt_edits: async (params, {auth, agentLoopContext}) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -968,7 +969,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -982,7 +983,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       });
 
       if (result.isErr()) {
-        return new Err(new MCPError(result.error, { tracked: false }));
+        return new Err(new MCPError(result.error, {tracked: false}));
       }
 
       const directives = result.value.map(
@@ -999,13 +1000,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create suggestion: ${normalizeError(error).message}`,
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
   },
 
-  suggest_tools: async (params, { auth, agentLoopContext }) => {
+  suggest_tools: async (params, {auth, agentLoopContext}) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -1013,7 +1014,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -1027,7 +1028,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       });
 
       if (result.isErr()) {
-        return new Err(new MCPError(result.error, { tracked: false }));
+        return new Err(new MCPError(result.error, {tracked: false}));
       }
 
       const directives = result.value.map(
@@ -1044,13 +1045,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create suggestion: ${normalizeError(error).message}`,
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
   },
 
-  suggest_sub_agent: async (params, { auth, agentLoopContext }) => {
+  suggest_sub_agent: async (params, {auth, agentLoopContext}) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -1058,13 +1059,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
 
     // Validate that the sub-agent exists and is accessible.
-    const { action, subAgentId } = params;
+    const {action, subAgentId} = params;
     const subAgentConfiguration = await getAgentConfiguration(auth, {
       agentId: subAgentId,
       variant: "light",
@@ -1074,7 +1075,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `The sub-agent ID "${subAgentId}" is invalid or not accessible.`,
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -1090,7 +1091,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "The run_agent server is not available in this workspace.",
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -1100,7 +1101,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       await AgentSuggestionResource.listByAgentConfigurationId(
         auth,
         agentConfigurationId,
-        { states: ["pending"], kind: "sub_agent" }
+        {states: ["pending"], kind: "sub_agent"}
       );
 
     const remainingPending = await markDuplicateSuggestionsAsOutdated(
@@ -1118,7 +1119,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       currentPendingCount: remainingPending.length,
     });
     if (!limitCheck.allowed) {
-      return new Err(new MCPError(limitCheck.errorMessage, { tracked: false }));
+      return new Err(new MCPError(limitCheck.errorMessage, {tracked: false}));
     }
 
     // Fetch the latest version of the agent configuration.
@@ -1166,13 +1167,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create suggestion: ${normalizeError(error).message}`,
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
   },
 
-  suggest_skills: async (params, { auth, agentLoopContext }) => {
+  suggest_skills: async (params, {auth, agentLoopContext}) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -1180,7 +1181,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -1194,7 +1195,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       });
 
       if (result.isErr()) {
-        return new Err(new MCPError(result.error, { tracked: false }));
+        return new Err(new MCPError(result.error, {tracked: false}));
       }
 
       const directives = result.value.map(
@@ -1211,22 +1212,22 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create suggestion: ${normalizeError(error).message}`,
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
   },
 
-  suggest_model: async (params, { auth, agentLoopContext }) => {
+  suggest_model: async (params, {auth, agentLoopContext}) => {
     const availableModels = await getAvailableModelsForWorkspace(auth);
     const availableModelIds = availableModels.map((m) => m.modelId);
 
-    const { modelId } = params.suggestion;
+    const {modelId} = params.suggestion;
     if (!availableModelIds.includes(modelId)) {
       return new Err(
         new MCPError(
           `Invalid model ID: ${modelId}. Check <workspace_context> for valid model IDs.`,
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -1238,7 +1239,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -1280,13 +1281,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create suggestion: ${normalizeError(error).message}`,
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
   },
 
-  search_knowledge: async ({ query, topK }, { auth }) => {
+  search_knowledge: async ({query, topK}, {auth}) => {
     const dataSourceViews = await listAllKnowledgeDataSourceViews(auth);
 
     if (dataSourceViews.length === 0) {
@@ -1358,12 +1359,12 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: JSON.stringify({ matches }, null, 2),
+        text: JSON.stringify({matches}, null, 2),
       },
     ]);
   },
 
-  suggest_knowledge: async (params, { auth, agentLoopContext }) => {
+  suggest_knowledge: async (params, {auth, agentLoopContext}) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -1371,21 +1372,21 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
 
     // Validate that the data source view exists and is accessible.
-    const { action, method, dataSourceViewId, description } = params.suggestion;
+    const {action, method, dataSourceViewId, description} = params.suggestion;
     const view = await DataSourceViewResource.fetchById(auth, dataSourceViewId);
 
     if (!view) {
       return new Err(
         new MCPError(
           `The data source view ID "${dataSourceViewId}" is invalid or not accessible. ` +
-            `Use get_available_knowledge or search_knowledge to find valid data source views.`,
-          { tracked: false }
+          `Use get_available_knowledge or search_knowledge to find valid data source views.`,
+          {tracked: false}
         )
       );
     }
@@ -1395,7 +1396,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       await AgentSuggestionResource.listByAgentConfigurationId(
         auth,
         agentConfigurationId,
-        { states: ["pending"], kind: "knowledge" }
+        {states: ["pending"], kind: "knowledge"}
       );
 
     const remainingPending = await markDuplicateSuggestionsAsOutdated(
@@ -1413,7 +1414,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       currentPendingCount: remainingPending.length,
     });
     if (!limitCheck.allowed) {
-      return new Err(new MCPError(limitCheck.errorMessage, { tracked: false }));
+      return new Err(new MCPError(limitCheck.errorMessage, {tracked: false}));
     }
 
     // Fetch the latest version of the agent configuration.
@@ -1461,13 +1462,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create suggestion: ${normalizeError(error).message}`,
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
   },
 
-  list_suggestions: async (params, { auth, agentLoopContext }) => {
+  list_suggestions: async (params, {auth, agentLoopContext}) => {
     const agentConfigurationId =
       getAgentConfigurationIdFromContext(agentLoopContext);
 
@@ -1475,7 +1476,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -1510,8 +1511,8 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
   },
 
   inspect_conversation: async (
-    { conversationId, fromMessageIndex, toMessageIndex },
-    { auth }
+    {conversationId, fromMessageIndex, toMessageIndex},
+    {auth}
   ) => {
     const conversationRes = await getShrinkWrappedConversation(auth, {
       conversationId,
@@ -1523,7 +1524,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Conversation not found or not accessible: ${conversationId}`,
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -1531,7 +1532,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     return new Ok([conversationRes.value]);
   },
 
-  inspect_message: async ({ conversationId, messageId }, extra) => {
+  inspect_message: async ({conversationId, messageId}, extra) => {
     const auth = extra.auth;
     if (!auth) {
       return new Err(new MCPError("Authentication required"));
@@ -1542,7 +1543,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Conversation not found or not accessible: ${conversationId}`,
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -1550,11 +1551,12 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     const conversation = conversationRes.value;
 
     // Flatten to last version of each message, find the target by sId.
-    let foundMessage: UserMessageType | AgentMessageType | null = null;
+    let foundMessage: UserMessageType | AgentMessageType | CompactionMessageType | null = null;
     let foundIndex = -1;
     const flatMessages: (
       | UserMessageType
       | AgentMessageType
+      | CompactionMessageType
       | ContentFragmentType
     )[] = [];
 
@@ -1563,16 +1565,13 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
         continue;
       }
       const lastVersion = messageVersions[messageVersions.length - 1];
-      if (isCompactionMessageType(lastVersion)) {
-        continue;
-      }
       flatMessages.push(lastVersion);
     }
 
     for (let i = 0; i < flatMessages.length; i++) {
       const msg = flatMessages[i];
       if (
-        (isUserMessageType(msg) || isAgentMessageType(msg)) &&
+        (isUserMessageType(msg) || isAgentMessageType(msg) || isCompactionMessageType(msg)) &&
         msg.sId === messageId
       ) {
         foundMessage = msg;
@@ -1607,7 +1606,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Message not found: ${messageId} in conversation ${conversationId}`,
-          { tracked: false }
+          {tracked: false}
         )
       );
     }
@@ -1638,6 +1637,23 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
         }
         lines.push("");
       }
+
+      lines.push("## Content");
+      lines.push(foundMessage.content ?? "_empty_");
+      lines.push("");
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: lines.join("\n"),
+        },
+      ]);
+    }
+
+    if (isCompactionMessageType(foundMessage)) {
+      lines.push(`# Compaction message ${foundMessage.sId}`);
+      lines.push(`at ${foundMessage.created}`);
+      lines.push("");
 
       lines.push("## Content");
       lines.push(foundMessage.content ?? "_empty_");
@@ -1708,7 +1724,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
 
     // Find agents that this message handed off to.
-    const handoffTargets: { agentId: string; agentName: string }[] = [];
+    const handoffTargets: {agentId: string; agentName: string}[] = [];
     for (const msg of flatMessages) {
       if (
         isAgentMessageType(msg) &&
@@ -1745,8 +1761,8 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  update_suggestions_state: async (params, { auth }) => {
-    const { suggestions: suggestionUpdates } = params;
+  update_suggestions_state: async (params, {auth}) => {
+    const {suggestions: suggestionUpdates} = params;
 
     const suggestionIds = suggestionUpdates.map((s) => s.suggestionId);
     const suggestions = await AgentSuggestionResource.fetchByIds(
@@ -1767,7 +1783,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       AgentSuggestionResource[]
     >();
 
-    for (const { suggestionId, state } of suggestionUpdates) {
+    for (const {suggestionId, state} of suggestionUpdates) {
       const suggestion = suggestionsById.get(suggestionId);
       if (!suggestion) {
         results.push({
@@ -1788,7 +1804,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       try {
         await AgentSuggestionResource.bulkUpdateState(auth, group, state);
         results.push(
-          ...group.map((s) => ({ success: true, suggestionId: s.sId }))
+          ...group.map((s) => ({success: true, suggestionId: s.sId}))
         );
       } catch (error) {
         const msg = normalizeError(error).message;
@@ -1805,12 +1821,12 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: JSON.stringify({ results }, null, 2),
+        text: JSON.stringify({results}, null, 2),
       },
     ]);
   },
 
-  search_agent_templates: async ({ jobType, query }, { auth }) => {
+  search_agent_templates: async ({jobType, query}, {auth}) => {
     const res = await getTemplatesForSidekick({
       auth,
       jobType: jobType && isJobType(jobType) ? jobType : undefined,
@@ -1818,7 +1834,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       limit: 10,
     });
     if (res.isErr()) {
-      return new Err(new MCPError(res.error.message, { tracked: false }));
+      return new Err(new MCPError(res.error.message, {tracked: false}));
     }
     return new Ok([
       {
@@ -1828,7 +1844,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_agent_template: async ({ templateId }, _extra) => {
+  get_agent_template: async ({templateId}, _extra) => {
     const template = await TemplateResource.fetchByExternalId(templateId);
 
     if (!template) {

--- a/front/lib/api/actions/servers/project_manager/tools/conversation_formatting.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/conversation_formatting.ts
@@ -1,8 +1,8 @@
 import { isMessageUnread } from "@app/components/assistant/conversation/utils";
 import {
   type AgentMessageType,
+  type CompactionMessageType,
   type ConversationType,
-  isCompactionMessageType,
   isLightConversationType,
   type LightAgentMessageType,
   type LightConversationType,
@@ -20,6 +20,7 @@ function formatMessage(
     | AgentMessageType
     | ContentFragmentType
     | LightAgentMessageType
+    | CompactionMessageType
     | UserMessageTypeWithContentFragments,
   lastReadMs: number | null
 ) {
@@ -34,13 +35,18 @@ function formatMessage(
   }
 
   if (msg.type === "agent_message") {
-    const agentName = msg.configuration?.name ?? "Assistant";
+    const agentName = msg.configuration?.name ?? "Agent";
     const content = msg.content ?? "";
-    return `>> Assistant (${agentName}) [${dateStr}]${unreadFormatted}:\n${msg.visibility === "deleted" ? "Deleted message" : content}\n`;
+    return `>> Agent (${agentName}) [${dateStr}]${unreadFormatted}:\n${msg.visibility === "deleted" ? "Deleted message" : content}\n`;
   }
 
   if (msg.type === "content_fragment") {
     return `>> Content Fragment [${dateStr}]${unreadFormatted}:\nID: ${msg.contentFragmentId}\nContent-Type: ${msg.contentType}\nTitle: ${msg.title}\nVersion: ${msg.version}\nSource URL: ${msg.sourceUrl}\n`;
+  }
+
+  if (msg.type === "compaction_message") {
+    const content = msg.content ?? "";
+    return `>> Compaction [${dateStr}]:\n ${content}\n`;
   }
 
   return "";
@@ -57,11 +63,9 @@ export function formatConversationForDisplay(
   // Convert conversation content to formatted messages
   const messages: string[] = [];
 
+  // TODO(compaction): stop at compaction boundary
   if (isLightConversationType(conversation)) {
     for (const msg of conversation.content) {
-      if (isCompactionMessageType(msg)) {
-        continue;
-      }
       const formattedMessage = formatMessage(msg, conversation.lastReadMs);
       if (formattedMessage) {
         messages.push(formattedMessage);
@@ -71,7 +75,7 @@ export function formatConversationForDisplay(
     for (const versions of conversation.content) {
       // Only take the last version of each rank
       const msg = versions[versions.length - 1];
-      if (!msg || isCompactionMessageType(msg)) {
+      if (!msg) {
         continue;
       }
 

--- a/front/lib/api/actions/servers/project_manager/tools/conversation_formatting.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/conversation_formatting.ts
@@ -2,6 +2,7 @@ import { isMessageUnread } from "@app/components/assistant/conversation/utils";
 import {
   type AgentMessageType,
   type ConversationType,
+  isCompactionMessageType,
   isLightConversationType,
   type LightAgentMessageType,
   type LightConversationType,
@@ -58,6 +59,9 @@ export function formatConversationForDisplay(
 
   if (isLightConversationType(conversation)) {
     for (const msg of conversation.content) {
+      if (isCompactionMessageType(msg)) {
+        continue;
+      }
       const formattedMessage = formatMessage(msg, conversation.lastReadMs);
       if (formattedMessage) {
         messages.push(formattedMessage);
@@ -67,7 +71,7 @@ export function formatConversationForDisplay(
     for (const versions of conversation.content) {
       // Only take the last version of each rank
       const msg = versions[versions.length - 1];
-      if (!msg) {
+      if (!msg || isCompactionMessageType(msg)) {
         continue;
       }
 

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -31,6 +31,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import {
   isAgentMessageType,
+  isCompactionMessageType,
   isProjectConversation,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
@@ -323,7 +324,7 @@ export async function validateUserMention(
         },
       });
     }
-  } else if (isContentFragmentType(message)) {
+  } else if (isContentFragmentType(message) || isCompactionMessageType(message)) {
     return new Err({
       status_code: 400,
       api_error: {
@@ -365,6 +366,7 @@ export async function validateUserMention(
     if (
       latestMessage.visibility !== "deleted" &&
       !isContentFragmentType(latestMessage) &&
+      !isCompactionMessageType(latestMessage) &&
       latestMessage.richMentions.some(
         (m) => isPendingStatus(m.status) && m.id === userId
       )
@@ -517,7 +519,7 @@ export async function dismissMention(
         },
       });
     }
-  } else if (isContentFragmentType(message)) {
+  } else if (isContentFragmentType(message) || isCompactionMessageType(message)) {
     return new Err({
       status_code: 400,
       api_error: {
@@ -568,6 +570,7 @@ export async function dismissMention(
     if (
       latestMessage.visibility !== "deleted" &&
       !isContentFragmentType(latestMessage) &&
+      !isCompactionMessageType(latestMessage) &&
       latestMessage.richMentions.some(predicate)
     ) {
       const mentionModel = await MentionModel.findOne({

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -324,7 +324,10 @@ export async function validateUserMention(
         },
       });
     }
-  } else if (isContentFragmentType(message) || isCompactionMessageType(message)) {
+  } else if (
+    isContentFragmentType(message) ||
+    isCompactionMessageType(message)
+  ) {
     return new Err({
       status_code: 400,
       api_error: {
@@ -519,7 +522,10 @@ export async function dismissMention(
         },
       });
     }
-  } else if (isContentFragmentType(message) || isCompactionMessageType(message)) {
+  } else if (
+    isContentFragmentType(message) ||
+    isCompactionMessageType(message)
+  ) {
     return new Err({
       status_code: 400,
       api_error: {

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -19,6 +19,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import {
   isAgentMessageType,
+  isCompactionMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
 import type {
@@ -202,6 +203,9 @@ export async function renderAllMessages(
           messages.push(renderedContentFragment);
         }
       }
+    } else if (isCompactionMessageType(m)) {
+      // Compaction messages are not rendered for now.
+      continue;
     } else {
       assertNever(m);
     }

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -204,7 +204,7 @@ export async function renderAllMessages(
         }
       }
     } else if (isCompactionMessageType(m)) {
-      // Compaction messages are not rendered for now.
+      // TODO(compaction): rendering
       continue;
     } else {
       assertNever(m);

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -26,13 +26,13 @@ import type {
 } from "@app/types/assistant/agent_message_content";
 import type {
   AgentMessageType,
+  CompactionMessageType,
   LegacyLightMessageType,
   LightAgentMessageType,
   LightMessageType,
   MessageType,
   RichMentionWithStatus,
   UserMessageType,
-  UserMessageTypeWithContentFragments,
   UserMessageTypeWithoutMentions,
 } from "@app/types/assistant/conversation";
 import {
@@ -50,6 +50,7 @@ import { isContentFragmentType } from "@app/types/content_fragment";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { UserType } from "@app/types/user";
 import assert from "assert";
@@ -748,6 +749,14 @@ async function batchRenderContentFragment(
   });
 }
 
+async function batchRenderCompactionMessages(
+  _auth: Authenticator,
+  _messages: MessageModel[]
+): Promise<CompactionMessageType[]> {
+  // TODO(compaction): implement batch rendering of compaction messages.
+  return [];
+}
+
 type RenderMessageVariant = "legacy-light" | "full" | "light";
 
 export async function batchRenderMessages<V extends RenderMessageVariant>(
@@ -768,16 +777,18 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
     ConversationError
   >
 > {
-  const [userMessages, agentMessagesRes, contentFragments] = await Promise.all([
-    batchRenderUserMessages(auth, messages),
-    batchRenderAgentMessages(
-      auth,
-      messages,
-      viewType,
-      messagesWithToolOutputContent
-    ),
-    batchRenderContentFragment(auth, conversation.sId, messages),
-  ]);
+  const [userMessages, agentMessagesRes, contentFragments, compactionMessages] =
+    await Promise.all([
+      batchRenderUserMessages(auth, messages),
+      batchRenderAgentMessages(
+        auth,
+        messages,
+        viewType,
+        messagesWithToolOutputContent
+      ),
+      batchRenderContentFragment(auth, conversation.sId, messages),
+      batchRenderCompactionMessages(auth, messages),
+    ]);
 
   if (agentMessagesRes.isErr()) {
     return agentMessagesRes;
@@ -789,6 +800,7 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
     ...userMessages,
     ...agentMessages,
     ...contentFragments,
+    ...compactionMessages,
   ].sort((a, b) => a.rank - b.rank || a.version - b.version);
 
   if (viewType === "light") {
@@ -797,15 +809,13 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
     let tempContentFragments: ContentFragmentType[] = [];
 
     renderedMessages.forEach((message) => {
-      if (isCompactionMessageType(message)) {
-        return;
-      } else if (isContentFragmentType(message)) {
+      if (isContentFragmentType(message)) {
         tempContentFragments.push(message); // Collect content fragments.
       } else {
-        let messageWithContentFragments: UserMessageTypeWithContentFragments;
+        // let messageWithContentFragments: UserMessageTypeWithContentFragments;
         if (isUserMessageType(message)) {
           // Attach collected content fragments to the user message.
-          messageWithContentFragments = {
+          const messageWithContentFragments = {
             ...message,
             contentFragments: tempContentFragments,
           };
@@ -813,9 +823,13 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
 
           // Start a new group for user messages.
           output.push(messageWithContentFragments);
-        } else {
+        } else if (message.type === "agent_message") {
           // I know this is safe because we are in the light view.
           output.push(message as LightAgentMessageType);
+        } else if (isCompactionMessageType(message)) {
+          output.push(message);
+        } else {
+          assertNever(message);
         }
       }
     });

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -37,6 +37,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import {
   ConversationError,
+  isCompactionMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
 import {
@@ -796,7 +797,9 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
     let tempContentFragments: ContentFragmentType[] = [];
 
     renderedMessages.forEach((message) => {
-      if (isContentFragmentType(message)) {
+      if (isCompactionMessageType(message)) {
+        return;
+      } else if (isContentFragmentType(message)) {
         tempContentFragments.push(message); // Collect content fragments.
       } else {
         let messageWithContentFragments: UserMessageTypeWithContentFragments;

--- a/front/lib/api/v1/backward_compatibility.ts
+++ b/front/lib/api/v1/backward_compatibility.ts
@@ -123,7 +123,7 @@ export function addBackwardCompatibleConversationFields(
       ) {
         return filterOutInteractiveContentFileContentTypes(c);
       } else if (isCompactionMessageType(c[0])) {
-        // Compaction messages are not exposed in the public API.
+        // TODO(compaction): expose compaction messages in the public API.
         return [];
       }
       assertNever(c[0]);

--- a/front/lib/api/v1/backward_compatibility.ts
+++ b/front/lib/api/v1/backward_compatibility.ts
@@ -12,6 +12,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import {
   isAgentMessageType,
+  isCompactionMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
@@ -121,6 +122,9 @@ export function addBackwardCompatibleConversationFields(
         isArrayOf<MessageType, ContentFragmentType>(c, isContentFragmentType)
       ) {
         return filterOutInteractiveContentFileContentTypes(c);
+      } else if (isCompactionMessageType(c[0])) {
+        // Compaction messages are not exposed in the public API.
+        return [];
       }
       assertNever(c[0]);
     }),

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -232,12 +232,14 @@ const getConversationDetails = async ({
     mentionedUserIds = message.richMentions
       .filter((m) => isRichUserMention(m) && m.status === "approved")
       .map((m) => m.id);
-  } else {
+  } else if (message.type === "agent_message") {
     author = message.configuration.name
       ? `@${message.configuration.name}`
       : "An agent";
     avatarUrl = message.configuration.pictureUrl ?? undefined;
     authorIsAgent = true;
+  } else {
+    assertNever(message);
   }
 
   const unreadMessages = conversation.content

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -26,6 +26,7 @@ import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import {
   ConversationError,
   isCompactionMessageType,
+  isLightAgentMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
 import { isRichUserMention } from "@app/types/assistant/mentions";
@@ -232,7 +233,7 @@ const getConversationDetails = async ({
     mentionedUserIds = message.richMentions
       .filter((m) => isRichUserMention(m) && m.status === "approved")
       .map((m) => m.id);
-  } else if (message.type === "agent_message") {
+  } else if (isLightAgentMessageType(message)) {
     author = message.configuration.name
       ? `@${message.configuration.name}`
       : "An agent";

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -25,6 +25,7 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import {
   ConversationError,
+  isCompactionMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
 import { isRichUserMention } from "@app/types/assistant/mentions";
@@ -215,7 +216,10 @@ const getConversationDetails = async ({
       ? message.content
       : "";
 
-  if (isContentFragmentType(message)) {
+  if (isCompactionMessageType(message)) {
+    // Compaction messages don't trigger notifications.
+    return new Err(new ConversationError("message_not_found"));
+  } else if (isContentFragmentType(message)) {
     // Content fragments don't have author info.
     author = "Someone else";
     authorIsAgent = false;
@@ -243,7 +247,7 @@ const getConversationDetails = async ({
   const hasUnreadMessages = unreadMessages.length > 0;
 
   const hasUnreadMentions = unreadMessages.some((msg) => {
-    if (isContentFragmentType(msg)) {
+    if (isContentFragmentType(msg) || isCompactionMessageType(msg)) {
       return false;
     }
     return msg.richMentions.some(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -23,6 +23,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import {
   isAgentMessageType,
+  isCompactionMessageType,
   isProjectConversation,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
@@ -110,7 +111,7 @@ async function handler(
   }
 
   const message = conversation.content.flat().find((m) => m.sId === messageId);
-  if (!message) {
+  if (!message || isCompactionMessageType(message)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -111,7 +111,7 @@ async function handler(
   }
 
   const message = conversation.content.flat().find((m) => m.sId === messageId);
-  if (!message || isCompactionMessageType(message)) {
+  if (!message) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -120,6 +120,16 @@ async function handler(
       },
     });
   }
+  if(isCompactionMessageType(message)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Reactions are not allowed on compaction messages.",
+      },
+    });
+  }
+
 
   switch (req.method) {
     case "POST":

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -120,7 +120,7 @@ async function handler(
       },
     });
   }
-  if(isCompactionMessageType(message)) {
+  if (isCompactionMessageType(message)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -129,7 +129,6 @@ async function handler(
       },
     });
   }
-
 
   switch (req.method) {
     case "POST":

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -37,18 +37,21 @@ export type MessageReactionType = {
 export type MessageType =
   | AgentMessageType
   | UserMessageType
-  | ContentFragmentType;
+  | ContentFragmentType
+  | CompactionMessageType;
 
 // This is the old format where content fragments are separated from the user messages.
 export type LegacyLightMessageType =
   | LightAgentMessageType
   | UserMessageType
-  | ContentFragmentType;
+  | ContentFragmentType
+  | CompactionMessageType;
 
 // This is the new format where content fragments are attached to the user messages.
 export type LightMessageType =
   | LightAgentMessageType
-  | UserMessageTypeWithContentFragments;
+  | UserMessageTypeWithContentFragments
+  | CompactionMessageType;
 
 /**
  * User messages
@@ -316,6 +319,30 @@ export function isAgentMessageType(arg: MessageType): arg is AgentMessageType {
 }
 
 /**
+ * Compaction messages
+ */
+export type CompactionMessageStatus = "created" | "succeeded" | "failed";
+
+export type CompactionMessageType = {
+  type: "compaction_message";
+  id: ModelId;
+  sId: string;
+  created: number;
+  visibility: MessageVisibility;
+  version: number;
+  rank: number;
+  branchId: string | null;
+  status: CompactionMessageStatus; // Lifecycle: created → succeeded | failed.
+  content: string | null; // null while status is "created".
+};
+
+export function isCompactionMessageType(
+  arg: MessageType | LegacyLightMessageType | LightMessageType
+): arg is CompactionMessageType {
+  return arg.type === "compaction_message";
+}
+
+/**
  * Conversations
  */
 
@@ -369,7 +396,12 @@ export type ConversationWithoutContentType = {
 export type ConversationType = ConversationWithoutContentType & {
   owner: WorkspaceType;
   visibility: ConversationVisibility;
-  content: (UserMessageType[] | AgentMessageType[] | ContentFragmentType[])[];
+  content: (
+    | UserMessageType[]
+    | AgentMessageType[]
+    | ContentFragmentType[]
+    | CompactionMessageType[]
+  )[];
 };
 
 /**
@@ -379,7 +411,11 @@ export type ConversationType = ConversationWithoutContentType & {
 export type LightConversationType = ConversationWithoutContentType & {
   owner: WorkspaceType;
   visibility: ConversationVisibility;
-  content: (LightAgentMessageType | UserMessageTypeWithContentFragments)[];
+  content: (
+    | LightAgentMessageType
+    | UserMessageTypeWithContentFragments
+    | CompactionMessageType
+  )[];
 };
 
 export function isLightConversationType(

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -318,6 +318,14 @@ export function isAgentMessageType(arg: MessageType): arg is AgentMessageType {
   return arg.type === "agent_message";
 }
 
+// This guard is used to distinguish (light) agent message from the messages on the content of a
+// LightConversationType.
+export function isLightAgentMessageType(
+  message: LightMessageType
+): message is LightAgentMessageType {
+  return message.type === "agent_message";
+}
+
 /**
  * Compaction messages
  */

--- a/x/spolu/compaction/compaction.md
+++ b/x/spolu/compaction/compaction.md
@@ -70,7 +70,7 @@ type CompactionMessageType = {
 
   // Compaction payload.
   status: CompactionMessageStatus;  // Lifecycle: created → succeeded | failed.
-  summary: string | null;           // null while status is "created".
+  content: string | null;           // null while status is "created".
 };
 ```
 
@@ -83,9 +83,9 @@ MessageType = AgentMessageType | UserMessageType | ContentFragmentType | Compact
 
 ### Status Lifecycle
 
-- `"created"` — compaction is in progress (LLM is generating the summary). The `summary` field
+- `"created"` — compaction is in progress (LLM is generating the summary). The `content` field
   is `null`. The UI shows a loading indicator. `postUserMessage` is blocked.
-- `"succeeded"` — summary generation completed. `summary` is populated. The compaction message
+- `"succeeded"` — summary generation completed. `content` is populated. The compaction message
   acts as a history boundary for model rendering.
 - `"failed"` — summary generation failed. The compaction message is inert (not a history
   boundary). The conversation continues normally with full history.
@@ -100,7 +100,7 @@ the async work completes.
 
 export class CompactionMessageModel extends WorkspaceAwareModel<CompactionMessageModel> {
   declare status: CompactionMessageStatus;
-  declare summary: string | null;
+  declare content: string | null;
 }
 ```
 
@@ -115,7 +115,7 @@ Message (sId, rank, version, branchId, visibility)
   ├─ 0:1 ── UserMessage
   ├─ 0:1 ── AgentMessage
   ├─ 0:1 ── ContentFragment
-  └─ 0:1 ── CompactionMessage (status, summary)
+  └─ 0:1 ── CompactionMessage (status, content)
 ```
 
 ### Rendering for the Model
@@ -246,13 +246,13 @@ export async function compactConversation(
 **Flow:**
 
 1. Acquire the conversation advisory lock (`getConversationRankVersionLock`).
-2. Create a `CompactionMessage` with `status: "created"` and `summary: null`. This immediately
+2. Create a `CompactionMessage` with `status: "created"` and `content: null`. This immediately
    signals to the rest of the system that compaction is in progress.
 3. Launch a Temporal workflow (`compactConversationWorkflow`) that:
    a. Reads all messages before the compaction message (or since the last succeeded compaction).
    b. Renders them into a compaction prompt.
    c. Calls an LLM to generate the summary.
-   d. Updates the `CompactionMessage` with `status: "succeeded"` and the generated `summary`.
+   d. Updates the `CompactionMessage` with `status: "succeeded"` and the generated `content`.
    e. On failure, updates to `status: "failed"`.
 4. Publish a `CompactionMessageNewEvent` on the conversation SSE channel (mirrors
    `AgentMessageNewEvent` pattern).
@@ -362,7 +362,7 @@ arriving _after_ the context window has been exceeded.
 | # | Work | Notes |
 |---|------|-------|
 | 1 | Add `CompactionMessageType` to `front/types/assistant/conversation.ts` | New type in `MessageType` union, type guard `isCompactionMessageType()` |
-| 2 | Add `CompactionMessageModel` in `front/lib/models/agent/conversation.ts` | New Sequelize model with `status`, `summary` |
+| 2 | Add `CompactionMessageModel` in `front/lib/models/agent/conversation.ts` | New Sequelize model with `status`, `content` |
 | 3 | Migration: add `compaction_message` table + `compactionMessageId` FK on `message` table | Update CHECK constraint on MessageModel validation hook |
 | 4 | Handle `"compaction_message"` in all exhaustive switches on `MessageType` | Audit all switch/if-else on message type discrimination |
 
@@ -373,7 +373,7 @@ arriving _after_ the context window has been exceeded.
 | 5 | Add `compactConversation` in `conversation.ts` | Advisory lock, create `CompactionMessage` with `status: "created"`, launch Temporal workflow |
 | 6 | Block `postUserMessage` when a `CompactionMessage` with `status: "created"` exists | Return 409, following steering pattern |
 | 7 | Add `CompactionMessageNewEvent` / `CompactionMessageDoneEvent` SSE events | Mirrors `AgentMessageNewEvent` / `AgentMessageDoneEvent` pattern |
-| 8 | Implement `compactConversationWorkflow` Temporal workflow | Read messages, call LLM, update `CompactionMessage` with summary + `status: "succeeded"` |
+| 8 | Implement `compactConversationWorkflow` Temporal workflow | Read messages, call LLM, update `CompactionMessage` with content + `status: "succeeded"` |
 | 9 | Implement compaction summary generation prompt | LLM call with compaction prompt (adapt from Claude Code's approach) |
 
 ### Phase 3: Rendering, API & Pruning

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -12,7 +12,7 @@ Type-only change, no DB or runtime impact.
 
 - Add `CompactionMessageStatus = "created" | "succeeded" | "failed"` to
   `front/types/assistant/conversation.ts`.
-- Add `CompactionMessageType` (with `type: "compaction_message"`, `status`, `summary`) to
+- Add `CompactionMessageType` (with `type: "compaction_message"`, `status`, `content`) to
   `front/types/assistant/conversation.ts`.
 - Add `isCompactionMessageType()` type guard.
 - Add `CompactionMessageType` to the `MessageType` union (line 37), the `LegacyLightMessageType`
@@ -24,7 +24,7 @@ Type-only change, no DB or runtime impact.
 DB schema change, no runtime behavior.
 
 - Add `CompactionMessageModel` in `front/lib/models/agent/conversation.ts` with fields: `status`,
-  `summary` (TEXT, nullable).
+  `content` (TEXT, nullable).
 - Migration: create `compaction_message` table, add `compactionMessageId` FK on `message` table.
 - Update `MessageModel` (line 662): add `compactionMessageId` FK declaration.
 - Update `MessageModel` validation hook (line 809): extend the exactly-one-FK-non-null check to
@@ -121,14 +121,14 @@ Core orchestration. No feature flag needed — compaction is inert until Phase 5
 
 - Add `compactConversation()` in `front/lib/api/assistant/conversation.ts`:
   - Acquire `getConversationRankVersionLock`.
-  - Create `CompactionMessage` with `status: "created"`, `summary: null`.
+  - Create `CompactionMessage` with `status: "created"`, `content: null`.
   - Publish `CompactionMessageNewEvent`.
   - Launch `compactConversationWorkflow` (fire-and-forget).
 - In `postUserMessage` (line ~528): check for `CompactionMessageModel` with
   `status: "created"` in the conversation — return 409 if found (same pattern as steering's
   pending message check).
 - In `compactConversationActivity`:
-  - On success: update `CompactionMessage` to `status: "succeeded"` + `summary`.
+  - On success: update `CompactionMessage` to `status: "succeeded"` + `content`.
   - On failure: update to `status: "failed"`.
   - Publish `CompactionMessageDoneEvent`.
 
@@ -142,7 +142,7 @@ The LLM call that produces the summary.
     conversation + "summarize" instruction, see `x/spolu/compaction/claude_compaction.md` for
     reference).
   - Call the LLM via `callModel` / `queryModelWithStreaming` to generate the summary.
-  - Store the summary on the `CompactionMessage`.
+  - Store the content on the `CompactionMessage`.
 - Add the compaction prompt template (can live in the activity file or a dedicated prompt file
   under `front/temporal/compaction/`).
 

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -6,9 +6,9 @@ Five phases of bitesize PRs. Each PR should be small, reviewable, and independen
 
 Foundational type and model changes. No runtime behavior changes — new type is inert everywhere.
 
-### - [ ] PR 1.1 — Add `CompactionMessageType` + type guard
+### - [x] PR 1.1 — Add `CompactionMessageType` + type guard
 
-Type-only change, no DB or runtime impact.
+Type-only change, no DB or runtime impact. Combined with PR 1.3 into a single PR (#24048).
 
 - Add `CompactionMessageStatus = "created" | "succeeded" | "failed"` to
   `front/types/assistant/conversation.ts`.
@@ -33,26 +33,22 @@ DB schema change, no runtime behavior.
 - Add association: `CompactionMessageModel.hasOne(MessageModel)` /
   `MessageModel.belongsTo(CompactionMessageModel)`.
 
-### - [ ] PR 1.3 — Handle `"compaction_message"` in all exhaustive switches
+### - [x] PR 1.3 — Handle `"compaction_message"` in all exhaustive switches
 
-Make the codebase compile and pass with the new type. Compaction messages are filtered out / no-op
-everywhere.
+Combined with PR 1.1 into a single PR (#24048). All exhaustive switches handled. Compaction
+messages are filtered out / no-op everywhere.
 
-- `front/lib/api/assistant/conversation/fetch.ts` (`_getConversation`, line ~250): add
-  `CompactionMessageModel` to the `MessageModel` eager include, render compaction messages into the
-  conversation content array.
-- `front/lib/api/assistant/messages.ts` (`batchRenderMessages`): add rendering path for compaction
-  messages (trivial — just map model fields to type).
-- `front/lib/api/assistant/conversation_rendering/message_rendering.ts` (`renderAllMessages`,
-  line ~157): add `isCompactionMessageType` branch — skip for now (no rendering to model yet).
-- `front/lib/api/assistant/conversation/interactions.ts` (`groupMessagesIntoInteractions`): treat
-  compaction messages as interaction boundaries (or skip).
-- `front/components/poke/pages/ConversationPage.tsx` (line ~612): add case for
-  `"compaction_message"`.
-- `front/lib/client/conversation/event_handlers.ts` (line ~21): add `isCompactionMessageType`
-  branch (no-op).
-- All other if/else chains on `isUserMessageType` / `isAgentMessageType` /
-  `isContentFragmentType` — audit and add compaction handling (filter out or no-op).
+Remaining `TODO(compaction)` markers left for future PRs:
+- `front/components/assistant/conversation/types.ts` — render compaction messages in UI instead of
+  filtering (→ PR 5.2).
+- `front/lib/api/assistant/messages.ts` — implement `batchRenderCompactionMessages` (→ PR 1.2,
+  once the DB model exists).
+- `front/lib/api/assistant/conversation_rendering/message_rendering.ts` — render compaction as
+  history boundary (→ PR 4.1).
+- `front/lib/api/actions/servers/project_manager/tools/conversation_formatting.ts` — stop at
+  compaction boundary (→ PR 4.1).
+- `front/lib/api/v1/backward_compatibility.ts` — expose compaction messages in the public API
+  (→ future, post-Phase 5).
 
 ---
 


### PR DESCRIPTION
## Description

Adds `CompactionMessageType` to the `MessageType` union and handles it across the codebase (PR 1.1 + 1.3 from the compaction plan). Also renames `summary` to `content` in the proposal/plan.

- New `CompactionMessageType` with `status` (`created`/`succeeded`/`failed`) and `content` fields
- `isCompactionMessageType()` type guard
- Updated `ConversationType.content` and `LightConversationType.content` to include compaction messages
- All exhaustive switches/if-else chains on message types now handle `compaction_message`
- Compaction messages are filtered out / skipped in rendering, notifications, reactions, mentions, backward compatibility, etc.
- Poke page renders compaction messages with a basic view
- Updated `x/spolu/compaction/` proposal and plan (`summary` → `content`)

## Tests

- `npx tsgo --noEmit` passes
- `npm run lint` passes
- `npm run format` passes

No behavior changes: no `CompactionMessageModel` or migration yet, so no compaction messages can exist in production

## Risk

Low — type-only changes with no runtime behavior change. Compaction messages cannot be created yet (no DB model/migration).

## Deploy Plan

N/a