### PR TITLE
[Connectors] chore(slack): remove native streaming feature flag

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1,7 +1,6 @@
 import {
   makeErrorBlock,
   makeMarkdownBlock,
-  makeMessageUpdateBlocksAndText,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/slack/chat/blocks";
 import { SlackStreamHandler } from "@connectors/connectors/slack/chat/slack_stream_handler";
@@ -74,7 +73,7 @@ import {
   Ok,
   removeNulls,
 } from "@dust-tt/client";
-import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";
+import type { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
 import removeMarkdown from "remove-markdown";
 
@@ -661,11 +660,10 @@ async function processErrorResult(
         ? res.error.message
         : `An error occurred : ${res.error.message}. Our team has been notified and will work on it as soon as possible.`;
 
-    const { slackChatBotMessage, mainMessage, streamTs } =
+    const { slackChatBotMessage, streamTs } =
       res.error instanceof SlackMessageError
         ? res.error
         : {
-            mainMessage: undefined,
             streamTs: undefined,
             slackChatBotMessage: undefined,
           };
@@ -683,9 +681,7 @@ async function processErrorResult(
       errorMessage
     );
 
-    const updateTs = streamTs ?? mainMessage?.ts;
-
-    if (updateTs) {
+    if (streamTs) {
       reportSlackUsage({
         connectorId: connector.id,
         method: "chat.update",
@@ -701,7 +697,7 @@ async function processErrorResult(
           slackClient.chat.update({
             ...errorPost,
             channel: slackChannel,
-            ts: updateTs,
+            ts: streamTs,
           }),
         { source: "processErrorResult" }
       );
@@ -1135,52 +1131,25 @@ async function answerMessage(
     }
   }
 
-  const useNativeStreaming = await getNativeStreamingFromFeatureFlag(dustAPI);
-
-  let mainMessage: ChatPostMessageResponse | undefined;
-  let streamHandler: SlackStreamHandler | undefined;
-
-  if (useNativeStreaming) {
-    let streamRecipientUserId = slackUserId;
-    if (!streamRecipientUserId) {
-      const botUserIdRes = await getBotUserIdResponse(
-        slackClient,
-        connector.id
-      );
-      if (botUserIdRes.isErr()) {
-        throw botUserIdRes.error;
-      }
-      streamRecipientUserId = botUserIdRes.value;
+  if (!slackUserId) {
+    const botUserIdRes = await getBotUserIdResponse(slackClient, connector.id);
+    if (botUserIdRes.isErr()) {
+      throw botUserIdRes.error;
     }
-    streamHandler = new SlackStreamHandler(slackClient, connector.id, {
-      slackChannel,
-      slackMessageTs,
-      slackThreadTs,
-      slackTeamId,
-      slackUserId: streamRecipientUserId,
-    });
-    await streamHandler.setThinking(
-      mention.agentName === "dust"
-        ? "is thinking..."
-        : `(${mention.agentName}) is thinking...`
-    );
-  } else {
-    mainMessage = await slackClient.chat.postMessage({
-      ...makeMessageUpdateBlocksAndText(null, connector.workspaceId, {
-        assistantName: mention.agentName,
-        agentConfigurations: mostPopularAgentConfigurations,
-        isThinking: true,
-      }),
-      channel: slackChannel,
-      thread_ts: slackMessageTs,
-      metadata: {
-        event_type: "user_message",
-        event_payload: {
-          message_id: slackChatBotMessage.id,
-        },
-      },
-    });
+    slackUserId = botUserIdRes.value;
   }
+  const streamHandler = new SlackStreamHandler(slackClient, connector.id, {
+    slackChannel,
+    slackMessageTs,
+    slackThreadTs,
+    slackTeamId,
+    slackUserId,
+  });
+  await streamHandler.setThinking(
+    mention.agentName === "dust"
+      ? "is thinking..."
+      : `(${mention.agentName}) is thinking...`
+  );
 
   const buildSlackMessageError = (
     errRes: Err<Error | APIError>,
@@ -1205,8 +1174,7 @@ async function answerMessage(
       new SlackMessageError(
         errRes.error.message,
         slackChatBotMessage.get(),
-        mainMessage,
-        streamHandler?.messageTs
+        streamHandler.messageTs
       )
     );
   };
@@ -1317,7 +1285,6 @@ async function answerMessage(
     assistantName: mention.agentName,
     connector,
     conversation,
-    mainMessage,
     streamHandler,
     slack: {
       slackChannelId: slackChannel,
@@ -1721,14 +1688,4 @@ async function isAgentAccessingRestrictedSpace(
       )
     );
   }
-}
-
-async function getNativeStreamingFromFeatureFlag(
-  dustAPI: DustAPI
-): Promise<boolean> {
-  const flagsRes = await dustAPI.getWorkspaceFeatureFlags();
-  if (flagsRes.isErr()) {
-    return false;
-  }
-  return flagsRes.value.includes("slack_native_streaming");
 }

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -40,21 +40,8 @@ import type {
   UserMessageType,
 } from "@dust-tt/client";
 import { assertNever, DustAPI, Err, Ok, removeNulls } from "@dust-tt/client";
-import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";
+import type { WebClient } from "@slack/web-api";
 import * as t from "io-ts";
-import throttle from "lodash/throttle";
-import slackifyMarkdown from "slackify-markdown";
-
-const SLACK_MESSAGE_UPDATE_THROTTLE_MS = 1_000;
-const SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS = 5_000;
-const SLACK_MESSAGE_LONG_THRESHOLD_CHARS = 400;
-
-const getThrottleDelay = (textLength: number): number => {
-  if (textLength >= SLACK_MESSAGE_LONG_THRESHOLD_CHARS) {
-    return SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS;
-  }
-  return SLACK_MESSAGE_UPDATE_THROTTLE_MS;
-};
 
 export const SlackBlockIdStaticAgentConfigSchema = t.type({
   slackChatBotMessageId: t.number,
@@ -124,8 +111,7 @@ interface StreamConversationToSlackParams {
   assistantName: string;
   connector: ConnectorResource;
   conversation: ConversationPublicType;
-  mainMessage?: ChatPostMessageResponse;
-  streamHandler?: SlackStreamHandler;
+  streamHandler: SlackStreamHandler;
   slack: {
     slackChannelId: string;
     slackClient: WebClient;
@@ -173,17 +159,15 @@ export async function streamConversationToSlack(
     conversation.sId
   );
 
-  const planHandler = streamHandler
-    ? new PlanMessageHandler({
-        dustAPI,
-        slackClient,
-        slackChannelId,
-        slackMessageTs,
-        conversationUrl,
-        assistantName,
-        workspaceId: connector.workspaceId,
-      })
-    : null;
+  const planHandler = new PlanMessageHandler({
+    dustAPI,
+    slackClient,
+    slackChannelId,
+    slackMessageTs,
+    conversationUrl,
+    assistantName,
+    workspaceId: connector.workspaceId,
+  });
 
   try {
     return await streamAgentAnswerToSlack(
@@ -193,9 +177,9 @@ export async function streamConversationToSlack(
     );
   } finally {
     // Cleanup streams and plan message on unexpected error
-    planHandler?.abortAllChildStreams();
-    await planHandler?.deletePlanMessage();
-    await streamHandler?.stop();
+    planHandler.abortAllChildStreams();
+    await planHandler.deletePlanMessage();
+    await streamHandler.stop();
   }
 }
 
@@ -208,12 +192,11 @@ class SlackAnswerRetryableError extends Error {
 async function streamAgentAnswerToSlack(
   dustAPI: DustAPI,
   conversationData: StreamConversationToSlackParams,
-  planHandler: PlanMessageHandler | null
+  planHandler: PlanMessageHandler
 ) {
   const {
     assistantName,
     conversation,
-    mainMessage,
     userMessage,
     slackChatBotMessage,
     agentConfigurations,
@@ -248,12 +231,6 @@ async function streamAgentAnswerToSlack(
 
   const { streamHandler } = conversationData;
 
-  let currentThrottleDelay = SLACK_MESSAGE_UPDATE_THROTTLE_MS;
-  let throttledPostSlackMessageUpdate = throttle(
-    postSlackMessageUpdate,
-    currentThrottleDelay
-  );
-
   for await (const event of streamRes.value.eventStream) {
     switch (event.type) {
       case "tool_params":
@@ -265,7 +242,7 @@ async function streamAgentAnswerToSlack(
         if (isRunAgent && event.type === "tool_notification") {
           const output = getRunAgentNotificationOutput(event);
           if (output) {
-            await planHandler?.startChildStream(output);
+            await planHandler.startChildStream(output);
           }
           break;
         }
@@ -273,30 +250,8 @@ async function streamAgentAnswerToSlack(
         // For all other tools, rotate a single default task card.
         const thinkingAction = getActionRunningLabel(event.action);
 
-        if (planHandler) {
-          planHandler.setDefaultTask(
-            thinkingAction,
-            "in_progress",
-            event.action
-          );
-          await planHandler.upsertPlanMessage(thinkingAction);
-        } else {
-          await throttledPostSlackMessageUpdate({
-            messageUpdate: {
-              isThinking: true,
-              assistantName,
-              agentConfigurations,
-              text: answer,
-              thinkingAction,
-            },
-            ...conversationData,
-            canBeIgnored: true,
-            extraLogs: {
-              source: "streamAgentAnswerToSlack",
-              eventType: event.type,
-            },
-          });
-        }
+        planHandler.setDefaultTask(thinkingAction, "in_progress", event.action);
+        await planHandler.upsertPlanMessage(thinkingAction);
         break;
       }
 
@@ -319,11 +274,9 @@ async function streamAgentAnswerToSlack(
           conversationId: event.conversationId,
           messageId: event.messageId,
           actionId: event.actionId,
-          slackThreadTs: streamHandler
-            ? slackMessageTs
-            : mainMessage?.message?.thread_ts,
-          messageTs: streamHandler?.messageTs ?? mainMessage?.message?.ts,
-          botId: streamHandler ? undefined : mainMessage?.message?.bot_id,
+          slackThreadTs: slackMessageTs,
+          messageTs: streamHandler.messageTs,
+          botId: undefined,
           slackChatBotMessageId: slackChatBotMessage.id,
         });
 
@@ -375,24 +328,8 @@ async function streamAgentAnswerToSlack(
           };
         }
 
-        if (planHandler) {
-          planHandler.setDefaultTask("Waiting for authentication…", "pending");
-          await planHandler.upsertPlanMessage("Waiting for authentication…");
-        } else {
-          await throttledPostSlackMessageUpdate({
-            messageUpdate: {
-              text: "Agent is waiting for authentication…",
-              assistantName,
-              agentConfigurations,
-            },
-            ...conversationData,
-            canBeIgnored: false,
-            extraLogs: {
-              source: "streamAgentAnswerToSlack",
-              eventType: event.type,
-            },
-          });
-        }
+        planHandler.setDefaultTask("Waiting for authentication…", "pending");
+        await planHandler.upsertPlanMessage("Waiting for authentication…");
         break;
       }
 
@@ -420,23 +357,7 @@ async function streamAgentAnswerToSlack(
           });
         }
 
-        if (streamHandler) {
-          await streamHandler.setThinking("Waiting for file authorization...");
-        } else {
-          await throttledPostSlackMessageUpdate({
-            messageUpdate: {
-              text: "Agent is waiting for file authorization…",
-              assistantName,
-              agentConfigurations,
-            },
-            ...conversationData,
-            canBeIgnored: false,
-            extraLogs: {
-              source: "streamAgentAnswerToSlack",
-              eventType: event.type,
-            },
-          });
-        }
+        await streamHandler.setThinking("Waiting for file authorization...");
         break;
       }
 
@@ -456,8 +377,8 @@ async function streamAgentAnswerToSlack(
         );
       }
       case "agent_error": {
-        planHandler?.abortAllChildStreams();
-        await planHandler?.deletePlanMessage();
+        planHandler.abortAllChildStreams();
+        await planHandler.deletePlanMessage();
         return new Err(
           new Error(
             `Agent message error: code: ${event.error.code} message: ${event.error.message}`
@@ -478,7 +399,7 @@ async function streamAgentAnswerToSlack(
         }
 
         // Mark default task complete (for non-run_agent tools).
-        if (planHandler && event.action.internalMCPServerName !== "run_agent") {
+        if (event.action.internalMCPServerName !== "run_agent") {
           const doneLabel = getActionDoneLabel(event.action);
           planHandler.setDefaultTask(doneLabel, "complete", event.action);
           await planHandler.upsertPlanMessage(doneLabel);
@@ -495,91 +416,43 @@ async function streamAgentAnswerToSlack(
 
         answer += event.text;
 
-        // Streaming path: append text or stop if too long.
-        if (streamHandler?.isStopped) {
+        if (streamHandler.isStopped) {
           break;
         }
-        if (streamHandler && answer.length <= MAX_SLACK_MESSAGE_LENGTH) {
+        if (answer.length <= MAX_SLACK_MESSAGE_LENGTH) {
           await streamHandler.appendText(event.text);
           break;
         }
-        if (streamHandler) {
-          // Message too long for streaming: stop and fall back to chat.update
-          // with truncated content + footer.
-          await streamHandler.stop();
-          await planHandler?.deletePlanMessage();
-          const { formattedContent, footnotes } = annotateCitations(
-            answer,
-            actions
-          );
 
-          await postSlackMessageUpdate({
-            messageUpdate: {
-              text: formattedContent,
-              assistantName,
-              agentConfigurations,
-              footnotes,
-            },
-            ...conversationData,
-            canBeIgnored: false,
-            extraLogs: {
-              source: "streamAgentAnswerToSlack",
-              eventType: "stream_fallback",
-            },
-          });
-          break;
-        }
+        // Message too long for streaming: stop and fall back to chat.update.
+        await streamHandler.stop();
+        await planHandler.deletePlanMessage();
+        const { formattedContent, footnotes } = annotateCitations(
+          answer,
+          actions
+        );
 
-        // Non-streaming path: throttled chat.update.
-        {
-          const { formattedContent, footnotes } = annotateCitations(
-            answer,
-            actions
-          );
-          const slackContent = safelyPrepareAnswer(formattedContent);
-          // If the answer cannot be prepared safely, skip processing these tokens.
-          if (!slackContent) {
-            break;
-          }
-          // If the message is too long, we avoid the update entirely (to reduce
-          // rate limiting) the previous update will have shown the "..." and the
-          // link to continue the conversation so this is fine.
-          if (slackContent.length > MAX_SLACK_MESSAGE_LENGTH) {
-            break;
-          }
-
-          const newThrottleDelay = getThrottleDelay(slackContent.length);
-          if (newThrottleDelay !== currentThrottleDelay) {
-            currentThrottleDelay = newThrottleDelay;
-            throttledPostSlackMessageUpdate.cancel();
-            throttledPostSlackMessageUpdate = throttle(
-              postSlackMessageUpdate,
-              currentThrottleDelay
-            );
-          }
-
-          await throttledPostSlackMessageUpdate({
-            messageUpdate: {
-              text: slackContent,
-              assistantName,
-              agentConfigurations,
-              footnotes,
-            },
-            ...conversationData,
-            canBeIgnored: true,
-            extraLogs: {
-              source: "streamAgentAnswerToSlack",
-              eventType: event.type,
-            },
-          });
-        }
+        await postSlackMessageUpdate({
+          messageUpdate: {
+            text: formattedContent,
+            assistantName,
+            agentConfigurations,
+            footnotes,
+          },
+          ...conversationData,
+          canBeIgnored: false,
+          extraLogs: {
+            source: "streamAgentAnswerToSlack",
+            eventType: "stream_fallback",
+          },
+        });
         break;
       }
 
       case "agent_message_gracefully_stopped":
       case "agent_message_success": {
-        planHandler?.abortAllChildStreams();
-        await planHandler?.deletePlanMessage();
+        planHandler.abortAllChildStreams();
+        await planHandler.deletePlanMessage();
 
         const finalAnswer = event.message.content ?? "";
         const actions = event.message.actions;
@@ -599,15 +472,11 @@ async function streamAgentAnswerToSlack(
           filesUploaded = await getFilesFromDust(files, dustAPI);
         }
 
-        const slackContent = streamHandler
-          ? formattedContent
-          : slackifyMarkdown(normalizeContentForSlack(formattedContent));
-
-        await streamHandler?.stop();
+        await streamHandler.stop();
 
         {
           const messageUpdate: SlackMessageUpdate = {
-            text: slackContent,
+            text: formattedContent,
             assistantName,
             agentConfigurations,
             footnotes,
@@ -616,16 +485,14 @@ async function streamAgentAnswerToSlack(
           };
 
           const shouldSplitMessage =
-            slackContent.length > MAX_SLACK_MESSAGE_LENGTH
+            formattedContent.length > MAX_SLACK_MESSAGE_LENGTH
               ? await getMessageSplittingFromFeatureFlag(
                   conversationData.connector
                 )
               : false;
 
           if (shouldSplitMessage) {
-            const splitMessages = splitContentForSlack(slackContent);
-
-            throttledPostSlackMessageUpdate.cancel();
+            const splitMessages = splitContentForSlack(formattedContent);
 
             if (filesUploaded.length > 0) {
               await deleteAndRepostMessageWithFiles({
@@ -680,11 +547,9 @@ async function streamAgentAnswerToSlack(
         ) {
           const blockId = SlackBlockIdStaticAgentConfigSchema.encode({
             slackChatBotMessageId: slackChatBotMessage.id,
-            slackThreadTs: streamHandler
-              ? slackMessageTs
-              : mainMessage?.message?.thread_ts,
-            messageTs: streamHandler?.messageTs ?? mainMessage?.message?.ts,
-            botId: streamHandler ? undefined : mainMessage?.message?.bot_id,
+            slackThreadTs: slackMessageTs,
+            messageTs: streamHandler.messageTs,
+            botId: undefined,
           });
 
           const feedbackParams =
@@ -724,22 +589,19 @@ async function streamAgentAnswerToSlack(
       }
 
       case "agent_generation_cancelled": {
-        planHandler?.abortAllChildStreams();
-        await planHandler?.deletePlanMessage();
-        await streamHandler?.stop();
+        planHandler.abortAllChildStreams();
+        await planHandler.deletePlanMessage();
+        await streamHandler.stop();
 
         const cancelledMessage = "_Message generation was cancelled._";
         const {
           formattedContent: cancelledContent,
           footnotes: cancelledFootnotes,
         } = annotateCitations(answer || cancelledMessage, actions);
-        const cancelledSlackContent = slackifyMarkdown(
-          normalizeContentForSlack(cancelledContent)
-        );
 
         await postSlackMessageUpdate({
           messageUpdate: {
-            text: cancelledSlackContent,
+            text: cancelledContent,
             assistantName,
             agentConfigurations,
             footnotes: cancelledFootnotes,
@@ -791,9 +653,9 @@ async function streamAgentAnswerToSlack(
   }
 
   // Clean up if the event stream ended without a terminal event.
-  planHandler?.abortAllChildStreams();
-  await planHandler?.deletePlanMessage();
-  await streamHandler?.stop();
+  planHandler.abortAllChildStreams();
+  await planHandler.deletePlanMessage();
+  await streamHandler.stop();
 
   return new Err(
     new SlackAnswerRetryableError("Failed to get the final answer from Dust")
@@ -805,7 +667,6 @@ async function deleteAndRepostMessageWithFiles({
   slack,
   connector,
   conversation,
-  mainMessage,
   streamHandler,
   uploadedFiles,
 }: {
@@ -819,8 +680,7 @@ async function deleteAndRepostMessageWithFiles({
   };
   connector: ConnectorResource;
   conversation: ConversationPublicType;
-  mainMessage?: ChatPostMessageResponse;
-  streamHandler?: SlackStreamHandler;
+  streamHandler: SlackStreamHandler;
   uploadedFiles: { file: Buffer; filename: string }[];
 }): Promise<void> {
   const { slackChannelId, slackClient, slackMessageTs } = slack;
@@ -829,8 +689,7 @@ async function deleteAndRepostMessageWithFiles({
     conversation.sId
   );
 
-  const threadTs = mainMessage?.message?.thread_ts ?? slackMessageTs;
-  const deleteTs = streamHandler?.messageTs ?? mainMessage?.ts;
+  const deleteTs = streamHandler.messageTs;
 
   // First post a new message with files
   const response = await slackClient.filesUploadV2({
@@ -842,7 +701,7 @@ async function deleteAndRepostMessageWithFiles({
     ),
     channel_id: slackChannelId,
     file_uploads: uploadedFiles,
-    thread_ts: threadTs, // Preserve thread context if it exists
+    thread_ts: slackMessageTs,
   });
 
   if (response?.error) {
@@ -883,7 +742,6 @@ async function postSlackMessageUpdate({
   slack,
   connector,
   conversation,
-  mainMessage,
   streamHandler,
   canBeIgnored,
   extraLogs,
@@ -898,12 +756,11 @@ async function postSlackMessageUpdate({
   };
   connector: ConnectorResource;
   conversation: ConversationPublicType;
-  mainMessage?: ChatPostMessageResponse;
-  streamHandler?: SlackStreamHandler;
+  streamHandler: SlackStreamHandler;
   canBeIgnored: boolean;
   extraLogs: Record<string, string>;
 }): Promise<void> {
-  const targetTs = streamHandler?.messageTs ?? mainMessage?.ts;
+  const targetTs = streamHandler.messageTs;
   if (!targetTs) {
     return;
   }
@@ -954,28 +811,6 @@ async function postSlackMessageUpdate({
       "Failed to update Slack message."
     );
   }
-}
-
-/**
- * Safely prepare the answer by normalizing the content for Slack and converting it to Markdown.
- * In streaming mode, partial links might trigger errors in the `slackifyMarkdown` function.
- * This function handles such errors gracefully, ensuring that the full text will be displayed
- * once a valid URL is available.
- */
-function safelyPrepareAnswer(text: string): string | null {
-  const rawAnswer = normalizeContentForSlack(text);
-
-  try {
-    return slackifyMarkdown(rawAnswer);
-  } catch (_err) {
-    // It's safe to swallow the error as we'll catch up once a valid URL is fully received.
-    return null;
-  }
-}
-
-function normalizeContentForSlack(content: string): string {
-  // Remove language hint from code blocks.
-  return content.replace(/```[a-z\-_]*\n/g, "```\n");
 }
 
 /**
@@ -1035,15 +870,14 @@ async function postThreadFollowUpMessages(
   followUpMessages: string[],
   conversationData: StreamConversationToSlackParams
 ): Promise<void> {
-  const { slack, connector, conversation, mainMessage } = conversationData;
+  const { slack, connector, conversation } = conversationData;
   const { slackChannelId, slackClient, slackMessageTs } = slack;
-  const threadTs = mainMessage?.message?.thread_ts ?? slackMessageTs;
 
   for (let i = 0; i < followUpMessages.length; i++) {
     const threadResponse = await slackClient.chat.postMessage({
       channel: slackChannelId,
       blocks: makeMarkdownBlock(followUpMessages[i] || ""),
-      thread_ts: threadTs,
+      thread_ts: slackMessageTs,
     });
 
     if (threadResponse.error) {

--- a/connectors/src/connectors/slack/lib/errors.ts
+++ b/connectors/src/connectors/slack/lib/errors.ts
@@ -1,6 +1,5 @@
 import type { SlackChatBotMessageModel } from "@connectors/lib/models/slack";
 import type {
-  ChatPostMessageResponse,
   CodedError,
   WebAPIHTTPError,
   WebAPIPlatformError,
@@ -19,7 +18,6 @@ export class SlackMessageError extends Error {
   constructor(
     message: string,
     public slackChatBotMessage: Attributes<SlackChatBotMessageModel>,
-    public mainMessage?: ChatPostMessageResponse,
     public streamTs?: string
   ) {
     super(message);

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -177,11 +177,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable splitting agent responses into multiple Slack messages for Slack (instead of truncation)",
     stage: "dust_only",
   },
-  slack_native_streaming: {
-    description:
-      "Use Slack's native streaming API for bot responses instead of throttled chat.update loop",
-    stage: "dust_only",
-  },
   slack_bot_mcp: {
     description: "Slack bot MCP server for workspace-level Slack integration",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -734,7 +734,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "slack_bot_mcp"
   | "slack_enhanced_default_agent"
   | "slack_message_splitting"
-  | "slack_native_streaming"
   | "slideshow"
   | "snowflake_tool"
   | "run_tools_from_prompt"


### PR DESCRIPTION
## Description

`slack_native_streaming` has been GA for all workspaces. This removes the flag and the old throttled `chat.update` fallback path that it guarded.

## Tests

Tested locally.