### PR TITLE
[Sessions] Add conversation fork resource

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -10,7 +10,6 @@ import {
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
-import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import {
   AgentMessageSkillModel,
   ConversationSkillModel,
@@ -19,6 +18,7 @@ import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
+import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -34,7 +34,7 @@ import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import chunk from "lodash/chunk";
-import { Op, type WhereOptions } from "sequelize";
+import type { WhereOptions } from "sequelize";
 
 const DESTROY_MESSAGE_BATCH = 50;
 
@@ -66,11 +66,8 @@ async function destroyMessageRelatedResources(
 ) {
   const owner = auth.getNonNullableWorkspace();
 
-  await ConversationForkModel.destroy({
-    where: {
-      workspaceId: owner.id,
-      sourceMessageId: messageIds,
-    },
+  await ConversationForkResource.deleteBySourceMessageModelIds(auth, {
+    sourceMessageModelIds: messageIds,
   });
 
   await ConversationBranchModel.destroy({
@@ -180,14 +177,8 @@ export async function destroyConversation(
 ): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  await ConversationForkModel.destroy({
-    where: {
-      workspaceId: owner.id,
-      [Op.or]: [
-        { parentConversationId: conversation.id },
-        { childConversationId: conversation.id },
-      ],
-    },
+  await ConversationForkResource.deleteForConversationModelId(auth, {
+    conversationModelId: conversation.id,
   });
 
   // Clean up all branches attached to this conversation before deleting messages.

--- a/front/lib/resources/conversation_fork_resource.test.ts
+++ b/front/lib/resources/conversation_fork_resource.test.ts
@@ -202,7 +202,7 @@ describe("ConversationForkResource", () => {
     expect(fetched[0].id).toBe(fork.id);
   });
 
-  it("filters sId fetches by parent and child conversation permissions", async () => {
+  it("filters fork reads only by child conversation permissions", async () => {
     const adminUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
     let adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -227,6 +227,10 @@ describe("ConversationForkResource", () => {
         spaceId: restrictedSpace.id,
       }
     );
+    const readableChildConversation = await makeConversation(
+      workspace,
+      "Readable child"
+    );
     const restrictedChildConversation = await makeConversation(
       workspace,
       "Restricted child",
@@ -240,32 +244,54 @@ describe("ConversationForkResource", () => {
       conversationModelId: restrictedParentConversation.id,
     });
 
-    const fork = await ConversationForkResource.makeNew(adminAuth, {
-      parentConversation: restrictedParentConversation,
-      childConversation: restrictedChildConversation,
-      sourceMessageModelId: restrictedSourceMessage.id,
-      branchedAt: new Date("2026-04-10T10:00:00.000Z"),
-    });
+    const readableChildFork = await ConversationForkResource.makeNew(
+      adminAuth,
+      {
+        parentConversation: restrictedParentConversation,
+        childConversation: readableChildConversation,
+        sourceMessageModelId: restrictedSourceMessage.id,
+        branchedAt: new Date("2026-04-10T10:00:00.000Z"),
+      }
+    );
+    const restrictedChildFork = await ConversationForkResource.makeNew(
+      adminAuth,
+      {
+        parentConversation: restrictedParentConversation,
+        childConversation: restrictedChildConversation,
+        sourceMessageModelId: restrictedSourceMessage.id,
+        branchedAt: new Date("2026-04-10T11:00:00.000Z"),
+      }
+    );
 
     const adminFetchedByChild =
       await ConversationForkResource.fetchByChildConversationIds(adminAuth, [
+        readableChildConversation.sId,
         restrictedChildConversation.sId,
       ]);
-    expect(adminFetchedByChild.map((f) => f.id)).toEqual([fork.id]);
-    await expect(
-      ConversationForkResource.fetchById(auth, fork.sId)
-    ).resolves.toBeNull();
-    await expect(
-      ConversationForkResource.fetchByChildConversationIds(auth, [
+    expect(adminFetchedByChild.map((f) => f.id).sort((a, b) => a - b)).toEqual(
+      [readableChildFork.id, restrictedChildFork.id].sort((a, b) => a - b)
+    );
+
+    const userFetchedByChild =
+      await ConversationForkResource.fetchByChildConversationIds(auth, [
+        readableChildConversation.sId,
         restrictedChildConversation.sId,
-      ])
-    ).resolves.toEqual([]);
+      ]);
+    expect(userFetchedByChild.map((f) => f.id)).toEqual([readableChildFork.id]);
+    await expect(
+      ConversationForkResource.fetchById(auth, readableChildFork.sId)
+    ).resolves.toMatchObject({
+      id: readableChildFork.id,
+    });
+    await expect(
+      ConversationForkResource.fetchById(auth, restrictedChildFork.sId)
+    ).resolves.toBeNull();
     await expect(
       ConversationForkResource.listByParentConversationModelId(
         auth,
         restrictedParentConversation.id
       )
-    ).resolves.toEqual([]);
+    ).resolves.toMatchObject([{ id: readableChildFork.id }]);
   });
 
   it("lists forks from a parent conversation from newest to oldest", async () => {

--- a/front/lib/resources/conversation_fork_resource.test.ts
+++ b/front/lib/resources/conversation_fork_resource.test.ts
@@ -1,0 +1,334 @@
+import { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  ConversationModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+async function makeConversation(
+  workspace: WorkspaceType,
+  title: string
+): Promise<ConversationResource> {
+  const conversation = await ConversationModel.create({
+    workspaceId: workspace.id,
+    sId: generateRandomModelSId(),
+    title,
+    requestedSpaceIds: [],
+  });
+
+  return new ConversationResource(
+    ConversationResource.model,
+    conversation.get(),
+    null
+  );
+}
+
+async function makeSourceAgentMessage({
+  auth,
+  conversationModelId,
+}: {
+  auth: Authenticator;
+  conversationModelId: ModelId;
+}): Promise<MessageModel> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const agentMessage = await AgentMessageModel.create({
+    workspaceId: workspace.id,
+    agentConfigurationId: "agent-configuration-id",
+    agentConfigurationVersion: 0,
+    skipToolsValidation: false,
+  });
+
+  return MessageModel.create({
+    workspaceId: workspace.id,
+    sId: generateRandomModelSId(),
+    rank: 1,
+    conversationId: conversationModelId,
+    parentId: null,
+    userMessageId: null,
+    agentMessageId: agentMessage.id,
+    contentFragmentId: null,
+  });
+}
+
+async function makeUserMessage({
+  auth,
+  conversationModelId,
+}: {
+  auth: Authenticator;
+  conversationModelId: ModelId;
+}): Promise<MessageModel> {
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+
+  const userMessage = await UserMessageModel.create({
+    userId: user.id,
+    workspaceId: workspace.id,
+    content: "Source message",
+    userContextUsername: "testuser",
+    userContextTimezone: "UTC",
+    userContextFullName: "Test User",
+    userContextEmail: "test@example.com",
+    userContextProfilePictureUrl: null,
+    userContextOrigin: "web",
+    clientSideMCPServerIds: [],
+  });
+
+  return MessageModel.create({
+    workspaceId: workspace.id,
+    sId: generateRandomModelSId(),
+    rank: 0,
+    conversationId: conversationModelId,
+    parentId: null,
+    userMessageId: userMessage.id,
+    agentMessageId: null,
+    contentFragmentId: null,
+  });
+}
+
+describe("ConversationForkResource", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let auth: Authenticator;
+  let user: Awaited<ReturnType<typeof UserFactory.basic>>;
+  let parentConversation: ConversationResource;
+  let childConversation: ConversationResource;
+  let sourceMessage: MessageModel;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    parentConversation = await makeConversation(workspace, "Parent");
+    childConversation = await makeConversation(workspace, "Child");
+    sourceMessage = await makeSourceAgentMessage({
+      auth,
+      conversationModelId: parentConversation.id,
+    });
+  });
+
+  it("creates a fork attributed to the authenticated user", async () => {
+    const branchedAt = new Date("2026-04-10T10:00:00.000Z");
+
+    const fork = await ConversationForkResource.makeNew(auth, {
+      parentConversation,
+      childConversation,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt,
+    });
+
+    expect(fork.sId).toMatch(/^cfk_/);
+    expect(fork.workspaceId).toBe(workspace.id);
+    expect(fork.parentConversationId).toBe(parentConversation.id);
+    expect(fork.childConversationId).toBe(childConversation.id);
+    expect(fork.createdByUserId).toBe(user.id);
+    expect(fork.sourceMessageId).toBe(sourceMessage.id);
+
+    expect(fork.toJSON()).toMatchObject({
+      id: fork.id,
+      sId: fork.sId,
+      parentConversationId: parentConversation.sId,
+      parentConversationModelId: parentConversation.id,
+      childConversationId: childConversation.sId,
+      childConversationModelId: childConversation.id,
+      createdByUserId: user.sId,
+      createdByUserModelId: user.id,
+      sourceMessageId: sourceMessage.sId,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt: branchedAt.getTime(),
+    });
+  });
+
+  it("fetches forks by child conversation ids within the authenticated workspace", async () => {
+    const fork = await ConversationForkResource.makeNew(auth, {
+      parentConversation,
+      childConversation,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt: new Date("2026-04-10T10:00:00.000Z"),
+    });
+
+    const otherWorkspace = await WorkspaceFactory.basic();
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(otherWorkspace, otherUser, {
+      role: "user",
+    });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      otherWorkspace.sId
+    );
+    const otherParent = await makeConversation(otherWorkspace, "Other parent");
+    const otherChild = await makeConversation(otherWorkspace, "Other child");
+    const otherSourceMessage = await makeSourceAgentMessage({
+      auth: otherAuth,
+      conversationModelId: otherParent.id,
+    });
+
+    await ConversationForkResource.makeNew(otherAuth, {
+      parentConversation: otherParent,
+      childConversation: otherChild,
+      sourceMessageModelId: otherSourceMessage.id,
+      branchedAt: new Date("2026-04-10T11:00:00.000Z"),
+    });
+
+    const fetched = await ConversationForkResource.fetchByChildConversationIds(
+      auth,
+      [childConversation.sId, otherChild.sId]
+    );
+
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0].id).toBe(fork.id);
+  });
+
+  it("lists forks from a parent conversation from newest to oldest", async () => {
+    const firstChild = childConversation;
+    const secondChild = await makeConversation(workspace, "Second child");
+
+    await ConversationForkResource.makeNew(auth, {
+      parentConversation,
+      childConversation: firstChild,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt: new Date("2026-04-10T10:00:00.000Z"),
+    });
+    await ConversationForkResource.makeNew(auth, {
+      parentConversation,
+      childConversation: secondChild,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt: new Date("2026-04-10T11:00:00.000Z"),
+    });
+
+    const forks =
+      await ConversationForkResource.listByParentConversationModelId(
+        auth,
+        parentConversation.id
+      );
+
+    expect(forks.map((f) => f.childConversationId)).toEqual([
+      secondChild.id,
+      firstChild.id,
+    ]);
+  });
+
+  it("rejects source messages outside the parent conversation", async () => {
+    const wrongSourceMessage = await makeSourceAgentMessage({
+      auth,
+      conversationModelId: childConversation.id,
+    });
+    const secondChild = await makeConversation(workspace, "Second child");
+
+    await expect(
+      ConversationForkResource.makeNew(auth, {
+        parentConversation,
+        childConversation: secondChild,
+        sourceMessageModelId: wrongSourceMessage.id,
+        branchedAt: new Date("2026-04-10T10:00:00.000Z"),
+      })
+    ).rejects.toThrow(
+      "Cannot create a conversation fork from a missing source agent message."
+    );
+  });
+
+  it("rejects source messages that are not agent messages", async () => {
+    const userMessage = await makeUserMessage({
+      auth,
+      conversationModelId: parentConversation.id,
+    });
+    const secondChild = await makeConversation(workspace, "Second child");
+
+    await expect(
+      ConversationForkResource.makeNew(auth, {
+        parentConversation,
+        childConversation: secondChild,
+        sourceMessageModelId: userMessage.id,
+        branchedAt: new Date("2026-04-10T10:00:00.000Z"),
+      })
+    ).rejects.toThrow(
+      "Cannot create a conversation fork from a missing source agent message."
+    );
+  });
+
+  it("deletes fork rows by source message model ids", async () => {
+    await ConversationForkResource.makeNew(auth, {
+      parentConversation,
+      childConversation,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt: new Date("2026-04-10T10:00:00.000Z"),
+    });
+
+    const deletedCount =
+      await ConversationForkResource.deleteBySourceMessageModelIds(auth, {
+        sourceMessageModelIds: [sourceMessage.id],
+      });
+
+    expect(deletedCount).toBe(1);
+    const fetched = await ConversationForkResource.fetchByChildConversationIds(
+      auth,
+      [childConversation.sId]
+    );
+    expect(fetched).toEqual([]);
+  });
+
+  it("deletes fork rows where a conversation is either parent or child", async () => {
+    const grandParentConversation = await makeConversation(
+      workspace,
+      "Grand parent"
+    );
+    const grandParentSourceMessage = await makeSourceAgentMessage({
+      auth,
+      conversationModelId: grandParentConversation.id,
+    });
+
+    await ConversationForkResource.makeNew(auth, {
+      parentConversation: grandParentConversation,
+      childConversation: parentConversation,
+      sourceMessageModelId: grandParentSourceMessage.id,
+      branchedAt: new Date("2026-04-10T09:00:00.000Z"),
+    });
+    await ConversationForkResource.makeNew(auth, {
+      parentConversation,
+      childConversation,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt: new Date("2026-04-10T10:00:00.000Z"),
+    });
+
+    const deletedCount =
+      await ConversationForkResource.deleteForConversationModelId(auth, {
+        conversationModelId: parentConversation.id,
+      });
+
+    expect(deletedCount).toBe(2);
+    const fetched = await ConversationForkResource.fetchByChildConversationIds(
+      auth,
+      [parentConversation.sId, childConversation.sId]
+    );
+    expect(fetched).toEqual([]);
+  });
+
+  it("deletes fork rows in the authenticated workspace", async () => {
+    const fork = await ConversationForkResource.makeNew(auth, {
+      parentConversation,
+      childConversation,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt: new Date("2026-04-10T10:00:00.000Z"),
+    });
+
+    const deleteResult = await fork.delete(auth, {});
+    expect(deleteResult.isOk()).toBe(true);
+
+    const fetched = await ConversationForkResource.fetchById(auth, fork.sId);
+    expect(fetched).toBeNull();
+  });
+});

--- a/front/lib/resources/conversation_fork_resource.test.ts
+++ b/front/lib/resources/conversation_fork_resource.test.ts
@@ -198,7 +198,7 @@ describe("ConversationForkResource", () => {
     expect(fetched[0].id).toBe(fork.id);
   });
 
-  it("filters fork reads only by child conversation permissions", async () => {
+  it("canReadFork only depends on child conversation readability", async () => {
     const adminUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
     let adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -259,35 +259,108 @@ describe("ConversationForkResource", () => {
       }
     );
 
-    const adminFetchedByChild =
-      await ConversationForkResource.fetchByChildConversationIds(adminAuth, [
-        readableChildConversation.sId,
-        restrictedChildConversation.sId,
-      ]);
-    expect(adminFetchedByChild.map((f) => f.id).sort((a, b) => a - b)).toEqual(
-      [readableChildFork.id, restrictedChildFork.id].sort((a, b) => a - b)
+    expect(await readableChildFork.canReadFork(adminAuth)).toBe(true);
+    expect(await restrictedChildFork.canReadFork(adminAuth)).toBe(true);
+    expect(await readableChildFork.canReadFork(auth)).toBe(true);
+    expect(await restrictedChildFork.canReadFork(auth)).toBe(false);
+
+    const otherWorkspace = await WorkspaceFactory.basic();
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(otherWorkspace, otherUser, {
+      role: "user",
+    });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      otherWorkspace.sId
     );
 
-    const userFetchedByChild =
+    expect(await readableChildFork.canReadFork(otherAuth)).toBe(false);
+  });
+
+  it("keeps fetch helpers workspace-scoped without applying canReadFork", async () => {
+    const adminUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+    let adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const addMembersRes = await restrictedSpace.addMembers(adminAuth, {
+      userIds: [adminUser.sId],
+    });
+    expect(addMembersRes.isOk()).toBe(true);
+    adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    const restrictedParentConversation = await makeConversation(
+      workspace,
+      "Restricted parent",
+      {
+        requestedSpaceIds: [restrictedSpace.id],
+        spaceId: restrictedSpace.id,
+      }
+    );
+    const readableChildConversation = await makeConversation(
+      workspace,
+      "Readable child"
+    );
+    const restrictedChildConversation = await makeConversation(
+      workspace,
+      "Restricted child",
+      {
+        requestedSpaceIds: [restrictedSpace.id],
+        spaceId: restrictedSpace.id,
+      }
+    );
+    const restrictedSourceMessage = await makeSourceAgentMessage({
+      auth: adminAuth,
+      conversationModelId: restrictedParentConversation.id,
+    });
+
+    const readableChildFork = await ConversationForkResource.makeNew(
+      adminAuth,
+      {
+        parentConversation: restrictedParentConversation,
+        childConversation: readableChildConversation,
+        sourceMessageModelId: restrictedSourceMessage.id,
+        branchedAt: new Date("2026-04-10T10:00:00.000Z"),
+      }
+    );
+    const restrictedChildFork = await ConversationForkResource.makeNew(
+      adminAuth,
+      {
+        parentConversation: restrictedParentConversation,
+        childConversation: restrictedChildConversation,
+        sourceMessageModelId: restrictedSourceMessage.id,
+        branchedAt: new Date("2026-04-10T11:00:00.000Z"),
+      }
+    );
+
+    const fetchedByChild =
       await ConversationForkResource.fetchByChildConversationIds(auth, [
         readableChildConversation.sId,
         restrictedChildConversation.sId,
       ]);
-    expect(userFetchedByChild.map((f) => f.id)).toEqual([readableChildFork.id]);
-    await expect(
-      ConversationForkResource.fetchById(auth, readableChildFork.sId)
-    ).resolves.toMatchObject({
-      id: readableChildFork.id,
-    });
+    expect(fetchedByChild.map((f) => f.id).sort((a, b) => a - b)).toEqual(
+      [readableChildFork.id, restrictedChildFork.id].sort((a, b) => a - b)
+    );
+
     await expect(
       ConversationForkResource.fetchById(auth, restrictedChildFork.sId)
-    ).resolves.toBeNull();
+    ).resolves.toMatchObject({
+      id: restrictedChildFork.id,
+    });
     await expect(
       ConversationForkResource.listByParentConversationModelId(
         auth,
         restrictedParentConversation.id
       )
-    ).resolves.toMatchObject([{ id: readableChildFork.id }]);
+    ).resolves.toMatchObject([
+      { id: restrictedChildFork.id },
+      { id: readableChildFork.id },
+    ]);
   });
 
   it("lists forks from a parent conversation from newest to oldest", async () => {

--- a/front/lib/resources/conversation_fork_resource.test.ts
+++ b/front/lib/resources/conversation_fork_resource.test.ts
@@ -9,6 +9,7 @@ import { ConversationForkResource } from "@app/lib/resources/conversation_fork_r
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -17,13 +18,21 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 async function makeConversation(
   workspace: WorkspaceType,
-  title: string
+  title: string,
+  {
+    requestedSpaceIds = [],
+    spaceId = null,
+  }: {
+    requestedSpaceIds?: ModelId[];
+    spaceId?: ModelId | null;
+  } = {}
 ): Promise<ConversationResource> {
   const conversation = await ConversationModel.create({
     workspaceId: workspace.id,
     sId: generateRandomModelSId(),
     title,
-    requestedSpaceIds: [],
+    requestedSpaceIds,
+    spaceId,
   });
 
   return new ConversationResource(
@@ -191,6 +200,72 @@ describe("ConversationForkResource", () => {
 
     expect(fetched).toHaveLength(1);
     expect(fetched[0].id).toBe(fork.id);
+  });
+
+  it("filters sId fetches by parent and child conversation permissions", async () => {
+    const adminUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+    let adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const addMembersRes = await restrictedSpace.addMembers(adminAuth, {
+      userIds: [adminUser.sId],
+    });
+    expect(addMembersRes.isOk()).toBe(true);
+    adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    const restrictedParentConversation = await makeConversation(
+      workspace,
+      "Restricted parent",
+      {
+        requestedSpaceIds: [restrictedSpace.id],
+        spaceId: restrictedSpace.id,
+      }
+    );
+    const restrictedChildConversation = await makeConversation(
+      workspace,
+      "Restricted child",
+      {
+        requestedSpaceIds: [restrictedSpace.id],
+        spaceId: restrictedSpace.id,
+      }
+    );
+    const restrictedSourceMessage = await makeSourceAgentMessage({
+      auth: adminAuth,
+      conversationModelId: restrictedParentConversation.id,
+    });
+
+    const fork = await ConversationForkResource.makeNew(adminAuth, {
+      parentConversation: restrictedParentConversation,
+      childConversation: restrictedChildConversation,
+      sourceMessageModelId: restrictedSourceMessage.id,
+      branchedAt: new Date("2026-04-10T10:00:00.000Z"),
+    });
+
+    const adminFetchedByChild =
+      await ConversationForkResource.fetchByChildConversationIds(adminAuth, [
+        restrictedChildConversation.sId,
+      ]);
+    expect(adminFetchedByChild.map((f) => f.id)).toEqual([fork.id]);
+    await expect(
+      ConversationForkResource.fetchById(auth, fork.sId)
+    ).resolves.toBeNull();
+    await expect(
+      ConversationForkResource.fetchByChildConversationIds(auth, [
+        restrictedChildConversation.sId,
+      ])
+    ).resolves.toEqual([]);
+    await expect(
+      ConversationForkResource.listByParentConversationModelId(
+        auth,
+        restrictedParentConversation.id
+      )
+    ).resolves.toEqual([]);
   });
 
   it("lists forks from a parent conversation from newest to oldest", async () => {

--- a/front/lib/resources/conversation_fork_resource.test.ts
+++ b/front/lib/resources/conversation_fork_resource.test.ts
@@ -343,9 +343,7 @@ describe("ConversationForkResource", () => {
         readableChildConversation.sId,
         restrictedChildConversation.sId,
       ]);
-    expect(fetchedByChild.map((f) => f.id).sort((a, b) => a - b)).toEqual(
-      [readableChildFork.id, restrictedChildFork.id].sort((a, b) => a - b)
-    );
+    expect(fetchedByChild.map((f) => f.id)).toEqual([readableChildFork.id]);
 
     await expect(
       ConversationForkResource.fetchById(auth, restrictedChildFork.sId)

--- a/front/lib/resources/conversation_fork_resource.test.ts
+++ b/front/lib/resources/conversation_fork_resource.test.ts
@@ -151,13 +151,9 @@ describe("ConversationForkResource", () => {
       id: fork.id,
       sId: fork.sId,
       parentConversationId: parentConversation.sId,
-      parentConversationModelId: parentConversation.id,
       childConversationId: childConversation.sId,
-      childConversationModelId: childConversation.id,
       createdByUserId: user.sId,
-      createdByUserModelId: user.id,
       sourceMessageId: sourceMessage.sId,
-      sourceMessageModelId: sourceMessage.id,
       branchedAt: branchedAt.getTime(),
     });
   });

--- a/front/lib/resources/conversation_fork_resource.ts
+++ b/front/lib/resources/conversation_fork_resource.ts
@@ -266,13 +266,10 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
       return [];
     }
 
-    const childConversations = await ConversationModel.findAll({
-      attributes: ["id"],
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        sId: childConversationIds,
-      },
-    });
+    const childConversations = await ConversationResource.fetchByIds(
+      auth,
+      childConversationIds
+    );
 
     return this.fetchByChildConversationModelIds(
       auth,

--- a/front/lib/resources/conversation_fork_resource.ts
+++ b/front/lib/resources/conversation_fork_resource.ts
@@ -5,11 +5,14 @@ import {
 } from "@app/lib/models/agent/conversation";
 import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import {
+  getResourceNameAndIdFromSId,
+  makeSId,
+} from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -164,6 +167,37 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
     return forks.map((f) => this.fromModel(f));
   }
 
+  private static async filterByReadableConversations(
+    auth: Authenticator,
+    forks: ConversationForkResource[]
+  ): Promise<ConversationForkResource[]> {
+    if (forks.length === 0) {
+      return [];
+    }
+
+    const conversationSIds = [
+      ...new Set(
+        forks.flatMap((fork) => [
+          fork.parentConversationSId,
+          fork.childConversationSId,
+        ])
+      ),
+    ];
+    const readableConversations = await ConversationResource.fetchByIds(
+      auth,
+      conversationSIds
+    );
+    const readableConversationIds = new Set(
+      readableConversations.map((conversation) => conversation.id)
+    );
+
+    return forks.filter(
+      (fork) =>
+        readableConversationIds.has(fork.parentConversationId) &&
+        readableConversationIds.has(fork.childConversationId)
+    );
+  }
+
   static async makeNew(
     auth: Authenticator,
     blob: Pick<CreationAttributes<ConversationForkModel>, "branchedAt"> & {
@@ -241,13 +275,21 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
     auth: Authenticator,
     conversationForkId: string
   ): Promise<ConversationForkResource | null> {
-    const modelId = getResourceIdFromSId(conversationForkId);
-    if (modelId === null) {
+    const ids = getResourceNameAndIdFromSId(conversationForkId);
+    if (
+      ids === null ||
+      ids.resourceName !== "conversation_fork" ||
+      ids.workspaceModelId !== auth.getNonNullableWorkspace().id
+    ) {
       return null;
     }
 
-    const [fork] = await this.fetchByModelIds(auth, [modelId]);
-    return fork ?? null;
+    const [fork] = await this.fetchByModelIds(auth, [ids.resourceModelId]);
+    const [readableFork] = await this.filterByReadableConversations(
+      auth,
+      fork ? [fork] : []
+    );
+    return readableFork ?? null;
   }
 
   static async fetchByChildConversationModelIds(
@@ -273,25 +315,24 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
       return [];
     }
 
-    const childConversations = await ConversationModel.findAll({
-      attributes: ["id"],
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        sId: childConversationIds,
-      },
-    });
+    const childConversations = await ConversationResource.fetchByIds(
+      auth,
+      childConversationIds
+    );
 
-    return this.fetchByChildConversationModelIds(
+    const forks = await this.fetchByChildConversationModelIds(
       auth,
       childConversations.map((c) => c.id)
     );
+
+    return this.filterByReadableConversations(auth, forks);
   }
 
   static async listByParentConversationModelId(
     auth: Authenticator,
     parentConversationModelId: ModelId
   ): Promise<ConversationForkResource[]> {
-    return this.baseFetch(auth, {
+    const forks = await this.baseFetch(auth, {
       where: {
         parentConversationId: parentConversationModelId,
       } as WhereOptions<ConversationForkModel>,
@@ -300,6 +341,8 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
         ["id", "DESC"],
       ],
     });
+
+    return this.filterByReadableConversations(auth, forks);
   }
 
   static async deleteBySourceMessageModelIds(

--- a/front/lib/resources/conversation_fork_resource.ts
+++ b/front/lib/resources/conversation_fork_resource.ts
@@ -32,13 +32,9 @@ export type ConversationForkType = {
   created: number;
   updated: number;
   parentConversationId: string;
-  parentConversationModelId: ModelId;
   childConversationId: string;
-  childConversationModelId: ModelId;
   createdByUserId: string;
-  createdByUserModelId: ModelId;
   sourceMessageId: string;
-  sourceMessageModelId: ModelId;
   branchedAt: number;
 };
 
@@ -392,13 +388,9 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
       created: this.createdAt.getTime(),
       updated: this.updatedAt.getTime(),
       parentConversationId: this.resourceIds.parentConversationId,
-      parentConversationModelId: this.parentConversationId,
       childConversationId: this.resourceIds.childConversationId,
-      childConversationModelId: this.childConversationId,
       createdByUserId: this.resourceIds.createdByUserId,
-      createdByUserModelId: this.createdByUserId,
       sourceMessageId: this.resourceIds.sourceMessageId,
-      sourceMessageModelId: this.sourceMessageId,
       branchedAt: this.branchedAt.getTime(),
     };
   }

--- a/front/lib/resources/conversation_fork_resource.ts
+++ b/front/lib/resources/conversation_fork_resource.ts
@@ -42,6 +42,14 @@ export type ConversationForkType = {
   branchedAt: number;
 };
 
+type ConversationForkResourceIds = Pick<
+  ConversationForkType,
+  | "parentConversationId"
+  | "childConversationId"
+  | "createdByUserId"
+  | "sourceMessageId"
+>;
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ConversationForkResource
   extends ReadonlyAttributesType<ConversationForkModel> {}
@@ -51,32 +59,16 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
   static model: ModelStaticWorkspaceAware<ConversationForkModel> =
     ConversationForkModel;
 
-  readonly parentConversationSId: string;
-  readonly childConversationSId: string;
-  readonly createdByUserSId: string;
-  readonly sourceMessageSId: string;
+  private readonly resourceIds: ConversationForkResourceIds;
 
   constructor(
     model: ModelStaticWorkspaceAware<ConversationForkModel>,
     blob: Attributes<ConversationForkModel>,
-    {
-      parentConversationSId,
-      childConversationSId,
-      createdByUserSId,
-      sourceMessageSId,
-    }: {
-      parentConversationSId: string;
-      childConversationSId: string;
-      createdByUserSId: string;
-      sourceMessageSId: string;
-    }
+    resourceIds: ConversationForkResourceIds
   ) {
     super(model, blob);
 
-    this.parentConversationSId = parentConversationSId;
-    this.childConversationSId = childConversationSId;
-    this.createdByUserSId = createdByUserSId;
-    this.sourceMessageSId = sourceMessageSId;
+    this.resourceIds = resourceIds;
   }
 
   get sId(): string {
@@ -114,10 +106,10 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
     );
 
     return new this(this.model, fork.get(), {
-      parentConversationSId: fork.parentConversation.sId,
-      childConversationSId: fork.childConversation.sId,
-      createdByUserSId: fork.createdByUser.sId,
-      sourceMessageSId: fork.sourceMessage.sId,
+      parentConversationId: fork.parentConversation.sId,
+      childConversationId: fork.childConversation.sId,
+      createdByUserId: fork.createdByUser.sId,
+      sourceMessageId: fork.sourceMessage.sId,
     });
   }
 
@@ -167,7 +159,7 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
     return forks.map((f) => this.fromModel(f));
   }
 
-  private static async filterByReadableConversations(
+  private static async filterByReadableChildConversations(
     auth: Authenticator,
     forks: ConversationForkResource[]
   ): Promise<ConversationForkResource[]> {
@@ -175,26 +167,16 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
       return [];
     }
 
-    const conversationSIds = [
-      ...new Set(
-        forks.flatMap((fork) => [
-          fork.parentConversationSId,
-          fork.childConversationSId,
-        ])
-      ),
-    ];
-    const readableConversations = await ConversationResource.fetchByIds(
+    const readableChildConversations = await ConversationResource.fetchByIds(
       auth,
-      conversationSIds
+      [...new Set(forks.map((fork) => fork.resourceIds.childConversationId))]
     );
-    const readableConversationIds = new Set(
-      readableConversations.map((conversation) => conversation.id)
+    const readableChildConversationIds = new Set(
+      readableChildConversations.map((conversation) => conversation.id)
     );
 
-    return forks.filter(
-      (fork) =>
-        readableConversationIds.has(fork.parentConversationId) &&
-        readableConversationIds.has(fork.childConversationId)
+    return forks.filter((fork) =>
+      readableChildConversationIds.has(fork.childConversationId)
     );
   }
 
@@ -285,7 +267,7 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
     }
 
     const [fork] = await this.fetchByModelIds(auth, [ids.resourceModelId]);
-    const [readableFork] = await this.filterByReadableConversations(
+    const [readableFork] = await this.filterByReadableChildConversations(
       auth,
       fork ? [fork] : []
     );
@@ -320,12 +302,10 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
       childConversationIds
     );
 
-    const forks = await this.fetchByChildConversationModelIds(
+    return this.fetchByChildConversationModelIds(
       auth,
       childConversations.map((c) => c.id)
     );
-
-    return this.filterByReadableConversations(auth, forks);
   }
 
   static async listByParentConversationModelId(
@@ -342,7 +322,7 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
       ],
     });
 
-    return this.filterByReadableConversations(auth, forks);
+    return this.filterByReadableChildConversations(auth, forks);
   }
 
   static async deleteBySourceMessageModelIds(
@@ -411,13 +391,13 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
       sId: this.sId,
       created: this.createdAt.getTime(),
       updated: this.updatedAt.getTime(),
-      parentConversationId: this.parentConversationSId,
+      parentConversationId: this.resourceIds.parentConversationId,
       parentConversationModelId: this.parentConversationId,
-      childConversationId: this.childConversationSId,
+      childConversationId: this.resourceIds.childConversationId,
       childConversationModelId: this.childConversationId,
-      createdByUserId: this.createdByUserSId,
+      createdByUserId: this.resourceIds.createdByUserId,
       createdByUserModelId: this.createdByUserId,
-      sourceMessageId: this.sourceMessageSId,
+      sourceMessageId: this.resourceIds.sourceMessageId,
       sourceMessageModelId: this.sourceMessageId,
       branchedAt: this.branchedAt.getTime(),
     };

--- a/front/lib/resources/conversation_fork_resource.ts
+++ b/front/lib/resources/conversation_fork_resource.ts
@@ -29,8 +29,6 @@ import { Op } from "sequelize";
 export type ConversationForkType = {
   id: ModelId;
   sId: string;
-  created: number;
-  updated: number;
   parentConversationId: string;
   childConversationId: string;
   createdByUserId: string;
@@ -155,27 +153,6 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
     return forks.map((f) => this.fromModel(f));
   }
 
-  private static async filterByReadableChildConversations(
-    auth: Authenticator,
-    forks: ConversationForkResource[]
-  ): Promise<ConversationForkResource[]> {
-    if (forks.length === 0) {
-      return [];
-    }
-
-    const readableChildConversations = await ConversationResource.fetchByIds(
-      auth,
-      [...new Set(forks.map((fork) => fork.resourceIds.childConversationId))]
-    );
-    const readableChildConversationIds = new Set(
-      readableChildConversations.map((conversation) => conversation.id)
-    );
-
-    return forks.filter((fork) =>
-      readableChildConversationIds.has(fork.childConversationId)
-    );
-  }
-
   static async makeNew(
     auth: Authenticator,
     blob: Pick<CreationAttributes<ConversationForkModel>, "branchedAt"> & {
@@ -263,11 +240,7 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
     }
 
     const [fork] = await this.fetchByModelIds(auth, [ids.resourceModelId]);
-    const [readableFork] = await this.filterByReadableChildConversations(
-      auth,
-      fork ? [fork] : []
-    );
-    return readableFork ?? null;
+    return fork ?? null;
   }
 
   static async fetchByChildConversationModelIds(
@@ -293,10 +266,13 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
       return [];
     }
 
-    const childConversations = await ConversationResource.fetchByIds(
-      auth,
-      childConversationIds
-    );
+    const childConversations = await ConversationModel.findAll({
+      attributes: ["id"],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        sId: childConversationIds,
+      },
+    });
 
     return this.fetchByChildConversationModelIds(
       auth,
@@ -308,7 +284,7 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
     auth: Authenticator,
     parentConversationModelId: ModelId
   ): Promise<ConversationForkResource[]> {
-    const forks = await this.baseFetch(auth, {
+    return this.baseFetch(auth, {
       where: {
         parentConversationId: parentConversationModelId,
       } as WhereOptions<ConversationForkModel>,
@@ -317,8 +293,6 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
         ["id", "DESC"],
       ],
     });
-
-    return this.filterByReadableChildConversations(auth, forks);
   }
 
   static async deleteBySourceMessageModelIds(
@@ -381,12 +355,23 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
     return new Ok(undefined);
   }
 
+  async canReadFork(auth: Authenticator): Promise<boolean> {
+    if (auth.getNonNullableWorkspace().id !== this.workspaceId) {
+      return false;
+    }
+
+    const childConversation = await ConversationResource.fetchById(
+      auth,
+      this.resourceIds.childConversationId
+    );
+
+    return childConversation !== null;
+  }
+
   toJSON(): ConversationForkType {
     return {
       id: this.id,
       sId: this.sId,
-      created: this.createdAt.getTime(),
-      updated: this.updatedAt.getTime(),
       parentConversationId: this.resourceIds.parentConversationId,
       childConversationId: this.resourceIds.childConversationId,
       createdByUserId: this.resourceIds.createdByUserId,

--- a/front/lib/resources/conversation_fork_resource.ts
+++ b/front/lib/resources/conversation_fork_resource.ts
@@ -1,0 +1,382 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  ConversationModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import assert from "assert";
+import type {
+  Attributes,
+  CreationAttributes,
+  Transaction,
+  WhereOptions,
+} from "sequelize";
+import { Op } from "sequelize";
+
+export type ConversationForkType = {
+  id: ModelId;
+  sId: string;
+  created: number;
+  updated: number;
+  parentConversationId: string;
+  parentConversationModelId: ModelId;
+  childConversationId: string;
+  childConversationModelId: ModelId;
+  createdByUserId: string;
+  createdByUserModelId: ModelId;
+  sourceMessageId: string;
+  sourceMessageModelId: ModelId;
+  branchedAt: number;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ConversationForkResource
+  extends ReadonlyAttributesType<ConversationForkModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ConversationForkResource extends BaseResource<ConversationForkModel> {
+  static model: ModelStaticWorkspaceAware<ConversationForkModel> =
+    ConversationForkModel;
+
+  readonly parentConversationSId: string;
+  readonly childConversationSId: string;
+  readonly createdByUserSId: string;
+  readonly sourceMessageSId: string;
+
+  constructor(
+    model: ModelStaticWorkspaceAware<ConversationForkModel>,
+    blob: Attributes<ConversationForkModel>,
+    {
+      parentConversationSId,
+      childConversationSId,
+      createdByUserSId,
+      sourceMessageSId,
+    }: {
+      parentConversationSId: string;
+      childConversationSId: string;
+      createdByUserSId: string;
+      sourceMessageSId: string;
+    }
+  ) {
+    super(model, blob);
+
+    this.parentConversationSId = parentConversationSId;
+    this.childConversationSId = childConversationSId;
+    this.createdByUserSId = createdByUserSId;
+    this.sourceMessageSId = sourceMessageSId;
+  }
+
+  get sId(): string {
+    return ConversationForkResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("conversation_fork", { id, workspaceId });
+  }
+
+  private static fromModel(
+    fork: ConversationForkModel
+  ): ConversationForkResource {
+    assert(
+      fork.parentConversation,
+      "Conversation fork parent conversation must be loaded."
+    );
+    assert(
+      fork.childConversation,
+      "Conversation fork child conversation must be loaded."
+    );
+    assert(fork.createdByUser, "Conversation fork creator must be loaded.");
+    assert(
+      fork.sourceMessage,
+      "Conversation fork source message must be loaded."
+    );
+
+    return new this(this.model, fork.get(), {
+      parentConversationSId: fork.parentConversation.sId,
+      childConversationSId: fork.childConversation.sId,
+      createdByUserSId: fork.createdByUser.sId,
+      sourceMessageSId: fork.sourceMessage.sId,
+    });
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    options?: ResourceFindOptions<ConversationForkModel> & {
+      transaction?: Transaction;
+    }
+  ): Promise<ConversationForkResource[]> {
+    const { where, ...rest } = options ?? {};
+    const owner = auth.getNonNullableWorkspace();
+
+    const forks = await this.model.findAll({
+      where: {
+        ...where,
+        workspaceId: owner.id,
+      },
+      include: [
+        {
+          model: ConversationModel,
+          as: "parentConversation",
+          required: true,
+          attributes: ["sId"],
+        },
+        {
+          model: ConversationModel,
+          as: "childConversation",
+          required: true,
+          attributes: ["sId"],
+        },
+        {
+          model: UserModel,
+          as: "createdByUser",
+          required: true,
+          attributes: ["sId"],
+        },
+        {
+          model: MessageModel,
+          as: "sourceMessage",
+          required: true,
+          attributes: ["sId"],
+        },
+      ],
+      ...rest,
+    });
+
+    return forks.map((f) => this.fromModel(f));
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    blob: Pick<CreationAttributes<ConversationForkModel>, "branchedAt"> & {
+      parentConversation: ConversationResource;
+      childConversation: ConversationResource;
+      sourceMessageModelId: ModelId;
+    },
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<ConversationForkResource> {
+    const owner = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
+
+    if (
+      blob.parentConversation.workspaceId !== owner.id ||
+      blob.childConversation.workspaceId !== owner.id
+    ) {
+      throw new Error("Cannot create a conversation fork across workspaces.");
+    }
+
+    if (blob.parentConversation.id === blob.childConversation.id) {
+      throw new Error("Cannot create a conversation fork from itself.");
+    }
+
+    const sourceMessage = await MessageModel.findOne({
+      attributes: ["id"],
+      where: {
+        id: blob.sourceMessageModelId,
+        workspaceId: owner.id,
+        conversationId: blob.parentConversation.id,
+        agentMessageId: { [Op.ne]: null },
+      },
+      transaction,
+    });
+    if (!sourceMessage) {
+      throw new Error(
+        "Cannot create a conversation fork from a missing source agent message."
+      );
+    }
+
+    const fork = await this.model.create(
+      {
+        workspaceId: owner.id,
+        parentConversationId: blob.parentConversation.id,
+        childConversationId: blob.childConversation.id,
+        createdByUserId: user.id,
+        sourceMessageId: blob.sourceMessageModelId,
+        branchedAt: blob.branchedAt,
+      },
+      { transaction }
+    );
+
+    const [resource] = await this.fetchByModelIds(auth, [fork.id], {
+      transaction,
+    });
+    assert(resource, "Created conversation fork must be fetchable.");
+    return resource;
+  }
+
+  static async fetchByModelIds(
+    auth: Authenticator,
+    ids: ModelId[],
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<ConversationForkResource[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+
+    return this.baseFetch(auth, {
+      where: { id: ids },
+      ...(transaction && { transaction }),
+    });
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    conversationForkId: string
+  ): Promise<ConversationForkResource | null> {
+    const modelId = getResourceIdFromSId(conversationForkId);
+    if (modelId === null) {
+      return null;
+    }
+
+    const [fork] = await this.fetchByModelIds(auth, [modelId]);
+    return fork ?? null;
+  }
+
+  static async fetchByChildConversationModelIds(
+    auth: Authenticator,
+    childConversationModelIds: ModelId[]
+  ): Promise<ConversationForkResource[]> {
+    if (childConversationModelIds.length === 0) {
+      return [];
+    }
+
+    return this.baseFetch(auth, {
+      where: {
+        childConversationId: childConversationModelIds,
+      } as WhereOptions<ConversationForkModel>,
+    });
+  }
+
+  static async fetchByChildConversationIds(
+    auth: Authenticator,
+    childConversationIds: string[]
+  ): Promise<ConversationForkResource[]> {
+    if (childConversationIds.length === 0) {
+      return [];
+    }
+
+    const childConversations = await ConversationModel.findAll({
+      attributes: ["id"],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        sId: childConversationIds,
+      },
+    });
+
+    return this.fetchByChildConversationModelIds(
+      auth,
+      childConversations.map((c) => c.id)
+    );
+  }
+
+  static async listByParentConversationModelId(
+    auth: Authenticator,
+    parentConversationModelId: ModelId
+  ): Promise<ConversationForkResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        parentConversationId: parentConversationModelId,
+      } as WhereOptions<ConversationForkModel>,
+      order: [
+        ["branchedAt", "DESC"],
+        ["id", "DESC"],
+      ],
+    });
+  }
+
+  static async deleteBySourceMessageModelIds(
+    auth: Authenticator,
+    {
+      sourceMessageModelIds,
+      transaction,
+    }: {
+      sourceMessageModelIds: ModelId[];
+      transaction?: Transaction;
+    }
+  ): Promise<number> {
+    if (sourceMessageModelIds.length === 0) {
+      return 0;
+    }
+
+    return this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        sourceMessageId: sourceMessageModelIds,
+      },
+      transaction,
+    });
+  }
+
+  static async deleteForConversationModelId(
+    auth: Authenticator,
+    {
+      conversationModelId,
+      transaction,
+    }: {
+      conversationModelId: ModelId;
+      transaction?: Transaction;
+    }
+  ): Promise<number> {
+    return this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        [Op.or]: [
+          { parentConversationId: conversationModelId },
+          { childConversationId: conversationModelId },
+        ],
+      },
+      transaction,
+    });
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+
+  toJSON(): ConversationForkType {
+    return {
+      id: this.id,
+      sId: this.sId,
+      created: this.createdAt.getTime(),
+      updated: this.updatedAt.getTime(),
+      parentConversationId: this.parentConversationSId,
+      parentConversationModelId: this.parentConversationId,
+      childConversationId: this.childConversationSId,
+      childConversationModelId: this.childConversationId,
+      createdByUserId: this.createdByUserSId,
+      createdByUserModelId: this.createdByUserId,
+      sourceMessageId: this.sourceMessageSId,
+      sourceMessageModelId: this.sourceMessageId,
+      branchedAt: this.branchedAt.getTime(),
+    };
+  }
+}

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -84,6 +84,7 @@ export const RESOURCES_PREFIX = {
 
   // Conversation branches.
   conversation_branch: "cbr",
+  conversation_fork: "cfk",
 
   // Provider credentials (BYOK).
   provider_credential: "pcr",

--- a/x/pr/branching.md
+++ b/x/pr/branching.md
@@ -205,6 +205,12 @@ The user who forked becomes the initial participant of the child.
 Private conversation payloads expose fork lineage so the UI can render a
 small "Branched from ..." surface in the child conversation.
 
+Fork lineage readability follows the child conversation. A user who can read
+the child can read its fork metadata even if they cannot read the parent. The
+parent conversation and source message references remain lineage pointers:
+callers must still perform normal parent conversation access checks before
+dereferencing them or showing parent content.
+
 #### Files and Filesystem Isolation
 
 This is the critical behavior boundary of the feature.


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24040.

Adds the internal `ConversationForkResource` and typed `ConversationForkType` for the `conversation_forks` table. The resource creates fork lineage from an agent message only, exposes parent/child fetch helpers, and owns cleanup helpers now used by conversation destroy flows. Resource fetches stay workspace-scoped only; child-conversation readability is enforced separately via `canReadFork`, while parent/source access remains separately enforced when dereferencing those pointers. The serialized fork type is limited to lineage data only. This does not expose fork metadata on serialized conversations yet.

## Risks
Blast radius: front conversation fork lineage resource and existing conversation hard-delete cleanup.
Risk: low

## Deploy Plan
- deploy front
