### PR TITLE
Allow to disable batch mode for reinforcement

### DIFF
--- a/front/components/pages/workspace/WorkspaceSettingsPage.tsx
+++ b/front/components/pages/workspace/WorkspaceSettingsPage.tsx
@@ -1,3 +1,4 @@
+import { ReinforcementSection } from "@app/components/workspace/settings/AgentReinforcementToggle";
 import { CapabilitiesSection } from "@app/components/workspace/settings/CapabilitiesSection";
 import { IntegrationsSection } from "@app/components/workspace/settings/IntegrationsSection";
 import { WorkspaceNameEditor } from "@app/components/workspace/settings/WorkspaceNameEditor";
@@ -52,6 +53,9 @@ export function WorkspaceSettingsPage() {
         discordBotDataSource={discordBotDataSource}
         isDiscordBotAvailable={isDiscordBotAvailable}
       />
+      {featureFlags.includes("reinforced_agents") && (
+        <ReinforcementSection owner={owner} />
+      )}
     </Page.Vertical>
   );
 }

--- a/front/components/workspace/settings/AgentReinforcementToggle.tsx
+++ b/front/components/workspace/settings/AgentReinforcementToggle.tsx
@@ -51,7 +51,7 @@ function ReinforcementBatchModeToggle({ owner }: ReinforcementSectionProps) {
 
   return (
     <ContextItem
-      title="Allow batch mode for reinforcement"
+      title="Enable batch processing"
       visual={<Square3Stack3DIcon className="h-6 w-6 shrink-0" />}
       hasSeparatorIfLast={true}
       action={

--- a/front/components/workspace/settings/AgentReinforcementToggle.tsx
+++ b/front/components/workspace/settings/AgentReinforcementToggle.tsx
@@ -62,7 +62,7 @@ function ReinforcementBatchModeToggle({ owner }: ReinforcementSectionProps) {
         />
       }
     >
-      <ContextItem.Description description="Conversations are sent in batches to reduce costs. Data may remain on LLM provider servers for several hours while waiting for processing, which is incompatible with strict Zero Data Retention policies. Dust guarantees that data is immediately deleted afterward. Disabling batch mode significantly increases the cost of reinforcement." />
+      <ContextItem.Description description="Conversations are sent in batches to reduce costs. Data may remain on LLM provider servers for up to several hours before processing. Disable to ensure immediate data deletion (ZDR-compatible). This will increase your plan's pricing." />
     </ContextItem>
   );
 }

--- a/front/components/workspace/settings/AgentReinforcementToggle.tsx
+++ b/front/components/workspace/settings/AgentReinforcementToggle.tsx
@@ -1,28 +1,68 @@
-import { useReinforcementToggle } from "@app/lib/swr/useReinforcementToggle";
+import {
+  useReinforcementBatchModeToggle,
+  useReinforcementToggle,
+} from "@app/lib/swr/useReinforcementToggle";
 import type { WorkspaceType } from "@app/types/user";
-import { ContextItem, SliderToggle, SparklesIcon } from "@dust-tt/sparkle";
+import {
+  ContextItem,
+  Page,
+  SliderToggle,
+  SparklesIcon,
+  Square3Stack3DIcon,
+} from "@dust-tt/sparkle";
 
-interface ReinforcementToggleProps {
+interface ReinforcementSectionProps {
   owner: WorkspaceType;
 }
 
-export function ReinforcementToggle({ owner }: ReinforcementToggleProps) {
+export function ReinforcementSection({ owner }: ReinforcementSectionProps) {
   const { isEnabled, isChanging, doToggleReinforcement } =
     useReinforcementToggle({ owner });
 
+  // TODO(reinforcement): Add link to doc
+  return (
+    <Page.Vertical align="stretch" gap="md">
+      <Page.H variant="h4">Reinforcement</Page.H>
+      <ContextItem.List>
+        <div className="h-full border-b border-border dark:border-border-night" />
+        <ContextItem
+          title="Allow reinforcement"
+          visual={<SparklesIcon className="h-6 w-6 shrink-0" />}
+          hasSeparatorIfLast={true}
+          action={
+            <SliderToggle
+              selected={isEnabled}
+              disabled={isChanging}
+              onClick={doToggleReinforcement}
+            />
+          }
+        >
+          <ContextItem.Description description="Allow Dust to analyze conversations to improve your workspace's skills. Dust does not use conversations to train models." />
+        </ContextItem>
+        {isEnabled && <ReinforcementBatchModeToggle owner={owner} />}
+      </ContextItem.List>
+    </Page.Vertical>
+  );
+}
+
+function ReinforcementBatchModeToggle({ owner }: ReinforcementSectionProps) {
+  const { isEnabled, isChanging, doToggleBatchMode } =
+    useReinforcementBatchModeToggle({ owner });
+
   return (
     <ContextItem
-      title="Allow reinforcement"
-      subElement="Allow Dust to analyse conversations to suggest improvements."
-      visual={<SparklesIcon className="h-6 w-6" />}
+      title="Allow batch mode for reinforcement"
+      visual={<Square3Stack3DIcon className="h-6 w-6 shrink-0" />}
       hasSeparatorIfLast={true}
       action={
         <SliderToggle
           selected={isEnabled}
           disabled={isChanging}
-          onClick={doToggleReinforcement}
+          onClick={doToggleBatchMode}
         />
       }
-    />
+    >
+      <ContextItem.Description description="Conversations are sent in batches to reduce costs. Data may remain on LLM provider servers for several hours while waiting for processing, which is incompatible with strict Zero Data Retention policies. Dust guarantees that data is immediately deleted afterward. Disabling batch mode significantly increases the cost of reinforcement." />
+    </ContextItem>
   );
 }

--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -1,9 +1,8 @@
-import { ReinforcementToggle } from "@app/components/workspace/settings/AgentReinforcementToggle";
 import { EmailAgentsToggle } from "@app/components/workspace/settings/EmailAgentsToggle";
 import { InteractiveContentSharingToggle } from "@app/components/workspace/settings/InteractiveContentSharingToggle";
 import { RestrictAgentsPublishingCapability } from "@app/components/workspace/settings/RestrictAgentsPublishingCapability";
 import { VoiceTranscriptionToggle } from "@app/components/workspace/settings/VoiceTranscriptionToggle";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
 import { ContextItem, Page } from "@dust-tt/sparkle";
 
@@ -17,7 +16,6 @@ export function CapabilitiesSection({
   publishingRestrictionMessage,
 }: CapabilitiesSectionProps) {
   const { subscription } = useAuth();
-  const { hasFeature } = useFeatureFlags();
 
   return (
     <Page.Vertical align="stretch" gap="md">
@@ -29,9 +27,6 @@ export function CapabilitiesSection({
           <VoiceTranscriptionToggle owner={owner} />
         )}
         <EmailAgentsToggle owner={owner} />
-        {hasFeature("reinforced_agents") && (
-          <ReinforcementToggle owner={owner} />
-        )}
         {publishingRestrictionMessage && (
           <RestrictAgentsPublishingCapability
             subElement={publishingRestrictionMessage}

--- a/front/lib/reinforced_agent/workspace_check.ts
+++ b/front/lib/reinforced_agent/workspace_check.ts
@@ -16,3 +16,12 @@ export async function hasReinforcementEnabled(
   const workspace = auth.getNonNullableWorkspace();
   return workspace.metadata?.allowReinforcement !== false;
 }
+
+/**
+ * Check whether batch mode is allowed for reinforcement in this workspace.
+ * Defaults to true when not explicitly set.
+ */
+export function isReinforcementBatchModeAllowed(auth: Authenticator): boolean {
+  const workspace = auth.getNonNullableWorkspace();
+  return workspace.metadata?.allowReinforcementBatchMode !== false;
+}

--- a/front/lib/swr/useReinforcementToggle.ts
+++ b/front/lib/swr/useReinforcementToggle.ts
@@ -51,3 +51,53 @@ export function useReinforcementToggle({ owner }: UseReinforcementToggleProps) {
     doToggleReinforcement,
   };
 }
+
+interface UseReinforcementBatchModeToggleProps {
+  owner: LightWorkspaceType;
+}
+
+export function useReinforcementBatchModeToggle({
+  owner,
+}: UseReinforcementBatchModeToggleProps) {
+  const [isChanging, setIsChanging] = useState(false);
+  const sendNotification = useSendNotification();
+  const [isEnabled, setIsEnabled] = useState(
+    owner.metadata?.allowReinforcementBatchMode !== false
+  );
+
+  const doToggleBatchMode = async () => {
+    setIsChanging(true);
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          allowReinforcementBatchMode: !isEnabled,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to update reinforcement batch mode setting");
+      }
+      setIsEnabled(!isEnabled);
+      return true;
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to update reinforcement batch mode setting",
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsChanging(false);
+    }
+  };
+
+  return {
+    isEnabled,
+    isChanging,
+    doToggleBatchMode,
+  };
+}

--- a/front/pages/api/w/[wId]/index.test.ts
+++ b/front/pages/api/w/[wId]/index.test.ts
@@ -285,6 +285,52 @@ describe("POST /api/w/[wId]", () => {
     });
   });
 
+  it("enables reinforcement batch mode", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.body = {
+      allowReinforcementBatchMode: true,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      workspace: expect.objectContaining({
+        id: workspace.id,
+        metadata: expect.objectContaining({
+          allowReinforcementBatchMode: true,
+        }),
+      }),
+    });
+  });
+
+  it("disables reinforcement batch mode", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.body = {
+      allowReinforcementBatchMode: false,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      workspace: expect.objectContaining({
+        id: workspace.id,
+        metadata: expect.objectContaining({
+          allowReinforcementBatchMode: false,
+        }),
+      }),
+    });
+  });
+
   it("returns 405 for non-POST methods", async () => {
     for (const method of ["PUT", "DELETE"] as const) {
       const { req, res } = await createPrivateApiMockRequest({

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -79,6 +79,10 @@ const WorkspaceAgentReinforcementUpdateBodySchema = t.type({
   allowReinforcement: t.boolean,
 });
 
+const WorkspaceReinforcementBatchModeUpdateBodySchema = t.type({
+  allowReinforcementBatchMode: t.boolean,
+});
+
 const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceAllowedDomainUpdateBodySchema,
   WorkspaceBatchDomainUpdateBodySchema,
@@ -91,6 +95,7 @@ const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceVoiceTranscriptionUpdateBodySchema,
   WorkspaceEmailAgentsUpdateBodySchema,
   WorkspaceAgentReinforcementUpdateBodySchema,
+  WorkspaceReinforcementBatchModeUpdateBodySchema,
 ]);
 
 async function handler(
@@ -227,6 +232,14 @@ async function handler(
         const newMetadata = {
           ...previousMetadata,
           allowReinforcement: body.allowReinforcement,
+        };
+        await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+        owner.metadata = newMetadata;
+      } else if ("allowReinforcementBatchMode" in body) {
+        const previousMetadata = owner.metadata ?? {};
+        const newMetadata = {
+          ...previousMetadata,
+          allowReinforcementBatchMode: body.allowReinforcementBatchMode,
         };
         await workspace.updateWorkspaceSettings({ metadata: newMetadata });
         owner.metadata = newMetadata;

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -16,7 +16,10 @@ import {
   type ReinforcedToolActionInfo,
   storeTerminalToolCallResults,
 } from "@app/lib/reinforced_agent/tool_execution";
-import { hasReinforcementEnabled } from "@app/lib/reinforced_agent/workspace_check";
+import {
+  hasReinforcementEnabled,
+  isReinforcementBatchModeAllowed,
+} from "@app/lib/reinforced_agent/workspace_check";
 import {
   buildSkillAggregationBatchMap,
   buildSkillAggregationSystemPrompt,
@@ -228,15 +231,20 @@ async function runReinforcedSkillsStep({
 // ---------------------------------------------------------------------------
 
 /**
- * Checks if skill reinforcement is allowed for this workspace.
+ * Checks reinforcement settings for this workspace:
+ * - whether reinforcement is enabled at all
+ * - whether batch mode is allowed
  */
-export async function isSkillReinforcementAllowedActivity({
+export async function getReinforcementSettingsActivity({
   workspaceId,
 }: {
   workspaceId: string;
-}): Promise<boolean> {
+}): Promise<{ reinforcementEnabled: boolean; batchModeAllowed: boolean }> {
   const auth = await getAuthForWorkspace(workspaceId);
-  return hasReinforcementEnabled(auth);
+  return {
+    reinforcementEnabled: await hasReinforcementEnabled(auth),
+    batchModeAllowed: isReinforcementBatchModeAllowed(auth),
+  };
 }
 
 /**

--- a/front/temporal/reinforcement/workflows.ts
+++ b/front/temporal/reinforcement/workflows.ts
@@ -22,11 +22,11 @@ export const interceptors: WorkflowInterceptorsFactory = () => ({
   internals: [new OpenTelemetryInternalsInterceptor()],
 });
 
-const { isSkillReinforcementAllowedActivity } = proxyActivities<
-  typeof activities
->({
-  startToCloseTimeout: "5 minutes",
-});
+const { getReinforcementSettingsActivity } = proxyActivities<typeof activities>(
+  {
+    startToCloseTimeout: "5 minutes",
+  }
+);
 
 const { getRecentConversationsWithSkillsActivity } = proxyActivities<
   typeof activities
@@ -303,10 +303,15 @@ export async function reinforcedSkillsWorkspaceWorkflow({
   conversationLookbackDays?: number;
   disableNotifications?: boolean;
 }): Promise<void> {
-  const isAllowed = await isSkillReinforcementAllowedActivity({ workspaceId });
-  if (!isAllowed) {
+  const { reinforcementEnabled, batchModeAllowed } =
+    await getReinforcementSettingsActivity({ workspaceId });
+  if (!reinforcementEnabled) {
     return;
   }
+
+  // Resolve effective batch mode: the caller may request batch mode, but the
+  // workspace setting can override it to streaming.
+  const effectiveBatchMode = useBatchMode && batchModeAllowed;
 
   if (!skipDelay) {
     const delayMs = computeWorkspaceDelayMs(workspaceId);
@@ -327,7 +332,7 @@ export async function reinforcedSkillsWorkspaceWorkflow({
     return;
   }
 
-  if (useBatchMode) {
+  if (effectiveBatchMode) {
     // Phase 2: Batch-analyze conversations with multi-step loop.
     let pendingConversations = conversationsWithSkills;
     let reinforcementConversationMap: Record<string, string> | undefined;


### PR DESCRIPTION
## Description

 - Move allow reinforcement settings to a new section.
 - Allow the admin to disable batch mode. This will increase their cost.

<img width="2312" height="518" alt="image" src="https://github.com/user-attachments/assets/7f186cb5-1b16-406c-9fc6-f70c55752449" />

<img width="2330" height="308" alt="image" src="https://github.com/user-attachments/assets/5895bf29-4ce5-4bc7-8fc5-51a821a844c2" />


## Tests

Tested locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
