### PR TITLE
Add conversation context-usage endpoint

### DIFF
--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -12,6 +12,7 @@ const STATUS_FOR_ERROR_TYPE: Record<ConversationErrorType, number> = {
   message_not_found: 404,
   message_deletion_not_authorized: 403,
   branch_not_found: 404,
+  conversation_context_usage_not_found: 404,
 };
 
 export function apiErrorForConversation(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -18,6 +18,7 @@ import {
   createResourcePermissionsFromSpacesWithMap,
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
+import { RunResource } from "@app/lib/resources/run_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
@@ -1835,12 +1836,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return pendingMessages;
   }
 
-  async getLatestCompletedAgentMessage(
+  async getLatestCompletedAgentMessageRun(
     auth: Authenticator
-  ): Promise<AgentMessageModel | null> {
+  ): Promise<RunResource | null> {
     const owner = auth.getNonNullableWorkspace();
 
-    return AgentMessageModel.findOne({
+    const agentMessage = await AgentMessageModel.findOne({
       where: {
         workspaceId: owner.id,
         status: ["succeeded", "gracefully_stopped"],
@@ -1858,6 +1859,16 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       ],
       order: [["createdAt", "DESC"]],
     });
+
+    if (!agentMessage?.runIds?.length) {
+      return null;
+    }
+
+    // runIds is ordered chronologically (appended step by step in the agent loop), so the last
+    // element is the most recent run.
+    const lastRunId = agentMessage.runIds[agentMessage.runIds.length - 1];
+
+    return RunResource.fetchByDustRunId(auth, { dustRunId: lastRunId });
   }
 
   static async getMessageByIdInConversation(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1835,6 +1835,32 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return pendingMessages;
   }
 
+  static async getMostRecentAgentMessageInConversation(
+    auth: Authenticator,
+    { conversation }: { conversation: ConversationResource }
+  ): Promise<AgentMessageModel | null> {
+    const owner = auth.getNonNullableWorkspace();
+
+    return AgentMessageModel.findOne({
+      where: {
+        workspaceId: owner.id,
+        status: ["succeeded", "gracefully_stopped"],
+      },
+      include: [
+        {
+          model: MessageModel,
+          as: "message",
+          required: true,
+          where: {
+            conversationId: conversation.id,
+            workspaceId: owner.id,
+          },
+        },
+      ],
+      order: [["createdAt", "DESC"]],
+    });
+  }
+
   static async getMessageByIdInConversation(
     auth: Authenticator,
     conversation: ConversationWithoutContentType,

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1835,7 +1835,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return pendingMessages;
   }
 
-  async getMostRecentAgentMessage(
+  async getMostRecentCompletedAgentMessage(
     auth: Authenticator
   ): Promise<AgentMessageModel | null> {
     const owner = auth.getNonNullableWorkspace();

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1835,7 +1835,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return pendingMessages;
   }
 
-  async getMostRecentCompletedAgentMessage(
+  async getLatestCompletedAgentMessage(
     auth: Authenticator
   ): Promise<AgentMessageModel | null> {
     const owner = auth.getNonNullableWorkspace();

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1841,32 +1841,31 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   ): Promise<RunResource | null> {
     const owner = auth.getNonNullableWorkspace();
 
-    const agentMessage = await AgentMessageModel.findOne({
+    const message = await MessageModel.findOne({
       where: {
+        conversationId: this.id,
         workspaceId: owner.id,
-        status: ["succeeded", "gracefully_stopped"],
       },
       include: [
         {
-          model: MessageModel,
-          as: "message",
+          model: AgentMessageModel,
+          as: "agentMessage",
           required: true,
           where: {
-            conversationId: this.id,
-            workspaceId: owner.id,
+            status: ["succeeded", "gracefully_stopped"],
           },
         },
       ],
-      order: [["createdAt", "DESC"]],
+      order: [["rank", "DESC"]],
     });
 
-    if (!agentMessage?.runIds?.length) {
+    if (!message?.agentMessage?.runIds?.length) {
       return null;
     }
 
     // runIds is ordered chronologically (appended step by step in the agent loop), so the last
     // element is the most recent run.
-    const lastRunId = agentMessage.runIds[agentMessage.runIds.length - 1];
+    const lastRunId = message.agentMessage.runIds[message.agentMessage.runIds.length - 1];
 
     return RunResource.fetchByDustRunId(auth, { dustRunId: lastRunId });
   }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1865,7 +1865,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     // runIds is ordered chronologically (appended step by step in the agent loop), so the last
     // element is the most recent run.
-    const lastRunId = message.agentMessage.runIds[message.agentMessage.runIds.length - 1];
+    const lastRunId =
+      message.agentMessage.runIds[message.agentMessage.runIds.length - 1];
 
     return RunResource.fetchByDustRunId(auth, { dustRunId: lastRunId });
   }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1835,9 +1835,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return pendingMessages;
   }
 
-  static async getMostRecentAgentMessageInConversation(
-    auth: Authenticator,
-    { conversation }: { conversation: ConversationResource }
+  async getMostRecentAgentMessage(
+    auth: Authenticator
   ): Promise<AgentMessageModel | null> {
     const owner = auth.getNonNullableWorkspace();
 
@@ -1852,7 +1851,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           as: "message",
           required: true,
           where: {
-            conversationId: conversation.id,
+            conversationId: this.id,
             workspaceId: owner.id,
           },
         },

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -169,10 +169,10 @@ export class RunResource extends BaseResource<RunModel> {
     return runs.map((r) => new this(this.model, r.get()));
   }
 
-  static async fetchRunUsagesByDustRunId(
+  static async fetchByDustRunId(
     auth: Authenticator,
     { dustRunId }: { dustRunId: string }
-  ): Promise<RunUsageType[] | null> {
+  ): Promise<RunResource | null> {
     const run = await this.model.findOne({
       where: {
         dustRunId,
@@ -184,8 +184,7 @@ export class RunResource extends BaseResource<RunModel> {
       return null;
     }
 
-    const resource = new this(this.model, run.get());
-    return resource.listRunUsages(auth);
+    return new this(this.model, run.get());
   }
 
   static async countByAppAndRunType(

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -169,6 +169,25 @@ export class RunResource extends BaseResource<RunModel> {
     return runs.map((r) => new this(this.model, r.get()));
   }
 
+  static async fetchRunUsagesByDustRunId(
+    auth: Authenticator,
+    { dustRunId }: { dustRunId: string }
+  ): Promise<RunUsageType[] | null> {
+    const run = await this.model.findOne({
+      where: {
+        dustRunId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    if (!run) {
+      return null;
+    }
+
+    const resource = new this(this.model, run.get());
+    return resource.listRunUsages(auth);
+  }
+
   static async countByAppAndRunType(
     workspace: LightWorkspaceType,
     { appId, runType }: { appId: ModelId; runType: string | string[] }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -67,11 +67,23 @@ async function handler(
       const lastRunId =
         lastAgentMessage.runIds[lastAgentMessage.runIds.length - 1];
 
-      const usages = await RunResource.fetchRunUsagesByDustRunId(auth, {
+      const run = await RunResource.fetchByDustRunId(auth, {
         dustRunId: lastRunId,
       });
 
-      if (!usages || usages.length === 0) {
+      if (!run) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "conversation_not_found",
+            message: "No run found for the last agent message.",
+          },
+        });
+      }
+
+      const usages = await run.listRunUsages(auth);
+
+      if (usages.length === 0) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -5,12 +5,12 @@ import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { apiError } from "@app/logger/withlogging";
+import type { SupportedModel } from "@app/types/assistant/models/types";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetConversationContextUsageResponse = {
-  providerId: string;
-  modelId: string;
+  model: SupportedModel;
   promptTokens: number;
   contextSize: number;
 };
@@ -90,17 +90,18 @@ async function handler(
         });
       }
 
-      // Take the max promptTokens across usages of the last run — in a
-      // multi-step agent loop, each step sees all previous steps' outputs, so
-      // the last step's promptTokens is the full context size as seen by the
-      // model.
+      // Take the max promptTokens across usages of the last run — in a multi-step agent loop, each
+      // step sees all previous steps' outputs, so the last step's promptTokens is the full context
+      // size as seen by the model.
       const lastUsage = usages[usages.length - 1];
       const promptTokens = Math.max(...usages.map((u) => u.promptTokens));
       const modelConfig = getModelConfigByModelId(lastUsage.modelId);
 
       return res.status(200).json({
-        providerId: lastUsage.providerId,
-        modelId: lastUsage.modelId,
+        model: {
+          providerId: lastUsage.providerId,
+          modelId: lastUsage.modelId,
+        },
         promptTokens,
         contextSize: modelConfig?.contextSize ?? 0,
       });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -11,7 +11,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetConversationContextUsageResponse = {
   model: SupportedModel;
-  promptTokens: number;
+  contextUsage: number;
   contextSize: number;
 };
 
@@ -94,7 +94,7 @@ async function handler(
       // step sees all previous steps' outputs, so the last step's promptTokens is the full context
       // size as seen by the model.
       const lastUsage = usages[usages.length - 1];
-      const promptTokens = Math.max(...usages.map((u) => u.promptTokens));
+      const contextUsage = Math.max(...usages.map((u) => u.promptTokens));
       const modelConfig = getModelConfigByModelId(lastUsage.modelId);
 
       return res.status(200).json({
@@ -102,7 +102,7 @@ async function handler(
           providerId: lastUsage.providerId,
           modelId: lastUsage.modelId,
         },
-        promptTokens,
+        contextUsage,
         contextSize: modelConfig?.contextSize ?? 0,
       });
     }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -1,0 +1,127 @@
+/** @ignoreswagger */
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetConversationContextUsageResponse = {
+  providerId: string;
+  modelId: string;
+  promptTokens: number;
+  contextSize: number;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetConversationContextUsageResponse>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!(typeof req.query.cId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET is supported.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const conversation = conversationRes.value;
+
+  // Find the last terminal agent message in the conversation.
+  const lastAgentMessage = await AgentMessageModel.findOne({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      status: ["succeeded", "gracefully_stopped"],
+    },
+    include: [
+      {
+        model: MessageModel,
+        as: "message",
+        required: true,
+        where: {
+          conversationId: conversation.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      },
+    ],
+    order: [["createdAt", "DESC"]],
+  });
+
+  if (!lastAgentMessage || !lastAgentMessage.runIds?.length) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "No completed agent message found in this conversation.",
+      },
+    });
+  }
+
+  // runIds is ordered chronologically (appended step by step in the agent loop),
+  // so the last element is the most recent run.
+  const lastRunId = lastAgentMessage.runIds[lastAgentMessage.runIds.length - 1];
+
+  const usages = await RunResource.fetchRunUsagesByDustRunId(auth, {
+    dustRunId: lastRunId,
+  });
+
+  if (!usages || usages.length === 0) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "No run usage found for the last agent message.",
+      },
+    });
+  }
+
+  // Take the max promptTokens across usages of the last run — in a multi-step
+  // agent loop, each step sees all previous steps' outputs, so the last step's
+  // promptTokens is the full context size as seen by the model.
+  const lastUsage = usages[usages.length - 1];
+  const promptTokens = Math.max(...usages.map((u) => u.promptTokens));
+
+  const modelConfig = getModelConfigByModelId(lastUsage.modelId);
+
+  res.status(200).json({
+    providerId: lastUsage.providerId,
+    modelId: lastUsage.modelId,
+    promptTokens,
+    contextSize: modelConfig?.contextSize ?? 0,
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -71,10 +71,9 @@ async function handler(
         });
       }
 
-      // Take the max promptTokens across usages of the last run — in a
-      // multi-step agent loop, each step sees all previous steps' outputs, so
-      // the last step's promptTokens is the full context size as seen by the
-      // model.
+      // Take the max promptTokens across usages of the last run — in a multi-step agent loop,
+      // each step sees all previous steps' outputs, so the last step's promptTokens is the full
+      // context size as seen by the model.
       const lastUsage = usages[usages.length - 1];
       const contextUsage = Math.max(...usages.map((u) => u.promptTokens));
       const modelConfig = getModelConfigByModelId(lastUsage.modelId);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -50,7 +50,7 @@ async function handler(
       }
 
       const lastAgentMessage =
-        await conversation.getMostRecentCompletedAgentMessage(auth);
+        await conversation.getLatestCompletedAgentMessage(auth);
 
       if (!lastAgentMessage || !lastAgentMessage.runIds?.length) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -47,8 +47,7 @@ async function handler(
         });
       }
 
-      const run =
-        await conversation.getLatestCompletedAgentMessageRun(auth);
+      const run = await conversation.getLatestCompletedAgentMessageRun(auth);
       if (!run) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -1,12 +1,7 @@
 /** @ignoreswagger */
-import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
-import {
-  AgentMessageModel,
-  MessageModel,
-} from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -37,91 +32,83 @@ async function handler(
     });
   }
 
-  if (req.method !== "GET") {
-    return apiError(req, res, {
-      status_code: 405,
-      api_error: {
-        type: "method_not_supported_error",
-        message: "Only GET is supported.",
-      },
-    });
-  }
+  switch (req.method) {
+    case "GET": {
+      const conversation = await ConversationResource.fetchById(
+        auth,
+        req.query.cId
+      );
 
-  const conversationId = req.query.cId;
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      conversationId
-    );
+      if (!conversation) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "conversation_not_found",
+            message: "Conversation not found.",
+          },
+        });
+      }
 
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
-  }
+      const lastAgentMessage =
+        await ConversationResource.getMostRecentAgentMessageInConversation(
+          auth,
+          { conversation }
+        );
 
-  const conversation = conversationRes.value;
+      if (!lastAgentMessage || !lastAgentMessage.runIds?.length) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "conversation_not_found",
+            message: "No completed agent message found in this conversation.",
+          },
+        });
+      }
 
-  // Find the last terminal agent message in the conversation.
-  const lastAgentMessage = await AgentMessageModel.findOne({
-    where: {
-      workspaceId: auth.getNonNullableWorkspace().id,
-      status: ["succeeded", "gracefully_stopped"],
-    },
-    include: [
-      {
-        model: MessageModel,
-        as: "message",
-        required: true,
-        where: {
-          conversationId: conversation.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
+      // runIds is ordered chronologically (appended step by step in the agent
+      // loop), so the last element is the most recent run.
+      const lastRunId =
+        lastAgentMessage.runIds[lastAgentMessage.runIds.length - 1];
+
+      const usages = await RunResource.fetchRunUsagesByDustRunId(auth, {
+        dustRunId: lastRunId,
+      });
+
+      if (!usages || usages.length === 0) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "conversation_not_found",
+            message: "No run usage found for the last agent message.",
+          },
+        });
+      }
+
+      // Take the max promptTokens across usages of the last run — in a
+      // multi-step agent loop, each step sees all previous steps' outputs, so
+      // the last step's promptTokens is the full context size as seen by the
+      // model.
+      const lastUsage = usages[usages.length - 1];
+      const promptTokens = Math.max(...usages.map((u) => u.promptTokens));
+      const modelConfig = getModelConfigByModelId(lastUsage.modelId);
+
+      return res.status(200).json({
+        providerId: lastUsage.providerId,
+        modelId: lastUsage.modelId,
+        promptTokens,
+        contextSize: modelConfig?.contextSize ?? 0,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
         },
-      },
-    ],
-    order: [["createdAt", "DESC"]],
-  });
-
-  if (!lastAgentMessage || !lastAgentMessage.runIds?.length) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "No completed agent message found in this conversation.",
-      },
-    });
+      });
   }
-
-  // runIds is ordered chronologically (appended step by step in the agent loop),
-  // so the last element is the most recent run.
-  const lastRunId = lastAgentMessage.runIds[lastAgentMessage.runIds.length - 1];
-
-  const usages = await RunResource.fetchRunUsagesByDustRunId(auth, {
-    dustRunId: lastRunId,
-  });
-
-  if (!usages || usages.length === 0) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "No run usage found for the last agent message.",
-      },
-    });
-  }
-
-  // Take the max promptTokens across usages of the last run — in a multi-step
-  // agent loop, each step sees all previous steps' outputs, so the last step's
-  // promptTokens is the full context size as seen by the model.
-  const lastUsage = usages[usages.length - 1];
-  const promptTokens = Math.max(...usages.map((u) => u.promptTokens));
-
-  const modelConfig = getModelConfigByModelId(lastUsage.modelId);
-
-  res.status(200).json({
-    providerId: lastUsage.providerId,
-    modelId: lastUsage.modelId,
-    promptTokens,
-    contextSize: modelConfig?.contextSize ?? 0,
-  });
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -50,10 +50,7 @@ async function handler(
       }
 
       const lastAgentMessage =
-        await ConversationResource.getMostRecentAgentMessageInConversation(
-          auth,
-          { conversation }
-        );
+        await conversation.getMostRecentAgentMessage(auth);
 
       if (!lastAgentMessage || !lastAgentMessage.runIds?.length) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -50,32 +50,29 @@ async function handler(
       }
 
       const lastAgentMessage =
-        await conversation.getMostRecentAgentMessage(auth);
+        await conversation.getMostRecentCompletedAgentMessage(auth);
 
       if (!lastAgentMessage || !lastAgentMessage.runIds?.length) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {
-            type: "conversation_not_found",
+            type: "conversation_context_usage_not_found",
             message: "No completed agent message found in this conversation.",
           },
         });
       }
 
-      // runIds is ordered chronologically (appended step by step in the agent
-      // loop), so the last element is the most recent run.
-      const lastRunId =
-        lastAgentMessage.runIds[lastAgentMessage.runIds.length - 1];
-
+      // runIds is ordered chronologically (appended step by step in the agent loop), so the last
+      // element is the most recent run.
       const run = await RunResource.fetchByDustRunId(auth, {
-        dustRunId: lastRunId,
+        dustRunId: lastAgentMessage.runIds[lastAgentMessage.runIds.length - 1],
       });
 
       if (!run) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {
-            type: "conversation_not_found",
+            type: "conversation_context_usage_not_found",
             message: "No run found for the last agent message.",
           },
         });
@@ -87,7 +84,7 @@ async function handler(
         return apiError(req, res, {
           status_code: 404,
           api_error: {
-            type: "conversation_not_found",
+            type: "conversation_context_usage_not_found",
             message: "No run usage found for the last agent message.",
           },
         });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -6,6 +6,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetConversationContextUsageResponse = {
@@ -21,7 +22,8 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!(typeof req.query.cId === "string")) {
+  const { cId } = req.query;
+  if (!isString(cId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -33,10 +35,7 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const conversation = await ConversationResource.fetchById(
-        auth,
-        req.query.cId
-      );
+      const conversation = await ConversationResource.fetchById(auth, cId);
 
       if (!conversation) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -3,7 +3,6 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { RunResource } from "@app/lib/resources/run_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -49,10 +48,9 @@ async function handler(
         });
       }
 
-      const lastAgentMessage =
-        await conversation.getLatestCompletedAgentMessage(auth);
-
-      if (!lastAgentMessage || !lastAgentMessage.runIds?.length) {
+      const run =
+        await conversation.getLatestCompletedAgentMessageRun(auth);
+      if (!run) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {
@@ -62,24 +60,7 @@ async function handler(
         });
       }
 
-      // runIds is ordered chronologically (appended step by step in the agent loop), so the last
-      // element is the most recent run.
-      const run = await RunResource.fetchByDustRunId(auth, {
-        dustRunId: lastAgentMessage.runIds[lastAgentMessage.runIds.length - 1],
-      });
-
-      if (!run) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "conversation_context_usage_not_found",
-            message: "No run found for the last agent message.",
-          },
-        });
-      }
-
       const usages = await run.listRunUsages(auth);
-
       if (usages.length === 0) {
         return apiError(req, res, {
           status_code: 404,
@@ -90,9 +71,10 @@ async function handler(
         });
       }
 
-      // Take the max promptTokens across usages of the last run — in a multi-step agent loop, each
-      // step sees all previous steps' outputs, so the last step's promptTokens is the full context
-      // size as seen by the model.
+      // Take the max promptTokens across usages of the last run — in a
+      // multi-step agent loop, each step sees all previous steps' outputs, so
+      // the last step's promptTokens is the full context size as seen by the
+      // model.
       const lastUsage = usages[usages.length - 1];
       const contextUsage = Math.max(...usages.map((u) => u.promptTokens));
       const modelConfig = getModelConfigByModelId(lastUsage.modelId);

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -474,6 +474,7 @@ export const CONVERSATION_ERROR_TYPES = [
   "message_not_found",
   "message_deletion_not_authorized",
   "branch_not_found",
+  "conversation_context_usage_not_found",
 ] as const;
 
 export type ConversationErrorType = (typeof CONVERSATION_ERROR_TYPES)[number];

--- a/x/spolu/compaction/compaction.md
+++ b/x/spolu/compaction/compaction.md
@@ -195,32 +195,35 @@ When the threshold is crossed, trigger compaction:
 
 ### Where to Get the Token Count
 
-The token count is already available in the finalization path of the agent loop:
+The token count is not stored as a dedicated column — it's resolved on-the-fly from the existing
+run usage data:
 
-- `finalizeSuccessfulAgentLoopActivity` and `finalizeGracefullyStoppedAgentLoopActivity` both have
-  access to the `agentLoopArgs` which contains `runIds`.
-- Query `RunResource.listByDustRunIds()` → take the last run → `listRunUsages()` → read
-  `promptTokens`. Note: ensure results are returned ordered (e.g., by `createdAt`) so that "last
-  run" is deterministic.
-- Alternatively, surface the token count earlier in the agent loop (it's available from the
-  `TokenUsageEvent` during streaming) and pass it through to finalization.
+- `AgentMessageModel.runIds` contains the dustRunIds for each agent message.
+- Query `RunResource.listByDustRunIds()` → take the last run (ordered by `createdAt`) →
+  `listRunUsages()` → read `promptTokens`.
+- This is a read-only lookup, no new columns needed.
 
 ### Client-Side Context Usage Reporting
 
 The last `runId` of the most recent `AgentMessage` gives us the best estimate of the current
-conversation's token footprint. We surface this to the client so the UI can display context usage
-(e.g. a progress bar showing how full the context window is).
-
-On `agent_message_success` (and `agent_message_gracefully_stopped`), the finalization path
-resolves the last run's `promptTokens` and includes it in the event payload (or on the
-`AgentMessageType` itself). The client can then compute:
+conversation's token footprint. We expose this through a dedicated endpoint that resolves the
+token count on-the-fly:
 
 ```
-contextUsagePercent = lastPromptTokens / modelContextWindow
+GET /api/w/[wId]/assistant/conversations/[cId]/context-usage
+→ { promptTokens: number | null, modelContextWindow: number }
+```
+
+The endpoint finds the last succeeded/gracefully-stopped `AgentMessage`, resolves its last run's
+`promptTokens` from `RunResource`, and returns it alongside the model's context window. The client
+can then compute:
+
+```
+contextUsagePercent = promptTokens / modelContextWindow
 ```
 
 This avoids any client-side token estimation — the number comes directly from the provider's
-usage report.
+usage report, resolved on-the-fly from the existing run data.
 
 ---
 

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -58,28 +58,16 @@ Remaining `TODO(compaction)` markers left for future PRs:
 ## Phase 2: Token Consumption Evaluation
 
 Surface the model's reported `promptTokens` so we can determine when to trigger compaction.
+No new DB columns — token counts are resolved on-the-fly from existing run usage data.
 
-### - [ ] PR 2.1 — Read `promptTokens` in finalization and store on `AgentMessageModel`
+### - [ ] PR 2.1 — Add conversation context usage endpoint
 
-- Add `promptTokens` column (INTEGER, nullable) to `AgentMessageModel`. Migration.
-- In `finalizeSuccessfulAgentLoopActivity` and `finalizeGracefullyStoppedAgentLoopActivity`
-  (`front/temporal/agent_loop/activities/finalize.ts`): after existing side-effects, resolve the
-  last run's prompt tokens:
-  - Use `agentLoopArgs.dustRunIds` (or fall back to `agentMessage.runIds`).
-  - Call `RunResource.listByDustRunIds()` → take the last run (ordered by `createdAt`) →
-    `listRunUsages()` → sum `promptTokens`.
-  - Update `AgentMessageModel.promptTokens` with the value.
-- This is read-only side-effect work — no behavior change.
-
-### - [ ] PR 2.2 — Surface `promptTokens` on `AgentMessageType` and events
-
-- Add `promptTokens: number | null` to `AgentMessageType` and `LightAgentMessageType` in
-  `front/types/assistant/conversation.ts`.
-- Include `promptTokens` in `batchRenderAgentMessages()` output
-  (`front/lib/api/assistant/messages.ts`).
-- Include `promptTokens` in `AgentMessageSuccessEvent` and
-  `AgentMessageGracefullyStoppedEvent` payloads (`front/types/assistant/agent.ts`).
-- Frontend can now read `agentMessage.promptTokens` for display (Phase 5).
+- Add `GET /api/w/[wId]/assistant/conversations/[cId]/context-usage` endpoint.
+- Finds the last succeeded/gracefully-stopped `AgentMessage` in the conversation.
+- Resolves its last run's `promptTokens` via `RunResource.listByDustRunIds()` → last run
+  (ordered by `createdAt`) → `listRunUsages()` → sum `promptTokens`.
+- Returns `{ promptTokens: number | null, modelContextWindow: number }`.
+- Frontend uses this for the context usage indicator (Phase 5).
 
 ---
 
@@ -175,8 +163,8 @@ Make compaction actually affect what the model sees.
 
 ### - [ ] PR 5.1 — Context usage indicator in conversation UI
 
-- Use `agentMessage.promptTokens` (from PR 2.2) and the model's context window size to compute
-  usage percentage on the client.
+- Use the context-usage endpoint (from PR 2.2) to get `promptTokens` and `modelContextWindow`,
+  compute usage percentage on the client.
 - Display a progress bar or indicator showing context fullness.
 - Show a warning when approaching the compaction threshold.
 

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -60,20 +60,24 @@ Remaining `TODO(compaction)` markers left for future PRs:
 Surface the model's reported `promptTokens` so we can determine when to trigger compaction.
 No new DB columns — token counts are resolved on-the-fly from existing run usage data.
 
-### - [ ] PR 2.1 — Add conversation context usage endpoint
+### - [x] PR 2.1 — Add conversation context usage endpoint
+
+PR #24086.
 
 - Add `GET /api/w/[wId]/assistant/conversations/[cId]/context-usage` endpoint.
-- Finds the last succeeded/gracefully-stopped `AgentMessage` in the conversation.
-- Resolves its last run's `promptTokens` via `RunResource.listByDustRunIds()` → last run
-  (ordered by `createdAt`) → `listRunUsages()` → sum `promptTokens`.
-- Returns `{ promptTokens: number | null, modelContextWindow: number }`.
+- `ConversationResource.getLatestCompletedAgentMessageRun()` — instance method that finds the last
+  succeeded/gracefully-stopped agent message, takes its last `runId`, and returns a `RunResource`.
+- `RunResource.fetchByDustRunId()` — fetch a run resource by its dustRunId.
+- Endpoint calls `run.listRunUsages()`, takes max `promptTokens` across usages, resolves model
+  config for `contextSize`.
+- Returns `{ model: SupportedModel, contextUsage: number, contextSize: number }`.
 - Frontend uses this for the context usage indicator (Phase 5).
 
 ---
 
 ## Phase 3: Compaction Method & Temporal Workflow
 
-Build the compaction pipeline end-to-end, gated behind a feature flag.
+Build the compaction pipeline end-to-end. No feature flag needed — inert until Phase 5 provides a trigger.
 
 ### - [ ] PR 3.1 — Add compaction Temporal workflow skeleton
 


### PR DESCRIPTION
## Description

PR 2.1 from the compaction plan. Adds a `GET /api/w/[wId]/assistant/conversations/[cId]/context-usage` endpoint that returns the token consumption of the last completed agent message in a conversation.

- `ConversationResource.getMostRecentCompletedAgentMessage()` — instance method to find the last succeeded/gracefully-stopped agent message
- `RunResource.fetchByDustRunId()` — fetch a run resource by its dustRunId
- Endpoint resolves the last run's `promptTokens` (max across usages) and returns it with `providerId`, `modelId`, and `contextSize` (from model config)
- Updated compaction proposal and plan for Phase 2

## Tests

- `npx tsgo --noEmit` passes
- No behavior changes to existing endpoints
- Tested locally

## Risk

Low — new endpoint only, no changes to existing code paths.

## Deploy Plan

Standard deploy, no migration needed.