### PR TITLE
Skill builder pre/post process instruction markdown

### DIFF
--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -6,6 +6,7 @@ import {
   buildSkillInstructionsExtensions,
   INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
 } from "@app/lib/editor/build_skill_instructions_extensions";
+import { preprocessMarkdown } from "@app/lib/editor/skill_instructions_preprocessing";
 import { cn } from "@dust-tt/sparkle";
 import { CharacterCount, Placeholder } from "@tiptap/extensions";
 import type { Transaction } from "@tiptap/pm/state";
@@ -40,7 +41,7 @@ function useEditorService(editor: Editor | null) {
       setContent(content: string) {
         // Safety check for Safari: ensure editor and docView are available
         if (editor && !editor.isDestroyed) {
-          editor.commands.setContent(content, {
+          editor.commands.setContent(preprocessMarkdown(content), {
             emitUpdate: false,
             contentType: "markdown",
           });
@@ -150,7 +151,7 @@ export function useSkillInstructionsEditor({
       // This fixes Safari crashes where docView is accessed before render
       requestAnimationFrame(() => {
         if (editor && !editor.isDestroyed) {
-          editor.commands.setContent(content, {
+          editor.commands.setContent(preprocessMarkdown(content), {
             emitUpdate: false,
             contentType: "markdown",
           });

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -8,6 +8,10 @@ import {
 import { SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT } from "@app/components/skill_builder/events";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
+import {
+  postProcessMarkdown,
+  preprocessMarkdown,
+} from "@app/lib/editor/skill_instructions_preprocessing";
 import { cn } from "@dust-tt/sparkle";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
@@ -71,9 +75,13 @@ export function SkillBuilderInstructionsEditor({
     () =>
       debounce((editor: Editor) => {
         if (!isDiffMode && !editor.isDestroyed) {
-          setValue(INSTRUCTIONS_FIELD_NAME, editor.getMarkdown().trim(), {
-            shouldDirty: true,
-          });
+          setValue(
+            INSTRUCTIONS_FIELD_NAME,
+            postProcessMarkdown(editor.getMarkdown().trim()),
+            {
+              shouldDirty: true,
+            }
+          );
           setValue(
             ATTACHED_KNOWLEDGE_FIELD_NAME,
             toAttachedKnowledge(collectKnowledgeItems(editor)),
@@ -195,13 +203,16 @@ export function SkillBuilderInstructionsEditor({
     ) {
       return;
     }
-    const currentContent = editor.getMarkdown();
+    const currentContent = postProcessMarkdown(editor.getMarkdown());
     if (currentContent !== instructionsField.value) {
       setTimeout(() => {
-        editor.commands.setContent(instructionsField.value, {
-          emitUpdate: false,
-          contentType: "markdown",
-        });
+        editor.commands.setContent(
+          preprocessMarkdown(instructionsField.value),
+          {
+            emitUpdate: false,
+            contentType: "markdown",
+          }
+        );
       }, 0);
     }
   }, [editor, instructionsField.value]);
@@ -217,9 +228,9 @@ export function SkillBuilderInstructionsEditor({
       }
 
       const compareText = compareVersion.instructions ?? "";
-      const currentText = instructionsField.value ?? "";
+      const currentText = postProcessMarkdown(instructionsField.value ?? "");
 
-      editor.commands.setContent(currentText, {
+      editor.commands.setContent(preprocessMarkdown(currentText), {
         emitUpdate: false,
         contentType: "markdown",
       });

--- a/front/lib/editor/skill_instructions_html.test.ts
+++ b/front/lib/editor/skill_instructions_html.test.ts
@@ -1,4 +1,4 @@
-import { convertMarkdownToBlockHtml } from "@app/lib/skill_instructions_html";
+import { convertMarkdownToBlockHtml } from "@app/lib/editor/skill_instructions_html";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import * as cheerio from "cheerio";
 import { describe, expect, it } from "vitest";

--- a/front/lib/editor/skill_instructions_html.ts
+++ b/front/lib/editor/skill_instructions_html.ts
@@ -4,6 +4,7 @@ import {
 } from "@app/components/editor/extensions/instructions/BlockIdExtension";
 import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
 import { buildSkillInstructionsExtensions } from "@app/lib/editor/build_skill_instructions_extensions";
+import { preprocessMarkdown } from "@app/lib/editor/skill_instructions_preprocessing";
 import { generateShortBlockId } from "@app/lib/generate_short_block_id";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import type { JSONContent } from "@tiptap/core";
@@ -16,7 +17,6 @@ const SKILL_EDITOR_EXTENSIONS = buildSkillInstructionsExtensions(true);
 const MARKDOWN_MANAGER = new MarkdownManager({
   extensions: SKILL_EDITOR_EXTENSIONS,
 });
-const ZWS = "\u200B";
 
 const NODE_TYPES_WITH_BLOCK_ID = new Set<string>([
   ...BLOCK_ID_UNIQUE_ID_NODE_TYPES,
@@ -53,24 +53,11 @@ function stripPresentationAttributes(html: string): string {
 }
 
 /**
- * Prepare markdown for conversion to HTML.
- *
- * Inserts a zero-width space after every `<` that is not already ZWS-prefixed.
- * We do not require more complex logic given InstructionBlockExtension is not used in the skill editor.
- *
- */
-function preprocessMarkdownForConversion(markdown: string): string {
-  return markdown.replace(new RegExp(`<(?!${ZWS})`, "g"), `<${ZWS}`);
-}
-
-/**
  * Convert Markdown to stored skill instructionsHtml.
  * Uses the same extension schema as the browser editor, then strips CSS class attrs.
  */
 export function convertMarkdownToBlockHtml(markdown: string): string {
-  const preprocessed = markdown.trim()
-    ? preprocessMarkdownForConversion(markdown)
-    : null;
+  const preprocessed = markdown.trim() ? preprocessMarkdown(markdown) : null;
   const parsedDoc = preprocessed ? MARKDOWN_MANAGER.parse(preprocessed) : null;
 
   const json: JSONContent = {

--- a/front/lib/editor/skill_instructions_preprocessing.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.ts
@@ -1,0 +1,16 @@
+const ZWS = "\u200B";
+
+/**
+ * Prepare markdown for conversion to HTML or for loading into the TipTap editor.
+ *
+ * Inserts a zero-width space after every `<` that is not already ZWS-prefixed.
+ * This prevents marked (used by TipTap's MarkdownManager and the browser editor)
+ * from treating XML-like tags (e.g. <instructions>) as raw HTML tokens and dropping them.
+ */
+export function preprocessMarkdown(markdown: string): string {
+  return markdown.replace(new RegExp(`<(?!${ZWS})`, "g"), `<${ZWS}`);
+}
+
+export function postProcessMarkdown(markdown: string): string {
+  return markdown.replace(new RegExp(ZWS, "g"), "");
+}

--- a/front/scripts/validate_skill_html_migration.ts
+++ b/front/scripts/validate_skill_html_migration.ts
@@ -13,11 +13,11 @@
  */
 
 import { BLOCK_ID_ATTRIBUTE } from "@app/components/editor/extensions/instructions/BlockIdExtension";
-import { SkillConfigurationModel } from "@app/lib/models/skill";
 import {
   convertBlockHtmlToMarkdown,
   convertMarkdownToBlockHtml,
 } from "@app/lib/editor/skill_instructions_html";
+import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/scripts/validate_skill_html_migration.ts
+++ b/front/scripts/validate_skill_html_migration.ts
@@ -17,7 +17,7 @@ import { SkillConfigurationModel } from "@app/lib/models/skill";
 import {
   convertBlockHtmlToMarkdown,
   convertMarkdownToBlockHtml,
-} from "@app/lib/skill_instructions_html";
+} from "@app/lib/editor/skill_instructions_html";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import { normalizeError } from "@app/types/shared/utils/error_utils";


### PR DESCRIPTION
## Description

* Not related to roundtrip validation, but getting ahead of a potential issue where invalid raw HTML inside of the skill instructions can cause it not to be rendered
* Moving files to not be under top level front/lib

## Tests
<img width="1441" height="351" alt="Screenshot 2026-04-10 at 12 19 59 PM" src="https://github.com/user-attachments/assets/4c728e85-33e6-465a-867f-91356e693f3e" />

## Risk

* Low

## Deploy Plan

* Deploy front