### PR TITLE
Fix: small issue with project renaming

### DIFF
--- a/front/components/assistant/conversation/EditProjectTitleDialog.tsx
+++ b/front/components/assistant/conversation/EditProjectTitleDialog.tsx
@@ -114,7 +114,6 @@ export const EditProjectTitleDialog = ({
               if (e.key === "Enter") {
                 e.preventDefault();
                 void editTitle();
-                onClose();
               }
             }}
           />

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -200,7 +200,8 @@ export function ProjectMenu({
     ((isMember && !isProjectEditor) || // regular members can leave the project
       (isProjectEditor && projectEditors.length > 1)) && // editors can leave if there's at least another editor
     isProject;
-  const canRename = spaceInfo?.canWrite ?? false; // Only admins can rename
+  // Must match PATCH /spaces/[spaceId] (canAdministrate). canWrite is true for project members too.
+  const canRename = spaceInfo?.isEditor ?? false;
 
   return (
     <div


### PR DESCRIPTION
## Description

Two small fixes to the project rename flow.

- `canRename` was using `canWrite` which is true for all project members, not just admins. It now uses `isEditor` to match the actual PATCH `/spaces/[spaceId]` permission check (`canAdministrate`)
- Pressing Enter in the rename input was calling `onClose()` before the async `editTitle()` completed, dismissing the dialog before the rename was saved

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`
