### PR TITLE
fix: new project on mobile

### DIFF
--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -20,12 +20,14 @@ import { useCallback, useEffect, useState } from "react";
 interface CreateProjectModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onCreated: () => void;
   owner: LightWorkspaceType;
 }
 
 export function CreateProjectModal({
   isOpen,
   onClose,
+  onCreated,
   owner,
 }: CreateProjectModalProps) {
   const [projectName, setProjectName] = useState<string>("");
@@ -90,6 +92,7 @@ export function CreateProjectModal({
 
     if (createdSpace) {
       void mutateSpaceSummary();
+      onCreated();
       handleClose();
       void router.push(getProjectRoute(owner.sId, createdSpace.sId));
     }
@@ -98,6 +101,7 @@ export function CreateProjectModal({
     isNameAvailable,
     isPublic,
     doCreate,
+    onCreated,
     handleClose,
     mutateSpaceSummary,
     router,

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -39,7 +39,6 @@ import { useAppRouter } from "@app/lib/platform";
 import { SKILL_ICON } from "@app/lib/skill";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
-import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import {
@@ -401,8 +400,6 @@ export function AgentSidebarMenu({
   const { hasFeature } = useFeatureFlags();
   const moveConversationToProject = useMoveConversationToProject(owner);
 
-  const isMobile = useIsMobile();
-
   const { providersHealth } = useAuth();
   const noHealthyProviders = !hasHealthyProviders(providersHealth);
 
@@ -686,7 +683,6 @@ export function AgentSidebarMenu({
           overflowHasActivity={hiddenOverflowHasActivity}
           open={!isProjectsSectionCollapsed}
           onOpenChange={(open) => setProjectsSectionCollapsed(!open)}
-          actionOnHover={!isMobile}
           action={
             summary.length > 0 ? (
               <>
@@ -794,10 +790,8 @@ export function AgentSidebarMenu({
       />
       <CreateProjectModal
         isOpen={isCreateProjectModalOpen}
-        onClose={() => {
-          setIsCreateProjectModalOpen(false);
-          setSidebarOpen(false);
-        }}
+        onClose={() => setIsCreateProjectModalOpen(false)}
+        onCreated={() => setSidebarOpen(false)}
         owner={owner}
       />
       {isImportSkillDialogOpen && (

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -39,6 +39,7 @@ import { useAppRouter } from "@app/lib/platform";
 import { SKILL_ICON } from "@app/lib/skill";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import {
@@ -400,6 +401,8 @@ export function AgentSidebarMenu({
   const { hasFeature } = useFeatureFlags();
   const moveConversationToProject = useMoveConversationToProject(owner);
 
+  const isMobile = useIsMobile();
+
   const { providersHealth } = useAuth();
   const noHealthyProviders = !hasHealthyProviders(providersHealth);
 
@@ -683,6 +686,7 @@ export function AgentSidebarMenu({
           overflowHasActivity={hiddenOverflowHasActivity}
           open={!isProjectsSectionCollapsed}
           onOpenChange={(open) => setProjectsSectionCollapsed(!open)}
+          actionOnHover={!isMobile}
           action={
             summary.length > 0 ? (
               <>
@@ -790,7 +794,10 @@ export function AgentSidebarMenu({
       />
       <CreateProjectModal
         isOpen={isCreateProjectModalOpen}
-        onClose={() => setIsCreateProjectModalOpen(false)}
+        onClose={() => {
+          setIsCreateProjectModalOpen(false);
+          setSidebarOpen(false);
+        }}
         owner={owner}
       />
       {isImportSkillDialogOpen && (

--- a/front/components/assistant/conversation/sidebar/ProjectsBrowsePopover.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsBrowsePopover.tsx
@@ -93,7 +93,7 @@ export function ProjectsBrowsePopover({ owner }: ProjectsBrowsePopoverProps) {
   }, [projects]);
 
   return (
-    <div className="hidden sm:block">
+    <div>
       <PopoverRoot open={isOpen} onOpenChange={setIsOpen} modal>
         <PopoverTrigger asChild>
           <Button size="xs" icon={MoreIcon} variant="ghost" />

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -424,7 +424,7 @@ const NavigationListCollapsibleSection = React.forwardRef<
         className={cn(
           "s-m-1.5 s-flex s-gap-1 s-pr-0.5 s-transition-opacity",
           actionOnHover
-            ? "s-opacity-0 hover:s-opacity-100 group-focus-within/menu-item:s-opacity-100 group-hover/menu-item:s-opacity-100"
+            ? "[@media(hover:hover)]:s-opacity-0 hover:s-opacity-100 group-focus-within/menu-item:s-opacity-100 group-hover/menu-item:s-opacity-100"
             : "s-opacity-100"
         )}
         onClick={(e) => {


### PR DESCRIPTION
## Description

This PR fixes the project creation experience on mobile devices.

- Always display the "New" project button on mobile
- Auto-closes the sidebar when creating a new project on mobile
- Made the projects browse popover visible on mobile by removing the `hidden sm:block` class

<img width="295" height="40" alt="Capture d’écran 2026-04-13 à 10 25 26" src="https://github.com/user-attachments/assets/c4113770-f2cc-4a4d-839e-677f568737af" />


## Tests

Manually

## Risks

Low - only affects mobile UI interactions for project creation

## Deploy Plan

Standard deployment - no special considerations needed
