### PR TITLE
fix: conversation title width mobile

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -62,7 +62,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
 
   if (spaceId && spaceInfo) {
     breadcrumbItems.push({
-      icon: ArrowLeftIcon,
+      icon: isMobile ? undefined : ArrowLeftIcon,
       label: spaceInfo.name,
       onClick: () => {
         void router.push(getProjectRoute(owner.sId, spaceId), undefined, {
@@ -85,12 +85,14 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
         className="grid h-full min-w-0 max-w-full grid-cols-[1fr,auto] items-center gap-3"
         onContextMenu={handleRightClick}
       >
-        <Breadcrumbs
-          items={breadcrumbItems}
-          className="dd-privacy-mask"
-          truncateLengthMiddle={isMobile ? undefined : 35}
-          truncateLengthEnd={isMobile ? undefined : 120}
-        />
+        <div className="min-w-0 overflow-scroll">
+          <Breadcrumbs
+            items={breadcrumbItems}
+            className="dd-privacy-mask"
+            truncateLengthMiddle={35}
+            truncateLengthEnd={120}
+          />
+        </div>
         <EditConversationTitleDialog
           isOpen={showRenameDialog}
           onClose={() => setShowRenameDialog(false)}
@@ -101,7 +103,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
         <div className="flex items-center gap-2">
           <Button
             size="sm"
-            label="Files"
+            label={isMobile ? undefined : "Files"}
             icon={AttachmentIcon}
             variant="ghost"
             onClick={() => openPanel({ type: "files" })}


### PR DESCRIPTION

## Description

This PR fixes the conversation title width on mobile by improving responsive behavior and making sure that the "Files" button and the action dropdown always appear.

- Hides the back arrow icon in breadcrumbs on mobile devices
- Wraps breadcrumbs component in a scrollable container with `min-w-0 overflow-scroll` to handle long titles
- Shows only the attachment icon without the "Files" label text on mobile

Before:

<img width="357" height="424" alt="Capture d’écran 2026-04-13 à 10 03 26" src="https://github.com/user-attachments/assets/025c8d04-4312-4f87-9b08-5e419b7f620c" />

After:
<img width="357" height="424" alt="Capture d’écran 2026-04-13 à 09 58 07" src="https://github.com/user-attachments/assets/f958d165-53ec-460e-ada6-553e1a52bb68" />


## Tests

Manually

## Risk

Low - UI-only changes affecting mobile layout of conversation title component.

## Deploy Plan

Standard deployment.
