### PR TITLE
Add an endpoint to list skill suggestions and change their status

### DIFF
--- a/front/hooks/useSkillSuggestions.ts
+++ b/front/hooks/useSkillSuggestions.ts
@@ -1,0 +1,123 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  emptyArray,
+  getErrorFromResponse,
+  useFetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
+import type {
+  GetSkillSuggestionsQuery,
+  GetSkillSuggestionsResponseBody,
+  PatchSkillSuggestionRequestBody,
+  PatchSkillSuggestionResponseBody,
+} from "@app/pages/api/w/[wId]/assistant/skills/[sId]/suggestions";
+import { useCallback } from "react";
+import type { Fetcher } from "swr";
+
+export function useSkillSuggestions({
+  skillId,
+  disabled,
+  kind,
+  states,
+  limit,
+  workspaceId,
+}: {
+  skillId: string | null;
+  disabled?: boolean;
+  kind?: GetSkillSuggestionsQuery["kind"];
+  states?: GetSkillSuggestionsQuery["states"];
+  limit?: number;
+  workspaceId: string;
+}) {
+  const { fetcher } = useFetcher();
+  const suggestionsFetcher: Fetcher<GetSkillSuggestionsResponseBody> = fetcher;
+
+  const urlParams = new URLSearchParams();
+  if (states) {
+    states.forEach((s) => urlParams.append("states", s));
+  }
+  if (kind) {
+    urlParams.append("kind", kind);
+  }
+  if (limit !== undefined) {
+    urlParams.append("limit", limit.toString());
+  }
+
+  const queryString = urlParams.toString();
+
+  const { data, error, mutate, isValidating, isLoading } = useSWRWithDefaults(
+    skillId
+      ? `/api/w/${workspaceId}/assistant/skills/${skillId}/suggestions?${queryString}`
+      : null,
+    suggestionsFetcher,
+    { disabled }
+  );
+
+  return {
+    suggestions: data?.suggestions ?? emptyArray(),
+    isSuggestionsLoading: isLoading,
+    isSuggestionsError: !!error,
+    isSuggestionsValidating: isValidating,
+    mutateSuggestions: mutate,
+  };
+}
+
+export function usePatchSkillSuggestions({
+  skillId,
+  workspaceId,
+}: {
+  skillId: string | null;
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const patchSuggestions = useCallback(
+    async (
+      suggestionIds: string[],
+      state: PatchSkillSuggestionRequestBody["state"]
+    ): Promise<PatchSkillSuggestionResponseBody | null> => {
+      if (!skillId || suggestionIds.length === 0) {
+        return null;
+      }
+
+      try {
+        const res = await clientFetch(
+          `/api/w/${workspaceId}/assistant/skills/${skillId}/suggestions`,
+          {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              suggestionIds,
+              state,
+            } satisfies PatchSkillSuggestionRequestBody),
+          }
+        );
+
+        if (!res.ok) {
+          const errorData = await getErrorFromResponse(res);
+          sendNotification({
+            type: "error",
+            title: "Failed to update skill suggestion",
+            description: errorData.message,
+          });
+          return null;
+        }
+
+        const data = await res.json();
+        return data;
+      } catch {
+        sendNotification({
+          type: "error",
+          title: "Failed to update skill suggestion",
+        });
+        return null;
+      }
+    },
+    [skillId, sendNotification, workspaceId]
+  );
+
+  return { patchSuggestions };
+}

--- a/front/hooks/useSkillSuggestions.ts
+++ b/front/hooks/useSkillSuggestions.ts
@@ -15,6 +15,15 @@ import type {
 import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
+interface UseSkillSuggestionsParams {
+  skillId: string | null;
+  disabled?: boolean;
+  kind?: GetSkillSuggestionsQuery["kind"];
+  states?: GetSkillSuggestionsQuery["states"];
+  limit?: number;
+  workspaceId: string;
+}
+
 export function useSkillSuggestions({
   skillId,
   disabled,
@@ -22,14 +31,7 @@ export function useSkillSuggestions({
   states,
   limit,
   workspaceId,
-}: {
-  skillId: string | null;
-  disabled?: boolean;
-  kind?: GetSkillSuggestionsQuery["kind"];
-  states?: GetSkillSuggestionsQuery["states"];
-  limit?: number;
-  workspaceId: string;
-}) {
+}: UseSkillSuggestionsParams) {
   const { fetcher } = useFetcher();
   const suggestionsFetcher: Fetcher<GetSkillSuggestionsResponseBody> = fetcher;
 
@@ -46,7 +48,7 @@ export function useSkillSuggestions({
 
   const queryString = urlParams.toString();
 
-  const { data, error, mutate, isValidating, isLoading } = useSWRWithDefaults(
+  const { data, error, mutate, isValidating } = useSWRWithDefaults(
     skillId
       ? `/api/w/${workspaceId}/assistant/skills/${skillId}/suggestions?${queryString}`
       : null,
@@ -56,20 +58,22 @@ export function useSkillSuggestions({
 
   return {
     suggestions: data?.suggestions ?? emptyArray(),
-    isSuggestionsLoading: isLoading,
+    isSuggestionsLoading: !error && !data && !disabled,
     isSuggestionsError: !!error,
     isSuggestionsValidating: isValidating,
     mutateSuggestions: mutate,
   };
 }
 
+interface UsePatchSkillSuggestionsParams {
+  skillId: string | null;
+  workspaceId: string;
+}
+
 export function usePatchSkillSuggestions({
   skillId,
   workspaceId,
-}: {
-  skillId: string | null;
-  workspaceId: string;
-}) {
+}: UsePatchSkillSuggestionsParams) {
   const sendNotification = useSendNotification();
 
   const patchSuggestions = useCallback(

--- a/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.test.ts
+++ b/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.test.ts
@@ -1,0 +1,526 @@
+import { Authenticator } from "@app/lib/auth";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import type { SkillSuggestionState } from "@app/types/suggestions/skill_suggestion";
+import type { RequestMethod } from "node-mocks-http";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/reinforced_agent/workspace_check", () => ({
+  hasReinforcementEnabled: vi.fn().mockResolvedValue(true),
+}));
+
+import handler from "./suggestions";
+
+async function setupTest(
+  options: { method?: RequestMethod; role?: MembershipRoleType } = {}
+) {
+  const method = options.method ?? "PATCH";
+  const role = options.role ?? "builder";
+
+  const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+    role,
+    method,
+  });
+
+  const skill = await SkillFactory.create(auth);
+
+  // Refresh authenticator to pick up the skill's editor group membership.
+  await auth.refresh();
+
+  req.query = { wId: workspace.sId, sId: skill.sId };
+
+  return { req, res, workspace, auth, skill };
+}
+
+describe("PATCH /api/w/[wId]/assistant/skills/[sId]/suggestions", () => {
+  it("returns 404 for non-existent skill", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      role: "builder",
+      method: "PATCH",
+    });
+
+    req.query = { wId: workspace.sId, sId: "non-existent-skill" };
+    req.body = {
+      suggestionIds: ["test-id"],
+      state: "approved",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("skill_not_found");
+  });
+
+  it("returns 400 for missing suggestionIds", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      state: "approved",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for empty suggestionIds array", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      suggestionIds: [],
+      state: "approved",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for missing state", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      suggestionIds: ["test-id"],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for invalid state value", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      suggestionIds: ["test-id"],
+      state: "invalid_state",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 when trying to set state to pending", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      suggestionIds: ["test-id"],
+      state: "pending",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 404 for non-existent suggestion", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      suggestionIds: ["non-existent-id"],
+      state: "approved",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("agent_suggestion_not_found");
+  });
+
+  it("returns 400 when suggestion belongs to a different skill", async () => {
+    const { req, res, auth, skill } = await setupTest();
+
+    // Create another skill owned by the same user.
+    const otherSkill = await SkillFactory.create(auth, {
+      name: "Other Skill",
+    });
+    await auth.refresh();
+
+    // Create a suggestion for the other skill.
+    const suggestion = await SkillSuggestionFactory.create(auth, otherSkill);
+
+    // Try to update the suggestion via the first skill's endpoint.
+    req.query = { ...req.query, sId: skill.sId };
+    req.body = {
+      suggestionIds: [suggestion.sId],
+      state: "approved",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    expect(res._getJSONData().error.message).toContain(
+      "do not belong to the specified skill configuration"
+    );
+  });
+
+  it("returns 405 for unsupported methods", async () => {
+    for (const method of ["POST", "PUT", "DELETE"] as const) {
+      const { req, res } = await setupTest({ method });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+      expect(res._getJSONData().error.type).toBe("method_not_supported_error");
+    }
+  });
+
+  it.each<Exclude<SkillSuggestionState, "pending">>([
+    "approved",
+    "rejected",
+    "outdated",
+  ])("updates suggestion state to %s", async (newState) => {
+    const { req, res, auth, skill } = await setupTest();
+
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    req.body = {
+      suggestionIds: [suggestion.sId],
+      state: newState,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData.suggestions).toBeDefined();
+    expect(responseData.suggestions).toHaveLength(1);
+    expect(responseData.suggestions[0].state).toBe(newState);
+    expect(responseData.suggestions[0].sId).toBe(suggestion.sId);
+
+    // Verify the state was persisted.
+    const fetchedSuggestion = await SkillSuggestionResource.fetchById(
+      auth,
+      suggestion.sId
+    );
+    expect(fetchedSuggestion?.state).toBe(newState);
+  });
+
+  it("returns the full suggestion object with all fields", async () => {
+    const { req, res, auth, skill } = await setupTest();
+
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      suggestion: {
+        instructionEdits: [
+          {
+            old_string: "original text",
+            new_string: "updated instructions",
+            expected_occurrences: 1,
+          },
+        ],
+      },
+      analysis: "Test analysis",
+      state: "pending",
+      source: "reinforcement",
+    });
+
+    req.body = {
+      suggestionIds: [suggestion.sId],
+      state: "approved",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData.suggestions).toHaveLength(1);
+    expect(responseData.suggestions[0]).toMatchObject({
+      sId: suggestion.sId,
+      state: "approved",
+      kind: "edit",
+      analysis: "Test analysis",
+      source: "reinforcement",
+      suggestion: {
+        instructionEdits: [
+          {
+            old_string: "original text",
+            new_string: "updated instructions",
+            expected_occurrences: 1,
+          },
+        ],
+      },
+    });
+    expect(responseData.suggestions[0].createdAt).toBeDefined();
+    expect(responseData.suggestions[0].updatedAt).toBeDefined();
+  });
+
+  it("admin can update suggestions in their workspace", async () => {
+    const { req, res, auth, skill } = await setupTest({
+      role: "admin",
+    });
+
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    req.body = {
+      suggestionIds: [suggestion.sId],
+      state: "approved",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().suggestions[0].state).toBe("approved");
+  });
+
+  it("returns 403 for non-editor of the skill", async () => {
+    const { req, res, workspace } = await setupTest();
+
+    // Create another user owning a different skill.
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: "builder",
+    });
+    const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+    const otherSkill = await SkillFactory.create(ownerAuth, {
+      name: "Other Skill",
+    });
+    await ownerAuth.refresh();
+
+    const suggestion = await SkillSuggestionFactory.create(
+      ownerAuth,
+      otherSkill,
+      { state: "pending" }
+    );
+
+    // Update request to target the other skill.
+    req.query = { ...req.query, sId: otherSkill.sId };
+    req.body = {
+      suggestionIds: [suggestion.sId],
+      state: "approved",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error.type).toBe("agent_group_permission_error");
+  });
+
+  it("updates multiple suggestions in a single request", async () => {
+    const { req, res, auth, skill } = await setupTest();
+
+    const suggestion1 = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+    const suggestion2 = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    req.body = {
+      suggestionIds: [suggestion1.sId, suggestion2.sId],
+      state: "approved",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData.suggestions).toHaveLength(2);
+    expect(
+      responseData.suggestions.every(
+        (s: { state: string }) => s.state === "approved"
+      )
+    ).toBe(true);
+
+    // Verify both were persisted.
+    const fetched1 = await SkillSuggestionResource.fetchById(
+      auth,
+      suggestion1.sId
+    );
+    const fetched2 = await SkillSuggestionResource.fetchById(
+      auth,
+      suggestion2.sId
+    );
+    expect(fetched1?.state).toBe("approved");
+    expect(fetched2?.state).toBe("approved");
+  });
+
+  it("returns 400 when reinforcement is disabled", async () => {
+    const { hasReinforcementEnabled } = await import(
+      "@app/lib/reinforced_agent/workspace_check"
+    );
+    vi.mocked(hasReinforcementEnabled).mockResolvedValueOnce(false);
+
+    const { req, res, auth, skill } = await setupTest();
+
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    req.body = {
+      suggestionIds: [suggestion.sId],
+      state: "approved",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "Reinforcement is not enabled"
+    );
+  });
+});
+
+describe("GET /api/w/[wId]/assistant/skills/[sId]/suggestions", () => {
+  it("returns skill's suggestions", async () => {
+    const { req, res, auth, skill } = await setupTest({
+      method: "GET",
+    });
+
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.suggestions).toHaveLength(1);
+    expect(responseData.suggestions[0].sId).toBe(suggestion.sId);
+  });
+
+  it("should not return other skill's suggestions", async () => {
+    const { req, res, auth, skill } = await setupTest({
+      method: "GET",
+    });
+
+    const skill2 = await SkillFactory.create(auth, {
+      name: "Test Skill 2",
+    });
+    await auth.refresh();
+
+    const suggestion1 = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+    await SkillSuggestionFactory.create(auth, skill2, {
+      state: "pending",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.suggestions).toHaveLength(1);
+    expect(responseData.suggestions[0].sId).toBe(suggestion1.sId);
+  });
+
+  it("filters on kind and state correctly", async () => {
+    const { req, res, auth, skill } = await setupTest({
+      method: "GET",
+    });
+
+    const matchingSuggestion = await SkillSuggestionFactory.create(
+      auth,
+      skill,
+      {
+        state: "pending",
+        kind: "edit",
+      }
+    );
+    await SkillSuggestionFactory.create(auth, skill, {
+      state: "approved",
+      kind: "edit",
+    });
+
+    req.query = {
+      ...req.query,
+      states: ["pending"],
+      kind: "edit",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.suggestions).toHaveLength(1);
+    expect(responseData.suggestions[0].sId).toBe(matchingSuggestion.sId);
+    expect(responseData.suggestions[0].kind).toBe("edit");
+    expect(responseData.suggestions[0].state).toBe("pending");
+  });
+
+  it("limits the number of returned suggestions", async () => {
+    const { req, res, auth, skill } = await setupTest({
+      method: "GET",
+    });
+
+    await SkillSuggestionFactory.create(auth, skill, { state: "pending" });
+    await SkillSuggestionFactory.create(auth, skill, { state: "pending" });
+    await SkillSuggestionFactory.create(auth, skill, { state: "pending" });
+
+    req.query = { ...req.query, limit: "2" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.suggestions).toHaveLength(2);
+  });
+
+  it("returns 403 for non-editor of the skill", async () => {
+    const { req, res, workspace } = await setupTest({
+      method: "GET",
+    });
+
+    // Create another user owning the skill and creating the suggestion.
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: "builder",
+    });
+    const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+    const otherSkill = await SkillFactory.create(ownerAuth, {
+      name: "Other Skill",
+    });
+    await ownerAuth.refresh();
+
+    // Create suggestion for the skill (as owner).
+    await SkillSuggestionFactory.create(ownerAuth, otherSkill, {
+      state: "pending",
+    });
+
+    // Make API request as non-editor of the skill.
+    req.query = { ...req.query, sId: otherSkill.sId };
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error.type).toBe("agent_group_permission_error");
+  });
+
+  it("returns empty suggestions when reinforcement is disabled", async () => {
+    const { hasReinforcementEnabled } = await import(
+      "@app/lib/reinforced_agent/workspace_check"
+    );
+    vi.mocked(hasReinforcementEnabled).mockResolvedValueOnce(false);
+
+    const { req, res, auth, skill } = await setupTest({ method: "GET" });
+
+    await SkillSuggestionFactory.create(auth, skill, { state: "pending" });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().suggestions).toHaveLength(0);
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.ts
@@ -1,0 +1,224 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { hasReinforcementEnabled } from "@app/lib/reinforced_agent/workspace_check";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+import { SkillSuggestionSchema } from "@app/types/suggestions/skill_suggestion";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const PatchSkillSuggestionRequestBodySchema = z.object({
+  suggestionIds: z.array(z.string()).min(1),
+  state: z.enum(["approved", "rejected", "outdated"]),
+});
+
+export type PatchSkillSuggestionRequestBody = z.infer<
+  typeof PatchSkillSuggestionRequestBodySchema
+>;
+
+export const PatchSkillSuggestionResponseBodySchema = z.object({
+  suggestions: z.array(SkillSuggestionSchema),
+});
+export type PatchSkillSuggestionResponseBody = z.infer<
+  typeof PatchSkillSuggestionResponseBodySchema
+>;
+
+const StateSchema = z.enum(["pending", "approved", "rejected", "outdated"]);
+
+// Next.js serializes single query param values as string, multiple as array.
+const stringOrArrayToArray = z.preprocess(
+  (v) => (typeof v === "string" ? [v] : v),
+  z.array(StateSchema)
+);
+
+const GetSkillSuggestionsQuerySchema = z.object({
+  states: stringOrArrayToArray.optional(),
+  kind: z.enum(["edit"]).optional(),
+  limit: z.string().optional(),
+});
+
+export type GetSkillSuggestionsQuery = z.infer<
+  typeof GetSkillSuggestionsQuerySchema
+>;
+
+export const GetSkillSuggestionsResponseBodySchema = z.object({
+  suggestions: z.array(SkillSuggestionSchema),
+});
+export type GetSkillSuggestionsResponseBody = z.infer<
+  typeof GetSkillSuggestionsResponseBodySchema
+>;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      PatchSkillSuggestionResponseBody | GetSkillSuggestionsResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const { sId } = req.query;
+  if (!isString(sId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid skill configuration ID in path.",
+      },
+    });
+  }
+
+  const skill = await SkillResource.fetchById(auth, sId);
+  if (!skill) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "skill_not_found",
+        message: "The skill configuration was not found.",
+      },
+    });
+  }
+
+  if (!skill.canWrite(auth)) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "agent_group_permission_error",
+        message:
+          "Only editors of the skill or workspace admins can view suggestions.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      if (!(await hasReinforcementEnabled(auth))) {
+        return res.status(200).json({ suggestions: [] });
+      }
+
+      const queryValidation = GetSkillSuggestionsQuerySchema.safeParse(
+        req.query
+      );
+      if (!queryValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${queryValidation.error.message}`,
+          },
+        });
+      }
+
+      const { states, kind, limit } = queryValidation.data;
+
+      const parsedLimit = limit ? parseInt(limit, 10) : undefined;
+      if (parsedLimit !== undefined && isNaN(parsedLimit)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid limit parameter: must be a number",
+          },
+        });
+      }
+
+      const suggestions =
+        await SkillSuggestionResource.listBySkillConfigurationId(auth, sId, {
+          states,
+          sources: ["reinforcement"],
+          kind,
+          limit: parsedLimit,
+        });
+
+      return res
+        .status(200)
+        .json({ suggestions: suggestions.map((s) => s.toJSON()) });
+    }
+
+    case "PATCH": {
+      if (!(await hasReinforcementEnabled(auth))) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Reinforcement is not enabled for this workspace.",
+          },
+        });
+      }
+
+      const bodyValidation = PatchSkillSuggestionRequestBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${bodyValidation.error.message}`,
+          },
+        });
+      }
+
+      const { suggestionIds, state } = bodyValidation.data;
+
+      const suggestions = await SkillSuggestionResource.fetchByIds(
+        auth,
+        suggestionIds
+      );
+
+      if (suggestions.length !== suggestionIds.length) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "agent_suggestion_not_found",
+            message: "One or more skill suggestions were not found.",
+          },
+        });
+      }
+
+      for (const suggestion of suggestions) {
+        if (suggestion.skillConfigurationSId !== skill.sId) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "One or more skill suggestions do not belong to the specified skill configuration.",
+            },
+          });
+        }
+      }
+
+      await SkillSuggestionResource.bulkUpdateState(auth, suggestions, state);
+
+      // Bulk update doesn't mutate the resources, so we need to refetch here.
+      const updatedSuggestions = await SkillSuggestionResource.fetchByIds(
+        auth,
+        suggestionIds
+      );
+
+      return res.status(200).json({
+        suggestions: updatedSuggestions.map(
+          (s): SkillSuggestionType => s.toJSON()
+        ),
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or PATCH is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/7446

 - Add endpoint to get skills suggestions and patch their state, it will be used to show and interact with suggestions in the skill builder
 - Add unit tests covering the endpoint
 - Add a hook to use the endpoint, the hook itself is currently unused and will be used by skill builder

## Tests
Unit tests

```
 ✓ pages/api/w/[wId]/assistant/skills/[sId]/suggestions.test.ts (23 tests) 787ms
   ✓ PATCH /api/w/[wId]/assistant/skills/[sId]/suggestions (17)
     ✓ returns 404 for non-existent skill 84ms
     ✓ returns 400 for missing suggestionIds 34ms
     ✓ returns 400 for empty suggestionIds array 34ms
     ✓ returns 400 for missing state 28ms
     ✓ returns 400 for invalid state value 27ms
     ✓ returns 400 when trying to set state to pending 25ms
     ✓ returns 404 for non-existent suggestion 24ms
     ✓ returns 400 when suggestion belongs to a different skill 40ms
     ✓ returns 405 for unsupported methods 65ms
     ✓ updates suggestion state to approved 36ms
     ✓ updates suggestion state to rejected 34ms
     ✓ updates suggestion state to outdated 33ms
     ✓ returns the full suggestion object with all fields 34ms
     ✓ admin can update suggestions in their workspace 35ms
     ✓ returns 403 for non-editor of the skill 31ms
     ✓ updates multiple suggestions in a single request 41ms
     ✓ returns 400 when reinforcement is disabled 24ms
   ✓ GET /api/w/[wId]/assistant/skills/[sId]/suggestions (6)
     ✓ returns skill's suggestions 28ms
     ✓ should not return other skill's suggestions 29ms
     ✓ filters on kind and state correctly 26ms
     ✓ limits the number of returned suggestions 27ms
     ✓ returns 403 for non-editor of the skill 27ms
     ✓ returns empty suggestions when reinforcement is disabled 21ms

 Test Files  1 passed (1)
      Tests  23 passed (23)
   Start at  18:41:46
   Duration  9.89s (transform 2.20s, setup 247ms, import 5.13s, tests 787ms, environment 290ms)
```

## Risk

low

## Deploy Plan

deploy front
