### PR TITLE
fix: retry Twilio sendOtp on transient network errors and stop panic logging

### DIFF
--- a/front/lib/api/workspace_verification/twilio/verify.test.ts
+++ b/front/lib/api/workspace_verification/twilio/verify.test.ts
@@ -138,4 +138,50 @@ describe("sendOtp", () => {
       );
     }
   });
+
+  describe("transient network errors", () => {
+    it("should retry on ECONNRESET and succeed", async () => {
+      const econnResetError = new Error("read ECONNRESET");
+      mockVerificationsCreate
+        .mockRejectedValueOnce(econnResetError)
+        .mockResolvedValueOnce({
+          sid: VERIFICATION_SID,
+          status: "pending",
+        });
+
+      const result = await sendOtp(VALID_PHONE_NUMBER);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.verificationSid).toBe(VERIFICATION_SID);
+      }
+      expect(mockVerificationsCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it("should return error after exhausting retries on ECONNRESET", async () => {
+      const econnResetError = new Error("read ECONNRESET");
+      mockVerificationsCreate.mockRejectedValue(econnResetError);
+
+      const result = await sendOtp(VALID_PHONE_NUMBER);
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toBe(
+          "Failed to send verification code. Please try again."
+        );
+      }
+      expect(mockVerificationsCreate).toHaveBeenCalledTimes(3);
+    });
+
+    it("should not retry on non-transient errors", async () => {
+      mockVerificationsCreate.mockRejectedValue(
+        new Error("Invalid parameter `To`: +invalid")
+      );
+
+      const result = await sendOtp("+invalid");
+
+      expect(result.isErr()).toBe(true);
+      expect(mockVerificationsCreate).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/front/lib/api/workspace_verification/twilio/verify.ts
+++ b/front/lib/api/workspace_verification/twilio/verify.ts
@@ -6,6 +6,23 @@ import { z } from "zod";
 
 import { getTwilioClient, getTwilioVerifyServiceSid } from "./client";
 
+const MAX_SEND_OTP_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 500;
+
+const TRANSIENT_NETWORK_ERROR_PATTERNS = [
+  /ECONNRESET/i,
+  /ETIMEDOUT/i,
+  /ECONNREFUSED/i,
+  /socket hang up/i,
+];
+
+function isTransientNetworkError(error: unknown): boolean {
+  const message = normalizeError(error).message;
+  return TRANSIENT_NETWORK_ERROR_PATTERNS.some((pattern) =>
+    pattern.test(message)
+  );
+}
+
 const TwilioErrorSchema = z.object({
   code: z.number(),
 });
@@ -27,62 +44,85 @@ export async function sendOtp(
   const client = getTwilioClient();
   const serviceSid = getTwilioVerifyServiceSid();
 
-  let verification;
-  try {
-    verification = await client.verify.v2
-      .services(serviceSid)
-      .verifications.create({
-        to: phoneNumber,
-        channel: "sms",
-        ...(statusCallbackUrl && { statusCallback: statusCallbackUrl }),
+  for (let attempt = 1; attempt <= MAX_SEND_OTP_RETRIES; attempt++) {
+    try {
+      const verification = await client.verify.v2
+        .services(serviceSid)
+        .verifications.create({
+          to: phoneNumber,
+          channel: "sms",
+          ...(statusCallbackUrl && { statusCallback: statusCallbackUrl }),
+        });
+
+      return new Ok({
+        verificationSid: verification.sid,
+        status: verification.status,
       });
-  } catch (error) {
-    const err = normalizeError(error);
-    logger.error(
-      { err, phoneNumber: phoneNumber.slice(0, 6) + "***" },
-      "Twilio sendOtp error"
-    );
-
-    if (err.message.includes("Invalid parameter `To`")) {
-      return new Err(new Error("Invalid phone number format"));
-    }
-
-    if (
-      err.message.includes("Max send attempts reached") ||
-      err.message.includes("rate limit")
-    ) {
-      return new Err(new Error("Too many attempts. Please try again later."));
-    }
-
-    switch (getTwilioErrorCode(error)) {
-      case 60220:
-      case 60605:
-        return new Err(
-          new Error(
-            "SMS verification is not available in your region. Please contact support for alternatives."
-          )
+    } catch (error) {
+      if (isTransientNetworkError(error) && attempt < MAX_SEND_OTP_RETRIES) {
+        logger.warn(
+          { phoneNumber: phoneNumber.slice(0, 6) + "***", attempt },
+          "Twilio sendOtp transient error, retrying"
         );
-      case 60410:
-        return new Err(
-          new Error(
-            "Verification temporarily unavailable. Please try again later."
-          )
+        await new Promise((resolve) =>
+          setTimeout(resolve, RETRY_BASE_DELAY_MS * attempt)
         );
-      default:
+        continue;
+      }
+
+      return handleSendOtpError(error, phoneNumber);
+    }
+  }
+
+  // Unreachable: loop always returns via Ok or handleSendOtpError.
+  return new Err(
+    new Error("Failed to send verification code. Please try again.")
+  );
+}
+
+function handleSendOtpError(error: unknown, phoneNumber: string): Err<Error> {
+  const err = normalizeError(error);
+  logger.error(
+    { err, phoneNumber: phoneNumber.slice(0, 6) + "***" },
+    "Twilio sendOtp error"
+  );
+
+  if (err.message.includes("Invalid parameter `To`")) {
+    return new Err(new Error("Invalid phone number format"));
+  }
+
+  if (
+    err.message.includes("Max send attempts reached") ||
+    err.message.includes("rate limit")
+  ) {
+    return new Err(new Error("Too many attempts. Please try again later."));
+  }
+
+  switch (getTwilioErrorCode(error)) {
+    case 60220:
+    case 60605:
+      return new Err(
+        new Error(
+          "SMS verification is not available in your region. Please contact support for alternatives."
+        )
+      );
+    case 60410:
+      return new Err(
+        new Error(
+          "Verification temporarily unavailable. Please try again later."
+        )
+      );
+    default:
+      if (!isTransientNetworkError(error)) {
         logger.error(
           { err, phoneNumber: phoneNumber.slice(0, 6) + "***", panic: true },
           "Twilio sendOtp error, investigate and ask @jd"
         );
-        return new Err(
-          new Error("Failed to send verification code. Please try again.")
-        );
-    }
+      }
+      return new Err(
+        new Error("Failed to send verification code. Please try again.")
+      );
   }
-
-  return new Ok({
-    verificationSid: verification.sid,
-    status: verification.status,
-  });
 }
 
 export type VerifyOtpResult = {


### PR DESCRIPTION
## Description

We were getting panic logs (paging eng oncall) for ECONNRESET errors on the Twilio Verify API. These are transient network issues that resolve on their own and don't need human investigation: [Logs](https://app.datadoghq.eu/logs?query=%40panic%3Atrue%20region%3Aus-central1%20%22Twilio%20sendOtp%20error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ1SYPGMupq-4QAAABhBWjFTWVBnSUFBQktuLWU1dWE3ZThBQVoAAAAkMDE5ZDUyNzUtNzhjOC00ODI4LWI0MmQtOTRkOGM2MzZjODA4AAmO_Q&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1774776289317&to_ts=1776072289317&live=true)

 This change does two things:
1. Adds a retry loop (up to 3 attempts with linear backoff) around the Twilio verification create call. Only transient network errors (ECONNRESET, ETIMEDOUT, ECONNREFUSED, socket hang up) trigger a retry. All other errors fail immediately as before.
2. Removes the panic: true flag from log entries when the error is a transient network error. The error is still logged, just without paging oncall.

Non-transient unknown errors still panic as before.
The error handling logic has been extracted into a handleSendOtpError function to keep the retry loop readable.
Tests added for: successful retry after ECONNRESET, failure after exhausting retries, and confirming non-transient errors are not retried.

Review with hidden whitespaces advised: https://github.com/dust-tt/dust/pull/24132/changes?w=1

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 