### PR TITLE
Add compaction workflow scaffold on agent loop queue

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2579,16 +2579,18 @@ export async function isConversationEventAllowedForAuth(
   }
 }
 
-export async function updateCompactionMessageWithFinalStatus(
+export async function updateCompactionMessageWithContentAndFinalStatus(
   auth: Authenticator,
   {
     conversation,
     compactionMessage,
     status,
+    content,
   }: {
     conversation: ConversationWithoutContentType;
     compactionMessage: CompactionMessageType;
     status: "succeeded" | "failed";
+    content: string;
   }
 ): Promise<{
   completedTs: number;
@@ -2596,7 +2598,7 @@ export async function updateCompactionMessageWithFinalStatus(
 }> {
   const completedAt = new Date();
 
-  // TODO(compaction): implement (with proper locking)
+  // TODO(compaction): implement update to CompactionMessage (with proper locking)
 
   return {
     completedTs: completedAt.getTime(),

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -109,6 +109,7 @@ import type {
   AgentMessageType,
   AgentMessageTypeWithoutMentions,
   CitationType,
+  CompactionMessageType,
   ConversationMetadata,
   ConversationType,
   ConversationVisibility,
@@ -2576,6 +2577,31 @@ export async function isConversationEventAllowedForAuth(
     default:
       assertNever(type);
   }
+}
+
+export async function updateCompactionMessageWithFinalStatus(
+  auth: Authenticator,
+  {
+    conversation,
+    compactionMessage,
+    status,
+  }: {
+    conversation: ConversationWithoutContentType;
+    compactionMessage: CompactionMessageType;
+    status: "succeeded" | "failed";
+  }
+): Promise<{
+  completedTs: number;
+  status: "succeeded" | "failed";
+}> {
+  const completedAt = new Date();
+
+  // TODO(compaction): implement (with proper locking)
+
+  return {
+    completedTs: completedAt.getTime(),
+    status: "succeeded",
+  };
 }
 
 /**

--- a/front/lib/api/assistant/conversation/compaction.ts
+++ b/front/lib/api/assistant/conversation/compaction.ts
@@ -1,0 +1,74 @@
+import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
+import {
+  CompactionMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import logger from "@app/logger/logger";
+
+export async function runCompaction(
+  authType: AuthenticatorType,
+  {
+    conversationId,
+    compactionMessageId,
+    compactionMessageVersion,
+  }: {
+    conversationId: string;
+    compactionMessageId: string;
+    compactionMessageVersion: number;
+  }
+): Promise<void> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    throw new Error(
+      `Failed to deserialize authenticator: ${authResult.error.code}`
+    );
+  }
+
+  const auth = authResult.value;
+  const workspaceId = auth.getNonNullableWorkspace().id;
+
+  const message = await MessageModel.findOne({
+    where: {
+      sId: compactionMessageId,
+      version: compactionMessageVersion,
+      workspaceId,
+    },
+    include: [
+      {
+        model: CompactionMessageModel,
+        as: "compactionMessage",
+        required: true,
+      },
+    ],
+  });
+
+  if (!message?.compactionMessage) {
+    throw new Error(
+      `Compaction message not found for message ${compactionMessageId} (workspace=${workspaceId}, conversation=${conversationId})`
+    );
+  }
+
+  const compactionMessage = message.compactionMessage;
+
+  try {
+    // TODO(compaction): implement actual compaction (fetch messages, call LLM, generate summary).
+    await compactionMessage.update({
+      status: "succeeded",
+      content: "[COMPACTION]",
+    });
+
+    logger.info(
+      { workspaceId, conversationId, compactionMessageId },
+      "Compaction completed"
+    );
+  } catch (error) {
+    await compactionMessage.update({ status: "failed" });
+
+    logger.error(
+      { workspaceId, conversationId, compactionMessageId, error },
+      "Compaction failed"
+    );
+
+    throw error;
+  }
+}

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -7,6 +7,7 @@ export type DustErrorCode =
   | "file_not_found"
   | "unauthorized"
   | "agent_loop_already_running"
+  | "compaction_already_running"
   | "data_source_not_found"
   | "data_source_view_not_found"
   | "space_not_found"

--- a/front/temporal/agent_loop/activities/compaction.ts
+++ b/front/temporal/agent_loop/activities/compaction.ts
@@ -1,5 +1,5 @@
-import { runCompaction } from "@app/temporal/agent_loop/lib/compaction";
 import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
+import { runCompaction } from "@app/temporal/agent_loop/lib/compaction";
 
 export async function compactionActivity(
   authType: AuthenticatorType,
@@ -21,9 +21,13 @@ export async function compactionActivity(
   }
   const auth = authResult.value;
 
-  await runCompaction(auth, {
+  const compactionRes = await runCompaction(auth, {
     conversationId,
     compactionMessageId,
     compactionMessageVersion,
   });
+
+  if (compactionRes.isErr()) {
+    throw new Error(`Compaction failed: ${compactionRes.error}`);
+  }
 }

--- a/front/temporal/agent_loop/activities/compaction.ts
+++ b/front/temporal/agent_loop/activities/compaction.ts
@@ -1,5 +1,5 @@
-import { runCompaction } from "@app/lib/api/assistant/conversation/compaction";
-import type { AuthenticatorType } from "@app/lib/auth";
+import { runCompaction } from "@app/temporal/agent_loop/lib/compaction";
+import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
 
 export async function compactionActivity(
   authType: AuthenticatorType,
@@ -13,7 +13,15 @@ export async function compactionActivity(
     compactionMessageVersion: number;
   }
 ): Promise<void> {
-  await runCompaction(authType, {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    throw new Error(
+      `Failed to deserialize authenticator: ${authResult.error.code}`
+    );
+  }
+  const auth = authResult.value;
+
+  await runCompaction(auth, {
     conversationId,
     compactionMessageId,
     compactionMessageVersion,

--- a/front/temporal/agent_loop/activities/compaction.ts
+++ b/front/temporal/agent_loop/activities/compaction.ts
@@ -1,0 +1,21 @@
+import { runCompaction } from "@app/lib/api/assistant/conversation/compaction";
+import type { AuthenticatorType } from "@app/lib/auth";
+
+export async function compactionActivity(
+  authType: AuthenticatorType,
+  {
+    conversationId,
+    compactionMessageId,
+    compactionMessageVersion,
+  }: {
+    conversationId: string;
+    compactionMessageId: string;
+    compactionMessageVersion: number;
+  }
+): Promise<void> {
+  await runCompaction(authType, {
+    conversationId,
+    compactionMessageId,
+    compactionMessageVersion,
+  });
+}

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -123,7 +123,7 @@ export async function launchCompactionWorkflow({
   conversationId: string;
   compactionMessageId: string;
   compactionMessageVersion: number;
-}): Promise<Result<undefined, Error>> {
+}): Promise<Result<undefined, Error | DustError<"compaction_already_running">>> {
   const authType = auth.toJSON();
   const client = await getTemporalClientForAgentNamespace();
 
@@ -164,7 +164,12 @@ export async function launchCompactionWorkflow({
       "Compaction workflow already running for this conversation."
     );
 
-    return new Err(new Error("Compaction workflow already running."));
+    return new Err(
+      new DustError(
+        "compaction_already_running",
+        "Compaction workflow already running for this conversation."
+      )
+    );
   }
 
   return new Ok(undefined);

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -4,7 +4,10 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { logAgentLoopStart } from "@app/temporal/agent_loop/activities/instrumentation";
-import { makeAgentLoopWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
+import {
+  makeAgentLoopWorkflowId,
+  makeCompactionWorkflowId,
+} from "@app/temporal/agent_loop/lib/workflow_ids";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -12,7 +15,7 @@ import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
 import assert from "assert";
 
 import { QUEUE_NAME } from "./config";
-import { agentLoopWorkflow } from "./workflows";
+import { agentLoopWorkflow, compactionWorkflow } from "./workflows";
 
 export async function launchAgentLoopWorkflow({
   auth,
@@ -105,6 +108,63 @@ export async function launchAgentLoopWorkflow({
         "Agent loop already running for this message."
       )
     );
+  }
+
+  return new Ok(undefined);
+}
+
+export async function launchCompactionWorkflow({
+  auth,
+  conversationId,
+  compactionMessageId,
+  compactionMessageVersion,
+}: {
+  auth: Authenticator;
+  conversationId: string;
+  compactionMessageId: string;
+  compactionMessageVersion: number;
+}): Promise<Result<undefined, Error>> {
+  const authType = auth.toJSON();
+  const client = await getTemporalClientForAgentNamespace();
+
+  assert(authType.workspaceId, "Workspace ID is required");
+  const workflowId = makeCompactionWorkflowId({
+    workspaceId: authType.workspaceId,
+    conversationId,
+  });
+
+  try {
+    await client.workflow.start(compactionWorkflow, {
+      args: [
+        {
+          authType,
+          conversationId,
+          compactionMessageId,
+          compactionMessageVersion,
+        },
+      ],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      searchAttributes: {
+        conversationId: [conversationId],
+        workspaceId: authType.workspaceId ? [authType.workspaceId] : undefined,
+      },
+      memo: {
+        conversationId,
+        workspaceId: authType.workspaceId,
+      },
+    });
+  } catch (error) {
+    if (!(error instanceof WorkflowExecutionAlreadyStartedError)) {
+      throw error;
+    }
+
+    logger.warn(
+      { workflowId, workspaceId: authType.workspaceId },
+      "Compaction workflow already running for this conversation."
+    );
+
+    return new Err(new Error("Compaction workflow already running."));
   }
 
   return new Ok(undefined);

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -123,7 +123,9 @@ export async function launchCompactionWorkflow({
   conversationId: string;
   compactionMessageId: string;
   compactionMessageVersion: number;
-}): Promise<Result<undefined, Error | DustError<"compaction_already_running">>> {
+}): Promise<
+  Result<undefined, Error | DustError<"compaction_already_running">>
+> {
   const authType = auth.toJSON();
   const client = await getTemporalClientForAgentNamespace();
 

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -1,4 +1,4 @@
-import { updateCompactionMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
+import { updateCompactionMessageWithContentAndFinalStatus } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
 import type { Authenticator } from "@app/lib/auth";
@@ -61,14 +61,17 @@ export async function runCompaction(
   }
 
   // TODO(compaction): implement actual compaction
+  const content = "[COMPACTION]";
 
-  const result = await updateCompactionMessageWithFinalStatus(auth, {
+  const result = await updateCompactionMessageWithContentAndFinalStatus(auth, {
     conversation,
     compactionMessage,
     status: "succeeded",
+    content,
   });
 
   compactionMessage.status = result.status;
+  compactionMessage.content = content;
 
   logger.info(
     { workspaceId: owner.sId, conversationId, compactionMessageId },

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -1,4 +1,4 @@
-import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
+import {Authenticator, type AuthenticatorType} from "@app/lib/auth";
 import {
   CompactionMessageModel,
   MessageModel,
@@ -6,7 +6,7 @@ import {
 import logger from "@app/logger/logger";
 
 export async function runCompaction(
-  authType: AuthenticatorType,
+  auth: Authenticator,
   {
     conversationId,
     compactionMessageId,
@@ -17,21 +17,13 @@ export async function runCompaction(
     compactionMessageVersion: number;
   }
 ): Promise<void> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    throw new Error(
-      `Failed to deserialize authenticator: ${authResult.error.code}`
-    );
-  }
-
-  const auth = authResult.value;
-  const workspaceId = auth.getNonNullableWorkspace().id;
+  const owner = auth.getNonNullableWorkspace();
 
   const message = await MessageModel.findOne({
     where: {
       sId: compactionMessageId,
       version: compactionMessageVersion,
-      workspaceId,
+      workspaceId: owner.id,
     },
     include: [
       {
@@ -44,7 +36,7 @@ export async function runCompaction(
 
   if (!message?.compactionMessage) {
     throw new Error(
-      `Compaction message not found for message ${compactionMessageId} (workspace=${workspaceId}, conversation=${conversationId})`
+      `Compaction message not found for message ${compactionMessageId} (workspace=${owner.sId}, conversation=${conversationId})`
     );
   }
 
@@ -58,14 +50,14 @@ export async function runCompaction(
     });
 
     logger.info(
-      { workspaceId, conversationId, compactionMessageId },
+      {workspaceId: owner.sId, conversationId, compactionMessageId},
       "Compaction completed"
     );
   } catch (error) {
-    await compactionMessage.update({ status: "failed" });
+    await compactionMessage.update({status: "failed"});
 
     logger.error(
-      { workspaceId, conversationId, compactionMessageId, error },
+      {workspaceId: owner.sId, conversationId, compactionMessageId, error},
       "Compaction failed"
     );
 

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -1,9 +1,14 @@
-import {Authenticator, type AuthenticatorType} from "@app/lib/auth";
-import {
-  CompactionMessageModel,
-  MessageModel,
-} from "@app/lib/models/agent/conversation";
+import { updateCompactionMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
+import {
+  type CompactionMessageType,
+  isCompactionMessageType,
+} from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 export async function runCompaction(
   auth: Authenticator,
@@ -16,51 +21,59 @@ export async function runCompaction(
     compactionMessageId: string;
     compactionMessageVersion: number;
   }
-): Promise<void> {
+): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const message = await MessageModel.findOne({
-    where: {
-      sId: compactionMessageId,
-      version: compactionMessageVersion,
-      workspaceId: owner.id,
-    },
-    include: [
-      {
-        model: CompactionMessageModel,
-        as: "compactionMessage",
-        required: true,
-      },
-    ],
+  const conversationRes = await getConversation(
+    auth,
+    conversationId,
+    false,
+    null,
+    PREVIOUS_INTERACTIONS_TO_PRESERVE + 1 // X previous + the last one
+  );
+  if (conversationRes.isErr()) {
+    return conversationRes;
+  }
+  const conversation = conversationRes.value;
+
+  let compactionMessage: CompactionMessageType | undefined;
+
+  for (
+    let i = conversation.content.length - 1;
+    i >= 0 && !compactionMessage;
+    i--
+  ) {
+    const messageGroup = conversation.content[i];
+    for (const msg of messageGroup) {
+      if (
+        isCompactionMessageType(msg) &&
+        msg.sId === compactionMessageId &&
+        msg.version === compactionMessageVersion
+      ) {
+        compactionMessage = msg;
+        break;
+      }
+    }
+  }
+
+  if (!compactionMessage) {
+    return new Err(new Error("Compaction message not found"));
+  }
+
+  // TODO(compaction): implement actual compaction
+
+  const result = await updateCompactionMessageWithFinalStatus(auth, {
+    conversation,
+    compactionMessage,
+    status: "succeeded",
   });
 
-  if (!message?.compactionMessage) {
-    throw new Error(
-      `Compaction message not found for message ${compactionMessageId} (workspace=${owner.sId}, conversation=${conversationId})`
-    );
-  }
+  compactionMessage.status = result.status;
 
-  const compactionMessage = message.compactionMessage;
+  logger.info(
+    { workspaceId: owner.sId, conversationId, compactionMessageId },
+    "Compaction completed"
+  );
 
-  try {
-    // TODO(compaction): implement actual compaction (fetch messages, call LLM, generate summary).
-    await compactionMessage.update({
-      status: "succeeded",
-      content: "[COMPACTION]",
-    });
-
-    logger.info(
-      {workspaceId: owner.sId, conversationId, compactionMessageId},
-      "Compaction completed"
-    );
-  } catch (error) {
-    await compactionMessage.update({status: "failed"});
-
-    logger.error(
-      {workspaceId: owner.sId, conversationId, compactionMessageId, error},
-      "Compaction failed"
-    );
-
-    throw error;
-  }
+  return new Ok(undefined);
 }

--- a/front/temporal/agent_loop/lib/workflow_ids.ts
+++ b/front/temporal/agent_loop/lib/workflow_ids.ts
@@ -13,6 +13,16 @@ export function makeAgentLoopWorkflowId({
   return `agent-loop-workflow-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
 
+export function makeCompactionWorkflowId({
+  workspaceId,
+  conversationId,
+}: {
+  workspaceId: string;
+  conversationId: string;
+}) {
+  return `compaction-workflow-${workspaceId}-${conversationId}`;
+}
+
 export function makeAgentLoopConversationTitleWorkflowId(
   authType: AuthenticatorType,
   runAgentArgs: AgentLoopArgs

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -6,6 +6,7 @@ import { NoopSpanExporter } from "@app/lib/api/instrumentation/noop_span_exporte
 import { getTemporalAgentWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
+import { compactionActivity } from "@app/temporal/agent_loop/activities/compaction";
 import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import {
   finalizeCancelledAgentLoopActivity,
@@ -47,6 +48,7 @@ export async function runAgentLoopWorker() {
       getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities: {
+      compactionActivity,
       ensureConversationTitleActivity,
       finalizeSuccessfulAgentLoopActivity,
       finalizeGracefullyStoppedAgentLoopActivity,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -4,6 +4,7 @@ import {
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
 import type { AuthenticatorType } from "@app/lib/auth";
+import type * as compactionActivities from "@app/temporal/agent_loop/activities/compaction";
 import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import type * as finalizeActivities from "@app/temporal/agent_loop/activities/finalize";
 import type * as publishDeferredEventsActivities from "@app/temporal/agent_loop/activities/publish_deferred_events";
@@ -106,6 +107,13 @@ const { ensureConversationTitleActivity } = proxyActivities<
   },
 });
 
+const { compactionActivity } = proxyActivities<typeof compactionActivities>({
+  startToCloseTimeout: "5 minutes",
+  retry: {
+    maximumAttempts: 3,
+  },
+});
+
 const {
   finalizeSuccessfulAgentLoopActivity,
   finalizeGracefullyStoppedAgentLoopActivity,
@@ -123,6 +131,24 @@ export async function agentLoopConversationTitleWorkflow({
   agentLoopArgs: AgentLoopArgs;
 }) {
   await ensureConversationTitleActivity(authType, agentLoopArgs);
+}
+
+export async function compactionWorkflow({
+  authType,
+  conversationId,
+  compactionMessageId,
+  compactionMessageVersion,
+}: {
+  authType: AuthenticatorType;
+  conversationId: string;
+  compactionMessageId: string;
+  compactionMessageVersion: number;
+}) {
+  await compactionActivity(authType, {
+    conversationId,
+    compactionMessageId,
+    compactionMessageVersion,
+  });
 }
 
 export async function agentLoopWorkflow({

--- a/x/spolu/compaction/compaction.md
+++ b/x/spolu/compaction/compaction.md
@@ -29,7 +29,7 @@ Four parts:
    conversation when compaction is completed.
 2. **Token consumption evaluation** — using the LLM's reported token usage from the last agent
    message to determine when compaction should trigger, and surfacing it client-side.
-3. **Compaction method** — a new `compactConversation` method in `conversation.ts` that triggers
+3. **Compaction method** — a new `compaction` method in `conversation.ts` that triggers
    compaction through Temporal.
 4. **Blocking during compaction** — preventing `postUserMessage` while compaction is in progress,
    similar to steering's pending message mechanism.
@@ -229,14 +229,14 @@ usage report, resolved on-the-fly from the existing run data.
 
 ## Part 3: Compaction Method
 
-### `compactConversation` in `conversation.ts`
+### `compaction` in `conversation.ts`
 
 A new method in `front/lib/api/assistant/conversation.ts` that orchestrates compaction through
 Temporal, following the same patterns as `postUserMessage` and
 `updateAgentMessageWithFinalStatus`:
 
 ```typescript
-export async function compactConversation(
+export async function compaction(
   auth: Authenticator,
   {
     conversation,
@@ -251,7 +251,7 @@ export async function compactConversation(
 1. Acquire the conversation advisory lock (`getConversationRankVersionLock`).
 2. Create a `CompactionMessage` with `status: "created"` and `content: null`. This immediately
    signals to the rest of the system that compaction is in progress.
-3. Launch a Temporal workflow (`compactConversationWorkflow`) that:
+3. Launch a Temporal workflow (`compactionWorkflow`) that:
    a. Reads all messages before the compaction message (or since the last succeeded compaction).
    b. Renders them into a compaction prompt.
    c. Calls an LLM to generate the summary.
@@ -273,7 +273,7 @@ Reasons for a separate workflow (vs inline in finalization):
 - It's independently retryable if the LLM call fails.
 - It cleanly separates the agent loop lifecycle from compaction lifecycle.
 
-The workflow is initially triggered from `compactConversation()` in `conversation.ts` (called by
+The workflow is initially triggered from `compaction()` in `conversation.ts` (called by
 the API endpoint). In the future it could also be triggered directly from the agent loop
 finalization path when context usage exceeds the compaction threshold, similar to how the title
 workflow is spawned as a child workflow after the first step.
@@ -379,10 +379,10 @@ arriving _after_ the context window has been exceeded.
 
 | # | Work | Notes |
 |---|------|-------|
-| 5 | Add `compactConversation` in `conversation.ts` | Advisory lock, create `CompactionMessage` with `status: "created"`, launch Temporal workflow |
+| 5 | Add `compaction` in `conversation.ts` | Advisory lock, create `CompactionMessage` with `status: "created"`, launch Temporal workflow |
 | 6 | Block `postUserMessage` when a `CompactionMessage` with `status: "created"` exists | Return 409, following steering pattern |
 | 7 | Add `CompactionMessageNewEvent` / `CompactionMessageDoneEvent` SSE events | Mirrors `AgentMessageNewEvent` / `AgentMessageDoneEvent` pattern |
-| 8 | Implement `compactConversationWorkflow` Temporal workflow | Read messages, call LLM, update `CompactionMessage` with content + `status: "succeeded"` |
+| 8 | Implement `compactionWorkflow` Temporal workflow | Read messages, call LLM, update `CompactionMessage` with content + `status: "succeeded"` |
 | 9 | Implement compaction summary generation prompt | LLM call with compaction prompt (adapt from Claude Code's approach) |
 
 ### Phase 3: Rendering, API & Pruning

--- a/x/spolu/compaction/compaction.md
+++ b/x/spolu/compaction/compaction.md
@@ -262,15 +262,21 @@ export async function compactConversation(
 
 ### Temporal Workflow
 
-The compaction runs as a separate Temporal workflow (not inline in the agent loop finalization)
-because:
+The compaction runs as a separate Temporal workflow on the **agent loop queue**
+(`agent-loop-queue-v2` in the `agent` namespace), collocated with the agent loop code under
+`front/temporal/agent_loop/`. This is similar to how `agentLoopConversationTitleWorkflow` lives
+alongside the main agent loop.
+
+Reasons for a separate workflow (vs inline in finalization):
 
 - Summary generation is an LLM call that can take 10-30s — too long to block finalization.
 - It's independently retryable if the LLM call fails.
 - It cleanly separates the agent loop lifecycle from compaction lifecycle.
 
-The workflow is triggered from the agent loop finalization path when the threshold is crossed, or
-could be triggered manually via an API endpoint.
+The workflow is initially triggered from `compactConversation()` in `conversation.ts` (called by
+the API endpoint). In the future it could also be triggered directly from the agent loop
+finalization path when context usage exceeds the compaction threshold, similar to how the title
+workflow is spawned as a child workflow after the first step.
 
 ---
 

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -79,19 +79,19 @@ PR #24086.
 
 Build the compaction pipeline end-to-end. No feature flag needed — inert until Phase 5 provides a trigger.
 
-### - [ ] PR 3.1 — Add compaction Temporal workflow skeleton
+### - [x] PR 3.1 — Add compaction Temporal workflow skeleton
 
-Infrastructure only — workflow, activity, client. No trigger yet. Collocated with the agent loop.
+PR #24104. Collocated with the agent loop on `agent-loop-queue-v2`.
 
-- Add `compactionWorkflow` in `front/temporal/agent_loop/workflows.ts` (alongside
-  `agentLoopConversationTitleWorkflow`). Calls a single activity.
-- Add `compactionActivity` stub in a new file under
-  `front/temporal/agent_loop/activities/` (reads messages, returns placeholder content for now).
-- Add `launchCompactConversationWorkflow()` client in `front/temporal/agent_loop/client.ts`
-  (deterministic workflow ID from conversationId, fire-and-forget, handle
-  `WorkflowExecutionAlreadyStartedError`).
-- Runs on the existing agent loop queue (`agent-loop-queue-v2`, `agent` namespace). No new worker
-  or queue needed. Register the activity in the existing agent loop worker.
+- `compactionWorkflow` in `workflows.ts` — single-activity workflow.
+- `compactionActivity` in `activities/compaction.ts` — thin wrapper, delegates to `runCompaction`.
+- `runCompaction` in `temporal/agent_loop/lib/compaction.ts` — fetches conversation, finds the
+  `CompactionMessageType` by sId+version, calls `updateCompactionMessageWithContentAndFinalStatus`
+  (stub sets content to `[COMPACTION]`).
+- `launchCompactionWorkflow` in `client.ts` — fire-and-forget, `DustError` on already-running.
+- `updateCompactionMessageWithContentAndFinalStatus` in `conversation.ts` — TODO: implement with
+  proper locking.
+- Activity registered in `worker.ts`.
 
 ### - [ ] PR 3.2 — Add SSE events for compaction lifecycle
 
@@ -114,13 +114,12 @@ Core orchestration. No feature flag needed — compaction is inert until Phase 5
   - Create `CompactionMessage` with `status: "created"`, `content: null`.
   - Publish `CompactionMessageNewEvent`.
   - Launch `compactionWorkflow` (fire-and-forget).
+- Implement `updateCompactionMessageWithContentAndFinalStatus` in `conversation.ts` (currently a
+  stub from PR 3.1): acquire advisory lock, update `CompactionMessageModel` status + content,
+  publish `CompactionMessageDoneEvent`.
 - In `postUserMessage` (line ~528): check for `CompactionMessageModel` with
   `status: "created"` in the conversation — return 409 if found (same pattern as steering's
   pending message check).
-- In `compactionActivity`:
-  - On success: update `CompactionMessage` to `status: "succeeded"` + `content`.
-  - On failure: update to `status: "failed"`.
-  - Publish `CompactionMessageDoneEvent`.
 
 ### - [ ] PR 3.4 — Implement compaction summary generation
 

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -83,9 +83,9 @@ Build the compaction pipeline end-to-end. No feature flag needed — inert until
 
 Infrastructure only — workflow, activity, client. No trigger yet. Collocated with the agent loop.
 
-- Add `compactConversationWorkflow` in `front/temporal/agent_loop/workflows.ts` (alongside
+- Add `compactionWorkflow` in `front/temporal/agent_loop/workflows.ts` (alongside
   `agentLoopConversationTitleWorkflow`). Calls a single activity.
-- Add `compactConversationActivity` stub in a new file under
+- Add `compactionActivity` stub in a new file under
   `front/temporal/agent_loop/activities/` (reads messages, returns placeholder content for now).
 - Add `launchCompactConversationWorkflow()` client in `front/temporal/agent_loop/client.ts`
   (deterministic workflow ID from conversationId, fire-and-forget, handle
@@ -105,19 +105,19 @@ Type-only + event plumbing.
 - Add cases in `isMessageEventParams()` switch
   (`front/lib/api/assistant/streaming/events.ts`, line ~106).
 
-### - [ ] PR 3.3 — Implement `compactConversation` + block `postUserMessage`
+### - [ ] PR 3.3 — Implement `compaction` + block `postUserMessage`
 
 Core orchestration. No feature flag needed — compaction is inert until Phase 5 provides a trigger.
 
-- Add `compactConversation()` in `front/lib/api/assistant/conversation.ts`:
+- Add `compaction()` in `front/lib/api/assistant/conversation.ts`:
   - Acquire `getConversationRankVersionLock`.
   - Create `CompactionMessage` with `status: "created"`, `content: null`.
   - Publish `CompactionMessageNewEvent`.
-  - Launch `compactConversationWorkflow` (fire-and-forget).
+  - Launch `compactionWorkflow` (fire-and-forget).
 - In `postUserMessage` (line ~528): check for `CompactionMessageModel` with
   `status: "created"` in the conversation — return 409 if found (same pattern as steering's
   pending message check).
-- In `compactConversationActivity`:
+- In `compactionActivity`:
   - On success: update `CompactionMessage` to `status: "succeeded"` + `content`.
   - On failure: update to `status: "failed"`.
   - Publish `CompactionMessageDoneEvent`.
@@ -126,7 +126,7 @@ Core orchestration. No feature flag needed — compaction is inert until Phase 5
 
 The LLM call that produces the summary.
 
-- In `compactConversationActivity` (`front/temporal/agent_loop/activities/`):
+- In `compactionActivity` (`front/temporal/agent_loop/activities/`):
   - Fetch all messages since the last succeeded `CompactionMessage` (or all messages if none).
   - Render them into a compaction prompt (adapt from Claude Code's approach — system prompt +
     conversation + "summarize" instruction, see `x/spolu/compaction/claude_compaction.md` for
@@ -181,7 +181,7 @@ Make compaction actually affect what the model sees.
 ### - [ ] PR 5.3 — Manual compaction trigger
 
 - Add a UI affordance (button in the context usage indicator, or a `/compact` command) that calls
-  `compactConversation`.
+  `compaction`.
 - Initially, compaction is user-triggered only — block the input bar once context usage reaches a
   high threshold, prompting the user to compact.
 - API endpoint: `POST /api/w/[wId]/assistant/conversations/[cId]/compact`.

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -81,18 +81,17 @@ Build the compaction pipeline end-to-end. No feature flag needed — inert until
 
 ### - [ ] PR 3.1 — Add compaction Temporal workflow skeleton
 
-Infrastructure only — workflow, worker, client, config. No trigger yet.
+Infrastructure only — workflow, activity, client. No trigger yet. Collocated with the agent loop.
 
-- Create `front/temporal/compaction/` with:
-  - `config.ts` — queue name (`compaction-queue`).
-  - `workflows.ts` — `compactConversationWorkflow` that calls a single activity.
-  - `activities.ts` — `compactConversationActivity` stub (reads messages, returns placeholder
-    summary for now).
-  - `client.ts` — `launchCompactConversationWorkflow()` following the mentions/credit_alerts
-    pattern (deterministic workflow ID from conversationId, fire-and-forget, handle
-    `WorkflowExecutionAlreadyStartedError`).
-  - `worker.ts` — register on the `front` Temporal namespace.
-- Add to `worker_registry.ts`.
+- Add `compactConversationWorkflow` in `front/temporal/agent_loop/workflows.ts` (alongside
+  `agentLoopConversationTitleWorkflow`). Calls a single activity.
+- Add `compactConversationActivity` stub in a new file under
+  `front/temporal/agent_loop/activities/` (reads messages, returns placeholder content for now).
+- Add `launchCompactConversationWorkflow()` client in `front/temporal/agent_loop/client.ts`
+  (deterministic workflow ID from conversationId, fire-and-forget, handle
+  `WorkflowExecutionAlreadyStartedError`).
+- Runs on the existing agent loop queue (`agent-loop-queue-v2`, `agent` namespace). No new worker
+  or queue needed. Register the activity in the existing agent loop worker.
 
 ### - [ ] PR 3.2 — Add SSE events for compaction lifecycle
 
@@ -127,7 +126,7 @@ Core orchestration. No feature flag needed — compaction is inert until Phase 5
 
 The LLM call that produces the summary.
 
-- In `compactConversationActivity` (`front/temporal/compaction/activities.ts`):
+- In `compactConversationActivity` (`front/temporal/agent_loop/activities/`):
   - Fetch all messages since the last succeeded `CompactionMessage` (or all messages if none).
   - Render them into a compaction prompt (adapt from Claude Code's approach — system prompt +
     conversation + "summarize" instruction, see `x/spolu/compaction/claude_compaction.md` for
@@ -135,7 +134,7 @@ The LLM call that produces the summary.
   - Call the LLM via `callModel` / `queryModelWithStreaming` to generate the summary.
   - Store the content on the `CompactionMessage`.
 - Add the compaction prompt template (can live in the activity file or a dedicated prompt file
-  under `front/temporal/compaction/`).
+  under `front/temporal/agent_loop/`).
 
 ---
 


### PR DESCRIPTION
## Description

PR 3.1 from the compaction plan. Adds the compaction workflow scaffold, collocated with the agent loop.

- `compactionWorkflow` in `workflows.ts` — single-activity workflow on `agent-loop-queue-v2`
- `compactionActivity` in `activities/compaction.ts` — thin wrapper delegating to `runCompaction`
- `runCompaction` in `lib/api/assistant/conversation/compaction.ts` — looks up the `CompactionMessage` via `MessageModel.sId` + version, updates status to `"succeeded"` and content to `"[COMPACTION]"` (stub), or `"failed"` on error
- `launchCompactionWorkflow` in `client.ts` — fire-and-forget launch with `WorkflowExecutionAlreadyStartedError` handling
- `makeCompactionWorkflowId` in `lib/workflow_ids.ts`
- Activity registered in `worker.ts`
- Updated proposal and plan

## Tests

- `npx tsgo --noEmit` passes (pre-existing tiptap errors only)
- `npm run lint` / `npm run format` pass

## Risk

Low — scaffold only, no trigger exists yet. The workflow cannot be started until `compactConversation` is implemented (PR 3.3).

## Deploy Plan

Standard deploy, no migration needed. Worker picks up the new activity on next restart.