### PR TITLE
[Connectors] fix(slack): handle stream expiry, plan message cleanup, and local dev setup

### DIFF
--- a/connectors/src/connectors/slack/chat/slack_stream_handler.ts
+++ b/connectors/src/connectors/slack/chat/slack_stream_handler.ts
@@ -3,7 +3,6 @@ import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
 import { throttleWithRedis } from "@connectors/lib/throttle";
 import logger from "@connectors/logger/logger";
 import type { ChatStreamer, WebClient } from "@slack/web-api";
-import type { ChatAppendStreamArguments } from "@slack/web-api/dist/types/request/chat";
 
 export class SlackStreamHandler {
   private streamer: ChatStreamer;
@@ -55,27 +54,23 @@ export class SlackStreamHandler {
     });
   }
 
-  private async append(
-    payload: Omit<ChatAppendStreamArguments, "channel" | "ts">
-  ) {
-    const res = await throttleWithRedis(
-      RATE_LIMITS["chat.appendStream"],
-      `${this.connectorId}-chat-appendStream`,
-      { canBeIgnored: false },
-      () => this.streamer.append(payload),
-      {}
-    );
-    if (!this.messageTs && res?.ts) {
-      this.messageTs = res.ts;
-    }
-  }
-
   async appendText(text: string) {
     if (this.stopped) {
       return;
     }
+
     try {
-      await this.append({ markdown_text: text });
+      const res = await throttleWithRedis(
+        RATE_LIMITS["chat.appendStream"],
+        `${this.connectorId}-chat-appendStream`,
+        { canBeIgnored: false },
+        () => this.streamer.append({ markdown_text: text }),
+        {}
+      );
+
+      if (!this.messageTs && res?.ts) {
+        this.messageTs = res.ts;
+      }
     } catch (e) {
       if (
         isSlackWebAPIPlatformError(e) &&
@@ -88,6 +83,7 @@ export class SlackStreamHandler {
         );
         return;
       }
+
       throw e;
     }
   }
@@ -96,8 +92,10 @@ export class SlackStreamHandler {
     if (this.stopped) {
       return;
     }
+
     this.stopped = true;
     const res = await this.streamer.stop();
+
     if (!this.messageTs && res?.ts) {
       this.messageTs = res.ts;
     }

--- a/connectors/src/connectors/slack/chat/slack_stream_handler.ts
+++ b/connectors/src/connectors/slack/chat/slack_stream_handler.ts
@@ -1,5 +1,7 @@
+import { isSlackWebAPIPlatformError } from "@connectors/connectors/slack/lib/errors";
 import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
 import { throttleWithRedis } from "@connectors/lib/throttle";
+import logger from "@connectors/logger/logger";
 import type { ChatStreamer, WebClient } from "@slack/web-api";
 import type { ChatAppendStreamArguments } from "@slack/web-api/dist/types/request/chat";
 
@@ -69,10 +71,31 @@ export class SlackStreamHandler {
   }
 
   async appendText(text: string) {
-    await this.append({ markdown_text: text });
+    if (this.stopped) {
+      return;
+    }
+    try {
+      await this.append({ markdown_text: text });
+    } catch (e) {
+      if (
+        isSlackWebAPIPlatformError(e) &&
+        e.data?.error === "message_not_in_streaming_state"
+      ) {
+        this.stopped = true;
+        logger.warn(
+          { connectorId: this.connectorId },
+          "Slack stream expired mid-answer, falling back to chat.update on agent_message_success"
+        );
+        return;
+      }
+      throw e;
+    }
   }
 
   async stop() {
+    if (this.stopped) {
+      return;
+    }
     this.stopped = true;
     const res = await this.streamer.stop();
     if (!this.messageTs && res?.ts) {

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -144,8 +144,15 @@ export async function streamConversationToSlack(
   dustAPI: DustAPI,
   conversationData: StreamConversationToSlackParams
 ): Promise<Result<undefined, Error>> {
-  const { assistantName, agentConfigurations, streamHandler } =
-    conversationData;
+  const {
+    assistantName,
+    agentConfigurations,
+    streamHandler,
+    connector,
+    conversation,
+  } = conversationData;
+  const { slackChannelId, slackClient, slackMessageTs } =
+    conversationData.slack;
 
   if (!streamHandler) {
     // Old path: update placeholder with thinking state.
@@ -160,7 +167,36 @@ export async function streamConversationToSlack(
       extraLogs: { source: "streamConversationToSlack" },
     });
   }
-  return streamAgentAnswerToSlack(dustAPI, conversationData);
+
+  const conversationUrl = makeConversationUrl(
+    connector.workspaceId,
+    conversation.sId
+  );
+
+  const planHandler = streamHandler
+    ? new PlanMessageHandler({
+        dustAPI,
+        slackClient,
+        slackChannelId,
+        slackMessageTs,
+        conversationUrl,
+        assistantName,
+        workspaceId: connector.workspaceId,
+      })
+    : null;
+
+  try {
+    return await streamAgentAnswerToSlack(
+      dustAPI,
+      conversationData,
+      planHandler
+    );
+  } finally {
+    // Cleanup streams and plan message on unexpected error
+    planHandler?.abortAllChildStreams();
+    await planHandler?.deletePlanMessage();
+    await streamHandler?.stop();
+  }
 }
 
 class SlackAnswerRetryableError extends Error {
@@ -171,7 +207,8 @@ class SlackAnswerRetryableError extends Error {
 
 async function streamAgentAnswerToSlack(
   dustAPI: DustAPI,
-  conversationData: StreamConversationToSlackParams
+  conversationData: StreamConversationToSlackParams,
+  planHandler: PlanMessageHandler | null
 ) {
   const {
     assistantName,
@@ -210,26 +247,6 @@ async function streamAgentAnswerToSlack(
   } | null = null;
 
   const { streamHandler } = conversationData;
-
-  const conversationUrl = makeConversationUrl(
-    connector.workspaceId,
-    conversation.sId
-  );
-
-  // -- Plan message + child stream tracking --
-  // Only used when native streaming (streamHandler) is enabled.
-
-  const planHandler = streamHandler
-    ? new PlanMessageHandler({
-        dustAPI,
-        slackClient,
-        slackChannelId,
-        slackMessageTs,
-        conversationUrl,
-        assistantName,
-        workspaceId: connector.workspaceId,
-      })
-    : null;
 
   let currentThrottleDelay = SLACK_MESSAGE_UPDATE_THROTTLE_MS;
   let throttledPostSlackMessageUpdate = throttle(
@@ -586,9 +603,7 @@ async function streamAgentAnswerToSlack(
           ? formattedContent
           : slackifyMarkdown(normalizeContentForSlack(formattedContent));
 
-        if (streamHandler && !streamHandler.isStopped) {
-          await streamHandler.stop();
-        }
+        await streamHandler?.stop();
 
         {
           const messageUpdate: SlackMessageUpdate = {
@@ -711,9 +726,7 @@ async function streamAgentAnswerToSlack(
       case "agent_generation_cancelled": {
         planHandler?.abortAllChildStreams();
         await planHandler?.deletePlanMessage();
-        if (streamHandler && !streamHandler.isStopped) {
-          await streamHandler.stop();
-        }
+        await streamHandler?.stop();
 
         const cancelledMessage = "_Message generation was cancelled._";
         const {
@@ -780,9 +793,7 @@ async function streamAgentAnswerToSlack(
   // Clean up if the event stream ended without a terminal event.
   planHandler?.abortAllChildStreams();
   await planHandler?.deletePlanMessage();
-  if (streamHandler && !streamHandler.isStopped) {
-    await streamHandler.stop();
-  }
+  await streamHandler?.stop();
 
   return new Err(
     new SlackAnswerRetryableError("Failed to get the final answer from Dust")

--- a/firebase-functions/webhook-router/docker-compose.yml
+++ b/firebase-functions/webhook-router/docker-compose.yml
@@ -15,6 +15,15 @@ services:
       - "9199:9199" # storage
       - "4000:4000" # emulator UI
     command: ./docker-entrypoint.sh
+    environment:
+      # Fall back to host.docker.internal for local dev if not set in shell.
+      - US_CONNECTOR_URL=${US_CONNECTOR_URL:-http://host.docker.internal:3002}
+      - EU_CONNECTOR_URL=${EU_CONNECTOR_URL:-http://host.docker.internal:3002}
+      # Pass through secrets from shell environment (loaded via rc file).
+      - DUST_CONNECTORS_WEBHOOKS_SECRET
+      - SLACK_SIGNING_SECRET
+      - MICROSOFT_BOT_ID_SECRET
+      - NOTION_SIGNING_SECRET
 
 volumes:
   node_modules:


### PR DESCRIPTION
## What

Three small improvements to the Slack native streaming bot:

1. **Stream expiry handling** — when Slack's 5-min streaming window expires mid-answer (`message_not_in_streaming_state`), the handler now catches the error, marks the stream as stopped, and lets `agent_message_success` do a final `chat.update` with the complete answer instead of silently dropping it.

2. **Plan message cleanup on unexpected errors** — `planHandler` is now created in `streamConversationToSlack` and cleaned up via `try/finally`, guaranteeing `deletePlanMessage()` + `abortAllChildStreams()` + `streamHandler.stop()` run even on unexpected throws. Also removes now-redundant `!isStopped` guards since `stop()` is idempotent.

3. **Local dev docker-compose** — `firebase-functions/webhook-router/docker-compose.yml` now passes the connector URLs and secrets from the shell environment, falling back to `host.docker.internal:3002` for local development with mprocs.

## Context

- https://dust4ai.slack.com/archives/C050SM8NSPK/p1775812854139409