### PR TITLE
feat: add dedup of TODOs

### DIFF
--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -14,6 +14,7 @@ interface LLMTraceContextBase {
   operationType:
     | "agent_builder_description_suggestion"
     | "project_todo_analyze_conversation"
+    | "project_todo_deduplicate_candidates"
     | "agent_builder_emoji_suggestion"
     | "agent_builder_name_suggestion"
     | "agent_builder_tags_suggestion"

--- a/front/lib/project_todo/deduplicate_candidates.ts
+++ b/front/lib/project_todo/deduplicate_candidates.ts
@@ -1,0 +1,274 @@
+// Semantic deduplication for project TODO candidates during the merge workflow.
+//
+// batchDeduplicateCandidates groups candidates by (userId, category), runs one
+// LLM call per non-empty group, and returns a map from the candidate key
+// (`${userId}:${itemId}`) to the existing ProjectTodoResource that is a
+// semantic duplicate, if any.
+//
+// On LLM failure the affected group is treated as all-new (no entries in the
+// map for those candidates), so the caller always falls back to creating a
+// fresh todo rather than silently discarding data.
+
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import type { Authenticator } from "@app/lib/auth";
+import type { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { ProjectTodoCategory } from "@app/types/project_todo";
+import type { ModelId } from "@app/types/shared/model_id";
+import { z } from "zod";
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export type DeduplicateCandidate = {
+  itemId: string;
+  userId: ModelId;
+  text: string;
+  category: ProjectTodoCategory;
+};
+
+// Key: `${userId}:${itemId}`. Value: the existing ProjectTodoResource that this
+// candidate is a semantic duplicate of. Absence of a key means the candidate is
+// a genuinely new item (no duplicate found or dedup was skipped).
+export type DeduplicationMap = Map<string, ProjectTodoResource>;
+
+// ── LLM tool ─────────────────────────────────────────────────────────────────
+
+const REPORT_DUPLICATES_FUNCTION_NAME = "report_duplicates";
+
+const DeduplicationResultSchema = z.object({
+  matches: z.array(
+    z.object({
+      candidate_index: z.number().int(),
+      // Omitted when the candidate is a new, distinct item.
+      duplicate_of_sid: z.string().optional(),
+    })
+  ),
+});
+
+function buildDeduplicationSpec(): AgentActionSpecification {
+  return {
+    name: REPORT_DUPLICATES_FUNCTION_NAME,
+    description:
+      "Report which new candidate TODOs are semantic duplicates of existing ones.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        matches: {
+          type: "array",
+          description: "One entry per new candidate.",
+          items: {
+            type: "object",
+            properties: {
+              candidate_index: {
+                type: "integer",
+                description: "0-based index of the candidate in the list.",
+              },
+              duplicate_of_sid: {
+                type: "string",
+                description:
+                  "sId of the matching existing TODO. Omit if the candidate is a distinct new item.",
+              },
+            },
+            required: ["candidate_index"],
+          },
+        },
+      },
+      required: ["matches"],
+    },
+  };
+}
+
+// ── Prompt builder ────────────────────────────────────────────────────────────
+
+function buildDeduplicationPrompt(
+  category: ProjectTodoCategory,
+  candidates: DeduplicateCandidate[],
+  existingTodos: ProjectTodoResource[]
+): string {
+  const categoryLabel = category.replace(/_/g, " ");
+
+  const existingLines =
+    existingTodos.map((t) => `[${t.sId}] ${t.text}`).join("\n") || "(none)";
+
+  const candidateLines = candidates
+    .map((c, i) => `[${i}] ${c.text}`)
+    .join("\n");
+
+  return [
+    `Deduplicate TODO items for category "${categoryLabel}".`,
+    "Two items are duplicates when they describe the same task or decision,",
+    "regardless of wording differences.",
+    "",
+    "Existing TODOs:",
+    existingLines,
+    "",
+    "New candidates:",
+    candidateLines,
+    "",
+    "Call report_duplicates with one entry per candidate.",
+    "Include duplicate_of_sid only when the candidate is semantically equivalent",
+    "to an existing TODO.",
+  ].join("\n");
+}
+
+// ── LLM call for a single (userId, category) group ───────────────────────────
+
+// Returns a map from candidate index (0-based) to the sId of the matching
+// existing TODO, or an empty map on failure (treat all candidates as new).
+async function runDeduplicationLLMCall(
+  auth: Authenticator,
+  {
+    model,
+    candidates,
+    existingTodos,
+  }: {
+    model: ModelConfigurationType;
+    candidates: DeduplicateCandidate[];
+    existingTodos: ProjectTodoResource[];
+  }
+): Promise<Map<number, string>> {
+  const owner = auth.getNonNullableWorkspace();
+  const category = candidates[0].category;
+  const prompt = buildDeduplicationPrompt(category, candidates, existingTodos);
+  const specification = buildDeduplicationSpec();
+
+  const conv: ModelConversationTypeMultiActions = {
+    messages: [
+      {
+        role: "user",
+        name: "deduplication_task",
+        content: [{ type: "text", text: prompt }],
+      },
+    ],
+  };
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      providerId: model.providerId,
+      modelId: model.modelId,
+      functionCall: specification.name,
+      useCache: false,
+    },
+    {
+      conversation: conv,
+      prompt:
+        "You are a TODO deduplication assistant identifying semantic duplicates.",
+      specifications: [specification],
+      forceToolCall: specification.name,
+    },
+    {
+      context: {
+        operationType: "project_todo_deduplicate_candidates",
+        workspaceId: owner.sId,
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    logger.warn(
+      { error: res.error, workspaceId: owner.sId },
+      "Project todo dedup: LLM call failed, treating all candidates as new"
+    );
+    return new Map();
+  }
+
+  const action = res.value.actions?.[0];
+  if (!action?.arguments) {
+    logger.warn(
+      { workspaceId: owner.sId },
+      "Project todo dedup: no tool call in LLM response, treating all as new"
+    );
+    return new Map();
+  }
+
+  const parsed = DeduplicationResultSchema.safeParse(action.arguments);
+  if (!parsed.success) {
+    logger.warn(
+      { error: parsed.error, workspaceId: owner.sId },
+      "Project todo dedup: failed to parse LLM response, treating all as new"
+    );
+    return new Map();
+  }
+
+  // Map candidateIndex → matched existing sId (only when a match was reported).
+  const indexToMatchedSId = new Map<number, string>();
+  for (const match of parsed.data.matches) {
+    if (match.duplicate_of_sid) {
+      indexToMatchedSId.set(match.candidate_index, match.duplicate_of_sid);
+    }
+  }
+  return indexToMatchedSId;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+// Runs semantic deduplication for all new candidates against existing todos.
+// Groups candidates by (userId, category), executes one LLM call per non-empty
+// group (up to 4 concurrent), and returns a DeduplicationMap keyed by
+// `${userId}:${itemId}`. Missing entries mean no duplicate was found.
+export async function batchDeduplicateCandidates(
+  auth: Authenticator,
+  {
+    model,
+    candidates,
+    existingTodosByGroup,
+  }: {
+    model: ModelConfigurationType;
+    candidates: DeduplicateCandidate[];
+    existingTodosByGroup: Map<string, ProjectTodoResource[]>;
+  }
+): Promise<DeduplicationMap> {
+  const deduplicationMap: DeduplicationMap = new Map();
+
+  // Group candidates by `${userId}:${category}`.
+  const groups = new Map<string, DeduplicateCandidate[]>();
+  for (const candidate of candidates) {
+    const key = `${candidate.userId}:${candidate.category}`;
+    const group = groups.get(key) ?? [];
+    group.push(candidate);
+    groups.set(key, group);
+  }
+
+  await concurrentExecutor(
+    Array.from(groups.entries()),
+    async ([groupKey, groupCandidates]) => {
+      const existingTodos = existingTodosByGroup.get(groupKey) ?? [];
+
+      // No existing todos to compare against — skip the LLM call.
+      if (existingTodos.length === 0) {
+        return;
+      }
+
+      const indexToMatchedSId = await runDeduplicationLLMCall(auth, {
+        model,
+        candidates: groupCandidates,
+        existingTodos,
+      });
+
+      const todosBySId = new Map(existingTodos.map((t) => [t.sId, t]));
+
+      for (let i = 0; i < groupCandidates.length; i++) {
+        const candidate = groupCandidates[i];
+        const matchedSId = indexToMatchedSId.get(i);
+        if (!matchedSId) {
+          continue;
+        }
+        const matched = todosBySId.get(matchedSId);
+        if (matched) {
+          deduplicationMap.set(
+            `${candidate.userId}:${candidate.itemId}`,
+            matched
+          );
+        }
+      }
+    },
+    { concurrency: 4 }
+  );
+
+  return deduplicationMap;
+}

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -3,19 +3,27 @@
 // which itself is invoked by the per-project projectMergeWorkflow at most once
 // per MERGE_THROTTLE_MS (1 hour by default).
 //
-// High-level algorithm:
+// High-level algorithm (3 phases):
 //
-//   1. Fetch all takeaway snapshots (latest per conversation) for
-//      conversations that belong to the given spaceId.
-//   2. For each item (actionItem / keyDecision / notableFact):
-//        - Resolve target users (assigneeUserId, relevantUserIds, or conversation participants).
-//        - For each target user, look up existing agent-created ProjectTodo via
-//          ProjectTodoResource.fetchBySourceId(auth, { sourceId: itemId, userId }).
-//        - not found  → ProjectTodoResource.makeNew() + addSource({ sourceId: itemId })
-//        - found, changed  → existing.createVersion()
-//        - found, unchanged → skip
-//   3. For each agent-created ProjectTodo whose sourceId is absent from
-//      the latest snapshot → createVersion({ status: "done", markedAsDoneByType: "agent" }).
+//   Phase 1 — Collect new candidates.
+//     For every (takeaway, item, targetUser) triple:
+//       - fetchBySourceId(itemId, userId):
+//           found     → update text/status/doneAt if changed (no new row)
+//           not found → push to newCandidates[]
+//
+//   Phase 2 — Semantic deduplication.
+//     - Pre-fetch existing todos per (userId, category) for the space.
+//     - Run one LLM call per non-empty (userId, category) group to detect
+//       items that describe the same task despite different wording.
+//     - Build dedupMap: `${userId}:${itemId}` → matching ProjectTodoResource.
+//       Missing keys mean the candidate is genuinely new.
+//
+//   Phase 3 — Create or link.
+//     For each candidate in newCandidates:
+//       - Key in dedupMap → addSource on existing todo.
+//           If existing todo is user-created: preserve text/status (user wins).
+//           If existing todo is agent-created: also update if content changed.
+//       - Not in dedupMap → makeNew + addSource (current behaviour).
 //
 // Category mapping:
 //   actionItems  (open)    → "follow_ups",      status: "todo"
@@ -24,7 +32,13 @@
 //   keyDecisions (decided) → "key_decisions",   status: "done"
 //   notableFacts           → "notable_updates", status: "todo"
 
+import { getFastestWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import {
+  batchDeduplicateCandidates,
+  type DeduplicateCandidate,
+  type DeduplicationMap,
+} from "@app/lib/project_todo/deduplicate_candidates";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
@@ -44,6 +58,26 @@ import type {
 // for the internal merge workflow.
 const BUTLER_AGENT_SID = "butler";
 
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type TodoBlob = {
+  category: "follow_ups" | "key_decisions" | "notable_updates";
+  text: string;
+  status: "todo" | "done";
+  doneAt: Date | null;
+};
+
+// A candidate todo that has no existing source link yet and therefore needs to
+// go through the deduplication check before being created or linked.
+type PendingCandidate = {
+  itemId: string;
+  userId: ModelId;
+  blob: TodoBlob;
+  conversationSId: string;
+};
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
 export async function mergeTakeawaysIntoProject(
   auth: Authenticator,
   { spaceId }: { spaceId: string }
@@ -54,7 +88,7 @@ export async function mergeTakeawaysIntoProject(
     return;
   }
 
-  // 1. Fetch all latest takeaways for the space directly
+  // Fetch all latest takeaways for the space directly.
   const takeawaysWithSource = await TakeawaysResource.fetchLatestBySpaceId(
     auth,
     { spaceModelId }
@@ -64,8 +98,7 @@ export async function mergeTakeawaysIntoProject(
     return;
   }
 
-  // Batch-fetch conversations by sId — needed to pass ConversationResource
-  // objects to the item processor (for logging and future use).
+  // Batch-fetch conversations by sId.
   const conversationSIds = [
     ...new Set(
       takeawaysWithSource.map(({ conversationSId }) => conversationSId)
@@ -104,8 +137,56 @@ export async function mergeTakeawaysIntoProject(
     allUserIds.size > 0 ? await UserResource.fetchByIds([...allUserIds]) : [];
   const usersById = new Map<string, UserResource>(users.map((u) => [u.sId, u]));
 
-  // 2. For each takeaway, create new project todos for any items that do not
-  //    already have a corresponding todo for a given target user.
+  // ── Phase 1: collect new candidates, update already-linked items ──────────
+
+  const newCandidates = await collectNewCandidates(auth, {
+    takeawaysWithSource,
+    conversationBySId,
+    usersById,
+  });
+
+  if (newCandidates.length === 0) {
+    return;
+  }
+
+  // ── Phase 2: semantic deduplication ──────────────────────────────────────
+
+  const dedupMap = await buildDeduplicationMap(auth, {
+    newCandidates,
+    spaceModelId,
+  });
+
+  // ── Phase 3: create or link ───────────────────────────────────────────────
+
+  await createOrLinkTodos(auth, {
+    newCandidates,
+    dedupMap,
+    spaceModelId,
+  });
+}
+
+// ── Phase 1 ───────────────────────────────────────────────────────────────────
+
+// For each (takeaway, item, targetUser) triple: if a source link already exists,
+// update the todo's content if it has changed. Otherwise, push the item to the
+// returned candidates list for semantic dedup in phase 2.
+async function collectNewCandidates(
+  auth: Authenticator,
+  {
+    takeawaysWithSource,
+    conversationBySId,
+    usersById,
+  }: {
+    takeawaysWithSource: Array<{
+      takeaway: TakeawaysResource;
+      conversationSId: string;
+    }>;
+    conversationBySId: Map<string, ConversationResource>;
+    usersById: Map<string, UserResource>;
+  }
+): Promise<PendingCandidate[]> {
+  const newCandidates: PendingCandidate[] = [];
+
   await concurrentExecutor(
     takeawaysWithSource,
     async ({ takeaway, conversationSId }) => {
@@ -117,132 +198,203 @@ export async function mergeTakeawaysIntoProject(
         );
         return;
       }
-      await processConversationTakeaway(auth, {
-        conversation,
+      const candidates = await collectConversationCandidates(auth, {
+        conversationSId,
         takeaway,
-        spaceModelId,
         usersById,
       });
+      newCandidates.push(...candidates);
     },
     { concurrency: 4 }
   );
+
+  return newCandidates;
 }
 
-async function processConversationTakeaway(
+// Processes one conversation's takeaway: updates todos whose source link already
+// exists, and returns items that need to go through dedup + creation.
+async function collectConversationCandidates(
   auth: Authenticator,
   {
-    conversation,
+    conversationSId,
     takeaway,
-    spaceModelId,
     usersById,
   }: {
-    conversation: ConversationResource;
+    conversationSId: string;
     takeaway: TakeawaysResource;
-    spaceModelId: ModelId;
     usersById: Map<string, UserResource>;
   }
-): Promise<void> {
-  // Resolve target user ModelIds for a given set of user sIds
-  async function resolveTargetUserIds(userIds: string[]): Promise<ModelId[]> {
-    return userIds
+): Promise<PendingCandidate[]> {
+  const candidates: PendingCandidate[] = [];
+
+  function resolveTargetUserIds(userSIds: string[]): ModelId[] {
+    return userSIds
       .map((sId) => usersById.get(sId)?.id)
       .filter((id): id is ModelId => id !== undefined);
   }
 
-  // Process action items → "follow_ups" category.
-  for (const item of takeaway.actionItems) {
-    const targetUserIds = await resolveTargetUserIds(
-      item.assigneeUserId ? [item.assigneeUserId] : []
-    );
-    await createNewTodosForItem(auth, {
-      conversation,
-      spaceModelId,
-      itemId: item.sId,
-      targetUserIds,
-      makeBlob: () => actionItemBlob(item),
-    });
-  }
-
-  // Process key decisions → "key_decisions" category.
-  for (const item of takeaway.keyDecisions) {
-    const targetUserIds = await resolveTargetUserIds(item.relevantUserIds);
-    await createNewTodosForItem(auth, {
-      conversation,
-      spaceModelId,
-      itemId: item.sId,
-      targetUserIds,
-      makeBlob: () => keyDecisionBlob(item),
-    });
-  }
-
-  // Process notable facts → "notable_updates" category.
-  for (const item of takeaway.notableFacts) {
-    const targetUserIds = await resolveTargetUserIds(item.relevantUserIds);
-    await createNewTodosForItem(auth, {
-      conversation,
-      spaceModelId,
-      itemId: item.sId,
-      targetUserIds,
-      makeBlob: () => notableFactBlob(item),
-    });
-  }
-}
-
-// For each target user, checks whether a project todo already exists for this
-// source item. If not, creates one and links it to the source.
-async function createNewTodosForItem(
-  auth: Authenticator,
-  {
-    conversation,
-    spaceModelId,
-    itemId,
-    targetUserIds,
-    makeBlob,
-  }: {
-    conversation: ConversationResource;
-    spaceModelId: ModelId;
-    itemId: string;
-    targetUserIds: ModelId[];
-    makeBlob: () => TodoBlob;
-  }
-): Promise<void> {
-  await concurrentExecutor(
-    targetUserIds,
-    async (userId) => {
+  async function collectForItem(
+    itemId: string,
+    targetUserIds: ModelId[],
+    blob: TodoBlob
+  ): Promise<void> {
+    for (const userId of targetUserIds) {
       const existing = await ProjectTodoResource.fetchBySourceId(auth, {
         sourceId: itemId,
         userId,
       });
 
-      const blob = makeBlob();
-
       if (existing !== null) {
-        // The todo already exists. Create a new version only if the wording or
-        // completion state has changed since it was last recorded.
-        const textChanged = existing.text !== blob.text;
-        const statusChanged = existing.status !== blob.status;
-        const doneAtChanged =
-          existing.doneAt?.toISOString() !== blob.doneAt?.toISOString();
-
-        if (textChanged || statusChanged || doneAtChanged) {
-          await existing.createVersion(auth, {
-            text: blob.text,
-            status: blob.status,
-            doneAt: blob.doneAt,
-          });
-        }
-        return;
+        // Source link exists — update content if it has changed.
+        await updateTodoIfChanged(existing, auth, blob);
+      } else {
+        candidates.push({ itemId, userId, blob, conversationSId });
       }
-      const todo = await ProjectTodoResource.makeNew(auth, {
+    }
+  }
+
+  for (const item of takeaway.actionItems) {
+    const targetUserIds = resolveTargetUserIds(
+      item.assigneeUserId ? [item.assigneeUserId] : []
+    );
+    await collectForItem(item.sId, targetUserIds, actionItemBlob(item));
+  }
+
+  for (const item of takeaway.keyDecisions) {
+    const targetUserIds = resolveTargetUserIds(item.relevantUserIds);
+    await collectForItem(item.sId, targetUserIds, keyDecisionBlob(item));
+  }
+
+  for (const item of takeaway.notableFacts) {
+    const targetUserIds = resolveTargetUserIds(item.relevantUserIds);
+    await collectForItem(item.sId, targetUserIds, notableFactBlob(item));
+  }
+
+  return candidates;
+}
+
+// ── Phase 2 ───────────────────────────────────────────────────────────────────
+
+// Pre-fetches all existing todos per (userId, category) and runs batch semantic
+// deduplication via LLM. Returns an empty map if no model is available, which
+// causes all candidates to be treated as new in phase 3.
+async function buildDeduplicationMap(
+  auth: Authenticator,
+  {
+    newCandidates,
+    spaceModelId,
+  }: {
+    newCandidates: PendingCandidate[];
+    spaceModelId: ModelId;
+  }
+): Promise<DeduplicationMap> {
+  const model = getFastestWhitelistedModel(auth);
+  if (!model) {
+    logger.warn(
+      { workspaceId: auth.getNonNullableWorkspace().sId },
+      "Project todo merge: no whitelisted model, skipping deduplication"
+    );
+    return new Map();
+  }
+
+  // Fetch all existing todos for each unique target user in a single pass, then
+  // group them by `${userId}:${category}` for efficient lookup in the LLM calls.
+  const uniqueUserIds = [...new Set(newCandidates.map((c) => c.userId))];
+  const existingTodosByGroup = new Map<string, ProjectTodoResource[]>();
+
+  await concurrentExecutor(
+    uniqueUserIds,
+    async (userId) => {
+      const todos = await ProjectTodoResource.fetchLatestBySpaceForUser(auth, {
         spaceId: spaceModelId,
         userId,
+      });
+      for (const todo of todos) {
+        const key = `${userId}:${todo.category}`;
+        const group = existingTodosByGroup.get(key) ?? [];
+        group.push(todo);
+        existingTodosByGroup.set(key, group);
+      }
+    },
+    { concurrency: 4 }
+  );
+
+  const deduplicateCandidates: DeduplicateCandidate[] = newCandidates.map(
+    (c) => ({
+      itemId: c.itemId,
+      userId: c.userId,
+      text: c.blob.text,
+      category: c.blob.category,
+    })
+  );
+
+  return batchDeduplicateCandidates(auth, {
+    model,
+    candidates: deduplicateCandidates,
+    existingTodosByGroup,
+  });
+}
+
+// ── Phase 3 ───────────────────────────────────────────────────────────────────
+
+// For each candidate: if a semantic duplicate was found, attach the source link
+// to the existing todo (updating content for agent-created ones if needed).
+// Otherwise, create a new todo and link the source.
+async function createOrLinkTodos(
+  auth: Authenticator,
+  {
+    newCandidates,
+    dedupMap,
+    spaceModelId,
+  }: {
+    newCandidates: PendingCandidate[];
+    dedupMap: DeduplicationMap;
+    spaceModelId: ModelId;
+  }
+): Promise<void> {
+  await concurrentExecutor(
+    newCandidates,
+    async (candidate) => {
+      const match =
+        dedupMap.get(`${candidate.userId}:${candidate.itemId}`) ?? null;
+
+      if (match !== null) {
+        // Semantic duplicate found — link the new source to the existing todo.
+        await match.addSource(auth, {
+          sourceType: "conversation",
+          sourceId: candidate.itemId,
+        });
+
+        // For agent-created todos also propagate content updates. User-created
+        // todos are left untouched: the user's text and status take priority.
+        if (match.createdByType === "agent") {
+          await updateTodoIfChanged(match, auth, candidate.blob);
+        }
+
+        logger.info(
+          {
+            existingTodoSId: match.sId,
+            itemId: candidate.itemId,
+            userId: candidate.userId,
+            conversationSId: candidate.conversationSId,
+            createdByType: match.createdByType,
+          },
+          "Project todo merge: linked source to existing todo (semantic duplicate)"
+        );
+        return;
+      }
+
+      // No duplicate — create a fresh todo and link the source.
+      const todo = await ProjectTodoResource.makeNew(auth, {
+        spaceId: spaceModelId,
+        userId: candidate.userId,
         createdByType: "agent",
         createdByUserId: null,
         createdByAgentConfigurationId: BUTLER_AGENT_SID,
-        category: blob.category,
-        text: blob.text,
-        status: blob.status,
-        doneAt: blob.doneAt,
+        category: candidate.blob.category,
+        text: candidate.blob.text,
+        status: candidate.blob.status,
+        doneAt: candidate.blob.doneAt,
         actorRationale: null,
         markedAsDoneByType: null,
         markedAsDoneByUserId: null,
@@ -252,15 +404,15 @@ async function createNewTodosForItem(
 
       await todo.addSource(auth, {
         sourceType: "conversation",
-        sourceId: itemId,
+        sourceId: candidate.itemId,
       });
 
       logger.info(
         {
           todoSId: todo.sId,
-          conversationId: conversation.id,
-          itemId,
-          userId,
+          itemId: candidate.itemId,
+          userId: candidate.userId,
+          conversationSId: candidate.conversationSId,
         },
         "Project todo merge: created new todo"
       );
@@ -269,14 +421,29 @@ async function createNewTodosForItem(
   );
 }
 
-// ── Blob helpers ─────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
-type TodoBlob = {
-  category: "follow_ups" | "key_decisions" | "notable_updates";
-  text: string;
-  status: "todo" | "done";
-  doneAt: Date | null;
-};
+// Creates a new version of a todo only when text, status, or doneAt has changed.
+async function updateTodoIfChanged(
+  todo: ProjectTodoResource,
+  auth: Authenticator,
+  blob: TodoBlob
+): Promise<void> {
+  const textChanged = todo.text !== blob.text;
+  const statusChanged = todo.status !== blob.status;
+  const doneAtChanged =
+    todo.doneAt?.toISOString() !== blob.doneAt?.toISOString();
+
+  if (textChanged || statusChanged || doneAtChanged) {
+    await todo.createVersion(auth, {
+      text: blob.text,
+      status: blob.status,
+      doneAt: blob.doneAt,
+    });
+  }
+}
+
+// ── Blob helpers ─────────────────────────────────────────────────────────────
 
 function actionItemBlob(item: TodoVersionedActionItem): TodoBlob {
   const isDone = item.status === "done";

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -175,6 +175,33 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     return Array.from(latestBySId.values());
   }
 
+  // Returns the latest version of each logical todo for an explicit target userId
+  // in the given space. Mirrors fetchLatestBySpace but takes an explicit userId
+  // instead of using auth.user — needed by the merge workflow, which acts on
+  // behalf of specific target users rather than the authenticated principal.
+  static async fetchLatestBySpaceForUser(
+    auth: Authenticator,
+    { spaceId, userId }: { spaceId: ModelId; userId: ModelId }
+  ): Promise<ProjectTodoResource[]> {
+    const all = await this.baseFetch(auth, {
+      where: { spaceId, userId },
+      order: [
+        ["sId", "ASC"],
+        ["version", "DESC"],
+      ],
+    });
+
+    // O(n) deduplication — keep the first occurrence per sId (highest version).
+    const latestBySId = new Map<string, ProjectTodoResource>();
+    for (const todo of all) {
+      if (!latestBySId.has(todo.sId)) {
+        latestBySId.set(todo.sId, todo);
+      }
+    }
+
+    return Array.from(latestBySId.values());
+  }
+
   // Returns every version row for (spaceId, userId), across all sIds. Used by the
   // diff algorithm to reconstruct snapshots at arbitrary cutoff dates.
   static async fetchAllVersionsBySpace(


### PR DESCRIPTION
## Description

Adds dedup of TODOs.

We collect all potential new TODOs, and for each category x user, we run a LLM to dedup tasks. 

We always keep existing tasks first

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
