### PR TITLE
Grant free credits on Metronome

### DIFF
--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -82,7 +82,9 @@ type AuditAction =
   | "datasource.deleted_admin"
   // Audit Logs.
   | "audit_log.viewed"
-  | "audit_log.export_configured";
+  | "audit_log.export_configured"
+  // Credits
+  | "credit.granted";
 
 export type EmitAuditLogEventParams = {
   auth: Authenticator;

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -4,7 +4,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import Metronome, { ConflictError } from "@metronome/sdk";
-
+import type { ContractV2 } from "@metronome/sdk/resources";
 import type {
   MetronomeBalance,
   MetronomeEvent,
@@ -365,12 +365,14 @@ export async function getMetronomeContractPackageAliases({
   metronomeContractId: string;
 }): Promise<Result<string[], Error>> {
   try {
-    const contractResponse = await getMetronomeClient().v1.contracts.retrieve({
+    const contractResponse = await getMetronomeClient().v2.contracts.retrieve({
       customer_id: metronomeCustomerId,
       contract_id: metronomeContractId,
     });
 
-    const packageId = contractResponse.data.package_id;
+    const packageId = (
+      contractResponse.data as ContractV2 & { package_id: string } // package_id is missing in ContractV2 but is actually returned
+    ).package_id;
     if (!packageId) {
       return new Ok([]);
     }

--- a/front/lib/metronome/credits.ts
+++ b/front/lib/metronome/credits.ts
@@ -59,7 +59,7 @@ export async function grantMetronomeFreeCredits({
       return;
     }
 
-    // Convert micro-USD to cents (Metronome credits are in cents).
+    // Convert micro-USD to custom credit units (1 unit ≈ $0.01, so divide by 1M).
     const amount = Math.ceil(amountMicroUsd / 10_000_000);
 
     const monthKey = `${startDate.getUTCFullYear()}-${String(startDate.getUTCMonth() + 1).padStart(2, "0")}`;

--- a/front/lib/metronome/credits.ts
+++ b/front/lib/metronome/credits.ts
@@ -1,0 +1,108 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEventDirect,
+} from "@app/lib/api/audit/workos_audit";
+import { calculateFreeCreditAmountMicroUsd } from "@app/lib/credits/free";
+import {
+  createMetronomeCredit,
+  getMetronomeActiveContract,
+} from "@app/lib/metronome/client";
+import {
+  getCreditTypeProgrammaticUsdId,
+  getProductFreeMonthlyCreditId,
+} from "@app/lib/metronome/constants";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+/**
+ * Grant monthly free programmatic credits to a Metronome-billed workspace.
+ * Uses the same bracket formula as the Stripe credit system.
+ * Idempotent via uniqueness_key: free-legacy-{workspaceSId}-{YYYY-MM}.
+ */
+export async function grantMetronomeFreeCredits({
+  workspace,
+  startDate,
+  endDate,
+}: {
+  workspace: WorkspaceResource;
+  startDate: Date;
+  endDate: Date;
+}): Promise<void> {
+  if (!workspace.metronomeCustomerId) {
+    return;
+  }
+
+  try {
+    // Resolve the active contract.
+    const contractResult = await getMetronomeActiveContract(
+      workspace.metronomeCustomerId
+    );
+    if (contractResult.isErr() || !contractResult.value) {
+      logger.error(
+        { workspaceId: workspace.sId },
+        "[Metronome] No active Metronome contract found for free credit grant"
+      );
+      return;
+    }
+
+    const productId = getProductFreeMonthlyCreditId();
+
+    // Count active members and compute bracket amount.
+    const memberCount = await MembershipResource.countActiveSeatsInWorkspace(
+      workspace.sId
+    );
+    const amountMicroUsd = calculateFreeCreditAmountMicroUsd(memberCount);
+    if (amountMicroUsd <= 0) {
+      return;
+    }
+
+    // Convert micro-USD to cents (Metronome credits are in cents).
+    const amount = Math.ceil(amountMicroUsd / 10_000_000);
+
+    const monthKey = `${startDate.getUTCFullYear()}-${String(startDate.getUTCMonth() + 1).padStart(2, "0")}`;
+
+    const result = await createMetronomeCredit({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      productId,
+      creditTypeId: getCreditTypeProgrammaticUsdId(),
+      amount,
+      startingAt: startDate.toISOString(),
+      endingBefore: endDate.toISOString(),
+      name: `Free Monthly Credits (${memberCount} users, ${monthKey})`,
+      idempotencyKey: `free-legacy-${workspace.sId}-${monthKey}`,
+    });
+
+    if (result.isOk()) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          memberCount,
+          amount,
+          monthKey,
+        },
+        "[Metronome] Metronome free credits granted"
+      );
+      void emitAuditLogEventDirect({
+        workspace: renderLightWorkspaceType({ workspace }),
+        action: "credit.granted",
+        actor: { type: "system", id: "metronome-webhook" },
+        targets: [buildAuditLogTarget("workspace", workspace)],
+        context: { location: "internal" },
+        metadata: {
+          amount: String(amount),
+          memberCount: String(memberCount),
+          monthKey,
+          source: "metronome-commit-segment",
+        },
+      });
+    }
+  } catch (err) {
+    logger.error(
+      { workspaceId: workspace.sId, error: normalizeError(err) },
+      "[Metronome] Failed to grant Metronome free credits"
+    );
+  }
+}

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -24,12 +24,12 @@ type ResponseBody = {
   message?: string;
 };
 
-const CommitSegmentStartEventSchema = z.object({
-  type: z.literal("commit.segment.start"),
+const InvoiceFinalizedEventSchema = z.object({
+  type: z.literal("invoice.finalized"),
   customer_id: z.string(),
   contract_id: z.string(),
-  commit_id: z.string(),
-  segment_id: z.string(),
+  start_timestamp: z.string(),
+  end_timestamp: z.string(),
 });
 
 const ContractEndEventSchema = z.object({
@@ -119,97 +119,12 @@ async function handler(
           logger.info({ event }, "[Metronome Webhook] Approaching spend limit");
           break;
 
-        case "commit.segment.start": {
+        case "commit.segment.start":
           logger.info(
             { event },
             "[Metronome Webhook] New commit segment started (credits available)"
           );
-
-          const segmentParsed = CommitSegmentStartEventSchema.safeParse(event);
-          if (!segmentParsed.success) {
-            logger.error(
-              { event, error: segmentParsed.error.message },
-              "[Metronome Webhook] Invalid commit.segment.start event"
-            );
-            break;
-          }
-
-          const {
-            customer_id: segmentCustomerId,
-            contract_id: segmentContractId,
-            commit_id: commitId,
-            segment_id: segmentId,
-          } = segmentParsed.data;
-
-          const segmentWorkspace =
-            await WorkspaceResource.fetchByMetronomeCustomerId(
-              segmentCustomerId
-            );
-          if (!segmentWorkspace) {
-            logger.warn(
-              { customerId: segmentCustomerId },
-              "[Metronome Webhook] commit.segment.start: workspace not found"
-            );
-            break;
-          }
-
-          // Only grant free credits for legacy contracts.
-          const aliasesResult = await getMetronomeContractPackageAliases({
-            metronomeCustomerId: segmentCustomerId,
-            metronomeContractId: segmentContractId,
-          });
-          if (aliasesResult.isErr()) {
-            logger.error(
-              {
-                workspaceId: segmentWorkspace.sId,
-                error: aliasesResult.error,
-              },
-              "[Metronome Webhook] commit.segment.start: failed to get package aliases"
-            );
-            break;
-          }
-          const isLegacy = aliasesResult.value.some((alias) =>
-            PRO_OR_BUSINESS_PACKAGE_ALIASES.has(alias)
-          );
-          if (!isLegacy) {
-            break;
-          }
-
-          // Retrieve the commit's access schedule to find the segment's billing period.
-          const commits = await getMetronomeClient().v1.customers.commits.list({
-            customer_id: segmentCustomerId,
-            commit_id: commitId,
-            include_contract_commits: true,
-          });
-
-          const commit = commits.data?.[0];
-          const scheduleItem = commit?.access_schedule?.schedule_items?.find(
-            (item) => item.id === segmentId
-          );
-          if (!scheduleItem) {
-            logger.error(
-              {
-                workspaceId: segmentWorkspace.sId,
-                commitId,
-                segmentId,
-              },
-              "[Metronome Webhook] commit.segment.start: no matching schedule item found for segment"
-            );
-            break;
-          }
-
-          const billingStart = new Date(scheduleItem.starting_at);
-          const billingEnd = new Date(scheduleItem.ending_before);
-
-          // Fire-and-forget: failure should not block the webhook.
-          void grantMetronomeFreeCredits({
-            workspace: segmentWorkspace,
-            startDate: billingStart,
-            endDate: billingEnd,
-          });
-
           break;
-        }
 
         case "credit.create":
           logger.info(
@@ -316,9 +231,74 @@ async function handler(
           break;
         }
 
-        case "invoice.finalized":
+        case "invoice.finalized": {
           logger.info({ event }, "[Metronome Webhook] Invoice finalized");
+
+          const invoiceParsed = InvoiceFinalizedEventSchema.safeParse(event);
+          if (!invoiceParsed.success) {
+            // Not a contract invoice or missing billing period — skip.
+            break;
+          }
+
+          const {
+            customer_id: invoiceCustomerId,
+            contract_id: invoiceContractId,
+            start_timestamp: startTimestamp,
+            end_timestamp: endTimestamp,
+          } = invoiceParsed.data;
+
+          const invoiceWorkspace =
+            await WorkspaceResource.fetchByMetronomeCustomerId(
+              invoiceCustomerId
+            );
+          if (!invoiceWorkspace) {
+            logger.warn(
+              { customerId: invoiceCustomerId },
+              "[Metronome Webhook] invoice.finalized: workspace not found"
+            );
+            break;
+          }
+
+          // Only grant free credits for legacy contracts.
+          const invoiceAliasesResult = await getMetronomeContractPackageAliases(
+            {
+              metronomeCustomerId: invoiceCustomerId,
+              metronomeContractId: invoiceContractId,
+            }
+          );
+          if (invoiceAliasesResult.isErr()) {
+            logger.error(
+              {
+                workspaceId: invoiceWorkspace.sId,
+                error: invoiceAliasesResult.error,
+              },
+              "[Metronome Webhook] invoice.finalized: failed to get package aliases"
+            );
+            break;
+          }
+          const isLegacy = invoiceAliasesResult.value.some((alias) =>
+            PRO_OR_BUSINESS_PACKAGE_ALIASES.has(alias)
+          );
+          if (!isLegacy) {
+            break;
+          }
+
+          // The invoice covers the period that just ended.
+          // Grant free credits for the next billing period.
+          const invoiceStart = new Date(startTimestamp);
+          const invoiceEnd = new Date(endTimestamp);
+          const periodMs = invoiceEnd.getTime() - invoiceStart.getTime();
+          const nextPeriodEnd = new Date(invoiceEnd.getTime() + periodMs);
+
+          // Fire-and-forget: failure should not block the webhook.
+          void grantMetronomeFreeCredits({
+            workspace: invoiceWorkspace,
+            startDate: invoiceEnd,
+            endDate: nextPeriodEnd,
+          });
+
           break;
+        }
 
         case "invoice.billing_provider_error":
           logger.error(

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -1,4 +1,8 @@
 /** @ignoreswagger */
+import {
+  buildAuditLogTarget,
+  emitAuditLogEventDirect,
+} from "@app/lib/api/audit/workos_audit";
 import apiConfig from "@app/lib/api/config";
 import { calculateFreeCreditAmountMicroUsd } from "@app/lib/credits/free";
 import {
@@ -15,6 +19,7 @@ import { PRO_OR_BUSINESS_PACKAGE_ALIASES } from "@app/lib/metronome/types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
@@ -113,6 +118,19 @@ async function grantMetronomeFreeCredits({
         },
         "[Metronome Webhook] Metronome free credits granted"
       );
+      void emitAuditLogEventDirect({
+        workspace: renderLightWorkspaceType({ workspace }),
+        action: "credit.granted",
+        actor: { type: "system", id: "metronome-webhook" },
+        targets: [buildAuditLogTarget("workspace", workspace)],
+        context: { location: "internal" },
+        metadata: {
+          amountCents: String(amountCents),
+          memberCount: String(memberCount),
+          monthKey,
+          source: "metronome-commit-segment",
+        },
+      });
     }
   } catch (err) {
     logger.error(

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -1,25 +1,13 @@
 /** @ignoreswagger */
-import {
-  buildAuditLogTarget,
-  emitAuditLogEventDirect,
-} from "@app/lib/api/audit/workos_audit";
 import apiConfig from "@app/lib/api/config";
-import { calculateFreeCreditAmountMicroUsd } from "@app/lib/credits/free";
 import {
-  createMetronomeCredit,
-  getMetronomeActiveContract,
   getMetronomeClient,
   getMetronomeContractPackageAliases,
 } from "@app/lib/metronome/client";
-import {
-  getCreditTypeProgrammaticUsdId,
-  getProductFreeMonthlyCreditId,
-} from "@app/lib/metronome/constants";
+import { grantMetronomeFreeCredits } from "@app/lib/metronome/credits";
 import { PRO_OR_BUSINESS_PACKAGE_ALIASES } from "@app/lib/metronome/types";
-import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
@@ -49,96 +37,6 @@ const ContractEndEventSchema = z.object({
   contract_id: z.string(),
   customer_id: z.string(),
 });
-
-/**
- * Grant monthly free programmatic credits to a Metronome-billed workspace.
- * Uses the same bracket formula as the Stripe credit system.
- * Idempotent via uniqueness_key: free-legacy-{workspaceSId}-{YYYY-MM}.
- */
-async function grantMetronomeFreeCredits({
-  workspace,
-  startDate,
-  endDate,
-}: {
-  workspace: WorkspaceResource;
-  startDate: Date;
-  endDate: Date;
-}): Promise<void> {
-  if (!workspace.metronomeCustomerId) {
-    return;
-  }
-
-  try {
-    // Resolve the active contract.
-    const contractResult = await getMetronomeActiveContract(
-      workspace.metronomeCustomerId
-    );
-    if (contractResult.isErr() || !contractResult.value) {
-      logger.error(
-        { workspaceId: workspace.sId },
-        "[Metronome Webhook] No active Metronome contract found for free credit grant"
-      );
-      return;
-    }
-
-    const productId = getProductFreeMonthlyCreditId();
-
-    // Count active members and compute bracket amount.
-    const memberCount = await MembershipResource.countActiveSeatsInWorkspace(
-      workspace.sId
-    );
-    const amountMicroUsd = calculateFreeCreditAmountMicroUsd(memberCount);
-    if (amountMicroUsd <= 0) {
-      return;
-    }
-
-    // Convert micro-USD to cents (Metronome credits are in cents).
-    const amount = Math.ceil(amountMicroUsd / 10_000_000);
-
-    const monthKey = `${startDate.getUTCFullYear()}-${String(startDate.getUTCMonth() + 1).padStart(2, "0")}`;
-
-    const result = await createMetronomeCredit({
-      metronomeCustomerId: workspace.metronomeCustomerId,
-      productId,
-      creditTypeId: getCreditTypeProgrammaticUsdId(),
-      amount,
-      startingAt: startDate.toISOString(),
-      endingBefore: endDate.toISOString(),
-      name: `Free Monthly Credits (${memberCount} users, ${monthKey})`,
-      idempotencyKey: `free-legacy-${workspace.sId}-${monthKey}`,
-    });
-
-    if (result.isOk()) {
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          memberCount,
-          amount,
-          monthKey,
-        },
-        "[Metronome Webhook] Metronome free credits granted"
-      );
-      void emitAuditLogEventDirect({
-        workspace: renderLightWorkspaceType({ workspace }),
-        action: "credit.granted",
-        actor: { type: "system", id: "metronome-webhook" },
-        targets: [buildAuditLogTarget("workspace", workspace)],
-        context: { location: "internal" },
-        metadata: {
-          amountCents: String(amountCents),
-          memberCount: String(memberCount),
-          monthKey,
-          source: "metronome-commit-segment",
-        },
-      });
-    }
-  } catch (err) {
-    logger.error(
-      { workspaceId: workspace.sId, error: normalizeError(err) },
-      "[Metronome Webhook] Failed to grant Metronome free credits"
-    );
-  }
-}
 
 // Disable Next.js body parsing so we can read the raw body for signature verification.
 export const config = {
@@ -238,6 +136,7 @@ async function handler(
 
           const {
             customer_id: segmentCustomerId,
+            contract_id: segmentContractId,
             commit_id: commitId,
             segment_id: segmentId,
           } = segmentParsed.data;
@@ -254,18 +153,10 @@ async function handler(
             break;
           }
 
-          const subscription =
-            await SubscriptionResource.fetchActiveByWorkspaceModelId(
-              segmentWorkspace.id
-            );
-          if (!subscription?.metronomeContractId) {
-            break;
-          }
-
           // Only grant free credits for legacy contracts.
           const aliasesResult = await getMetronomeContractPackageAliases({
             metronomeCustomerId: segmentCustomerId,
-            metronomeContractId: subscription.metronomeContractId,
+            metronomeContractId: segmentContractId,
           });
           if (aliasesResult.isErr()) {
             logger.error(

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -1,6 +1,18 @@
 /** @ignoreswagger */
 import apiConfig from "@app/lib/api/config";
-import { getMetronomeClient } from "@app/lib/metronome/client";
+import { calculateFreeCreditAmountMicroUsd } from "@app/lib/credits/free";
+import {
+  createMetronomeCredit,
+  getMetronomeActiveContract,
+  getMetronomeClient,
+  getMetronomeContractPackageAliases,
+} from "@app/lib/metronome/client";
+import {
+  getCreditTypeProgrammaticUsdId,
+  getProductFreeMonthlyCreditId,
+} from "@app/lib/metronome/constants";
+import { PRO_OR_BUSINESS_PACKAGE_ALIASES } from "@app/lib/metronome/types";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
@@ -19,11 +31,96 @@ type ResponseBody = {
   message?: string;
 };
 
+const CommitSegmentStartEventSchema = z.object({
+  type: z.literal("commit.segment.start"),
+  customer_id: z.string(),
+  contract_id: z.string(),
+  commit_id: z.string(),
+  segment_id: z.string(),
+});
+
 const ContractEndEventSchema = z.object({
   type: z.literal("contract.end"),
   contract_id: z.string(),
   customer_id: z.string(),
 });
+
+/**
+ * Grant monthly free programmatic credits to a Metronome-billed workspace.
+ * Uses the same bracket formula as the Stripe credit system.
+ * Idempotent via uniqueness_key: free-legacy-{workspaceSId}-{YYYY-MM}.
+ */
+async function grantMetronomeFreeCredits({
+  workspace,
+  startDate,
+  endDate,
+}: {
+  workspace: WorkspaceResource;
+  startDate: Date;
+  endDate: Date;
+}): Promise<void> {
+  if (!workspace.metronomeCustomerId) {
+    return;
+  }
+
+  try {
+    // Resolve the active contract.
+    const contractResult = await getMetronomeActiveContract(
+      workspace.metronomeCustomerId
+    );
+    if (contractResult.isErr() || !contractResult.value) {
+      logger.error(
+        { workspaceId: workspace.sId },
+        "[Metronome Webhook] No active Metronome contract found for free credit grant"
+      );
+      return;
+    }
+
+    const productId = getProductFreeMonthlyCreditId();
+
+    // Count active members and compute bracket amount.
+    const memberCount = await MembershipResource.countActiveSeatsInWorkspace(
+      workspace.sId
+    );
+    const amountMicroUsd = calculateFreeCreditAmountMicroUsd(memberCount);
+    if (amountMicroUsd <= 0) {
+      return;
+    }
+
+    // Convert micro-USD to cents (Metronome credits are in cents).
+    const amount = Math.ceil(amountMicroUsd / 10_000_000);
+
+    const monthKey = `${startDate.getUTCFullYear()}-${String(startDate.getUTCMonth() + 1).padStart(2, "0")}`;
+
+    const result = await createMetronomeCredit({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      productId,
+      creditTypeId: getCreditTypeProgrammaticUsdId(),
+      amount,
+      startingAt: startDate.toISOString(),
+      endingBefore: endDate.toISOString(),
+      name: `Free Monthly Credits (${memberCount} users, ${monthKey})`,
+      idempotencyKey: `free-legacy-${workspace.sId}-${monthKey}`,
+    });
+
+    if (result.isOk()) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          memberCount,
+          amount,
+          monthKey,
+        },
+        "[Metronome Webhook] Metronome free credits granted"
+      );
+    }
+  } catch (err) {
+    logger.error(
+      { workspaceId: workspace.sId, error: normalizeError(err) },
+      "[Metronome Webhook] Failed to grant Metronome free credits"
+    );
+  }
+}
 
 // Disable Next.js body parsing so we can read the raw body for signature verification.
 export const config = {
@@ -106,12 +203,104 @@ async function handler(
           logger.info({ event }, "[Metronome Webhook] Approaching spend limit");
           break;
 
-        case "commit.segment.start":
+        case "commit.segment.start": {
           logger.info(
             { event },
             "[Metronome Webhook] New commit segment started (credits available)"
           );
+
+          const segmentParsed = CommitSegmentStartEventSchema.safeParse(event);
+          if (!segmentParsed.success) {
+            logger.error(
+              { event, error: segmentParsed.error.message },
+              "[Metronome Webhook] Invalid commit.segment.start event"
+            );
+            break;
+          }
+
+          const {
+            customer_id: segmentCustomerId,
+            commit_id: commitId,
+            segment_id: segmentId,
+          } = segmentParsed.data;
+
+          const segmentWorkspace =
+            await WorkspaceResource.fetchByMetronomeCustomerId(
+              segmentCustomerId
+            );
+          if (!segmentWorkspace) {
+            logger.warn(
+              { customerId: segmentCustomerId },
+              "[Metronome Webhook] commit.segment.start: workspace not found"
+            );
+            break;
+          }
+
+          const subscription =
+            await SubscriptionResource.fetchActiveByWorkspaceModelId(
+              segmentWorkspace.id
+            );
+          if (!subscription?.metronomeContractId) {
+            break;
+          }
+
+          // Only grant free credits for legacy contracts.
+          const aliasesResult = await getMetronomeContractPackageAliases({
+            metronomeCustomerId: segmentCustomerId,
+            metronomeContractId: subscription.metronomeContractId,
+          });
+          if (aliasesResult.isErr()) {
+            logger.error(
+              {
+                workspaceId: segmentWorkspace.sId,
+                error: aliasesResult.error,
+              },
+              "[Metronome Webhook] commit.segment.start: failed to get package aliases"
+            );
+            break;
+          }
+          const isLegacy = aliasesResult.value.some((alias) =>
+            PRO_OR_BUSINESS_PACKAGE_ALIASES.has(alias)
+          );
+          if (!isLegacy) {
+            break;
+          }
+
+          // Retrieve the commit's access schedule to find the segment's billing period.
+          const commits = await getMetronomeClient().v1.customers.commits.list({
+            customer_id: segmentCustomerId,
+            commit_id: commitId,
+            include_contract_commits: true,
+          });
+
+          const commit = commits.data?.[0];
+          const scheduleItem = commit?.access_schedule?.schedule_items?.find(
+            (item) => item.id === segmentId
+          );
+          if (!scheduleItem) {
+            logger.error(
+              {
+                workspaceId: segmentWorkspace.sId,
+                commitId,
+                segmentId,
+              },
+              "[Metronome Webhook] commit.segment.start: no matching schedule item found for segment"
+            );
+            break;
+          }
+
+          const billingStart = new Date(scheduleItem.starting_at);
+          const billingEnd = new Date(scheduleItem.ending_before);
+
+          // Fire-and-forget: failure should not block the webhook.
+          void grantMetronomeFreeCredits({
+            workspace: segmentWorkspace,
+            startDate: billingStart,
+            endDate: billingEnd,
+          });
+
           break;
+        }
 
         case "credit.create":
           logger.info(

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -14,7 +14,6 @@ import {
   voidFailedProCreditPurchaseInvoice,
 } from "@app/lib/credits/committed";
 import {
-  calculateFreeCreditAmountMicroUsd,
   grantFreeCreditFromSubscriptionStateChangeYearly,
   grantFreeCreditsFromSubscriptionStateChange,
 } from "@app/lib/credits/free";
@@ -25,14 +24,9 @@ import {
 } from "@app/lib/credits/payg";
 import { handleMetronomeSetupCheckout } from "@app/lib/metronome/checkout";
 import {
-  createMetronomeCredit,
   reactivateMetronomeContract,
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
-import {
-  getCreditTypeProgrammaticUsdId,
-  getProductFreeMonthlyCreditId,
-} from "@app/lib/metronome/constants";
 import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
 import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
@@ -169,73 +163,6 @@ async function shadowProvisionMetronome({
     logger.error(
       { workspaceId: workspace.sId, error: normalizeError(err) },
       "[Stripe Webhook] Failed to shadow-provision Metronome"
-    );
-  }
-}
-
-/**
- * Grant monthly free programmatic credits to a Metronome-billed workspace.
- * Uses the same bracket formula as the Stripe credit system.
- * Idempotent via uniqueness_key: free-legacy-{workspaceId}-{YYYY-MM}.
- */
-async function grantMetronomeFreeCredits({
-  workspace,
-  stripeSubscription,
-}: {
-  workspace: WorkspaceResource;
-  stripeSubscription: Stripe.Subscription;
-}): Promise<void> {
-  if (!workspace.metronomeCustomerId) {
-    return;
-  }
-
-  try {
-    const productId = getProductFreeMonthlyCreditId();
-
-    // Count active members and compute bracket amount.
-    const memberCount = await MembershipResource.countActiveSeatsInWorkspace(
-      workspace.sId
-    );
-    const amountMicroUsd = calculateFreeCreditAmountMicroUsd(memberCount);
-    if (amountMicroUsd <= 0) {
-      return;
-    }
-
-    // Convert micro-USD to custom credit units (1 unit ≈ $0.01, so divide by 1M).
-    const amount = Math.ceil(amountMicroUsd / 1_000_000);
-
-    const periodStart = new Date(
-      stripeSubscription.current_period_start * 1000
-    );
-    const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
-    const monthKey = `${periodStart.getUTCFullYear()}-${String(periodStart.getUTCMonth() + 1).padStart(2, "0")}`;
-
-    const result = await createMetronomeCredit({
-      metronomeCustomerId: workspace.metronomeCustomerId,
-      productId,
-      creditTypeId: getCreditTypeProgrammaticUsdId(),
-      amount,
-      startingAt: periodStart.toISOString(),
-      endingBefore: periodEnd.toISOString(),
-      name: `Free Monthly Credits (${memberCount} users, ${monthKey})`,
-      idempotencyKey: `free-legacy-${workspace.sId}-${monthKey}`,
-    });
-
-    if (result.isOk()) {
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          memberCount,
-          amount,
-          monthKey,
-        },
-        "[Stripe Webhook] Metronome free credits granted"
-      );
-    }
-  } catch (err) {
-    logger.error(
-      { workspaceId: workspace.sId, error: normalizeError(err) },
-      "[Stripe Webhook] Failed to grant Metronome free credits"
     );
   }
 }
@@ -1163,13 +1090,6 @@ async function handler(
                 "[Stripe Webhook] Error granting free credits"
               );
             }
-
-            // Grant free credits in Metronome for legacy workspaces.
-            // Fire-and-forget: Metronome failure should not block the webhook.
-            void grantMetronomeFreeCredits({
-              workspace,
-              stripeSubscription,
-            });
 
             if (subscriptionCycleChanged) {
               const paygEnabled = await isPAYGEnabled(auth);


### PR DESCRIPTION
## Description

Moves monthly free credit grants for legacy plans from the Stripe webhook to the Metronome webhook. Now triggered on the `commit.segment.start` event (fired at the beginning of each billing period) instead of Stripe subscription renewal.

The free credit logic is moved from `pages/api/stripe/webhook.ts` to `pages/api/metronome/webhook.ts` and only grants credits for legacy contracts (Pro/Business package aliases). Uses the same bracket formula as before: 1–10 users → $5/user, 11–50 users → $2/user, 51–100 users → $1/user. Idempotency key remains `free-legacy-{workspaceSId}-{YYYY-MM}`.

## Tests


## Risk

Low. Only affects legacy Metronome-billed workspaces. Idempotent via uniqueness key. Fire-and-forget pattern prevents webhook blocking.

## Deploy Plan

Deploy front.