### PR TITLE
Add swagger docs for CompactionMessageType

### DIFF
--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -172,6 +172,7 @@
  *                     - $ref: '#/components/schemas/PrivateUserMessage'
  *                     - $ref: '#/components/schemas/PrivateAgentMessage'
  *                     - $ref: '#/components/schemas/PrivateContentFragment'
+ *                     - $ref: '#/components/schemas/PrivateCompactionMessage'
  *     PrivateUserMessage:
  *       type: object
  *       description: A user message in a conversation.
@@ -526,6 +527,45 @@
  *         nodeDataSourceViewId:
  *           type: string
  *           nullable: true
+ *     PrivateCompactionMessage:
+ *       type: object
+ *       description: A compaction message summarizing earlier conversation content.
+ *       required:
+ *         - type
+ *         - sId
+ *         - status
+ *         - version
+ *         - rank
+ *         - created
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [compaction_message]
+ *         id:
+ *           type: integer
+ *         compactionMessageId:
+ *           type: integer
+ *         sId:
+ *           type: string
+ *         created:
+ *           type: integer
+ *         visibility:
+ *           type: string
+ *           enum: [visible, deleted]
+ *         version:
+ *           type: integer
+ *         rank:
+ *           type: integer
+ *         branchId:
+ *           type: string
+ *           nullable: true
+ *         status:
+ *           type: string
+ *           enum: [created, succeeded, failed]
+ *         content:
+ *           type: string
+ *           nullable: true
+ *           description: Compacted summary. Null while status is "created".
  *     PrivateLightAgentConfiguration:
  *       type: object
  *       description: Agent configuration as returned by the private list endpoint.
@@ -1011,6 +1051,8 @@
  *         - $ref: '#/components/schemas/PrivateUserMessageNewEvent'
  *         - $ref: '#/components/schemas/PrivateAgentMessageNewEvent'
  *         - $ref: '#/components/schemas/PrivateAgentMessageDoneEvent'
+ *         - $ref: '#/components/schemas/PrivateCompactionMessageNewEvent'
+ *         - $ref: '#/components/schemas/PrivateCompactionMessageDoneEvent'
  *         - $ref: '#/components/schemas/PrivateConversationTitleEvent'
  *     PrivateUserMessageNewEvent:
  *       type: object
@@ -1058,6 +1100,32 @@
  *         status:
  *           type: string
  *           enum: [success, error]
+ *     PrivateCompactionMessageNewEvent:
+ *       type: object
+ *       required: [type, created, messageId, message]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [compaction_message_new]
+ *         created:
+ *           type: integer
+ *         messageId:
+ *           type: string
+ *         message:
+ *           $ref: '#/components/schemas/PrivateCompactionMessage'
+ *     PrivateCompactionMessageDoneEvent:
+ *       type: object
+ *       required: [type, created, messageId, message]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [compaction_message_done]
+ *         created:
+ *           type: integer
+ *         messageId:
+ *           type: string
+ *         message:
+ *           $ref: '#/components/schemas/PrivateCompactionMessage'
  *     PrivateConversationTitleEvent:
  *       type: object
  *       required: [type, created, title]

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -9320,6 +9320,9 @@
                       },
                       {
                         "$ref": "#/components/schemas/PrivateContentFragment"
+                      },
+                      {
+                        "$ref": "#/components/schemas/PrivateCompactionMessage"
                       }
                     ]
                   }
@@ -9866,6 +9869,68 @@
           "nodeDataSourceViewId": {
             "type": "string",
             "nullable": true
+          }
+        }
+      },
+      "PrivateCompactionMessage": {
+        "type": "object",
+        "description": "A compaction message summarizing earlier conversation content.",
+        "required": [
+          "type",
+          "sId",
+          "status",
+          "version",
+          "rank",
+          "created"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "compaction_message"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "compactionMessageId": {
+            "type": "integer"
+          },
+          "sId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "integer"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "visible",
+              "deleted"
+            ]
+          },
+          "version": {
+            "type": "integer"
+          },
+          "rank": {
+            "type": "integer"
+          },
+          "branchId": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "created",
+              "succeeded",
+              "failed"
+            ]
+          },
+          "content": {
+            "type": "string",
+            "nullable": true,
+            "description": "Compacted summary. Null while status is \"created\"."
           }
         }
       },
@@ -10642,6 +10707,12 @@
             "$ref": "#/components/schemas/PrivateAgentMessageDoneEvent"
           },
           {
+            "$ref": "#/components/schemas/PrivateCompactionMessageNewEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateCompactionMessageDoneEvent"
+          },
+          {
             "$ref": "#/components/schemas/PrivateConversationTitleEvent"
           }
         ]
@@ -10737,6 +10808,58 @@
               "success",
               "error"
             ]
+          }
+        }
+      },
+      "PrivateCompactionMessageNewEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "messageId",
+          "message"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "compaction_message_new"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "message": {
+            "$ref": "#/components/schemas/PrivateCompactionMessage"
+          }
+        }
+      },
+      "PrivateCompactionMessageDoneEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "messageId",
+          "message"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "compaction_message_done"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "message": {
+            "$ref": "#/components/schemas/PrivateCompactionMessage"
           }
         }
       },

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -331,6 +331,9 @@ export function isLightAgentMessageType(
  */
 export type CompactionMessageStatus = "created" | "succeeded" | "failed";
 
+/**
+ * @swaggerschema PrivateCompactionMessage (swagger_private_schemas.ts)
+ */
 export type CompactionMessageType = {
   type: "compaction_message";
   id: ModelId;


### PR DESCRIPTION
## Description

Add private swagger documentation for the `CompactionMessageType` introduced in #24109:

- `PrivateCompactionMessage` schema with all fields (type, id, compactionMessageId, sId, created, visibility, version, rank, branchId, status, content)
- Added `$ref` to `PrivateCompactionMessage` in `PrivateFullConversation.content` oneOf
- `PrivateCompactionMessageNewEvent` and `PrivateCompactionMessageDoneEvent` SSE event schemas
- Added both event refs to `PrivateConversationEvent` oneOf
- `@swaggerschema` annotation on `CompactionMessageType`

## Tests

Swagger annotation lint passes. Type-check passes.

## Risk

Low — documentation-only change.

## Deploy Plan

Regular deploy.