### PR TITLE
[front] enh: Make mcp server error more user friendly

### DIFF
--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -2,7 +2,10 @@ import { CustomHeadersConfigurationSection } from "@app/components/actions/mcp/c
 import { InternalBearerTokenSection } from "@app/components/actions/mcp/create/InternalBearerTokenSection";
 import { RemoteMCPServerConfigurationSection } from "@app/components/actions/mcp/create/RemoteMCPServerConfigurationSection";
 import { getStaticCredentialForm } from "@app/components/actions/mcp/create/static_credential_forms";
-import { submitCreateMCPServerDialogForm } from "@app/components/actions/mcp/forms/submitCreateMCPServerDialogForm";
+import {
+  isCreateServerError,
+  submitCreateMCPServerDialogForm,
+} from "@app/components/actions/mcp/forms/submitCreateMCPServerDialogForm";
 import type { CreateMCPServerDialogFormValues } from "@app/components/actions/mcp/forms/types";
 import { createMCPServerDialogFormSchema } from "@app/components/actions/mcp/forms/types";
 import {
@@ -35,12 +38,14 @@ import {
 import { validateOAuthCredentials } from "@app/types/oauth/lib";
 import type { WorkspaceType } from "@app/types/user";
 import {
+  ContentMessage,
   Dialog,
   DialogContainer,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  ExclamationCircleIcon,
   Input,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -173,6 +178,11 @@ export function CreateMCPServerDialog({
   }, [needsCustomName, viewName, existingViewNames]);
 
   const [isLoading, setIsLoading] = useState(false);
+  const [serverError, setServerError] = useState<{
+    message: string;
+    domain: string;
+    isRemoteServerError: boolean;
+  } | null>(null);
 
   // Workflow state - managed via useState, not form state.
   // These are server-derived values (from OAuth discovery or internal server config),
@@ -233,6 +243,7 @@ export function CreateMCPServerDialog({
     setAuthorization(null);
     setRemoteMCPServerOAuthDiscoveryDone(false);
     setIsStaticFormValid(false);
+    setServerError(null);
     // Reset form state.
     form.reset(defaultValues);
   };
@@ -244,6 +255,7 @@ export function CreateMCPServerDialog({
     }
 
     setIsLoading(true);
+    setServerError(null);
 
     const submitRes = await submitCreateMCPServerDialogForm({
       owner,
@@ -261,8 +273,22 @@ export function CreateMCPServerDialog({
     });
 
     if (submitRes.isErr()) {
+      const err = submitRes.error;
+      if (isCreateServerError(err)) {
+        setServerError({
+          message: err.message,
+          domain: new URL(values.remoteServerUrl).hostname,
+          isRemoteServerError: err.isRemoteServerError,
+        });
+        setIsLoading(false);
+        setExternalIsLoading(false);
+        setRemoteMCPServerOAuthDiscoveryDone(
+          err.remoteMCPServerOAuthDiscoveryDone
+        );
+        return;
+      }
       handleCreateMCPServerDialogSubmitError({
-        error: submitRes.error,
+        error: err,
         context: {
           remoteServerUrl: values.remoteServerUrl,
           provider: authorization?.provider ?? null,
@@ -438,6 +464,20 @@ export function CreateMCPServerDialog({
           </DialogHeader>
           <DialogContainer className="max-h-[80vh]">
             <div className="space-y-4">
+              {serverError && (
+                <ContentMessage
+                  variant="warning"
+                  icon={ExclamationCircleIcon}
+                  size="lg"
+                  title={
+                    serverError.isRemoteServerError
+                      ? `Server error from ${serverError.domain}`
+                      : "Failed to connect to the server"
+                  }
+                >
+                  {serverError.message}
+                </ContentMessage>
+              )}
               {needsCustomName && (
                 <div className="space-y-4">
                   <div className="heading-lg text-foreground dark:text-foreground-night">

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -3,7 +3,10 @@ import { requiresBearerTokenConfiguration } from "@app/lib/actions/mcp_helper";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import type { RegionInfo } from "@app/lib/api/regions/config";
-import type { MCPConnectionType } from "@app/lib/swr/mcp_servers";
+import {
+  isMCPCreateServerError,
+  type MCPConnectionType,
+} from "@app/lib/swr/mcp_servers";
 import type { CreateMCPServerResponseBody } from "@app/pages/api/w/[wId]/mcp";
 import type { DiscoverOAuthMetadataResponseBody } from "@app/pages/api/w/[wId]/mcp/discover_oauth_metadata";
 import { setupOAuthConnection } from "@app/types/oauth/client/setup";
@@ -35,20 +38,33 @@ export type CreateMCPServerDialogSubmitErrorKind =
 export class CreateMCPServerDialogSubmitError extends Error {
   readonly kind: CreateMCPServerDialogSubmitErrorKind;
   readonly remoteMCPServerOAuthDiscoveryDone: boolean;
+  readonly isRemoteServerError: boolean;
 
   constructor({
     kind,
     message,
     remoteMCPServerOAuthDiscoveryDone,
+    isRemoteServerError = false,
   }: {
     kind: CreateMCPServerDialogSubmitErrorKind;
     message: string;
     remoteMCPServerOAuthDiscoveryDone: boolean;
+    isRemoteServerError?: boolean;
   }) {
     super(message);
     this.kind = kind;
     this.remoteMCPServerOAuthDiscoveryDone = remoteMCPServerOAuthDiscoveryDone;
+    this.isRemoteServerError = isRemoteServerError;
   }
+}
+
+export function isCreateServerError(
+  error: Error
+): error is CreateMCPServerDialogSubmitError & { kind: "create_server" } {
+  return (
+    error instanceof CreateMCPServerDialogSubmitError &&
+    error.kind === "create_server"
+  );
 }
 
 type DiscoverOAuthMetadataFn = (
@@ -290,12 +306,15 @@ export async function submitCreateMCPServerDialogForm({
     });
 
     if (createRes.isErr()) {
+      const err = createRes.error;
       return new Err(
         new CreateMCPServerDialogSubmitError({
           kind: "create_server",
-          message: createRes.error.message,
+          message: err.message,
           remoteMCPServerOAuthDiscoveryDone:
             nextRemoteMCPServerOAuthDiscoveryDone,
+          isRemoteServerError:
+            isMCPCreateServerError(err) && err.isRemoteServerError,
         })
       );
     }

--- a/front/lib/actions/mcp_errors.ts
+++ b/front/lib/actions/mcp_errors.ts
@@ -6,6 +6,18 @@ export class MCPServerNotFoundError extends Error {
   }
 }
 
+export class RemoteMCPServerError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export function isRemoteMCPServerError(
+  error: Error
+): error is RemoteMCPServerError {
+  return error instanceof RemoteMCPServerError;
+}
+
 export class MCPError extends Error {
   // Whether the error should be tracked and reported on our observability stack.
   public readonly tracked: boolean;

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -12,7 +12,10 @@ import {
   MCPServerPersonalAuthenticationRequiredError,
   MCPServerRequiresAdminAuthenticationError,
 } from "@app/lib/actions/mcp_authentication";
-import { MCPServerNotFoundError } from "@app/lib/actions/mcp_errors";
+import {
+  MCPServerNotFoundError,
+  RemoteMCPServerError,
+} from "@app/lib/actions/mcp_errors";
 import {
   getServerTypeAndIdFromSId,
   isMcpTimeoutError,
@@ -52,6 +55,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
@@ -62,8 +66,32 @@ import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { McpError, type Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
 
 const DEFAULT_MCP_CLIENT_CONNECT_TIMEOUT_MS = 25_000;
+
+const JsonRpcErrorSchema = z.object({
+  jsonrpc: z.string(),
+  error: z.object({
+    message: z.string(),
+  }),
+});
+
+function extractMCPErrorMessage(errorMessage: string): string {
+  const jsonMatch = errorMessage.match(/\{[\s\S]*"jsonrpc"[\s\S]*\}/);
+  if (!jsonMatch) {
+    return errorMessage;
+  }
+  const parseResult = safeParseJSON(jsonMatch[0]);
+  if (parseResult.isErr()) {
+    return errorMessage;
+  }
+  const rpcResult = JsonRpcErrorSchema.safeParse(parseResult.value);
+  if (!rpcResult.success) {
+    return errorMessage;
+  }
+  return rpcResult.data.error.message;
+}
 
 // Short timeout: the Redis round-trip is near-instant when the browser
 // is connected. If it takes longer than 5s the browser is likely
@@ -656,7 +684,8 @@ export async function connectToMCPServer(
           },
           "Error establishing connection to remote MCP server via URL"
         );
-        return new Err(normalizeError(e));
+        const msg = extractMCPErrorMessage(normalizeError(e).message);
+        return new Err(new RemoteMCPServerError(msg));
       }
       break;
     }
@@ -886,7 +915,9 @@ async function fetchRemoteServerMetaData(
       "Error fetching metadata from remote MCP server"
     );
     return new Err(
-      new Error("Error getting metadata from the remote MCP server.")
+      new RemoteMCPServerError(
+        extractMCPErrorMessage(normalizeError(e).message)
+      )
     );
   }
 }

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -369,6 +369,20 @@ export function useDiscoverOAuthMetadata(owner: LightWorkspaceType) {
   return { discoverOAuthMetadata };
 }
 
+export class MCPCreateServerError extends Error {
+  readonly isRemoteServerError: boolean;
+  constructor(message: string, isRemoteServerError: boolean) {
+    super(message);
+    this.isRemoteServerError = isRemoteServerError;
+  }
+}
+
+export function isMCPCreateServerError(
+  error: Error
+): error is MCPCreateServerError {
+  return error instanceof MCPCreateServerError;
+}
+
 /**
  * Hook to create a new MCP server from a URL
  */
@@ -421,8 +435,11 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
       if (!response.ok) {
         const body = await response.json();
         return new Err(
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          new Error(body.error?.message || "Failed to create server")
+          new MCPCreateServerError(
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            body.error?.message || "Failed to create server",
+            body.isRemoteServerError === true
+          )
         );
       }
       await mutate();

--- a/front/pages/api/w/[wId]/mcp/[serverId]/sync.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/sync.ts
@@ -76,7 +76,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Error fetching remote server metadata, URL may be invalid.",
+        message: `Error fetching remote server metadata: ${r.error.message}`,
       },
     });
   }

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 import { isCustomResourceIconType } from "@app/components/resources/resources_icons";
 import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/constants";
+import { isRemoteMCPServerError } from "@app/lib/actions/mcp_errors";
 import { requiresBearerTokenConfiguration } from "@app/lib/actions/mcp_helper";
 import {
   allowsMultipleInstancesOfInternalMCPServerByName,
@@ -28,7 +29,6 @@ import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_r
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types/error";
 import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
 import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
 import { isLeft } from "fp-ts/lib/Either";
@@ -87,12 +87,17 @@ const PostQueryParamsSchema = t.union([
   }),
 ]);
 
+type MCPEndpointErrorResponse = {
+  error: { type: string; message: string };
+  isRemoteServerError?: boolean;
+};
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorResponse<
-      GetMCPServersResponseBody | CreateMCPServerResponseBody
-    >
+    | GetMCPServersResponseBody
+    | CreateMCPServerResponseBody
+    | MCPEndpointErrorResponse
   >,
   auth: Authenticator
 ): Promise<void> {
@@ -211,13 +216,14 @@ async function handler(
 
           const r = await fetchRemoteServerMetaDataByURL(auth, url, headers);
           if (r.isErr()) {
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
+            res.status(400).json({
+              error: {
                 type: "invalid_request_error",
-                message: `Error fetching remote server metadata: ${r.error.message}`,
+                message: r.error.message,
               },
+              isRemoteServerError: isRemoteMCPServerError(r.error),
             });
+            return;
           }
 
           const metadata = r.value;


### PR DESCRIPTION
## Description

Currently when there's a mcp server error on fetching metadata, we return a 400 with a small pop-up message, that is hard to read and ephemeral.
To help our users troubleshoot mcp connection, this PR changes this into an error message front and center, with an attempt to parse the jsonrpc error message (if any), and if the mcp server does not follow standards we simply return the raw error, better than nothing.

<img width="758" height="460" alt="image" src="https://github.com/user-attachments/assets/499989f9-acdb-4b05-bd30-17f34fd62436" />


## Tests

Tested manually

## Risk

Low

## Deploy Plan

- [ ] deploy front