### PR TITLE
[front] enh: improve action details for web browse output

### DIFF
--- a/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
@@ -1,13 +1,48 @@
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import { ToolGeneratedFileDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import type { BrowseResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   isBrowseResultResourceType,
   isToolGeneratedFile,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isWebbrowseInputType } from "@app/lib/actions/mcp_internal_actions/types";
 import { validateUrl } from "@app/types/shared/utils/url_utils";
-import { FaviconIcon, GlobeAltIcon, LinkWrapper } from "@dust-tt/sparkle";
+import { Card, FaviconIcon, GlobeAltIcon } from "@dust-tt/sparkle";
+
+interface BrowseResultItemProps {
+  result: BrowseResultResourceType;
+}
+
+function BrowseResultItem({ result }: BrowseResultItemProps) {
+  const isSuccess = result.responseCode === "200";
+  const urlValidation = validateUrl(result.uri);
+  const title = result.title ?? result.requestedUrl;
+  const subtitle = isSuccess
+    ? result.description
+    : `Error ${result.responseCode}${result.errorMessage ? `: ${result.errorMessage}` : ""}`;
+
+  const linkProps = urlValidation.valid
+    ? { href: urlValidation.standardized, target: "_blank" as const }
+    : {};
+
+  return (
+    <Card variant={isSuccess ? "primary" : "warning"} size="sm" {...linkProps}>
+      <div className="flex items-start gap-2">
+        <FaviconIcon websiteUrl={result.uri} size="md" className="mt-0.5 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <span className="truncate text-sm font-medium">{title}</span>
+          {subtitle && (
+            // Only show at most 2 lines, with an ellipsis if too big.
+            <p className="line-clamp-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+              {subtitle}
+            </p>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
 
 export function MCPBrowseActionDetails({
   toolOutput,

--- a/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
@@ -29,7 +29,11 @@ function BrowseResultItem({ result }: BrowseResultItemProps) {
   return (
     <Card variant={isSuccess ? "primary" : "warning"} size="sm" {...linkProps}>
       <div className="flex items-start gap-2">
-        <FaviconIcon websiteUrl={result.uri} size="md" className="mt-0.5 shrink-0" />
+        <FaviconIcon
+          websiteUrl={result.uri}
+          size="md"
+          className="mt-0.5 shrink-0"
+        />
         <div className="min-w-0 flex-1">
           <span className="truncate text-sm font-medium">{title}</span>
           {subtitle && (
@@ -68,13 +72,15 @@ export function MCPBrowseActionDetails({
       visual={GlobeAltIcon}
     >
       <div className="flex flex-col gap-4 pl-6 pt-4">
-        {(displayContext === "conversation" ||
-          browseResults.length === 0) &&
+        {(displayContext === "conversation" || browseResults.length === 0) &&
         urls ? (
           <div className="flex flex-col gap-1">
             {urls.map((url, idx) => (
               <div className="group flex items-center gap-1" key={idx}>
-                <FaviconIcon websiteUrl={url} className="grayscale transition-all duration-150 group-hover:grayscale-0" />
+                <FaviconIcon
+                  websiteUrl={url}
+                  className="grayscale transition-all duration-150 group-hover:grayscale-0"
+                />
                 <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                   {url}
                 </span>

--- a/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
@@ -68,63 +68,26 @@ export function MCPBrowseActionDetails({
       visual={GlobeAltIcon}
     >
       <div className="flex flex-col gap-4 pl-6 pt-4">
-        <div className="flex flex-col gap-1">
-          <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-            {(displayContext === "conversation" ||
-              browseResults.length === 0) &&
-            urls
-              ? urls.map((url, idx) => (
-                  <div
-                    className="group flex max-h-60 flex-row items-center gap-x-1 overflow-y-auto overflow-x-hidden pb-1"
-                    key={idx}
-                  >
-                    <span className="grayscale transition-all duration-150 ease-in-out group-hover:grayscale-0">
-                      <FaviconIcon websiteUrl={url} />
-                    </span>
-                    <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                      {url}
-                    </span>
-                  </div>
-                ))
-              : browseResults.map((r, idx) => (
-                  <div
-                    className="flex max-h-60 flex-col gap-2 overflow-y-auto overflow-x-hidden pb-4"
-                    key={idx}
-                  >
-                    {r.responseCode === "200" ? (
-                      <>
-                        {(() => {
-                          const urlValidation = validateUrl(r.uri);
-                          return urlValidation.valid ? (
-                            <LinkWrapper
-                              href={urlValidation.standardized}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {r.title ?? r.requestedUrl}
-                            </LinkWrapper>
-                          ) : (
-                            <span className="text-sm text-foreground dark:text-foreground-night">
-                              {r.title ?? r.requestedUrl} (invalid URL)
-                            </span>
-                          );
-                        })()}
-                        {r.text && (
-                          <span className="whitespace-pre-wrap text-sm text-foreground dark:text-foreground-night">
-                            {r.description ?? r.text.slice(0, 2048)}
-                          </span>
-                        )}
-                      </>
-                    ) : (
-                      <span className="text-sm text-foreground dark:text-foreground-night">
-                        Cannot fetch content for {r.uri}, error code:{" "}
-                        {r.responseCode}. {r.errorMessage}
-                      </span>
-                    )}
-                  </div>
-                ))}
+        {(displayContext === "conversation" ||
+          browseResults.length === 0) &&
+        urls ? (
+          <div className="flex flex-col gap-1">
+            {urls.map((url, idx) => (
+              <div className="group flex items-center gap-1" key={idx}>
+                <FaviconIcon websiteUrl={url} className="grayscale transition-all duration-150 group-hover:grayscale-0" />
+                <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                  {url}
+                </span>
+              </div>
+            ))}
           </div>
-        </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {browseResults.map((r, idx) => (
+              <BrowseResultItem key={idx} result={r} />
+            ))}
+          </div>
+        )}
 
         {generatedFiles.length > 0 && (
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Description

- This PR improves the UI for the action details of the web browse action.
- Goal is to highlight better the important information and actions: the entire content of the page is hard to parse at a glance, what bears the most meaning is mostly the title, description.

Before

<img width="888" height="751" alt="Screenshot 2026-04-10 at 5 01 43 PM" src="https://github.com/user-attachments/assets/4b16413f-d245-4fca-8bee-ef3d5e27ddfb" />

After

<img width="888" height="751" alt="Screenshot 2026-04-10 at 5 07 13 PM" src="https://github.com/user-attachments/assets/947863ea-d3cf-47c7-b720-d9a792560bf5" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
