### PR TITLE
Add CompactionMessageModel + migration

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -25,6 +25,7 @@ import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import {
   AgentMessageFeedbackModel,
   AgentMessageModel,
+  CompactionMessageModel,
   ConversationModel,
   ConversationParticipantModel,
   MentionModel,
@@ -195,6 +196,7 @@ export function loadAllModels() {
     AgentMessageModel,
     AgentMessageFeedbackModel,
     ContentFragmentModel,
+    CompactionMessageModel,
     MessageModel,
     MessageReactionModel,
     MentionModel,

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -4,6 +4,7 @@ import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import {
   AgentMessageFeedbackModel,
   AgentMessageModel,
+  CompactionMessageModel,
   MentionModel,
   MessageModel,
   MessageReactionModel,
@@ -205,6 +206,7 @@ export async function destroyConversation(
       "userMessageId",
       "agentMessageId",
       "contentFragmentId",
+      "compactionMessageId",
     ],
     where: {
       conversationId: conversation.id,
@@ -221,6 +223,9 @@ export async function destroyConversation(
     );
     const agentMessageIds = removeNulls(
       messagesChunk.map((m) => m.agentMessageId)
+    );
+    const compactionMessageIds = removeNulls(
+      messagesChunk.map((m) => m.compactionMessageId)
     );
     const messageAndContentFragmentIds = removeNulls(
       messagesChunk.map((m) => {
@@ -267,6 +272,13 @@ export async function destroyConversation(
 
     await destroyContentFragments(auth, messageAndContentFragmentIds, {
       conversationId: conversation.sId,
+    });
+
+    await CompactionMessageModel.destroy({
+      where: {
+        id: compactionMessageIds,
+        workspaceId: owner.id,
+      },
     });
 
     await destroyMessageRelatedResources(auth, messageIds);

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -11,6 +11,7 @@ import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspa
 import { makeSId } from "@app/lib/resources/string_ids";
 import type {
   AgentMessageStatus,
+  CompactionMessageStatus,
   ConversationMetadata,
   ConversationVisibility,
   MessageVisibility,
@@ -676,10 +677,12 @@ export class MessageModel extends WorkspaceAwareModel<MessageModel> {
   declare userMessageId: ForeignKey<UserMessageModel["id"]> | null;
   declare agentMessageId: ForeignKey<AgentMessageModel["id"]> | null;
   declare contentFragmentId: ForeignKey<ContentFragmentModel["id"]> | null;
+  declare compactionMessageId: ForeignKey<CompactionMessageModel["id"]> | null;
 
   declare userMessage?: NonAttribute<UserMessageModel>;
   declare agentMessage?: NonAttribute<AgentMessageModel>;
   declare contentFragment?: NonAttribute<ContentFragmentModel>;
+  declare compactionMessage?: NonAttribute<CompactionMessageModel>;
   declare reactions?: NonAttribute<MessageReactionModel[]>;
 
   declare conversation?: NonAttribute<ConversationModel>;
@@ -793,6 +796,10 @@ MessageModel.init(
         concurrently: true,
       },
       {
+        fields: ["compactionMessageId"],
+        concurrently: true,
+      },
+      {
         fields: ["parentId"],
         concurrently: true,
       },
@@ -810,11 +817,12 @@ MessageModel.init(
         if (
           Number(!!message.userMessageId) +
             Number(!!message.agentMessageId) +
-            Number(!!message.contentFragmentId) !==
+            Number(!!message.contentFragmentId) +
+            Number(!!message.compactionMessageId) !==
           1
         ) {
           throw new Error(
-            "Exactly one of userMessageId, agentMessageId, contentFragmentId must be non-null"
+            "Exactly one of userMessageId, agentMessageId, contentFragmentId, compactionMessageId must be non-null"
           );
         }
       },
@@ -860,6 +868,52 @@ MessageModel.belongsTo(ContentFragmentModel, {
   as: "contentFragment",
   foreignKey: { name: "contentFragmentId", allowNull: true },
 });
+
+export class CompactionMessageModel extends WorkspaceAwareModel<CompactionMessageModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare status: CompactionMessageStatus;
+  declare content: string | null;
+}
+
+CompactionMessageModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "created",
+    },
+    content: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+  },
+  {
+    modelName: "compaction_message",
+    sequelize: frontSequelize,
+  }
+);
+
+CompactionMessageModel.hasOne(MessageModel, {
+  as: "message",
+  foreignKey: { name: "compactionMessageId", allowNull: true },
+});
+MessageModel.belongsTo(CompactionMessageModel, {
+  as: "compactionMessage",
+  foreignKey: { name: "compactionMessageId", allowNull: true },
+});
+
 export class MessageReactionModel extends WorkspaceAwareModel<MessageReactionModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -660,6 +660,42 @@ AgentMessageFeedbackModel.belongsTo(AgentMessageModel, {
   as: "agentMessage",
 });
 
+export class CompactionMessageModel extends WorkspaceAwareModel<CompactionMessageModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare status: CompactionMessageStatus;
+  declare content: string | null;
+}
+
+CompactionMessageModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "created",
+    },
+    content: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+  },
+  {
+    modelName: "compaction_message",
+    sequelize: frontSequelize,
+  }
+);
+
 export class MessageModel extends WorkspaceAwareModel<MessageModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -868,42 +904,6 @@ MessageModel.belongsTo(ContentFragmentModel, {
   as: "contentFragment",
   foreignKey: { name: "contentFragmentId", allowNull: true },
 });
-
-export class CompactionMessageModel extends WorkspaceAwareModel<CompactionMessageModel> {
-  declare createdAt: CreationOptional<Date>;
-  declare updatedAt: CreationOptional<Date>;
-
-  declare status: CompactionMessageStatus;
-  declare content: string | null;
-}
-
-CompactionMessageModel.init(
-  {
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    status: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      defaultValue: "created",
-    },
-    content: {
-      type: DataTypes.TEXT,
-      allowNull: true,
-    },
-  },
-  {
-    modelName: "compaction_message",
-    sequelize: frontSequelize,
-  }
-);
 
 CompactionMessageModel.hasOne(MessageModel, {
   as: "message",

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -693,6 +693,12 @@ CompactionMessageModel.init(
   {
     modelName: "compaction_message",
     sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["workspaceId"],
+        concurrently: true,
+      },
+    ],
   }
 );
 

--- a/front/migrations/db/migration_576.sql
+++ b/front/migrations/db/migration_576.sql
@@ -1,4 +1,5 @@
 -- Migration created on Apr 10, 2026
 CREATE TABLE IF NOT EXISTS "compaction_messages" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "status" VARCHAR(255) NOT NULL DEFAULT 'created', "content" TEXT, "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , PRIMARY KEY ("id"));
+CREATE INDEX CONCURRENTLY "compaction_messages_workspace_id" ON "compaction_messages" ("workspaceId");
 ALTER TABLE "public"."messages" ADD COLUMN "compactionMessageId" BIGINT REFERENCES "compaction_messages" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
 CREATE INDEX CONCURRENTLY "messages_compaction_message_id" ON "messages" ("compactionMessageId");

--- a/front/migrations/db/migration_576.sql
+++ b/front/migrations/db/migration_576.sql
@@ -1,0 +1,4 @@
+-- Migration created on Apr 10, 2026
+CREATE TABLE IF NOT EXISTS "compaction_messages" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "status" VARCHAR(255) NOT NULL DEFAULT 'created', "content" TEXT, "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , PRIMARY KEY ("id"));
+ALTER TABLE "public"."messages" ADD COLUMN "compactionMessageId" BIGINT REFERENCES "compaction_messages" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+CREATE INDEX CONCURRENTLY "messages_compaction_message_id" ON "messages" ("compactionMessageId");

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -19,19 +19,22 @@ Type-only change, no DB or runtime impact. Combined with PR 1.3 into a single PR
   union (line 43), and the `LightMessageType` union (line 49).
 - Update `ConversationType.content` type (line 372) to include `CompactionMessageType[]`.
 
-### - [ ] PR 1.2 — Add `CompactionMessageModel` + migration
+### - [x] PR 1.2 — Add `CompactionMessageModel` + migration
 
-DB schema change, no runtime behavior.
+DB schema change, no runtime behavior. PR #24065.
 
 - Add `CompactionMessageModel` in `front/lib/models/agent/conversation.ts` with fields: `status`,
-  `content` (TEXT, nullable).
-- Migration: create `compaction_message` table, add `compactionMessageId` FK on `message` table.
-- Update `MessageModel` (line 662): add `compactionMessageId` FK declaration.
-- Update `MessageModel` validation hook (line 809): extend the exactly-one-FK-non-null check to
-  include `compactionMessageId`.
-- Add `compactionMessageId` index on `message` table (following [BACK13]).
-- Add association: `CompactionMessageModel.hasOne(MessageModel)` /
+  `content` (TEXT, nullable). Defined above `MessageModel` so the FK type is available.
+- Migration 576: create `compaction_messages` table (with `workspaceId` index), add
+  `compactionMessageId` FK + index on `messages` table.
+- Update `MessageModel`: add `compactionMessageId` FK declaration.
+- Update `MessageModel` validation hook: extend the exactly-one-FK-non-null check to include
+  `compactionMessageId`.
+- Add `compactionMessageId` index on `messages` table (following [BACK13]).
+- Add associations: `CompactionMessageModel.hasOne(MessageModel)` /
   `MessageModel.belongsTo(CompactionMessageModel)`.
+- Register in `admin/db.ts`.
+- Handle `CompactionMessageModel` cleanup in `destroyConversation`.
 
 ### - [x] PR 1.3 — Handle `"compaction_message"` in all exhaustive switches
 


### PR DESCRIPTION
## Description

Adds the `CompactionMessageModel` Sequelize model and extends `MessageModel` with a `compactionMessageId` FK.

- `CompactionMessageModel` with `status` (VARCHAR, default `"created"`) and `content` (TEXT, nullable)
- `compactionMessageId` FK on `MessageModel` (nullable, indexed)
- Updated `MessageModel` validation hook: exactly one of `userMessageId`, `agentMessageId`, `contentFragmentId`, `compactionMessageId` must be non-null
- `destroyConversation` handles compaction message deletion
- Registered in `admin/db.ts`
- Migration SQL (purely additive)

## Tests

N/A Simple model addition

## Risk

Medium as it touches our core models.

## Deploy Plan

- Run migration `migration_576.sql` 
- deploy `front`