### PR TITLE
Implement compactConversation + block postUserMessage

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1,5 +1,6 @@
 import { archiveAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import {
+  compactConversation,
   editUserMessage,
   isConversationEventAllowedForAuth,
   postNewContentFragment,
@@ -16,6 +17,8 @@ import { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import {
+  AgentMessageModel,
+  CompactionMessageModel,
   ConversationModel,
   MentionModel,
   MessageModel,
@@ -59,10 +62,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mock the dependencies
 vi.mock("@app/temporal/agent_loop/client", () => ({
   launchAgentLoopWorkflow: vi.fn(),
+  launchCompactionWorkflow: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/assistant/streaming/events", () => ({
   publishAgentMessagesEvents: vi.fn(),
+  publishConversationEvent: vi.fn(),
   publishMessageEventsOnMessagePostOrEdit: vi.fn(),
 }));
 
@@ -1454,6 +1459,105 @@ describe("postUserMessage", () => {
     }
   });
 
+  describe("compaction blocking", () => {
+    it("should reject posting when a compaction message is running", async () => {
+      const user = auth.getNonNullableUser();
+      const userJson = user.toJSON();
+
+      // Insert a compaction message with status "created" into the conversation.
+      const compactionMessageRow = await CompactionMessageModel.create({
+        status: "created",
+        content: null,
+        workspaceId: workspace.id,
+      });
+      await MessageModel.create({
+        sId: generateRandomModelSId(),
+        rank: 0,
+        conversationId: conversation.id,
+        compactionMessageId: compactionMessageRow.id,
+        workspaceId: workspace.id,
+      });
+
+      // Re-fetch the conversation so its content includes the compaction message.
+      const fetched = await getConversation(auth, conversation.sId);
+      expect(fetched.isOk()).toBe(true);
+      if (fetched.isErr()) {
+        return;
+      }
+
+      const result = await postUserMessage(auth, {
+        conversation: fetched.value,
+        content: "should be blocked",
+        mentions: [],
+        context: {
+          username: userJson.username,
+          timezone: "UTC",
+          fullName: userJson.fullName,
+          email: userJson.email,
+          profilePictureUrl: userJson.image,
+          origin: "web",
+        },
+        skipToolsValidation: false,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.status_code).toBe(409);
+        expect(result.error.api_error.message).toContain("compacted");
+      }
+    });
+
+    it("should allow posting when a compaction message has succeeded", async () => {
+      const user = auth.getNonNullableUser();
+      const userJson = user.toJSON();
+
+      const rateLimiterSpy = vi
+        .spyOn(rateLimiterModule, "rateLimiter")
+        .mockResolvedValue(100);
+
+      // Insert a completed compaction message into the conversation.
+      const compactionMessageRow = await CompactionMessageModel.create({
+        status: "succeeded",
+        content: "compacted summary",
+        workspaceId: workspace.id,
+      });
+      await MessageModel.create({
+        sId: generateRandomModelSId(),
+        rank: 0,
+        conversationId: conversation.id,
+        compactionMessageId: compactionMessageRow.id,
+        workspaceId: workspace.id,
+      });
+
+      // Re-fetch the conversation so its content includes the compaction message.
+      const fetched = await getConversation(auth, conversation.sId);
+      expect(fetched.isOk()).toBe(true);
+      if (fetched.isErr()) {
+        rateLimiterSpy.mockRestore();
+        return;
+      }
+
+      const result = await postUserMessage(auth, {
+        conversation: fetched.value,
+        content: "should be allowed",
+        mentions: [],
+        context: {
+          username: userJson.username,
+          timezone: "UTC",
+          fullName: userJson.fullName,
+          email: userJson.email,
+          profilePictureUrl: userJson.image,
+          origin: "web",
+        },
+        skipToolsValidation: false,
+      });
+
+      rateLimiterSpy.mockRestore();
+
+      expect(result.isOk()).toBe(true);
+    });
+  });
+
   describe("auto-mention global @dust when posting without mentions", () => {
     const expectedDustMentionPrefix = serializeMention({
       id: GLOBAL_AGENTS_SID.DUST,
@@ -2398,6 +2502,92 @@ describe("postUserMessage", () => {
         rateLimiterSpy.mockRestore();
       });
     });
+  });
+});
+
+describe("compactConversation", () => {
+  let auth: Authenticator;
+  let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+  let conversation: ConversationType;
+  let agentConfig: LightAgentConfigurationType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+
+    agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent Description",
+    });
+
+    const conversationWithoutContent = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const fetched = await getConversation(auth, conversationWithoutContent.sId);
+    if (fetched.isErr()) {
+      throw new Error("Failed to fetch conversation");
+    }
+    conversation = fetched.value;
+
+    vi.clearAllMocks();
+  });
+
+  it("should create a compaction message on an idle conversation", async () => {
+    const result = await compactConversation(auth, { conversation });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    const { compactionMessage } = result.value;
+    expect(compactionMessage.status).toBe("created");
+    expect(compactionMessage.content).toBeNull();
+  });
+
+  it("should reject compaction when an agent message is running", async () => {
+    // Insert a user message then an agent message with status "created" (running).
+    const { messageRow: userMessageRow } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "hello",
+      });
+    const agentMessageRow = await AgentMessageModel.create({
+      status: "created",
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: 0,
+      workspaceId: workspace.id,
+      skipToolsValidation: false,
+    });
+    await MessageModel.create({
+      sId: generateRandomModelSId(),
+      rank: 1,
+      conversationId: conversation.id,
+      parentId: userMessageRow.id,
+      agentMessageId: agentMessageRow.id,
+      workspaceId: workspace.id,
+    });
+
+    // Re-fetch so the conversation content includes the running agent message.
+    const fetched = await getConversation(auth, conversation.sId);
+    expect(fetched.isOk()).toBe(true);
+    if (fetched.isErr()) {
+      return;
+    }
+
+    const result = await compactConversation(auth, {
+      conversation: fetched.value,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(409);
+    }
   });
 });
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -128,6 +128,7 @@ import type {
 import {
   ConversationError,
   isAgentMessageType,
+  isCompactionMessageType,
   isProjectConversation,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
@@ -613,9 +614,8 @@ export async function postUserMessage(
   // Block posting while compaction is in progress, for now. It's not too hard to add support for
   // pending messages on top of compaction. We start without support for it to simplify. Note that
   // we don't currently re-check the existence of a compaction message inside the critical section
-  // below which means compaction could be triggered along an agent loop. This is not that
-  // problematic if it happens.
-  // TODO(compaction): ensure in critical section that there is no compaction message.
+  // below which means an agent loop could be triggered whle a compaction is running. This is not
+  // that problematic if it happens (agent message after the compaction message).
   const runningCompactionMessage = conversation.content
     .flat()
     .find(
@@ -2624,19 +2624,26 @@ export async function compactConversation(
 > {
   const owner = auth.getNonNullableWorkspace();
 
-  // Block compaction while compaction is in progress.
-  let runningCompactionMessage = conversation.content
+  // Block compaction while an agent message is running or a compaction is running.
+  const runningAgentMessage = conversation.content
     .flat()
     .find(
       (m): m is AgentMessageType =>
         isAgentMessageType(m) && m.status === "created"
     );
-  if (runningCompactionMessage) {
+  const runningCompaction = conversation.content
+    .flat()
+    .find(
+      (m): m is CompactionMessageType =>
+        isCompactionMessageType(m) && m.status === "created"
+    );
+  if (runningAgentMessage || runningCompaction) {
     return new Err({
       status_code: 409,
       api_error: {
         type: "invalid_request_error",
-        message: "Conversation is already being compacted.",
+        message:
+          "Cannot compact while another compaction or an agent message is running.",
       },
     });
   }
@@ -2644,26 +2651,43 @@ export async function compactConversation(
   const { compactionMessage } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
-    // Re-check the existence of acompaction message inside the critical section of the advisory
-    // lock.
-    const pendingCompaction = await MessageModel.findOne({
-      where: {
-        conversationId: conversation.id,
-        workspaceId: owner.id,
-      },
-      include: [
-        {
-          model: CompactionMessageModel,
-          as: "compactionMessage",
-          required: true,
-          where: { status: "created" },
+    // Re-check the existence of a compaction message or running agent message inside the critical
+    // section of the advisory lock to avoid stacking compaction with other compaction or running
+    // agent loop.
+    const [runningCompactionMessage, runningAgentMessage] = await Promise.all([
+      MessageModel.findOne({
+        where: {
+          conversationId: conversation.id,
+          workspaceId: owner.id,
         },
-      ],
-      transaction: t,
-    });
+        include: [
+          {
+            model: CompactionMessageModel,
+            as: "compactionMessage",
+            required: true,
+            where: { status: "created" },
+          },
+        ],
+        transaction: t,
+      }),
+      MessageModel.findOne({
+        where: {
+          conversationId: conversation.id,
+          workspaceId: owner.id,
+        },
+        include: [
+          {
+            model: AgentMessageModel,
+            as: "agentMessage",
+            required: true,
+            where: { status: "created" },
+          },
+        ],
+        transaction: t,
+      }),
+    ]);
 
-    if (pendingCompaction) {
-      // If we already have a compaction running we exit early.
+    if (runningCompactionMessage || runningAgentMessage) {
       return { compactionMessage: null };
     }
 
@@ -2693,12 +2717,12 @@ export async function compactConversation(
       status_code: 409,
       api_error: {
         type: "invalid_request_error",
-        message: "Conversation is already being compacted.",
+        message:
+          "Cannot compact while another compaction or an agent message is running.",
       },
     });
   }
 
-  // Publish the compaction_message_new event outside the transaction.
   await publishConversationEvent(
     {
       type: "compaction_message_new",
@@ -2709,7 +2733,6 @@ export async function compactConversation(
     { conversationId: conversation.sId }
   );
 
-  // Launch the compaction workflow fire-and-forget.
   void launchCompactionWorkflow({
     auth,
     conversationId: conversation.sId,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2766,32 +2766,15 @@ export async function updateCompactionMessageWithContentAndFinalStatus(
   await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
-    // Look up the CompactionMessageModel via the MessageModel join.
-    const message = await MessageModel.findOne({
-      where: {
-        sId: compactionMessage.sId,
-        version: compactionMessage.version,
-        workspaceId: owner.id,
-      },
-      include: [
-        {
-          model: CompactionMessageModel,
-          as: "compactionMessage",
-          required: true,
-        },
-      ],
-      transaction: t,
-    });
-
-    if (!message?.compactionMessage) {
-      throw new Error(
-        `Compaction message not found: sId=${compactionMessage.sId}, version=${compactionMessage.version}`
-      );
-    }
-
-    await message.compactionMessage.update(
+    await CompactionMessageModel.update(
       { status, content },
-      { transaction: t }
+      {
+        where: {
+          id: compactionMessage.compactionMessageId,
+          workspaceId: owner.id,
+        },
+        transaction: t,
+      }
     );
   });
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -61,6 +61,7 @@ import {
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
   AgentMessageModel,
+  CompactionMessageModel,
   ConversationModel,
   MentionModel,
   MessageModel,
@@ -89,7 +90,10 @@ import {
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger, { auditLog } from "@app/logger/logger";
-import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import {
+  launchAgentLoopWorkflow,
+  launchCompactionWorkflow,
+} from "@app/temporal/agent_loop/client";
 import {
   launchOrSignalProjectTodoWorkflow,
   signalProjectTodoComplete,
@@ -123,6 +127,7 @@ import type {
 import {
   ConversationError,
   isAgentMessageType,
+  isCompactionMessageType,
   isProjectConversation,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
@@ -603,6 +608,23 @@ export async function postUserMessage(
   const limitResult = await checkMessagesLimit(auth, { mentions, context });
   if (limitResult.isErr()) {
     return limitResult;
+  }
+
+  // Block posting while compaction is in progress.
+  const hasActiveCompaction = conversation.content
+    .flat()
+    .some(
+      (m): m is CompactionMessageType =>
+        isCompactionMessageType(m) && m.status === "created"
+    );
+  if (hasActiveCompaction) {
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Conversation is being compacted, please wait.",
+      },
+    });
   }
 
   const agentMentions = mentions.filter(isAgentMention);
@@ -2581,6 +2603,127 @@ export async function isConversationEventAllowedForAuth(
   }
 }
 
+/**
+ * Create a CompactionMessage in the conversation and launch the compaction workflow.
+ *
+ * The CompactionMessage is created with status "created" inside the conversation advisory lock,
+ * ensuring it's serialized with other conversation operations. The workflow is launched
+ * fire-and-forget after the transaction commits.
+ */
+export async function compactConversation(
+  auth: Authenticator,
+  { conversation }: { conversation: ConversationType }
+): Promise<Result<CompactionMessageType, APIErrorWithStatusCode>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const compactionMessage = await withTransaction(async (t) => {
+    await getConversationRankVersionLock(auth, conversation, t);
+
+    // Check for an in-progress compaction.
+    const pendingCompaction = await MessageModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: owner.id,
+      },
+      include: [
+        {
+          model: CompactionMessageModel,
+          as: "compactionMessage",
+          required: true,
+          where: { status: "created" },
+        },
+      ],
+      transaction: t,
+    });
+
+    if (pendingCompaction) {
+      return null;
+    }
+
+    const nextMessageRank =
+      ((await MessageModel.max<number | null, MessageModel>("rank", {
+        where: {
+          workspaceId: owner.id,
+          conversationId: conversation.id,
+          branchId: conversation.branchId
+            ? getResourceIdFromSId(conversation.branchId)
+            : null,
+        },
+        transaction: t,
+      })) ?? -1) + 1;
+
+    const compactionMessageRow = await CompactionMessageModel.create(
+      {
+        status: "created",
+        content: null,
+        workspaceId: owner.id,
+      },
+      { transaction: t }
+    );
+
+    const messageRow = await MessageModel.create(
+      {
+        sId: generateRandomModelSId(),
+        rank: nextMessageRank,
+        conversationId: conversation.id,
+        branchId: conversation.branchId
+          ? getResourceIdFromSId(conversation.branchId)
+          : null,
+        version: 0,
+        compactionMessageId: compactionMessageRow.id,
+        workspaceId: owner.id,
+      },
+      { transaction: t }
+    );
+
+    const compactionMessage: CompactionMessageType = {
+      type: "compaction_message",
+      id: messageRow.id,
+      sId: messageRow.sId,
+      created: messageRow.createdAt.getTime(),
+      visibility: messageRow.visibility,
+      version: messageRow.version,
+      rank: messageRow.rank,
+      branchId: conversation.branchId,
+      status: "created",
+      content: null,
+    };
+
+    return compactionMessage;
+  });
+
+  if (!compactionMessage) {
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Conversation is being compacted, please wait.",
+      },
+    });
+  }
+
+  // Publish the compaction_message_new event outside the transaction.
+  await publishConversationEvent(
+    {
+      type: "compaction_message_new",
+      created: Date.now(),
+      messageId: compactionMessage.sId,
+      message: compactionMessage,
+    },
+    { conversationId: conversation.sId }
+  );
+
+  // Launch the compaction workflow fire-and-forget.
+  void launchCompactionWorkflow({
+    auth,
+    conversationId: conversation.sId,
+    compactionMessageId: compactionMessage.sId,
+    compactionMessageVersion: compactionMessage.version,
+  });
+
+  return new Ok(compactionMessage);
+}
+
 export async function updateCompactionMessageWithContentAndFinalStatus(
   auth: Authenticator,
   {
@@ -2599,12 +2742,43 @@ export async function updateCompactionMessageWithContentAndFinalStatus(
   status: "succeeded" | "failed";
 }> {
   const completedAt = new Date();
+  const owner = auth.getNonNullableWorkspace();
 
-  // TODO(compaction): implement update to CompactionMessage (with proper locking)
+  await withTransaction(async (t) => {
+    await getConversationRankVersionLock(auth, conversation, t);
+
+    // Look up the CompactionMessageModel via the MessageModel join.
+    const message = await MessageModel.findOne({
+      where: {
+        sId: compactionMessage.sId,
+        version: compactionMessage.version,
+        workspaceId: owner.id,
+      },
+      include: [
+        {
+          model: CompactionMessageModel,
+          as: "compactionMessage",
+          required: true,
+        },
+      ],
+      transaction: t,
+    });
+
+    if (!message?.compactionMessage) {
+      throw new Error(
+        `Compaction message not found: sId=${compactionMessage.sId}, version=${compactionMessage.version}`
+      );
+    }
+
+    await message.compactionMessage.update(
+      { status, content },
+      { transaction: t }
+    );
+  });
 
   return {
     completedTs: completedAt.getTime(),
-    status: "succeeded",
+    status,
   };
 }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -619,8 +619,8 @@ export async function postUserMessage(
   const runningCompactionMessage = conversation.content
     .flat()
     .find(
-      (m): m is AgentMessageType =>
-        isAgentMessageType(m) && m.status === "created"
+      (m): m is CompactionMessageType =>
+        isCompactionMessageType(m) && m.status === "created"
     );
   if (runningCompactionMessage) {
     return new Err({

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -127,7 +127,6 @@ import type {
 import {
   ConversationError,
   isAgentMessageType,
-  isCompactionMessageType,
   isProjectConversation,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
@@ -623,7 +622,8 @@ export async function postUserMessage(
       status_code: 409,
       api_error: {
         type: "invalid_request_error",
-        message: "User messages cannot be posted while conversation is being compacted.",
+        message:
+          "User messages cannot be posted while conversation is being compacted.",
       },
     });
   }
@@ -2614,13 +2614,33 @@ export async function isConversationEventAllowedForAuth(
 export async function compactConversation(
   auth: Authenticator,
   { conversation }: { conversation: ConversationType }
-): Promise<Result<CompactionMessageType, APIErrorWithStatusCode>> {
+): Promise<
+  Result<{ compactionMessage: CompactionMessageType }, APIErrorWithStatusCode>
+> {
   const owner = auth.getNonNullableWorkspace();
 
-  const compactionMessage = await withTransaction(async (t) => {
+  // Block compaction while compaction is in progress.
+  let runningCompactionMessage = conversation.content
+    .flat()
+    .find(
+      (m): m is AgentMessageType =>
+        isAgentMessageType(m) && m.status === "created"
+    );
+  if (runningCompactionMessage) {
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Conversation is already being compacted.",
+      },
+    });
+  }
+
+  const { compactionMessage } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
-    // Check for an in-progress compaction.
+    // Re-check the existence of acompaction message inside the critical section of the advisory
+    // lock.
     const pendingCompaction = await MessageModel.findOne({
       where: {
         conversationId: conversation.id,
@@ -2638,7 +2658,8 @@ export async function compactConversation(
     });
 
     if (pendingCompaction) {
-      return null;
+      // If we already have a compaction running we exit early.
+      return { compactionMessage: null };
     }
 
     const nextMessageRank =
@@ -2690,7 +2711,7 @@ export async function compactConversation(
       content: null,
     };
 
-    return compactionMessage;
+    return { compactionMessage };
   });
 
   if (!compactionMessage) {
@@ -2698,7 +2719,7 @@ export async function compactConversation(
       status_code: 409,
       api_error: {
         type: "invalid_request_error",
-        message: "Conversation is being compacted, please wait.",
+        message: "Conversation is already being compacted.",
       },
     });
   }
@@ -2722,7 +2743,7 @@ export async function compactConversation(
     compactionMessageVersion: compactionMessage.version,
   });
 
-  return new Ok(compactionMessage);
+  return new Ok({ compactionMessage });
 }
 
 export async function updateCompactionMessageWithContentAndFinalStatus(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -12,6 +12,7 @@ import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/cont
 import { createUserMentions } from "@app/lib/api/assistant/conversation/mentions";
 import {
   createAgentMessages,
+  createCompactionMessage,
   createUserMessage,
 } from "@app/lib/api/assistant/conversation/messages";
 import {
@@ -610,7 +611,11 @@ export async function postUserMessage(
   }
 
   // Block posting while compaction is in progress, for now. It's not too hard to add support for
-  // pending messages on top of compaction. We start without support for it.
+  // pending messages on top of compaction. We start without support for it to simplify. Note that
+  // we don't currently re-check the existence of a compaction message inside the critical section
+  // below which means compaction could be triggered along an agent loop. This is not that
+  // problematic if it happens.
+  // TODO(compaction): ensure in critical section that there is no compaction message.
   const runningCompactionMessage = conversation.content
     .flat()
     .find(
@@ -2674,42 +2679,11 @@ export async function compactConversation(
         transaction: t,
       })) ?? -1) + 1;
 
-    const compactionMessageRow = await CompactionMessageModel.create(
-      {
-        status: "created",
-        content: null,
-        workspaceId: owner.id,
-      },
-      { transaction: t }
-    );
-
-    const messageRow = await MessageModel.create(
-      {
-        sId: generateRandomModelSId(),
-        rank: nextMessageRank,
-        conversationId: conversation.id,
-        branchId: conversation.branchId
-          ? getResourceIdFromSId(conversation.branchId)
-          : null,
-        version: 0,
-        compactionMessageId: compactionMessageRow.id,
-        workspaceId: owner.id,
-      },
-      { transaction: t }
-    );
-
-    const compactionMessage: CompactionMessageType = {
-      type: "compaction_message",
-      id: messageRow.id,
-      sId: messageRow.sId,
-      created: messageRow.createdAt.getTime(),
-      visibility: messageRow.visibility,
-      version: messageRow.version,
-      rank: messageRow.rank,
-      branchId: conversation.branchId,
-      status: "created",
-      content: null,
-    };
+    const compactionMessage = await createCompactionMessage(auth, {
+      conversation,
+      rank: nextMessageRank,
+      transaction: t,
+    });
 
     return { compactionMessage };
   });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -610,19 +610,20 @@ export async function postUserMessage(
     return limitResult;
   }
 
-  // Block posting while compaction is in progress.
-  const hasActiveCompaction = conversation.content
+  // Block posting while compaction is in progress, for now. It's not too hard to add support for
+  // pending messages on top of compaction. We start without support for it.
+  const runningCompactionMessage = conversation.content
     .flat()
-    .some(
-      (m): m is CompactionMessageType =>
-        isCompactionMessageType(m) && m.status === "created"
+    .find(
+      (m): m is AgentMessageType =>
+        isAgentMessageType(m) && m.status === "created"
     );
-  if (hasActiveCompaction) {
+  if (runningCompactionMessage) {
     return new Err({
       status_code: 409,
       api_error: {
         type: "invalid_request_error",
-        message: "Conversation is being compacted, please wait.",
+        message: "User messages cannot be posted while conversation is being compacted.",
       },
     });
   }

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -270,6 +270,7 @@ async function _getConversation<V extends "light" | "full">(
     const typeCheckedContent: (
       | LightAgentMessageType
       | UserMessageTypeWithContentFragments
+      | CompactionMessageType
     )[] = removeNulls(
       (content as LightMessageType[][]).map((c) => {
         if (c.length === 0) {

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -3,6 +3,7 @@ import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
+  CompactionMessageModel,
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
@@ -11,6 +12,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import type {
   AgentMessageType,
+  CompactionMessageType,
   ConversationType,
   LightAgentMessageType,
   LightConversationType,
@@ -22,6 +24,7 @@ import type {
 import {
   ConversationError,
   isAgentMessageType,
+  isCompactionMessageType,
   isUserMessageType,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
@@ -177,6 +180,11 @@ async function _getConversation<V extends "light" | "full">(
           as: "contentFragment",
           required: false,
         },
+        {
+          model: CompactionMessageModel,
+          as: "compactionMessage",
+          required: false,
+        },
       ],
     });
   }
@@ -282,6 +290,13 @@ async function _getConversation<V extends "light" | "full">(
           )
         ) {
           return c[c.length - 1];
+        } else if (
+          isArrayOf<LightMessageType, CompactionMessageType>(
+            c,
+            isCompactionMessageType
+          )
+        ) {
+          return c[c.length - 1];
         } else {
           throw new Error(
             "Unexpected content type as everything should be array of same type. This should never happen."
@@ -334,6 +349,7 @@ async function _getConversation<V extends "light" | "full">(
       | AgentMessageType[]
       | UserMessageType[]
       | ContentFragmentType[]
+      | CompactionMessageType[]
     )[] = removeNulls(
       (content as MessageType[][]).map((c) => {
         if (c.length === 0) {
@@ -348,6 +364,13 @@ async function _getConversation<V extends "light" | "full">(
           return c.map((m) => m);
         } else if (
           isArrayOf<MessageType, ContentFragmentType>(c, isContentFragmentType)
+        ) {
+          return c.map((m) => m);
+        } else if (
+          isArrayOf<MessageType, CompactionMessageType>(
+            c,
+            isCompactionMessageType
+          )
         ) {
           return c.map((m) => m);
         } else {

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -393,8 +393,9 @@ export const createAgentMessages = async (
               return;
             }
 
-            // In case of Project's conversation, we need to check if the agent configuration is using only the project spaces or public spaces/
-            // Otherwise we reject the mention and do not create the agent message.
+            // In case of Project's conversation, we need to check if the agent configuration is
+            // using only the project spaces or public spaces/ Otherwise we reject the mention and
+            // do not create the agent message.
             if (isProjectConversation(conversation)) {
               const canAgentBeUsed = await canAgentBeUsedInProjectConversation(
                 auth,
@@ -405,8 +406,8 @@ export const createAgentMessages = async (
               );
 
               if (!canAgentBeUsed) {
-                // This create the mentions from the original user message.
-                // Not to be mixed with the mentions from the agent message (which will be filled later).
+                // This create the mentions from the original user message. Not to be mixed with
+                // the mentions from the agent message (which will be filled later).
                 const mentionRow = await MentionModel.create(
                   {
                     messageId: metadata.userMessage.id,
@@ -429,8 +430,8 @@ export const createAgentMessages = async (
               }
             }
 
-            // This create the mentions from the original user message.
-            // Not to be mixed with the mentions from the agent message (which will be filled later).
+            // This create the mentions from the original user message. Not to be mixed with the
+            // mentions from the agent message (which will be filled later).
             const mentionRow = await MentionModel.create(
               {
                 messageId: metadata.userMessage.id,

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -673,6 +673,7 @@ export async function createCompactionMessage(
   return {
     type: "compaction_message",
     id: messageRow.id,
+    compactionMessageId: compactionMessageRow.id,
     sId: messageRow.sId,
     created: messageRow.createdAt.getTime(),
     visibility: messageRow.visibility,

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -7,6 +7,7 @@ import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
+  CompactionMessageModel,
   MentionModel,
   MessageModel,
   UserMessageModel,
@@ -22,6 +23,7 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgenticMessageData,
   AgentMessageType,
+  CompactionMessageType,
   ConversationWithoutContentType,
   MessageVisibility,
   RichMentionWithStatus,
@@ -627,5 +629,57 @@ export async function getUserMessageIdFromMessageId(
     userMessageUserId: parentMessage.userMessage.userId,
     userMessageOrigin: parentMessage.userMessage.userContextOrigin,
     branchId: agentMessage.getBranchId(),
+  };
+}
+
+export async function createCompactionMessage(
+  auth: Authenticator,
+  {
+    conversation,
+    rank,
+    transaction,
+  }: {
+    conversation: ConversationWithoutContentType;
+    rank: number;
+    transaction: Transaction;
+  }
+): Promise<CompactionMessageType> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const compactionMessageRow = await CompactionMessageModel.create(
+    {
+      status: "created",
+      content: null,
+      workspaceId: workspace.id,
+    },
+    { transaction }
+  );
+
+  const messageRow = await MessageModel.create(
+    {
+      sId: generateRandomModelSId(),
+      rank,
+      conversationId: conversation.id,
+      branchId: conversation.branchId
+        ? getResourceIdFromSId(conversation.branchId)
+        : null,
+      version: 0,
+      compactionMessageId: compactionMessageRow.id,
+      workspaceId: workspace.id,
+    },
+    { transaction }
+  );
+
+  return {
+    type: "compaction_message",
+    id: messageRow.id,
+    sId: messageRow.sId,
+    created: messageRow.createdAt.getTime(),
+    visibility: messageRow.visibility,
+    version: messageRow.version,
+    rank: messageRow.rank,
+    branchId: conversation.branchId,
+    status: "created",
+    content: null,
   };
 }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -8,7 +8,6 @@ import {
   getCoTDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
 import {
-  CompactionMessageModel,
   MentionModel,
   MessageModel,
   UserMessageModel,

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -8,6 +8,7 @@ import {
   getCoTDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
 import {
+  CompactionMessageModel,
   MentionModel,
   MessageModel,
   UserMessageModel,

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -104,21 +104,18 @@ PR #24106. Type-only + event plumbing.
 - `ConversationViewer`: no-op cases (TODO for UI in Phase 5).
 - Public API v1: filtered out (not exposed).
 
-### - [ ] PR 3.3 — Implement `compaction` + block `postUserMessage`
+### - [x] PR 3.3 — Implement `compaction` + block `postUserMessage`
 
-Core orchestration. No feature flag needed — compaction is inert until Phase 5 provides a trigger.
+PR #24107.
 
-- Add `compaction()` in `front/lib/api/assistant/conversation.ts`:
-  - Acquire `getConversationRankVersionLock`.
-  - Create `CompactionMessage` with `status: "created"`, `content: null`.
-  - Publish `CompactionMessageNewEvent`.
-  - Launch `compactionWorkflow` (fire-and-forget).
-- Implement `updateCompactionMessageWithContentAndFinalStatus` in `conversation.ts` (currently a
-  stub from PR 3.1): acquire advisory lock, update `CompactionMessageModel` status + content,
-  publish `CompactionMessageDoneEvent`.
-- In `postUserMessage` (line ~528): check for `CompactionMessageModel` with
-  `status: "created"` in the conversation — return 409 if found (same pattern as steering's
-  pending message check).
+- `compactConversation()` in `conversation.ts`: acquires advisory lock, creates
+  `CompactionMessageModel` + `MessageModel`, publishes `compaction_message_new`, launches
+  `compactionWorkflow` fire-and-forget. Returns 409 if compaction already in progress.
+- `updateCompactionMessageWithContentAndFinalStatus`: acquires advisory lock, looks up
+  `CompactionMessageModel` via `MessageModel` join, updates status + content. The
+  `compaction_message_done` event is emitted from `runCompaction` (PR 3.1).
+- `postUserMessage` blocking: checks for active compaction (`status: "created"`) in conversation
+  content, returns 409 if found.
 
 ### - [ ] PR 3.4 — Implement compaction summary generation
 


### PR DESCRIPTION
## Description

PR 3.3 from the compaction plan. Implements the core compaction orchestration in `conversation.ts`.

- **`compactConversation()`**: creates `CompactionMessage` + `MessageModel` inside the advisory lock (same pattern as `postUserMessage`), publishes `compaction_message_new` event, launches `compactionWorkflow` fire-and-forget. Returns 409 if a compaction is already in progress.
- **`updateCompactionMessageWithContentAndFinalStatus()`**: replaces the stub from PR 3.1. Acquires advisory lock, looks up `CompactionMessageModel` via `MessageModel` join, updates status + content in a transaction.
- **`postUserMessage` blocking**: checks for active compaction (`CompactionMessageType` with `status: "created"`) before proceeding. Returns 409 if found.

## Tests

- `npx tsgo --noEmit` passes
- `npm run lint` / `npm run format` pass

## Risk

Low — `compactConversation` cannot be called yet (no API endpoint or trigger). The `postUserMessage` blocking is inert since no compaction messages can exist until a trigger is added (Phase 5).

## Deploy Plan

Standard deploy.