### PR TITLE
Add egress proxy parser and auth foundations

### DIFF
--- a/egress-proxy/Cargo.lock
+++ b/egress-proxy/Cargo.lock
@@ -80,6 +80,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -149,10 +150,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -246,8 +259,11 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "jsonwebtoken",
  "rustls",
+ "serde",
  "tempfile",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -514,6 +530,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+dependencies = [
+ "aws-lc-rs",
+ "base64",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +728,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,7 +772,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -772,7 +822,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -806,6 +856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -890,6 +941,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +1011,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1117,6 +1197,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -1155,6 +1241,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/egress-proxy/Cargo.toml
+++ b/egress-proxy/Cargo.toml
@@ -11,7 +11,10 @@ path = "src/main.rs"
 anyhow = "1.0"
 axum = "=0.8.4"
 clap = { version = "=4.5.40", features = ["derive", "env"] }
+jsonwebtoken = { version = "10.3.0", default-features = false, features = ["aws_lc_rs"] }
 rustls = "0.23"
+serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0.57"
 tokio = { version = "1.38", features = ["full"] }
 tokio-rustls = "0.26"
 tracing = "0.1"

--- a/egress-proxy/README.md
+++ b/egress-proxy/README.md
@@ -34,8 +34,8 @@ EGRESS_PROXY_ENV=production
 EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK=
 ```
 
-`EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK=1` is test-only and startup rejects it unless
-`EGRESS_PROXY_ENV=test`.
+`EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK` only accepts `1`, `0`, or unset. `1` is test-only and
+startup rejects it unless `EGRESS_PROXY_ENV=test`.
 
 ## Local Checks
 

--- a/egress-proxy/README.md
+++ b/egress-proxy/README.md
@@ -6,16 +6,14 @@ Current functionality:
 
 - `/healthz` process health endpoint.
 - minimal process startup/shutdown wiring.
-- startup validation for proxy config and TLS assets.
+- startup validation for proxy config, TLS assets, and the temporary allowlist.
 - TLS certificate and private-key loading.
+- foundational modules for handshake parsing and JWT validation, covered by unit tests.
 - Docker build and GitHub workflow coverage.
 
 Not implemented yet:
 
 - proxy listener
-- handshake parsing
-- JWT validation
-- allowlist enforcement
 - DNS resolution
 - SSRF blocking
 - upstream connection
@@ -30,7 +28,14 @@ EGRESS_PROXY_LISTEN_ADDR=0.0.0.0:4443
 EGRESS_PROXY_HEALTH_ADDR=0.0.0.0:8080
 EGRESS_PROXY_TLS_CERT=/etc/certs/tls.crt
 EGRESS_PROXY_TLS_KEY=/etc/certs/tls.key
+EGRESS_PROXY_JWT_SECRET=<shared with front>
+EGRESS_PROXY_ALLOWED_DOMAINS=example.com,*.example.com
+EGRESS_PROXY_ENV=production
+EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK=
 ```
+
+`EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK=1` is test-only and startup rejects it unless
+`EGRESS_PROXY_ENV=test`.
 
 ## Local Checks
 

--- a/egress-proxy/src/config.rs
+++ b/egress-proxy/src/config.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use crate::policy::TemporaryAllowlist;
+use anyhow::{anyhow, Result};
 use clap::Parser;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -9,6 +10,10 @@ pub struct Config {
     pub health_addr: SocketAddr,
     pub tls_cert_path: PathBuf,
     pub tls_key_path: PathBuf,
+    pub jwt_secret: String,
+    pub temporary_allowlist: TemporaryAllowlist,
+    pub environment: String,
+    pub unsafe_skip_ssrf_check: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -25,17 +30,83 @@ struct RawConfig {
 
     #[arg(long, env = "EGRESS_PROXY_TLS_KEY")]
     tls_key: PathBuf,
+
+    #[arg(long, env = "EGRESS_PROXY_JWT_SECRET")]
+    jwt_secret: String,
+
+    #[arg(long, env = "EGRESS_PROXY_ALLOWED_DOMAINS")]
+    allowed_domains: String,
+
+    #[arg(long, env = "EGRESS_PROXY_ENV", default_value = "production")]
+    environment: String,
+
+    #[arg(long, env = "EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK")]
+    unsafe_skip_ssrf_check: Option<String>,
 }
 
 impl Config {
     pub fn from_env() -> Result<Self> {
-        let raw = RawConfig::parse();
+        Self::try_from(RawConfig::parse())
+    }
+}
+
+impl TryFrom<RawConfig> for Config {
+    type Error = anyhow::Error;
+
+    fn try_from(raw: RawConfig) -> Result<Self> {
+        if raw.jwt_secret.trim().is_empty() {
+            return Err(anyhow!("EGRESS_PROXY_JWT_SECRET must not be empty"));
+        }
+
+        // TODO(sandbox-egress): Remove EGRESS_PROXY_ALLOWED_DOMAINS when a later PR replaces the
+        // temporary process-wide allowlist with GCS-backed per-sandbox policies.
+        let temporary_allowlist = TemporaryAllowlist::parse(&raw.allowed_domains)?;
+
+        // TODO(sandbox-egress): Remove this test-only bypass once integration tests can exercise
+        // forwarding through a non-private deterministic upstream.
+        let unsafe_skip_ssrf_check = parse_bool_env(raw.unsafe_skip_ssrf_check.as_deref())?;
+        if unsafe_skip_ssrf_check && raw.environment != "test" {
+            return Err(anyhow!(
+                "EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK requires EGRESS_PROXY_ENV=test"
+            ));
+        }
 
         Ok(Self {
             listen_addr: raw.listen_addr,
             health_addr: raw.health_addr,
             tls_cert_path: raw.tls_cert,
             tls_key_path: raw.tls_key,
+            jwt_secret: raw.jwt_secret,
+            temporary_allowlist,
+            environment: raw.environment,
+            unsafe_skip_ssrf_check,
         })
+    }
+}
+
+fn parse_bool_env(value: Option<&str>) -> Result<bool> {
+    match value.map(str::trim).filter(|value| !value.is_empty()) {
+        None => Ok(false),
+        Some("1") | Some("true") | Some("TRUE") | Some("yes") | Some("YES") => Ok(true),
+        Some("0") | Some("false") | Some("FALSE") | Some("no") | Some("NO") => Ok(false),
+        Some(value) => Err(anyhow!("invalid boolean env value: {value}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_bool_env;
+
+    #[test]
+    fn parses_bool_env() {
+        assert!(!parse_bool_env(None).unwrap());
+        assert!(!parse_bool_env(Some("")).unwrap());
+        assert!(parse_bool_env(Some("1")).unwrap());
+        assert!(!parse_bool_env(Some("0")).unwrap());
+        assert!(parse_bool_env(Some("true")).unwrap());
+        assert!(!parse_bool_env(Some("false")).unwrap());
+        assert!(parse_bool_env(Some("YES")).unwrap());
+        assert!(!parse_bool_env(Some("NO")).unwrap());
+        assert!(parse_bool_env(Some("maybe")).is_err());
     }
 }

--- a/egress-proxy/src/config.rs
+++ b/egress-proxy/src/config.rs
@@ -99,14 +99,14 @@ mod tests {
 
     #[test]
     fn parses_bool_env() {
-        assert!(!parse_bool_env(None).unwrap());
-        assert!(!parse_bool_env(Some("")).unwrap());
-        assert!(parse_bool_env(Some("1")).unwrap());
-        assert!(!parse_bool_env(Some("0")).unwrap());
-        assert!(parse_bool_env(Some("true")).unwrap());
-        assert!(!parse_bool_env(Some("false")).unwrap());
-        assert!(parse_bool_env(Some("YES")).unwrap());
-        assert!(!parse_bool_env(Some("NO")).unwrap());
+        assert!(!parse_bool_env(None).expect("missing bool env should default to false"));
+        assert!(!parse_bool_env(Some("")).expect("empty bool env should default to false"));
+        assert!(parse_bool_env(Some("1")).expect("1 should parse as true"));
+        assert!(!parse_bool_env(Some("0")).expect("0 should parse as false"));
+        assert!(parse_bool_env(Some("true")).expect("true should parse as true"));
+        assert!(!parse_bool_env(Some("false")).expect("false should parse as false"));
+        assert!(parse_bool_env(Some("YES")).expect("YES should parse as true"));
+        assert!(!parse_bool_env(Some("NO")).expect("NO should parse as false"));
         assert!(parse_bool_env(Some("maybe")).is_err());
     }
 }

--- a/egress-proxy/src/config.rs
+++ b/egress-proxy/src/config.rs
@@ -87,9 +87,11 @@ impl TryFrom<RawConfig> for Config {
 fn parse_bool_env(value: Option<&str>) -> Result<bool> {
     match value.map(str::trim).filter(|value| !value.is_empty()) {
         None => Ok(false),
-        Some("1") | Some("true") | Some("TRUE") | Some("yes") | Some("YES") => Ok(true),
-        Some("0") | Some("false") | Some("FALSE") | Some("no") | Some("NO") => Ok(false),
-        Some(value) => Err(anyhow!("invalid boolean env value: {value}")),
+        Some("1") => Ok(true),
+        Some("0") => Ok(false),
+        Some(value) => Err(anyhow!(
+            "invalid boolean env value: {value}; expected 0 or 1"
+        )),
     }
 }
 
@@ -103,10 +105,10 @@ mod tests {
         assert!(!parse_bool_env(Some("")).expect("empty bool env should default to false"));
         assert!(parse_bool_env(Some("1")).expect("1 should parse as true"));
         assert!(!parse_bool_env(Some("0")).expect("0 should parse as false"));
-        assert!(parse_bool_env(Some("true")).expect("true should parse as true"));
-        assert!(!parse_bool_env(Some("false")).expect("false should parse as false"));
-        assert!(parse_bool_env(Some("YES")).expect("YES should parse as true"));
-        assert!(!parse_bool_env(Some("NO")).expect("NO should parse as false"));
+        assert!(parse_bool_env(Some("true")).is_err());
+        assert!(parse_bool_env(Some("false")).is_err());
+        assert!(parse_bool_env(Some("YES")).is_err());
+        assert!(parse_bool_env(Some("NO")).is_err());
         assert!(parse_bool_env(Some("maybe")).is_err());
     }
 }

--- a/egress-proxy/src/domain.rs
+++ b/egress-proxy/src/domain.rs
@@ -34,6 +34,8 @@ pub fn normalize_dns_name(value: &str) -> Result<String, DomainValidationError> 
 }
 
 fn is_valid_dns_name(value: &str) -> bool {
+    // A DNS name is at most 255 octets on the wire including the root terminator. We normalize
+    // away a trailing dot above, so the presentation form here is capped at 253 characters.
     if value.len() > 253 {
         return false;
     }

--- a/egress-proxy/src/domain.rs
+++ b/egress-proxy/src/domain.rs
@@ -64,15 +64,23 @@ mod tests {
     #[test]
     fn normalizes_dns_names_and_ip_literals() {
         assert_eq!(
-            normalize_domain_or_ip("Example.COM.").unwrap(),
+            normalize_domain_or_ip("Example.COM.")
+                .expect("mixed-case DNS name should normalize successfully"),
             "example.com"
         );
-        assert_eq!(normalize_domain_or_ip("127.0.0.1").unwrap(), "127.0.0.1");
         assert_eq!(
-            normalize_domain_or_ip("::ffff:127.0.0.1").unwrap(),
+            normalize_domain_or_ip("127.0.0.1").expect("IPv4 literal should be accepted"),
+            "127.0.0.1"
+        );
+        assert_eq!(
+            normalize_domain_or_ip("::ffff:127.0.0.1").expect("IPv6 literal should be accepted"),
             "::ffff:127.0.0.1"
         );
-        assert_eq!(normalize_dns_name("LOCALHOST").unwrap(), "localhost");
+        assert_eq!(
+            normalize_dns_name("LOCALHOST")
+                .expect("DNS-only normalization should accept hostnames"),
+            "localhost"
+        );
     }
 
     #[test]

--- a/egress-proxy/src/domain.rs
+++ b/egress-proxy/src/domain.rs
@@ -1,0 +1,103 @@
+use std::net::IpAddr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DomainValidationError {
+    Empty,
+    Invalid,
+}
+
+pub fn normalize_domain_or_ip(value: &str) -> Result<String, DomainValidationError> {
+    let value = value.to_ascii_lowercase();
+    let value = value.strip_suffix('.').unwrap_or(&value).to_string();
+
+    if value.is_empty() {
+        return Err(DomainValidationError::Empty);
+    }
+
+    if value.parse::<IpAddr>().is_ok() {
+        return Ok(value);
+    }
+
+    if is_valid_dns_name(&value) {
+        return Ok(value);
+    }
+
+    Err(DomainValidationError::Invalid)
+}
+
+pub fn normalize_dns_name(value: &str) -> Result<String, DomainValidationError> {
+    let value = normalize_domain_or_ip(value)?;
+    if value.parse::<IpAddr>().is_ok() {
+        return Err(DomainValidationError::Invalid);
+    }
+    Ok(value)
+}
+
+fn is_valid_dns_name(value: &str) -> bool {
+    if value.len() > 253 {
+        return false;
+    }
+
+    let mut labels = value.split('.');
+    labels.all(is_valid_dns_label)
+}
+
+fn is_valid_dns_label(label: &str) -> bool {
+    if label.is_empty() || label.len() > 63 {
+        return false;
+    }
+
+    let bytes = label.as_bytes();
+    if !bytes[0].is_ascii_alphanumeric() || !bytes[bytes.len() - 1].is_ascii_alphanumeric() {
+        return false;
+    }
+
+    bytes
+        .iter()
+        .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_dns_name, normalize_domain_or_ip};
+
+    #[test]
+    fn normalizes_dns_names_and_ip_literals() {
+        assert_eq!(
+            normalize_domain_or_ip("Example.COM.").unwrap(),
+            "example.com"
+        );
+        assert_eq!(normalize_domain_or_ip("127.0.0.1").unwrap(), "127.0.0.1");
+        assert_eq!(
+            normalize_domain_or_ip("::ffff:127.0.0.1").unwrap(),
+            "::ffff:127.0.0.1"
+        );
+        assert_eq!(normalize_dns_name("LOCALHOST").unwrap(), "localhost");
+    }
+
+    #[test]
+    fn rejects_malformed_dns_names() {
+        for value in [
+            "*",
+            "*.*.com",
+            "*example.com",
+            ".example.com",
+            "example..com",
+            "host:443",
+            "bad domain",
+            " example.com",
+            "ex_ample.com",
+            "éxample.com",
+            "-example.com",
+            "example-.com",
+        ] {
+            assert!(normalize_domain_or_ip(value).is_err(), "{value}");
+        }
+    }
+
+    #[test]
+    fn rejects_ip_literals_for_dns_only_validation() {
+        assert!(normalize_dns_name("127.0.0.1").is_err());
+        assert!(normalize_dns_name("::1").is_err());
+    }
+}

--- a/egress-proxy/src/handshake.rs
+++ b/egress-proxy/src/handshake.rs
@@ -75,8 +75,10 @@ where
 pub fn build_frame(token: &str, domain: &str, original_dest_port: u16) -> Vec<u8> {
     let token_bytes = token.as_bytes();
     let domain_bytes = domain.as_bytes();
-    let token_length = u16::try_from(token_bytes.len()).unwrap();
-    let domain_length = u16::try_from(domain_bytes.len()).unwrap();
+    let token_length =
+        u16::try_from(token_bytes.len()).expect("test token length should fit in u16");
+    let domain_length =
+        u16::try_from(domain_bytes.len()).expect("test domain length should fit in u16");
     let mut frame = Vec::with_capacity(1 + 2 + token_bytes.len() + 2 + domain_bytes.len() + 2);
 
     frame.push(PROTOCOL_VERSION);
@@ -145,7 +147,9 @@ mod tests {
     async fn parses_valid_handshake() {
         let frame = build_frame("token", "Example.COM.", 443);
         let mut reader = frame.as_slice();
-        let handshake = read_handshake(&mut reader).await.unwrap();
+        let handshake = read_handshake(&mut reader)
+            .await
+            .expect("valid handshake frame should parse");
 
         assert_eq!(handshake.token, "token");
         assert_eq!(handshake.domain, "example.com");
@@ -156,7 +160,9 @@ mod tests {
     async fn accepts_empty_domain() {
         let frame = build_frame("token", "", 443);
         let mut reader = frame.as_slice();
-        let handshake = read_handshake(&mut reader).await.unwrap();
+        let handshake = read_handshake(&mut reader)
+            .await
+            .expect("empty domain is valid in the wire protocol");
 
         assert_eq!(handshake.domain, "");
     }

--- a/egress-proxy/src/handshake.rs
+++ b/egress-proxy/src/handshake.rs
@@ -1,0 +1,205 @@
+// TODO(sandbox-egress): Remove this allowance in the next PR when the proxy listener starts
+// reading real sandbox handshakes.
+#![allow(dead_code)]
+
+use crate::domain::{normalize_domain_or_ip, DomainValidationError};
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+pub const PROTOCOL_VERSION: u8 = 0x01;
+pub const ALLOW_RESPONSE: u8 = 0x00;
+pub const DENY_RESPONSE: u8 = 0x01;
+
+const MAX_TOKEN_LENGTH: usize = 16 * 1024;
+const MAX_DOMAIN_LENGTH: usize = 253;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Handshake {
+    pub token: String,
+    pub domain: String,
+    pub original_dest_port: u16,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum HandshakeError {
+    #[error("malformed handshake")]
+    MalformedHandshake,
+    #[error("truncated handshake")]
+    TruncatedHandshake,
+    #[error("unsupported protocol version")]
+    UnsupportedProtocolVersion,
+}
+
+pub async fn read_handshake<R>(reader: &mut R) -> Result<Handshake, HandshakeError>
+where
+    R: AsyncRead + Unpin,
+{
+    // TODO(sandbox-egress): Keep this protocol parser in sync with dsbx forward when the
+    // in-sandbox forwarder is implemented.
+    let version = read_u8(reader).await?;
+    if version != PROTOCOL_VERSION {
+        return Err(HandshakeError::UnsupportedProtocolVersion);
+    }
+
+    let token_length = read_u16(reader).await?;
+    if token_length == 0 || usize::from(token_length) > MAX_TOKEN_LENGTH {
+        return Err(HandshakeError::MalformedHandshake);
+    }
+
+    let token_bytes = read_bytes(reader, usize::from(token_length)).await?;
+    let token = String::from_utf8(token_bytes).map_err(|_| HandshakeError::MalformedHandshake)?;
+
+    let domain_length = read_u16(reader).await?;
+    if usize::from(domain_length) > MAX_DOMAIN_LENGTH {
+        return Err(HandshakeError::MalformedHandshake);
+    }
+
+    let domain_bytes = read_bytes(reader, usize::from(domain_length)).await?;
+    let raw_domain =
+        String::from_utf8(domain_bytes).map_err(|_| HandshakeError::MalformedHandshake)?;
+    let domain = normalize_domain(&raw_domain)?;
+
+    let original_dest_port = read_u16(reader).await?;
+    if original_dest_port == 0 {
+        return Err(HandshakeError::MalformedHandshake);
+    }
+
+    Ok(Handshake {
+        token,
+        domain,
+        original_dest_port,
+    })
+}
+
+#[cfg(test)]
+pub fn build_frame(token: &str, domain: &str, original_dest_port: u16) -> Vec<u8> {
+    let token_bytes = token.as_bytes();
+    let domain_bytes = domain.as_bytes();
+    let token_length = u16::try_from(token_bytes.len()).unwrap();
+    let domain_length = u16::try_from(domain_bytes.len()).unwrap();
+    let mut frame = Vec::with_capacity(1 + 2 + token_bytes.len() + 2 + domain_bytes.len() + 2);
+
+    frame.push(PROTOCOL_VERSION);
+    frame.extend_from_slice(&token_length.to_be_bytes());
+    frame.extend_from_slice(token_bytes);
+    frame.extend_from_slice(&domain_length.to_be_bytes());
+    frame.extend_from_slice(domain_bytes);
+    frame.extend_from_slice(&original_dest_port.to_be_bytes());
+
+    frame
+}
+
+fn normalize_domain(domain: &str) -> Result<String, HandshakeError> {
+    if domain.is_empty() {
+        return Ok(String::new());
+    }
+
+    match normalize_domain_or_ip(domain) {
+        Ok(domain) => Ok(domain),
+        Err(DomainValidationError::Empty) => Err(HandshakeError::MalformedHandshake),
+        Err(DomainValidationError::Invalid) => Err(HandshakeError::MalformedHandshake),
+    }
+}
+
+async fn read_u8<R>(reader: &mut R) -> Result<u8, HandshakeError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buffer = [0; 1];
+    reader
+        .read_exact(&mut buffer)
+        .await
+        .map_err(|_| HandshakeError::TruncatedHandshake)?;
+    Ok(buffer[0])
+}
+
+async fn read_u16<R>(reader: &mut R) -> Result<u16, HandshakeError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buffer = [0; 2];
+    reader
+        .read_exact(&mut buffer)
+        .await
+        .map_err(|_| HandshakeError::TruncatedHandshake)?;
+    Ok(u16::from_be_bytes(buffer))
+}
+
+async fn read_bytes<R>(reader: &mut R, length: usize) -> Result<Vec<u8>, HandshakeError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buffer = vec![0; length];
+    reader
+        .read_exact(&mut buffer)
+        .await
+        .map_err(|_| HandshakeError::TruncatedHandshake)?;
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_frame, read_handshake, HandshakeError, PROTOCOL_VERSION};
+
+    #[tokio::test]
+    async fn parses_valid_handshake() {
+        let frame = build_frame("token", "Example.COM.", 443);
+        let mut reader = frame.as_slice();
+        let handshake = read_handshake(&mut reader).await.unwrap();
+
+        assert_eq!(handshake.token, "token");
+        assert_eq!(handshake.domain, "example.com");
+        assert_eq!(handshake.original_dest_port, 443);
+    }
+
+    #[tokio::test]
+    async fn accepts_empty_domain() {
+        let frame = build_frame("token", "", 443);
+        let mut reader = frame.as_slice();
+        let handshake = read_handshake(&mut reader).await.unwrap();
+
+        assert_eq!(handshake.domain, "");
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_version() {
+        let mut frame = build_frame("token", "example.com", 443);
+        frame[0] = PROTOCOL_VERSION + 1;
+        let mut reader = frame.as_slice();
+
+        assert_eq!(
+            read_handshake(&mut reader).await.unwrap_err(),
+            HandshakeError::UnsupportedProtocolVersion
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_truncated_handshake() {
+        let frame = [PROTOCOL_VERSION, 0x00];
+        let mut reader = frame.as_slice();
+
+        assert_eq!(
+            read_handshake(&mut reader).await.unwrap_err(),
+            HandshakeError::TruncatedHandshake
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_complete_malformed_handshakes() {
+        for frame in [
+            build_frame("", "example.com", 443),
+            build_frame("token", " example.com", 443),
+            build_frame("token", "example..com", 443),
+            build_frame("token", "host:443", 443),
+            build_frame("token", ".", 443),
+            build_frame("token", "example.com", 0),
+        ] {
+            let mut reader = frame.as_slice();
+
+            assert_eq!(
+                read_handshake(&mut reader).await.unwrap_err(),
+                HandshakeError::MalformedHandshake
+            );
+        }
+    }
+}

--- a/egress-proxy/src/jwt.rs
+++ b/egress-proxy/src/jwt.rs
@@ -1,0 +1,182 @@
+// TODO(sandbox-egress): Remove this allowance in the next PR when connection handling validates
+// forwarder JWTs.
+#![allow(dead_code)]
+
+use jsonwebtoken::{decode, Algorithm, DecodingKey, TokenData, Validation};
+use serde::Deserialize;
+use std::time::{SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+
+const EXPECTED_ISSUER: &str = "dust-front";
+const EXPECTED_AUDIENCE: &str = "dust-egress-proxy";
+
+#[derive(Clone)]
+pub struct JwtValidator {
+    decoding_key: DecodingKey,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedSandboxToken {
+    pub sb_id: String,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum JwtValidationError {
+    #[error("expired jwt")]
+    Expired,
+    #[error("invalid jwt claims")]
+    InvalidClaims,
+    #[error("invalid jwt")]
+    InvalidJwt,
+}
+
+#[derive(Debug, Deserialize)]
+struct Claims {
+    #[serde(rename = "sbId")]
+    sb_id: String,
+    iss: String,
+    aud: String,
+    exp: usize,
+}
+
+impl JwtValidator {
+    pub fn new(secret: &str) -> Self {
+        Self {
+            decoding_key: DecodingKey::from_secret(secret.as_bytes()),
+        }
+    }
+
+    pub fn validate(&self, raw_token: &str) -> Result<ValidatedSandboxToken, JwtValidationError> {
+        // TODO(sandbox-egress): Front will mint these JWTs during sandbox setup and write the
+        // per-sandbox policy before user code can execute.
+        let mut validation = Validation::new(Algorithm::HS256);
+        // TODO(sandbox-egress): Nice-to-have once front token minting is wired: make the
+        // front/proxy clock-skew tolerance explicit and cover it with a unit test.
+        validation.validate_exp = false;
+        validation.set_issuer(&[EXPECTED_ISSUER]);
+        validation.set_audience(&[EXPECTED_AUDIENCE]);
+        validation.required_spec_claims.insert("exp".to_string());
+        validation.required_spec_claims.insert("iss".to_string());
+        validation.required_spec_claims.insert("aud".to_string());
+
+        let token =
+            decode::<Claims>(raw_token, &self.decoding_key, &validation).map_err(map_jwt_error)?;
+
+        claims_to_validated_token(token)
+    }
+}
+
+fn claims_to_validated_token(
+    token: TokenData<Claims>,
+) -> Result<ValidatedSandboxToken, JwtValidationError> {
+    let claims = token.claims;
+    let now_seconds = current_unix_timestamp_seconds()?;
+    if claims.sb_id.trim().is_empty()
+        || claims.iss != EXPECTED_ISSUER
+        || claims.aud != EXPECTED_AUDIENCE
+        || claims.exp == 0
+    {
+        return Err(JwtValidationError::InvalidClaims);
+    }
+
+    if claims.exp <= now_seconds {
+        return Err(JwtValidationError::Expired);
+    }
+
+    Ok(ValidatedSandboxToken {
+        sb_id: claims.sb_id,
+    })
+}
+
+fn current_unix_timestamp_seconds() -> Result<usize, JwtValidationError> {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| JwtValidationError::InvalidClaims)?;
+    usize::try_from(duration.as_secs()).map_err(|_| JwtValidationError::InvalidClaims)
+}
+
+fn map_jwt_error(error: jsonwebtoken::errors::Error) -> JwtValidationError {
+    match error.kind() {
+        jsonwebtoken::errors::ErrorKind::ExpiredSignature => JwtValidationError::Expired,
+        jsonwebtoken::errors::ErrorKind::InvalidIssuer
+        | jsonwebtoken::errors::ErrorKind::InvalidAudience
+        | jsonwebtoken::errors::ErrorKind::MissingRequiredClaim(_) => {
+            JwtValidationError::InvalidClaims
+        }
+        _ => JwtValidationError::InvalidJwt,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{JwtValidationError, JwtValidator, EXPECTED_AUDIENCE, EXPECTED_ISSUER};
+    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+    use serde::Serialize;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[derive(Debug, Serialize)]
+    struct TestClaims<'a> {
+        #[serde(rename = "sbId")]
+        sb_id: &'a str,
+        iss: &'a str,
+        aud: &'a str,
+        exp: usize,
+    }
+
+    #[test]
+    fn validates_expected_claims() {
+        let validator = JwtValidator::new("secret");
+        let token = token("secret", "sbx", EXPECTED_ISSUER, EXPECTED_AUDIENCE, 60);
+
+        let validated = validator.validate(&token).unwrap();
+
+        assert_eq!(validated.sb_id, "sbx");
+    }
+
+    #[test]
+    fn rejects_expired_tokens() {
+        let validator = JwtValidator::new("secret");
+        let token = token("secret", "sbx", EXPECTED_ISSUER, EXPECTED_AUDIENCE, -60);
+
+        assert_eq!(
+            validator.validate(&token).unwrap_err(),
+            JwtValidationError::Expired
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_audience() {
+        let validator = JwtValidator::new("secret");
+        let token = token("secret", "sbx", EXPECTED_ISSUER, "wrong", 60);
+
+        assert_eq!(
+            validator.validate(&token).unwrap_err(),
+            JwtValidationError::InvalidClaims
+        );
+    }
+
+    fn token(secret: &str, sb_id: &str, iss: &str, aud: &str, exp_offset_seconds: i64) -> String {
+        let now_seconds = i64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        )
+        .unwrap();
+        let exp_seconds = now_seconds + exp_offset_seconds;
+        let exp = usize::try_from(exp_seconds).unwrap();
+        let claims = TestClaims {
+            sb_id,
+            iss,
+            aud,
+            exp,
+        };
+
+        encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .unwrap()
+    }
+}

--- a/egress-proxy/src/jwt.rs
+++ b/egress-proxy/src/jwt.rs
@@ -128,7 +128,9 @@ mod tests {
         let validator = JwtValidator::new("secret");
         let token = token("secret", "sbx", EXPECTED_ISSUER, EXPECTED_AUDIENCE, 60);
 
-        let validated = validator.validate(&token).unwrap();
+        let validated = validator
+            .validate(&token)
+            .expect("token with valid claims should validate");
 
         assert_eq!(validated.sb_id, "sbx");
     }
@@ -159,12 +161,12 @@ mod tests {
         let now_seconds = i64::try_from(
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .unwrap()
+                .expect("current time should be after the Unix epoch")
                 .as_secs(),
         )
-        .unwrap();
+        .expect("current Unix timestamp should fit in i64");
         let exp_seconds = now_seconds + exp_offset_seconds;
-        let exp = usize::try_from(exp_seconds).unwrap();
+        let exp = usize::try_from(exp_seconds).expect("expiration timestamp should fit in usize");
         let claims = TestClaims {
             sb_id,
             iss,
@@ -177,6 +179,6 @@ mod tests {
             &claims,
             &EncodingKey::from_secret(secret.as_bytes()),
         )
-        .unwrap()
+        .expect("test helper should encode JWT successfully")
     }
 }

--- a/egress-proxy/src/main.rs
+++ b/egress-proxy/src/main.rs
@@ -1,5 +1,9 @@
 mod config;
+mod domain;
+mod handshake;
 mod health;
+mod jwt;
+mod policy;
 mod server;
 mod tls;
 

--- a/egress-proxy/src/policy.rs
+++ b/egress-proxy/src/policy.rs
@@ -1,0 +1,127 @@
+// TODO(sandbox-egress): Remove this allowance in the next PR when the proxy runtime starts
+// enforcing allowlist decisions.
+#![allow(dead_code)]
+
+use crate::domain::{normalize_dns_name, normalize_domain_or_ip};
+use anyhow::{anyhow, Result};
+
+#[derive(Debug, Clone)]
+pub struct TemporaryAllowlist {
+    patterns: Vec<DomainPattern>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DomainPattern {
+    Exact(String),
+    WildcardSuffix(String),
+}
+
+impl TemporaryAllowlist {
+    pub fn parse(value: &str) -> Result<Self> {
+        let mut patterns = Vec::new();
+
+        for raw_entry in value.split(',') {
+            let entry = raw_entry.trim();
+            if entry.is_empty() {
+                continue;
+            }
+            patterns.push(DomainPattern::parse(entry)?);
+        }
+
+        if patterns.is_empty() {
+            return Err(anyhow!("EGRESS_PROXY_ALLOWED_DOMAINS must not be empty"));
+        }
+
+        Ok(Self { patterns })
+    }
+
+    pub fn allows(&self, domain: &str, sb_id: &str) -> bool {
+        // TODO(sandbox-egress): Replace this static env allowlist with the GCS-backed
+        // per-sandbox policy provider. The production policy source is
+        // gs://<regional-sandbox-egress-policies>/policies/{sbId}.json.
+
+        // TODO(sandbox-egress): Use sb_id to fetch policies/{sbId}.json from GCS. PR 1 uses
+        // the same temporary allowlist for every sandbox so we can validate the proxy protocol
+        // independently from front and GCS integration.
+        let _ = sb_id;
+
+        self.patterns.iter().any(|pattern| pattern.matches(domain))
+    }
+}
+
+impl DomainPattern {
+    fn parse(value: &str) -> Result<Self> {
+        // TODO(sandbox-egress): Replace the minimal domain allowlist with the full policy schema
+        // (defaultAction + rules) once front starts writing policy files.
+        let value = value.trim().to_ascii_lowercase();
+        if let Some(suffix) = value.strip_prefix("*.") {
+            let suffix = normalize_dns_name(suffix)
+                .map_err(|_| anyhow!("invalid wildcard domain entry: {value}"))?;
+            if suffix.split('.').count() < 2 {
+                return Err(anyhow!("invalid wildcard domain entry: {value}"));
+            }
+            return Ok(Self::WildcardSuffix(suffix));
+        }
+
+        let value =
+            normalize_domain_or_ip(&value).map_err(|_| anyhow!("invalid domain entry: {value}"))?;
+        Ok(Self::Exact(value))
+    }
+
+    fn matches(&self, domain: &str) -> bool {
+        match self {
+            Self::Exact(exact) => domain == exact,
+            Self::WildcardSuffix(suffix) => {
+                domain.ends_with(suffix)
+                    && domain.len() > suffix.len()
+                    && domain.as_bytes()[domain.len() - suffix.len() - 1] == b'.'
+            }
+        }
+    }
+}
+
+// TODO(sandbox-egress): Add a bounded TTL cache for GCS policies to avoid reading on
+// every connection.
+
+#[cfg(test)]
+mod tests {
+    use super::TemporaryAllowlist;
+
+    #[test]
+    fn exact_domains_match_case_insensitively_after_parse() {
+        let allowlist = TemporaryAllowlist::parse("Example.COM").unwrap();
+
+        assert!(allowlist.allows("example.com", "sbx"));
+        assert!(!allowlist.allows("api.example.com", "sbx"));
+    }
+
+    #[test]
+    fn exact_ip_literals_are_valid_entries() {
+        let allowlist = TemporaryAllowlist::parse("127.0.0.1,::ffff:127.0.0.1").unwrap();
+
+        assert!(allowlist.allows("127.0.0.1", "sbx"));
+        assert!(allowlist.allows("::ffff:127.0.0.1", "sbx"));
+    }
+
+    #[test]
+    fn wildcard_matches_subdomains_only() {
+        let allowlist = TemporaryAllowlist::parse("*.example.com").unwrap();
+
+        assert!(allowlist.allows("api.example.com", "sbx"));
+        assert!(allowlist.allows("a.b.example.com", "sbx"));
+        assert!(!allowlist.allows("example.com", "sbx"));
+    }
+
+    #[test]
+    fn invalid_entries_fail_startup() {
+        assert!(TemporaryAllowlist::parse("example.com, bad domain").is_err());
+        assert!(TemporaryAllowlist::parse(" , ").is_err());
+        assert!(TemporaryAllowlist::parse("*").is_err());
+        assert!(TemporaryAllowlist::parse("*.*.com").is_err());
+        assert!(TemporaryAllowlist::parse("*example.com").is_err());
+        assert!(TemporaryAllowlist::parse(".example.com").is_err());
+        assert!(TemporaryAllowlist::parse("example..com").is_err());
+        assert!(TemporaryAllowlist::parse("host:443").is_err());
+        assert!(TemporaryAllowlist::parse("*.com").is_err());
+    }
+}

--- a/egress-proxy/src/policy.rs
+++ b/egress-proxy/src/policy.rs
@@ -89,7 +89,8 @@ mod tests {
 
     #[test]
     fn exact_domains_match_case_insensitively_after_parse() {
-        let allowlist = TemporaryAllowlist::parse("Example.COM").unwrap();
+        let allowlist =
+            TemporaryAllowlist::parse("Example.COM").expect("valid domain entry should parse");
 
         assert!(allowlist.allows("example.com", "sbx"));
         assert!(!allowlist.allows("api.example.com", "sbx"));
@@ -97,7 +98,8 @@ mod tests {
 
     #[test]
     fn exact_ip_literals_are_valid_entries() {
-        let allowlist = TemporaryAllowlist::parse("127.0.0.1,::ffff:127.0.0.1").unwrap();
+        let allowlist = TemporaryAllowlist::parse("127.0.0.1,::ffff:127.0.0.1")
+            .expect("valid IP literal entries should parse");
 
         assert!(allowlist.allows("127.0.0.1", "sbx"));
         assert!(allowlist.allows("::ffff:127.0.0.1", "sbx"));
@@ -105,7 +107,8 @@ mod tests {
 
     #[test]
     fn wildcard_matches_subdomains_only() {
-        let allowlist = TemporaryAllowlist::parse("*.example.com").unwrap();
+        let allowlist =
+            TemporaryAllowlist::parse("*.example.com").expect("valid wildcard entry should parse");
 
         assert!(allowlist.allows("api.example.com", "sbx"));
         assert!(allowlist.allows("a.b.example.com", "sbx"));

--- a/egress-proxy/src/server.rs
+++ b/egress-proxy/src/server.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::health;
+use crate::jwt::JwtValidator;
 use crate::tls::load_tls_acceptor;
 use anyhow::{anyhow, Result};
 use tokio::net::TcpListener;
@@ -13,16 +14,22 @@ pub async fn run(config: Config) -> Result<()> {
         health_addr,
         tls_cert_path,
         tls_key_path,
+        jwt_secret,
+        temporary_allowlist,
+        environment,
+        unsafe_skip_ssrf_check,
     } = config;
 
     let _tls_acceptor = load_tls_acceptor(&tls_cert_path, &tls_key_path)?;
+    let _jwt_validator = JwtValidator::new(&jwt_secret);
+    let _temporary_allowlist = temporary_allowlist;
 
     let listener = TcpListener::bind(health_addr).await?;
     let health_addr = listener.local_addr()?;
 
-    // TODO(sandbox-egress): Bind and accept the sandbox forwarder listener on listen_addr in a
-    // later PR once the parser/auth building blocks have landed.
-    let _ = listen_addr;
+    // TODO(sandbox-egress): Bind and accept the sandbox forwarder listener on listen_addr in the
+    // next PR once the parser/auth building blocks have landed.
+    let _ = (listen_addr, environment, unsafe_skip_ssrf_check);
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let mut health_handle = tokio::spawn(health::serve(listener, shutdown_rx));
 

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
+const SECRET: &str = "test-secret";
+
 struct ProxyProcess {
     child: Child,
     health_addr: SocketAddr,
@@ -42,6 +44,30 @@ async fn invalid_tls_assets_fail_startup() -> Result<()> {
         .env("EGRESS_PROXY_HEALTH_ADDR", health_addr.to_string())
         .env("EGRESS_PROXY_TLS_CERT", temp_dir.path().join("missing.crt"))
         .env("EGRESS_PROXY_TLS_KEY", &tls_key_path)
+        .env("EGRESS_PROXY_JWT_SECRET", SECRET)
+        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "example.com")
+        .env("EGRESS_PROXY_ENV", "production")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    wait_for_startup_failure(&mut child).await
+}
+
+#[tokio::test]
+async fn invalid_allowed_domain_fails_startup() -> Result<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let certs = generate_test_certs(temp_dir.path())?;
+    let health_addr = free_addr()?;
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_egress-proxy"))
+        .env("EGRESS_PROXY_LISTEN_ADDR", "127.0.0.1:4443")
+        .env("EGRESS_PROXY_HEALTH_ADDR", health_addr.to_string())
+        .env("EGRESS_PROXY_TLS_CERT", &certs.server_cert_path)
+        .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
+        .env("EGRESS_PROXY_JWT_SECRET", SECRET)
+        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "example..com")
+        .env("EGRESS_PROXY_ENV", "production")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()?;
@@ -60,6 +86,9 @@ async fn start_proxy() -> Result<ProxyProcess> {
             .env("EGRESS_PROXY_HEALTH_ADDR", health_addr.to_string())
             .env("EGRESS_PROXY_TLS_CERT", &certs.server_cert_path)
             .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
+            .env("EGRESS_PROXY_JWT_SECRET", SECRET)
+            .env("EGRESS_PROXY_ALLOWED_DOMAINS", "example.com")
+            .env("EGRESS_PROXY_ENV", "production")
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()?,


### PR DESCRIPTION
## Description

This PR adds the parser and auth building blocks for the egress proxy on top of the config/TLS foundation branch.

It includes:
- shared domain and IP-literal normalization
- the proxy handshake parser and unit tests
- JWT validation and unit tests
- the temporary allowlist parser and unit tests
- startup validation for `EGRESS_PROXY_JWT_SECRET` and `EGRESS_PROXY_ALLOWED_DOMAINS`
- README updates and a black-box startup-failure test for invalid allowlist config

It still does not bind the proxy listener or implement DNS resolution, SSRF checks, upstream connects, forwarding, or lifecycle hardening. Those follow in later PRs.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo build`
- `cargo audit -q`
- `docker build -f dockerfiles/egress-proxy.Dockerfile -t dust-egress-proxy-pr1b .`

## Risk

This is low runtime risk because the binary still only serves `/healthz` and validates startup configuration. The new parser/auth modules are covered by unit tests but are not yet wired into live proxy traffic.

## Deploy Plan

- Merge after PR #24094 and PR #24123
- Deploy normally once the stacked base is merged
- No behavior change for live proxy traffic because the proxy listener is still not active