### PR TITLE
feat: upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/build-and-lint-dust-hive.yml
+++ b/.github/workflows/build-and-lint-dust-hive.yml
@@ -17,7 +17,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         working-directory: x/henry/dust-hive
@@ -29,7 +29,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         working-directory: x/henry/dust-hive
@@ -41,7 +41,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         working-directory: x/henry/dust-hive

--- a/.github/workflows/build-and-test-connectors.yml
+++ b/.github/workflows/build-and-test-connectors.yml
@@ -16,7 +16,7 @@ jobs:
   tsgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -32,7 +32,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-and-test-core.yml
+++ b/.github/workflows/build-and-test-core.yml
@@ -15,7 +15,7 @@ jobs:
       core-changed: ${{ steps.changes.outputs.core }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Check for relevant changes
         uses: dorny/paths-filter@v3
@@ -46,7 +46,7 @@ jobs:
     if: needs.check-changes.outputs.core-changed == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install minimal stable
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -33,7 +33,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -71,7 +71,7 @@ jobs:
   tsgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -88,7 +88,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-canary-image.yml
+++ b/.github/workflows/build-canary-image.yml
@@ -50,7 +50,7 @@ jobs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
       long_sha: ${{ steps.short_sha.outputs.long_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Get short sha
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -64,7 +64,7 @@ jobs:
     outputs:
       thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Notify Build And Deploy Start
         id: build_message
@@ -102,7 +102,7 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 50 # Fetch last 50 commits for commit diff functionality
 

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Install build dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/build-dust-sandbox.yml
+++ b/.github/workflows/build-dust-sandbox.yml
@@ -15,7 +15,7 @@ jobs:
       dust-sandbox-changed: ${{ steps.changes.outputs.dust-sandbox }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Check for relevant changes
         uses: dorny/paths-filter@v3
@@ -46,7 +46,7 @@ jobs:
     if: needs.check-changes.outputs.dust-sandbox-changed == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install minimal stable
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -18,7 +18,7 @@ jobs:
   tsgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-spa.yaml
+++ b/.github/workflows/build-spa.yaml
@@ -17,7 +17,7 @@ jobs:
   tsgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-sparkle.yml
+++ b/.github/workflows/build-sparkle.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-viz.yml
+++ b/.github/workflows/build-viz.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
       # Only proceed if the label is added.
       - name: Checkout code
         if: steps.should-run.outputs.result == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0 # Fetch full history for accurate diffs
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0 # Full depth for better git operations
 

--- a/.github/workflows/deploy-docs-openapi.yml
+++ b/.github/workflows/deploy-docs-openapi.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Run `openapi` command 🚀
         uses: readmeio/rdme@v8

--- a/.github/workflows/deploy-spa-production.yaml
+++ b/.github/workflows/deploy-spa-production.yaml
@@ -32,7 +32,7 @@ jobs:
           || format('["{0}"]', github.event.client_payload.app || inputs.app)
           ) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps

--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -80,7 +80,7 @@ jobs:
     outputs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Get short sha
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -92,7 +92,7 @@ jobs:
     outputs:
       thread_ts: ${{ inputs.thread_ts || steps.build_message.outputs.thread_ts }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Notify SPA Deploy Start
         if: ${{ !inputs.thread_ts }}
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,7 +88,7 @@ jobs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
       long_sha: ${{ steps.short_sha.outputs.long_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Get short sha
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -102,7 +102,7 @@ jobs:
     outputs:
       thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Notify Build And Deploy Start
         id: build_message
@@ -149,7 +149,7 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 50 # Fetch last 50 commits for commit diff functionality
 
@@ -214,7 +214,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && (needs.ensure-sandbox-images.result == 'success' || needs.ensure-sandbox-images.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Generate token
         id: generate-token

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -28,7 +28,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v4
         with:
           node-version: 22.22.0

--- a/.github/workflows/node24-compat.yml
+++ b/.github/workflows/node24-compat.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -47,7 +47,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/package-extension.yaml
+++ b/.github/workflows/package-extension.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -18,7 +18,7 @@ jobs:
     # This ensures the workflow only runs on main branch
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v4
         with:
           node-version: "22.22.0"

--- a/.github/workflows/publish-sdk-client.yml
+++ b/.github/workflows/publish-sdk-client.yml
@@ -18,7 +18,7 @@ jobs:
     # This ensures the workflow only runs on main branch
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - uses: actions/setup-node@v4
         with:
           node-version: "22.22.0"

--- a/.github/workflows/release-dsbx-cli.yml
+++ b/.github/workflows/release-dsbx-cli.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release-sandbox-tool.yml
+++ b/.github/workflows/release-sandbox-tool.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codex repo at pinned tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           repository: openai/codex
           ref: ${{ inputs.codex_tag }}

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -65,7 +65,7 @@ jobs:
     outputs:
       thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Notify Start
         id: build_message
@@ -103,7 +103,7 @@ jobs:
         region: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
       fail-fast: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Set project ID
         id: project
@@ -160,7 +160,7 @@ jobs:
     needs: [notify-start, validate-image]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Generate token
         id: generate-token

--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sandbox-bedrock-release.yml
+++ b/.github/workflows/sandbox-bedrock-release.yml
@@ -32,7 +32,7 @@ jobs:
           private-key: ${{ secrets.SPARKLE_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/sandbox-img-registry.yml
+++ b/.github/workflows/sandbox-img-registry.yml
@@ -25,7 +25,7 @@ jobs:
       has-missing: ${{ steps.check.outputs.has-missing }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
@@ -64,7 +64,7 @@ jobs:
       matrix: ${{ fromJson(needs.check.outputs.build-matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps


### PR DESCRIPTION
## Description

[Node 20 is deprecated in github actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), so let's upgrade to the latest [checkout so it uses node 24](https://github.com/actions/checkout)
## Tests

CI
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
