### PR TITLE
[front] fix: Call mutateEditors on agent save

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -144,7 +144,7 @@ export default function AgentBuilder({
     }
   );
 
-  const { editors } = useEditors({
+  const { editors, mutateEditors } = useEditors({
     owner,
     agentConfigurationId: agentConfiguration?.sId ?? null,
   });
@@ -444,7 +444,12 @@ export default function AgentBuilder({
       }
 
       // Mutate triggers and actions to refresh from backend
-      await Promise.all([mutateTriggers(), mutateActions(), mutateSkills()]);
+      await Promise.all([
+        mutateTriggers(),
+        mutateActions(),
+        mutateSkills(),
+        mutateEditors(),
+      ]);
       onSaved?.();
 
       if (isCreatingNew && createdAgent.sId) {


### PR DESCRIPTION
## Description

We don't call mutateEditors on agent save, leading to stale agent editors after save.
This PR fixes that.

Fixes https://github.com/dust-tt/tasks/issues/7456

## Tests

Tested locally

## Risk

Low
Blast radius: Agent builder

## Deploy Plan

- [ ] Deploy spa