### PR TITLE
feat: check available names on project edit

### DIFF
--- a/front/components/assistant/conversation/EditProjectTitleDialog.tsx
+++ b/front/components/assistant/conversation/EditProjectTitleDialog.tsx
@@ -1,6 +1,7 @@
 import { useSpaceConversationsSummary } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
+import { useCheckProjectName } from "@app/lib/swr/projects";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -32,6 +33,16 @@ export const EditProjectTitleDialog = ({
   currentTitle,
 }: EditProjectTitleDialogProps) => {
   const [title, setTitle] = useState<string>(currentTitle);
+  const {
+    isNameAvailable,
+    isChecking: isCheckingName,
+    setValue: setNameToCheck,
+  } = useCheckProjectName({
+    owner,
+    whitelistedName: currentTitle,
+  });
+  const nameNotAvailable =
+    title.trim().length > 0 && !isCheckingName && !isNameAvailable;
   const inputRef = useRef<HTMLInputElement>(null);
   const sendNotification = useSendNotification();
   const { mutateSpaceInfo } = useSpaceInfo({
@@ -109,7 +120,10 @@ export const EditProjectTitleDialog = ({
             ref={inputRef}
             placeholder="Enter new title..."
             value={title}
-            onChange={(e) => setTitle(e.target.value)}
+            onChange={(e) => {
+              setTitle(e.target.value);
+              setNameToCheck(e.target.value);
+            }}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 e.preventDefault();
@@ -117,12 +131,18 @@ export const EditProjectTitleDialog = ({
               }
             }}
           />
+          {nameNotAvailable && (
+            <div className="text-xs text-warning-500">
+              A project or space with this name already exists.
+            </div>
+          )}
         </DialogContainer>
         <DialogFooter
           rightButtonProps={{
             label: "Save",
             variant: "primary",
             onClick: editTitle,
+            disabled: nameNotAvailable || isCheckingName,
           }}
           leftButtonProps={{
             label: "Cancel",

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -3,6 +3,7 @@ import { MembersTable } from "@app/components/assistant/conversation/space/about
 import { ConfirmContext } from "@app/components/Confirm";
 import { useSpaceConversationsSummary } from "@app/hooks/conversations";
 import { useArchiveProject } from "@app/hooks/useArchiveProject";
+import { useCheckProjectName } from "@app/lib/swr/projects";
 import {
   useProjectMetadata,
   useSpaceInfo,
@@ -68,6 +69,16 @@ export function SpaceAboutTab({
 
   const [projectName, setProjectName] = useState(space.name);
   const [isEditingName, setIsEditingName] = useState(false);
+  const {
+    isNameAvailable,
+    isChecking: isCheckingName,
+    setValue: setNameToCheck,
+  } = useCheckProjectName({
+    owner,
+    whitelistedName: space.name,
+  });
+  const nameNotAvailable =
+    projectName.trim().length > 0 && !isCheckingName && !isNameAvailable;
   const [projectDescription, setProjectDescription] = useState(
     projectMetadata?.description ?? ""
   );
@@ -256,6 +267,7 @@ export function SpaceAboutTab({
               disabled={!isProjectEditor}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 setProjectName(e.target.value);
+                setNameToCheck(e.target.value);
                 setIsEditingName(e.target.value.trim() !== space.name.trim());
               }}
               placeholder="Enter project name"
@@ -263,18 +275,29 @@ export function SpaceAboutTab({
             />
             {isEditingName && (
               <>
-                <Button label="Save" variant="highlight" onClick={onSaveName} />
+                <Button
+                  label="Save"
+                  variant="highlight"
+                  onClick={onSaveName}
+                  disabled={nameNotAvailable || isCheckingName}
+                />
                 <Button
                   label="Cancel"
                   variant="outline"
                   onClick={() => {
                     setProjectName(space.name);
+                    setNameToCheck("");
                     setIsEditingName(false);
                   }}
                 />
               </>
             )}
           </div>
+          {isEditingName && nameNotAvailable && (
+            <div className="text-xs text-warning-500">
+              A project or space with this name already exists.
+            </div>
+          )}
         </div>
         <div className="flex w-full flex-col gap-2">
           <div className="heading-lg">Description</div>

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -278,9 +278,11 @@ export function useRenameProjectFile({ owner }: { owner: LightWorkspaceType }) {
 export function useCheckProjectName({
   owner,
   initialName = "",
+  whitelistedName,
 }: {
   owner: LightWorkspaceType;
   initialName?: string;
+  whitelistedName?: string;
 }) {
   const { fetcher } = useFetcher();
   const {
@@ -292,9 +294,16 @@ export function useCheckProjectName({
     minLength: 1,
   });
 
+  // If the name matches the whitelisted name (case-insensitive), skip the API
+  // call entirely — the name is available by definition (e.g. when renaming a
+  // space to its current name).
+  const isWhitelisted =
+    !!whitelistedName &&
+    debouncedName.trim().toLowerCase() === whitelistedName.trim().toLowerCase();
+
   const shouldFetch = useMemo(() => {
-    return debouncedName.trim().length > 0;
-  }, [debouncedName]);
+    return debouncedName.trim().length > 0 && !isWhitelisted;
+  }, [debouncedName, isWhitelisted]);
 
   const checkKey = shouldFetch
     ? `/api/w/${owner.sId}/spaces/check-name?name=${encodeURIComponent(debouncedName)}`
@@ -305,8 +314,8 @@ export function useCheckProjectName({
   const { data, isLoading } = useSWRWithDefaults(checkKey, checkFetcher);
 
   return {
-    isNameAvailable: data?.available ?? true,
-    isChecking: isLoading || isDebouncing,
+    isNameAvailable: isWhitelisted || (data?.available ?? true),
+    isChecking: !isWhitelisted && (isLoading || isDebouncing),
     setValue,
   };
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7468

This PR adds project name validation when editing a project name to prevent creating duplicates.

- Integrates the `useCheckProjectName` hook into the `SpaceAboutTab` component to validate name availability as users type
- Adds a `whitelistedName` parameter to `useCheckProjectName` to skip API validation when the edited name matches the current project name
- Displays a warning message when the entered name is already taken
- Disables the "Save" button when the name is unavailable or being checked

<img width="935" height="148" alt="Capture d’écran 2026-04-13 à 11 53 05" src="https://github.com/user-attachments/assets/b7c87cbb-10f1-4971-9bae-8a3de10fd94a" />


## Tests

Manually

## Risks

Low. The change only adds client-side validation to provide better UX feedback.

## Deploy Plan

Standard deployment. No special steps required.
