### PR TITLE
Project sync: split large conversations in multi docs.

### DIFF
--- a/connectors/migrations/db/migration_120.sql
+++ b/connectors/migrations/db/migration_120.sql
@@ -1,0 +1,4 @@
+-- Migration created on Apr 11, 2026
+-- Tracks how many data-source documents a synced conversation uses (1 = monolithic id, N>1 = base-part-1..N) for efficient delete.
+ALTER TABLE "public"."dust_project_conversations"
+ADD COLUMN "documentPartCount" INTEGER;

--- a/connectors/src/connectors/dust_project/lib/conversation_formatting.test.ts
+++ b/connectors/src/connectors/dust_project/lib/conversation_formatting.test.ts
@@ -1,0 +1,70 @@
+import type { ConversationPublicType } from "@dust-tt/client";
+import { describe, expect, it } from "vitest";
+
+import {
+  CONVERSATION_MESSAGES_PER_DOCUMENT,
+  chunkMessageSectionsForDocuments,
+  getConversationDocumentUpsertTitle,
+} from "./conversation_formatting";
+
+function minimalConversation(
+  overrides: Partial<ConversationPublicType>
+): ConversationPublicType {
+  return {
+    id: 1,
+    created: 0,
+    unread: false,
+    actionRequired: false,
+    owner: {} as ConversationPublicType["owner"],
+    sId: "conv-1",
+    title: "T",
+    visibility: "workspace",
+    content: [],
+    url: "https://example.com/c",
+    ...overrides,
+  };
+}
+
+describe("chunkMessageSectionsForDocuments", () => {
+  it("returns one empty chunk for no messages", () => {
+    expect(chunkMessageSectionsForDocuments([])).toEqual([[]]);
+  });
+
+  it("keeps a single chunk when under the limit", () => {
+    const sections = Array.from({ length: 10 }, (_, i) => ({
+      prefix: `${i}`,
+      content: "x",
+      sections: [] as [],
+    }));
+    const chunks = chunkMessageSectionsForDocuments(sections);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toHaveLength(10);
+  });
+
+  it(`splits at ${CONVERSATION_MESSAGES_PER_DOCUMENT} messages`, () => {
+    const n = CONVERSATION_MESSAGES_PER_DOCUMENT;
+    const sections = Array.from({ length: n + 1 }, (_, i) => ({
+      prefix: `${i}`,
+      content: "x",
+      sections: [] as [],
+    }));
+    const chunks = chunkMessageSectionsForDocuments(sections);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toHaveLength(n);
+    expect(chunks[1]).toHaveLength(1);
+  });
+});
+
+describe("getConversationDocumentUpsertTitle", () => {
+  it("has no suffix for a single document", () => {
+    const c = minimalConversation({ title: "Hello" });
+    expect(getConversationDocumentUpsertTitle(c, 1, 1)).toBe("Hello");
+  });
+
+  it("adds part suffix when split into multiple documents", () => {
+    const c = minimalConversation({ title: "Hello" });
+    expect(getConversationDocumentUpsertTitle(c, 2, 5)).toBe(
+      "Hello (part 2 of 5)"
+    );
+  });
+});

--- a/connectors/src/connectors/dust_project/lib/conversation_formatting.ts
+++ b/connectors/src/connectors/dust_project/lib/conversation_formatting.ts
@@ -5,22 +5,18 @@ import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types";
 import type { ConversationPublicType } from "@dust-tt/client";
 
+/** Max messages (user / agent / content_fragment) per Core document to avoid upsert size limits. */
+export const CONVERSATION_MESSAGES_PER_DOCUMENT = 256;
+
 /**
- * Formats raw conversation content into a plain text document section for data source upsert.
- * This creates a simple text representation suitable for indexing.
+ * Builds one document section per message (last version per rank) for indexing.
  */
-export async function formatConversationForUpsert({
-  dataSourceConfig,
-  conversation,
-}: {
-  dataSourceConfig: DataSourceConfig;
-  conversation: ConversationPublicType;
-}): Promise<CoreAPIDataSourceDocumentSection> {
-  // Convert conversation content to document sections
+export function buildConversationMessageSections(
+  conversation: ConversationPublicType
+): CoreAPIDataSourceDocumentSection[] {
   const messageSections: CoreAPIDataSourceDocumentSection[] = [];
 
   for (const versions of conversation.content) {
-    // Only take the last version of each rank
     const msg = versions[versions.length - 1];
 
     if (!msg) {
@@ -65,21 +61,97 @@ export async function formatConversationForUpsert({
     }
   }
 
+  return messageSections;
+}
+
+/**
+ * Splits message sections into chunks of at most {@link CONVERSATION_MESSAGES_PER_DOCUMENT} messages each.
+ * Empty conversations yield a single empty chunk so we still emit one document.
+ */
+export function chunkMessageSectionsForDocuments(
+  sections: CoreAPIDataSourceDocumentSection[]
+): CoreAPIDataSourceDocumentSection[][] {
+  const size = CONVERSATION_MESSAGES_PER_DOCUMENT;
+  if (sections.length === 0) {
+    return [[]];
+  }
+  const chunks: CoreAPIDataSourceDocumentSection[][] = [];
+  for (let i = 0; i < sections.length; i += size) {
+    chunks.push(sections.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Title for a Core document: base conversation title, with ` (part i of n)` when split across multiple documents.
+ */
+export function getConversationDocumentUpsertTitle(
+  conversation: ConversationPublicType,
+  partIndex: number,
+  totalParts: number
+): string {
+  const base = conversation.title || `Conversation ${conversation.sId}`;
+  if (totalParts <= 1) {
+    return base;
+  }
+  return `${base} (part ${partIndex} of ${totalParts})`;
+}
+
+/**
+ * Formats a slice of message sections into the Core document payload (title + metadata + sections).
+ */
+export async function formatConversationSectionsForUpsert({
+  dataSourceConfig,
+  conversation,
+  sections,
+  partIndex,
+  totalParts,
+}: {
+  dataSourceConfig: DataSourceConfig;
+  conversation: ConversationPublicType;
+  sections: CoreAPIDataSourceDocumentSection[];
+  partIndex: number;
+  totalParts: number;
+}): Promise<CoreAPIDataSourceDocumentSection> {
   const contentSection: CoreAPIDataSourceDocumentSection = {
-    // Create the main content section with all messages
     prefix: null,
     content: null,
-    sections: messageSections,
+    sections,
   };
 
-  // Use renderDocumentTitleAndContent to add metadata
+  const title = getConversationDocumentUpsertTitle(
+    conversation,
+    partIndex,
+    totalParts
+  );
+
   return renderDocumentTitleAndContent({
     dataSourceConfig,
-    title: conversation.title || `Conversation ${conversation.id}`,
+    title,
     createdAt: new Date(conversation.created),
     updatedAt: new Date(conversation.updated ?? conversation.created),
 
     content: contentSection,
+  });
+}
+
+/**
+ * Formats full conversation into a single document (used when chunking is not required by caller).
+ */
+export async function formatConversationForUpsert({
+  dataSourceConfig,
+  conversation,
+}: {
+  dataSourceConfig: DataSourceConfig;
+  conversation: ConversationPublicType;
+}): Promise<CoreAPIDataSourceDocumentSection> {
+  const sections = buildConversationMessageSections(conversation);
+  return formatConversationSectionsForUpsert({
+    dataSourceConfig,
+    conversation,
+    sections,
+    partIndex: 1,
+    totalParts: 1,
   });
 }
 
@@ -100,4 +172,14 @@ export function getConversationMessageInternalId(
   conversationId: string
 ): string {
   return `dust-project-${connectorId}-project-${projectId}-conversation-${conversationId}`;
+}
+
+/**
+ * Document id for a split conversation (part 1..N). Not used when the conversation fits in one document.
+ */
+export function getConversationPartDocumentInternalId(
+  baseConversationDocumentId: string,
+  partNumber: number
+): string {
+  return `${baseConversationDocumentId}-part-${partNumber}`;
 }

--- a/connectors/src/connectors/dust_project/lib/sync_conversation.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_conversation.ts
@@ -10,10 +10,43 @@ import { INTERNAL_MIME_TYPES } from "@connectors/types/shared/internal_mime_type
 import type { ConversationPublicType } from "@dust-tt/client";
 
 import {
-  formatConversationForUpsert,
+  buildConversationMessageSections,
+  chunkMessageSectionsForDocuments,
+  formatConversationSectionsForUpsert,
+  getConversationDocumentUpsertTitle,
   getConversationFolderInternalId,
   getConversationMessageInternalId,
+  getConversationPartDocumentInternalId,
 } from "./conversation_formatting";
+
+async function deleteConversationDocumentSafe(
+  dataSourceConfig: DataSourceConfig,
+  documentId: string,
+  loggerArgs: Record<string, string | number>
+): Promise<void> {
+  await deleteDataSourceDocument(dataSourceConfig, documentId, loggerArgs);
+}
+
+/**
+ * Best-effort DELETE for `base-part-{n}` with 1-based `n` in
+ * `[startPartIndex, startPartIndex + attemptCount)` (e.g. `1` + `previousParts` ⇒ parts `1…previousParts`).
+ */
+async function deletePartDocumentShardsBestEffort(
+  dataSourceConfig: DataSourceConfig,
+  baseDocumentId: string,
+  startPartIndex: number,
+  attemptCount: number,
+  loggerArgs: Record<string, string | number>
+): Promise<void> {
+  const endExclusive = startPartIndex + attemptCount;
+  for (let p = startPartIndex; p < endExclusive; p++) {
+    await deleteConversationDocumentSafe(
+      dataSourceConfig,
+      getConversationPartDocumentInternalId(baseDocumentId, p),
+      loggerArgs
+    );
+  }
+}
 
 /**
  * Deletes a conversation from the data source and database.
@@ -36,24 +69,34 @@ export async function deleteConversation({
   });
 
   try {
-    const messageInternalId = getConversationMessageInternalId(
+    const baseDocumentId = getConversationMessageInternalId(
       connectorId,
       projectId,
       conversationId
     );
 
-    // Delete from data source
-    await deleteDataSourceDocument(dataSourceConfig, messageInternalId, {
-      conversationId,
-      projectId,
-    });
-
-    // Delete from database
     const existingConversation =
       await DustProjectConversationResource.fetchByConnectorIdAndConversationId(
         connectorId,
         conversationId
       );
+
+    const storedParts = existingConversation?.documentPartCount ?? 1;
+
+    await deleteConversationDocumentSafe(dataSourceConfig, baseDocumentId, {
+      conversationId,
+      projectId,
+    });
+
+    if (storedParts > 1) {
+      await deletePartDocumentShardsBestEffort(
+        dataSourceConfig,
+        baseDocumentId,
+        1,
+        storedParts,
+        { conversationId, projectId }
+      );
+    }
 
     if (existingConversation) {
       await existingConversation.delete();
@@ -68,6 +111,9 @@ export async function deleteConversation({
 
 /**
  * Syncs a single conversation: formats it from raw content and upserts it to the data source.
+ * Large conversations are split into multiple documents (`conversation_formatting`). If this
+ * conversation was synced before, prior `base-part-*` shards are removed after the folder upsert
+ * so layout changes always replace split documents cleanly.
  * If the conversation is deleted (visibility === "deleted"), it will be removed from the data source.
  */
 export async function syncConversation({
@@ -89,7 +135,6 @@ export async function syncConversation({
     projectId,
   });
 
-  // If conversation is deleted, remove it from the data source
   if (conversation.visibility === "deleted") {
     await deleteConversation({
       connectorId,
@@ -105,24 +150,21 @@ export async function syncConversation({
   );
 
   try {
-    // Format conversation for upsert (converts raw content to plain text)
-    const documentContent = await formatConversationForUpsert({
-      dataSourceConfig,
-      conversation,
-    });
+    const messageSections = buildConversationMessageSections(conversation);
+    const chunks = chunkMessageSectionsForDocuments(messageSections);
+    const totalParts = chunks.length;
 
-    // Generate internal IDs
-    const folderInternalId = getConversationFolderInternalId(
-      connectorId,
-      projectId
-    );
-    const messageInternalId = getConversationMessageInternalId(
+    const baseDocumentId = getConversationMessageInternalId(
       connectorId,
       projectId,
       conversation.sId
     );
 
-    // Ensure folder exists (idempotent)
+    const folderInternalId = getConversationFolderInternalId(
+      connectorId,
+      projectId
+    );
+
     await upsertDataSourceFolder({
       dataSourceConfig,
       folderId: folderInternalId,
@@ -132,40 +174,110 @@ export async function syncConversation({
       mimeType: INTERNAL_MIME_TYPES.DUST_PROJECT.CONVERSATION_FOLDER,
     });
 
-    // Upsert conversation document
-    await upsertDataSourceDocument({
-      dataSourceConfig,
-      documentId: messageInternalId,
-      documentContent,
-      timestampMs: conversation.updated ?? conversation.created,
-      tags: [`project:${projectId}`, `conversation:${conversation.sId}`],
-      documentUrl: conversation.url,
-      parents: [messageInternalId, folderInternalId],
-      parentId: folderInternalId,
-      upsertContext: {
-        sync_type: syncType,
-      },
-      title: conversation.title || `Conversation ${conversation.sId}`,
-      mimeType: INTERNAL_MIME_TYPES.DUST_PROJECT.CONVERSATION_MESSAGES,
-      async: true,
-      loggerArgs: {
-        conversationId: conversation.sId,
-        projectId,
-      },
-    });
-
-    // Update or insert conversation record
-
     const existingConversation =
       await DustProjectConversationResource.fetchByConnectorIdAndConversationId(
         connectorId,
         conversation.sId
       );
 
+    // Clean up existing conversation documents if they exist
+    if (existingConversation) {
+      const storedParts = existingConversation?.documentPartCount ?? 1;
+
+      await deleteConversationDocumentSafe(dataSourceConfig, baseDocumentId, {
+        conversationId: conversation.sId,
+        projectId,
+      });
+
+      if (storedParts > 1) {
+        await deletePartDocumentShardsBestEffort(
+          dataSourceConfig,
+          baseDocumentId,
+          1,
+          storedParts,
+          { conversationId: conversation.sId, projectId }
+        );
+      }
+    }
+
+    if (totalParts === 1) {
+      const documentContent = await formatConversationSectionsForUpsert({
+        dataSourceConfig,
+        conversation,
+        sections: chunks[0] ?? [],
+        partIndex: 1,
+        totalParts: 1,
+      });
+
+      await upsertDataSourceDocument({
+        dataSourceConfig,
+        documentId: baseDocumentId,
+        documentContent,
+        timestampMs: conversation.updated ?? conversation.created,
+        tags: [`project:${projectId}`, `conversation:${conversation.sId}`],
+        documentUrl: conversation.url,
+        parents: [baseDocumentId, folderInternalId],
+        parentId: folderInternalId,
+        upsertContext: {
+          sync_type: syncType,
+        },
+        title: getConversationDocumentUpsertTitle(conversation, 1, 1),
+        mimeType: INTERNAL_MIME_TYPES.DUST_PROJECT.CONVERSATION_MESSAGES,
+        async: true,
+        loggerArgs: {
+          conversationId: conversation.sId,
+          projectId,
+        },
+      });
+    } else {
+      for (let i = 0; i < totalParts; i++) {
+        const partIndex = i + 1;
+        const partDocumentId = getConversationPartDocumentInternalId(
+          baseDocumentId,
+          partIndex
+        );
+        const documentContent = await formatConversationSectionsForUpsert({
+          dataSourceConfig,
+          conversation,
+          sections: chunks[i] ?? [],
+          partIndex,
+          totalParts,
+        });
+
+        await upsertDataSourceDocument({
+          dataSourceConfig,
+          documentId: partDocumentId,
+          documentContent,
+          timestampMs: conversation.updated ?? conversation.created,
+          tags: [`project:${projectId}`, `conversation:${conversation.sId}`],
+          documentUrl: conversation.url,
+          parents: [partDocumentId, folderInternalId],
+          parentId: folderInternalId,
+          upsertContext: {
+            sync_type: syncType,
+          },
+          title: getConversationDocumentUpsertTitle(
+            conversation,
+            partIndex,
+            totalParts
+          ),
+          mimeType: INTERNAL_MIME_TYPES.DUST_PROJECT.CONVERSATION_MESSAGES,
+          async: true,
+          loggerArgs: {
+            conversationId: conversation.sId,
+            projectId,
+            partIndex,
+            totalParts,
+          },
+        });
+      }
+    }
+
     if (existingConversation) {
       await existingConversation.update({
         lastSyncedAt: new Date(),
         sourceUpdatedAt,
+        documentPartCount: totalParts,
       });
     } else {
       await DustProjectConversationResource.makeNew({
@@ -173,10 +285,11 @@ export async function syncConversation({
         conversationId: conversation.sId,
         projectId,
         sourceUpdatedAt,
+        documentPartCount: totalParts,
       });
     }
 
-    localLogger.info("Successfully synced conversation");
+    localLogger.info({ totalParts }, "Successfully synced conversation");
   } catch (error) {
     localLogger.error({ error }, "Failed to sync conversation");
     throw error;

--- a/connectors/src/lib/models/dust_project.ts
+++ b/connectors/src/lib/models/dust_project.ts
@@ -50,6 +50,8 @@ export class DustProjectConversationModel extends ConnectorBaseModel<DustProject
   declare projectId: string;
   declare lastSyncedAt: CreationOptional<Date | null>;
   declare sourceUpdatedAt: Date;
+  /** 1 = monolithic document id; N > 1 = base-part-1 … base-part-N. Null for rows synced before this column existed. */
+  declare documentPartCount: CreationOptional<number | null>;
 }
 
 DustProjectConversationModel.init(
@@ -80,6 +82,10 @@ DustProjectConversationModel.init(
     sourceUpdatedAt: {
       type: DataTypes.DATE,
       allowNull: false,
+    },
+    documentPartCount: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
   },
   {

--- a/connectors/src/resources/dust_project_conversation_resource.ts
+++ b/connectors/src/resources/dust_project_conversation_resource.ts
@@ -36,12 +36,14 @@ export class DustProjectConversationResource extends BaseResource<DustProjectCon
     conversationId,
     projectId,
     sourceUpdatedAt,
+    documentPartCount,
     transaction,
   }: {
     connectorId: ModelId;
     conversationId: string;
     projectId: string;
     sourceUpdatedAt: Date;
+    documentPartCount: number;
     transaction?: Transaction;
   }): Promise<DustProjectConversationResource> {
     const model = await DustProjectConversationModel.create(
@@ -50,6 +52,7 @@ export class DustProjectConversationResource extends BaseResource<DustProjectCon
         conversationId,
         projectId,
         sourceUpdatedAt,
+        documentPartCount,
       },
       { transaction }
     );
@@ -189,6 +192,7 @@ export class DustProjectConversationResource extends BaseResource<DustProjectCon
       projectId: this.projectId,
       lastSyncedAt: this.lastSyncedAt,
       sourceUpdatedAt: this.sourceUpdatedAt,
+      documentPartCount: this.documentPartCount,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };


### PR DESCRIPTION
## Description

Core has a document upsert size limit. Long project conversations can exceed it and cause sync failures. Splitting large conversations into multiple smaller documents avoids the limit and also improves retrieval precision (smaller chunks rank better).

- Add `CONVERSATION_MESSAGES_PER_DOCUMENT = 256` constant
- Extract `buildConversationMessageSections` (pure, sync) and add `chunkMessageSectionsForDocuments` to split sections into chunks
- Add `formatConversationSectionsForUpsert` taking a pre-built slice + `partIndex`/`totalParts`; old `formatConversationForUpsert` becomes a thin wrapper for the single-doc case
- Add `getConversationPartDocumentInternalId` for `{base}-part-{n}` document IDs, and `getConversationDocumentUpsertTitle` that appends `(part i of n)` when split
- In `sync_conversation`: upsert one Core document per chunk; delete stale shards when part count shrinks (best-effort range delete)
- Add `documentPartCount` to `DustProjectConversation` to track the number of parts per conversation for efficient cleanup
- DB migration: add `documentPartCount` column to `dust_project_conversations`
- Add tests for `chunkMessageSectionsForDocuments` and `getConversationDocumentUpsertTitle`

## Tests

Local + green (new tests added)

## Risk

Medium — changes document IDs for split conversations; existing single-doc conversations are unaffected (part count = 1 uses the base document id)

## Deploy Plan

Run migration, deploy `connectors`, monitor in prod.
