### PR TITLE
Remove instruction root/doc block from skill instructions

### DIFF
--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -6,7 +6,6 @@ import {
   buildSkillInstructionsExtensions,
   INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
 } from "@app/lib/editor/build_skill_instructions_extensions";
-import { preprocessMarkdown } from "@app/lib/editor/skill_instructions_preprocessing";
 import { cn } from "@dust-tt/sparkle";
 import { CharacterCount, Placeholder } from "@tiptap/extensions";
 import type { Transaction } from "@tiptap/pm/state";
@@ -41,7 +40,7 @@ function useEditorService(editor: Editor | null) {
       setContent(content: string) {
         // Safety check for Safari: ensure editor and docView are available
         if (editor && !editor.isDestroyed) {
-          editor.commands.setContent(preprocessMarkdown(content), {
+          editor.commands.setContent(content, {
             emitUpdate: false,
             contentType: "markdown",
           });
@@ -151,7 +150,7 @@ export function useSkillInstructionsEditor({
       // This fixes Safari crashes where docView is accessed before render
       requestAnimationFrame(() => {
         if (editor && !editor.isDestroyed) {
-          editor.commands.setContent(preprocessMarkdown(content), {
+          editor.commands.setContent(content, {
             emitUpdate: false,
             contentType: "markdown",
           });

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -8,10 +8,6 @@ import {
 import { SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT } from "@app/components/skill_builder/events";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
-import {
-  postProcessMarkdown,
-  preprocessMarkdown,
-} from "@app/lib/editor/skill_instructions_preprocessing";
 import { cn } from "@dust-tt/sparkle";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
@@ -75,13 +71,9 @@ export function SkillBuilderInstructionsEditor({
     () =>
       debounce((editor: Editor) => {
         if (!isDiffMode && !editor.isDestroyed) {
-          setValue(
-            INSTRUCTIONS_FIELD_NAME,
-            postProcessMarkdown(editor.getMarkdown().trim()),
-            {
-              shouldDirty: true,
-            }
-          );
+          setValue(INSTRUCTIONS_FIELD_NAME, editor.getMarkdown().trim(), {
+            shouldDirty: true,
+          });
           setValue(
             ATTACHED_KNOWLEDGE_FIELD_NAME,
             toAttachedKnowledge(collectKnowledgeItems(editor)),
@@ -203,16 +195,13 @@ export function SkillBuilderInstructionsEditor({
     ) {
       return;
     }
-    const currentContent = postProcessMarkdown(editor.getMarkdown());
+    const currentContent = editor.getMarkdown();
     if (currentContent !== instructionsField.value) {
       setTimeout(() => {
-        editor.commands.setContent(
-          preprocessMarkdown(instructionsField.value),
-          {
-            emitUpdate: false,
-            contentType: "markdown",
-          }
-        );
+        editor.commands.setContent(instructionsField.value, {
+          emitUpdate: false,
+          contentType: "markdown",
+        });
       }, 0);
     }
   }, [editor, instructionsField.value]);
@@ -228,9 +217,9 @@ export function SkillBuilderInstructionsEditor({
       }
 
       const compareText = compareVersion.instructions ?? "";
-      const currentText = postProcessMarkdown(instructionsField.value ?? "");
+      const currentText = instructionsField.value ?? "";
 
-      editor.commands.setContent(preprocessMarkdown(currentText), {
+      editor.commands.setContent(currentText, {
         emitUpdate: false,
         contentType: "markdown",
       });

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -13,22 +13,25 @@ export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 /**
  * Build the TipTap extension list for the skill instructions editor.
  *
- * @param isReadOnly - When true, only the base parsing/rendering extensions are
- *   included. When false, caller must supply `editableExtensions` with the
- *   browser-only extensions (SlashCommand, Placeholder, CharacterCount, etc.)
- *   that cannot be statically imported in server/Node contexts.
+ * @param isReadOnly - When true, interactive editing extensions are omitted.
  * @param editableExtensions - Extensions appended when `isReadOnly` is false.
+ * @param serverSide - When true, includes InstructionsDocumentExtension,
+ *   InstructionsRootExtension, and BlockIdExtension for server-side HTML
  */
 export function buildSkillInstructionsExtensions(
   isReadOnly: boolean,
-  editableExtensions: Extensions = []
+  editableExtensions: Extensions = [],
+  { serverSide = false }: { serverSide?: boolean } = {}
 ): Extensions {
   const baseExtensions: Extensions = [
-    InstructionsDocumentExtension,
-    InstructionsRootExtension,
+    ...(serverSide
+      ? [InstructionsDocumentExtension, InstructionsRootExtension]
+      : []),
     Markdown,
     StarterKit.configure({
-      document: false,
+      // document: false is required when InstructionsDocumentExtension is present
+      // (it replaces StarterKit's default Document node).
+      ...(serverSide ? { document: false } : {}),
       orderedList: {
         HTMLAttributes: {
           class: markdownStyles.orderedList(),
@@ -70,7 +73,7 @@ export function buildSkillInstructionsExtensions(
         class: "mt-4 mb-3",
       },
     }),
-    BlockIdExtension,
+    ...(serverSide ? [BlockIdExtension] : []),
     KnowledgeNode,
   ];
 

--- a/front/lib/editor/skill_instructions_html.ts
+++ b/front/lib/editor/skill_instructions_html.ts
@@ -13,11 +13,12 @@ import { MarkdownManager } from "@tiptap/markdown";
 import { renderToHTMLString } from "@tiptap/static-renderer/pm/html-string";
 import * as cheerio from "cheerio";
 
-const SKILL_EDITOR_EXTENSIONS = buildSkillInstructionsExtensions(true);
+const SKILL_EDITOR_EXTENSIONS = buildSkillInstructionsExtensions(true, [], {
+  serverSide: true,
+});
 const MARKDOWN_MANAGER = new MarkdownManager({
   extensions: SKILL_EDITOR_EXTENSIONS,
 });
-
 const NODE_TYPES_WITH_BLOCK_ID = new Set<string>([
   ...BLOCK_ID_UNIQUE_ID_NODE_TYPES,
   INSTRUCTIONS_ROOT_NODE_NAME,


### PR DESCRIPTION
## Description
* Removing instruction root/doc block from skill instruction. Right now, there are a couple edge cases for invalid instructions that can lead to blank instructions being shown (such as invalid inline HTML)
* This introduces a very complicated class of ProseMirror issues because it cant handle complex hierarchies. Will need to perform migrations before introducing anything client side. 

## Tests

* Verified all skills show as expected (unless there was a previously existing issue with our extensions)

## Risk

* Low (reverting to previous state)

## Deploy Plan

* Deploy front