### PR TITLE
fix(deploy): remove sourcemaps from Cloudflare asset upload

### DIFF
--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -178,6 +178,10 @@ jobs:
             --release-version=${{ github.sha }} \
             --service=${{ inputs.app }}-spa-browser
 
+      - name: Remove sourcemaps
+        working-directory: front-spa
+        run: find dist -name "*.map" -delete
+
       - name: Upload version
         id: upload_version
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Description

Deletes .map files from the SPA build output before uploading to Cloudflare Workers. Sourcemaps are already uploaded to Datadog for production debugging, so they don't need to be served from Cloudflare. This cuts the number of uploaded assets roughly in half, working around intermittent Cloudflare asset upload API failures we've been hitting today.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
