### PR TITLE
Add: include tool for projects.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -482,6 +482,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "attach_to_conversation": "low",
     "edit_description": "low",
     "get_information": "never_ask",
+    "retrieve_recent_documents": "never_ask",
     "update_file": "medium",
   },
   "query_tables_v2": {

--- a/front/lib/api/actions/servers/include_data/include_function.ts
+++ b/front/lib/api/actions/servers/include_data/include_function.ts
@@ -1,0 +1,168 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type {
+  IncludeResultResourceType,
+  WarningResourceType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { checkConflictingTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
+import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import {
+  makeIncludeResultResource,
+  makeIncludeWarningResource,
+} from "@app/lib/api/actions/servers/include_data/helpers";
+import { getRefs } from "@app/lib/api/assistant/citations";
+import config from "@app/lib/api/config";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { CoreAPI } from "@app/types/core/core_api";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { TimeFrame } from "@app/types/shared/utils/time_frame";
+import { timeFrameFromNow } from "@app/types/shared/utils/time_frame";
+import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
+import assert from "assert";
+
+/**
+ * Core retrieval used by include_data and by project_manager's retrieve_recent_documents.
+ * Assigns citation refs from {@link getRefs} the same way as the include_data server.
+ */
+export async function runIncludeDataRetrieval(
+  auth: Authenticator,
+  agentLoopContext: AgentLoopContextType,
+  {
+    timeFrame,
+    dataSources,
+    tagsIn,
+    tagsNot,
+  }: {
+    timeFrame?: TimeFrame;
+    dataSources: DataSourcesToolConfigurationType;
+    tagsIn?: string[];
+    tagsNot?: string[];
+  }
+): Promise<
+  Result<
+    (
+      | TextContent
+      | {
+          type: "resource";
+          resource: IncludeResultResourceType | WarningResourceType;
+        }
+    )[],
+    MCPError
+  >
+> {
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+  const credentials = await getLlmCredentials(auth);
+
+  if (!agentLoopContext.runContext) {
+    return new Err(
+      new MCPError("No conversation context available", { tracked: false })
+    );
+  }
+
+  const { citationsOffset, retrievalTopK } =
+    agentLoopContext.runContext.stepContext;
+
+  const coreSearchArgsResults = await getCoreSearchArgs(auth, dataSources);
+
+  if (coreSearchArgsResults.isErr()) {
+    return new Err(
+      new MCPError(coreSearchArgsResults.error.message, { tracked: false })
+    );
+  }
+
+  const coreSearchArgs = coreSearchArgsResults.value;
+
+  const conflictingTagsError = checkConflictingTags(
+    coreSearchArgs.map(({ filter }) => filter.tags),
+    { tagsIn, tagsNot }
+  );
+  if (conflictingTagsError) {
+    return new Err(new MCPError(conflictingTagsError, { tracked: false }));
+  }
+
+  const searchResults = await coreAPI.searchDataSources(
+    "",
+    retrievalTopK,
+    credentials,
+    false,
+    coreSearchArgs.map((args) => {
+      const finalTagsIn = [...(args.filter.tags?.in ?? []), ...(tagsIn ?? [])];
+      const finalTagsNot = [
+        ...(args.filter.tags?.not ?? []),
+        ...(tagsNot ?? []),
+      ];
+
+      return {
+        projectId: args.projectId,
+        dataSourceId: args.dataSourceId,
+        filter: {
+          ...args.filter,
+          tags: {
+            in: finalTagsIn.length > 0 ? finalTagsIn : null,
+            not: finalTagsNot.length > 0 ? finalTagsNot : null,
+          },
+          timestamp: {
+            gt: timeFrame ? timeFrameFromNow(timeFrame) : null,
+            lt: null,
+          },
+        },
+        view_filter: args.view_filter,
+      };
+    })
+  );
+
+  if (searchResults.isErr()) {
+    return new Err(new MCPError(searchResults.error.message));
+  }
+
+  if (citationsOffset + retrievalTopK > getRefs().length) {
+    return new Err(
+      new MCPError(
+        "The inclusion exhausted the total number of references available for citations"
+      )
+    );
+  }
+
+  const refs = getRefs().slice(
+    citationsOffset,
+    citationsOffset + retrievalTopK
+  );
+
+  const results: IncludeResultResourceType[] =
+    searchResults.value.documents.map((doc) => {
+      const dataSourceView = coreSearchArgs.find(
+        (args) =>
+          args.dataSourceView.dataSource.dustAPIDataSourceId ===
+          doc.data_source_id
+      )?.dataSourceView;
+
+      assert(dataSourceView, "DataSource view not found");
+
+      return makeIncludeResultResource(doc, dataSourceView, refs);
+    });
+
+  const warningResource = makeIncludeWarningResource(
+    searchResults.value.documents,
+    retrievalTopK,
+    timeFrame ?? null
+  );
+
+  return new Ok([
+    ...results.map((result) => ({
+      type: "resource" as const,
+      resource: result,
+    })),
+    ...(warningResource
+      ? [
+          {
+            type: "resource" as const,
+            resource: warningResource,
+          },
+        ]
+      : []),
+  ]);
+}

--- a/front/lib/api/actions/servers/include_data/tools/index.ts
+++ b/front/lib/api/actions/servers/include_data/tools/index.ts
@@ -1,38 +1,14 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
-import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type {
-  IncludeResultResourceType,
-  WarningResourceType,
-} from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import {
-  checkConflictingTags,
-  shouldAutoGenerateTags,
-} from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
-import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import {
-  makeIncludeResultResource,
-  makeIncludeWarningResource,
-} from "@app/lib/api/actions/servers/include_data/helpers";
+import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
 import {
   INCLUDE_DATA_BASE_TOOLS_METADATA,
   INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/include_data/metadata";
 import { executeFindTags } from "@app/lib/api/actions/tools/find_tags";
-import { getRefs } from "@app/lib/api/assistant/citations";
-import config from "@app/lib/api/config";
-import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
-import logger from "@app/logger/logger";
-import { CoreAPI } from "@app/types/core/core_api";
-import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
-import type { TimeFrame } from "@app/types/shared/utils/time_frame";
-import { timeFrameFromNow } from "@app/types/shared/utils/time_frame";
-import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
-import assert from "assert";
 
 // Create tools with access to auth via closure
 export function createIncludeDataTools(
@@ -43,153 +19,16 @@ export function createIncludeDataTools(
     ? shouldAutoGenerateTags(agentLoopContext)
     : false;
 
-  async function includeFunction({
-    timeFrame,
-    dataSources,
-    tagsIn,
-    tagsNot,
-  }: {
-    timeFrame?: TimeFrame;
-    dataSources: DataSourcesToolConfigurationType;
-    tagsIn?: string[];
-    tagsNot?: string[];
-  }): Promise<
-    Result<
-      (
-        | TextContent
-        | {
-            type: "resource";
-            resource: IncludeResultResourceType | WarningResourceType;
-          }
-      )[],
-      MCPError
-    >
-  > {
-    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-    const credentials = await getLlmCredentials(auth);
-
-    if (!agentLoopContext?.runContext) {
-      throw new Error(
-        "agentLoopRunContext is required where the tool is called."
-      );
-    }
-
-    const { citationsOffset, retrievalTopK } =
-      agentLoopContext.runContext.stepContext;
-
-    // Get the core search args for each data source, fail if any of them are invalid.
-    const coreSearchArgsResults = await getCoreSearchArgs(auth, dataSources);
-
-    // If any of the data sources are invalid, return an error message.
-    if (coreSearchArgsResults.isErr()) {
-      return new Err(
-        new MCPError(coreSearchArgsResults.error.message, { tracked: false })
-      );
-    }
-
-    const coreSearchArgs = coreSearchArgsResults.value;
-
-    const conflictingTagsError = checkConflictingTags(
-      coreSearchArgs.map(({ filter }) => filter.tags),
-      { tagsIn, tagsNot }
-    );
-    if (conflictingTagsError) {
-      return new Err(new MCPError(conflictingTagsError, { tracked: false }));
-    }
-
-    const searchResults = await coreAPI.searchDataSources(
-      "",
-      retrievalTopK,
-      credentials,
-      false,
-      coreSearchArgs.map((args) => {
-        // In addition to the tags provided by the user, we also add the tags that the model inferred
-        // from the conversation history.
-        const finalTagsIn = [
-          ...(args.filter.tags?.in ?? []),
-          ...(tagsIn ?? []),
-        ];
-        const finalTagsNot = [
-          ...(args.filter.tags?.not ?? []),
-          ...(tagsNot ?? []),
-        ];
-
-        return {
-          projectId: args.projectId,
-          dataSourceId: args.dataSourceId,
-          filter: {
-            ...args.filter,
-            tags: {
-              in: finalTagsIn.length > 0 ? finalTagsIn : null,
-              not: finalTagsNot.length > 0 ? finalTagsNot : null,
-            },
-            timestamp: {
-              gt: timeFrame ? timeFrameFromNow(timeFrame) : null,
-              lt: null,
-            },
-          },
-          view_filter: args.view_filter,
-        };
-      })
-    );
-
-    if (searchResults.isErr()) {
-      return new Err(new MCPError(searchResults.error.message));
-    }
-
-    if (citationsOffset + retrievalTopK > getRefs().length) {
-      return new Err(
-        new MCPError(
-          "The inclusion exhausted the total number of references available for citations"
-        )
-      );
-    }
-
-    const refs = getRefs().slice(
-      citationsOffset,
-      citationsOffset + retrievalTopK
-    );
-
-    const results: IncludeResultResourceType[] =
-      searchResults.value.documents.map((doc) => {
-        const dataSourceView = coreSearchArgs.find(
-          (args) =>
-            args.dataSourceView.dataSource.dustAPIDataSourceId ===
-            doc.data_source_id
-        )?.dataSourceView;
-
-        assert(dataSourceView, "DataSource view not found");
-
-        return makeIncludeResultResource(doc, dataSourceView, refs);
-      });
-
-    const warningResource = makeIncludeWarningResource(
-      searchResults.value.documents,
-      retrievalTopK,
-      timeFrame ?? null
-    );
-
-    return new Ok([
-      ...results.map((result) => ({
-        type: "resource" as const,
-        resource: result,
-      })),
-      ...(warningResource
-        ? [
-            {
-              type: "resource" as const,
-              resource: warningResource,
-            },
-          ]
-        : []),
-    ]);
-  }
-
   if (!areTagsDynamic) {
     // Return base tools without tags
     const handlers: ToolHandlers<typeof INCLUDE_DATA_BASE_TOOLS_METADATA> = {
       retrieve_recent_documents: async (params, _extra) => {
-        return includeFunction(params);
+        if (!agentLoopContext?.runContext) {
+          throw new Error(
+            "agentLoopRunContext is required where the tool is called."
+          );
+        }
+        return runIncludeDataRetrieval(auth, agentLoopContext, params);
       },
     };
     return buildTools(INCLUDE_DATA_BASE_TOOLS_METADATA, handlers);
@@ -198,7 +37,12 @@ export function createIncludeDataTools(
   // Return tools with tags support
   const handlers: ToolHandlers<typeof INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA> = {
     retrieve_recent_documents: async (params, _extra) => {
-      return includeFunction(params);
+      if (!agentLoopContext?.runContext) {
+        throw new Error(
+          "agentLoopRunContext is required where the tool is called."
+        );
+      }
+      return runIncludeDataRetrieval(auth, agentLoopContext, params);
     },
     find_tags: async ({ query, dataSources }, _extra) => {
       return executeFindTags(auth, query, dataSources);

--- a/front/lib/api/actions/servers/project_manager/index.ts
+++ b/front/lib/api/actions/servers/project_manager/index.ts
@@ -12,7 +12,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
  * This server provides tools for managing projects:
  * - File operations: list, add, and update project files
  * - Metadata operations: edit description, add/edit URLs
- * - Search operations: search unread conversations
+ * - Retrieval: recent documents from the project data source and context nodes
  */
 function createServer(
   auth: Authenticator,

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -1,6 +1,7 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { IncludeInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
@@ -141,6 +142,22 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
       done: "Get project information",
     },
   },
+  retrieve_recent_documents: {
+    description:
+      "Fetch the most recent documents from this project's knowledge data source (full project scope) and from any content nodes linked in the project context, in reverse chronological order up to the retrieval limit. Respects optional time window. Does not use tag filters.",
+    schema: {
+      timeFrame: IncludeInputSchema.shape.timeFrame,
+      dustProject:
+        ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+        ].optional(),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving recent project documents",
+      done: "Retrieve recent project documents",
+    },
+  },
 });
 
 const PROJECT_MANAGER_INSTRUCTIONS =
@@ -148,6 +165,7 @@ const PROJECT_MANAGER_INSTRUCTIONS =
   "Only text-based files are supported for adding/updating. " +
   "You can add/update files by providing text content directly, or by copying from existing files (like those you've generated). " +
   "You can also attach an existing project context file to the current conversation without recreating it. " +
+  "Use retrieve_recent_documents to load recent content from the project data source and from knowledge nodes in the project context. " +
   "Requires write permissions on the project space. " +
   "After adding or updating files, always list the file names you changed in your response so the user knows exactly what was modified.";
 

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -1,10 +1,13 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import { getDataSourceURI } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ToolDefinition,
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
 import {
   getProjectSpace,
   getWritableProjectContext,
@@ -13,16 +16,21 @@ import {
   withErrorHandling,
 } from "@app/lib/api/actions/servers/project_manager/helpers";
 import { PROJECT_MANAGER_TOOLS_METADATA } from "@app/lib/api/actions/servers/project_manager/metadata";
-import { renderAttachmentXml } from "@app/lib/api/assistant/conversation/attachments";
+import {
+  isContentNodeAttachmentType,
+  renderAttachmentXml,
+} from "@app/lib/api/assistant/conversation/attachments";
 import config from "@app/lib/api/config";
 import {
   addFileToProject,
   fetchLatestProjectContextFileContentFragment,
+  fetchProjectDataSourceView,
   listProjectContextAttachments,
 } from "@app/lib/api/projects";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { getProjectRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import {
@@ -31,6 +39,52 @@ import {
 } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+
+async function buildProjectRetrieveDataSources(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<DataSourcesToolConfigurationType> {
+  const owner = auth.getNonNullableWorkspace();
+  const dataSources: DataSourcesToolConfigurationType = [];
+
+  const projectDsViewRes = await fetchProjectDataSourceView(auth, space);
+  if (projectDsViewRes.isOk()) {
+    dataSources.push({
+      uri: getDataSourceURI({
+        workspaceId: owner.sId,
+        dataSourceViewId: projectDsViewRes.value.sId,
+        filter: { parents: null, tags: null },
+      }),
+      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+    });
+  }
+
+  const attachments = await listProjectContextAttachments(auth, space);
+  const seenContentNodeKeys = new Set<string>();
+  for (const attachment of attachments) {
+    if (!isContentNodeAttachmentType(attachment)) {
+      continue;
+    }
+    const key = `${attachment.nodeDataSourceViewId}:${attachment.nodeId}`;
+    if (seenContentNodeKeys.has(key)) {
+      continue;
+    }
+    seenContentNodeKeys.add(key);
+    dataSources.push({
+      uri: getDataSourceURI({
+        workspaceId: owner.sId,
+        dataSourceViewId: attachment.nodeDataSourceViewId,
+        filter: {
+          parents: { in: [attachment.nodeId], not: [] },
+          tags: null,
+        },
+      }),
+      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+    });
+  }
+
+  return dataSources;
+}
 
 /**
  * Reads content from a source file.
@@ -451,6 +505,43 @@ export function createProjectManagerTools(
           })
         );
       }, "Failed to get project information");
+    },
+
+    retrieve_recent_documents: async (params) => {
+      return withErrorHandling(async () => {
+        if (!agentLoopContext) {
+          return new Err(
+            new MCPError("No conversation context available", {
+              tracked: false,
+            })
+          );
+        }
+
+        const contextRes = await getProjectSpace(auth, {
+          agentLoopContext,
+          dustProject: params.dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const { space } = contextRes.value;
+        const dataSources = await buildProjectRetrieveDataSources(auth, space);
+
+        if (dataSources.length === 0) {
+          return new Err(
+            new MCPError(
+              "No project data source or project context nodes available to retrieve from.",
+              { tracked: false }
+            )
+          );
+        }
+
+        return runIncludeDataRetrieval(auth, agentLoopContext, {
+          timeFrame: params.timeFrame,
+          dataSources,
+        });
+      }, "Failed to retrieve recent project documents");
     },
   };
 


### PR DESCRIPTION
## Description

Add a `retrieve_recent_documents` tool to the project manager, reusing the include data retrieval logic.
- Extract `runIncludeDataRetrieval` from `include_data/tools/index.ts` into a standalone `include_function.ts`, shared by both servers
- Add `retrieve_recent_documents` to `project_manager` — runs the same include retrieval scoped to the project's data source, with citation refs assigned the same way as `include_data`
- Update snapshot for the new tool's stake

## Tests

Local + green

## Risk

Low

## Deploy Plan

Deploy `front`
