### PR TITLE
Use custom credits

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -2,7 +2,10 @@ import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { createEnterpriseCreditPurchase } from "@app/lib/credits/committed";
 import { createMetronomeCredit } from "@app/lib/metronome/client";
-import { getProductFreeMonthlyCreditId } from "@app/lib/metronome/constants";
+import {
+  getCreditTypeProgrammaticUsdId,
+  getProductFreeMonthlyCreditId,
+} from "@app/lib/metronome/constants";
 import {
   getStripeSubscription,
   isEnterpriseSubscription,
@@ -195,11 +198,12 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
       const metronomeCustomerId = workspace.metronomeCustomerId;
 
       if (metronomeCustomerId) {
-        const amountCents = Math.ceil(amountMicroUsd / 10_000);
+        const amount = Math.ceil(amountMicroUsd / 1_000_000);
         const metronomeResult = await createMetronomeCredit({
           metronomeCustomerId,
           productId: getProductFreeMonthlyCreditId(),
-          amountCents,
+          creditTypeId: getCreditTypeProgrammaticUsdId(),
+          amount,
           startingAt: startDate.toISOString(),
           endingBefore: expirationDate.toISOString(),
           name: `Free poke credit ($${originalAmount.toFixed(2)})`,

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -1,7 +1,10 @@
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import type { Authenticator } from "@app/lib/auth";
 import { createMetronomeCommit } from "@app/lib/metronome/client";
-import { getProductPrepaidCommitId } from "@app/lib/metronome/constants";
+import {
+  getCreditTypeProgrammaticUsdId,
+  getProductPrepaidCommitId,
+} from "@app/lib/metronome/constants";
 import type { CustomerFacingInvoiceInfo } from "@app/lib/plans/stripe";
 import {
   ENTERPRISE_N30_PAYMENTS_DAYS,
@@ -114,7 +117,7 @@ export async function startCreditFromProOneOffInvoice({
   if (creditAmountCents) {
     const metronomeResult = await addMetronomeCommitsForWorkspace({
       auth,
-      amountCents: creditAmountCents,
+      amountCredits: creditAmountCents / 100,
     });
     if (metronomeResult.isErr()) {
       return new Err(metronomeResult.error);
@@ -311,7 +314,7 @@ export async function createEnterpriseCreditPurchase({
 
   const metronomeResult = await addMetronomeCommitsForWorkspace({
     auth,
-    amountCents: amountMicroUsd / 10_000,
+    amountCredits: amountMicroUsd / 1_000_000,
     startDate,
     expirationDate,
   });
@@ -486,12 +489,13 @@ export async function deleteCreditFromVoidedInvoice({
 
 async function addMetronomeCommitsForWorkspace({
   auth,
-  amountCents,
+  amountCredits,
   startDate,
   expirationDate,
 }: {
   auth: Authenticator;
-  amountCents: number;
+  /** Amount in custom credit units (not cents). */
+  amountCredits: number;
   startDate?: Date;
   expirationDate?: Date;
 }): Promise<Result<void, Error>> {
@@ -519,11 +523,12 @@ async function addMetronomeCommitsForWorkspace({
   const result = await createMetronomeCommit({
     metronomeCustomerId,
     productId,
-    amountCents,
+    creditTypeId: getCreditTypeProgrammaticUsdId(),
+    amount: amountCredits,
     startingAt: effectiveStartDate,
     endingBefore: effectiveExpirationDate,
     name: `Prepaid commit (${effectiveStartDate.toISOString()})`,
-    idempotencyKey: `commit-${workspace.sId}-${effectiveStartDate.getTime()}-${amountCents}`,
+    idempotencyKey: `commit-${workspace.sId}-${effectiveStartDate.getTime()}-${amountCredits}`,
     priority: 2, // Committed credits should be applied after any free credits (priority 1) but before any PAYG commits (priority 3)
   });
 
@@ -532,7 +537,7 @@ async function addMetronomeCommitsForWorkspace({
       {
         workspaceId: workspace.sId,
         metronomeCustomerId,
-        amountCents,
+        amountCredits,
         error: result.error.message,
       },
       "[Commit Purchase] Failed to add commits to Metronome"

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -471,7 +471,8 @@ export async function updateSubscriptionQuantity({
 export async function createMetronomeCommit({
   metronomeCustomerId,
   productId,
-  amountCents,
+  creditTypeId,
+  amount,
   startingAt,
   endingBefore,
   name,
@@ -480,7 +481,8 @@ export async function createMetronomeCommit({
 }: {
   metronomeCustomerId: string;
   productId: string;
-  amountCents: number;
+  creditTypeId: string;
+  amount: number;
   startingAt: Date;
   endingBefore: Date;
   idempotencyKey: string;
@@ -495,7 +497,8 @@ export async function createMetronomeCommit({
       {
         metronomeCustomerId,
         productId,
-        amountCents,
+        creditTypeId,
+        amount,
         roundedStartingAt,
         roundedEndingBefore,
       },
@@ -510,9 +513,10 @@ export async function createMetronomeCommit({
       applicable_product_tags: ["usage"],
       priority: priority ?? 2, // Apply after any free credits
       access_schedule: {
+        credit_type_id: creditTypeId,
         schedule_items: [
           {
-            amount: amountCents,
+            amount,
             starting_at: roundedStartingAt,
             ending_before: roundedEndingBefore,
           },
@@ -525,7 +529,7 @@ export async function createMetronomeCommit({
       {
         metronomeCustomerId,
         productId,
-        amountCents,
+        amount,
         roundedStartingAt,
         roundedEndingBefore,
       },
@@ -539,7 +543,7 @@ export async function createMetronomeCommit({
         error,
         metronomeCustomerId,
         productId,
-        amountCents,
+        amount,
         roundedStartingAt,
         roundedEndingBefore,
       },
@@ -714,7 +718,8 @@ export async function listMetronomeUsageWithGroups({
 export async function createMetronomeCredit({
   metronomeCustomerId,
   productId,
-  amountCents,
+  creditTypeId,
+  amount,
   startingAt,
   endingBefore,
   name,
@@ -722,7 +727,8 @@ export async function createMetronomeCredit({
 }: {
   metronomeCustomerId: string;
   productId: string;
-  amountCents: number;
+  creditTypeId: string;
+  amount: number;
   startingAt: string;
   endingBefore: string;
   name: string;
@@ -740,9 +746,10 @@ export async function createMetronomeCredit({
       priority: 1, // Apply credits before any prepaid commits
       applicable_product_tags: ["usage"],
       access_schedule: {
+        credit_type_id: creditTypeId,
         schedule_items: [
           {
-            amount: amountCents,
+            amount,
             starting_at: roundedStartingAt,
             ending_before: roundedEndingBefore,
           },

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -77,6 +77,10 @@ export const CREDIT_TYPE_EUR_ID = "58f0be15-cc47-4220-bdaf-072ab0e44f96";
 const DEV_CREDIT_TYPE_AWU_ID = "1ad632f0-4e5a-44d6-a1bf-aa6f6bc550d8";
 const PROD_CREDIT_TYPE_AWU_ID = "e53a841e-b741-4bc3-8148-f377c1fb2501";
 
+// AWU (Agentic Work Units) differs per environment.
+const DEV_CREDIT_TYPE_PROG_USD_ID = "713dda3d-4e9c-456f-91cf-c79cf5b71412";
+const PROD_CREDIT_TYPE_PROG_USD_ID = "db4b2912-4dfc-43ee-a910-1a894b89fe60";
+
 /** Map Stripe currency code to Metronome credit type ID. */
 export const CURRENCY_TO_CREDIT_TYPE_ID: Record<string, string> = {
   usd: CREDIT_TYPE_USD_ID,
@@ -91,6 +95,9 @@ function devOrProd<T>(dev: T, prod: T): T {
 
 export const getCreditTypeAwuId = () =>
   devOrProd(DEV_CREDIT_TYPE_AWU_ID, PROD_CREDIT_TYPE_AWU_ID);
+
+export const getCreditTypeProgrammaticUsdId = () =>
+  devOrProd(DEV_CREDIT_TYPE_PROG_USD_ID, PROD_CREDIT_TYPE_PROG_USD_ID);
 
 // Metrics
 export const getMetricLlmProviderCostProgrammaticId = () =>

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -29,7 +29,10 @@ import {
   reactivateMetronomeContract,
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
-import { getProductFreeMonthlyCreditId } from "@app/lib/metronome/constants";
+import {
+  getCreditTypeProgrammaticUsdId,
+  getProductFreeMonthlyCreditId,
+} from "@app/lib/metronome/constants";
 import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
 import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
@@ -198,8 +201,8 @@ async function grantMetronomeFreeCredits({
       return;
     }
 
-    // Convert micro-USD to cents (Metronome credits are in cents).
-    const amountCents = Math.ceil(amountMicroUsd / 10_000);
+    // Convert micro-USD to custom credit units (1 unit ≈ $0.01, so divide by 1M).
+    const amount = Math.ceil(amountMicroUsd / 1_000_000);
 
     const periodStart = new Date(
       stripeSubscription.current_period_start * 1000
@@ -210,7 +213,8 @@ async function grantMetronomeFreeCredits({
     const result = await createMetronomeCredit({
       metronomeCustomerId: workspace.metronomeCustomerId,
       productId,
-      amountCents,
+      creditTypeId: getCreditTypeProgrammaticUsdId(),
+      amount,
       startingAt: periodStart.toISOString(),
       endingBefore: periodEnd.toISOString(),
       name: `Free Monthly Credits (${memberCount} users, ${monthKey})`,
@@ -222,7 +226,7 @@ async function grantMetronomeFreeCredits({
         {
           workspaceId: workspace.sId,
           memberCount,
-          amountCents,
+          amount,
           monthKey,
         },
         "[Stripe Webhook] Metronome free credits granted"

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -17,6 +17,7 @@ import {
   CREDIT_TYPE_EUR_ID,
   CREDIT_TYPE_USD_ID,
   getCreditTypeAwuId,
+  getCreditTypeProgrammaticUsdId,
 } from "@app/lib/metronome/constants";
 
 if (!process.env.METRONOME_API_KEY) {
@@ -323,6 +324,12 @@ function getRateCards(): RateCardDef[] {
         "Grandfathered Pro plan. $29/seat via seat subscription. AI usage 30% markup.",
       aliases: [{ name: "legacy-pro-monthly" }],
       fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: 0.01,
+        },
+      ],
       rates: [
         {
           product_name: "Workspace Seat",
@@ -337,7 +344,8 @@ function getRateCards(): RateCardDef[] {
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
-          price: 100,
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
         },
       ],
     },
@@ -347,6 +355,12 @@ function getRateCards(): RateCardDef[] {
         "Grandfathered Business plan. $45/seat via seat subscription. AI usage 30% markup.",
       aliases: [{ name: "legacy-business" }],
       fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: 0.01,
+        },
+      ],
       rates: [
         {
           product_name: "Workspace Seat",
@@ -361,7 +375,8 @@ function getRateCards(): RateCardDef[] {
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
-          price: 100,
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
         },
       ],
     },
@@ -371,6 +386,12 @@ function getRateCards(): RateCardDef[] {
         "Grandfathered Pro plan (annual). $27/seat/month billed monthly. AI usage 30% markup.",
       aliases: [{ name: "legacy-pro-annual" }],
       fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: 0.01,
+        },
+      ],
       rates: [
         {
           product_name: "Workspace Seat",
@@ -385,7 +406,8 @@ function getRateCards(): RateCardDef[] {
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
-          price: 100,
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
         },
       ],
     },
@@ -399,6 +421,12 @@ function getRateCards(): RateCardDef[] {
         "Enterprise plan. Per-MAU billing + programmatic usage at cost with 30% markup.",
       aliases: [{ name: "legacy-enterprise" }],
       fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: 0.01,
+        },
+      ],
       rates: [
         {
           product_name: "MAU Billing (1+)",
@@ -427,7 +455,8 @@ function getRateCards(): RateCardDef[] {
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
-          price: 100,
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
         },
       ],
     },
@@ -442,6 +471,12 @@ function getRateCards(): RateCardDef[] {
         "Grandfathered Pro plan (EUR). 29€/seat via seat subscription. AI usage 30% markup.",
       aliases: [{ name: "legacy-pro-monthly-eur" }],
       fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: 0.87,
+        },
+      ],
       rates: [
         {
           product_name: "Workspace Seat",
@@ -457,8 +492,8 @@ function getRateCards(): RateCardDef[] {
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
-          price: 0.87,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
         },
       ],
     },
@@ -468,6 +503,12 @@ function getRateCards(): RateCardDef[] {
         "Grandfathered Business plan (EUR). 45€/seat via seat subscription. AI usage 30% markup.",
       aliases: [{ name: "legacy-business-eur" }],
       fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: 0.87,
+        },
+      ],
       rates: [
         {
           product_name: "Workspace Seat",
@@ -483,8 +524,8 @@ function getRateCards(): RateCardDef[] {
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
-          price: 0.87,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
         },
       ],
     },
@@ -494,6 +535,12 @@ function getRateCards(): RateCardDef[] {
         "Grandfathered Pro plan (EUR, annual). 27€/seat/month billed monthly. AI usage 30% markup.",
       aliases: [{ name: "legacy-pro-annual-eur" }],
       fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: 0.87,
+        },
+      ],
       rates: [
         {
           product_name: "Workspace Seat",
@@ -509,8 +556,8 @@ function getRateCards(): RateCardDef[] {
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
-          price: 0.87,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
         },
       ],
     },
@@ -520,6 +567,12 @@ function getRateCards(): RateCardDef[] {
         "Enterprise plan (EUR). Per-MAU billing + programmatic usage at cost with 30% markup.",
       aliases: [{ name: "legacy-enterprise-eur" }],
       fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: 0.87,
+        },
+      ],
       rates: [
         {
           product_name: "MAU Billing (1+)",
@@ -550,8 +603,8 @@ function getRateCards(): RateCardDef[] {
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
-          price: 0.87,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
         },
       ],
     },


### PR DESCRIPTION
## Description

Introduce a custom "Programmatic USD" credit type for all programmatic usage billing in Metronome, replacing direct USD (cents) pricing.

### Why
- Metronome's USD pricing unit is "USD (cents)" while EUR is "EUR" (whole euros) — mixing them on a single rate card requires `credit_type_conversions`, but Metronome only supports conversions for **custom** credit types, not between two fiat currencies.
- A custom credit type for programmatic usage allows: consistent `price: 1` (1 custom credit per unit) across all rate cards, with the fiat conversion handled by `fiat_per_custom_credit` on each rate card (USD: $0.01, EUR: €0.87).
- This also opens the door to credit-only billing for programmatic usage (charges held until a credit/commit is created).

### Changes

**`metronome_setup.ts`**:
- All rate cards now declare `credit_type_conversions` with the Programmatic USD custom credit type
  - USD rate cards: `fiat_per_custom_credit: 0.01` (1 credit = $0.01)
  - EUR rate cards: `fiat_per_custom_credit: 0.87` (1 credit = €0.87, matches Stripe FX rate)
- All Programmatic Usage rates: `price: 1, credit_type_id: getCreditTypeProgrammaticUsdId()` (1 custom credit per unit, same across USD and EUR)
- Enterprise USD rate card: Programmatic Usage now correctly uses the custom credit type (was missing `credit_type_id`)

**`constants.ts`**:
- Added `getCreditTypeProgrammaticUsdId()` getter for the custom credit type (different IDs per env)

**`client.ts`**:
- `createMetronomeCommit`: renamed `amountCents` → `amount`, added required `creditTypeId` param, passes `credit_type_id` in `access_schedule`
- `createMetronomeCredit`: same rename + `creditTypeId` param

**Callers (all updated to use custom credit units instead of cents)**:
- `stripe/webhook.ts` (free monthly credits): `amountMicroUsd / 10_000` → `amountMicroUsd / 1_000_000`
- `committed.ts` (prepaid commits): `creditAmountCents` → `creditAmountCents / 100`, `amountMicroUsd / 10_000` → `amountMicroUsd / 1_000_000`
- `buy_programmatic_usage_credits.ts` (poke free credits): same ÷100 conversion

**Migration script**: unchanged — MAU floor recurring commit correctly uses fiat credit type (USD/EUR), not the programmatic custom credit.

## Tests

Ran `metronome_setup.ts --execute` in sandbox. Rate cards created with correct `credit_type_conversions`. Verified credit grants use the custom credit type.

## Risk

Low. All amounts are divided by 100 consistently — the custom credit unit is ~$0.01 (via `fiat_per_custom_credit: 0.01`), so the math is equivalent. The `quantity_conversion` on the Programmatic Usage product already handles `cost_micro_usd → units`, and the rate card conversion handles `units → fiat`.

## Deploy Plan

1. Merge base PR (handle-eur-contracts) first
2. Merge this PR
3. Run `metronome_setup.ts --execute` to update rate cards with custom credit type conversions
4. Migrate existing contracts to pick up new rate card versions