### PR TITLE
Fix /list command not working in steering mode

### DIFF
--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -628,7 +628,12 @@ export function useAgentMessageStream({
           // text segment (intermediate segments were flushed to content steps).
           // The server's full message includes ALL text, so we override with
           // the tracked final segment. In non-inline mode, we trust the server.
+          // Only override when tokens were actually streamed (lastClassification
+          // is non-null); otherwise the content was set server-side without
+          // streaming (e.g. prompt commands like /list) and the server's value
+          // should be used as-is.
           const finalSegment = content.current;
+          const hadStreamedTokens = lastClassification.current !== null;
           lastClassification.current = null;
           methods.data.map((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
@@ -644,7 +649,7 @@ export function useAgentMessageStream({
             return {
               ...m,
               ...getLightAgentMessageFromAgentMessage(messageSuccess.message),
-              ...(isInlineActivityEnabled
+              ...(isInlineActivityEnabled && hadStreamedTokens
                 ? { content: finalSegment || null }
                 : {}),
               streaming: {


### PR DESCRIPTION
## Description

- When enable_steering is on, the /list prompt command works on the first message but displays nothing on subsequent messages
- Root cause: the agent_message_success stream handler in inline activity mode always overrides server content with the locally tracked text segment, which is empty when no model tokens were streamed (as with /list and /run final steps)
- Fix: only apply the content override when tokens were actually streamed (hadStreamedTokens flag), otherwise trust the server's content

## Tests

Tested the `/list` & `/run` work again in Dust workspace

## Risk

Need to make sure it doesn't break steering

## Deploy Plan

Front