### PR TITLE
Project tools update: remove list_unread, clarify conv search, add attach_to_conversation.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -479,9 +479,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "project_manager": {
     "add_file": "low",
+    "attach_to_conversation": "low",
     "edit_description": "low",
     "get_information": "never_ask",
-    "list_unread": "never_ask",
     "update_file": "medium",
   },
   "query_tables_v2": {

--- a/front/lib/api/actions/servers/conversation_files/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/index.ts
@@ -2,12 +2,8 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { CONVERSATION_FILES_SERVER_NAME } from "@app/lib/api/actions/servers/conversation_files/metadata";
-import {
-  TOOLS,
-  TOOLS_IN_PROJECT,
-} from "@app/lib/api/actions/servers/conversation_files/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/conversation_files/tools";
 import type { Authenticator } from "@app/lib/auth";
-import { isProjectConversation } from "@app/types/assistant/conversation";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
@@ -16,22 +12,10 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("conversation_files");
 
-  const conversation =
-    agentLoopContext?.runContext?.conversation ??
-    agentLoopContext?.listToolsContext?.conversation;
-
-  if (conversation && isProjectConversation(conversation)) {
-    for (const tool of TOOLS_IN_PROJECT) {
-      registerTool(auth, agentLoopContext, server, tool, {
-        monitoringName: CONVERSATION_FILES_SERVER_NAME,
-      });
-    }
-  } else {
-    for (const tool of TOOLS) {
-      registerTool(auth, agentLoopContext, server, tool, {
-        monitoringName: CONVERSATION_FILES_SERVER_NAME,
-      });
-    }
+  for (const tool of TOOLS) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: CONVERSATION_FILES_SERVER_NAME,
+    });
   }
   return server;
 }

--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -59,7 +59,7 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
   },
   [CONVERSATION_SEARCH_FILES_ACTION_NAME]: {
     description:
-      "Perform a semantic search within the files attached to the conversation.",
+      "Perform a semantic search within the files and content nodes attached to the conversation.",
     schema: {
       query: z.string().describe("The query to search for."),
     },
@@ -68,21 +68,6 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
       running: "Searching files in conversation",
       done: "Search files in conversation",
     },
-  },
-});
-
-// Add a custom description on each tool to indicate that the tools are available in the project context.
-export const CONVERSATION_FILES_TOOLS_IN_PROJECT_METADATA = createToolsRecord({
-  ...CONVERSATION_FILES_TOOLS_METADATA,
-  [CONVERSATION_LIST_FILES_ACTION_NAME]: {
-    ...CONVERSATION_FILES_TOOLS_METADATA[CONVERSATION_LIST_FILES_ACTION_NAME],
-    description:
-      "List all files attached to the conversation and in the project context.",
-  },
-  [CONVERSATION_SEARCH_FILES_ACTION_NAME]: {
-    ...CONVERSATION_FILES_TOOLS_METADATA[CONVERSATION_SEARCH_FILES_ACTION_NAME],
-    description:
-      "Perform a semantic search within the files attached to the conversation and in the project context.",
   },
 });
 

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -8,7 +8,6 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   CONVERSATION_CAT_FILE_ACTION_NAME,
-  CONVERSATION_FILES_TOOLS_IN_PROJECT_METADATA,
   CONVERSATION_FILES_TOOLS_METADATA,
   CONVERSATION_LIST_FILES_ACTION_NAME,
   CONVERSATION_SEARCH_FILES_ACTION_NAME,
@@ -22,23 +21,15 @@ import {
   isContentNodeAttachmentType,
   renderAttachmentXml,
 } from "@app/lib/api/assistant/conversation/attachments";
-import {
-  getConversationDataSourceViews,
-  getProjectContextDataSourceView,
-} from "@app/lib/api/assistant/jit/utils";
+import { getConversationDataSourceViews } from "@app/lib/api/assistant/jit/utils";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
-import { PROJECT_CONTEXT_FOLDER_ID } from "@app/lib/api/projects/constants";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import {
   CONTENT_OUTDATED_MSG,
   getContentFragmentFromAttachmentFile,
 } from "@app/lib/resources/content_fragment_resource";
-import logger from "@app/logger/logger";
-import {
-  type ConversationType,
-  isProjectConversation,
-} from "@app/types/assistant/conversation";
+import type { ConversationType } from "@app/types/assistant/conversation";
 import type {
   ImageContent,
   TextContent,
@@ -326,33 +317,6 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
       });
     }
 
-    const isPartOfProject = isProjectConversation(conversation);
-
-    if (isPartOfProject) {
-      const projectDatasourceView = await getProjectContextDataSourceView(
-        auth,
-        conversation
-      );
-
-      if (!projectDatasourceView) {
-        logger.warn(
-          { conversationId: conversation.sId },
-          "Project context datasource view not found for conversation."
-        );
-      } else {
-        dataSources.push({
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          dataSourceViewId: projectDatasourceView.sId,
-          filter: {
-            // Intentionaly only search the project context folder, not the entire project.
-            // The conversations from the project can be searched using the project search action.
-            parents: { in: [PROJECT_CONTEXT_FOLDER_ID], not: [] },
-            tags: null,
-          },
-        });
-      }
-    }
-
     const searchResults = await searchFunction(auth, {
       query,
       relativeTimeFrame: "all",
@@ -428,7 +392,3 @@ async function getFileFromConversation(
 }
 
 export const TOOLS = buildTools(CONVERSATION_FILES_TOOLS_METADATA, handlers);
-export const TOOLS_IN_PROJECT = buildTools(
-  CONVERSATION_FILES_TOOLS_IN_PROJECT_METADATA,
-  handlers
-);

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -73,6 +73,24 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
       done: "Update file in project",
     },
   },
+  attach_to_conversation: {
+    description:
+      "Attach an existing project context file to the current conversation without creating or copying a new file.",
+    schema: {
+      fileId: z
+        .string()
+        .describe("ID of an existing file in the project context to attach"),
+      dustProject:
+        ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+        ].optional(),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Attaching project file to conversation",
+      done: "Attach project file to conversation",
+    },
+  },
   edit_description: {
     description:
       "Edit the project description. Only plain text is accepted (no markdown, HTML, or formatting). Descriptions should be brief and concise.",
@@ -108,42 +126,13 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
       done: "Get project information",
     },
   },
-  list_unread: {
-    description:
-      "List unread conversations in the project. Returns conversations that have been updated since the user last read them, " +
-      "within an optional time window (defaults to 30 days).",
-    schema: {
-      daysBack: z
-        .number()
-        .optional()
-        .default(30)
-        .describe(
-          "Number of days to look back for unread conversations (default: 30 days)"
-        ),
-      limit: z
-        .number()
-        .optional()
-        .default(20)
-        .describe(
-          "Maximum number of conversations to return (default: 20, max: 100)"
-        ),
-      dustProject:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
-        ].optional(),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Searching unread conversations",
-      done: "Search unread conversations",
-    },
-  },
 });
 
 const PROJECT_MANAGER_INSTRUCTIONS =
   "Project files and metadata are shared across all conversations in this project. " +
   "Only text-based files are supported for adding/updating. " +
   "You can add/update files by providing text content directly, or by copying from existing files (like those you've generated). " +
+  "You can also attach an existing project context file to the current conversation without recreating it. " +
   "Requires write permissions on the project space. " +
   "After adding or updating files, always list the file names you changed in your response so the user knows exactly what was modified.";
 

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -13,24 +13,21 @@ import {
   withErrorHandling,
 } from "@app/lib/api/actions/servers/project_manager/helpers";
 import { PROJECT_MANAGER_TOOLS_METADATA } from "@app/lib/api/actions/servers/project_manager/metadata";
-import { formatConversationsForDisplay } from "@app/lib/api/actions/servers/project_manager/tools/conversation_formatting";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { renderAttachmentXml } from "@app/lib/api/assistant/conversation/attachments";
 import config from "@app/lib/api/config";
 import {
   addFileToProject,
-  listProjectContextFiles,
+  fetchLatestProjectContextFileContentFragment,
+  listProjectContextAttachments,
 } from "@app/lib/api/projects";
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getProjectRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import {
   contentTypeFromFileName,
   isAllSupportedFileContentType,
-  isSupportedFileContentType,
 } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -310,6 +307,58 @@ export function createProjectManagerTools(
       }, "Failed to update file");
     },
 
+    attach_to_conversation: async (params) => {
+      return withErrorHandling(async () => {
+        if (!agentLoopContext?.runContext?.conversation) {
+          return new Err(
+            new MCPError("No conversation context available", {
+              tracked: false,
+            })
+          );
+        }
+
+        const contextRes = await getProjectSpace(auth, {
+          agentLoopContext,
+          dustProject: params.dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const { space } = contextRes.value;
+        const { fileId } = params;
+
+        const projectFile = await fetchLatestProjectContextFileContentFragment(
+          auth,
+          space,
+          fileId
+        );
+        if (!projectFile) {
+          return new Err(
+            new MCPError("File not found in this project context", {
+              tracked: false,
+            })
+          );
+        }
+        const { file } = projectFile;
+
+        return new Ok([
+          {
+            type: "resource" as const,
+            resource: {
+              mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+              uri: file.getPublicUrl(auth),
+              fileId: file.sId,
+              title: file.fileName,
+              contentType: file.contentType,
+              snippet: file.snippet,
+              text: `File "${file.fileName}" (${file.sId}) attached to the current conversation.`,
+            },
+          },
+        ]);
+      }, "Failed to attach project file to conversation");
+    },
+
     edit_description: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getWritableProjectContext(auth, {
@@ -368,15 +417,7 @@ export function createProjectManagerTools(
           space
         );
 
-        const files = await listProjectContextFiles(auth, space);
-
-        const fileList = files
-          .filter((file) => isSupportedFileContentType(file.contentType))
-          .map((file) => ({
-            fileId: file.sId,
-            fileName: file.fileName,
-            contentType: file.contentType,
-          }));
+        const attachments = await listProjectContextAttachments(auth, space);
 
         // Construct project URL
         const projectPath = getProjectRoute(owner.sId, space.sId);
@@ -390,85 +431,26 @@ export function createProjectManagerTools(
               name: space.name,
               url: projectUrl,
               description: metadata?.description ?? null,
-              fileCount: files.length,
-              files: fileList,
+              context: {
+                count: attachments.length,
+                attachments: attachments
+                  .map((a) =>
+                    renderAttachmentXml({
+                      attachment: a,
+                      content: "",
+                      // When in the project context, the flags might be misleading, version is useless (it's always the latest)
+                      // eg: a csv might have been uploaded in a convo (becoming queryable) but then moved to the project context.
+                      // This will be obsolete once we run query directly in the sandbox.
+                      hideFlagsAndVersion: true,
+                    })
+                  )
+                  .join("\n"),
+              },
             },
             message: "Successfully retrieved project information",
           })
         );
       }, "Failed to get project information");
-    },
-
-    list_unread: async (params) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getProjectSpace(auth, {
-          agentLoopContext,
-          dustProject: params.dustProject,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-
-        const { space } = contextRes.value;
-        const { daysBack = 30, limit = 20 } = params;
-
-        // Calculate the cutoff date for the time window
-        const cutoffDate = new Date();
-        cutoffDate.setDate(cutoffDate.getDate() - daysBack);
-
-        // List conversations in the project space updated since cutoff
-        const spaceConversations =
-          await ConversationResource.listConversationsInSpace(auth, {
-            spaceId: space.sId,
-            options: {
-              updatedSince: cutoffDate.getTime(),
-              excludeTest: true,
-            },
-          });
-
-        // Fetch full conversations with content
-        const conversationResults = await concurrentExecutor(
-          spaceConversations,
-          async (c) => getConversation(auth, c.sId, false),
-          { concurrency: 10 }
-        );
-
-        // Extract successful conversations
-        const conversationsFull = conversationResults
-          .filter((r) => r.isOk())
-          .map((r) => r.value);
-
-        // Filter for unread conversations based on the unread flag, and apply limit
-        const unreadConversations = conversationsFull.filter((c) => c.unread);
-
-        // Apply limit
-        const limitedConversations = unreadConversations.slice(0, limit);
-
-        if (limitedConversations.length === 0) {
-          return new Ok([
-            {
-              type: "text" as const,
-              text: `No unread conversations found in project "${space.name}" from the last ${daysBack} days.`,
-            },
-          ]);
-        }
-
-        const formattedConversations = formatConversationsForDisplay(
-          limitedConversations,
-          auth.getNonNullableWorkspace().sId
-        );
-
-        return new Ok(
-          makeSuccessResponse({
-            success: true,
-            count: limitedConversations.length,
-            total: unreadConversations.length,
-            daysBack,
-            conversations: formattedConversations,
-            message: `Found ${limitedConversations.length} unread conversation(s) in project "${space.name}"${unreadConversations.length > limit ? ` (showing first ${limit} of ${unreadConversations.length})` : ""}.`,
-          })
-        );
-      }, "Failed to search unread conversations");
     },
   };
 

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -294,23 +294,30 @@ export function renderLargePasteXml({
 export function renderAttachmentXml({
   attachment,
   content = null,
+  hideFlagsAndVersion = false,
 }: {
   attachment: ConversationAttachmentType;
   content?: string | null;
+  hideFlagsAndVersion?: boolean;
 }): string {
   const params = [
     `id="${conversationAttachmentId(attachment)}"`,
     `type="${attachment.contentType}"`,
     `title="${attachment.title}"`,
-    `version="${attachment.contentFragmentVersion}"`,
-    `isInProjectContext="${attachment.isInProjectContext}"`,
-    `isIncludable="${attachment.isIncludable}"`,
-    `isQueryable="${attachment.isQueryable}"`,
-    `isSearchable="${attachment.isSearchable}"`,
+    ...(hideFlagsAndVersion
+      ? []
+      : [
+          `version="${attachment.contentFragmentVersion}"`,
+          `isInProjectContext="${attachment.isInProjectContext}"`,
+          `isIncludable="${attachment.isIncludable}"`,
+          `isQueryable="${attachment.isQueryable}"`,
+          `isSearchable="${attachment.isSearchable}"`,
+        ]),
   ];
 
   if (isContentNodeAttachmentType(attachment) && attachment.sourceUrl) {
     params.push(`sourceUrl="${attachment.sourceUrl}"`);
+    params.push(`nodeId="${attachment.nodeId}"`);
   }
 
   let tag = `<attachment ${params.join(" ")}`;

--- a/front/lib/api/projects/butler.ts
+++ b/front/lib/api/projects/butler.ts
@@ -69,7 +69,7 @@ export async function generateUserProjectDigest(
 ): Promise<string> {
   const owner = auth.getNonNullableWorkspace();
 
-  // Fetch unread conversations (same logic as list_unread tool).
+  // Fetch unread conversations.
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - DAYS_BACK);
 

--- a/front/lib/api/projects/index.ts
+++ b/front/lib/api/projects/index.ts
@@ -6,7 +6,6 @@ export {
   fetchLatestProjectContextFileContentFragment,
   listProjectContentFragments,
   listProjectContextAttachments,
-  listProjectContextFiles,
   removeContentNodeFromProject,
   removeFileFromProject,
 } from "./context";


### PR DESCRIPTION
## Description

Clean up and extend project manager tools.
- Remove `list_unread` from `project_manager` — superseded by `list_conversations` with `unreadOnly=true` in the `project_conversation` server
- Add `attach_to_conversation` to `project_manager` — attaches an existing project context file to the current conversation without copying it
- Remove `TOOLS_IN_PROJECT` / `CONVERSATION_FILES_TOOLS_IN_PROJECT_METADATA` — no longer needed now that project context search is handled via unified search and we want to be clear what is attached to the conversation vs what is not.
- Remove project context data source injection from `search_conversation_files` (was scoping searches to `PROJECT_CONTEXT_FOLDER_ID` when in a project conversation)
- Clarify `search_conversation_files` description to mention content nodes

## Tests

Local + green
<img width="1616" height="1026" alt="image" src="https://github.com/user-attachments/assets/dd31f82c-1dd0-4bea-8ed0-46aa0460456b" />
<img width="365" height="218" alt="image" src="https://github.com/user-attachments/assets/3b0ac9c8-0dc7-4a2a-b89a-eb98fea80fb3" />

## Risk

Low

## Deploy Plan

Deploy `front`
