### PR TITLE
Add compactionMessageId and implement batch rendering

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -756,19 +756,24 @@ async function batchRenderCompactionMessages(
   const compactionMessages = messages.filter((m) => !!m.compactionMessage);
 
   return compactionMessages.map((m) => {
-    const cm = m.compactionMessage!;
+    if (!m.compactionMessage) {
+      throw new Error(
+        "Unreachable: batchRenderCompactionMessages has been filtered on compaction message"
+      );
+    }
+    const compactionMessage = m.compactionMessage;
     return {
       type: "compaction_message" as const,
       id: m.id,
-      compactionMessageId: cm.id,
+      compactionMessageId: compactionMessage.id,
       sId: m.sId,
       created: m.createdAt.getTime(),
       visibility: m.visibility,
       version: m.version,
       rank: m.rank,
       branchId: m.getBranchId(),
-      status: cm.status,
-      content: cm.content,
+      status: compactionMessage.status,
+      content: compactionMessage.content,
     };
   });
 }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -751,10 +751,26 @@ async function batchRenderContentFragment(
 
 async function batchRenderCompactionMessages(
   _auth: Authenticator,
-  _messages: MessageModel[]
+  messages: MessageModel[]
 ): Promise<CompactionMessageType[]> {
-  // TODO(compaction): implement batch rendering of compaction messages.
-  return [];
+  const compactionMessages = messages.filter((m) => !!m.compactionMessage);
+
+  return compactionMessages.map((m) => {
+    const cm = m.compactionMessage!;
+    return {
+      type: "compaction_message" as const,
+      id: m.id,
+      compactionMessageId: cm.id,
+      sId: m.sId,
+      created: m.createdAt.getTime(),
+      visibility: m.visibility,
+      version: m.version,
+      rank: m.rank,
+      branchId: m.getBranchId(),
+      status: cm.status,
+      content: cm.content,
+    };
+  });
 }
 
 type RenderMessageVariant = "legacy-light" | "full" | "light";

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2,6 +2,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
 import {
   AgentMessageModel,
+  CompactionMessageModel,
   ConversationModel,
   ConversationParticipantModel,
   MentionModel,
@@ -2129,6 +2130,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         {
           model: ContentFragmentModel,
           as: "contentFragment",
+          required: false,
+        },
+        {
+          model: CompactionMessageModel,
+          as: "compactionMessage",
           required: false,
         },
       ],

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -334,6 +334,7 @@ export type CompactionMessageStatus = "created" | "succeeded" | "failed";
 export type CompactionMessageType = {
   type: "compaction_message";
   id: ModelId;
+  compactionMessageId: ModelId;
   sId: string;
   created: number;
   visibility: MessageVisibility;

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -44,8 +44,6 @@ messages are filtered out / no-op everywhere.
 Remaining `TODO(compaction)` markers left for future PRs:
 - `front/components/assistant/conversation/types.ts` — render compaction messages in UI instead of
   filtering (→ PR 5.2).
-- `front/lib/api/assistant/messages.ts` — implement `batchRenderCompactionMessages` (→ PR 1.2,
-  once the DB model exists).
 - `front/lib/api/assistant/conversation_rendering/message_rendering.ts` — render compaction as
   history boundary (→ PR 4.1).
 - `front/lib/api/actions/servers/project_manager/tools/conversation_formatting.ts` — stop at


### PR DESCRIPTION
## Description

Adds the `compactionMessageId` field to `CompactionMessageType`, mirroring the `agentMessageId`
pattern on `AgentMessageType`. This points to the `CompactionMessageModel` primary key, enabling
direct updates without a `MessageModel` join lookup.

Implements `batchRenderCompactionMessages` (previously a TODO stub returning `[]`) and eagerly
loads `CompactionMessageModel` in `fetchMessagesForPage` so compaction messages are rendered
alongside other message types.

## Tests

Type-check and biome lint pass. No runtime behavior change yet (no compaction messages exist in
production).

Tested locally.

## Risk

Medium. Modifies query for conversation resource.

## Deploy Plan

- deploy `front`