### PR TITLE
fix: project page height on mobile

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -21,6 +21,7 @@ import {
 } from "@app/components/sparkle/AppLayoutContext";
 import { useConversation } from "@app/hooks/conversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
+import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
 import { useURLSheet } from "@app/hooks/useURLSheet";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { ONBOARDING_CONVERSATION_ENABLED } from "@app/lib/onboarding";
@@ -68,6 +69,7 @@ const ConversationLayoutContent = ({
   const { onOpenChange: onOpenChangeAgentModal } = useURLSheet("agentDetails");
   const { onOpenChange: onOpenChangeUserModal } = useURLSheet("userDetails");
   const activeConversationId = useActiveConversationId();
+  const activeSpaceId = useActiveSpaceId();
   const { conversation, conversationError } = useConversation({
     conversationId: activeConversationId,
     workspaceId: owner.sId,
@@ -118,7 +120,7 @@ const ConversationLayoutContent = ({
     [owner]
   );
 
-  useSetHasTitle(!!activeConversationId);
+  useSetHasTitle(!!activeConversationId || !!activeSpaceId);
   useSetPageTitle(pageTitle);
   useSetNavChildren(navChildren);
 

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -325,7 +325,7 @@ export function SpaceConversationsPage() {
         onValueChange={(value) => handleTabChange(value as SpaceTab)}
         className="flex min-h-0 flex-1 flex-col pt-3"
       >
-        <div className="flex items-start justify-between border-b border-separator px-6 dark:border-separator-night">
+        <div className="flex items-start justify-between border-b border-separator pl-14 pr-6 lg:px-6 dark:border-separator-night">
           <TabsList border={false}>
             {!spaceInfo.archivedAt && (
               <>


### PR DESCRIPTION
## Description

This PR fixes the project page height issue on mobile devices.

- Sets `hasTitle` to true when viewing a space page (not just conversations) to avoid having a double header (see screenshot). The double header made it impossible to scroll to the bottom of the page on mobile
- Adjusts horizontal padding on the tabs container to accommodate mobile layout

Before:

<img width="357" height="115" alt="Capture d’écran 2026-04-10 à 14 54 57" src="https://github.com/user-attachments/assets/189b9e23-cd15-4d5b-96d1-0e1f0ae5b8d0" />

After:

<img width="357" height="115" alt="Capture d’écran 2026-04-10 à 14 55 07" src="https://github.com/user-attachments/assets/155b9ec0-2823-487b-a2e7-2e1895c4e25a" />


## Tests

Manually

## Risks

Low - UI-only changes affecting layout on mobile devices

## Deploy Plan

Standard deployment
