### PR TITLE
fix: project member table mobile

### DIFF
--- a/front/components/assistant/conversation/space/about/MembersTable.tsx
+++ b/front/components/assistant/conversation/space/about/MembersTable.tsx
@@ -163,7 +163,7 @@ export function MembersTable({
         id: "name",
         sortingFn: "text",
         meta: {
-          className: "w-full",
+          className: "w-[250px]",
         },
         cell: (info: MemberRowInfo) => {
           return (
@@ -322,6 +322,10 @@ export function MembersTable({
       filter={searchSelectedMembers}
       filterColumn="email"
       sorting={[{ id: "name", desc: false }]}
+      columnsBreakpoints={{
+        email: "sm",
+        joinedAt: "sm",
+      }}
     />
   );
 }

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -356,7 +356,7 @@ export function SpaceAboutTab({
               value={searchSelectedMembers}
               onChange={setSearchSelectedMembers}
             />
-            <ScrollArea className="h-full">
+            <ScrollArea className="h-full" orientation="horizontal">
               <MembersTable
                 owner={owner}
                 space={space}


### PR DESCRIPTION
## Description

This PR fixes the mobile layout of the project member table in the space about section.

- Set a fixed width of 250px for the name column instead of full width to avoid the column disappearing when there is not enough space. Note that a min-width would be ignored by the table fixed layout.
- Added horizontal scrolling to the ScrollArea component to be able to scroll horizontally
- Configured column breakpoints to hide email and joinedAt columns on small screens


Before:

<img width="357" height="424" alt="Capture d’écran 2026-04-10 à 15 48 26" src="https://github.com/user-attachments/assets/217d1bf3-f404-4d09-8311-0d76baa4bb2f" />

After:

<img width="357" height="424" alt="Capture d’écran 2026-04-10 à 15 44 22" src="https://github.com/user-attachments/assets/aaa39ac9-96f4-44ea-bc05-8cb95fd6372c" />

## Tests

Manually

## Risks

Low - UI-only changes affecting the display of the members table on mobile devices

## Deploy Plan

Standard deployment - no special considerations needed
