### PR TITLE
[Email Agents] Skip unread notifications for email-origin replies

### DIFF
--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -436,6 +436,8 @@ describe("conversation-unread workflow business logic", () => {
     let messageId: string;
 
     beforeEach(async () => {
+      vi.clearAllMocks();
+
       workspace = await WorkspaceFactory.basic();
       user1 = await UserFactory.basic();
       user2 = await UserFactory.basic();
@@ -584,6 +586,105 @@ describe("conversation-unread workflow business logic", () => {
       // even though user2 has "never" preference and gets filtered out
       expect(vi.mocked(getNovuClient)).toHaveBeenCalled();
     });
+
+    it("should skip notifications for email-origin user messages", async () => {
+      const { ConversationParticipantModel } = await import(
+        "@app/lib/models/agent/conversation"
+      );
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Email Agent",
+        description: "Test",
+      });
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+      });
+
+      const { messageRow } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Forwarded by email",
+        origin: "email",
+      });
+
+      await ConversationParticipantModel.upsert({
+        conversationId: conversation.id,
+        userId: user1.id,
+        workspaceId: workspace.id,
+        action: "posted",
+        actionRequired: false,
+      });
+      await ConversationParticipantModel.upsert({
+        conversationId: conversation.id,
+        userId: user2.id,
+        workspaceId: workspace.id,
+        action: "posted",
+        actionRequired: false,
+      });
+
+      const result = await triggerConversationUnreadNotifications(auth, {
+        conversationId: conversation.sId,
+        messageId: messageRow.sId,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(vi.mocked(getNovuClient)).not.toHaveBeenCalled();
+    });
+
+    it("should skip notifications for agent replies to email-origin user messages", async () => {
+      const { ConversationParticipantModel } = await import(
+        "@app/lib/models/agent/conversation"
+      );
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Email Agent",
+        description: "Test",
+      });
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+      });
+
+      const { messageRow: userMessageRow } =
+        await ConversationFactory.createUserMessage({
+          auth,
+          workspace,
+          conversation,
+          content: "Forwarded by email",
+          origin: "email",
+        });
+      const agentMessageRow =
+        await ConversationFactory.createAgentMessageWithRank({
+          workspace,
+          conversationId: conversation.id,
+          rank: 1,
+          agentConfigurationId: agent.sId,
+          parentId: userMessageRow.id,
+        });
+
+      await ConversationParticipantModel.upsert({
+        conversationId: conversation.id,
+        userId: user1.id,
+        workspaceId: workspace.id,
+        action: "posted",
+        actionRequired: false,
+      });
+      await ConversationParticipantModel.upsert({
+        conversationId: conversation.id,
+        userId: user2.id,
+        workspaceId: workspace.id,
+        action: "posted",
+        actionRequired: false,
+      });
+
+      const result = await triggerConversationUnreadNotifications(auth, {
+        conversationId: conversation.sId,
+        messageId: agentMessageRow.sId,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(vi.mocked(getNovuClient)).not.toHaveBeenCalled();
+    });
   });
 });
 
@@ -594,6 +695,7 @@ describe("getMessagePreview", () => {
     authorIsAgent: false,
     avatarUrl: "https://example.com/avatar.jpg",
     isFromTrigger: false,
+    isFromEmailAgentConversation: false,
     workspaceName: "Test Workspace",
     mentionedUserIds: [],
     hasUnreadMessages: true,
@@ -727,6 +829,7 @@ describe("getEmailSummary", () => {
     author: "Test User",
     authorIsAgent: false,
     isFromTrigger: false,
+    isFromEmailAgentConversation: false,
     workspaceName: "Test Workspace",
     mentionedUserIds: [],
     hasUnreadMessages: true,

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -108,6 +108,7 @@ const ConversationDetailsSchema = z.object({
   authorIsAgent: z.boolean(),
   avatarUrl: z.string().optional(),
   isFromTrigger: z.boolean(),
+  isFromEmailAgentConversation: z.boolean(),
   workspaceName: z.string(),
   mentionedUserIds: z.array(z.string()),
   hasUnreadMessages: z.boolean(),
@@ -154,6 +155,7 @@ const getConversationDetails = async ({
         author: "Deleted conversation",
         authorIsAgent: false,
         isFromTrigger: false,
+        isFromEmailAgentConversation: false,
         workspaceName: "Deleted conversation",
         mentionedUserIds: [],
         avatarUrl: undefined,
@@ -216,6 +218,16 @@ const getConversationDetails = async ({
     message.type === "agent_message" || message.type === "user_message"
       ? message.content
       : "";
+  const parentUserMessage = isLightAgentMessageType(message)
+    ? conversation.content
+        .flat()
+        .find((msg) => msg.sId === message.parentMessageId)
+    : undefined;
+  const isFromEmailAgentConversation =
+    (isUserMessageType(message) && message.context.origin === "email") ||
+    (parentUserMessage !== undefined &&
+      isUserMessageType(parentUserMessage) &&
+      parentUserMessage.context.origin === "email");
 
   if (isCompactionMessageType(message)) {
     // Compaction messages don't trigger notifications.
@@ -276,6 +288,7 @@ const getConversationDetails = async ({
     authorIsAgent,
     avatarUrl,
     isFromTrigger,
+    isFromEmailAgentConversation,
     workspaceName,
     mentionedUserIds,
     hasUnreadMessages,
@@ -962,6 +975,9 @@ export const triggerConversationUnreadNotifications = async (
   });
   if (detailsResult.isErr()) {
     // Conversation or message was deleted - no notification needed.
+    return new Ok(undefined);
+  }
+  if (detailsResult.value.isFromEmailAgentConversation) {
     return new Ok(undefined);
   }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7459
Guard unread notifications when the triggering message is email-origin, or an agent reply whose parent user message is email-origin.

This keeps emailed agents from also fanning out Slack, email, and in-app unread notifications while preserving normal notifications for later non-email turns in the same conversation.

## Risks
Blast radius: unread conversation notifications for email-agent conversations in front
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run ./lib/notifications/workflows/conversation-unread.test.ts -t "skip notifications for"`
