### PR TITLE
Fix poke plugin drop-down so it's not truncated

### DIFF
--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -65,7 +65,6 @@ export function EnumSelect({
       </PopoverTrigger>
       <PopoverContent
         className="z-[100] w-[var(--radix-popover-trigger-width)]"
-        mountPortal={false}
         onKeyDown={(e) => {
           e.stopPropagation();
         }}

--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -65,6 +65,7 @@ export function EnumSelect({
       </PopoverTrigger>
       <PopoverContent
         className="z-[100] w-[var(--radix-popover-trigger-width)]"
+        mountPortal={false}
         onKeyDown={(e) => {
           e.stopPropagation();
         }}

--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -89,6 +89,7 @@ export function RunPluginDialog({
           "bg-muted-background dark:bg-muted-background-night",
           "sm:min-w-[600px] sm:max-w-[1000px]"
         )}
+        style={{ overflow: "visible" }}
       >
         <DialogHeader className="bg-structure-100 dark:bg-structure-100-night rounded-t-2xl pb-4">
           <DialogTitle>Run {plugin.name} plugin</DialogTitle>

--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -87,9 +87,9 @@ export function RunPluginDialog({
         className={cn(
           "w-auto",
           "bg-muted-background dark:bg-muted-background-night",
-          "sm:min-w-[600px] sm:max-w-[1000px]"
+          "sm:min-w-[600px] sm:max-w-[1000px]",
+          "overflow-visible"
         )}
-        style={{ overflow: "visible" }}
       >
         <DialogHeader className="bg-structure-100 dark:bg-structure-100-night rounded-t-2xl pb-4">
           <DialogTitle>Run {plugin.name} plugin</DialogTitle>


### PR DESCRIPTION
## Description

- The feature flag multi-select dropdown in the Poke "Toggle Feature Flag" plugin was clipped by the dialog's overflow: hidden, showing only one item
- Added overflow-visible on the DialogContent so the inline popover can extend beyond the dialog boundaries
 
Before:
<img width="972" height="403" alt="Screenshot 2026-04-13 at 09 31 40" src="https://github.com/user-attachments/assets/0bb2151c-62a1-4232-96a0-65abdb69dfe8" />

After:
<img width="983" height="472" alt="Screenshot 2026-04-13 at 09 31 42" src="https://github.com/user-attachments/assets/aed65f16-cedb-4d6f-8c49-830811181f5d" />


## Tests

Manual

## Risk

Poke only

## Deploy Plan

Front