### PR TITLE
Add Poke credits to Metronome

### DIFF
--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -154,109 +154,120 @@ export function PluginForm({
         onSubmit={form.handleSubmit(handleSubmit)}
         className="max-w-[600px] space-y-8"
       >
-        {Object.entries(manifest.args).map(([key, arg]) => {
-          const isDependentFieldHidden =
-            arg.dependsOn &&
-            watchedValues[arg.dependsOn.field] !== arg.dependsOn.value;
+        <div className="max-h-[50vh] space-y-8 overflow-y-auto pr-2">
+          {Object.entries(manifest.args).map(([key, arg]) => {
+            const isDependentFieldHidden =
+              arg.dependsOn &&
+              watchedValues[arg.dependsOn.field] !== arg.dependsOn.value;
 
-          if (isDependentFieldHidden) {
-            return null;
-          }
+            if (isDependentFieldHidden) {
+              return null;
+            }
 
-          let defaultValue = undefined;
-          let options = undefined;
+            let defaultValue = undefined;
+            let options = undefined;
 
-          if (arg.type === "enum") {
-            options =
-              arg.async && asyncArgs?.[key]
-                ? (asyncArgs[key] as AsyncEnumValues)
-                : arg.values;
-            defaultValue = options.filter((v) => v.checked).map((v) => v.value);
-          }
-          const fieldDescription =
-            arg.asyncDescription &&
-            asyncArgs?.[`${key}_description`] !== undefined
-              ? String(asyncArgs[`${key}_description`])
-              : arg.description;
+            if (arg.type === "enum") {
+              options =
+                arg.async && asyncArgs?.[key]
+                  ? (asyncArgs[key] as AsyncEnumValues)
+                  : arg.values;
+              defaultValue = options
+                .filter((v) => v.checked)
+                .map((v) => v.value);
+            }
+            const fieldDescription =
+              arg.asyncDescription &&
+              asyncArgs?.[`${key}_description`] !== undefined
+                ? String(asyncArgs[`${key}_description`])
+                : arg.description;
 
-          return (
-            <PokeFormField
-              key={key}
-              control={form.control}
-              name={key}
-              disabled={disabled}
-              defaultValue={defaultValue}
-              render={({ field }) => (
-                <PokeFormItem>
-                  <div
-                    className={
-                      arg.type === "boolean"
-                        ? "flex flex-row items-center gap-x-2"
-                        : "flex flex-col gap-y-2"
-                    }
-                  >
-                    <PokeFormLabel>{arg.label}</PokeFormLabel>
-                    <PokeFormControl>
-                      <>
-                        {arg.type === "text" && <PokeFormTextArea {...field} />}
-                        {arg.type === "string" && <PokeFormInput {...field} />}
-                        {arg.type === "number" && (
-                          <PokeFormInput
-                            type={arg.variant === "text" ? "text" : "number"}
-                            {...field}
-                            onChange={(e) => {
-                              const parsed = Number(e.target.value);
-                              if (isFinite(parsed)) {
-                                field.onChange(parsed);
-                              }
-                            }}
-                          />
-                        )}
-                        {arg.type === "boolean" && arg.variant === "toggle" && (
-                          <SliderToggle
-                            selected={field.value}
-                            onClick={() => field.onChange(!field.value)}
-                            disabled={field.disabled}
-                          />
-                        )}
-                        {arg.type === "boolean" &&
-                          (arg.variant === "checkbox" ||
-                            arg.variant === undefined) && (
-                            <Checkbox
-                              checked={field.value}
-                              onCheckedChange={field.onChange}
+            return (
+              <PokeFormField
+                key={key}
+                control={form.control}
+                name={key}
+                disabled={disabled}
+                defaultValue={defaultValue}
+                render={({ field }) => (
+                  <PokeFormItem>
+                    <div
+                      className={
+                        arg.type === "boolean"
+                          ? "flex flex-row items-center gap-x-2"
+                          : "flex flex-col gap-y-2"
+                      }
+                    >
+                      <PokeFormLabel>{arg.label}</PokeFormLabel>
+                      <PokeFormControl>
+                        <>
+                          {arg.type === "text" && (
+                            <PokeFormTextArea {...field} />
+                          )}
+                          {arg.type === "string" && (
+                            <PokeFormInput {...field} />
+                          )}
+                          {arg.type === "number" && (
+                            <PokeFormInput
+                              type={arg.variant === "text" ? "text" : "number"}
+                              {...field}
+                              onChange={(e) => {
+                                const parsed = Number(e.target.value);
+                                if (isFinite(parsed)) {
+                                  field.onChange(parsed);
+                                }
+                              }}
                             />
                           )}
-                        {arg.type === "enum" && (
-                          <EnumSelect
-                            label={arg.label}
-                            onValuesChange={(values) => field.onChange(values)}
-                            options={options ?? []}
-                            placeholder="Select value"
-                            values={field.value}
-                            multiple={arg.multiple}
-                          />
-                        )}
-                        {arg.type === "file" && (
-                          <PokeFormUpload type="file" {...field} />
-                        )}
-                        {arg.type === "date" && (
-                          <PokeFormInput type="date" {...field} />
-                        )}
-                      </>
-                    </PokeFormControl>
-                  </div>
-                  {fieldDescription && (
-                    <PokeFormDescription>
-                      {fieldDescription}
-                    </PokeFormDescription>
-                  )}
-                  <PokeFormMessage />
-                </PokeFormItem>
-              )}
-            />
-          );
-        })}
+                          {arg.type === "boolean" &&
+                            arg.variant === "toggle" && (
+                              <SliderToggle
+                                selected={field.value}
+                                onClick={() => field.onChange(!field.value)}
+                                disabled={field.disabled}
+                              />
+                            )}
+                          {arg.type === "boolean" &&
+                            (arg.variant === "checkbox" ||
+                              arg.variant === undefined) && (
+                              <Checkbox
+                                checked={field.value}
+                                onCheckedChange={field.onChange}
+                              />
+                            )}
+                          {arg.type === "enum" && (
+                            <EnumSelect
+                              label={arg.label}
+                              onValuesChange={(values) =>
+                                field.onChange(values)
+                              }
+                              options={options ?? []}
+                              placeholder="Select value"
+                              values={field.value}
+                              multiple={arg.multiple}
+                            />
+                          )}
+                          {arg.type === "file" && (
+                            <PokeFormUpload type="file" {...field} />
+                          )}
+                          {arg.type === "date" && (
+                            <PokeFormInput type="date" {...field} />
+                          )}
+                        </>
+                      </PokeFormControl>
+                    </div>
+                    {fieldDescription && (
+                      <PokeFormDescription>
+                        {fieldDescription}
+                      </PokeFormDescription>
+                    )}
+                    <PokeFormMessage />
+                  </PokeFormItem>
+                )}
+              />
+            );
+          })}
+        </div>
         <Button
           type="submit"
           variant="outline"

--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -15,7 +15,6 @@ import {
   Button,
   cn,
   Dialog,
-  DialogContainer,
   DialogContent,
   DialogDescription,
   DialogHeader,
@@ -86,7 +85,7 @@ export function RunPluginDialog({
     <Dialog open={true} onOpenChange={handleClose}>
       <DialogContent
         className={cn(
-          "w-auto overflow-visible",
+          "w-auto",
           "bg-muted-background dark:bg-muted-background-night",
           "sm:min-w-[600px] sm:max-w-[1000px]"
         )}
@@ -95,7 +94,7 @@ export function RunPluginDialog({
           <DialogTitle>Run {plugin.name} plugin</DialogTitle>
           <DialogDescription>{plugin.description}</DialogDescription>
         </DialogHeader>
-        <DialogContainer>
+        <div className="flex flex-col gap-2 px-5 py-4 text-foreground dark:text-foreground-night">
           {isLoading || (hasAsyncArgs && isLoadingAsyncArgs) ? (
             <Spinner />
           ) : !manifest ? (
@@ -175,7 +174,7 @@ export function RunPluginDialog({
               )}
             </>
           )}
-        </DialogContainer>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -1,12 +1,15 @@
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { createEnterpriseCreditPurchase } from "@app/lib/credits/committed";
+import { createMetronomeCredit } from "@app/lib/metronome/client";
+import { getProductFreeMonthlyCreditId } from "@app/lib/metronome/constants";
 import {
   getStripeSubscription,
   isEnterpriseSubscription,
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { addYears, format } from "date-fns";
 import { z } from "zod";
@@ -186,6 +189,37 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
       });
       if (startResult.isErr()) {
         return new Err(startResult.error);
+      }
+
+      // Mirror the free credit in Metronome if the workspace is provisioned.
+      const metronomeCustomerId = workspace.metronomeCustomerId;
+
+      if (metronomeCustomerId) {
+        const amountCents = Math.ceil(amountMicroUsd / 10_000);
+        const metronomeResult = await createMetronomeCredit({
+          metronomeCustomerId,
+          productId: getProductFreeMonthlyCreditId(),
+          amountCents,
+          startingAt: startDate.toISOString(),
+          endingBefore: expirationDate.toISOString(),
+          name: `Free poke credit ($${originalAmount.toFixed(2)})`,
+          idempotencyKey,
+        });
+
+        if (metronomeResult.isErr()) {
+          logger.error(
+            {
+              workspaceId: workspace.sId,
+              error: metronomeResult.error.message,
+            },
+            "[Poke Plugin] Failed to create free credit in Metronome"
+          );
+          return new Err(
+            new Error(
+              `Credit created locally but failed to mirror in Metronome: ${metronomeResult.error.message}`
+            )
+          );
+        }
       }
 
       return new Ok({

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -496,18 +496,11 @@ async function addMetronomeCommitsForWorkspace({
   expirationDate?: Date;
 }): Promise<Result<void, Error>> {
   const workspace = auth.getNonNullableWorkspace();
-  const subscription = auth.subscription();
-
   const metronomeCustomerId = workspace.metronomeCustomerId;
-  const metronomeContractId = subscription?.metronomeContractId;
 
-  if (!metronomeCustomerId || !metronomeContractId) {
+  if (!metronomeCustomerId) {
     logger.info(
-      { subscription },
-      "[Commit Purchase] Subscription missing Metronome contract ID, skipping credit addition"
-    );
-    logger.info(
-      { workspaceId: workspace.sId, metronomeCustomerId, metronomeContractId },
+      { workspaceId: workspace.sId },
       "[Commit Purchase] Workspace not provisioned in Metronome, skipping credit addition"
     );
     return new Ok(undefined);
@@ -525,7 +518,6 @@ async function addMetronomeCommitsForWorkspace({
 
   const result = await createMetronomeCommit({
     metronomeCustomerId,
-    contractId: metronomeContractId,
     productId,
     amountCents,
     startingAt: effectiveStartDate,
@@ -540,7 +532,6 @@ async function addMetronomeCommitsForWorkspace({
       {
         workspaceId: workspace.sId,
         metronomeCustomerId,
-        metronomeContractId,
         amountCents,
         error: result.error.message,
       },

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -466,11 +466,10 @@ export async function updateSubscriptionQuantity({
 // ---------------------------------------------------------------------------
 
 /**
- * Add paid credits (=commits) to a Metronome contract via a contract edit.
+ * Add paid credits (=commits) to a Metronome customer.
  */
 export async function createMetronomeCommit({
   metronomeCustomerId,
-  contractId,
   productId,
   amountCents,
   startingAt,
@@ -480,7 +479,6 @@ export async function createMetronomeCommit({
   priority,
 }: {
   metronomeCustomerId: string;
-  contractId: string;
   productId: string;
   amountCents: number;
   startingAt: Date;
@@ -496,51 +494,42 @@ export async function createMetronomeCommit({
     logger.info(
       {
         metronomeCustomerId,
-        contractId,
         productId,
         amountCents,
         roundedStartingAt,
         roundedEndingBefore,
       },
-      "[Metronome] Adding commits to contract"
+      "[Metronome] Adding commits to customer"
     );
 
-    await getMetronomeClient().v2.contracts.edit(
-      {
-        customer_id: metronomeCustomerId,
-        contract_id: contractId,
-        add_commits: [
+    await getMetronomeClient().v1.customers.commits.create({
+      customer_id: metronomeCustomerId,
+      type: "PREPAID",
+      product_id: productId,
+      name: name ?? "Commit purchase",
+      applicable_product_tags: ["usage"],
+      priority: priority ?? 2, // Apply after any free credits
+      access_schedule: {
+        schedule_items: [
           {
-            type: "PREPAID",
-            product_id: productId,
-            name: name ?? "Commit purchase",
-            applicable_product_tags: ["usage"],
-            priority,
-            access_schedule: {
-              schedule_items: [
-                {
-                  amount: amountCents,
-                  starting_at: roundedStartingAt,
-                  ending_before: roundedEndingBefore,
-                },
-              ],
-            },
+            amount: amountCents,
+            starting_at: roundedStartingAt,
+            ending_before: roundedEndingBefore,
           },
         ],
       },
-      { idempotencyKey }
-    );
+      uniqueness_key: idempotencyKey,
+    });
 
     logger.info(
       {
         metronomeCustomerId,
-        contractId,
         productId,
         amountCents,
         roundedStartingAt,
         roundedEndingBefore,
       },
-      "[Metronome] Commits added to contract"
+      "[Metronome] Commits added to customer"
     );
     return new Ok(undefined);
   } catch (err) {
@@ -549,13 +538,12 @@ export async function createMetronomeCommit({
       {
         error,
         metronomeCustomerId,
-        contractId,
         productId,
         amountCents,
         roundedStartingAt,
         roundedEndingBefore,
       },
-      "[Metronome] Failed to add commits to contract"
+      "[Metronome] Failed to add commits to customer"
     );
     return new Err(error);
   }
@@ -725,7 +713,6 @@ export async function listMetronomeUsageWithGroups({
  */
 export async function createMetronomeCredit({
   metronomeCustomerId,
-  contractId,
   productId,
   amountCents,
   startingAt,
@@ -734,7 +721,6 @@ export async function createMetronomeCredit({
   idempotencyKey,
 }: {
   metronomeCustomerId: string;
-  contractId: string;
   productId: string;
   amountCents: number;
   startingAt: string;
@@ -747,30 +733,23 @@ export async function createMetronomeCredit({
   const roundedEndingBefore = ceilToHourISO(new Date(endingBefore));
 
   try {
-    const response = await getMetronomeClient().v2.contracts.edit(
-      {
-        customer_id: metronomeCustomerId,
-        contract_id: contractId,
-        add_credits: [
+    const response = await getMetronomeClient().v1.customers.credits.create({
+      customer_id: metronomeCustomerId,
+      product_id: productId,
+      name,
+      priority: 1, // Apply credits before any prepaid commits
+      applicable_product_tags: ["usage"],
+      access_schedule: {
+        schedule_items: [
           {
-            product_id: productId,
-            name,
-            priority: 1, // Apply credits before any prepaid commits
-            applicable_product_tags: ["usage"],
-            access_schedule: {
-              schedule_items: [
-                {
-                  amount: amountCents,
-                  starting_at: roundedStartingAt,
-                  ending_before: roundedEndingBefore,
-                },
-              ],
-            },
+            amount: amountCents,
+            starting_at: roundedStartingAt,
+            ending_before: roundedEndingBefore,
           },
         ],
       },
-      { idempotencyKey }
-    );
+      uniqueness_key: idempotencyKey,
+    });
 
     return new Ok({ creditId: response.data.id });
   } catch (err) {

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -26,7 +26,6 @@ import {
 import { handleMetronomeSetupCheckout } from "@app/lib/metronome/checkout";
 import {
   createMetronomeCredit,
-  getMetronomeActiveContract,
   reactivateMetronomeContract,
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
@@ -187,18 +186,6 @@ async function grantMetronomeFreeCredits({
   }
 
   try {
-    // Resolve the active contract.
-    const contractResult = await getMetronomeActiveContract(
-      workspace.metronomeCustomerId
-    );
-    if (contractResult.isErr() || !contractResult.value) {
-      logger.error(
-        { workspaceId: workspace.sId },
-        "[Stripe Webhook] No active Metronome contract found for free credit grant"
-      );
-      return;
-    }
-
     const productId = getProductFreeMonthlyCreditId();
 
     // Count active members and compute bracket amount.
@@ -221,7 +208,6 @@ async function grantMetronomeFreeCredits({
 
     const result = await createMetronomeCredit({
       metronomeCustomerId: workspace.metronomeCustomerId,
-      contractId: contractResult.value.contractId,
       productId,
       amountCents,
       startingAt: periodStart.toISOString(),


### PR DESCRIPTION
## Description

Migrates Metronome credit and commit creation from contract-based API (v2.contracts.edit) to customer-based API (v1.customers.credits.create and v1.customers.commits.create). This removes the `contractId` dependency when adding credits or commits to a workspace, allowing credits to be added directly to the customer regardless of their contract status.

The poke plugin for buying programmatic usage credits now also mirrors free credits to Metronome when the workspace has a `metronomeCustomerId`, ensuring credit balances remain synchronized.

## Tests

Manually tested free credit creation via poke plugin for Metronome-provisioned workspaces.

## Risk

Low. Idempotent via `uniqueness_key`. Changes only affect Metronome-billed workspaces (those with `metronomeCustomerId` set). The migration gracefully handles failures by logging errors without blocking the credit creation flow.

## Deploy Plan

Deploy front.