### PR TITLE
Implement compaction message content generation

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -2540,7 +2540,10 @@ describe("compactConversation", () => {
   });
 
   it("should create a compaction message on an idle conversation", async () => {
-    const result = await compactConversation(auth, { conversation });
+    const result = await compactConversation(auth, {
+      conversation,
+      model: { providerId: "anthropic", modelId: "claude-haiku-4-5-20251001" },
+    });
 
     expect(result.isOk()).toBe(true);
     if (result.isErr()) {
@@ -2586,6 +2589,7 @@ describe("compactConversation", () => {
 
     const result = await compactConversation(auth, {
       conversation: fetched.value,
+      model: { providerId: "anthropic", modelId: "claude-haiku-4-5-20251001" },
     });
 
     expect(result.isErr()).toBe(true);

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2762,7 +2762,7 @@ export async function updateCompactionMessageWithContentAndFinalStatus(
     conversation: ConversationWithoutContentType;
     compactionMessage: CompactionMessageType;
     status: "succeeded" | "failed";
-    content: string;
+    content: string | null;
   }
 ): Promise<{
   completedTs: number;

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -133,6 +133,7 @@ import {
   isUserMessageType,
 } from "@app/types/assistant/conversation";
 import type { MentionType } from "@app/types/assistant/mentions";
+import type { SupportedModel } from "@app/types/assistant/models/types";
 import {
   isAgentMention,
   isUserMention,
@@ -2618,7 +2619,13 @@ export async function isConversationEventAllowedForAuth(
  */
 export async function compactConversation(
   auth: Authenticator,
-  { conversation }: { conversation: ConversationType }
+  {
+    conversation,
+    model,
+  }: {
+    conversation: ConversationType;
+    model: SupportedModel;
+  }
 ): Promise<
   Result<{ compactionMessage: CompactionMessageType }, APIErrorWithStatusCode>
 > {
@@ -2738,6 +2745,7 @@ export async function compactConversation(
     conversationId: conversation.sId,
     compactionMessageId: compactionMessage.sId,
     compactionMessageVersion: compactionMessage.version,
+    model,
   });
 
   return new Ok({ compactionMessage });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -133,12 +133,12 @@ import {
   isUserMessageType,
 } from "@app/types/assistant/conversation";
 import type { MentionType } from "@app/types/assistant/mentions";
-import type { SupportedModel } from "@app/types/assistant/models/types";
 import {
   isAgentMention,
   isUserMention,
   toMentionType,
 } from "@app/types/assistant/mentions";
+import type { SupportedModel } from "@app/types/assistant/models/types";
 import type {
   ContentFragmentContextType,
   ContentFragmentType,

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -19,6 +19,7 @@ interface LLMTraceContextBase {
     | "agent_builder_name_suggestion"
     | "agent_builder_tags_suggestion"
     | "agent_conversation"
+    | "compaction"
     | "agent_observability_summary"
     | "agent_suggestion"
     | "conversation_title_suggestion"

--- a/front/temporal/agent_loop/activities/compaction.ts
+++ b/front/temporal/agent_loop/activities/compaction.ts
@@ -1,6 +1,6 @@
 import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
-import type { SupportedModel } from "@app/types/assistant/models/types";
 import { runCompaction } from "@app/temporal/agent_loop/lib/compaction";
+import type { SupportedModel } from "@app/types/assistant/models/types";
 
 export async function compactionActivity(
   authType: AuthenticatorType,

--- a/front/temporal/agent_loop/activities/compaction.ts
+++ b/front/temporal/agent_loop/activities/compaction.ts
@@ -1,4 +1,5 @@
 import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
+import type { SupportedModel } from "@app/types/assistant/models/types";
 import { runCompaction } from "@app/temporal/agent_loop/lib/compaction";
 
 export async function compactionActivity(
@@ -7,10 +8,12 @@ export async function compactionActivity(
     conversationId,
     compactionMessageId,
     compactionMessageVersion,
+    model,
   }: {
     conversationId: string;
     compactionMessageId: string;
     compactionMessageVersion: number;
+    model: SupportedModel;
   }
 ): Promise<void> {
   const authResult = await Authenticator.fromJSON(authType);
@@ -25,6 +28,7 @@ export async function compactionActivity(
     conversationId,
     compactionMessageId,
     compactionMessageVersion,
+    model,
   });
 
   if (compactionRes.isErr()) {

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -9,6 +9,7 @@ import {
   makeCompactionWorkflowId,
 } from "@app/temporal/agent_loop/lib/workflow_ids";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import type { SupportedModel } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
@@ -118,11 +119,13 @@ export async function launchCompactionWorkflow({
   conversationId,
   compactionMessageId,
   compactionMessageVersion,
+  model,
 }: {
   auth: Authenticator;
   conversationId: string;
   compactionMessageId: string;
   compactionMessageVersion: number;
+  model: SupportedModel;
 }): Promise<
   Result<undefined, Error | DustError<"compaction_already_running">>
 > {
@@ -143,6 +146,7 @@ export async function launchCompactionWorkflow({
           conversationId,
           compactionMessageId,
           compactionMessageVersion,
+          model,
         },
       ],
       taskQueue: QUEUE_NAME,

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -177,6 +177,8 @@ async function generateCompactionSummary(
   // running agent messages, producing exactly the messages that need to be summarized.
   const renderedMessages = renderConversationAsText(conversation, {
     includeTimestamps: true,
+    includeActions: true,
+    includeActionDetails: true,
     skipRunningAgentMessages: true,
   });
 
@@ -187,7 +189,7 @@ async function generateCompactionSummary(
         content: [
           {
             type: "text",
-            text: `Here is the conversation to summarize:\n\n${renderedMessages}`,
+            text: `Conversation to summarize:\n\n${renderedMessages}`,
           },
         ],
         name: "",

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -228,5 +228,10 @@ async function generateCompactionSummary(
     return new Err(new Error("Compaction LLM returned empty generation"));
   }
 
-  return new Ok(extractSummary(generation));
+  const summary = extractSummary(generation);
+  if (!summary) {
+    return new Err(new Error("Compaction LLM returned empty summary"));
+  }
+
+  return new Ok(summary);
 }

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -40,9 +40,10 @@ After your analysis, provide your detailed summary in <summary> tags with these 
 1. **Primary Request and Intent** — All explicit user requests and intents.
 2. **Key Topics and Concepts** — Main subjects, domains, or frameworks discussed.
 3. **Information Exchanged** — Important data, references, or artifacts shared during the conversation.
-4. **Issues and Resolutions** — Problems encountered, how they were resolved, and user feedback.
-5. **Pending Tasks** — Explicitly requested work that is still pending.
-6. **Current State** — What was being discussed or worked on immediately before this summary.
+4. **Key Files and Resources** — Important files, documents, or resources referenced or shared in the conversation that are useful to the current work (content fragments, attachments, links).
+5. **Issues and Resolutions** — Problems encountered, how they were resolved, and user feedback.
+6. **Pending Tasks** — Explicitly requested work that is still pending.
+7. **Current State** — What was being discussed or worked on immediately before this summary.
 
 Only the content of the <summary> block will be used to continue the conversation — the <analysis> \
 block is a scratchpad and will be discarded. Make sure the summary is self-contained and includes \

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -111,19 +111,24 @@ export async function runCompaction(
     return new Err(new Error("Compaction message not found"));
   }
 
+  const summaryRes = await generateCompactionSummary(auth, {
+    conversation,
+    model,
+  });
+
   let content: string;
   let status: "succeeded" | "failed";
 
-  try {
-    content = await generateCompactionSummary(auth, { conversation, model });
+  if (summaryRes.isOk()) {
+    content = summaryRes.value;
     status = "succeeded";
-  } catch (err) {
+  } else {
     logger.error(
       {
         workspaceId: owner.sId,
         conversationId,
         compactionMessageId,
-        error: err,
+        error: summaryRes.error,
       },
       "Compaction summary generation failed"
     );
@@ -165,7 +170,7 @@ async function generateCompactionSummary(
     conversation,
     model,
   }: { conversation: ConversationType; model: SupportedModel }
-): Promise<string> {
+): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
   // renderConversationAsText stops at the last succeeded compaction boundary by default and skips
@@ -215,13 +220,13 @@ async function generateCompactionSummary(
   );
 
   if (res.isErr()) {
-    throw res.error;
+    return res;
   }
 
   const generation = res.value.generation;
   if (!generation) {
-    throw new Error("Compaction LLM returned empty generation");
+    return new Err(new Error("Compaction LLM returned empty generation"));
   }
 
-  return extractSummary(generation);
+  return new Ok(extractSummary(generation));
 }

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -1,15 +1,172 @@
+import type { LLMConfig } from "@app/lib/api/assistant/call_llm";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { updateCompactionMessageWithContentAndFinalStatus } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import {
-  type CompactionMessageType,
-  isCompactionMessageType,
+import type {
+  AgentMessageType,
+  CompactionMessageType,
+  ConversationType,
+  MessageType,
+  UserMessageType,
 } from "@app/types/assistant/conversation";
+import { isCompactionMessageType } from "@app/types/assistant/conversation";
+import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
+import type { SupportedModel } from "@app/types/assistant/models/types";
+import type { ContentFragmentType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+const COMPACTION_PROMPT = `Your task is to create a detailed summary of the conversation so far, \
+paying close attention to the user's explicit requests and the agents' previous actions and \
+responses. This summary should be thorough enough that the conversation can continue without \
+losing important context.
+
+Before providing your final summary, wrap your analysis in <analysis> tags to organize your \
+thoughts and ensure you've covered all necessary points. In your analysis:
+
+1. Chronologically analyze each message in the conversation. For each section identify:
+   - The user's explicit requests and intents
+   - The agents' approaches to addressing those requests
+   - Key decisions and information exchanged
+   - Specific details: data, names, references, or artifacts mentioned
+   - Any errors or issues encountered and how they were resolved
+   - Pay special attention to user feedback and corrections
+
+2. Double-check for accuracy and completeness.
+
+After your analysis, provide your summary in <summary> tags with these sections:
+
+1. **Primary Request and Intent** — All explicit user requests and intents.
+2. **Key Topics and Concepts** — Main subjects, domains, or frameworks discussed.
+3. **Information Exchanged** — Important data, references, or artifacts shared during the conversation.
+4. **Issues and Resolutions** — Problems encountered, how they were resolved, and user feedback.
+5. **Pending Tasks** — Explicitly requested work that is still pending.
+6. **Current State** — What was being discussed or worked on immediately before this summary.
+
+IMPORTANT: Respond with TEXT ONLY. Do NOT attempt to use any tools. Your entire response must be \
+plain text: an <analysis> block followed by a <summary> block.`;
+
+/**
+ * Render the messages that need to be compacted into a text representation suitable for the
+ * compaction LLM prompt. Only messages after the last succeeded compaction are included.
+ */
+function renderMessagesForCompaction(conversation: ConversationType): string {
+  const messages: string[] = [];
+  let pastCompactionBoundary = false;
+
+  // Find the last succeeded compaction message to use as boundary.
+  let lastSucceededCompactionIdx = -1;
+  for (let i = conversation.content.length - 1; i >= 0; i--) {
+    const group = conversation.content[i];
+    const msg = group[group.length - 1];
+    if (
+      msg &&
+      isCompactionMessageType(msg) &&
+      msg.status === "succeeded" &&
+      msg.content
+    ) {
+      lastSucceededCompactionIdx = i;
+      break;
+    }
+  }
+
+  for (let i = 0; i < conversation.content.length; i++) {
+    const group = conversation.content[i];
+    const msg = group[group.length - 1];
+    if (!msg) {
+      continue;
+    }
+
+    // Skip everything up to and including the last succeeded compaction.
+    if (lastSucceededCompactionIdx >= 0 && i <= lastSucceededCompactionIdx) {
+      if (i === lastSucceededCompactionIdx) {
+        pastCompactionBoundary = true;
+      }
+      continue;
+    }
+
+    // Skip compaction messages with status "created" (the one being generated).
+    if (isCompactionMessageType(msg) && msg.status === "created") {
+      continue;
+    }
+
+    const formatted = formatMessageForCompaction(msg);
+    if (formatted) {
+      messages.push(formatted);
+    }
+  }
+
+  // If there was a previous compaction, prepend its summary as context.
+  if (pastCompactionBoundary) {
+    const compactionGroup = conversation.content[lastSucceededCompactionIdx];
+    const compactionMsg = compactionGroup[compactionGroup.length - 1];
+    if (compactionMsg && isCompactionMessageType(compactionMsg)) {
+      messages.unshift(
+        `[Previous compaction summary]\n${compactionMsg.content}\n`
+      );
+    }
+  }
+
+  return messages.join("\n");
+}
+
+function formatMessageForCompaction(msg: MessageType): string | null {
+  switch (msg.type) {
+    case "user_message":
+      return formatUserMessage(msg);
+    case "agent_message":
+      return formatAgentMessage(msg);
+    case "content_fragment":
+      return formatContentFragment(msg);
+    case "compaction_message":
+      // Succeeded compaction messages in the middle of the range are included as-is.
+      if (msg.status === "succeeded" && msg.content) {
+        return `[Compaction summary]\n${msg.content}\n`;
+      }
+      return null;
+    default:
+      assertNever(msg);
+  }
+}
+
+function formatUserMessage(msg: UserMessageType): string {
+  const userName = msg.user?.fullName ?? msg.user?.username ?? "User";
+  const content = msg.content ?? "";
+  if (msg.visibility === "deleted") {
+    return `>> User (${userName}):\n[Deleted message]\n`;
+  }
+  return `>> User (${userName}):\n${content}\n`;
+}
+
+function formatAgentMessage(msg: AgentMessageType): string {
+  const agentName = msg.configuration?.name ?? "Agent";
+  const content = msg.content ?? "";
+  if (msg.visibility === "deleted") {
+    return `>> Agent (${agentName}):\n[Deleted message]\n`;
+  }
+  return `>> Agent (${agentName}):\n${content}\n`;
+}
+
+function formatContentFragment(msg: ContentFragmentType): string {
+  return `>> Content Fragment:\nTitle: ${msg.title}\nContent-Type: ${msg.contentType}\n`;
+}
+
+/**
+ * Extract the <summary> block from the LLM response, stripping the <analysis> scratchpad.
+ */
+function extractSummary(generation: string): string {
+  const summaryMatch = generation.match(/<summary>([\s\S]*?)<\/summary>/);
+  if (summaryMatch) {
+    return summaryMatch[1].trim();
+  }
+  // Fallback: if no <summary> tags, return the full generation stripped of <analysis>.
+  return generation.replace(/<analysis>[\s\S]*?<\/analysis>/g, "").trim();
+}
 
 export async function runCompaction(
   auth: Authenticator,
@@ -17,10 +174,12 @@ export async function runCompaction(
     conversationId,
     compactionMessageId,
     compactionMessageVersion,
+    model,
   }: {
     conversationId: string;
     compactionMessageId: string;
     compactionMessageVersion: number;
+    model: SupportedModel;
   }
 ): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
@@ -61,13 +220,30 @@ export async function runCompaction(
     return new Err(new Error("Compaction message not found"));
   }
 
-  // TODO(compaction): implement actual compaction
-  const content = "[COMPACTION]";
+  let content: string;
+  let status: "succeeded" | "failed";
+
+  try {
+    content = await generateCompactionSummary(auth, { conversation, model });
+    status = "succeeded";
+  } catch (err) {
+    logger.error(
+      {
+        workspaceId: owner.sId,
+        conversationId,
+        compactionMessageId,
+        error: err,
+      },
+      "Compaction summary generation failed"
+    );
+    content = "";
+    status = "failed";
+  }
 
   const result = await updateCompactionMessageWithContentAndFinalStatus(auth, {
     conversation,
     compactionMessage,
-    status: "succeeded",
+    status,
     content,
   });
 
@@ -85,9 +261,71 @@ export async function runCompaction(
   );
 
   logger.info(
-    { workspaceId: owner.sId, conversationId, compactionMessageId },
+    { workspaceId: owner.sId, conversationId, compactionMessageId, status },
     "Compaction completed"
   );
 
   return new Ok(undefined);
+}
+
+async function generateCompactionSummary(
+  auth: Authenticator,
+  {
+    conversation,
+    model,
+  }: { conversation: ConversationType; model: SupportedModel }
+): Promise<string> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const renderedMessages = renderMessagesForCompaction(conversation);
+
+  const conv: ModelConversationTypeMultiActions = {
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `Here is the conversation to summarize:\n\n${renderedMessages}`,
+          },
+        ],
+        name: "",
+      },
+    ],
+  };
+
+  const config: LLMConfig = {
+    providerId: model.providerId,
+    modelId: model.modelId,
+    temperature: 0,
+  };
+
+  const res = await runMultiActionsAgent(
+    auth,
+    config,
+    {
+      conversation: conv,
+      prompt: COMPACTION_PROMPT,
+      specifications: [],
+    },
+    {
+      context: {
+        operationType: "compaction",
+        conversationId: conversation.sId,
+        userId: auth.user()?.sId,
+        workspaceId: owner.sId,
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    throw res.error;
+  }
+
+  const generation = res.value.generation;
+  if (!generation) {
+    throw new Error("Compaction LLM returned empty generation");
+  }
+
+  return extractSummary(generation);
 }

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -2,24 +2,20 @@ import type { LLMConfig } from "@app/lib/api/assistant/call_llm";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { updateCompactionMessageWithContentAndFinalStatus } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type {
-  AgentMessageType,
   CompactionMessageType,
   ConversationType,
-  MessageType,
-  UserMessageType,
 } from "@app/types/assistant/conversation";
 import { isCompactionMessageType } from "@app/types/assistant/conversation";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { SupportedModel } from "@app/types/assistant/models/types";
-import type { ContentFragmentType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const COMPACTION_PROMPT = `Your task is to create a detailed summary of the conversation so far, \
 paying close attention to the user's explicit requests and the agents' previous actions and \
@@ -50,111 +46,6 @@ After your analysis, provide your summary in <summary> tags with these sections:
 
 IMPORTANT: Respond with TEXT ONLY. Do NOT attempt to use any tools. Your entire response must be \
 plain text: an <analysis> block followed by a <summary> block.`;
-
-/**
- * Render the messages that need to be compacted into a text representation suitable for the
- * compaction LLM prompt. Only messages after the last succeeded compaction are included.
- */
-function renderMessagesForCompaction(conversation: ConversationType): string {
-  const messages: string[] = [];
-  let pastCompactionBoundary = false;
-
-  // Find the last succeeded compaction message to use as boundary.
-  let lastSucceededCompactionIdx = -1;
-  for (let i = conversation.content.length - 1; i >= 0; i--) {
-    const group = conversation.content[i];
-    const msg = group[group.length - 1];
-    if (
-      msg &&
-      isCompactionMessageType(msg) &&
-      msg.status === "succeeded" &&
-      msg.content
-    ) {
-      lastSucceededCompactionIdx = i;
-      break;
-    }
-  }
-
-  for (let i = 0; i < conversation.content.length; i++) {
-    const group = conversation.content[i];
-    const msg = group[group.length - 1];
-    if (!msg) {
-      continue;
-    }
-
-    // Skip everything up to and including the last succeeded compaction.
-    if (lastSucceededCompactionIdx >= 0 && i <= lastSucceededCompactionIdx) {
-      if (i === lastSucceededCompactionIdx) {
-        pastCompactionBoundary = true;
-      }
-      continue;
-    }
-
-    // Skip compaction messages with status "created" (the one being generated).
-    if (isCompactionMessageType(msg) && msg.status === "created") {
-      continue;
-    }
-
-    const formatted = formatMessageForCompaction(msg);
-    if (formatted) {
-      messages.push(formatted);
-    }
-  }
-
-  // If there was a previous compaction, prepend its summary as context.
-  if (pastCompactionBoundary) {
-    const compactionGroup = conversation.content[lastSucceededCompactionIdx];
-    const compactionMsg = compactionGroup[compactionGroup.length - 1];
-    if (compactionMsg && isCompactionMessageType(compactionMsg)) {
-      messages.unshift(
-        `[Previous compaction summary]\n${compactionMsg.content}\n`
-      );
-    }
-  }
-
-  return messages.join("\n");
-}
-
-function formatMessageForCompaction(msg: MessageType): string | null {
-  switch (msg.type) {
-    case "user_message":
-      return formatUserMessage(msg);
-    case "agent_message":
-      return formatAgentMessage(msg);
-    case "content_fragment":
-      return formatContentFragment(msg);
-    case "compaction_message":
-      // Succeeded compaction messages in the middle of the range are included as-is.
-      if (msg.status === "succeeded" && msg.content) {
-        return `[Compaction summary]\n${msg.content}\n`;
-      }
-      return null;
-    default:
-      assertNever(msg);
-  }
-}
-
-function formatUserMessage(msg: UserMessageType): string {
-  const userName = msg.user?.fullName ?? msg.user?.username ?? "User";
-  const content = msg.content ?? "";
-  if (msg.visibility === "deleted") {
-    return `>> User (${userName}):\n[Deleted message]\n`;
-  }
-  return `>> User (${userName}):\n${content}\n`;
-}
-
-function formatAgentMessage(msg: AgentMessageType): string {
-  const agentName = msg.configuration?.name ?? "Agent";
-  const content = msg.content ?? "";
-  if (msg.visibility === "deleted") {
-    return `>> Agent (${agentName}):\n[Deleted message]\n`;
-  }
-  return `>> Agent (${agentName}):\n${content}\n`;
-}
-
-function formatContentFragment(msg: ContentFragmentType): string {
-  return `>> Content Fragment:\nTitle: ${msg.title}\nContent-Type: ${msg.contentType}\n`;
-}
 
 /**
  * Extract the <summary> block from the LLM response, stripping the <analysis> scratchpad.
@@ -277,7 +168,12 @@ async function generateCompactionSummary(
 ): Promise<string> {
   const owner = auth.getNonNullableWorkspace();
 
-  const renderedMessages = renderMessagesForCompaction(conversation);
+  // renderConversationAsText stops at the last succeeded compaction boundary by default and skips
+  // running agent messages, producing exactly the messages that need to be summarized.
+  const renderedMessages = renderConversationAsText(conversation, {
+    includeTimestamps: true,
+    skipRunningAgentMessages: true,
+  });
 
   const conv: ModelConversationTypeMultiActions = {
     messages: [

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -35,7 +35,7 @@ thoughts and ensure you've covered all necessary points. In your analysis:
 
 2. Double-check for accuracy and completeness.
 
-After your analysis, provide your summary in <summary> tags with these sections:
+After your analysis, provide your detailed summary in <summary> tags with these sections:
 
 1. **Primary Request and Intent** — All explicit user requests and intents.
 2. **Key Topics and Concepts** — Main subjects, domains, or frameworks discussed.
@@ -43,6 +43,10 @@ After your analysis, provide your summary in <summary> tags with these sections:
 4. **Issues and Resolutions** — Problems encountered, how they were resolved, and user feedback.
 5. **Pending Tasks** — Explicitly requested work that is still pending.
 6. **Current State** — What was being discussed or worked on immediately before this summary.
+
+Only the content of the <summary> block will be used to continue the conversation — the <analysis> \
+block is a scratchpad and will be discarded. Make sure the summary is self-contained and includes \
+all the context needed to continue without access to the original messages.
 
 IMPORTANT: Respond with TEXT ONLY. Do NOT attempt to use any tools. Your entire response must be \
 plain text: an <analysis> block followed by a <summary> block.`;
@@ -130,7 +134,7 @@ export async function runCompaction(
         compactionMessageId,
         error: summaryRes.error,
       },
-      "Compaction summary generation failed"
+      "Compaction generation failed"
     );
     content = null;
     status = "failed";
@@ -181,6 +185,9 @@ async function generateCompactionSummary(
     includeActionDetails: true,
     skipRunningAgentMessages: true,
   });
+
+  // TODO(compaction): Ensure we don't exceeds the model context size here, as we have no guarantee
+  // that the current conversation is not exceeding it already.
 
   const conv: ModelConversationTypeMultiActions = {
     messages: [

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -39,8 +39,10 @@ After your analysis, provide your detailed summary in <summary> tags with these 
 
 1. **Primary Request and Intent** — All explicit user requests and intents.
 2. **Key Topics and Concepts** — Main subjects, domains, or frameworks discussed.
-3. **Information Exchanged** — Important data, references, or artifacts shared during the conversation.
-4. **Key Files and Resources** — Important files, documents, or resources referenced or shared in the conversation that are useful to the current work (content fragments, attachments, links).
+3. **Information Exchanged** — Important data, references, or artifacts shared during the \
+conversation.
+4. **Key Files and Resources** — Important files, documents, or resources shared in the \
+conversation that are useful to the current work.
 5. **Issues and Resolutions** — Problems encountered, how they were resolved, and user feedback.
 6. **Pending Tasks** — Explicitly requested work that is still pending.
 7. **Current State** — What was being discussed or worked on immediately before this summary.

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -191,6 +191,8 @@ async function generateCompactionSummary(
 
   // TODO(compaction): Ensure we don't exceeds the model context size here, as we have no guarantee
   // that the current conversation is not exceeding it already.
+  // TODO(compaction): We may want to be more mechanical about files available to the model in
+  // conversation and projects by including a lsit as part of the summary.
 
   const conv: ModelConversationTypeMultiActions = {
     messages: [

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -116,7 +116,7 @@ export async function runCompaction(
     model,
   });
 
-  let content: string;
+  let content: string | null;
   let status: "succeeded" | "failed";
 
   if (summaryRes.isOk()) {
@@ -132,7 +132,7 @@ export async function runCompaction(
       },
       "Compaction summary generation failed"
     );
-    content = "";
+    content = null;
     status = "failed";
   }
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -4,6 +4,7 @@ import {
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
 import type { AuthenticatorType } from "@app/lib/auth";
+import type { SupportedModel } from "@app/types/assistant/models/types";
 import type * as compactionActivities from "@app/temporal/agent_loop/activities/compaction";
 import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import type * as finalizeActivities from "@app/temporal/agent_loop/activities/finalize";
@@ -138,16 +139,19 @@ export async function compactionWorkflow({
   conversationId,
   compactionMessageId,
   compactionMessageVersion,
+  model,
 }: {
   authType: AuthenticatorType;
   conversationId: string;
   compactionMessageId: string;
   compactionMessageVersion: number;
+  model: SupportedModel;
 }) {
   await compactionActivity(authType, {
     conversationId,
     compactionMessageId,
     compactionMessageVersion,
+    model,
   });
 }
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -4,7 +4,6 @@ import {
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
 import type { AuthenticatorType } from "@app/lib/auth";
-import type { SupportedModel } from "@app/types/assistant/models/types";
 import type * as compactionActivities from "@app/temporal/agent_loop/activities/compaction";
 import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import type * as finalizeActivities from "@app/temporal/agent_loop/activities/finalize";
@@ -23,6 +22,7 @@ import type {
   AgentLoopArgs,
   AgentLoopArgsWithTiming,
 } from "@app/types/assistant/agent_run";
+import type { SupportedModel } from "@app/types/assistant/models/types";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/common";
 import type {
   ChildWorkflowHandle,

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -117,19 +117,19 @@ PR #24107.
 - `postUserMessage` blocking: checks for active compaction (`status: "created"`) in conversation
   content, returns 409 if found.
 
-### - [ ] PR 3.4 — Implement compaction summary generation
+### - [x] PR 3.4 — Implement compaction summary generation
 
-The LLM call that produces the summary.
+PR #24111. The LLM call that produces the summary.
 
-- In `compactionActivity` (`front/temporal/agent_loop/activities/`):
-  - Fetch all messages since the last succeeded `CompactionMessage` (or all messages if none).
-  - Render them into a compaction prompt (adapt from Claude Code's approach — system prompt +
-    conversation + "summarize" instruction, see `x/spolu/compaction/claude_compaction.md` for
-    reference).
-  - Call the LLM via `callModel` / `queryModelWithStreaming` to generate the summary.
-  - Store the content on the `CompactionMessage`.
-- Add the compaction prompt template (can live in the activity file or a dedicated prompt file
-  under `front/temporal/agent_loop/`).
+- `renderMessagesForCompaction()`: renders messages since the last succeeded compaction into text,
+  prepending previous compaction summary as context if one exists.
+- `generateCompactionSummary()`: calls LLM via `runMultiActionsAgent` with an `<analysis>` +
+  `<summary>` block prompt adapted for Dust's multi-agent platform.
+- `extractSummary()`: parses LLM response, strips the `<analysis>` scratchpad.
+- Thread `SupportedModel` through the full chain: `compactConversation` →
+  `launchCompactionWorkflow` → workflow → activity → `runCompaction` →
+  `generateCompactionSummary`. The caller controls which model is used.
+- Add `"compaction"` to the LLM trace `operationType` union.
 
 ---
 


### PR DESCRIPTION
## Description

Implements PR 3.4 from the compaction plan — the LLM call that produces the compaction summary.

- Replace the `[COMPACTION]` stub in `runCompaction` with actual LLM-based summary generation.
- Compaction prompt uses `<analysis>`/`<summary>` block structure inspired by Claude code.
- `renderMessagesForCompaction()` renders messages since the last succeeded compaction into text.
- `extractSummary()` parses the LLM response, stripping the analysis scratchpad.
- Thread `SupportedModel` as argument through the full chain: `compactConversation` → `launchCompactionWorkflow` → workflow → activity → `runCompaction` → `generateCompactionSummary`.
- Add `"compaction"` to the LLM trace `operationType` union.

## Tests

Type-checking for now.

## Risk

Low. Unused

## Deploy Plan

- deploy `front`