### PR TITLE
Chg: keep optional internal tool configuration exposed to the model.

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -239,8 +239,10 @@ export function MCPActionDetails({
   }
 
   if (
-    internalMCPServerName === "include_data" &&
-    toolName === INCLUDE_TOOL_NAME
+    (internalMCPServerName === "include_data" &&
+      toolName === INCLUDE_TOOL_NAME) ||
+    (internalMCPServerName === "project_manager" &&
+      toolName === "retrieve_recent_documents")
   ) {
     return (
       <SearchResultDetails

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -255,7 +255,7 @@ const MAX_DESCRIPTION_LENGTH = 1024;
 export function buildToolSpecification(
   actionConfiguration: MCPToolConfigurationType
 ): AgentActionSpecification {
-  // Filter out properties from the inputSchema that have a mimeType matching any value in INTERNAL_MIME_TYPES.TOOL_INPUT
+  // Hide required tool-input configuration from the model; optional internal props stay visible.
   const filteredInputSchema = hideInternalConfiguration(
     actionConfiguration.inputSchema
   );

--- a/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
@@ -2,6 +2,7 @@ import type { ServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import {
   augmentInputsWithConfiguration,
   findPathsToConfiguration,
+  hideInternalConfiguration,
 } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import {
   ConfigurableToolInputJSONSchemas,
@@ -9,6 +10,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { isJSONSchemaObject } from "@app/lib/utils/json_schemas";
 import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -64,6 +66,453 @@ function createBasicMCPConfiguration(
     ...overrides,
   };
 }
+
+describe("hideInternalConfiguration", () => {
+  it("removes required internal tool-input properties and drops them from required; keeps optional internal props", () => {
+    const timeFrame =
+      ConfigurableToolInputJSONSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
+      ];
+    const inputSchema = {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query" },
+        dataSources:
+          ConfigurableToolInputJSONSchemas[
+            INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+          ],
+        timeFrame,
+      },
+      required: ["query", "dataSources"],
+    } as JSONSchema;
+
+    const result = hideInternalConfiguration(inputSchema);
+
+    expect(result.properties?.query).toEqual({
+      type: "string",
+      description: "Search query",
+    });
+    expect(result.properties?.timeFrame).toEqual(timeFrame);
+    expect(result.properties).not.toHaveProperty("dataSources");
+    expect(result.required).toEqual(["query"]);
+  });
+
+  it("keeps optional internal properties so the model can see inferable configuration fields", () => {
+    const dustProject =
+      ConfigurableToolInputJSONSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ];
+    const inputSchema = {
+      type: "object",
+      properties: {
+        fileName: { type: "string" },
+        dustProject,
+      },
+      required: ["fileName"],
+    } as JSONSchema;
+
+    const result = hideInternalConfiguration(inputSchema);
+
+    expect(result.properties?.fileName).toEqual({ type: "string" });
+    expect(result.properties?.dustProject).toEqual(dustProject);
+    expect(result.required).toEqual(["fileName"]);
+  });
+
+  it("recursively strips required internal properties inside nested objects but keeps optional ones", () => {
+    const agentSchema =
+      ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT];
+    const inputSchema = {
+      type: "object",
+      properties: {
+        wrapper: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            agent: agentSchema,
+            optionalAgent: agentSchema,
+          },
+          required: ["title", "agent"],
+        },
+      },
+      required: ["wrapper"],
+    } as JSONSchema;
+
+    const result = hideInternalConfiguration(inputSchema);
+
+    expect(result.properties?.wrapper).toMatchObject({
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        optionalAgent: agentSchema,
+      },
+      required: ["title"],
+    });
+  });
+
+  it("processes array items schema and removes internal fields from item objects", () => {
+    const inputSchema = {
+      type: "object",
+      properties: {
+        entries: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              label: { type: "string" },
+              table:
+                ConfigurableToolInputJSONSchemas[
+                  INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE
+                ],
+            },
+            required: ["label", "table"],
+          },
+        },
+      },
+    } as JSONSchema;
+
+    const result = hideInternalConfiguration(inputSchema);
+
+    const items = result.properties?.entries;
+    expect(items).toBeDefined();
+    expect(items).toMatchObject({ type: "array" });
+    expect(
+      isJSONSchemaObject((items as JSONSchema).items)
+        ? (items as JSONSchema).items
+        : null
+    ).toMatchObject({
+      type: "object",
+      properties: { label: { type: "string" } },
+      required: ["label"],
+    });
+  });
+
+  it("keeps optional internal fields on array item objects", () => {
+    const tableSchema =
+      ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE];
+    const inputSchema = {
+      type: "object",
+      properties: {
+        entries: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              label: { type: "string" },
+              requiredTable: tableSchema,
+              optionalTable: tableSchema,
+            },
+            required: ["label", "requiredTable"],
+          },
+        },
+      },
+    } as JSONSchema;
+
+    const result = hideInternalConfiguration(inputSchema);
+    const itemSchema = result.properties?.entries;
+    expect(itemSchema).toBeDefined();
+    expect(
+      isJSONSchemaObject((itemSchema as JSONSchema).items)
+        ? (itemSchema as JSONSchema).items
+        : null
+    ).toMatchObject({
+      type: "object",
+      properties: {
+        label: { type: "string" },
+        optionalTable: tableSchema,
+      },
+      required: ["label"],
+    });
+  });
+
+  it("processes tuple-style array items (distinct schema per index)", () => {
+    const inputSchema = {
+      type: "array",
+      items: [
+        { type: "string", const: "fixed" },
+        {
+          type: "object",
+          properties: {
+            configuredString:
+              ConfigurableToolInputJSONSchemas[
+                INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
+              ],
+          },
+          required: ["configuredString"],
+        },
+        { type: "number" },
+      ],
+    } as JSONSchema;
+
+    const result = hideInternalConfiguration(inputSchema);
+
+    expect(Array.isArray(result.items)).toBe(true);
+    expect(result.items).toHaveLength(3);
+    expect((result.items as JSONSchema[])[0]).toMatchObject({
+      type: "string",
+      const: "fixed",
+    });
+    expect((result.items as JSONSchema[])[1]).toMatchObject({
+      type: "object",
+      properties: {},
+    });
+    expect((result.items as JSONSchema[])[2]).toMatchObject({ type: "number" });
+  });
+
+  it("detects internal configuration behind $ref and removes the property when required", () => {
+    const dsSchema =
+      ConfigurableToolInputJSONSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+      ];
+    const inputSchema = {
+      type: "object",
+      definitions: {
+        ConfiguredDataSources: dsSchema,
+      },
+      properties: {
+        q: { type: "string" },
+        sources: { $ref: "#/definitions/ConfiguredDataSources" },
+      },
+      required: ["q", "sources"],
+    } as JSONSchema;
+
+    const result = hideInternalConfiguration(inputSchema);
+
+    expect(result.properties).toEqual({
+      q: { type: "string" },
+    });
+    expect(result.required).toEqual(["q"]);
+    expect(result.definitions).toEqual(inputSchema.definitions);
+  });
+
+  it("keeps internal configuration behind $ref when the property is optional", () => {
+    const dsSchema =
+      ConfigurableToolInputJSONSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+      ];
+    const inputSchema = {
+      type: "object",
+      definitions: {
+        ConfiguredDataSources: dsSchema,
+      },
+      properties: {
+        q: { type: "string" },
+        sources: { $ref: "#/definitions/ConfiguredDataSources" },
+      },
+      required: ["q"],
+    } as JSONSchema;
+
+    const result = hideInternalConfiguration(inputSchema);
+
+    expect(result.properties).toEqual({
+      q: { type: "string" },
+      sources: { $ref: "#/definitions/ConfiguredDataSources" },
+    });
+    expect(result.required).toEqual(["q"]);
+    expect(result.definitions).toEqual(inputSchema.definitions);
+  });
+
+  it("returns non-object schemas unchanged", () => {
+    expect(hideInternalConfiguration({ type: "string" } as JSONSchema)).toEqual(
+      {
+        type: "string",
+      }
+    );
+  });
+
+  it("passes through non-object property values without recursing", () => {
+    const inputSchema = {
+      type: "object",
+      properties: {
+        legacyFlag: true,
+      },
+    } as JSONSchema;
+
+    const result = hideInternalConfiguration(inputSchema);
+
+    expect(result.properties).toEqual({ legacyFlag: true });
+  });
+});
+
+describe("augmentInputsWithConfiguration after hideInternalConfiguration", () => {
+  it("fills required and optional internal fields from action configuration when raw inputs omit them", () => {
+    const timeFrameSchema =
+      ConfigurableToolInputJSONSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
+      ];
+    const dustProjectSchema =
+      ConfigurableToolInputJSONSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ];
+    const dataSourcesSchema =
+      ConfigurableToolInputJSONSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+      ];
+    const inputSchema = {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        dataSources: dataSourcesSchema,
+        timeFrame: timeFrameSchema,
+        dustProject: dustProjectSchema,
+      },
+      required: ["query", "dataSources"],
+    } as JSONSchema;
+
+    const hiddenForModel = hideInternalConfiguration(inputSchema);
+    expect(hiddenForModel.properties).not.toHaveProperty("dataSources");
+    expect(hiddenForModel.properties).toHaveProperty("timeFrame");
+    expect(hiddenForModel.properties).toHaveProperty("dustProject");
+
+    const config = createBasicMCPConfiguration({
+      dataSources: [
+        {
+          workspaceId: mockWorkspace.sId,
+          sId: "dsc_augment_optional",
+          dataSourceViewId: "view_augment",
+          filter: {
+            tags: { in: [], not: [], mode: "custom" },
+            parents: { in: [], not: [] },
+          },
+        },
+      ],
+      timeFrame: { duration: 14, unit: "day" },
+      dustProject: {
+        workspaceId: mockWorkspace.sId,
+        projectId: "project-sid-xyz",
+      },
+      inputSchema,
+    });
+
+    const augmented = augmentInputsWithConfiguration({
+      owner: mockWorkspace,
+      rawInputs: { query: "find docs" },
+      actionConfiguration: config,
+    });
+
+    expect(augmented.query).toBe("find docs");
+    expect(augmented.dataSources).toEqual([
+      {
+        uri: `data_source_configuration://dust/w/${mockWorkspace.sId}/data_source_configurations/dsc_augment_optional`,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+      },
+    ]);
+    expect(augmented.timeFrame).toEqual({
+      duration: 14,
+      unit: "day",
+      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME,
+    });
+    expect(augmented.dustProject).toEqual({
+      uri: `project://dust/w/${mockWorkspace.sId}/projects/project-sid-xyz`,
+      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT,
+    });
+  });
+
+  it("augments optional internal fields inside nested objects when missing", () => {
+    const agentSchema =
+      ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT];
+    const inputSchema = {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        wrapper: {
+          type: "object",
+          properties: {
+            optionalAgent: agentSchema,
+          },
+        },
+      },
+      required: ["query"],
+    } as JSONSchema;
+
+    const hiddenForModel = hideInternalConfiguration(inputSchema);
+    expect(hiddenForModel.properties?.wrapper).toMatchObject({
+      type: "object",
+      properties: { optionalAgent: agentSchema },
+    });
+
+    const config = createBasicMCPConfiguration({
+      childAgentId: "child-agent-sid",
+      inputSchema,
+    });
+
+    const augmented = augmentInputsWithConfiguration({
+      owner: mockWorkspace,
+      rawInputs: { query: "q" },
+      actionConfiguration: config,
+    });
+
+    expect(augmented.wrapper).toEqual({
+      optionalAgent: {
+        uri: `agent://dust/w/${mockWorkspace.sId}/agents/child-agent-sid`,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT,
+      },
+    });
+  });
+
+  it("does not overwrite optional internal fields when the model already provided them", () => {
+    const timeFrameSchema =
+      ConfigurableToolInputJSONSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
+      ];
+    const dataSourcesSchema =
+      ConfigurableToolInputJSONSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+      ];
+    const inputSchema = {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        dataSources: dataSourcesSchema,
+        timeFrame: timeFrameSchema,
+      },
+      required: ["query", "dataSources"],
+    } as JSONSchema;
+
+    const hiddenForModel = hideInternalConfiguration(inputSchema);
+    expect(hiddenForModel.properties).toHaveProperty("timeFrame");
+
+    const config = createBasicMCPConfiguration({
+      dataSources: [
+        {
+          workspaceId: mockWorkspace.sId,
+          sId: "dsc_cfg",
+          dataSourceViewId: "view_cfg",
+          filter: {
+            tags: { in: [], not: [], mode: "custom" },
+            parents: { in: [], not: [] },
+          },
+        },
+      ],
+      timeFrame: { duration: 99, unit: "year" },
+      inputSchema,
+    });
+
+    const userTimeFrame = {
+      duration: 3,
+      unit: "hour" as const,
+      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME,
+    };
+
+    const augmented = augmentInputsWithConfiguration({
+      owner: mockWorkspace,
+      rawInputs: {
+        query: "x",
+        timeFrame: userTimeFrame,
+      },
+      actionConfiguration: config,
+    });
+
+    expect(augmented.timeFrame).toEqual(userTimeFrame);
+    const augmentedDataSources = augmented.dataSources;
+    expect(Array.isArray(augmentedDataSources)).toBe(true);
+    if (Array.isArray(augmentedDataSources)) {
+      expect(augmentedDataSources).toHaveLength(1);
+      expect(augmentedDataSources[0]).toMatchObject({
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+      });
+    }
+  });
+});
 
 describe("augmentInputsWithConfiguration", () => {
   describe("basic functionality", () => {

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -333,8 +333,10 @@ function getDefaultValueAtPath(inputSchema: JSONSchema, keyPath: string) {
 }
 
 /**
- * Recursively filters out properties from the inputSchema that have a mimeType matching any value in INTERNAL_MIME_TYPES.TOOL_INPUT.
- * This function handles nested objects and arrays.
+ * Recursively filters out **required** properties whose schema matches a configurable
+ * `INTERNAL_MIME_TYPES.TOOL_INPUT` (those are injected server-side).
+ * Optional internal-configuration properties are kept so the model can see them and infer values when useful.
+ * Handles nested objects and arrays.
  */
 export function hideInternalConfiguration(inputSchema: JSONSchema): JSONSchema {
   const resultingSchema = { ...inputSchema };
@@ -360,11 +362,12 @@ export function hideInternalConfiguration(inputSchema: JSONSchema): JSONSchema {
           }
 
           if (schemasMatch) {
-            shouldInclude = false;
-            // Track removed properties that were in the required array.
-            if (resultingSchema.required?.includes(key)) {
+            const isRequired = resultingSchema.required?.includes(key) ?? false;
+            if (isRequired) {
+              shouldInclude = false;
               removedRequiredProps.push(key);
             }
+            // Optional internal configuration: keep in the exposed schema for the model.
             break;
           }
         }
@@ -389,21 +392,18 @@ export function hideInternalConfiguration(inputSchema: JSONSchema): JSONSchema {
     }
   }
 
-  // Filter array items
+  // Filter array items (tuple `items` is an array; check before isJSONSchemaObject, since arrays are objects in JS)
   if (resultingSchema.type === "array" && resultingSchema.items) {
-    if (isJSONSchemaObject(resultingSchema.items)) {
-      // Single schema for all items
-      resultingSchema.items = hideInternalConfiguration(resultingSchema.items);
-    } else if (Array.isArray(resultingSchema.items)) {
-      // Array of schemas for tuple validation
+    if (Array.isArray(resultingSchema.items)) {
       resultingSchema.items = resultingSchema.items.map((item) =>
         isJSONSchemaObject(item) ? hideInternalConfiguration(item) : item
       );
+    } else if (isJSONSchemaObject(resultingSchema.items)) {
+      resultingSchema.items = hideInternalConfiguration(resultingSchema.items);
     }
   }
 
-  // Note: we don't handle allOf, oneOf yet as we cannot disambiguate whether to inject the configuration
-  // since we entirely hide the configuration from the agent.
+  // Note: we don't handle allOf, oneOf yet as we cannot disambiguate whether to inject the configuration.
 
   return resultingSchema;
 }

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -37,8 +37,11 @@ export function getRetrievalTopK({
       isServerSideMCPToolConfigurationWithName(tool, "search") ||
       isServerSideMCPToolConfigurationWithName(tool, "conversation_files")
   );
-  const includeActions = stepActions.filter((tool) =>
-    isServerSideMCPToolConfigurationWithName(tool, "include_data")
+
+  const includeActions = stepActions.filter(
+    (tool) =>
+      isServerSideMCPToolConfigurationWithName(tool, "include_data") ||
+      isServerSideMCPToolConfigurationWithName(tool, "project_manager")
   );
   const dsFsActions = stepActions.filter((tool) =>
     isServerSideMCPToolConfigurationWithName(tool, "data_sources_file_system")

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -33,10 +33,13 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
         .describe(
           "MIME type (default: inferred from file extension, e.g. text/markdown for .md files, or text/plain if unknown. Inherited from sourceFileId if provided)"
         ),
-      dustProject:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
-        ].optional(),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to add the file to, will fallback to the conversation's project."
+        ),
     },
     stake: "low",
     displayLabels: {
@@ -62,10 +65,13 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
         .describe(
           "ID of an existing file to copy content from (provide either this or content)"
         ),
-      dustProject:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
-        ].optional(),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to update the file in, will fallback to the conversation's project."
+        ),
     },
     stake: "medium",
     displayLabels: {
@@ -80,10 +86,13 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
       fileId: z
         .string()
         .describe("ID of an existing file in the project context to attach"),
-      dustProject:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
-        ].optional(),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to attach the file to, will fallback to the conversation's project."
+        ),
     },
     stake: "low",
     displayLabels: {
@@ -100,10 +109,13 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
         .describe(
           "New project description. Must be plain text only (no markdown, HTML, or other formatting). Keep it brief and concise: 1-2 short sentences max."
         ),
-      dustProject:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
-        ].optional(),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to edit the description of, will fallback to the conversation's project."
+        ),
     },
     stake: "low",
     displayLabels: {
@@ -115,10 +127,13 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
     description:
       "Get comprehensive information about the project context, including project URL, description, file count, and file list.",
     schema: {
-      dustProject:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
-        ].optional(),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to get information from, will fallback to the conversation's project."
+        ),
     },
     stake: "never_ask",
     displayLabels: {


### PR DESCRIPTION
## Description

### Why

Expose optional tools params such as "timeFrame" to the model so it can infer the value if not pre-configured in agent builder.

### How

Keep optional internal tool-input properties visible to the model instead of hiding them all.
- Change `hideInternalConfiguration` to only strip *required* internal tool-input props from the spec sent to the model — optional ones (e.g. `dustProject`) are now kept so the model can infer and fill them (but we'll ultimately override if we have some pre-configured by the user)
- Update comment in `buildToolSpecification` to reflect the new intent
- Extend `MCPActionDetails` to render `SearchResultDetails` for `project_manager/retrieve_recent_documents` (same as `include_data`)
- Add comprehensive tests for `hideInternalConfiguration` (required vs optional, nested objects, array items)

Ideally, we would still hide optional parameters if we have a preconfigured value to make it even more principled. Will do in another PR later.

## Tests

Local + green (new tests added)

## Risk

Medium as it touches what we expose to the model but relatively low because optional() internal parameters are extremely rare.

## Deploy Plan

Deploy `front`
