### PR TITLE
LLM batch mode: delete the batch data after download

### DIFF
--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -409,6 +409,20 @@ export async function downloadBatchResultFromLlm(
     storedResultInfo.set(conversationId, info);
   }
 
+  const deleted = await llm.deleteBatch(batchId);
+  if (!deleted) {
+    const metadata = llm.getMetadata();
+    logger.warn(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        providerId: metadata.clientId,
+        modelId: metadata.modelId,
+        batchId,
+      },
+      "Failed to delete batch after downloading results"
+    );
+  }
+
   return { events, storedResultInfo };
 }
 

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -228,6 +228,11 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     return batch.id;
   }
 
+  override async deleteBatch(batchId: string): Promise<boolean> {
+    await this.client.messages.batches.delete(batchId);
+    return true;
+  }
+
   override async getBatchStatus(batchId: string): Promise<BatchStatus> {
     const batch = await this.client.messages.batches.retrieve(batchId);
     return batch.processing_status === "ended" ? "ready" : "computing";

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -203,6 +203,12 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
     return GoogleLLM.encodeBatchId(batch.name, customIds);
   }
 
+  override async deleteBatch(batchId: string): Promise<boolean> {
+    const { batchName } = GoogleLLM.decodeBatchId(batchId);
+    await this.client.batches.delete({ name: batchName });
+    return true;
+  }
+
   override async getBatchStatus(batchId: string): Promise<BatchStatus> {
     const { batchName } = GoogleLLM.decodeBatchId(batchId);
     const batch = await this.client.batches.get({ name: batchName });

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -148,6 +148,21 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
     return job.id;
   }
 
+  override async deleteBatch(batchId: string): Promise<boolean> {
+    const job = await this.client.batch.jobs.get({ jobId: batchId });
+
+    const fileIds = [job.inputFiles, job.outputFile]
+      .flat()
+      .filter((id): id is string => !!id);
+
+    // At most 2 elements (input + output files).
+    const results = await Promise.all(
+      fileIds.map((fileId) => this.client.files.delete({ fileId }))
+    );
+
+    return results.every((result) => result.deleted);
+  }
+
   override async getBatchStatus(batchId: string): Promise<BatchStatus> {
     const job = await this.client.batch.jobs.get({ jobId: batchId });
 

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -184,6 +184,21 @@ export class OpenAIResponsesLLM extends LLM<ResponseCreateParamsStreaming> {
     return batch.id;
   }
 
+  override async deleteBatch(batchId: string): Promise<boolean> {
+    const batch = await this.client.batches.retrieve(batchId);
+
+    const fileIds = [batch.input_file_id, batch.output_file_id].filter(
+      (id): id is string => !!id
+    );
+
+    // At most 2 elements (input + output files).
+    const results = await Promise.all(
+      fileIds.map((fileId) => this.client.files.delete(fileId))
+    );
+
+    return results.every((result) => result.deleted);
+  }
+
   override async getBatchStatus(batchId: string): Promise<BatchStatus> {
     const batch = await this.client.batches.retrieve(batchId);
 

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -446,6 +446,14 @@ export abstract class LLM<TPayload = unknown> {
   }
 
   /**
+   * Delete a batch. Returns true if the batch was successfully deleted.
+   * By default returns false (deletion not supported).
+   */
+  async deleteBatch(_batchId: string): Promise<boolean> {
+    return false;
+  }
+
+  /**
    * Poll the status of a previously submitted batch.
    */
   async getBatchStatus(_batchId: string): Promise<BatchStatus> {

--- a/front/lib/api/llm/tests/llmBatch.test.ts
+++ b/front/lib/api/llm/tests/llmBatch.test.ts
@@ -1,7 +1,6 @@
 import { isDeepStrictEqual } from "node:util";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { getLLM } from "@app/lib/api/llm";
-import { createMockAuthenticator } from "@app/lib/api/llm/tests/conversations";
 import { MODELS } from "@app/lib/api/llm/tests/models";
 import type { ResponseChecker } from "@app/lib/api/llm/tests/types";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
@@ -9,13 +8,22 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { setTimeoutAsync } from "@app/lib/utils/async_utils";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { isModelProviderId } from "@app/types/assistant/models/providers";
 import type { ModelIdType } from "@app/types/assistant/models/types";
+import { Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { describe, expect, it, vi } from "vitest";
 
 const POLL_INTERVAL_MS = 5000;
 const TEST_TIMEOUT_MS = 60 * 60 * 1000; // 1-hour timeout — batches can take a while
+
+// Mock the tokenizer to avoid CoreAPI dependency in tests.
+vi.mock("@app/lib/tokenization", () => ({
+  tokenCountForTexts: vi.fn(async (texts: string[]) => {
+    return new Ok(texts.map((t) => t.length));
+  }),
+}));
 
 // Mock the openai module to inject dangerouslyAllowBrowser: true
 vi.mock("openai", async (importOriginal) => {
@@ -252,21 +260,24 @@ const BATCH_TESTS: BatchTest[] = [
 describe.skipIf(!RUN_LLM_BATCH_TEST || modelsWithBatchSupport.length === 0)(
   "Batch Processing Integration Tests",
   () => {
-    describe.concurrent.each(
-      modelsWithBatchSupport
-    )("$providerId / $modelId", ({ modelId, providerId }) => {
+    describe.each(modelsWithBatchSupport)("$providerId / $modelId", ({
+      modelId,
+      providerId,
+    }) => {
       if (!isModelProviderId(providerId)) {
         throw new Error(`Invalid providerId: ${providerId}`);
       }
 
-      it.concurrent.each(BATCH_TESTS)(
+      it.each(BATCH_TESTS)(
         "$name",
         async ({ conversations }) => {
-          const mockedAuth = createMockAuthenticator();
-          const credentials = await getLlmCredentials(mockedAuth, {
+          const { authenticator } = await createResourceTest({
+            role: "admin",
+          });
+          const credentials = await getLlmCredentials(authenticator, {
             skipEmbeddingApiKeyRequirement: true,
           });
-          const llm = await getLLM(mockedAuth, {
+          const llm = await getLLM(authenticator, {
             modelId: modelId as ModelIdType,
             bypassFeatureFlag: true,
             credentials,
@@ -309,6 +320,9 @@ describe.skipIf(!RUN_LLM_BATCH_TEST || modelsWithBatchSupport.length === 0)(
               checkResponse(id, entry.events, expectedInResponse);
             }
           }
+
+          const deleted = await llm.deleteBatch(batchId);
+          expect(deleted).toBe(true);
         },
         TEST_TIMEOUT_MS
       );

--- a/front/lib/api/llm/tests/vite.config.js
+++ b/front/lib/api/llm/tests/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig(() => {
       env: {
         // Skip tests by default, unless explicitly enabled
         RUN_LLM_TEST: process.env.RUN_LLM_TEST ?? "false",
+        RUN_LLM_BATCH_TEST: process.env.RUN_LLM_BATCH_TEST ?? "false",
         // Map API keys from non-VITE env vars to VITE prefixed ones for browser compatibility
         DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY:
           process.env.DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY ?? "",


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/7446

It is not possible to 100% respect the ZDR when using batch mode, however we. do as best as possible by deleting the data after downloading the result.

## Tests

Tested for
 - mistral ✅ 
 - openai ✅ 
 - anthropic ✅ 
 - google ✅ 

## Risk

Low

## Deploy Plan

deploy front
