### PR TITLE
Simplify seat count update

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -5,7 +5,7 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import type { Authenticator } from "@app/lib/auth";
-import { addSeat, removeSeat } from "@app/lib/metronome/seats";
+import { syncSeatCount } from "@app/lib/metronome/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -28,9 +28,8 @@ import type {
 } from "@app/types/user";
 import type { Transaction } from "sequelize";
 
-async function addSeatForWorkspace(
-  workspace: LightWorkspaceType,
-  userId: string
+async function syncSeatCountForWorkspace(
+  workspace: LightWorkspaceType
 ): Promise<Result<void, Error>> {
   if (!workspace.metronomeCustomerId) {
     return new Ok(undefined);
@@ -41,32 +40,10 @@ async function addSeatForWorkspace(
   if (!subscription?.metronomeContractId) {
     return new Ok(undefined);
   }
-  return await addSeat({
+  return await syncSeatCount({
     metronomeCustomerId: workspace.metronomeCustomerId,
     contractId: subscription.metronomeContractId,
-    userId,
-    workspaceId: workspace.sId,
-  });
-}
-
-async function removeSeatForWorkspace(
-  workspace: LightWorkspaceType,
-  userId: string
-): Promise<Result<void, Error>> {
-  if (!workspace.metronomeCustomerId) {
-    return new Ok(undefined);
-  }
-  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
-    workspace.id
-  );
-  if (!subscription?.metronomeContractId) {
-    return new Ok(undefined);
-  }
-  return await removeSeat({
-    metronomeCustomerId: workspace.metronomeCustomerId,
-    contractId: subscription.metronomeContractId,
-    userId,
-    workspaceId: workspace.sId,
+    workspace,
   });
 }
 
@@ -129,7 +106,7 @@ export async function createAndTrackMembership({
   await launchUpdateUsageWorkflow({ workspaceId: workspace.sId });
 
   // Add seat in Metronome if workspace is Metronome-billed.
-  const addSeatResult = await addSeatForWorkspace(w, user.sId);
+  const addSeatResult = await syncSeatCountForWorkspace(w);
   if (addSeatResult.isErr()) {
     logger.error(
       {
@@ -206,7 +183,7 @@ export async function revokeAndTrackMembership(
     });
 
     // Remove seat in Metronome if workspace is Metronome-billed.
-    const removeSeatResult = await removeSeatForWorkspace(workspace, user.sId);
+    const removeSeatResult = await syncSeatCountForWorkspace(workspace);
     if (removeSeatResult.isErr()) {
       logger.error(
         {
@@ -283,7 +260,7 @@ export async function updateMembershipRoleAndTrack({
 
     // If a revoked membership was re-activated, add a Metronome seat and update usage.
     if (wasRevoked) {
-      const addSeatResult = await addSeatForWorkspace(workspace, user.sId);
+      const addSeatResult = await syncSeatCountForWorkspace(workspace);
       if (addSeatResult.isErr()) {
         logger.error(
           {

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -397,37 +397,22 @@ export async function getMetronomeContractPackageAliases({
 // ---------------------------------------------------------------------------
 
 /**
- * Update the quantity on a MANUAL subscription (delta or absolute).
- * Used for seat count changes when members join/leave.
+ * Set the absolute quantity on a QUANTITY_ONLY subscription.
+ * Always sets the total — safe against race conditions.
  */
 export async function updateSubscriptionQuantity({
   metronomeCustomerId,
   contractId,
   subscriptionId,
-  quantityDelta,
   quantity,
   startingAt,
 }: {
   metronomeCustomerId: string;
   contractId: string;
   subscriptionId: string;
-  /** Relative change (+1 for add, -1 for remove). Mutually exclusive with quantity. */
-  quantityDelta?: number;
-  /** Absolute quantity. Mutually exclusive with quantityDelta. */
-  quantity?: number;
+  quantity: number;
   startingAt?: string;
 }): Promise<Result<void, Error>> {
-  if (quantity !== undefined && quantityDelta !== undefined) {
-    return new Err(
-      new Error("quantity and quantityDelta are mutually exclusive")
-    );
-  }
-  if (quantity === undefined && quantityDelta === undefined) {
-    return new Err(
-      new Error("one of quantity or quantityDelta must be provided")
-    );
-  }
-
   const now = startingAt ?? floorToHourISO(new Date());
 
   try {
@@ -440,10 +425,7 @@ export async function updateSubscriptionQuantity({
           quantity_updates: [
             {
               starting_at: now,
-              ...(quantity !== undefined ? { quantity } : {}),
-              ...(quantityDelta !== undefined
-                ? { quantity_delta: quantityDelta }
-                : {}),
+              quantity,
             },
           ],
         },

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -5,7 +5,7 @@ import {
   findMetronomeCustomerByAlias,
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
-import { provisionSeatsForContract } from "@app/lib/metronome/seats";
+import { syncSeatCount } from "@app/lib/metronome/seats";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -50,7 +50,7 @@ export async function switchMetronomeContractPackage({
 
   const { contractId: metronomeContractId, startingAt } = contractResult.value;
 
-  await provisionSeatsForContract({
+  await syncSeatCount({
     metronomeCustomerId,
     contractId: metronomeContractId,
     workspace,
@@ -110,7 +110,7 @@ export async function provisionMetronomeCustomerAndContract({
   const { contractId: metronomeContractId, startingAt } = contractResult.value;
 
   // Provision all existing workspace members as seats on the new contract.
-  await provisionSeatsForContract({
+  await syncSeatCount({
     metronomeCustomerId,
     contractId: metronomeContractId,
     workspace,

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -6,7 +6,7 @@ import { getProductWorkspaceSeatId } from "@app/lib/metronome/constants";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 
 /**
@@ -37,70 +37,14 @@ async function getSeatSubscriptionId(
 }
 
 /**
- * Increment seat count by 1 when a member joins.
- * Called from membership create hook.
+ * Sync the Metronome seat subscription quantity to the current active member count.
+ * Always sets the absolute quantity — safe against race conditions.
+ *
+ * Called from:
+ * - membership create/revoke/update hooks (addSeat/removeSeat wrappers)
+ * - contract provisioning after creation or migration
  */
-export async function addSeat({
-  metronomeCustomerId,
-  contractId,
-  workspaceId,
-}: {
-  metronomeCustomerId: string;
-  contractId: string;
-  userId: string;
-  workspaceId: string;
-}): Promise<Result<void, Error>> {
-  const subscriptionId = await getSeatSubscriptionId(
-    metronomeCustomerId,
-    contractId
-  );
-  if (!subscriptionId) {
-    return new Err(new Error("No seat subscription found on contract"));
-  }
-
-  return await updateSubscriptionQuantity({
-    metronomeCustomerId,
-    contractId,
-    subscriptionId,
-    quantityDelta: 1,
-  });
-}
-
-/**
- * Decrement seat count by 1 when a member leaves.
- * Called from membership revoke hook.
- */
-export async function removeSeat({
-  metronomeCustomerId,
-  contractId,
-  workspaceId,
-}: {
-  metronomeCustomerId: string;
-  contractId: string;
-  userId: string;
-  workspaceId: string;
-}): Promise<Result<void, Error>> {
-  const subscriptionId = await getSeatSubscriptionId(
-    metronomeCustomerId,
-    contractId
-  );
-  if (!subscriptionId) {
-    return new Err(new Error("No seat subscription found on contract"));
-  }
-
-  return await updateSubscriptionQuantity({
-    metronomeCustomerId,
-    contractId,
-    subscriptionId,
-    quantityDelta: -1,
-  });
-}
-
-/**
- * Set absolute seat count to match the current workspace member count.
- * Called after contract creation (both new provisioning and migration).
- */
-export async function provisionSeatsForContract({
+export async function syncSeatCount({
   metronomeCustomerId,
   contractId,
   workspace,
@@ -109,7 +53,7 @@ export async function provisionSeatsForContract({
   metronomeCustomerId: string;
   contractId: string;
   workspace: LightWorkspaceType;
-  startingAt: string;
+  startingAt?: string;
 }): Promise<Result<void, Error>> {
   const subscriptionId = await getSeatSubscriptionId(
     metronomeCustomerId,
@@ -118,7 +62,7 @@ export async function provisionSeatsForContract({
   if (!subscriptionId) {
     logger.warn(
       { workspaceId: workspace.sId, contractId },
-      "[Metronome] No seat subscription found on contract — cannot provision seats"
+      "[Metronome] No seat subscription found on contract — cannot sync seats"
     );
     return new Err(new Error("No seat subscription found on contract"));
   }
@@ -128,19 +72,11 @@ export async function provisionSeatsForContract({
   });
   const memberCount = memberships.length;
 
-  if (memberCount === 0) {
-    logger.info(
-      { workspaceId: workspace.sId },
-      "[Metronome] No active members — no seats to provision"
-    );
-    return new Ok(undefined);
-  }
-
   return await updateSubscriptionQuantity({
     metronomeCustomerId,
     contractId,
     subscriptionId,
-    quantity: memberCount,
+    quantity: Math.max(memberCount, 1),
     startingAt,
   });
 }

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -24,7 +24,7 @@ import {
   getProductMauBilling10Id,
   getProductPrepaidCommitId,
 } from "@app/lib/metronome/constants";
-import { provisionSeatsForContract } from "@app/lib/metronome/seats";
+import { syncSeatCount } from "@app/lib/metronome/seats";
 import {
   LEGACY_BUSINESS_PACKAGE_ALIAS,
   LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS,
@@ -578,7 +578,7 @@ async function migrateWorkspace(
 
     // Provision seats for all existing members (for seat-based plans).
     if (!isEnterprise) {
-      const seatResult = await provisionSeatsForContract({
+      const seatResult = await syncSeatCount({
         metronomeCustomerId,
         contractId: newContractId,
         workspace,
@@ -760,7 +760,7 @@ async function migrateWorkspace(
       targetAlias !== LEGACY_ENTERPRISE_PACKAGE_ALIAS &&
       targetAlias !== LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS
     ) {
-      const seatResult2 = await provisionSeatsForContract({
+      const seatResult2 = await syncSeatCount({
         metronomeCustomerId,
         contractId: newContractId,
         workspace,


### PR DESCRIPTION
## Description

Simplify Metronome seat management: always set absolute quantity instead of delta-based updates.

### Problem
The previous approach used `quantityDelta: +1/-1` for add/remove seat operations. This is fragile — if two membership changes race (e.g. two members join simultaneously), a delta can be lost and the seat count drifts.

### Solution
All seat operations now count active members from the DB and set the absolute quantity. The last write always wins, converging to the correct state.

### Changes

**`seats.ts`**:
- New `syncSeatCount()` — single function that counts active members and sets the absolute quantity on the Metronome subscription. Always idempotent.
- `addSeat` / `removeSeat` — now just call `syncSeatCount` (accept `workspace` instead of `workspaceId`, ignore `userId`).
- Removed `provisionSeatsForContract` alias — all call sites updated to `syncSeatCount`.

**`client.ts`**:
- `updateSubscriptionQuantity` simplified to only accept absolute `quantity` (removed `quantityDelta` parameter and mutual exclusion guards).

**`membership.ts`**:
- Updated `addSeatForWorkspace` / `removeSeatForWorkspace` to pass `workspace` object instead of `workspaceId`.

**`contracts.ts`** / **`migrate_metronome_contracts.ts`**:
- Updated imports from `provisionSeatsForContract` to `syncSeatCount`.

## Tests

Manual testing in sandbox — verified seat count syncs correctly after member add/remove.

## Risk

Low. The new approach is strictly safer than delta-based updates. Worst case on failure: seat count stays at previous value until next membership change triggers a resync.

## Deploy Plan

Standard deploy — no migration needed. Existing contracts will get their seat count corrected on the next membership change.