### PR TITLE
[Sessions] Expose forkedFrom on conversation payloads

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -3508,6 +3508,7 @@ describe("conversation fetch forkedFrom", () => {
         parentConversationId: parentConversation.sId,
         sourceMessageId: sourceMessage.sId,
         branchedAt: branchedAt.getTime(),
+        user: auth.getNonNullableUser().toJSON(),
       });
     }
 
@@ -3522,6 +3523,7 @@ describe("conversation fetch forkedFrom", () => {
         parentConversationId: parentConversation.sId,
         sourceMessageId: sourceMessage.sId,
         branchedAt: branchedAt.getTime(),
+        user: auth.getNonNullableUser().toJSON(),
       });
     }
   });

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -8,7 +8,10 @@ import {
   softDeleteAgentMessage,
 } from "@app/lib/api/assistant/conversation";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import {
+  getConversation,
+  getLightConversation,
+} from "@app/lib/api/assistant/conversation/fetch";
 import { publishAgentMessagesEvents } from "@app/lib/api/assistant/streaming/events";
 import * as attachmentsModule from "@app/lib/api/files/attachments";
 import { fetchLatestProjectContextFileContentFragment } from "@app/lib/api/projects";
@@ -71,6 +74,7 @@ vi.mock("@app/lib/api/assistant/conversation/content_fragment", () => ({
 }));
 
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
+import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -3437,5 +3441,88 @@ describe("isConversationEventAllowedForAuth", () => {
       event,
     });
     expect(result).toBe(false);
+  });
+});
+
+describe("conversation fetch forkedFrom", () => {
+  it("includes forkedFrom in full and light conversation payloads", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Fork Fetch Agent",
+      description: "Fork fetch agent",
+    });
+
+    const parentConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date("2026-01-05T00:00:00.000Z")],
+    });
+    const childConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+
+    const parentConversationResource = await ConversationResource.fetchById(
+      auth,
+      parentConversation.sId
+    );
+    const childConversationResource = await ConversationResource.fetchById(
+      auth,
+      childConversation.sId
+    );
+    expect(parentConversationResource).not.toBeNull();
+    expect(childConversationResource).not.toBeNull();
+    if (!parentConversationResource || !childConversationResource) {
+      throw new Error("Failed to fetch fork conversations");
+    }
+
+    const sourceMessage = await MessageModel.findOne({
+      where: {
+        conversationId: parentConversation.id,
+        workspaceId: workspace.id,
+        rank: 1,
+      },
+    });
+    expect(sourceMessage).not.toBeNull();
+    if (!sourceMessage) {
+      throw new Error("Failed to fetch source message");
+    }
+
+    const branchedAt = new Date("2026-01-06T00:00:00.000Z");
+    await ConversationForkResource.makeNew(auth, {
+      parentConversation: parentConversationResource,
+      childConversation: childConversationResource,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt,
+    });
+
+    const fullConversationResult = await getConversation(
+      auth,
+      childConversation.sId
+    );
+    expect(fullConversationResult.isOk()).toBe(true);
+
+    if (fullConversationResult.isOk()) {
+      expect(fullConversationResult.value.forkedFrom).toEqual({
+        parentConversationId: parentConversation.sId,
+        sourceMessageId: sourceMessage.sId,
+        branchedAt: branchedAt.getTime(),
+      });
+    }
+
+    const lightConversationResult = await getLightConversation(
+      auth,
+      childConversation.sId
+    );
+    expect(lightConversationResult.isOk()).toBe(true);
+
+    if (lightConversationResult.isOk()) {
+      expect(lightConversationResult.value.forkedFrom).toEqual({
+        parentConversationId: parentConversation.sId,
+        sourceMessageId: sourceMessage.sId,
+        branchedAt: branchedAt.getTime(),
+      });
+    }
   });
 });

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -312,6 +312,7 @@ async function _getConversation<V extends "light" | "full">(
       spaceId: conversation.space?.sId ?? null,
       metadata: conversation.metadata,
       branchId,
+      ...(conversation.forkedFrom && { forkedFrom: conversation.forkedFrom }),
     };
 
     if (paginationHasMore !== undefined) {
@@ -381,6 +382,7 @@ async function _getConversation<V extends "light" | "full">(
       spaceId: conversation.space?.sId ?? null,
       metadata: conversation.metadata,
       branchId,
+      ...(conversation.forkedFrom && { forkedFrom: conversation.forkedFrom }),
     };
 
     if (paginationHasMore !== undefined) {

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -312,7 +312,9 @@ async function _getConversation<V extends "light" | "full">(
       spaceId: conversation.space?.sId ?? null,
       metadata: conversation.metadata,
       branchId,
-      ...(conversation.forkedFrom && { forkedFrom: conversation.forkedFrom }),
+      ...(conversation.forkedFromInfo && {
+        forkedFrom: conversation.forkedFromInfo,
+      }),
     };
 
     if (paginationHasMore !== undefined) {
@@ -382,7 +384,9 @@ async function _getConversation<V extends "light" | "full">(
       spaceId: conversation.space?.sId ?? null,
       metadata: conversation.metadata,
       branchId,
-      ...(conversation.forkedFrom && { forkedFrom: conversation.forkedFrom }),
+      ...(conversation.forkedFromInfo && {
+        forkedFrom: conversation.forkedFromInfo,
+      }),
     };
 
     if (paginationHasMore !== undefined) {

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -1,6 +1,7 @@
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import type { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import type { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
+import type { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
@@ -38,6 +39,7 @@ export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
   // Note: Using spaceId for the FK instead of vaultId as it is not a "ResourceWithSpace" and it's aligned with "requestedSpaceIds".
   declare spaceId: ForeignKey<SpaceModel["id"]> | null;
   declare space: NonAttribute<SpaceModel>;
+  declare forkedFrom?: NonAttribute<ConversationForkModel | null>;
 }
 
 ConversationModel.init(

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@app/lib/reinforced_agent/types";
 import { getReinforcedSkillsMetadata } from "@app/lib/reinforcement/types";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
+import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -132,6 +133,162 @@ describe("ConversationResource", () => {
         convoB.id,
       ]);
       expect(fetched.length).toBe(0);
+    });
+
+    it("should preload forkedFrom on forked child conversations", async () => {
+      const { workspace, authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Fork Source Agent",
+        description: "Fork source agent",
+      });
+
+      const parentConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [new Date("2026-01-01T00:00:00.000Z")],
+      });
+      const childConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+      });
+
+      const parentConversationResource = await ConversationResource.fetchById(
+        auth,
+        parentConversation.sId
+      );
+      const childConversationResource = await ConversationResource.fetchById(
+        auth,
+        childConversation.sId
+      );
+      assert(parentConversationResource, "Parent conversation not found");
+      assert(childConversationResource, "Child conversation not found");
+
+      const sourceMessage = await MessageModel.findOne({
+        where: {
+          conversationId: parentConversation.id,
+          workspaceId: workspace.id,
+          rank: 1,
+        },
+      });
+      assert(sourceMessage, "Source message not found");
+
+      const branchedAt = new Date("2026-01-02T00:00:00.000Z");
+      await ConversationForkResource.makeNew(auth, {
+        parentConversation: parentConversationResource,
+        childConversation: childConversationResource,
+        sourceMessageModelId: sourceMessage.id,
+        branchedAt,
+      });
+
+      const [fetchedChildConversation] =
+        await ConversationResource.fetchByModelIds(auth, [
+          childConversation.id,
+        ]);
+
+      expect(fetchedChildConversation.toJSON().forkedFrom).toEqual({
+        parentConversationId: parentConversation.sId,
+        sourceMessageId: sourceMessage.sId,
+        branchedAt: branchedAt.getTime(),
+      });
+
+      const childConversationWithoutContent =
+        await ConversationResource.fetchConversationWithoutContent(
+          auth,
+          childConversation.sId
+        );
+      expect(childConversationWithoutContent.isOk()).toBe(true);
+
+      if (childConversationWithoutContent.isOk()) {
+        expect(childConversationWithoutContent.value.forkedFrom).toEqual({
+          parentConversationId: parentConversation.sId,
+          sourceMessageId: sourceMessage.sId,
+          branchedAt: branchedAt.getTime(),
+        });
+      }
+    });
+
+    it("should expose forkedFrom even when the parent conversation is unreadable", async () => {
+      const {
+        workspace,
+        authenticator: adminAuth,
+        user: adminUser,
+      } = await createResourceTest({
+        role: "admin",
+      });
+      const regularUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, regularUser, {
+        role: "user",
+      });
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        regularUser.sId,
+        workspace.sId
+      );
+
+      const restrictedSpace = await SpaceFactory.regular(workspace);
+      const addMembersRes = await restrictedSpace.addMembers(adminAuth, {
+        userIds: [adminUser.sId],
+      });
+      assert(addMembersRes.isOk(), "Failed to add admin to restricted space");
+
+      const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+        name: "Restricted Fork Source Agent",
+        description: "Restricted fork source agent",
+      });
+      const parentConversation = await ConversationFactory.create(adminAuth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [new Date("2026-01-03T00:00:00.000Z")],
+        requestedSpaceIds: [restrictedSpace.id],
+        spaceId: restrictedSpace.id,
+      });
+      const childConversation = await ConversationFactory.create(userAuth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+      });
+
+      const parentConversationResource = await ConversationResource.fetchById(
+        adminAuth,
+        parentConversation.sId
+      );
+      const childConversationResource = await ConversationResource.fetchById(
+        adminAuth,
+        childConversation.sId
+      );
+      assert(parentConversationResource, "Parent conversation not found");
+      assert(childConversationResource, "Child conversation not found");
+
+      const sourceMessage = await MessageModel.findOne({
+        where: {
+          conversationId: parentConversation.id,
+          workspaceId: workspace.id,
+          rank: 1,
+        },
+      });
+      assert(sourceMessage, "Source message not found");
+
+      const branchedAt = new Date("2026-01-04T00:00:00.000Z");
+      await ConversationForkResource.makeNew(adminAuth, {
+        parentConversation: parentConversationResource,
+        childConversation: childConversationResource,
+        sourceMessageModelId: sourceMessage.id,
+        branchedAt,
+      });
+
+      expect(
+        await ConversationResource.fetchById(userAuth, parentConversation.sId)
+      ).toBeNull();
+
+      const fetchedChildConversation = await ConversationResource.fetchById(
+        userAuth,
+        childConversation.sId
+      );
+      assert(fetchedChildConversation, "Child conversation not found");
+
+      expect(fetchedChildConversation.toJSON().forkedFrom).toEqual({
+        parentConversationId: parentConversation.sId,
+        sourceMessageId: sourceMessage.sId,
+        branchedAt: branchedAt.getTime(),
+      });
     });
   });
 

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -190,6 +190,7 @@ describe("ConversationResource", () => {
         parentConversationId: parentConversation.sId,
         sourceMessageId: sourceMessage.sId,
         branchedAt: branchedAt.getTime(),
+        user: auth.getNonNullableUser().toJSON(),
       });
 
       const childConversationWithoutContent =
@@ -204,6 +205,7 @@ describe("ConversationResource", () => {
           parentConversationId: parentConversation.sId,
           sourceMessageId: sourceMessage.sId,
           branchedAt: branchedAt.getTime(),
+          user: auth.getNonNullableUser().toJSON(),
         });
       }
     });
@@ -288,6 +290,7 @@ describe("ConversationResource", () => {
         parentConversationId: parentConversation.sId,
         sourceMessageId: sourceMessage.sId,
         branchedAt: branchedAt.getTime(),
+        user: adminAuth.getNonNullableUser().toJSON(),
       });
     });
   });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -9,6 +9,7 @@ import {
   UserConversationReadsModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
+import "@app/lib/models/agent/conversation_fork";
 import { REINFORCEMENT_METADATA_KEYS } from "@app/lib/reinforced_agent/types";
 import { REINFORCED_SKILLS_METADATA_KEYS } from "@app/lib/reinforcement/types";
 import { BaseResource } from "@app/lib/resources/base_resource";

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -9,6 +9,7 @@ import {
   UserConversationReadsModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
+import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { REINFORCEMENT_METADATA_KEYS } from "@app/lib/reinforced_agent/types";
 import { REINFORCED_SKILLS_METADATA_KEYS } from "@app/lib/reinforcement/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -30,6 +31,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
+  ConversationForkedFromType,
   ConversationMCPServerViewType,
   ConversationVisibility,
   ConversationWithoutContentType,
@@ -78,6 +80,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   // User-specific fields (populated when conversations are listed for a user).
   private userParticipation?: UserParticipation;
   private userLastReadAt: Date | null = null;
+  private forkedFromData?: ConversationForkedFromType;
 
   constructor(
     model: ModelStaticWorkspaceAware<ConversationModel>,
@@ -117,7 +120,16 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
 
     // Note: no permission filtering here. Callers must ensure the auth is allowed.
-    return conversations.map((c) => new this(this.model, c.get(), null));
+    const resources = conversations.map(
+      (c) => new this(this.model, c.get(), null)
+    );
+    await this.enrichWithForkedFrom(auth, resources);
+
+    return resources;
+  }
+
+  get forkedFrom(): ConversationForkedFromType | undefined {
+    return this.forkedFromData;
   }
 
   get space(): SpaceResource | null {
@@ -356,6 +368,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       )
     );
 
+    await this.enrichWithForkedFrom(auth, spaceBasedAccessible);
+
     return spaceBasedAccessible;
   }
 
@@ -478,6 +492,58 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
 
     await this.enrichWithReadState(auth, conversations);
+  }
+
+  private static async enrichWithForkedFrom(
+    auth: Authenticator,
+    conversations: ConversationResource[]
+  ): Promise<void> {
+    if (conversations.length === 0) {
+      return;
+    }
+
+    const forks = await ConversationForkModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        childConversationId: conversations.map((c) => c.id),
+      },
+      include: [
+        {
+          model: ConversationModel,
+          as: "parentConversation",
+          required: true,
+          attributes: ["sId"],
+        },
+        {
+          model: MessageModel,
+          as: "sourceMessage",
+          required: true,
+          attributes: ["sId"],
+        },
+      ],
+    });
+    if (forks.length === 0) {
+      return;
+    }
+
+    const conversationsById = new Map(conversations.map((c) => [c.id, c]));
+
+    forks.forEach((fork) => {
+      if (!fork.parentConversation || !fork.sourceMessage) {
+        return;
+      }
+
+      const conversation = conversationsById.get(fork.childConversationId);
+      if (!conversation) {
+        return;
+      }
+
+      conversation.forkedFromData = {
+        parentConversationId: fork.parentConversation.sId,
+        sourceMessageId: fork.sourceMessage.sId,
+        branchedAt: fork.branchedAt.getTime(),
+      };
+    });
   }
 
   static async fetchByIds(
@@ -971,6 +1037,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       depth: conversation.depth,
       metadata: conversation.metadata,
       branchId: null,
+      ...(conversation.forkedFrom && { forkedFrom: conversation.forkedFrom }),
     });
   }
 
@@ -2684,6 +2751,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       depth: this.depth,
       metadata: this.metadata,
       branchId: null,
+      ...(this.forkedFrom && { forkedFrom: this.forkedFrom }),
     };
   }
 }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -90,6 +90,87 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     super(ConversationModel, blob);
   }
 
+  private static getForkedFromInclude() {
+    return [
+      {
+        model: ConversationForkModel,
+        as: "forkedFrom" as const,
+        required: false,
+        attributes: ["branchedAt", "childConversationId"],
+        include: [
+          {
+            model: ConversationModel,
+            as: "parentConversation" as const,
+            required: true,
+            attributes: ["sId"],
+          },
+          {
+            model: MessageModel,
+            as: "sourceMessage" as const,
+            required: true,
+            attributes: ["sId"],
+          },
+          {
+            model: UserResource.model,
+            as: "createdByUser" as const,
+            required: true,
+            attributes: [
+              "id",
+              "sId",
+              "createdAt",
+              "provider",
+              "username",
+              "email",
+              "firstName",
+              "lastName",
+              "imageUrl",
+              "lastLoginAt",
+            ],
+          },
+        ],
+      },
+    ];
+  }
+
+  private static getForkedFromData(
+    conversation: ConversationModel
+  ): ConversationForkedFromType | undefined {
+    const fork = conversation.forkedFrom;
+    if (!fork) {
+      return undefined;
+    }
+
+    assert(
+      fork.parentConversation,
+      "Forked conversation parent conversation must be loaded."
+    );
+    assert(
+      fork.sourceMessage,
+      "Forked conversation source message must be loaded."
+    );
+    assert(fork.createdByUser, "Forked conversation creator must be loaded.");
+
+    return {
+      parentConversationId: fork.parentConversation.sId,
+      sourceMessageId: fork.sourceMessage.sId,
+      branchedAt: fork.branchedAt.getTime(),
+      user: new UserResource(
+        UserResource.model,
+        fork.createdByUser.get()
+      ).toJSON(),
+    };
+  }
+
+  private static fromModel(
+    conversation: ConversationModel,
+    space: SpaceResource | null
+  ): ConversationResource {
+    const resource = new this(this.model, conversation.get(), space);
+    resource.forkedFromData = this.getForkedFromData(conversation);
+
+    return resource;
+  }
+
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
@@ -116,19 +197,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         ...(excludeTest ? { visibility: { [Op.ne]: "test" } } : {}),
         ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
       } as WhereOptions<ConversationModel>,
+      include: this.getForkedFromInclude(),
       transaction,
     });
 
     // Note: no permission filtering here. Callers must ensure the auth is allowed.
-    const resources = conversations.map(
-      (c) => new this(this.model, c.get(), null)
-    );
-    await this.enrichWithForkedFrom(auth, resources);
-
-    return resources;
+    return conversations.map((c) => this.fromModel(c, null));
   }
 
-  get forkedFrom(): ConversationForkedFromType | undefined {
+  get forkedFromInfo(): ConversationForkedFromType | undefined {
     return this.forkedFromData;
   }
 
@@ -307,6 +384,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         ...options.where,
         workspaceId: workspace.id,
       },
+      include: this.getForkedFromInclude(),
       limit: options.limit,
       order: options.order,
     });
@@ -327,13 +405,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const spaceIdToSpaceMap = new Map(spaces.map((s) => [s.id, s]));
 
     if (fetchConversationOptions?.dangerouslySkipPermissionFiltering) {
-      return conversations.map(
-        (c) =>
-          new this(
-            this.model,
-            c.get(),
-            c.spaceId ? (spaceIdToSpaceMap.get(c.spaceId) ?? null) : null
-          )
+      return conversations.map((c) =>
+        this.fromModel(
+          c,
+          c.spaceId ? (spaceIdToSpaceMap.get(c.spaceId) ?? null) : null
+        )
       );
     }
 
@@ -347,13 +423,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const foundSpaceIds = new Set(spaces.map((s) => s.id));
     const validConversations = conversations
       .filter((c) => c.requestedSpaceIds.every((id) => foundSpaceIds.has(id)))
-      .map(
-        (c) =>
-          new this(
-            this.model,
-            c.get(),
-            c.spaceId ? (spaceIdToSpaceMap.get(c.spaceId) ?? null) : null
-          )
+      .map((c) =>
+        this.fromModel(
+          c,
+          c.spaceId ? (spaceIdToSpaceMap.get(c.spaceId) ?? null) : null
+        )
       );
 
     // Create space-to-groups mapping once for efficient permission checks.
@@ -367,8 +441,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         )
       )
     );
-
-    await this.enrichWithForkedFrom(auth, spaceBasedAccessible);
 
     return spaceBasedAccessible;
   }
@@ -492,58 +564,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
 
     await this.enrichWithReadState(auth, conversations);
-  }
-
-  private static async enrichWithForkedFrom(
-    auth: Authenticator,
-    conversations: ConversationResource[]
-  ): Promise<void> {
-    if (conversations.length === 0) {
-      return;
-    }
-
-    const forks = await ConversationForkModel.findAll({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        childConversationId: conversations.map((c) => c.id),
-      },
-      include: [
-        {
-          model: ConversationModel,
-          as: "parentConversation",
-          required: true,
-          attributes: ["sId"],
-        },
-        {
-          model: MessageModel,
-          as: "sourceMessage",
-          required: true,
-          attributes: ["sId"],
-        },
-      ],
-    });
-    if (forks.length === 0) {
-      return;
-    }
-
-    const conversationsById = new Map(conversations.map((c) => [c.id, c]));
-
-    forks.forEach((fork) => {
-      if (!fork.parentConversation || !fork.sourceMessage) {
-        return;
-      }
-
-      const conversation = conversationsById.get(fork.childConversationId);
-      if (!conversation) {
-        return;
-      }
-
-      conversation.forkedFromData = {
-        parentConversationId: fork.parentConversation.sId,
-        sourceMessageId: fork.sourceMessage.sId,
-        branchedAt: fork.branchedAt.getTime(),
-      };
-    });
   }
 
   static async fetchByIds(
@@ -1037,7 +1057,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       depth: conversation.depth,
       metadata: conversation.metadata,
       branchId: null,
-      ...(conversation.forkedFrom && { forkedFrom: conversation.forkedFrom }),
+      ...(conversation.forkedFromInfo && {
+        forkedFrom: conversation.forkedFromInfo,
+      }),
     });
   }
 
@@ -2751,7 +2773,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       depth: this.depth,
       metadata: this.metadata,
       branchId: null,
-      ...(this.forkedFrom && { forkedFrom: this.forkedFrom }),
+      ...(this.forkedFromInfo && { forkedFrom: this.forkedFromInfo }),
     };
   }
 }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -9,7 +9,6 @@ import {
   UserConversationReadsModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
-import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { REINFORCEMENT_METADATA_KEYS } from "@app/lib/reinforced_agent/types";
 import { REINFORCED_SKILLS_METADATA_KEYS } from "@app/lib/reinforcement/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -93,26 +92,22 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   private static getForkedFromInclude() {
     return [
       {
-        model: ConversationForkModel,
-        as: "forkedFrom" as const,
+        association: "forkedFrom" as const,
         required: false,
         attributes: ["branchedAt", "childConversationId"],
         include: [
           {
-            model: ConversationModel,
-            as: "parentConversation" as const,
+            association: "parentConversation" as const,
             required: true,
             attributes: ["sId"],
           },
           {
-            model: MessageModel,
-            as: "sourceMessage" as const,
+            association: "sourceMessage" as const,
             required: true,
             attributes: ["sId"],
           },
           {
-            model: UserResource.model,
-            as: "createdByUser" as const,
+            association: "createdByUser" as const,
             required: true,
             attributes: [
               "id",

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -374,6 +374,7 @@ export type ConversationForkedFromType = {
   parentConversationId: string;
   sourceMessageId: string;
   branchedAt: number;
+  user: UserType;
 };
 
 /**

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -370,6 +370,12 @@ export type ConversationVisibility = "unlisted" | "deleted" | "test";
 
 export type ConversationMetadata = Record<string, unknown>;
 
+export type ConversationForkedFromType = {
+  parentConversationId: string;
+  sourceMessageId: string;
+  branchedAt: number;
+};
+
 /**
  * A lighter version of Conversation without the content (for menu display).
  *
@@ -390,6 +396,7 @@ export type ConversationWithoutContentType = {
   depth: number;
   metadata: ConversationMetadata;
   branchId: string | null;
+  forkedFrom?: ConversationForkedFromType;
 
   // Ideally, this property should be moved to the ConversationType.
   requestedSpaceIds: string[];


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24060.
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

Exposes optional `forkedFrom` lineage on private conversation payloads, including the user who created the fork. Conversation reads hydrate that lineage from the initial conversation query via the 1:1 `forkedFrom` join, instead of issuing a separate follow-up SQL query. Readability still follows the child conversation only.

Overhead on existing non-forked conversation is likely negligible (1 indexed probe for the row)

## Risks
Blast radius: front private conversation serialization and conversation fetch responses
Risk: low

## Deploy Plan
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/resources/conversation_resource.test.ts lib/api/assistant/conversation.test.ts`