### PR TITLE
Fix: always override models inputs when we already have one pre-configured.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
@@ -449,7 +449,7 @@ describe("augmentInputsWithConfiguration after hideInternalConfiguration", () =>
     });
   });
 
-  it("does not overwrite optional internal fields when the model already provided them", () => {
+  it("overwrites model-provided optional internal fields with action configuration", () => {
     const timeFrameSchema =
       ConfigurableToolInputJSONSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
@@ -484,6 +484,71 @@ describe("augmentInputsWithConfiguration after hideInternalConfiguration", () =>
         },
       ],
       timeFrame: { duration: 99, unit: "year" },
+      inputSchema,
+    });
+
+    const userTimeFrame = {
+      duration: 3,
+      unit: "hour" as const,
+      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME,
+    };
+
+    const augmented = augmentInputsWithConfiguration({
+      owner: mockWorkspace,
+      rawInputs: {
+        query: "x",
+        timeFrame: userTimeFrame,
+      },
+      actionConfiguration: config,
+    });
+
+    expect(augmented.timeFrame).toEqual({
+      duration: 99,
+      unit: "year",
+      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME,
+    });
+    const augmentedDataSources = augmented.dataSources;
+    expect(Array.isArray(augmentedDataSources)).toBe(true);
+    if (Array.isArray(augmentedDataSources)) {
+      expect(augmentedDataSources).toHaveLength(1);
+      expect(augmentedDataSources[0]).toMatchObject({
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+      });
+    }
+  });
+
+  it("keeps model-provided optional internal fields when action configuration has no value for them", () => {
+    const timeFrameSchema =
+      ConfigurableToolInputJSONSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
+      ];
+    const dataSourcesSchema =
+      ConfigurableToolInputJSONSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+      ];
+    const inputSchema = {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        dataSources: dataSourcesSchema,
+        timeFrame: timeFrameSchema,
+      },
+      required: ["query", "dataSources"],
+    } as JSONSchema;
+
+    const config = createBasicMCPConfiguration({
+      dataSources: [
+        {
+          workspaceId: mockWorkspace.sId,
+          sId: "dsc_cfg",
+          dataSourceViewId: "view_cfg",
+          filter: {
+            tags: { in: [], not: [], mode: "custom" },
+            parents: { in: [], not: [] },
+          },
+        },
+      ],
+      timeFrame: null,
       inputSchema,
     });
 

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -410,9 +410,10 @@ export function hideInternalConfiguration(inputSchema: JSONSchema): JSONSchema {
 
 /**
  * Augments the inputs with configuration data from actionConfiguration.
- * For each missing property that has a mimeType matching a value in INTERNAL_MIME_TYPES.TOOL_INPUT,
- * it adds the corresponding data from actionConfiguration.
- * This function uses Ajv validation errors to identify missing properties.
+ * For each property whose schema has a mimeType matching a value in INTERNAL_MIME_TYPES.TOOL_INPUT,
+ * it sets the corresponding data from actionConfiguration, overwriting model-provided values when
+ * the server has a value to inject. When the server has nothing for that field (`undefined` from
+ * generation) but the model already set the path, the model value is kept.
  */
 export function augmentInputsWithConfiguration({
   owner,
@@ -432,17 +433,19 @@ export function augmentInputsWithConfiguration({
   iterateOverSchemaPropertiesRecursive(inputSchema, (fullPath, propSchema) => {
     for (const mimeType of Object.values(INTERNAL_MIME_TYPES.TOOL_INPUT)) {
       if (isSchemaConfigurable(propSchema, mimeType)) {
-        const valueAtPath = getValueAtPath(inputs, fullPath);
-        if (valueAtPath) {
-          return false;
-        }
-
         const value = generateConfiguredInput({
           owner,
           actionConfiguration,
           mimeType,
           keyPath: fullPath.join("."),
         });
+
+        if (value === undefined) {
+          const existing = getValueAtPath(inputs, fullPath);
+          if (existing !== undefined) {
+            return false;
+          }
+        }
 
         // Ensure intermediate path exists
         ensurePathExists(inputs, fullPath);


### PR DESCRIPTION
## Description

`augmentInputsWithConfiguration` was skipping injection entirely when the model had already filled an internal field — even when the action configuration has an explicit value for it. This meant a pre-configured `timeFrame` or `dataSources` could be silently ignored if the model happened to provide something for that field first.

The correct precedence is: server-configured value wins, model-provided value is only kept as a fallback when the server has nothing to inject (`undefined` from `generateConfiguredInput`).

- Flip the guard in `augmentInputsWithConfiguration`: always call `generateConfiguredInput`, only fall back to the model value when the result is `undefined`
- Update the existing test and add a new one to cover both cases (override when configured, keep model value when not)

## Tests

Local + green (tests updated)

## Risk

Low

## Deploy Plan

Deploy `front`
