### PR TITLE
Add logic to filter what reinforced convos are analyzed

### DIFF
--- a/front/lib/reinforcement/constants.ts
+++ b/front/lib/reinforcement/constants.ts
@@ -16,3 +16,19 @@ export const CONVERSATION_ANALYSIS_CONCURRENCY = 4;
 
 // Maximum concurrent per-skill aggregations.
 export const SKILL_AGGREGATION_CONCURRENCY = 8;
+
+// --- Conversation scoring constants ---
+
+// Skills not modified within this window are excluded from reinforcement.
+export const SKILL_STALENESS_THRESHOLD_DAYS = 14;
+
+// Skills with pending reinforcement suggestions younger than this are excluded.
+export const PENDING_SUGGESTION_MAX_AGE_DAYS = 30;
+
+// Max conversations analyzed per skill in a single run.
+export const PER_SKILL_CONVERSATION_CAP = 20;
+
+// Scoring weights for conversation selection.
+export const WEIGHT_FEEDBACK = 0.45;
+export const WEIGHT_TOOL_ERRORS = 0.3;
+export const WEIGHT_USER_ENGAGEMENT = 0.25;

--- a/front/lib/reinforcement/selection.test.ts
+++ b/front/lib/reinforcement/selection.test.ts
@@ -1,0 +1,292 @@
+import {
+  PER_SKILL_CONVERSATION_CAP,
+  WEIGHT_FEEDBACK,
+  WEIGHT_TOOL_ERRORS,
+  WEIGHT_USER_ENGAGEMENT,
+} from "@app/lib/reinforcement/constants";
+import { scoreAndSelectConversations } from "@app/lib/reinforcement/selection";
+import type { ModelId } from "@app/types/shared/model_id";
+import { describe, expect, it } from "vitest";
+
+function makeConversationSkillMap(
+  entries: { convId: ModelId; skillIds: string[] }[]
+): Map<ModelId, Set<string>> {
+  const map = new Map<ModelId, Set<string>>();
+  for (const { convId, skillIds } of entries) {
+    map.set(convId, new Set(skillIds));
+  }
+  return map;
+}
+
+function makeConvIdMap(
+  entries: { convId: ModelId; sId: string }[]
+): Map<ModelId, string> {
+  return new Map(entries.map(({ convId, sId }) => [convId, sId]));
+}
+
+describe("scoreAndSelectConversations", () => {
+  it("returns empty when no conversations are provided", () => {
+    const results = scoreAndSelectConversations(
+      new Map(),
+      new Map(),
+      {
+        userMessageCount: new Map(),
+        feedbackCount: new Map(),
+        toolErrorCount: new Map(),
+      },
+      300
+    );
+    expect(results).toEqual([]);
+  });
+
+  it("excludes conversations with no feedback and fewer than 2 user messages", () => {
+    const skillMap = makeConversationSkillMap([
+      { convId: 1 as ModelId, skillIds: ["skill-a"] },
+      { convId: 2 as ModelId, skillIds: ["skill-a"] },
+    ]);
+    const convIdMap = makeConvIdMap([
+      { convId: 1 as ModelId, sId: "conv-1" },
+      { convId: 2 as ModelId, sId: "conv-2" },
+    ]);
+
+    const results = scoreAndSelectConversations(
+      skillMap,
+      convIdMap,
+      {
+        // conv-1: 1 user message, no feedback -> excluded
+        // conv-2: 0 user messages, no feedback -> excluded
+        userMessageCount: new Map([[1 as ModelId, 1]]),
+        feedbackCount: new Map(),
+        toolErrorCount: new Map(),
+      },
+      300
+    );
+    expect(results).toEqual([]);
+  });
+
+  it("includes conversation with feedback even if fewer than 2 user messages", () => {
+    const skillMap = makeConversationSkillMap([
+      { convId: 1 as ModelId, skillIds: ["skill-a"] },
+    ]);
+    const convIdMap = makeConvIdMap([{ convId: 1 as ModelId, sId: "conv-1" }]);
+
+    const results = scoreAndSelectConversations(
+      skillMap,
+      convIdMap,
+      {
+        userMessageCount: new Map([[1 as ModelId, 1]]),
+        feedbackCount: new Map([[1 as ModelId, 1]]),
+        toolErrorCount: new Map(),
+      },
+      300
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].conversationId).toBe("conv-1");
+  });
+
+  it("includes conversation with 2+ user messages even without feedback", () => {
+    const skillMap = makeConversationSkillMap([
+      { convId: 1 as ModelId, skillIds: ["skill-a"] },
+    ]);
+    const convIdMap = makeConvIdMap([{ convId: 1 as ModelId, sId: "conv-1" }]);
+
+    const results = scoreAndSelectConversations(
+      skillMap,
+      convIdMap,
+      {
+        userMessageCount: new Map([[1 as ModelId, 2]]),
+        feedbackCount: new Map(),
+        toolErrorCount: new Map(),
+      },
+      300
+    );
+    expect(results).toHaveLength(1);
+  });
+
+  it("scores conversations correctly and sorts by score descending", () => {
+    // conv-1: high feedback, no errors
+    // conv-2: no feedback, high errors
+    // conv-3: moderate feedback, moderate errors, high engagement
+    const skillMap = makeConversationSkillMap([
+      { convId: 1 as ModelId, skillIds: ["skill-a"] },
+      { convId: 2 as ModelId, skillIds: ["skill-a"] },
+      { convId: 3 as ModelId, skillIds: ["skill-a"] },
+    ]);
+    const convIdMap = makeConvIdMap([
+      { convId: 1 as ModelId, sId: "conv-1" },
+      { convId: 2 as ModelId, sId: "conv-2" },
+      { convId: 3 as ModelId, sId: "conv-3" },
+    ]);
+
+    const results = scoreAndSelectConversations(
+      skillMap,
+      convIdMap,
+      {
+        userMessageCount: new Map([
+          [1 as ModelId, 2],
+          [2 as ModelId, 2],
+          [3 as ModelId, 10],
+        ]),
+        feedbackCount: new Map([
+          [1 as ModelId, 5],
+          [3 as ModelId, 2],
+        ]),
+        toolErrorCount: new Map([
+          [2 as ModelId, 4],
+          [3 as ModelId, 2],
+        ]),
+      },
+      300
+    );
+
+    expect(results).toHaveLength(3);
+
+    // conv-1: feedback=5/5=1.0, errors=0/4=0, engagement=0/8=0
+    //   score = 0.45*1.0 + 0.30*0.0 + 0.25*0.0 = 0.45
+    // conv-2: feedback=0/5=0, errors=4/4=1.0, engagement=0/8=0
+    //   score = 0.45*0.0 + 0.30*1.0 + 0.25*0.0 = 0.30
+    // conv-3: feedback=2/5=0.4, errors=2/4=0.5, engagement=8/8=1.0
+    //   score = 0.45*0.4 + 0.30*0.5 + 0.25*1.0 = 0.18+0.15+0.25 = 0.58
+    expect(results[0].conversationId).toBe("conv-3"); // highest: 0.58
+    expect(results[1].conversationId).toBe("conv-1"); // second: 0.45
+    expect(results[2].conversationId).toBe("conv-2"); // third: 0.30
+  });
+
+  it("respects maxConversations limit", () => {
+    const entries = Array.from({ length: 5 }, (_, i) => ({
+      convId: (i + 1) as ModelId,
+      skillIds: ["skill-a"],
+    }));
+    const skillMap = makeConversationSkillMap(entries);
+    const convIdMap = makeConvIdMap(
+      entries.map((e) => ({ convId: e.convId, sId: `conv-${e.convId}` }))
+    );
+
+    const feedbackCount = new Map<ModelId, number>();
+    for (const e of entries) {
+      feedbackCount.set(e.convId, 1);
+    }
+
+    const results = scoreAndSelectConversations(
+      skillMap,
+      convIdMap,
+      {
+        userMessageCount: new Map(),
+        feedbackCount,
+        toolErrorCount: new Map(),
+      },
+      3
+    );
+    expect(results).toHaveLength(3);
+  });
+
+  it("enforces per-skill conversation cap", () => {
+    // Create PER_SKILL_CONVERSATION_CAP + 5 conversations all using skill-a.
+    const count = PER_SKILL_CONVERSATION_CAP + 5;
+    const entries = Array.from({ length: count }, (_, i) => ({
+      convId: (i + 1) as ModelId,
+      skillIds: ["skill-a"],
+    }));
+    const skillMap = makeConversationSkillMap(entries);
+    const convIdMap = makeConvIdMap(
+      entries.map((e) => ({ convId: e.convId, sId: `conv-${e.convId}` }))
+    );
+
+    const feedbackCount = new Map<ModelId, number>();
+    for (const e of entries) {
+      feedbackCount.set(e.convId, 1);
+    }
+
+    const results = scoreAndSelectConversations(
+      skillMap,
+      convIdMap,
+      {
+        userMessageCount: new Map(),
+        feedbackCount,
+        toolErrorCount: new Map(),
+      },
+      300
+    );
+    expect(results).toHaveLength(PER_SKILL_CONVERSATION_CAP);
+  });
+
+  it("conversation at cap for skill A can still be included for skill B", () => {
+    // Fill skill-a to its cap with conversations 1..CAP.
+    const capEntries = Array.from(
+      { length: PER_SKILL_CONVERSATION_CAP },
+      (_, i) => ({
+        convId: (i + 1) as ModelId,
+        skillIds: ["skill-a"],
+      })
+    );
+
+    // Conversation CAP+1 uses both skill-a and skill-b.
+    const multiSkillConvId = (PER_SKILL_CONVERSATION_CAP + 1) as ModelId;
+    const allEntries = [
+      ...capEntries,
+      { convId: multiSkillConvId, skillIds: ["skill-a", "skill-b"] },
+    ];
+
+    const skillMap = makeConversationSkillMap(allEntries);
+    const convIdMap = makeConvIdMap(
+      allEntries.map((e) => ({ convId: e.convId, sId: `conv-${e.convId}` }))
+    );
+
+    // Give all conversations equal feedback so they all score the same.
+    const feedbackCount = new Map<ModelId, number>();
+    for (const e of allEntries) {
+      feedbackCount.set(e.convId, 1);
+    }
+
+    const results = scoreAndSelectConversations(
+      skillMap,
+      convIdMap,
+      {
+        userMessageCount: new Map(),
+        feedbackCount,
+        toolErrorCount: new Map(),
+      },
+      300
+    );
+
+    // All CAP+1 conversations should be included.
+    expect(results).toHaveLength(PER_SKILL_CONVERSATION_CAP + 1);
+
+    // The multi-skill conversation should only be tagged with skill-b
+    // (skill-a is at cap).
+    const multiSkillResult = results.find(
+      (r) => r.conversationId === `conv-${multiSkillConvId}`
+    );
+    expect(multiSkillResult).toBeDefined();
+    expect(multiSkillResult!.skillIds).toEqual(["skill-b"]);
+  });
+
+  it("all signals contribute to score with correct weights", () => {
+    // Single conversation: verify the score formula.
+    const skillMap = makeConversationSkillMap([
+      { convId: 1 as ModelId, skillIds: ["skill-a"] },
+    ]);
+    const convIdMap = makeConvIdMap([{ convId: 1 as ModelId, sId: "conv-1" }]);
+
+    const results = scoreAndSelectConversations(
+      skillMap,
+      convIdMap,
+      {
+        // With a single conversation, all signals normalize to 1.0
+        // (or 0 if the raw value is 0).
+        userMessageCount: new Map([[1 as ModelId, 5]]), // engagement = 5-2 = 3
+        feedbackCount: new Map([[1 as ModelId, 3]]),
+        toolErrorCount: new Map([[1 as ModelId, 2]]),
+      },
+      300
+    );
+
+    expect(results).toHaveLength(1);
+    // With a single conversation, all normalized values are 1.0.
+    // score = WEIGHT_FEEDBACK*1 + WEIGHT_TOOL_ERRORS*1 + WEIGHT_USER_ENGAGEMENT*1
+    //       = 0.45 + 0.30 + 0.25 = 1.0
+    expect(WEIGHT_FEEDBACK + WEIGHT_TOOL_ERRORS + WEIGHT_USER_ENGAGEMENT).toBe(
+      1.0
+    );
+  });
+});

--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -1,10 +1,10 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
-import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill";
-import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { daysAgo } from "@app/lib/utils/timestamps";
 import logger from "@app/logger/logger";
@@ -59,26 +59,16 @@ async function fetchEligibleSkillIds(
   const stalenessThreshold = daysAgo(SKILL_STALENESS_THRESHOLD_DAYS);
   const pendingSuggestionCutoff = daysAgo(PENDING_SUGGESTION_MAX_AGE_DAYS);
 
-  // Parallel queries: stale skills and skills with pending reinforcement suggestions.
+  // Parallel queries: recently modified active skills and pending reinforcement suggestions.
   const [recentSkills, pendingSuggestions] = await Promise.all([
-    // Active skills that have been modified recently.
-    SkillConfigurationModel.findAll({
-      attributes: ["id"],
-      where: {
-        workspaceId: workspace.id,
-        status: "active",
-        updatedAt: { [Op.gte]: stalenessThreshold },
-      },
+    SkillResource.listByWorkspace(auth, {
+      status: "active",
+      updatedAfter: stalenessThreshold,
     }),
-    // Pending reinforcement suggestions.
-    SkillSuggestionModel.findAll({
-      attributes: ["skillConfigurationId"],
-      where: {
-        workspaceId: workspace.id,
-        state: "pending",
-        source: "reinforcement",
-        createdAt: { [Op.gte]: pendingSuggestionCutoff },
-      },
+    SkillSuggestionResource.listByWorkspace(auth, {
+      states: ["pending"],
+      sources: ["reinforcement"],
+      createdAfter: pendingSuggestionCutoff,
     }),
   ]);
 

--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -10,6 +10,7 @@ import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill
 import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { makeSId } from "@app/lib/resources/string_ids";
+import { daysAgo } from "@app/lib/utils/timestamps";
 import logger from "@app/logger/logger";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -59,17 +60,8 @@ async function fetchEligibleSkillIds(
   auth: Authenticator
 ): Promise<Set<ModelId>> {
   const workspace = auth.getNonNullableWorkspace();
-  const now = new Date();
-
-  const stalenessThreshold = new Date(now);
-  stalenessThreshold.setDate(
-    stalenessThreshold.getDate() - SKILL_STALENESS_THRESHOLD_DAYS
-  );
-
-  const pendingSuggestionCutoff = new Date(now);
-  pendingSuggestionCutoff.setDate(
-    pendingSuggestionCutoff.getDate() - PENDING_SUGGESTION_MAX_AGE_DAYS
-  );
+  const stalenessThreshold = daysAgo(SKILL_STALENESS_THRESHOLD_DAYS);
+  const pendingSuggestionCutoff = daysAgo(PENDING_SUGGESTION_MAX_AGE_DAYS);
 
   // Parallel queries: stale skills and skills with pending reinforcement suggestions.
   const [recentSkills, pendingSuggestions] = await Promise.all([
@@ -157,9 +149,11 @@ async function discoverConversations(
   }
 
   // Post-filter: discard records where the skill was invoked by a custom agent.
+  // A null agentConfigurationId means the skill was added to the conversation
+  // directly (not via an agent config), which is eligible.
   const filteredRecords = skillRecords.filter(
     (r) =>
-      r.agentConfigurationId !== null && isGlobalAgentId(r.agentConfigurationId)
+      r.agentConfigurationId === null || isGlobalAgentId(r.agentConfigurationId)
   );
 
   if (filteredRecords.length === 0) {
@@ -237,6 +231,7 @@ async function discoverConversations(
  * and tool error counts.
  */
 async function fetchConversationSignals(
+  workspaceId: ModelId,
   conversationIds: ModelId[]
 ): Promise<ConversationSignals> {
   if (conversationIds.length === 0) {
@@ -252,12 +247,10 @@ async function fetchConversationSignals(
     MessageModel.findAll({
       attributes: [
         "conversationId",
-        [
-          frontSequelize.fn("COUNT", frontSequelize.col("MessageModel.id")),
-          "count",
-        ],
+        [frontSequelize.fn("COUNT", frontSequelize.col("message.id")), "count"],
       ],
       where: {
+        workspaceId,
         conversationId: { [Op.in]: conversationIds },
         userMessageId: { [Op.ne]: null },
       },
@@ -269,15 +262,10 @@ async function fetchConversationSignals(
     AgentMessageFeedbackModel.findAll({
       attributes: [
         "conversationId",
-        [
-          frontSequelize.fn(
-            "COUNT",
-            frontSequelize.col("AgentMessageFeedbackModel.id")
-          ),
-          "count",
-        ],
+        [frontSequelize.fn("COUNT", frontSequelize.col("id")), "count"],
       ],
       where: {
+        workspaceId,
         conversationId: { [Op.in]: conversationIds },
       },
       group: ["conversationId"],
@@ -288,10 +276,7 @@ async function fetchConversationSignals(
     MessageModel.findAll({
       attributes: [
         "conversationId",
-        [
-          frontSequelize.fn("COUNT", frontSequelize.col("MessageModel.id")),
-          "count",
-        ],
+        [frontSequelize.fn("COUNT", frontSequelize.col("message.id")), "count"],
       ],
       include: [
         {
@@ -303,10 +288,11 @@ async function fetchConversationSignals(
         },
       ],
       where: {
+        workspaceId,
         conversationId: { [Op.in]: conversationIds },
         agentMessageId: { [Op.ne]: null },
       },
-      group: ["MessageModel.conversationId"],
+      group: ["message.conversationId"],
       raw: true,
     }),
   ]);
@@ -498,7 +484,10 @@ export async function findConversationsWithSkills(
 
   // Stage 3: Fetch signals.
   const candidateConversationIds = [...conversationSkillMap.keys()];
-  const signals = await fetchConversationSignals(candidateConversationIds);
+  const signals = await fetchConversationSignals(
+    workspace.id,
+    candidateConversationIds
+  );
 
   // Stage 4: Score and select.
   const results = scoreAndSelectConversations(

--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -42,7 +42,7 @@ interface ConversationSignals {
 
 interface ScoredConversation {
   conversationModelId: ModelId;
-  conversationSId: string;
+  conversationId: string;
   skillIds: string[];
   score: number;
 }
@@ -135,12 +135,12 @@ async function discoverConversations(
   }
 ): Promise<{
   conversationSkillMap: Map<ModelId, Set<string>>;
-  convIdToSId: Map<ModelId, string>;
+  convModelIdToId: Map<ModelId, string>;
 }> {
   const workspace = auth.getNonNullableWorkspace();
 
   if (eligibleSkillIds.size === 0) {
-    return { conversationSkillMap: new Map(), convIdToSId: new Map() };
+    return { conversationSkillMap: new Map(), convModelIdToId: new Map() };
   }
 
   // Query AgentMessageSkillModel for eligible custom skills.
@@ -153,7 +153,7 @@ async function discoverConversations(
   });
 
   if (skillRecords.length === 0) {
-    return { conversationSkillMap: new Map(), convIdToSId: new Map() };
+    return { conversationSkillMap: new Map(), convModelIdToId: new Map() };
   }
 
   // Post-filter: discard records where the skill was invoked by a custom agent.
@@ -167,7 +167,7 @@ async function discoverConversations(
       { workspaceId: workspace.sId },
       "ReinforcedSkills: all skill records were from custom agents, none eligible"
     );
-    return { conversationSkillMap: new Map(), convIdToSId: new Map() };
+    return { conversationSkillMap: new Map(), convModelIdToId: new Map() };
   }
 
   // Get unique conversation IDs and fetch qualifying conversations.
@@ -183,16 +183,16 @@ async function discoverConversations(
     },
   });
 
-  const convIdToSId = new Map<ModelId, string>(
+  const convModelIdToId = new Map<ModelId, string>(
     conversations.map((c) => [c.id, c.sId])
   );
 
-  // Build conversationId -> Set<skillSId> map.
+  // Build conversationId -> Set<skillId> map.
   const conversationSkillMap = new Map<ModelId, Set<string>>();
 
   for (const record of filteredRecords) {
-    const convSId = convIdToSId.get(record.conversationId);
-    if (!convSId) {
+    const convId = convModelIdToId.get(record.conversationId);
+    if (!convId) {
       continue;
     }
 
@@ -227,7 +227,7 @@ async function discoverConversations(
     "ReinforcedSkills: conversation discovery"
   );
 
-  return { conversationSkillMap, convIdToSId };
+  return { conversationSkillMap, convModelIdToId: convModelIdToId };
 }
 
 /**
@@ -341,7 +341,7 @@ async function fetchConversationSignals(
  */
 function scoreAndSelectConversations(
   conversationSkillMap: Map<ModelId, Set<string>>,
-  convIdToSId: Map<ModelId, string>,
+  convModelIdToId: Map<ModelId, string>,
   signals: ConversationSignals,
   maxConversations: number
 ): ConversationWithSkills[] {
@@ -399,7 +399,7 @@ function scoreAndSelectConversations(
 
     return {
       conversationModelId: c.conversationModelId,
-      conversationSId: convIdToSId.get(c.conversationModelId)!,
+      conversationId: convModelIdToId.get(c.conversationModelId)!,
       skillIds: c.skillIds,
       score,
     };
@@ -429,7 +429,7 @@ function scoreAndSelectConversations(
 
     // Include this conversation for the skills that still have room.
     results.push({
-      conversationId: conv.conversationSId,
+      conversationId: conv.conversationId,
       skillIds: eligibleSkillIds,
     });
 
@@ -480,9 +480,13 @@ export async function findConversationsWithSkills(
   }
 
   // Stage 2: Discover conversations.
-  const { conversationSkillMap, convIdToSId } = await discoverConversations(
+  const { conversationSkillMap, convModelIdToId } = await discoverConversations(
     auth,
-    { eligibleSkillIds, cutoffDate, skillId }
+    {
+      eligibleSkillIds,
+      cutoffDate,
+      skillId,
+    }
   );
   if (conversationSkillMap.size === 0) {
     logger.info(
@@ -499,7 +503,7 @@ export async function findConversationsWithSkills(
   // Stage 4: Score and select.
   const results = scoreAndSelectConversations(
     conversationSkillMap,
-    convIdToSId,
+    convModelIdToId,
     signals,
     maxConversations
   );

--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -1,14 +1,10 @@
 import type { Authenticator } from "@app/lib/auth";
-import {
-  AgentMessageFeedbackModel,
-  AgentMessageModel,
-  ConversationModel,
-  MessageModel,
-} from "@app/lib/models/agent/conversation";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill";
 import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
-import { frontSequelize } from "@app/lib/resources/storage";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { daysAgo } from "@app/lib/utils/timestamps";
 import logger from "@app/logger/logger";
@@ -231,7 +227,7 @@ async function discoverConversations(
  * and tool error counts.
  */
 async function fetchConversationSignals(
-  workspaceId: ModelId,
+  auth: Authenticator,
   conversationIds: ModelId[]
 ): Promise<ConversationSignals> {
   if (conversationIds.length === 0) {
@@ -242,78 +238,20 @@ async function fetchConversationSignals(
     };
   }
 
-  const [userMessageRows, feedbackRows, toolErrorRows] = await Promise.all([
-    // User message counts per conversation.
-    MessageModel.findAll({
-      attributes: [
-        "conversationId",
-        [frontSequelize.fn("COUNT", frontSequelize.col("message.id")), "count"],
-      ],
-      where: {
-        workspaceId,
-        conversationId: { [Op.in]: conversationIds },
-        userMessageId: { [Op.ne]: null },
-      },
-      group: ["conversationId"],
-      raw: true,
-    }),
-
-    // Feedback counts per conversation.
-    AgentMessageFeedbackModel.findAll({
-      attributes: [
-        "conversationId",
-        [frontSequelize.fn("COUNT", frontSequelize.col("id")), "count"],
-      ],
-      where: {
-        workspaceId,
-        conversationId: { [Op.in]: conversationIds },
-      },
-      group: ["conversationId"],
-      raw: true,
-    }),
-
-    // Tool error counts: agent messages with failed status, joined through MessageModel.
-    MessageModel.findAll({
-      attributes: [
-        "conversationId",
-        [frontSequelize.fn("COUNT", frontSequelize.col("message.id")), "count"],
-      ],
-      include: [
-        {
-          model: AgentMessageModel,
-          as: "agentMessage",
-          attributes: [],
-          required: true,
-          where: { status: "failed" },
-        },
-      ],
-      where: {
-        workspaceId,
-        conversationId: { [Op.in]: conversationIds },
-        agentMessageId: { [Op.ne]: null },
-      },
-      group: ["message.conversationId"],
-      raw: true,
-    }),
+  const [userMessageCount, feedbackCount, toolErrorCount] = await Promise.all([
+    ConversationResource.getUserMessageCountsByConversationIds(
+      auth,
+      conversationIds
+    ),
+    AgentMessageFeedbackResource.getFeedbackCountsByConversationIds(
+      auth,
+      conversationIds
+    ),
+    ConversationResource.getFailedAgentMessageCountsByConversationIds(
+      auth,
+      conversationIds
+    ),
   ]);
-
-  const userMessageCount = new Map<ModelId, number>();
-  for (const row of userMessageRows) {
-    const r = row as unknown as { conversationId: ModelId; count: string };
-    userMessageCount.set(r.conversationId, parseInt(r.count, 10));
-  }
-
-  const feedbackCount = new Map<ModelId, number>();
-  for (const row of feedbackRows) {
-    const r = row as unknown as { conversationId: ModelId; count: string };
-    feedbackCount.set(r.conversationId, parseInt(r.count, 10));
-  }
-
-  const toolErrorCount = new Map<ModelId, number>();
-  for (const row of toolErrorRows) {
-    const r = row as unknown as { conversationId: ModelId; count: string };
-    toolErrorCount.set(r.conversationId, parseInt(r.count, 10));
-  }
 
   return { userMessageCount, feedbackCount, toolErrorCount };
 }
@@ -485,7 +423,7 @@ export async function findConversationsWithSkills(
   // Stage 3: Fetch signals.
   const candidateConversationIds = [...conversationSkillMap.keys()];
   const signals = await fetchConversationSignals(
-    workspace.id,
+    auth,
     candidateConversationIds
   );
 

--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -248,7 +248,7 @@ async function fetchConversationSignals(
  * engagement. Conversations are then selected in score order, respecting
  * per-skill caps.
  */
-function scoreAndSelectConversations(
+export function scoreAndSelectConversations(
   conversationSkillMap: Map<ModelId, Set<string>>,
   convModelIdToId: Map<ModelId, string>,
   signals: ConversationSignals,

--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -1,5 +1,4 @@
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -153,15 +152,11 @@ async function discoverConversations(
   // Get unique conversation IDs and fetch qualifying conversations.
   const allConvIds = [...new Set(filteredRecords.map((r) => r.conversationId))];
 
-  const conversations = await ConversationModel.findAll({
-    attributes: ["id", "sId"],
-    where: {
-      workspaceId: workspace.id,
-      id: { [Op.in]: allConvIds },
-      visibility: { [Op.ne]: "test" },
-      createdAt: { [Op.gte]: cutoffDate },
-    },
-  });
+  const conversations = await ConversationResource.fetchByModelIds(
+    auth,
+    allConvIds,
+    { excludeTest: true, updatedAfter: cutoffDate }
+  );
 
   const convModelIdToId = new Map<ModelId, string>(
     conversations.map((c) => [c.id, c.sId])

--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -1,61 +1,177 @@
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationModel } from "@app/lib/models/agent/conversation";
+import {
+  AgentMessageFeedbackModel,
+  AgentMessageModel,
+  ConversationModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill";
+import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { makeSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
+import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Op } from "sequelize";
+
+import {
+  DEFAULT_MAX_CONVERSATIONS_PER_RUN,
+  PENDING_SUGGESTION_MAX_AGE_DAYS,
+  PER_SKILL_CONVERSATION_CAP,
+  SKILL_STALENESS_THRESHOLD_DAYS,
+  WEIGHT_FEEDBACK,
+  WEIGHT_TOOL_ERRORS,
+  WEIGHT_USER_ENGAGEMENT,
+} from "./constants";
 
 export interface ConversationWithSkills {
   conversationId: string;
   skillIds: string[];
 }
 
+// Minimum user messages required for a conversation to be eligible
+// (when it has no feedback).
+const MIN_USER_MESSAGES = 2;
+
+interface ConversationSignals {
+  userMessageCount: Map<ModelId, number>;
+  feedbackCount: Map<ModelId, number>;
+  toolErrorCount: Map<ModelId, number>;
+}
+
+interface ScoredConversation {
+  conversationModelId: ModelId;
+  conversationSId: string;
+  skillIds: string[];
+  score: number;
+}
+
 /**
- * Discover recent conversations that used custom skills.
+ * Stage 1: Determine which custom skills are eligible for reinforcement.
  *
- * Queries AgentMessageSkillModel joined with ConversationModel to find
- * conversations in the workspace that used custom skills within the given
- * date range. Excludes test conversations and optionally filters by skill.
+ * A skill is excluded if:
+ * - It has not been modified in the last SKILL_STALENESS_THRESHOLD_DAYS days.
+ * - It has pending suggestions with source=reinforcement younger than
+ *   PENDING_SUGGESTION_MAX_AGE_DAYS days.
  */
-export async function findConversationsWithSkills(
+async function fetchEligibleSkillIds(
+  auth: Authenticator
+): Promise<Set<ModelId>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const now = new Date();
+
+  const stalenessThreshold = new Date(now);
+  stalenessThreshold.setDate(
+    stalenessThreshold.getDate() - SKILL_STALENESS_THRESHOLD_DAYS
+  );
+
+  const pendingSuggestionCutoff = new Date(now);
+  pendingSuggestionCutoff.setDate(
+    pendingSuggestionCutoff.getDate() - PENDING_SUGGESTION_MAX_AGE_DAYS
+  );
+
+  // Parallel queries: stale skills and skills with pending reinforcement suggestions.
+  const [recentSkills, pendingSuggestions] = await Promise.all([
+    // Active skills that have been modified recently.
+    SkillConfigurationModel.findAll({
+      attributes: ["id"],
+      where: {
+        workspaceId: workspace.id,
+        status: "active",
+        updatedAt: { [Op.gte]: stalenessThreshold },
+      },
+    }),
+    // Pending reinforcement suggestions.
+    SkillSuggestionModel.findAll({
+      attributes: ["skillConfigurationId"],
+      where: {
+        workspaceId: workspace.id,
+        state: "pending",
+        source: "reinforcement",
+        createdAt: { [Op.gte]: pendingSuggestionCutoff },
+      },
+    }),
+  ]);
+
+  const skillsWithPendingSuggestions = new Set(
+    pendingSuggestions.map((s) => s.skillConfigurationId)
+  );
+
+  const eligibleIds = new Set<ModelId>();
+  for (const skill of recentSkills) {
+    if (!skillsWithPendingSuggestions.has(skill.id)) {
+      eligibleIds.add(skill.id);
+    }
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      recentSkillCount: recentSkills.length,
+      pendingSuggestionSkillCount: skillsWithPendingSuggestions.size,
+      eligibleSkillCount: eligibleIds.size,
+    },
+    "ReinforcedSkills: eligible skill determination"
+  );
+
+  return eligibleIds;
+}
+
+/**
+ * Stage 2: Discover conversations that used eligible custom skills,
+ * filtering out conversations where skills were invoked by custom agents.
+ */
+async function discoverConversations(
   auth: Authenticator,
   {
+    eligibleSkillIds,
     cutoffDate,
-    maxConversations,
     skillId,
   }: {
+    eligibleSkillIds: Set<ModelId>;
     cutoffDate: Date;
-    maxConversations: number;
     skillId?: string;
   }
-): Promise<ConversationWithSkills[]> {
+): Promise<{
+  conversationSkillMap: Map<ModelId, Set<string>>;
+  convIdToSId: Map<ModelId, string>;
+}> {
   const workspace = auth.getNonNullableWorkspace();
 
-  // Step 1: Find all agent_message_skills records with custom skills.
+  if (eligibleSkillIds.size === 0) {
+    return { conversationSkillMap: new Map(), convIdToSId: new Map() };
+  }
+
+  // Query AgentMessageSkillModel for eligible custom skills.
   const skillRecords = await AgentMessageSkillModel.findAll({
-    attributes: ["conversationId", "customSkillId"],
+    attributes: ["conversationId", "customSkillId", "agentConfigurationId"],
     where: {
       workspaceId: workspace.id,
-      customSkillId: { [Op.ne]: null },
+      customSkillId: { [Op.in]: [...eligibleSkillIds] },
     },
   });
 
   if (skillRecords.length === 0) {
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        cutoffDate: cutoffDate.toISOString(),
-      },
-      "ReinforcedSkills: no agent message skill records with custom skills found"
-    );
-    return [];
+    return { conversationSkillMap: new Map(), convIdToSId: new Map() };
   }
 
-  // Step 2: Get the unique conversation IDs and fetch qualifying conversations.
-  const allConvIds: ModelId[] = [
-    ...new Set(skillRecords.map((r) => r.conversationId)),
-  ];
+  // Post-filter: discard records where the skill was invoked by a custom agent.
+  const filteredRecords = skillRecords.filter(
+    (r) =>
+      r.agentConfigurationId !== null && isGlobalAgentId(r.agentConfigurationId)
+  );
+
+  if (filteredRecords.length === 0) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "ReinforcedSkills: all skill records were from custom agents, none eligible"
+    );
+    return { conversationSkillMap: new Map(), convIdToSId: new Map() };
+  }
+
+  // Get unique conversation IDs and fetch qualifying conversations.
+  const allConvIds = [...new Set(filteredRecords.map((r) => r.conversationId))];
 
   const conversations = await ConversationModel.findAll({
     attributes: ["id", "sId"],
@@ -67,27 +183,16 @@ export async function findConversationsWithSkills(
     },
   });
 
-  if (conversations.length === 0) {
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        cutoffDate: cutoffDate.toISOString(),
-      },
-      "ReinforcedSkills: no qualifying conversations found"
-    );
-    return [];
-  }
-
-  const convIdById = new Map<ModelId, string>(
+  const convIdToSId = new Map<ModelId, string>(
     conversations.map((c) => [c.id, c.sId])
   );
 
-  // Step 3: Build a map of conversationId -> Set<skillId>.
-  const conversationSkillMap = new Map<string, Set<string>>();
+  // Build conversationId -> Set<skillSId> map.
+  const conversationSkillMap = new Map<ModelId, Set<string>>();
 
-  for (const record of skillRecords) {
-    const convId = convIdById.get(record.conversationId);
-    if (!convId) {
+  for (const record of filteredRecords) {
+    const convSId = convIdToSId.get(record.conversationId);
+    if (!convSId) {
       continue;
     }
 
@@ -101,28 +206,312 @@ export async function findConversationsWithSkills(
       workspaceId: workspace.id,
     });
 
-    // If filtering by skillId, only include matching skills.
+    // If filtering by a specific skill, only include matching skills.
     if (skillId && localSkillId !== skillId) {
       continue;
     }
 
-    if (!conversationSkillMap.has(convId)) {
-      conversationSkillMap.set(convId, new Set());
+    if (!conversationSkillMap.has(record.conversationId)) {
+      conversationSkillMap.set(record.conversationId, new Set());
     }
-    conversationSkillMap.get(convId)!.add(localSkillId);
+    conversationSkillMap.get(record.conversationId)!.add(localSkillId);
   }
 
-  // Step 4: Convert to array and cap at maxConversations.
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      skillRecordsCount: skillRecords.length,
+      filteredRecordsCount: filteredRecords.length,
+      candidateConversationCount: conversationSkillMap.size,
+    },
+    "ReinforcedSkills: conversation discovery"
+  );
+
+  return { conversationSkillMap, convIdToSId };
+}
+
+/**
+ * Stage 3: Batch-fetch scoring signals for candidate conversations.
+ *
+ * Runs three parallel queries for user message counts, feedback counts,
+ * and tool error counts.
+ */
+async function fetchConversationSignals(
+  conversationIds: ModelId[]
+): Promise<ConversationSignals> {
+  if (conversationIds.length === 0) {
+    return {
+      userMessageCount: new Map(),
+      feedbackCount: new Map(),
+      toolErrorCount: new Map(),
+    };
+  }
+
+  const [userMessageRows, feedbackRows, toolErrorRows] = await Promise.all([
+    // User message counts per conversation.
+    MessageModel.findAll({
+      attributes: [
+        "conversationId",
+        [
+          frontSequelize.fn("COUNT", frontSequelize.col("MessageModel.id")),
+          "count",
+        ],
+      ],
+      where: {
+        conversationId: { [Op.in]: conversationIds },
+        userMessageId: { [Op.ne]: null },
+      },
+      group: ["conversationId"],
+      raw: true,
+    }),
+
+    // Feedback counts per conversation.
+    AgentMessageFeedbackModel.findAll({
+      attributes: [
+        "conversationId",
+        [
+          frontSequelize.fn(
+            "COUNT",
+            frontSequelize.col("AgentMessageFeedbackModel.id")
+          ),
+          "count",
+        ],
+      ],
+      where: {
+        conversationId: { [Op.in]: conversationIds },
+      },
+      group: ["conversationId"],
+      raw: true,
+    }),
+
+    // Tool error counts: agent messages with failed status, joined through MessageModel.
+    MessageModel.findAll({
+      attributes: [
+        "conversationId",
+        [
+          frontSequelize.fn("COUNT", frontSequelize.col("MessageModel.id")),
+          "count",
+        ],
+      ],
+      include: [
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          attributes: [],
+          required: true,
+          where: { status: "failed" },
+        },
+      ],
+      where: {
+        conversationId: { [Op.in]: conversationIds },
+        agentMessageId: { [Op.ne]: null },
+      },
+      group: ["MessageModel.conversationId"],
+      raw: true,
+    }),
+  ]);
+
+  const userMessageCount = new Map<ModelId, number>();
+  for (const row of userMessageRows) {
+    const r = row as unknown as { conversationId: ModelId; count: string };
+    userMessageCount.set(r.conversationId, parseInt(r.count, 10));
+  }
+
+  const feedbackCount = new Map<ModelId, number>();
+  for (const row of feedbackRows) {
+    const r = row as unknown as { conversationId: ModelId; count: string };
+    feedbackCount.set(r.conversationId, parseInt(r.count, 10));
+  }
+
+  const toolErrorCount = new Map<ModelId, number>();
+  for (const row of toolErrorRows) {
+    const r = row as unknown as { conversationId: ModelId; count: string };
+    toolErrorCount.set(r.conversationId, parseInt(r.count, 10));
+  }
+
+  return { userMessageCount, feedbackCount, toolErrorCount };
+}
+
+/**
+ * Stage 4: Score conversations and apply per-skill capping.
+ *
+ * Each conversation is scored based on feedback, tool errors, and user
+ * engagement. Conversations are then selected in score order, respecting
+ * per-skill caps.
+ */
+function scoreAndSelectConversations(
+  conversationSkillMap: Map<ModelId, Set<string>>,
+  convIdToSId: Map<ModelId, string>,
+  signals: ConversationSignals,
+  maxConversations: number
+): ConversationWithSkills[] {
+  // Filter conversations by eligibility: must have feedback OR >= MIN_USER_MESSAGES.
+  const eligible: {
+    conversationModelId: ModelId;
+    skillIds: string[];
+    feedback: number;
+    userMessages: number;
+    toolErrors: number;
+  }[] = [];
+
+  for (const [convModelId, skillIds] of conversationSkillMap) {
+    const feedback = signals.feedbackCount.get(convModelId) ?? 0;
+    const userMessages = signals.userMessageCount.get(convModelId) ?? 0;
+
+    if (feedback === 0 && userMessages < MIN_USER_MESSAGES) {
+      continue;
+    }
+
+    eligible.push({
+      conversationModelId: convModelId,
+      skillIds: [...skillIds],
+      feedback,
+      userMessages,
+      toolErrors: signals.toolErrorCount.get(convModelId) ?? 0,
+    });
+  }
+
+  if (eligible.length === 0) {
+    return [];
+  }
+
+  // Normalize signals by dividing by max across all eligible conversations.
+  const maxFeedback = Math.max(0, ...eligible.map((c) => c.feedback));
+  const maxToolErrors = Math.max(0, ...eligible.map((c) => c.toolErrors));
+  // For engagement, use messages beyond the minimum.
+  const maxEngagement = Math.max(
+    0,
+    ...eligible.map((c) => Math.max(0, c.userMessages - MIN_USER_MESSAGES))
+  );
+
+  const scored: ScoredConversation[] = eligible.map((c) => {
+    const normalizedFeedback = maxFeedback > 0 ? c.feedback / maxFeedback : 0;
+    const normalizedToolErrors =
+      maxToolErrors > 0 ? c.toolErrors / maxToolErrors : 0;
+    const engagement = Math.max(0, c.userMessages - MIN_USER_MESSAGES);
+    const normalizedEngagement =
+      maxEngagement > 0 ? engagement / maxEngagement : 0;
+
+    const score =
+      WEIGHT_FEEDBACK * normalizedFeedback +
+      WEIGHT_TOOL_ERRORS * normalizedToolErrors +
+      WEIGHT_USER_ENGAGEMENT * normalizedEngagement;
+
+    return {
+      conversationModelId: c.conversationModelId,
+      conversationSId: convIdToSId.get(c.conversationModelId)!,
+      skillIds: c.skillIds,
+      score,
+    };
+  });
+
+  // Sort by score descending.
+  scored.sort((a, b) => b.score - a.score);
+
+  // Score-then-cap pass: walk sorted list, enforce per-skill caps.
+  const skillConversationCount = new Map<string, number>();
   const results: ConversationWithSkills[] = [];
-  for (const [conversationId, skillIds] of conversationSkillMap) {
+
+  for (const conv of scored) {
     if (results.length >= maxConversations) {
       break;
     }
-    results.push({
-      conversationId,
-      skillIds: [...skillIds],
+
+    // Determine which skills still have room under the per-skill cap.
+    const eligibleSkillIds = conv.skillIds.filter((sid) => {
+      const count = skillConversationCount.get(sid) ?? 0;
+      return count < PER_SKILL_CONVERSATION_CAP;
     });
+
+    if (eligibleSkillIds.length === 0) {
+      continue;
+    }
+
+    // Include this conversation for the skills that still have room.
+    results.push({
+      conversationId: conv.conversationSId,
+      skillIds: eligibleSkillIds,
+    });
+
+    // Increment counters for the selected skills.
+    for (const sid of eligibleSkillIds) {
+      skillConversationCount.set(
+        sid,
+        (skillConversationCount.get(sid) ?? 0) + 1
+      );
+    }
   }
+
+  return results;
+}
+
+/**
+ * Discover and select recent conversations that used custom skills,
+ * applying a scoring-based selection pipeline.
+ *
+ * Pipeline stages:
+ * 1. Determine eligible skills (not stale, no pending suggestions).
+ * 2. Discover conversations using those skills (global agents only).
+ * 3. Batch-fetch scoring signals (feedback, user messages, tool errors).
+ * 4. Filter, score, and cap conversations per skill.
+ */
+export async function findConversationsWithSkills(
+  auth: Authenticator,
+  {
+    cutoffDate,
+    maxConversations = DEFAULT_MAX_CONVERSATIONS_PER_RUN,
+    skillId,
+  }: {
+    cutoffDate: Date;
+    maxConversations?: number;
+    skillId?: string;
+  }
+): Promise<ConversationWithSkills[]> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  // Stage 1: Eligible skills.
+  const eligibleSkillIds = await fetchEligibleSkillIds(auth);
+  if (eligibleSkillIds.size === 0) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "ReinforcedSkills: no eligible skills found, skipping"
+    );
+    return [];
+  }
+
+  // Stage 2: Discover conversations.
+  const { conversationSkillMap, convIdToSId } = await discoverConversations(
+    auth,
+    { eligibleSkillIds, cutoffDate, skillId }
+  );
+  if (conversationSkillMap.size === 0) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "ReinforcedSkills: no qualifying conversations found"
+    );
+    return [];
+  }
+
+  // Stage 3: Fetch signals.
+  const candidateConversationIds = [...conversationSkillMap.keys()];
+  const signals = await fetchConversationSignals(candidateConversationIds);
+
+  // Stage 4: Score and select.
+  const results = scoreAndSelectConversations(
+    conversationSkillMap,
+    convIdToSId,
+    signals,
+    maxConversations
+  );
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      candidateConversations: conversationSkillMap.size,
+      selectedConversations: results.length,
+    },
+    "ReinforcedSkills: conversation selection complete"
+  );
 
   return results;
 }

--- a/front/lib/resources/agent_message_feedback_resource.test.ts
+++ b/front/lib/resources/agent_message_feedback_resource.test.ts
@@ -1,0 +1,155 @@
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ModelId } from "@app/types/shared/model_id";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { Authenticator } from "../auth";
+
+async function createConvWithAgentMessage(
+  auth: Authenticator,
+  agentSId: string
+) {
+  const workspace = auth.getNonNullableWorkspace();
+  const conv = await ConversationFactory.create(auth, {
+    agentConfigurationId: agentSId,
+    messagesCreatedAt: [],
+  });
+  const messageRow = await ConversationFactory.createAgentMessageWithRank({
+    workspace,
+    conversationId: conv.id as ModelId,
+    rank: 0,
+    agentConfigurationId: agentSId,
+  });
+  return { conv, agentMessageId: messageRow.agentMessageId! };
+}
+
+describe("AgentMessageFeedbackResource.getFeedbackCountsByConversationIds", () => {
+  let auth: Authenticator;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({ role: "builder" });
+    auth = setup.authenticator;
+  });
+
+  it("returns empty map when no conversation IDs are provided", async () => {
+    const result =
+      await AgentMessageFeedbackResource.getFeedbackCountsByConversationIds(
+        auth,
+        []
+      );
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty map when conversations have no feedback", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const { conv } = await createConvWithAgentMessage(auth, agent.sId);
+
+    const result =
+      await AgentMessageFeedbackResource.getFeedbackCountsByConversationIds(
+        auth,
+        [conv.id as ModelId]
+      );
+    expect(result.size).toBe(0);
+  });
+
+  it("counts feedback per conversation correctly", async () => {
+    const workspace = auth.getNonNullableWorkspace();
+    const userId = auth.getNonNullableUser().id;
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const { conv: conv1, agentMessageId: amId1a } =
+      await createConvWithAgentMessage(auth, agent.sId);
+    // Create a second agent message in conv1 at a different rank.
+    const msgRow1b = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conv1.id as ModelId,
+      rank: 2,
+      agentConfigurationId: agent.sId,
+    });
+    const amId1b = msgRow1b.agentMessageId!;
+
+    const { conv: conv2, agentMessageId: amId2 } =
+      await createConvWithAgentMessage(auth, agent.sId);
+
+    // Add 2 feedbacks to conv1 (one per agent message), 1 to conv2.
+    for (const amId of [amId1a, amId1b]) {
+      await AgentMessageFeedbackResource.makeNew({
+        workspaceId: workspace.id,
+        agentConfigurationId: agent.sId,
+        agentConfigurationVersion: agent.version,
+        conversationId: conv1.id,
+        agentMessageId: amId,
+        userId,
+        thumbDirection: "up",
+        content: null,
+        isConversationShared: false,
+        dismissed: false,
+      });
+    }
+
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+      conversationId: conv2.id,
+      agentMessageId: amId2,
+      userId,
+      thumbDirection: "down",
+      content: null,
+      isConversationShared: false,
+      dismissed: false,
+    });
+
+    const result =
+      await AgentMessageFeedbackResource.getFeedbackCountsByConversationIds(
+        auth,
+        [conv1.id as ModelId, conv2.id as ModelId]
+      );
+
+    expect(result.get(conv1.id as ModelId)).toBe(2);
+    expect(result.get(conv2.id as ModelId)).toBe(1);
+  });
+
+  it("ignores conversations not in the requested list", async () => {
+    const workspace = auth.getNonNullableWorkspace();
+    const userId = auth.getNonNullableUser().id;
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const { conv: conv1, agentMessageId: amId1 } =
+      await createConvWithAgentMessage(auth, agent.sId);
+    const { conv: conv2, agentMessageId: amId2 } =
+      await createConvWithAgentMessage(auth, agent.sId);
+
+    // Add feedback to both conversations.
+    for (const [conv, amId] of [
+      [conv1, amId1],
+      [conv2, amId2],
+    ] as const) {
+      await AgentMessageFeedbackResource.makeNew({
+        workspaceId: workspace.id,
+        agentConfigurationId: agent.sId,
+        agentConfigurationVersion: agent.version,
+        conversationId: conv.id,
+        agentMessageId: amId,
+        userId,
+        thumbDirection: "up",
+        content: null,
+        isConversationShared: false,
+        dismissed: false,
+      });
+    }
+
+    // Only request conv1.
+    const result =
+      await AgentMessageFeedbackResource.getFeedbackCountsByConversationIds(
+        auth,
+        [conv1.id as ModelId]
+      );
+
+    expect(result.size).toBe(1);
+    expect(result.get(conv1.id as ModelId)).toBe(1);
+    expect(result.has(conv2.id as ModelId)).toBe(false);
+  });
+});

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -380,13 +380,11 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
         conversationId: { [Op.in]: conversationIds },
       },
       group: ["conversationId"],
-      raw: true,
     });
 
     const result = new Map<ModelId, number>();
     for (const row of rows) {
-      const r = row as unknown as { conversationId: ModelId; count: string };
-      result.set(r.conversationId, parseInt(r.count, 10));
+      result.set(row.conversationId, parseInt(row.get("count") as string, 10));
     }
     return result;
   }

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -354,6 +354,43 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     }[];
   }
 
+  /**
+   * Returns feedback counts grouped by conversationId for the given
+   * conversation model IDs.
+   */
+  static async getFeedbackCountsByConversationIds(
+    auth: Authenticator,
+    conversationIds: ModelId[]
+  ): Promise<Map<ModelId, number>> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const rows = await this.model.findAll({
+      attributes: [
+        "conversationId",
+        [
+          AgentMessageFeedbackModel.sequelize!.fn(
+            "COUNT",
+            AgentMessageFeedbackModel.sequelize!.col("id")
+          ),
+          "count",
+        ],
+      ],
+      where: {
+        workspaceId: workspace.id,
+        conversationId: { [Op.in]: conversationIds },
+      },
+      group: ["conversationId"],
+      raw: true,
+    });
+
+    const result = new Map<ModelId, number>();
+    for (const row of rows) {
+      const r = row as unknown as { conversationId: ModelId; count: string };
+      result.set(r.conversationId, parseInt(r.count, 10));
+    }
+    return result;
+  }
+
   static async getConversationFeedbacksForUser(
     auth: Authenticator,
     conversation: ConversationWithoutContentType

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -172,6 +172,79 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
   }
 
+  /**
+   * Returns user message counts grouped by conversationId for the given
+   * conversation model IDs.
+   */
+  static async getUserMessageCountsByConversationIds(
+    auth: Authenticator,
+    conversationIds: ModelId[]
+  ): Promise<Map<ModelId, number>> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const rows = await MessageModel.findAll({
+      attributes: [
+        "conversationId",
+        [frontSequelize.fn("COUNT", frontSequelize.col("id")), "count"],
+      ],
+      where: {
+        workspaceId: workspace.id,
+        conversationId: { [Op.in]: conversationIds },
+        userMessageId: { [Op.ne]: null },
+      },
+      group: ["conversationId"],
+      raw: true,
+    });
+
+    const result = new Map<ModelId, number>();
+    for (const row of rows) {
+      const r = row as unknown as { conversationId: ModelId; count: string };
+      result.set(r.conversationId, parseInt(r.count, 10));
+    }
+    return result;
+  }
+
+  /**
+   * Returns counts of failed agent messages grouped by conversationId for the
+   * given conversation model IDs.
+   */
+  static async getFailedAgentMessageCountsByConversationIds(
+    auth: Authenticator,
+    conversationIds: ModelId[]
+  ): Promise<Map<ModelId, number>> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const rows = await MessageModel.findAll({
+      attributes: [
+        "conversationId",
+        [frontSequelize.fn("COUNT", frontSequelize.col("message.id")), "count"],
+      ],
+      include: [
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          attributes: [],
+          required: true,
+          where: { status: "failed" },
+        },
+      ],
+      where: {
+        workspaceId: workspace.id,
+        conversationId: { [Op.in]: conversationIds },
+        agentMessageId: { [Op.ne]: null },
+      },
+      group: ["message.conversationId"],
+      raw: true,
+    });
+
+    const result = new Map<ModelId, number>();
+    for (const row of rows) {
+      const r = row as unknown as { conversationId: ModelId; count: string };
+      result.set(r.conversationId, parseInt(r.count, 10));
+    }
+    return result;
+  }
+
   private static getOptions(
     options?: FetchConversationOptions
   ): ResourceFindOptions<ConversationModel> {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -89,7 +89,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
-    { transaction }: { transaction?: Transaction } = {}
+    {
+      transaction,
+      excludeTest,
+      updatedAfter,
+    }: {
+      transaction?: Transaction;
+      excludeTest?: boolean;
+      updatedAfter?: Date;
+    } = {}
   ): Promise<ConversationResource[]> {
     if (ids.length === 0) {
       return [];
@@ -101,6 +109,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       where: {
         workspaceId: workspace.id,
         id: ids,
+        ...(excludeTest ? { visibility: { [Op.ne]: "test" } } : {}),
+        ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
       } as WhereOptions<ConversationModel>,
       transaction,
     });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -203,13 +203,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         userMessageId: { [Op.ne]: null },
       },
       group: ["conversationId"],
-      raw: true,
     });
 
     const result = new Map<ModelId, number>();
     for (const row of rows) {
-      const r = row as unknown as { conversationId: ModelId; count: string };
-      result.set(r.conversationId, parseInt(r.count, 10));
+      result.set(row.conversationId, parseInt(row.get("count") as string, 10));
     }
     return result;
   }
@@ -244,13 +242,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         agentMessageId: { [Op.ne]: null },
       },
       group: ["message.conversationId"],
-      raw: true,
     });
 
     const result = new Map<ModelId, number>();
     for (const row of rows) {
-      const r = row as unknown as { conversationId: ModelId; count: string };
-      result.set(r.conversationId, parseInt(r.count, 10));
+      result.set(row.conversationId, parseInt(row.get("count") as string, 10));
     }
     return result;
   }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1001,16 +1001,22 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       globalSpaceOnly,
       onlyCustom,
       isDefault,
+      updatedAfter,
     }: {
       status?: SkillStatus | SkillStatus[];
       limit?: number;
       globalSpaceOnly?: boolean;
       onlyCustom?: boolean;
       isDefault?: boolean;
+      updatedAfter?: Date;
     } = {}
   ): Promise<SkillResource[]> {
     const skills = await this.baseFetch(auth, {
-      where: { status, ...(isDefault !== undefined ? { isDefault } : {}) },
+      where: {
+        status,
+        ...(isDefault !== undefined ? { isDefault } : {}),
+        ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
+      },
       ...(limit ? { limit } : {}),
       onlyCustom,
     });

--- a/front/lib/resources/skill_suggestion_resource.ts
+++ b/front/lib/resources/skill_suggestion_resource.ts
@@ -239,6 +239,7 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
       sources?: SkillSuggestionSource[];
       kind?: SkillSuggestionKind;
       limit?: number;
+      createdAfter?: Date;
     }
   ): Promise<SkillSuggestionResource[]> {
     const sourceFilter =
@@ -251,6 +252,9 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
         filters.states.length > 0 && { state: filters.states }),
       ...sourceFilter,
       ...(filters?.kind && { kind: filters.kind }),
+      ...(filters?.createdAfter && {
+        createdAt: { [Op.gte]: filters.createdAfter },
+      }),
     };
 
     return this.baseFetch(auth, {

--- a/front/lib/utils/timestamps.ts
+++ b/front/lib/utils/timestamps.ts
@@ -1,5 +1,14 @@
 import { format, isToday, isTomorrow, isYesterday } from "date-fns";
 
+/**
+ * Returns a Date that is `days` days before the given reference date (defaults to now).
+ */
+export function daysAgo(days: number, from: Date = new Date()): Date {
+  const result = new Date(from);
+  result.setDate(result.getDate() - days);
+  return result;
+}
+
 export const cleanTimestamp = (
   timestamp: number | string | null | undefined
 ) => {


### PR DESCRIPTION
## Description

- Add scoring-based conversation selection for reinforced skills, replacing the naive "grab all recent conversations with skills" approach
- Pipeline filters in 4 stages: eligible skills (not stale, no pending suggestions) → conversation discovery (global agents only) → batch signal fetching (feedback, user messages, tool errors) → score and cap per skill
- Optimizes DB queries by batching all signal fetches into 3 parallel queries instead of per-conversation lookups

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
