### PR TITLE
Add egress proxy end-to-end semantics

### DIFF
--- a/egress-proxy/README.md
+++ b/egress-proxy/README.md
@@ -5,21 +5,20 @@
 Current functionality:
 
 - `/healthz` process health endpoint.
-- minimal process startup/shutdown wiring.
-- startup validation for proxy config, TLS assets, and the temporary allowlist.
 - TLS certificate and private-key loading.
-- foundational modules for handshake parsing and JWT validation, covered by unit tests.
+- startup validation for proxy config, TLS assets, JWT secret, and the temporary allowlist.
+- TLS-terminated proxy listener for sandbox forwarder connections.
+- handshake parsing, JWT validation, temporary allowlist enforcement, and global DoH blocklist
+  enforcement.
+- server-side DNS resolution, SSRF checks on resolved addresses, upstream TCP connection, and
+  bidirectional byte forwarding.
 - Docker build and GitHub workflow coverage.
 
 Not implemented yet:
 
-- proxy listener
-- DNS resolution
-- SSRF blocking
-- upstream connection
-- forwarding
 - GCS policy reads
-- production lifecycle hardening
+- production lifecycle hardening around listener supervision and graceful tunnel draining
+- configurable idle or max-lifetime policy for established tunnels
 
 ## Configuration
 

--- a/egress-proxy/src/blocklist.rs
+++ b/egress-proxy/src/blocklist.rs
@@ -1,0 +1,86 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+const GLOBAL_BLOCKED_DOMAINS: &[&str] = &[
+    // TODO(sandbox-egress): Move this list to the final managed policy/config path if we
+    // need runtime updates without redeploying the proxy.
+    "dns.google",
+    "dns.google.com",
+    "cloudflare-dns.com",
+    "one.one.one.one",
+    "1.1.1.1",
+    "1.0.0.1",
+    "dns.quad9.net",
+    "doh.opendns.com",
+    "dns.nextdns.io",
+];
+
+pub fn is_globally_blocked_domain(domain: &str) -> bool {
+    // TODO(sandbox-egress): Nice-to-have policy decision before GCS policies ship: decide
+    // whether global blocklist entries need suffix matching for provider-controlled subdomains.
+    GLOBAL_BLOCKED_DOMAINS.contains(&domain)
+}
+
+pub fn is_unsafe_ip(ip: IpAddr) -> bool {
+    // TODO(sandbox-egress): Add stable deny reason metrics for each blocked IP category.
+    match ip {
+        IpAddr::V4(ip) => is_unsafe_ipv4(ip),
+        IpAddr::V6(ip) => is_unsafe_ipv6(ip),
+    }
+}
+
+fn is_unsafe_ipv4(ip: Ipv4Addr) -> bool {
+    ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local()
+        || ip.is_unspecified()
+        // Explicitly block the well-known cloud metadata service address. This is already covered
+        // by the link-local check above, but keeping it visible documents the SSRF risk.
+        || ip == Ipv4Addr::new(169, 254, 169, 254)
+}
+
+fn is_unsafe_ipv6(ip: Ipv6Addr) -> bool {
+    if let Some(mapped_ipv4) = ip.to_ipv4_mapped() {
+        return is_unsafe_ipv4(mapped_ipv4);
+    }
+
+    ip.is_loopback() || ip.is_unspecified() || is_unique_local_ipv6(ip) || is_unicast_link_local(ip)
+}
+
+fn is_unique_local_ipv6(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xfe00) == 0xfc00
+}
+
+fn is_unicast_link_local(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xffc0) == 0xfe80
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_globally_blocked_domain, is_unsafe_ip};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn blocks_doh_domains() {
+        assert!(is_globally_blocked_domain("dns.google"));
+        assert!(is_globally_blocked_domain("1.1.1.1"));
+        assert!(!is_globally_blocked_domain("example.com"));
+    }
+
+    #[test]
+    fn classifies_unsafe_ips() {
+        assert!(is_unsafe_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+        assert!(is_unsafe_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+        assert!(is_unsafe_ip(IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))));
+        assert!(is_unsafe_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        assert!(is_unsafe_ip(IpAddr::V6(
+            Ipv4Addr::new(127, 0, 0, 1).to_ipv6_mapped()
+        )));
+        assert!(is_unsafe_ip(IpAddr::V6(
+            Ipv4Addr::new(10, 0, 0, 1).to_ipv6_mapped()
+        )));
+        assert!(is_unsafe_ip(IpAddr::V6(
+            Ipv4Addr::new(169, 254, 169, 254).to_ipv6_mapped()
+        )));
+        assert!(!is_unsafe_ip(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))));
+    }
+}

--- a/egress-proxy/src/config.rs
+++ b/egress-proxy/src/config.rs
@@ -12,7 +12,6 @@ pub struct Config {
     pub tls_key_path: PathBuf,
     pub jwt_secret: String,
     pub temporary_allowlist: TemporaryAllowlist,
-    pub environment: String,
     pub unsafe_skip_ssrf_check: bool,
 }
 
@@ -78,7 +77,6 @@ impl TryFrom<RawConfig> for Config {
             tls_key_path: raw.tls_key,
             jwt_secret: raw.jwt_secret,
             temporary_allowlist,
-            environment: raw.environment,
             unsafe_skip_ssrf_check,
         })
     }

--- a/egress-proxy/src/connection.rs
+++ b/egress-proxy/src/connection.rs
@@ -1,0 +1,390 @@
+use crate::blocklist::{is_globally_blocked_domain, is_unsafe_ip};
+use crate::config::Config;
+use crate::dns::DnsResolver;
+use crate::handshake::{read_handshake, Handshake, HandshakeError, ALLOW_RESPONSE, DENY_RESPONSE};
+use crate::jwt::{JwtValidationError, JwtValidator, ValidatedSandboxToken};
+use crate::policy::TemporaryAllowlist;
+use std::fmt;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{copy_bidirectional, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+use tokio_rustls::server::TlsStream;
+use tracing::{info, warn};
+
+const HANDSHAKE_TIMEOUT_SECONDS: u64 = 5;
+const DNS_TIMEOUT_SECONDS: u64 = 5;
+const UPSTREAM_CONNECT_TIMEOUT_SECONDS: u64 = 5;
+
+#[derive(Clone)]
+pub struct ConnectionState {
+    jwt_validator: JwtValidator,
+    temporary_allowlist: TemporaryAllowlist,
+    dns_resolver: DnsResolver,
+    unsafe_skip_ssrf_check: bool,
+}
+
+struct RequestMetadata {
+    domain: String,
+    original_dest_port: u16,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DenyReason {
+    MalformedHandshake,
+    UnsupportedProtocolVersion,
+    EmptyDomain,
+    InvalidJwt,
+    ExpiredJwt,
+    InvalidClaims,
+    GlobalBlocklist,
+    NotInTemporaryAllowlist,
+    DnsResolutionFailed,
+    UnsafeResolvedIp,
+    UpstreamConnectFailed,
+    IoError,
+}
+
+impl ConnectionState {
+    pub fn new(config: &Config) -> Self {
+        Self {
+            jwt_validator: JwtValidator::new(&config.jwt_secret),
+            temporary_allowlist: config.temporary_allowlist.clone(),
+            dns_resolver: DnsResolver::new(),
+            unsafe_skip_ssrf_check: config.unsafe_skip_ssrf_check,
+        }
+    }
+}
+
+impl DenyReason {
+    pub fn as_str(self) -> &'static str {
+        // TODO(sandbox-egress): Keep deny reason strings stable so dashboards and alerts can
+        // aggregate by reason.
+        match self {
+            Self::MalformedHandshake => "malformed_handshake",
+            Self::UnsupportedProtocolVersion => "unsupported_protocol_version",
+            Self::EmptyDomain => "empty_domain",
+            Self::InvalidJwt => "invalid_jwt",
+            Self::ExpiredJwt => "expired_jwt",
+            Self::InvalidClaims => "invalid_claims",
+            Self::GlobalBlocklist => "global_blocklist",
+            Self::NotInTemporaryAllowlist => "not_in_temporary_allowlist",
+            Self::DnsResolutionFailed => "dns_resolution_failed",
+            Self::UnsafeResolvedIp => "unsafe_resolved_ip",
+            Self::UpstreamConnectFailed => "upstream_connect_failed",
+            Self::IoError => "io_error",
+        }
+    }
+}
+
+impl fmt::Display for DenyReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+pub async fn handle_connection(mut stream: TlsStream<TcpStream>, state: Arc<ConnectionState>) {
+    let _ = handle_connection_inner(&mut stream, state).await;
+}
+
+async fn handle_connection_inner(
+    stream: &mut TlsStream<TcpStream>,
+    state: Arc<ConnectionState>,
+) -> Result<(), DenyReason> {
+    let handshake = match timeout(
+        Duration::from_secs(HANDSHAKE_TIMEOUT_SECONDS),
+        read_handshake(stream),
+    )
+    .await
+    {
+        Err(_) => {
+            warn!(
+                deny_reason = %DenyReason::MalformedHandshake,
+                handshake_timeout_seconds = HANDSHAKE_TIMEOUT_SECONDS,
+                "connection denied after handshake timeout"
+            );
+            return Err(DenyReason::MalformedHandshake);
+        }
+        Ok(Ok(handshake)) => handshake,
+        Ok(Err(HandshakeError::UnsupportedProtocolVersion)) => {
+            deny(stream, DenyReason::UnsupportedProtocolVersion, None, None).await;
+            return Err(DenyReason::UnsupportedProtocolVersion);
+        }
+        Ok(Err(HandshakeError::MalformedHandshake)) => {
+            deny(stream, DenyReason::MalformedHandshake, None, None).await;
+            return Err(DenyReason::MalformedHandshake);
+        }
+        Ok(Err(HandshakeError::TruncatedHandshake)) => {
+            warn!(
+                deny_reason = %DenyReason::MalformedHandshake,
+                "connection denied"
+            );
+            return Err(DenyReason::MalformedHandshake);
+        }
+    };
+
+    let Handshake {
+        token: raw_token,
+        domain,
+        original_dest_port,
+    } = handshake;
+    let request = RequestMetadata {
+        domain,
+        original_dest_port,
+    };
+
+    let token = match state.jwt_validator.validate(&raw_token) {
+        Ok(token) => token,
+        Err(error) => {
+            let reason = jwt_error_to_deny_reason(error);
+            deny(stream, reason, None, Some(&request)).await;
+            return Err(reason);
+        }
+    };
+    drop(raw_token);
+
+    if request.domain.is_empty() {
+        // TODO(sandbox-egress): Track empty_domain separately from malformed_handshake because
+        // this is the expected deny path for non-HTTP/non-TLS connections where dsbx cannot
+        // extract a Host header or TLS SNI.
+        deny(
+            stream,
+            DenyReason::EmptyDomain,
+            Some(&token),
+            Some(&request),
+        )
+        .await;
+        return Err(DenyReason::EmptyDomain);
+    }
+
+    if is_globally_blocked_domain(&request.domain) {
+        deny(
+            stream,
+            DenyReason::GlobalBlocklist,
+            Some(&token),
+            Some(&request),
+        )
+        .await;
+        return Err(DenyReason::GlobalBlocklist);
+    }
+
+    if !state
+        .temporary_allowlist
+        .allows(&request.domain, &token.sb_id)
+    {
+        deny(
+            stream,
+            DenyReason::NotInTemporaryAllowlist,
+            Some(&token),
+            Some(&request),
+        )
+        .await;
+        return Err(DenyReason::NotInTemporaryAllowlist);
+    }
+
+    let upstream_addresses = match timeout(
+        Duration::from_secs(DNS_TIMEOUT_SECONDS),
+        state
+            .dns_resolver
+            .resolve(&request.domain, request.original_dest_port),
+    )
+    .await
+    {
+        Ok(Ok(addresses)) => addresses,
+        Err(_) => {
+            warn!(
+                sb_id = %token.sb_id,
+                domain = %request.domain,
+                original_dest_port = request.original_dest_port,
+                dns_timeout_seconds = DNS_TIMEOUT_SECONDS,
+                "dns resolution timed out"
+            );
+            deny(
+                stream,
+                DenyReason::DnsResolutionFailed,
+                Some(&token),
+                Some(&request),
+            )
+            .await;
+            return Err(DenyReason::DnsResolutionFailed);
+        }
+        Ok(Err(error)) => {
+            warn!(
+                error = %error,
+                sb_id = %token.sb_id,
+                domain = %request.domain,
+                original_dest_port = request.original_dest_port,
+                "dns resolution failed"
+            );
+            deny(
+                stream,
+                DenyReason::DnsResolutionFailed,
+                Some(&token),
+                Some(&request),
+            )
+            .await;
+            return Err(DenyReason::DnsResolutionFailed);
+        }
+    };
+
+    if !state.unsafe_skip_ssrf_check
+        && upstream_addresses
+            .iter()
+            .any(|address| is_unsafe_ip(address.ip()))
+    {
+        deny(
+            stream,
+            DenyReason::UnsafeResolvedIp,
+            Some(&token),
+            Some(&request),
+        )
+        .await;
+        return Err(DenyReason::UnsafeResolvedIp);
+    }
+
+    let upstream_addr = match upstream_addresses.first().copied() {
+        Some(address) => address,
+        None => {
+            deny(
+                stream,
+                DenyReason::DnsResolutionFailed,
+                Some(&token),
+                Some(&request),
+            )
+            .await;
+            return Err(DenyReason::DnsResolutionFailed);
+        }
+    };
+
+    let mut upstream = match timeout(
+        Duration::from_secs(UPSTREAM_CONNECT_TIMEOUT_SECONDS),
+        TcpStream::connect(upstream_addr),
+    )
+    .await
+    {
+        Ok(Ok(upstream)) => upstream,
+        Err(_) => {
+            warn!(
+                sb_id = %token.sb_id,
+                domain = %request.domain,
+                original_dest_port = request.original_dest_port,
+                upstream_addr = %upstream_addr,
+                upstream_connect_timeout_seconds = UPSTREAM_CONNECT_TIMEOUT_SECONDS,
+                "upstream connect timed out"
+            );
+            deny(
+                stream,
+                DenyReason::UpstreamConnectFailed,
+                Some(&token),
+                Some(&request),
+            )
+            .await;
+            return Err(DenyReason::UpstreamConnectFailed);
+        }
+        Ok(Err(error)) => {
+            warn!(
+                error = %error,
+                sb_id = %token.sb_id,
+                domain = %request.domain,
+                original_dest_port = request.original_dest_port,
+                upstream_addr = %upstream_addr,
+                "upstream connect failed"
+            );
+            deny(
+                stream,
+                DenyReason::UpstreamConnectFailed,
+                Some(&token),
+                Some(&request),
+            )
+            .await;
+            return Err(DenyReason::UpstreamConnectFailed);
+        }
+    };
+
+    if stream.write_all(&[ALLOW_RESPONSE]).await.is_err() {
+        return Err(DenyReason::IoError);
+    }
+    if stream.flush().await.is_err() {
+        return Err(DenyReason::IoError);
+    }
+
+    info!(
+        sb_id = %token.sb_id,
+        domain = %request.domain,
+        original_dest_port = request.original_dest_port,
+        upstream_addr = %upstream_addr,
+        "connection allowed"
+    );
+
+    // TODO(sandbox-egress): Nice-to-have once product traffic patterns are known: enforce an
+    // explicit idle or max-lifetime policy for long-lived sandbox tunnels.
+    match copy_bidirectional(stream, &mut upstream).await {
+        Ok((from_client_bytes, from_upstream_bytes)) => {
+            info!(
+                sb_id = %token.sb_id,
+                domain = %request.domain,
+                original_dest_port = request.original_dest_port,
+                upstream_addr = %upstream_addr,
+                from_client_bytes,
+                from_upstream_bytes,
+                "connection closed"
+            );
+            Ok(())
+        }
+        Err(error) => {
+            warn!(
+                error = %error,
+                sb_id = %token.sb_id,
+                domain = %request.domain,
+                original_dest_port = request.original_dest_port,
+                upstream_addr = %upstream_addr,
+                "connection copy failed"
+            );
+            Err(DenyReason::IoError)
+        }
+    }
+}
+
+async fn deny(
+    stream: &mut TlsStream<TcpStream>,
+    reason: DenyReason,
+    token: Option<&ValidatedSandboxToken>,
+    request: Option<&RequestMetadata>,
+) {
+    // TODO(sandbox-egress): Emit allow/deny/JWT/GCS/upstream metrics once service telemetry
+    // is wired.
+    log_deny(reason, token, request, None);
+    if let Err(error) = stream.write_all(&[DENY_RESPONSE]).await {
+        warn!(error = %error, deny_reason = %reason, "failed to write deny response");
+        return;
+    }
+    if let Err(error) = stream.flush().await {
+        warn!(error = %error, deny_reason = %reason, "failed to flush deny response");
+    }
+}
+
+fn log_deny(
+    reason: DenyReason,
+    token: Option<&ValidatedSandboxToken>,
+    request: Option<&RequestMetadata>,
+    upstream_addr: Option<SocketAddr>,
+) {
+    warn!(
+        deny_reason = %reason,
+        sb_id = token.map(|token| token.sb_id.as_str()),
+        domain = request.map(|request| request.domain.as_str()),
+        original_dest_port = request.map(|request| request.original_dest_port),
+        upstream_addr = upstream_addr.map(|address| address.to_string()),
+        "connection denied"
+    );
+}
+
+fn jwt_error_to_deny_reason(error: JwtValidationError) -> DenyReason {
+    match error {
+        JwtValidationError::Expired => DenyReason::ExpiredJwt,
+        JwtValidationError::InvalidClaims => DenyReason::InvalidClaims,
+        JwtValidationError::InvalidJwt => DenyReason::InvalidJwt,
+    }
+}

--- a/egress-proxy/src/dns.rs
+++ b/egress-proxy/src/dns.rs
@@ -1,0 +1,32 @@
+use anyhow::{anyhow, Result};
+use std::net::{IpAddr, SocketAddr};
+use tokio::net::lookup_host;
+
+#[derive(Debug, Clone)]
+pub struct DnsResolver {}
+
+impl DnsResolver {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub async fn resolve(&self, domain: &str, port: u16) -> Result<Vec<SocketAddr>> {
+        if let Ok(ip) = domain.parse::<IpAddr>() {
+            return Ok(vec![SocketAddr::new(ip, port)]);
+        }
+
+        let addresses = lookup_host((domain, port)).await?.collect::<Vec<_>>();
+
+        if addresses.is_empty() {
+            return Err(anyhow!("no addresses resolved for domain"));
+        }
+
+        Ok(addresses)
+    }
+}
+
+impl Default for DnsResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/egress-proxy/src/handshake.rs
+++ b/egress-proxy/src/handshake.rs
@@ -1,7 +1,3 @@
-// TODO(sandbox-egress): Remove this allowance in the next PR when the proxy listener starts
-// reading real sandbox handshakes.
-#![allow(dead_code)]
-
 use crate::domain::{normalize_domain_or_ip, DomainValidationError};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt};

--- a/egress-proxy/src/jwt.rs
+++ b/egress-proxy/src/jwt.rs
@@ -1,7 +1,3 @@
-// TODO(sandbox-egress): Remove this allowance in the next PR when connection handling validates
-// forwarder JWTs.
-#![allow(dead_code)]
-
 use jsonwebtoken::{decode, Algorithm, DecodingKey, TokenData, Validation};
 use serde::Deserialize;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/egress-proxy/src/main.rs
+++ b/egress-proxy/src/main.rs
@@ -1,4 +1,7 @@
+mod blocklist;
 mod config;
+mod connection;
+mod dns;
 mod domain;
 mod handshake;
 mod health;

--- a/egress-proxy/src/policy.rs
+++ b/egress-proxy/src/policy.rs
@@ -1,7 +1,3 @@
-// TODO(sandbox-egress): Remove this allowance in the next PR when the proxy runtime starts
-// enforcing allowlist decisions.
-#![allow(dead_code)]
-
 use crate::domain::{normalize_dns_name, normalize_domain_or_ip};
 use anyhow::{anyhow, Result};
 

--- a/egress-proxy/src/server.rs
+++ b/egress-proxy/src/server.rs
@@ -1,38 +1,41 @@
 use crate::config::Config;
+use crate::connection::{handle_connection, ConnectionState};
 use crate::health;
-use crate::jwt::JwtValidator;
 use crate::tls::load_tls_acceptor;
 use anyhow::{anyhow, Result};
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::signal;
-use tokio::sync::watch;
-use tracing::{error, info};
+use tokio::sync::{watch, Semaphore};
+use tokio::time::timeout;
+use tracing::{error, info, warn};
+
+const TLS_ACCEPT_TIMEOUT_SECONDS: u64 = 5;
+const MAX_CONCURRENT_CONNECTIONS: usize = 1024;
 
 pub async fn run(config: Config) -> Result<()> {
-    let Config {
-        listen_addr,
-        health_addr,
-        tls_cert_path,
-        tls_key_path,
-        jwt_secret,
-        temporary_allowlist,
-        environment,
-        unsafe_skip_ssrf_check,
-    } = config;
+    let tls_acceptor = load_tls_acceptor(&config.tls_cert_path, &config.tls_key_path)?;
+    let listener = TcpListener::bind(config.listen_addr).await?;
+    let proxy_addr = listener.local_addr()?;
+    let health_listener = TcpListener::bind(config.health_addr).await?;
+    let health_addr = health_listener.local_addr()?;
+    let state = Arc::new(ConnectionState::new(&config));
 
-    let _tls_acceptor = load_tls_acceptor(&tls_cert_path, &tls_key_path)?;
-    let _jwt_validator = JwtValidator::new(&jwt_secret);
-    let _temporary_allowlist = temporary_allowlist;
-
-    let listener = TcpListener::bind(health_addr).await?;
-    let health_addr = listener.local_addr()?;
-
-    // TODO(sandbox-egress): Bind and accept the sandbox forwarder listener on listen_addr in the
-    // next PR once the parser/auth building blocks have landed.
-    let _ = (listen_addr, environment, unsafe_skip_ssrf_check);
+    // TODO(sandbox-egress): Confirm final certificate provisioning path once the Kubernetes
+    // deployment and DNS name are introduced.
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let mut health_handle = tokio::spawn(health::serve(listener, shutdown_rx));
 
+    let mut health_handle = tokio::spawn(health::serve(health_listener, shutdown_rx.clone()));
+    let proxy_handle = tokio::spawn(run_proxy_listener(
+        listener,
+        tls_acceptor,
+        state,
+        Arc::new(Semaphore::new(MAX_CONCURRENT_CONNECTIONS)),
+        shutdown_rx.clone(),
+    ));
+
+    info!(addr = %proxy_addr, "proxy listener started");
     info!(addr = %health_addr, "health listener started");
 
     tokio::select! {
@@ -40,6 +43,10 @@ pub async fn run(config: Config) -> Result<()> {
             info!("shutdown signal received");
             let _ = shutdown_tx.send(true);
 
+            if let Err(error) = proxy_handle.await? {
+                error!(error = %error, "proxy listener failed during shutdown");
+                return Err(error);
+            }
             if let Err(error) = health_handle.await? {
                 error!(error = %error, "health server failed during shutdown");
                 return Err(error);
@@ -53,6 +60,71 @@ pub async fn run(config: Config) -> Result<()> {
     }
 
     info!("egress proxy stopped");
+    Ok(())
+}
+
+async fn run_proxy_listener(
+    listener: TcpListener,
+    tls_acceptor: tokio_rustls::TlsAcceptor,
+    state: Arc<ConnectionState>,
+    connection_slots: Arc<Semaphore>,
+    mut shutdown: watch::Receiver<bool>,
+) -> Result<()> {
+    loop {
+        tokio::select! {
+            accept_result = listener.accept() => {
+                let (stream, peer_addr) = accept_result?;
+                let permit = match connection_slots.clone().try_acquire_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        warn!(
+                            peer_addr = %peer_addr,
+                            max_concurrent_connections = MAX_CONCURRENT_CONNECTIONS,
+                            "connection rejected because concurrency limit is reached"
+                        );
+                        drop(stream);
+                        continue;
+                    }
+                };
+                let tls_acceptor = tls_acceptor.clone();
+                let state = state.clone();
+
+                tokio::spawn(async move {
+                    let _permit = permit;
+                    match timeout(
+                        Duration::from_secs(TLS_ACCEPT_TIMEOUT_SECONDS),
+                        tls_acceptor.accept(stream),
+                    )
+                    .await
+                    {
+                        Ok(Ok(tls_stream)) => handle_connection(tls_stream, state).await,
+                        Ok(Err(error)) => {
+                            warn!(
+                                error = %error,
+                                peer_addr = %peer_addr,
+                                "tls handshake failed"
+                            );
+                        }
+                        Err(_) => {
+                            warn!(
+                                peer_addr = %peer_addr,
+                                tls_accept_timeout_seconds = TLS_ACCEPT_TIMEOUT_SECONDS,
+                                "tls handshake timed out"
+                            );
+                        }
+                    }
+                });
+            }
+            changed = shutdown.changed() => {
+                if changed.is_err() || *shutdown.borrow() {
+                    break;
+                }
+            }
+        }
+    }
+
+    // TODO(sandbox-egress): In PR 3, supervise the proxy listener task and give accepted
+    // connections a bounded drain window during shutdown instead of detaching them.
     Ok(())
 }
 

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -1,17 +1,39 @@
 use anyhow::{anyhow, Result};
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use rustls::pki_types::{pem::PemObject, CertificateDer, ServerName};
+use rustls::RootCertStore;
+use serde::Serialize;
 use std::fs::write;
-use std::net::{SocketAddr, TcpListener as StdTcpListener};
+use std::net::{Ipv6Addr, SocketAddr, TcpListener as StdTcpListener};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::time::Duration;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinSet;
+use tokio_rustls::TlsConnector;
 
 const SECRET: &str = "test-secret";
+const ALLOW_RESPONSE: u8 = 0x00;
+const DENY_RESPONSE: u8 = 0x01;
 
 struct ProxyProcess {
     child: Child,
+    _temp_dir: TempDir,
+    ca_cert_path: PathBuf,
+    proxy_addr: SocketAddr,
     health_addr: SocketAddr,
+}
+
+#[derive(Debug, Serialize)]
+struct TestClaims {
+    #[serde(rename = "sbId")]
+    sb_id: String,
+    iss: &'static str,
+    aud: &'static str,
+    exp: usize,
 }
 
 impl Drop for ProxyProcess {
@@ -23,7 +45,7 @@ impl Drop for ProxyProcess {
 
 #[tokio::test]
 async fn healthz_returns_ok() -> Result<()> {
-    let proxy = start_proxy().await?;
+    let proxy = start_proxy("example.com", false, "production").await?;
 
     let response = http_get(proxy.health_addr, "/healthz").await?;
 
@@ -34,13 +56,14 @@ async fn healthz_returns_ok() -> Result<()> {
 
 #[tokio::test]
 async fn invalid_tls_assets_fail_startup() -> Result<()> {
-    let temp_dir = tempfile::TempDir::new()?;
+    let temp_dir = TempDir::new()?;
     let tls_key_path = temp_dir.path().join("tls.key");
     write(&tls_key_path, "not a private key")?;
+    let proxy_addr = free_addr()?;
     let health_addr = free_addr()?;
 
     let mut child = Command::new(env!("CARGO_BIN_EXE_egress-proxy"))
-        .env("EGRESS_PROXY_LISTEN_ADDR", "127.0.0.1:4443")
+        .env("EGRESS_PROXY_LISTEN_ADDR", proxy_addr.to_string())
         .env("EGRESS_PROXY_HEALTH_ADDR", health_addr.to_string())
         .env("EGRESS_PROXY_TLS_CERT", temp_dir.path().join("missing.crt"))
         .env("EGRESS_PROXY_TLS_KEY", &tls_key_path)
@@ -56,12 +79,13 @@ async fn invalid_tls_assets_fail_startup() -> Result<()> {
 
 #[tokio::test]
 async fn invalid_allowed_domain_fails_startup() -> Result<()> {
-    let temp_dir = tempfile::TempDir::new()?;
+    let temp_dir = TempDir::new()?;
     let certs = generate_test_certs(temp_dir.path())?;
+    let proxy_addr = free_addr()?;
     let health_addr = free_addr()?;
 
     let mut child = Command::new(env!("CARGO_BIN_EXE_egress-proxy"))
-        .env("EGRESS_PROXY_LISTEN_ADDR", "127.0.0.1:4443")
+        .env("EGRESS_PROXY_LISTEN_ADDR", proxy_addr.to_string())
         .env("EGRESS_PROXY_HEALTH_ADDR", health_addr.to_string())
         .env("EGRESS_PROXY_TLS_CERT", &certs.server_cert_path)
         .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
@@ -75,23 +99,203 @@ async fn invalid_allowed_domain_fails_startup() -> Result<()> {
     wait_for_startup_failure(&mut child).await
 }
 
-async fn start_proxy() -> Result<ProxyProcess> {
-    let temp_dir = tempfile::TempDir::new()?;
+#[tokio::test]
+async fn allowed_domain_forwards_bytes() -> Result<()> {
+    let (upstream_port, mut upstream_handles) = start_localhost_echo_servers().await?;
+    let proxy = start_proxy("localhost", true, "test").await?;
+    let token = make_token(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_echo(&mut upstream_handles).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn denied_domain_returns_deny() -> Result<()> {
+    let proxy = start_proxy("example.com", false, "production").await?;
+    let token = make_token(SECRET, 60);
+
+    let response = send_handshake(&proxy, &token, "denied.example.com", 443).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_jwt_returns_deny() -> Result<()> {
+    let proxy = start_proxy("example.com", false, "production").await?;
+    let token = make_token("wrong-secret", 60);
+
+    let response = send_handshake(&proxy, &token, "example.com", 443).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn expired_jwt_returns_deny() -> Result<()> {
+    let proxy = start_proxy("example.com", false, "production").await?;
+    let token = make_token(SECRET, -60);
+
+    let response = send_handshake(&proxy, &token, "example.com", 443).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn allowed_loopback_without_ssrf_bypass_returns_deny() -> Result<()> {
+    let proxy = start_proxy("localhost", false, "production").await?;
+    let token = make_token(SECRET, 60);
+
+    let response = send_handshake(&proxy, &token, "localhost", 443).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn globally_blocklisted_domain_returns_deny() -> Result<()> {
+    let proxy = start_proxy("dns.google", false, "production").await?;
+    let token = make_token(SECRET, 60);
+
+    let response = send_handshake(&proxy, &token, "dns.google", 443).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn empty_domain_returns_deny() -> Result<()> {
+    let proxy = start_proxy("example.com", false, "production").await?;
+    let token = make_token(SECRET, 60);
+
+    let response = send_handshake(&proxy, &token, "", 443).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn truncated_handshake_closes_without_response() -> Result<()> {
+    let proxy = start_proxy("example.com", false, "production").await?;
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream.write_all(&[0x01, 0x00]).await?;
+    stream.shutdown().await?;
+
+    let mut response = [0; 1];
+    let read_result =
+        tokio::time::timeout(Duration::from_secs(2), stream.read(&mut response)).await;
+    match read_result {
+        Ok(Ok(0)) => {}
+        Ok(Err(_)) => {}
+        Ok(Ok(read_bytes)) => return Err(anyhow!("expected close, read {read_bytes} byte(s)")),
+        Err(error) => return Err(error.into()),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn complete_malformed_handshakes_return_deny() -> Result<()> {
+    let proxy = start_proxy("example.com", false, "production").await?;
+    let token = make_token(SECRET, 60);
+
+    for frame in [
+        build_frame("", "example.com", 443)?,
+        build_frame(&token, "example..com", 443)?,
+        build_frame(&token, "host:443", 443)?,
+        build_frame(&token, "example.com", 0)?,
+        build_oversized_domain_frame(&token),
+    ] {
+        let response = send_raw_frame(&proxy, &frame).await?;
+        assert_eq!(response, Some(DENY_RESPONSE));
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn unsupported_protocol_version_returns_deny() -> Result<()> {
+    let proxy = start_proxy("example.com", false, "production").await?;
+    let token = make_token(SECRET, 60);
+    let mut frame = build_frame(&token, "example.com", 443)?;
+    frame[0] = 0x02;
+
+    let response = send_raw_frame(&proxy, &frame).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn unsafe_ssrf_bypass_fails_startup_outside_test_env() -> Result<()> {
+    let temp_dir = TempDir::new()?;
     let certs = generate_test_certs(temp_dir.path())?;
+    let proxy_addr = free_addr()?;
     let health_addr = free_addr()?;
 
+    let mut child = Command::new(env!("CARGO_BIN_EXE_egress-proxy"))
+        .env("EGRESS_PROXY_LISTEN_ADDR", proxy_addr.to_string())
+        .env("EGRESS_PROXY_HEALTH_ADDR", health_addr.to_string())
+        .env("EGRESS_PROXY_TLS_CERT", certs.server_cert_path)
+        .env("EGRESS_PROXY_TLS_KEY", certs.server_key_path)
+        .env("EGRESS_PROXY_JWT_SECRET", SECRET)
+        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "127.0.0.1")
+        .env("EGRESS_PROXY_ENV", "production")
+        .env("EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK", "1")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    wait_for_startup_failure(&mut child).await
+}
+
+async fn start_proxy(
+    allowed_domains: &str,
+    unsafe_skip_ssrf_check: bool,
+    environment: &str,
+) -> Result<ProxyProcess> {
+    let temp_dir = TempDir::new()?;
+    let certs = generate_test_certs(temp_dir.path())?;
+    let proxy_addr = free_addr()?;
+    let health_addr = free_addr()?;
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_egress-proxy"));
+    command
+        .env("EGRESS_PROXY_LISTEN_ADDR", proxy_addr.to_string())
+        .env("EGRESS_PROXY_HEALTH_ADDR", health_addr.to_string())
+        .env("EGRESS_PROXY_TLS_CERT", &certs.server_cert_path)
+        .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
+        .env("EGRESS_PROXY_JWT_SECRET", SECRET)
+        .env("EGRESS_PROXY_ALLOWED_DOMAINS", allowed_domains)
+        .env("EGRESS_PROXY_ENV", environment)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    if unsafe_skip_ssrf_check {
+        command.env("EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK", "1");
+    }
+
     let mut proxy = ProxyProcess {
-        child: Command::new(env!("CARGO_BIN_EXE_egress-proxy"))
-            .env("EGRESS_PROXY_LISTEN_ADDR", "127.0.0.1:4443")
-            .env("EGRESS_PROXY_HEALTH_ADDR", health_addr.to_string())
-            .env("EGRESS_PROXY_TLS_CERT", &certs.server_cert_path)
-            .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
-            .env("EGRESS_PROXY_JWT_SECRET", SECRET)
-            .env("EGRESS_PROXY_ALLOWED_DOMAINS", "example.com")
-            .env("EGRESS_PROXY_ENV", "production")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()?,
+        child: command.spawn()?,
+        _temp_dir: temp_dir,
+        ca_cert_path: certs.ca_cert_path,
+        proxy_addr,
         health_addr,
     };
 
@@ -142,12 +346,108 @@ async fn http_get(addr: SocketAddr, path: &str) -> Result<String> {
     Ok(String::from_utf8(response)?)
 }
 
-fn free_addr() -> Result<SocketAddr> {
-    let listener = StdTcpListener::bind("127.0.0.1:0")?;
-    Ok(listener.local_addr()?)
+async fn send_handshake(
+    proxy: &ProxyProcess,
+    token: &str,
+    domain: &str,
+    original_dest_port: u16,
+) -> Result<Option<u8>> {
+    let frame = build_frame(token, domain, original_dest_port)?;
+    send_raw_frame(proxy, &frame).await
+}
+
+async fn send_raw_frame(proxy: &ProxyProcess, frame: &[u8]) -> Result<Option<u8>> {
+    let mut stream = connect_forwarder(proxy).await?;
+    stream.write_all(frame).await?;
+
+    let mut response = [0; 1];
+    let read_bytes = stream.read(&mut response).await?;
+    if read_bytes == 0 {
+        return Ok(None);
+    }
+
+    Ok(Some(response[0]))
+}
+
+async fn connect_forwarder(
+    proxy: &ProxyProcess,
+) -> Result<tokio_rustls::client::TlsStream<TcpStream>> {
+    let mut root_store = RootCertStore::empty();
+    for cert in load_certs(&proxy.ca_cert_path)? {
+        root_store.add(cert)?;
+    }
+
+    let tls_config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(tls_config));
+    let stream = TcpStream::connect(proxy.proxy_addr).await?;
+    let server_name = ServerName::try_from("localhost".to_string())?;
+
+    Ok(connector.connect(server_name, stream).await?)
+}
+
+fn load_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>> {
+    Ok(CertificateDer::pem_file_iter(path)?.collect::<Result<Vec<_>, _>>()?)
+}
+
+fn build_frame(token: &str, domain: &str, original_dest_port: u16) -> Result<Vec<u8>> {
+    let token_bytes = token.as_bytes();
+    let domain_bytes = domain.as_bytes();
+    let token_len = u16::try_from(token_bytes.len())?;
+    let domain_len = u16::try_from(domain_bytes.len())?;
+    let mut frame = Vec::with_capacity(1 + 2 + token_bytes.len() + 2 + domain_bytes.len() + 2);
+
+    frame.push(0x01);
+    frame.extend_from_slice(&token_len.to_be_bytes());
+    frame.extend_from_slice(token_bytes);
+    frame.extend_from_slice(&domain_len.to_be_bytes());
+    frame.extend_from_slice(domain_bytes);
+    frame.extend_from_slice(&original_dest_port.to_be_bytes());
+
+    Ok(frame)
+}
+
+fn build_oversized_domain_frame(token: &str) -> Vec<u8> {
+    let token_bytes = token.as_bytes();
+    let token_len = u16::try_from(token_bytes.len()).expect("test token length should fit in u16");
+    let mut frame = Vec::with_capacity(1 + 2 + token_bytes.len() + 2);
+
+    frame.push(0x01);
+    frame.extend_from_slice(&token_len.to_be_bytes());
+    frame.extend_from_slice(token_bytes);
+    frame.extend_from_slice(&254_u16.to_be_bytes());
+
+    frame
+}
+
+fn make_token(secret: &str, exp_offset_seconds: i64) -> String {
+    let now_seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("current time should be after the Unix epoch")
+        .as_secs();
+    let exp = if exp_offset_seconds.is_negative() {
+        now_seconds - exp_offset_seconds.unsigned_abs()
+    } else {
+        now_seconds + exp_offset_seconds.unsigned_abs()
+    };
+    let claims = TestClaims {
+        sb_id: "test-egress-proxy".to_string(),
+        iss: "dust-front",
+        aud: "dust-egress-proxy",
+        exp: usize::try_from(exp).expect("expiration timestamp should fit in usize"),
+    };
+
+    encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .expect("test helper should encode JWT successfully")
 }
 
 struct TestCerts {
+    ca_cert_path: PathBuf,
     server_cert_path: PathBuf,
     server_key_path: PathBuf,
 }
@@ -238,7 +538,47 @@ fn generate_test_certs(temp_dir: &Path) -> Result<TestCerts> {
     }
 
     Ok(TestCerts {
+        ca_cert_path,
         server_cert_path,
         server_key_path,
     })
+}
+
+async fn start_localhost_echo_servers() -> Result<(u16, JoinSet<Result<()>>)> {
+    let ipv4_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = ipv4_listener.local_addr()?.port();
+    let mut handles = JoinSet::new();
+    spawn_echo_server(&mut handles, ipv4_listener);
+
+    let ipv6_addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), port);
+    if let Ok(ipv6_listener) = TcpListener::bind(ipv6_addr).await {
+        spawn_echo_server(&mut handles, ipv6_listener);
+    }
+
+    Ok((port, handles))
+}
+
+fn spawn_echo_server(handles: &mut JoinSet<Result<()>>, listener: TcpListener) {
+    handles.spawn(async move {
+        let (mut stream, _) = listener.accept().await?;
+        let mut buffer = [0; 4];
+        stream.read_exact(&mut buffer).await?;
+        stream.write_all(&buffer).await?;
+        Ok(())
+    });
+}
+
+async fn wait_for_echo(handles: &mut JoinSet<Result<()>>) -> Result<()> {
+    let join_result = tokio::time::timeout(Duration::from_secs(2), handles.join_next()).await?;
+    handles.abort_all();
+
+    match join_result {
+        Some(result) => result?,
+        None => Err(anyhow!("no echo server handled the connection")),
+    }
+}
+
+fn free_addr() -> Result<SocketAddr> {
+    let listener = StdTcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?)
 }


### PR DESCRIPTION
## Description

This PR adds the first real proxy behavior on top of the parser/auth foundation branch.

It includes:
- the TLS-terminated proxy listener for sandbox forwarder connections
- handshake parsing, JWT validation, and immediate dropping of raw token material after validation
- explicit deny handling for empty domains, malformed handshakes, unsupported protocol versions, temporary allowlist failures, global DoH blocklist hits, DNS failures, SSRF failures, and upstream connect failures
- server-side DNS resolution and SSRF checks, including IPv4-mapped IPv6 coverage
- upstream TCP connect followed by `0x00` only after the upstream connection succeeds
- explicit flushes for `0x00` and `0x01`
- bidirectional byte forwarding
- black-box TLS integration coverage for allow, deny, malformed, and forwarding paths

This PR intentionally does not add proxy-task supervision or graceful tunnel draining. Those lifecycle concerns stay in the next PR so they remain easy to review separately.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo build`
- `cargo audit -q`
- `docker build -f dockerfiles/egress-proxy.Dockerfile -t dust-egress-proxy-pr2 .`

## Risk

This is the first PR that turns the service into a real egress proxy, so the main risk is incorrect allow/deny behavior on live connections. The risk is mitigated with end-to-end TLS tests that cover the protocol handshake, JWT rejection, allowlist denial, empty domain denial, blocklist denial, SSRF denial, malformed/truncated frames, and successful forwarding.

## Deploy Plan

- Merge after PR #24125
- Deploy normally once the stacked base is merged
- Keep production rollout conservative because PR 3 still needs to add task supervision and graceful shutdown draining