### PR TITLE
Add optional nodeIds filter to retrieve_recent_documents. Lower stake for add_file / attach_file_to_conversation.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -478,8 +478,8 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "search_conversations": "never_ask",
   },
   "project_manager": {
-    "add_file": "low",
-    "attach_to_conversation": "low",
+    "add_file": "never_ask",
+    "attach_to_conversation": "never_ask",
     "edit_description": "low",
     "get_information": "never_ask",
     "retrieve_recent_documents": "never_ask",

--- a/front/lib/api/actions/servers/include_data/include_function.ts
+++ b/front/lib/api/actions/servers/include_data/include_function.ts
@@ -5,7 +5,10 @@ import type {
   WarningResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { checkConflictingTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
-import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import {
+  applyNodeIdsFilterToCoreSearchArgs,
+  getCoreSearchArgs,
+} from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   makeIncludeResultResource,
@@ -34,11 +37,13 @@ export async function runIncludeDataRetrieval(
   {
     timeFrame,
     dataSources,
+    nodeIds,
     tagsIn,
     tagsNot,
   }: {
     timeFrame?: TimeFrame;
     dataSources: DataSourcesToolConfigurationType;
+    nodeIds?: string[];
     tagsIn?: string[];
     tagsNot?: string[];
   }
@@ -74,7 +79,10 @@ export async function runIncludeDataRetrieval(
     );
   }
 
-  const coreSearchArgs = coreSearchArgsResults.value;
+  const coreSearchArgs = applyNodeIdsFilterToCoreSearchArgs(
+    coreSearchArgsResults.value,
+    nodeIds
+  );
 
   const conflictingTagsError = checkConflictingTags(
     coreSearchArgs.map(({ filter }) => filter.tags),

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -45,7 +45,7 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
           "Optional project to add the file to, will fallback to the conversation's project."
         ),
     },
-    stake: "low",
+    stake: "never_ask",
     displayLabels: {
       running: "Adding file to project",
       done: "Add file to project",
@@ -98,7 +98,7 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
           "Optional project to attach the file to, will fallback to the conversation's project."
         ),
     },
-    stake: "low",
+    stake: "never_ask",
     displayLabels: {
       running: "Attaching project file to conversation",
       done: "Attach project file to conversation",
@@ -147,9 +147,10 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   retrieve_recent_documents: {
     description:
-      "Fetch the most recent documents from this project's knowledge data source (full project scope) and from any content nodes linked in the project context, in reverse chronological order up to the retrieval limit. Respects optional time window. Does not use tag filters.",
+      "Fetch the most recent documents from this project's knowledge data source and from any content nodes linked in the project context, in reverse chronological order up to the retrieval limit. Respects optional time window. Optionally restrict to subtrees using nodeIds.",
     schema: {
       timeFrame: IncludeInputSchema.shape.timeFrame,
+      nodeIds: SearchWithNodesInputSchema.shape.nodeIds,
       dustProject:
         ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -542,6 +542,7 @@ export function createProjectManagerTools(
         return runIncludeDataRetrieval(auth, agentLoopContext, {
           timeFrame: params.timeFrame,
           dataSources,
+          nodeIds: params.nodeIds,
         });
       }, "Failed to retrieve recent project documents");
     },


### PR DESCRIPTION
## Description

Two small improvements to `project_manager` tools.

- Add optional `nodeIds` to `retrieve_recent_documents` — threads through `runIncludeDataRetrieval` and `applyNodeIdsFilterToCoreSearchArgs` to let the model restrict retrieval to specific subtrees rather than the full project scope
- Lower stake of `add_file` and `attach_to_conversation` from `low` to `never_ask` — these tools are safe enough to run without confirmation, consistent with other read/write project tools like `retrieve_recent_documents` and `search_conversations`

## Tests

Local + green (snapshot updated)

## Risk

Low

## Deploy Plan

Deploy `front`
