### PR TITLE
[front] Add promotional banner for email agents

### DIFF
--- a/front/components/assistant/conversation/InAppBanner.tsx
+++ b/front/components/assistant/conversation/InAppBanner.tsx
@@ -1,5 +1,5 @@
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
-import { Button, ChromeLogo, XMarkIcon } from "@dust-tt/sparkle";
+import { Button, ChromeLogo, MovingMailIcon, XMarkIcon } from "@dust-tt/sparkle";
 import { AnimatePresence, motion } from "framer-motion";
 import { useState } from "react";
 
@@ -7,6 +7,10 @@ const EXTENSION_IMAGE_PATH = "/static/Extension_Banner.png";
 const EXTENSION_BANNER_LOCAL_STORAGE_KEY = "extension-banner-dismissed";
 const EXTENSION_BANNER_URL =
   "https://chromewebstore.google.com/detail/dust/fnkfcndbgingjcbdhaofkcnhcjpljhdn";
+
+const EMAIL_IMAGE_PATH = "/static/Email_Banner.png";
+const EMAIL_BANNER_LOCAL_STORAGE_KEY = "email-banner-dismissed";
+const EMAIL_BANNER_URL = "https://docs.dust.tt/docs/email-agents";
 
 interface ExtensionBannerProps {
   showExtensionBanner: boolean;
@@ -83,6 +87,78 @@ function ExtensionBanner({
   );
 }
 
+interface EmailBannerProps {
+  showEmailBanner: boolean;
+  onShowEmailBanner: (open: boolean) => void;
+}
+
+function EmailBanner({ showEmailBanner, onShowEmailBanner }: EmailBannerProps) {
+  const onDismiss = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    localStorage.setItem(EMAIL_BANNER_LOCAL_STORAGE_KEY, "true");
+    onShowEmailBanner(false);
+  };
+
+  const onLearnMore = () => {
+    window.open(EMAIL_BANNER_URL, "_blank", "noopener,noreferrer");
+  };
+
+  if (!showEmailBanner) {
+    return null;
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 100, translateY: "0%" }}
+      transition={{ duration: 0.1, ease: "easeIn" }}
+      exit={{ opacity: 0, translateY: "120%" }}
+      className="relative z-10 mx-2 mb-2 hidden max-w-[300px] cursor-pointer flex-col rounded-2xl border border-border-dark bg-white shadow-md dark:border-border-night dark:bg-background-night sm:flex"
+      onClick={withTracking(
+        TRACKING_AREAS.EMAIL,
+        "cta_email_banner",
+        onLearnMore
+      )}
+    >
+      <div className="relative overflow-hidden rounded-t-2xl">
+        <img
+          src={EMAIL_IMAGE_PATH}
+          alt="Email agents"
+          width={300}
+          height={98}
+          className="h-[98px] w-[300px] border-b border-border-dark object-cover dark:border-border-night"
+        />
+        <Button
+          variant="outline"
+          icon={XMarkIcon}
+          size="icon-xs"
+          className="absolute right-1 top-1"
+          onClick={onDismiss}
+        />
+      </div>
+      <div className="relative px-4 py-3">
+        <div className="mb-1 text-sm font-medium text-foreground dark:text-foreground-night">
+          Email your agents
+        </div>
+        <h4 className="mb-3 text-xs leading-tight text-primary dark:text-primary-night">
+          Forward any email to an agent — get answers right in your inbox.
+        </h4>
+        <Button
+          variant="highlight"
+          size="xs"
+          icon={MovingMailIcon}
+          label="Learn more"
+          onClick={withTracking(
+            TRACKING_AREAS.EMAIL,
+            "cta_email_banner",
+            onLearnMore
+          )}
+        />
+      </div>
+    </motion.div>
+  );
+}
+
 interface StackedInAppBannersProps {
   owner: { sId: string };
 }
@@ -93,9 +169,17 @@ export function StackedInAppBanners({
   const [showExtensionBanner, setShowExtensionBanner] = useState(() => {
     return localStorage.getItem(EXTENSION_BANNER_LOCAL_STORAGE_KEY) !== "true";
   });
+  const [showEmailBanner, setShowEmailBanner] = useState(() => {
+    return localStorage.getItem(EMAIL_BANNER_LOCAL_STORAGE_KEY) !== "true";
+  });
 
   return (
     <AnimatePresence>
+      <EmailBanner
+        key="email-banner"
+        showEmailBanner={showEmailBanner}
+        onShowEmailBanner={setShowEmailBanner}
+      />
       <ExtensionBanner
         key="extension-banner"
         showExtensionBanner={showExtensionBanner}

--- a/front/components/assistant/conversation/InAppBanner.tsx
+++ b/front/components/assistant/conversation/InAppBanner.tsx
@@ -1,4 +1,6 @@
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import { isAdmin } from "@app/types/user";
+import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
   ChromeLogo,
@@ -15,7 +17,7 @@ const EXTENSION_BANNER_URL =
 
 const EMAIL_IMAGE_PATH = "/static/Email_Banner.png";
 const EMAIL_BANNER_LOCAL_STORAGE_KEY = "email-banner-dismissed";
-const EMAIL_BANNER_URL = "https://docs.dust.tt/docs/email-agents";
+const EMAIL_DOCS_URL = "https://docs.dust.tt/docs/email-agents";
 
 interface ExtensionBannerProps {
   showExtensionBanner: boolean;
@@ -93,11 +95,19 @@ function ExtensionBanner({
 }
 
 interface EmailBannerProps {
+  owner: WorkspaceType;
   showEmailBanner: boolean;
   onShowEmailBanner: (open: boolean) => void;
 }
 
-function EmailBanner({ showEmailBanner, onShowEmailBanner }: EmailBannerProps) {
+function EmailBanner({
+  owner,
+  showEmailBanner,
+  onShowEmailBanner,
+}: EmailBannerProps) {
+  const emailEnabled = owner.metadata?.allowEmailAgents === true;
+  const userIsAdmin = isAdmin(owner);
+
   const onDismiss = (e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
@@ -105,9 +115,22 @@ function EmailBanner({ showEmailBanner, onShowEmailBanner }: EmailBannerProps) {
     onShowEmailBanner(false);
   };
 
-  const onLearnMore = () => {
-    window.open(EMAIL_BANNER_URL, "_blank", "noopener,noreferrer");
-  };
+  const ctaUrl = emailEnabled
+    ? // TODO: replace with mailto link content.
+      EMAIL_DOCS_URL
+    : userIsAdmin
+      ? `/w/${owner.sId}/workspace`
+      : null;
+
+  const onCtaClick = ctaUrl
+    ? () => {
+        window.open(
+          ctaUrl,
+          emailEnabled ? "_blank" : "_self",
+          "noopener,noreferrer",
+        );
+      }
+    : undefined;
 
   if (!showEmailBanner) {
     return null;
@@ -119,11 +142,11 @@ function EmailBanner({ showEmailBanner, onShowEmailBanner }: EmailBannerProps) {
       transition={{ duration: 0.1, ease: "easeIn" }}
       exit={{ opacity: 0, translateY: "120%" }}
       className="relative z-10 mx-2 mb-2 hidden max-w-[300px] cursor-pointer flex-col rounded-2xl border border-border-dark bg-white shadow-md dark:border-border-night dark:bg-background-night sm:flex"
-      onClick={withTracking(
-        TRACKING_AREAS.EMAIL,
-        "cta_email_banner",
-        onLearnMore,
-      )}
+      onClick={
+        onCtaClick
+          ? withTracking(TRACKING_AREAS.EMAIL, "cta_email_banner", onCtaClick)
+          : undefined
+      }
     >
       <div className="relative overflow-hidden rounded-t-2xl">
         <img
@@ -148,29 +171,71 @@ function EmailBanner({ showEmailBanner, onShowEmailBanner }: EmailBannerProps) {
         <h4 className="mb-3 text-xs leading-tight text-primary dark:text-primary-night">
           Forward any email to an agent — get answers right in your inbox.
         </h4>
-        <Button
-          variant="highlight"
-          size="xs"
-          icon={MovingMailIcon}
-          label="Learn more"
-          onClick={withTracking(
-            TRACKING_AREAS.EMAIL,
-            "cta_email_banner",
-            onLearnMore,
-          )}
+        <EmailBannerCta
+          emailEnabled={emailEnabled}
+          userIsAdmin={userIsAdmin}
+          onCtaClick={onCtaClick}
         />
       </div>
     </motion.div>
   );
 }
 
-interface StackedInAppBannersProps {
-  owner: { sId: string };
+interface EmailBannerCtaProps {
+  emailEnabled: boolean;
+  userIsAdmin: boolean;
+  onCtaClick: (() => void) | undefined;
 }
 
-export function StackedInAppBanners({
-  owner: _owner,
-}: StackedInAppBannersProps) {
+function EmailBannerCta({
+  emailEnabled,
+  userIsAdmin,
+  onCtaClick,
+}: EmailBannerCtaProps) {
+  if (emailEnabled) {
+    return (
+      <Button
+        variant="highlight"
+        size="xs"
+        icon={MovingMailIcon}
+        label="Try it now"
+        onClick={
+          onCtaClick
+            ? withTracking(TRACKING_AREAS.EMAIL, "cta_email_banner", onCtaClick)
+            : undefined
+        }
+      />
+    );
+  }
+
+  if (userIsAdmin) {
+    return (
+      <Button
+        variant="highlight"
+        size="xs"
+        icon={MovingMailIcon}
+        label="Enable in settings"
+        onClick={
+          onCtaClick
+            ? withTracking(TRACKING_AREAS.EMAIL, "cta_email_banner", onCtaClick)
+            : undefined
+        }
+      />
+    );
+  }
+
+  return (
+    <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+      Ask your admin to enable email agents.
+    </p>
+  );
+}
+
+interface StackedInAppBannersProps {
+  owner: WorkspaceType;
+}
+
+export function StackedInAppBanners({ owner }: StackedInAppBannersProps) {
   const [showExtensionBanner, setShowExtensionBanner] = useState(() => {
     return localStorage.getItem(EXTENSION_BANNER_LOCAL_STORAGE_KEY) !== "true";
   });
@@ -182,6 +247,7 @@ export function StackedInAppBanners({
     <AnimatePresence>
       <EmailBanner
         key="email-banner"
+        owner={owner}
         showEmailBanner={showEmailBanner}
         onShowEmailBanner={setShowEmailBanner}
       />

--- a/front/components/assistant/conversation/InAppBanner.tsx
+++ b/front/components/assistant/conversation/InAppBanner.tsx
@@ -1,5 +1,10 @@
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
-import { Button, ChromeLogo, MovingMailIcon, XMarkIcon } from "@dust-tt/sparkle";
+import {
+  Button,
+  ChromeLogo,
+  MovingMailIcon,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
 import { AnimatePresence, motion } from "framer-motion";
 import { useState } from "react";
 
@@ -45,7 +50,7 @@ function ExtensionBanner({
       onClick={withTracking(
         TRACKING_AREAS.EXTENSION,
         "cta_extension_banner",
-        onLearnMore
+        onLearnMore,
       )}
     >
       <div className="relative overflow-hidden rounded-t-2xl">
@@ -79,7 +84,7 @@ function ExtensionBanner({
           onClick={withTracking(
             TRACKING_AREAS.EXTENSION,
             "cta_extension_banner",
-            onLearnMore
+            onLearnMore,
           )}
         />
       </div>
@@ -117,7 +122,7 @@ function EmailBanner({ showEmailBanner, onShowEmailBanner }: EmailBannerProps) {
       onClick={withTracking(
         TRACKING_AREAS.EMAIL,
         "cta_email_banner",
-        onLearnMore
+        onLearnMore,
       )}
     >
       <div className="relative overflow-hidden rounded-t-2xl">
@@ -151,7 +156,7 @@ function EmailBanner({ showEmailBanner, onShowEmailBanner }: EmailBannerProps) {
           onClick={withTracking(
             TRACKING_AREAS.EMAIL,
             "cta_email_banner",
-            onLearnMore
+            onLearnMore,
           )}
         />
       </div>

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -55,6 +55,7 @@ export const TRACKING_AREAS = {
   SKILLS: "skills",
   SIDEKICK: "sidekick",
   EXTENSION: "extension",
+  EMAIL: "email",
 } as const;
 
 export type TrackingArea = (typeof TRACKING_AREAS)[keyof typeof TRACKING_AREAS];

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -128,7 +128,7 @@ export function withTracking<T extends Element = HTMLElement>(
   area: TrackingArea | string,
   object: string,
   handler?: (e: React.MouseEvent<T>) => void | Promise<void>,
-  extra?: TrackingExtra
+  extra?: TrackingExtra,
 ) {
   return (e: React.MouseEvent<T>) => {
     trackEvent({ area, object, action: TRACKING_ACTIONS.CLICK, extra });


### PR DESCRIPTION
## Summary
- Adds a new in-app promotional banner for the "email your agents" feature, following the same pattern as the existing Chrome Extension banner
- Banner appears in the conversation sidebar with dismiss/localStorage persistence and PostHog tracking
- Links to the docs page at https://docs.dust.tt/docs/email-agents

## TODO
- [ ] **Banner image**: needs `front/public/static/Email_Banner.png` (300×98px) from design
- [ ] Copy can be tweaked — currently: "Email your agents" / "Forward any email to an agent — get answers right in your inbox."

## Test plan
- [ ] Verify the banner appears in the conversation sidebar on desktop
- [ ] Verify clicking the banner opens the docs page in a new tab
- [ ] Verify the dismiss button hides the banner and persists across page reloads (localStorage)
- [ ] Verify the banner is hidden on mobile (sm:flex)
- [ ] Verify PostHog tracking events fire on click