### PR TITLE
chore: upgrade slackapi/slack-github-action to v3.0.1 (node24)

### DIFF
--- a/.github/actions/slack-check-deployment-blocked/action.yml
+++ b/.github/actions/slack-check-deployment-blocked/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Get channel info
       id: slack_channel_info
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@v3.0.1
       with:
         method: conversations.info
         token: ${{ inputs.slack_token }}

--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -67,7 +67,7 @@ runs:
     - name: Lookup by email
       if: inputs.step == 'start' || inputs.step == 'spa_start'
       id: email
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@v3.0.1
       with:
         errors: false
         method: users.lookupByEmail
@@ -90,7 +90,7 @@ runs:
     - name: Notify Build And Deploy Start
       if: inputs.step == 'start'
       id: start_notification
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
@@ -169,7 +169,7 @@ runs:
 
     - name: Notify Build Success
       if: inputs.step == 'build_success'
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
@@ -178,7 +178,7 @@ runs:
     - name: Notify SPA Deploy Start
       if: inputs.step == 'spa_start'
       id: spa_start_notification
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
@@ -194,7 +194,7 @@ runs:
 
     - name: Notify SPA Preview Uploaded
       if: inputs.step == 'spa_preview_success'
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
@@ -207,7 +207,7 @@ runs:
 
     - name: Notify SPA Deployed to Production
       if: inputs.step == 'spa_production_success'
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
@@ -220,7 +220,7 @@ runs:
 
     - name: Notify Deploy Failure
       if: inputs.step == 'failure'
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}


### PR DESCRIPTION
## Description

Upgrades `slackapi/slack-github-action` from `v2.0.0` to `v3.0.1` across the two composite actions that use it:

- `.github/actions/slack-notify/action.yml` (7 occurrences)
- `.github/actions/slack-check-deployment-blocked/action.yml` (1 occurrence)

v3.0.1 moves from `node20` to `node24` runtime, addressing the upcoming Node 20 deprecation in GitHub Actions. The API surface used (`method`, `payload`, `token`, `errors`) is unchanged between v2 and v3.

## Tests

Verified v3.0.1 action.yml inputs/outputs are backward-compatible with all current usages.

## Risk

Low — inputs and outputs used by these composite actions (`method`, `payload`, `token`, `errors`, `ok`, `response`, `ts`) are all present and unchanged in v3.

## Deploy Plan

No special deploy steps needed.
