### PR TITLE
fix(connectors): quote Snowflake identifiers in SQL queries

### DIFF
--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -30,6 +30,18 @@ import type {
 } from "snowflake-sdk";
 import snowflake from "snowflake-sdk";
 
+/**
+ * Escape a Snowflake identifier for use in double-quoted SQL.
+ * Doubles any internal double-quote characters to prevent SQL injection.
+ */
+function escapeSnowflakeIdentifier(identifier: string): string {
+  return identifier.replace(/"/g, '""');
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${escapeSnowflakeIdentifier(identifier)}"`;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SnowflakeRow = Record<string, any>;
 type SnowflakeRows = Array<SnowflakeRow>;
@@ -371,7 +383,7 @@ export const fetchSchemas = async ({
   fromDatabase: string;
   connection?: Connection;
 }): Promise<Result<Array<RemoteDBSchema>, Error>> => {
-  const query = `SHOW SCHEMAS IN DATABASE ${fromDatabase}`;
+  const query = `SHOW SCHEMAS IN DATABASE ${quoteIdentifier(fromDatabase)}`;
   return _fetchRows<RemoteDBSchema>({
     credentials,
     query,
@@ -397,9 +409,9 @@ export const fetchTables = async ({
   // We fetch the tables in the schema provided if defined, otherwise in the database provided if
   // defined, otherwise globally.
   const query = fromSchema
-    ? `SHOW TABLES IN SCHEMA ${fromSchema}`
+    ? `SHOW TABLES IN SCHEMA ${quoteIdentifier(fromSchema)}`
     : fromDatabase
-      ? `SHOW TABLES IN DATABASE ${fromDatabase}`
+      ? `SHOW TABLES IN DATABASE ${quoteIdentifier(fromDatabase)}`
       : "SHOW TABLES";
 
   return _fetchRows<RemoteDBTable>({
@@ -526,7 +538,10 @@ export const useWarehouse = async ({
   connection: Connection;
 }): Promise<Result<void, Error>> => {
   const warehouse = credentials.warehouse;
-  const res = await _executeQuery(connection, `USE WAREHOUSE ${warehouse}`);
+  const res = await _executeQuery(
+    connection,
+    `USE WAREHOUSE ${quoteIdentifier(warehouse)}`
+  );
   if (res.isErr()) {
     const e = normalizeError(res.error);
 
@@ -573,7 +588,7 @@ async function _checkRoleGrants(
   // Check current grants
   const currentGrantsRes = await _fetchRows<SnowflakeGrant>({
     credentials,
-    query: `SHOW GRANTS TO ${isDbRole ? "DATABASE ROLE" : "ROLE"} ${roleName}`,
+    query: `SHOW GRANTS TO ${isDbRole ? "DATABASE ROLE" : "ROLE"} ${quoteIdentifier(roleName)}`,
     codec: snowflakeGrantCodec,
     connection,
   });
@@ -588,7 +603,7 @@ async function _checkRoleGrants(
     // Check future grants
     futureGrantsRes = await _fetchRows<SnowflakeFutureGrant>({
       credentials,
-      query: `SHOW FUTURE GRANTS TO ROLE ${roleName}`,
+      query: `SHOW FUTURE GRANTS TO ROLE ${quoteIdentifier(roleName)}`,
       codec: snowflakeFutureGrantCodec,
       connection,
     });

--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -31,15 +31,11 @@ import type {
 import snowflake from "snowflake-sdk";
 
 /**
- * Escape a Snowflake identifier for use in double-quoted SQL.
- * Doubles any internal double-quote characters to prevent SQL injection.
+ * Quote a Snowflake identifier for safe use in SQL.
+ * Wraps in double quotes and doubles any internal double-quote characters.
  */
-function escapeSnowflakeIdentifier(identifier: string): string {
-  return identifier.replace(/"/g, '""');
-}
-
 function quoteIdentifier(identifier: string): string {
-  return `"${escapeSnowflakeIdentifier(identifier)}"`;
+  return `"${identifier.replace(/"/g, '""')}"`;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description

Database, schema, warehouse, and role names containing special characters (like @ or .) cause SQL compilation errors when interpolated unquoted into Snowflake queries. This is the case for connector 274877913006 whose Snowflake account has a database named @SWAN.IO_1775721551.

The front codebase already handles this correctly via escapeSnowflakeIdentifier in front/lib/utils/snowflake.ts. This PR applies the same pattern to the connectors side: a quoteIdentifier helper wraps identifiers in double quotes (with internal " escaped as "") before interpolation.

Six query sites are fixed in snowflake_api.ts: fetchSchemas, fetchTables (two branches), useWarehouse, and _checkRoleGrants (two queries).

Logs: [DD](https://app.datadoghq.eu/logs?query=%40workflowId%3Asnowflake-sync-274877913006&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ13g5jr-X0bOAAAABhBWjEzZzUyN0FBQVN2dFpTWmlHb0RRQUUAAAAkZjE5ZDc3ODYtZGVmNi00MzBhLTg5Y2YtN2NiNGVjMmNiNGM2AAANkQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1775825810339&to_ts=1775826710339&live=true)

Turns out swans are as dangerous in SQL as they are in real life. Swans are a no-go.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy connectors. 