### PR TITLE
[front] fix: lint on main on missing method `KillSwitchResource.isKillSwitchEnabledCached`

### DIFF
--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -1105,7 +1105,7 @@ export async function getGlobalAgents(
     mcpServerViews,
   ] = await Promise.all([
     isDeepDiveDisabledByAdmin(auth),
-    KillSwitchResource.isKillSwitchEnabledCached("global_dust_agents_fallback"),
+    KillSwitchResource.isKillSwitchEnabled("global_dust_agents_fallback"),
     variant === "full"
       ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
       : null,


### PR DESCRIPTION
## Description

- Didn't rebase https://github.com/dust-tt/dust/pull/24047 on https://github.com/dust-tt/dust/pull/24037, leading to a method name mismatch.

## Tests

- Typecheck.

## Risk

- Low.

## Deploy Plan

- Deploy front.
