### PR TITLE
fix: conversation list item overflow

### DIFF
--- a/sparkle/src/components/ConversationListItem.tsx
+++ b/sparkle/src/components/ConversationListItem.tsx
@@ -168,16 +168,16 @@ export function ConversationListItem({
       ) : null}
       <div className="s-mb-0.5 s-flex s-min-w-0 s-grow s-flex-col s-gap-1">
         <div className="s-heading-sm s-flex s-w-full s-items-center s-justify-between s-gap-2 s-text-foreground dark:s-text-foreground-night">
-          <div className="s-flex s-min-w-0 s-gap-2 s-truncate">
+          <div className="s-flex s-min-w-0 s-flex-1 s-gap-2 s-overflow-hidden">
             <span className="s-min-w-0 s-truncate">{conversation.title}</span>
             {creator && (
-              <span className="s-shrink-0  s-text-muted-foreground dark:s-text-muted-foreground-night">
+              <span className="s-hidden s-shrink-0 s-text-muted-foreground dark:s-text-muted-foreground-night sm:s-inline">
                 {creator.fullName}
               </span>
             )}
           </div>
-          <div className="s-flex s-items-center s-gap-2 s-text-xs s-text-muted-foreground dark:s-text-muted-foreground-night">
-            <span className="s-font-normal s-shrink-0">{time}</span>
+          <div className="s-flex s-shrink-0 s-items-center s-gap-2 s-text-xs s-text-muted-foreground dark:s-text-muted-foreground-night">
+            <span className="s-font-normal">{time}</span>
           </div>
         </div>
         {conversation.description && (


### PR DESCRIPTION
## Description

This PR fixes overflow issues in conversation list items on the project main page.

- Updates flex container for title to use `flex-1`
- Makes creator name hidden on small screens (there is already the creator avatar)

Before:
<img width="359" height="148" alt="Capture d’écran 2026-04-13 à 10 56 36" src="https://github.com/user-attachments/assets/7a19be9e-38ce-444b-9796-fd4b05c628aa" />

After:
<img width="358" height="148" alt="Capture d’écran 2026-04-13 à 10 49 06" src="https://github.com/user-attachments/assets/00db3aa0-5bd0-4844-a3e5-a739078ef96d" />


## Tests

Manually.

## Risks

Low risk - UI-only changes.

## Deploy Plan

Standard deployment.
