### PR TITLE
Fix: project sync workflows will now fail when metadata sync fails, leverage metadata's timestamp for the core document, do not sync if not updated.

### DIFF
--- a/connectors/src/connectors/dust_project/lib/sync_metadata.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_metadata.ts
@@ -65,7 +65,7 @@ export async function syncProjectMetadata({
     documentId,
     documentContent,
     documentUrl: undefined,
-    timestampMs: Date.now(),
+    timestampMs: metadata.updatedAt,
     tags: [`project:${projectId}`],
     parents: [documentId],
     parentId: null,

--- a/connectors/src/connectors/dust_project/temporal/activities.ts
+++ b/connectors/src/connectors/dust_project/temporal/activities.ts
@@ -120,11 +120,6 @@ export async function dustProjectConversationsFullSyncActivity({
       { concurrency: 5 } // Process 5 conversations at a time
     );
 
-    // Update lastSyncedAt
-    await configuration.update({ lastSyncedAt: new Date() });
-
-    await syncSucceeded(connectorId);
-
     // Launch incremental sync workflow after successful full sync
     const incrementalSyncResult =
       await launchDustProjectIncrementalSyncWorkflow(connectorId);
@@ -187,16 +182,20 @@ export async function dustProjectConversationsIncrementalSyncActivity({
       "Starting incremental sync for dust_project connector"
     );
 
-    // Use the max synced conversation's sourceUpdatedAt as the updatedSince parameter to get only the delta from last sync
+    // Watermark: max source `updatedAt` we have synced. Front's `updatedSince` filter uses
+    // `updatedAt >= updatedSince` (inclusive), so passing the raw max would re-fetch every
+    // conversation at that timestamp every run. Use max+1 so `>=` behaves like strictly after max.
     const maxSourceUpdatedAt =
       await DustProjectConversationResource.getMaxSourceUpdatedAt(connectorId);
 
-    // Fetch conversations updated since lastSyncedAt from Front API
     const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
     const conversationsResult =
       await dustAPI.getSpaceConversationsForDataSource({
         spaceId: configuration.projectId,
-        updatedSince: maxSourceUpdatedAt?.getTime(),
+        updatedSince:
+          maxSourceUpdatedAt != null
+            ? maxSourceUpdatedAt.getTime() + 1
+            : undefined,
       });
 
     if (conversationsResult.isErr()) {
@@ -230,11 +229,6 @@ export async function dustProjectConversationsIncrementalSyncActivity({
       },
       { concurrency: 5 } // Process 5 conversations at a time
     );
-
-    // Update lastSyncedAt
-    await configuration.update({ lastSyncedAt: new Date() });
-
-    await syncSucceeded(connectorId);
 
     // Run garbage collection to remove hard-deleted conversations
     // This checks for conversations that were completely removed from the database
@@ -361,8 +355,7 @@ async function dustProjectConversationsGarbageCollectActivity({
 
 /**
  * Sync metadata activity: Fetches and syncs project metadata (description).
- * This is called during both full and incremental syncs.
- * Errors are logged but don't fail the parent sync.
+ * On fetch/upsert failure, throws so the Temporal workflow fails.
  */
 export async function dustProjectSyncMetadataActivity({
   connectorId,
@@ -384,45 +377,80 @@ export async function dustProjectSyncMetadataActivity({
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  try {
-    localLogger.info(
-      { projectId: configuration.projectId },
-      "Fetching and syncing project metadata"
+  localLogger.info(
+    { projectId: configuration.projectId },
+    "Fetching and syncing project metadata"
+  );
+
+  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
+  const metadataResult = await dustAPI.getSpaceMetadata({
+    spaceId: configuration.projectId,
+  });
+
+  if (metadataResult.isErr()) {
+    localLogger.error(
+      {
+        error: metadataResult.error,
+        projectId: configuration.projectId,
+      },
+      "Failed to fetch project metadata"
     );
-
-    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
-    const metadataResult = await dustAPI.getSpaceMetadata({
-      spaceId: configuration.projectId,
-    });
-
-    if (metadataResult.isErr()) {
-      localLogger.warn(
-        {
-          error: metadataResult.error,
-          projectId: configuration.projectId,
-        },
-        "Failed to fetch project metadata, skipping metadata sync"
-      );
-      // Don't throw - metadata fetch failures shouldn't fail the sync
-      return;
-    }
-
-    await syncProjectMetadata({
-      dataSourceConfig,
-      connectorId,
-      projectId: configuration.projectId,
-      metadata: metadataResult.value.metadata,
-    });
-
-    localLogger.info(
-      { projectId: configuration.projectId },
-      "Successfully synced project metadata"
+    throw new Error(
+      `Failed to fetch project metadata: ${metadataResult.error.message}`
     );
-  } catch (error) {
-    localLogger.warn(
-      { error, projectId: configuration.projectId },
-      "Failed to sync project metadata"
-    );
-    // Don't throw - metadata sync failures shouldn't fail the parent sync
   }
+
+  const metadata = metadataResult.value.metadata;
+
+  if (!metadata) {
+    localLogger.info(
+      { projectId: configuration.projectId },
+      "No project metadata from API; skipping metadata upsert"
+    );
+    return;
+  }
+
+  const lastSyncedAtMs = configuration.lastSyncedAt?.getTime();
+  if (lastSyncedAtMs !== undefined && metadata.updatedAt < lastSyncedAtMs) {
+    localLogger.info(
+      {
+        projectId: configuration.projectId,
+        metadataUpdatedAt: metadata.updatedAt,
+        lastSyncedAt: configuration.lastSyncedAt,
+      },
+      "Skipping project metadata upsert (API metadata older than last full sync)"
+    );
+    return;
+  }
+
+  await syncProjectMetadata({
+    dataSourceConfig,
+    connectorId,
+    projectId: configuration.projectId,
+    metadata,
+  });
+
+  localLogger.info(
+    { projectId: configuration.projectId },
+    "Successfully synced project metadata"
+  );
+}
+
+/**
+ * Marks a successful dust_project sync run (conversations + metadata activities).
+ * Updates connector sync status via `syncSucceeded` and sets `lastSyncedAt` on the dust project configuration.
+ */
+export async function dustProjectMarkSyncedActivity({
+  connectorId,
+}: {
+  connectorId: ModelId;
+}): Promise<void> {
+  const configuration =
+    await DustProjectConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`Configuration not found for connector ${connectorId}`);
+  }
+
+  await syncSucceeded(connectorId);
+  await configuration.update({ lastSyncedAt: new Date() });
 }

--- a/connectors/src/connectors/dust_project/temporal/workflows.ts
+++ b/connectors/src/connectors/dust_project/temporal/workflows.ts
@@ -6,6 +6,7 @@ const {
   dustProjectConversationsFullSyncActivity,
   dustProjectConversationsIncrementalSyncActivity,
   dustProjectSyncMetadataActivity,
+  dustProjectMarkSyncedActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "60 minutes",
 });
@@ -34,6 +35,7 @@ export async function dustProjectFullSyncWorkflow({
 }): Promise<void> {
   await dustProjectConversationsFullSyncActivity({ connectorId });
   await dustProjectSyncMetadataActivity({ connectorId });
+  await dustProjectMarkSyncedActivity({ connectorId });
 }
 
 /**
@@ -47,4 +49,5 @@ export async function dustProjectIncrementalSyncWorkflow({
 }): Promise<void> {
   await dustProjectConversationsIncrementalSyncActivity({ connectorId });
   await dustProjectSyncMetadataActivity({ connectorId });
+  await dustProjectMarkSyncedActivity({ connectorId });
 }

--- a/connectors/src/lib/models/dust_project.ts
+++ b/connectors/src/lib/models/dust_project.ts
@@ -27,6 +27,7 @@ DustProjectConfigurationModel.init(
       allowNull: false,
       unique: true,
     },
+    // Last successful dust_project Temporal workflow (conversations + metadata); not conversation-only.
     lastSyncedAt: {
       type: DataTypes.DATE,
       allowNull: true,


### PR DESCRIPTION
## Description

Three fixes to the `dust_project` sync workflows.

**Fail on metadata sync errors** — metadata sync failures were silently swallowed (`catch` → log warn → return). Since metadata is critical to the project's searchability, failures now throw and let Temporal retry the workflow instead of silently succeeding.

**Use metadata's own `updatedAt` as the document timestamp** — the core document was indexed with `Date.now()` on every sync, making every run look like a fresh update regardless of actual changes. It now uses `metadata.updatedAt`, so the document timestamp accurately reflects when the project was last modified. Combined with a `lastSyncedAt` guard that skips the upsert when the metadata hasn't changed since the last full sync.

**Fix the incremental sync watermark** — `updatedSince` was passed as the raw `maxSourceUpdatedAt` timestamp. Since Front's filter is `updatedAt >= updatedSince` (inclusive), this re-fetched the most-recently-synced conversation on every incremental run. Passing `max + 1 ms` makes it strictly-after-max.

Also extracts `dustProjectMarkSyncedActivity` to cleanly separate "mark sync done" (`syncSucceeded` + `lastSyncedAt`) from the conversation and metadata activities, and calls it at the end of both full and incremental workflows.

## Tests

Local

## Risk

Medium — changes sync workflow sequencing and the metadata skip logic; rollback is safe (worst case: metadata re-syncs on next run)

## Deploy Plan

Migration, deploy `connectors`, monitor in prod.
