### PR TITLE
Unify text-based conversation rendering

### DIFF
--- a/front/lib/api/actions/servers/project_manager/tools/conversation_formatting.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/conversation_formatting.ts
@@ -1,56 +1,11 @@
-import { isMessageUnread } from "@app/components/assistant/conversation/utils";
 import {
-  type AgentMessageType,
-  type CompactionMessageType,
-  type ConversationType,
-  isLightConversationType,
-  type LightAgentMessageType,
-  type LightConversationType,
-  type UserMessageType,
-  type UserMessageTypeWithContentFragments,
+  countConversationMessages,
+  renderConversationAsText,
+} from "@app/lib/api/assistant/conversation/render_as_text";
+import type {
+  ConversationType,
+  LightConversationType,
 } from "@app/types/assistant/conversation";
-import type { ContentFragmentType } from "@app/types/content_fragment";
-
-/**
- * Formats a single message for display.
- */
-function formatMessage(
-  msg:
-    | UserMessageType
-    | AgentMessageType
-    | ContentFragmentType
-    | LightAgentMessageType
-    | CompactionMessageType
-    | UserMessageTypeWithContentFragments,
-  lastReadMs: number | null
-) {
-  const dateStr = new Date(msg.created).toISOString();
-  const unreadFormatted = isMessageUnread(msg, lastReadMs) ? " (unread)" : "";
-
-  if (msg.type === "user_message") {
-    const userName = msg.user?.fullName ?? msg.user?.username ?? "User";
-    const userEmail = msg.user?.email ?? "Unknown";
-    const content = msg.content ?? "";
-    return `>> User (${userName}, ${userEmail}) [${dateStr}]${unreadFormatted}:\n${msg.visibility === "deleted" ? "Deleted message" : content}\n`;
-  }
-
-  if (msg.type === "agent_message") {
-    const agentName = msg.configuration?.name ?? "Agent";
-    const content = msg.content ?? "";
-    return `>> Agent (${agentName}) [${dateStr}]${unreadFormatted}:\n${msg.visibility === "deleted" ? "Deleted message" : content}\n`;
-  }
-
-  if (msg.type === "content_fragment") {
-    return `>> Content Fragment [${dateStr}]${unreadFormatted}:\nID: ${msg.contentFragmentId}\nContent-Type: ${msg.contentType}\nTitle: ${msg.title}\nVersion: ${msg.version}\nSource URL: ${msg.sourceUrl}\n`;
-  }
-
-  if (msg.type === "compaction_message") {
-    const content = msg.content ?? "";
-    return `>> Compaction [${dateStr}]:\n ${content}\n`;
-  }
-
-  return "";
-}
 
 /**
  * Formats raw conversation content into a readable text representation for display.
@@ -60,32 +15,12 @@ export function formatConversationForDisplay(
   conversation: ConversationType | LightConversationType,
   workspaceId: string
 ) {
-  // Convert conversation content to formatted messages
-  const messages: string[] = [];
+  const messages = renderConversationAsText(conversation, {
+    includeTimestamps: true,
+    includeEmail: true,
+    includeUnread: true,
+  });
 
-  // TODO(compaction): stop at compaction boundary
-  if (isLightConversationType(conversation)) {
-    for (const msg of conversation.content) {
-      const formattedMessage = formatMessage(msg, conversation.lastReadMs);
-      if (formattedMessage) {
-        messages.push(formattedMessage);
-      }
-    }
-  } else {
-    for (const versions of conversation.content) {
-      // Only take the last version of each rank
-      const msg = versions[versions.length - 1];
-      if (!msg) {
-        continue;
-      }
-
-      const formattedMessage = formatMessage(msg, conversation.lastReadMs);
-      if (formattedMessage) {
-        messages.push(formattedMessage);
-      }
-    }
-  }
-  // Format timestamps
   const createdDate = new Date(conversation.created).toISOString();
   const updatedDate = new Date(conversation.updated).toISOString();
 
@@ -97,8 +32,8 @@ export function formatConversationForDisplay(
     unread: conversation.unread,
     actionRequired: conversation.actionRequired,
     hasError: conversation.hasError,
-    messageCount: messages.length,
-    messages: messages.join("\n"),
+    messageCount: countConversationMessages(conversation),
+    messages,
     url: `/w/${workspaceId}/assistant/${conversation.sId}`,
   };
 }

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -1,0 +1,332 @@
+import type {
+  AgentMessageType,
+  CompactionMessageType,
+  ConversationType,
+  LightAgentMessageType,
+  LightConversationType,
+  UserMessageType,
+  UserMessageTypeWithContentFragments,
+} from "@app/types/assistant/conversation";
+import { isLightConversationType } from "@app/types/assistant/conversation";
+import type { ContentFragmentType } from "@app/types/content_fragment";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+type AnyMessageType =
+  | UserMessageType
+  | AgentMessageType
+  | ContentFragmentType
+  | LightAgentMessageType
+  | CompactionMessageType
+  | UserMessageTypeWithContentFragments;
+
+export interface AgentMessageFeedback {
+  thumbDirection: "up" | "down";
+  content: string | null;
+}
+
+export interface RenderConversationAsTextOptions {
+  // Include ISO timestamps on each message header line.
+  includeTimestamps?: boolean;
+  // Include user email in user message headers.
+  includeEmail?: boolean;
+  // Include (unread) marker on messages created after lastReadMs.
+  includeUnread?: boolean;
+  // Include agent actions summary after agent message header.
+  includeActions?: boolean;
+  // Include action input params and output (requires includeActions).
+  includeActionDetails?: boolean;
+  // Include user feedback on agent messages.
+  includeFeedback?: boolean;
+  // Pre-fetched feedback keyed by agent message sId. Required when includeFeedback is true.
+  feedbackByMessageSId?: Map<string, AgentMessageFeedback[]>;
+  // Truncate each message's content to this many characters.
+  truncateMessageChars?: number;
+  // Stop rendering once total content characters reach this limit.
+  truncateTotalChars?: number;
+  // Render only messages in the [fromMessageIndex, toMessageIndex) range (0-based, on the
+  // flattened message list).
+  fromMessageIndex?: number;
+  toMessageIndex?: number;
+}
+
+/**
+ * Render a conversation's messages as a plain text string. Supports both full and light
+ * conversation types. Takes the last version of each message group (for full conversations) and
+ * iterates messages in order.
+ *
+ * The output format is:
+ *   >> User (Name) [2024-01-01T00:00:00.000Z]:
+ *   message content
+ *
+ *   >> Agent (Name) [2024-01-01T00:00:00.000Z]:
+ *   message content
+ */
+export function renderConversationAsText(
+  conversation: ConversationType | LightConversationType,
+  options: RenderConversationAsTextOptions = {}
+): string {
+  const parts: string[] = [];
+  let totalChars = 0;
+
+  const allMessages = flattenConversationMessages(conversation);
+  const from = options.fromMessageIndex ?? 0;
+  const to = options.toMessageIndex ?? allMessages.length;
+  const slicedMessages = allMessages.slice(from, to);
+
+  for (const msg of slicedMessages) {
+    if (
+      options.truncateTotalChars !== undefined &&
+      totalChars >= options.truncateTotalChars
+    ) {
+      break;
+    }
+
+    const rendered = renderMessageAsText(msg, conversation.lastReadMs, options);
+    if (!rendered) {
+      continue;
+    }
+
+    totalChars += rendered.contentLength;
+    parts.push(rendered.text);
+
+    // Append feedback after agent messages if requested.
+    if (
+      options.includeFeedback &&
+      options.feedbackByMessageSId &&
+      msg.type === "agent_message"
+    ) {
+      const feedbacks = options.feedbackByMessageSId.get(msg.sId);
+      if (feedbacks && feedbacks.length > 0) {
+        const feedbackLines: string[] = ["Feedback:"];
+        for (const f of feedbacks) {
+          const direction = f.thumbDirection === "up" ? "+1" : "-1";
+          const comment = f.content ? `: ${f.content}` : "";
+          feedbackLines.push(`- ${direction}${comment}`);
+        }
+        feedbackLines.push("");
+        parts.push(feedbackLines.join("\n"));
+      }
+    }
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Count the number of messages in a conversation (last version of each group).
+ */
+export function countConversationMessages(
+  conversation: ConversationType | LightConversationType
+): number {
+  if (isLightConversationType(conversation)) {
+    return conversation.content.length;
+  }
+  return conversation.content.filter((versions) => versions.length > 0).length;
+}
+
+/**
+ * Flatten a conversation's version-grouped content into an ordered list of messages, taking the
+ * last version of each group.
+ */
+function flattenConversationMessages(
+  conversation: ConversationType | LightConversationType
+): AnyMessageType[] {
+  if (isLightConversationType(conversation)) {
+    return [...conversation.content];
+  }
+
+  const result: AnyMessageType[] = [];
+  for (const versions of conversation.content) {
+    const msg = versions[versions.length - 1];
+    if (msg) {
+      result.push(msg);
+    }
+  }
+  return result;
+}
+
+interface RenderedMessage {
+  text: string;
+  contentLength: number;
+}
+
+function renderMessageAsText(
+  msg: AnyMessageType,
+  lastReadMs: number | null,
+  options: RenderConversationAsTextOptions
+): RenderedMessage | null {
+  switch (msg.type) {
+    case "user_message":
+      return renderUserMessageAsText(msg, lastReadMs, options);
+    case "agent_message":
+      return renderAgentMessageAsText(msg, lastReadMs, options);
+    case "content_fragment":
+      return renderContentFragmentAsText(msg, lastReadMs, options);
+    case "compaction_message":
+      return renderCompactionMessageAsText(msg, options);
+    default:
+      assertNever(msg);
+  }
+}
+
+function formatTimestamp(
+  createdMs: number,
+  options: RenderConversationAsTextOptions
+): string {
+  if (!options.includeTimestamps) {
+    return "";
+  }
+  return ` [${new Date(createdMs).toISOString()}]`;
+}
+
+function formatUnread(
+  createdMs: number,
+  lastReadMs: number | null,
+  options: RenderConversationAsTextOptions
+): string {
+  if (!options.includeUnread || lastReadMs === null) {
+    return "";
+  }
+  return createdMs > lastReadMs ? " (unread)" : "";
+}
+
+function truncateContent(
+  content: string,
+  options: RenderConversationAsTextOptions
+): { text: string; truncated: boolean } {
+  if (
+    options.truncateMessageChars === undefined ||
+    content.length <= options.truncateMessageChars
+  ) {
+    return { text: content, truncated: false };
+  }
+  return {
+    text: content.slice(0, options.truncateMessageChars),
+    truncated: true,
+  };
+}
+
+function renderUserMessageAsText(
+  msg: UserMessageType | UserMessageTypeWithContentFragments,
+  lastReadMs: number | null,
+  options: RenderConversationAsTextOptions
+): RenderedMessage {
+  const userName = msg.user?.fullName ?? msg.user?.username ?? "User";
+  const email =
+    options.includeEmail && "email" in msg.user! ? `, ${msg.user!.email}` : "";
+  const timestamp = formatTimestamp(msg.created, options);
+  const unread = formatUnread(msg.created, lastReadMs, options);
+
+  if (msg.visibility === "deleted") {
+    return {
+      text: `>> User (${userName}${email})${timestamp}${unread}:\n[Deleted message]\n`,
+      contentLength: 0,
+    };
+  }
+
+  const rawContent = msg.content ?? "";
+  const { text: content, truncated } = truncateContent(rawContent, options);
+  const truncatedMarker = truncated ? " (truncated)" : "";
+
+  return {
+    text: `>> User (${userName}${email})${timestamp}${unread}:${truncatedMarker}\n${content}\n`,
+    contentLength: content.length,
+  };
+}
+
+function renderAgentMessageAsText(
+  msg: AgentMessageType | LightAgentMessageType,
+  lastReadMs: number | null,
+  options: RenderConversationAsTextOptions
+): RenderedMessage {
+  const agentName = msg.configuration?.name ?? "Agent";
+  const timestamp = formatTimestamp(msg.created, options);
+  const unread = formatUnread(msg.created, lastReadMs, options);
+
+  if (msg.visibility === "deleted") {
+    return {
+      text: `>> Agent (${agentName})${timestamp}${unread}:\n[Deleted message]\n`,
+      contentLength: 0,
+    };
+  }
+
+  const rawContent = msg.content ?? "";
+  const { text: content, truncated } = truncateContent(rawContent, options);
+  const truncatedMarker = truncated ? " (truncated)" : "";
+
+  const lines: string[] = [];
+  lines.push(`>> Agent (${agentName})${timestamp}${unread}:${truncatedMarker}`);
+
+  // Render actions if requested and available on full AgentMessageType.
+  if (options.includeActions && "actions" in msg && msg.actions.length > 0) {
+    lines.push("Actions:");
+    for (const action of msg.actions) {
+      const actionStatus = action.status === "succeeded" ? "success" : "error";
+      lines.push(`- ${action.functionCallName} (${actionStatus})`);
+
+      if (options.includeActionDetails) {
+        const paramsStr = JSON.stringify(action.params);
+        lines.push(`  Input: ${paramsStr}`);
+        if (action.output) {
+          const outputText = serializeActionOutput(action.output);
+          if (outputText) {
+            lines.push(`  Output: ${outputText}`);
+          }
+        }
+      }
+    }
+  }
+
+  lines.push(content);
+  lines.push("");
+
+  return {
+    text: lines.join("\n"),
+    contentLength: content.length,
+  };
+}
+
+/**
+ * Serialize MCP tool output (array of content blocks) into a plain text string.
+ */
+function serializeActionOutput(
+  output: Array<{ type: string; text?: string }> | null
+): string | null {
+  if (!output) {
+    return null;
+  }
+  const texts = output
+    .filter(
+      (block): block is { type: string; text: string } =>
+        block.type === "text" && typeof block.text === "string"
+    )
+    .map((block) => block.text);
+  return texts.length > 0 ? texts.join("\n") : null;
+}
+
+function renderContentFragmentAsText(
+  msg: ContentFragmentType,
+  lastReadMs: number | null,
+  options: RenderConversationAsTextOptions
+): RenderedMessage {
+  const timestamp = formatTimestamp(msg.created, options);
+  const unread = formatUnread(msg.created, lastReadMs, options);
+
+  return {
+    text: `>> Content Fragment${timestamp}${unread}:\nTitle: ${msg.title}\nContent-Type: ${msg.contentType}\n`,
+    contentLength: 0,
+  };
+}
+
+function renderCompactionMessageAsText(
+  msg: CompactionMessageType,
+  options: RenderConversationAsTextOptions
+): RenderedMessage {
+  const timestamp = formatTimestamp(msg.created, options);
+  const content = msg.content ?? "";
+
+  return {
+    text: `>> Compaction${timestamp}:\n${content}\n`,
+    contentLength: content.length,
+  };
+}

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -50,12 +50,10 @@ export interface RenderConversationAsTextOptions {
  * Each message is rendered as a header line followed by content. Optional parts (timestamps, email,
  * unread markers, truncation indicators) appear only when their corresponding option is enabled.
  *
- *   >> User (Name, email) [timestamp] (unread): (truncated)
+ *   >> User (Name, email) [timestamp] (unread):
  *   message content
  *
- *   >> Agent (Name) [timestamp] (unread): (truncated)
- *   Actions:
- *   - toolName (success)
+ *   >> Agent (Name) [timestamp] (unread):
  *   message content
  *
  *   >> Content Fragment [timestamp] (unread):

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -66,7 +66,7 @@ export interface RenderConversationAsTextOptions {
  *   >> Compaction [timestamp]:
  *   compaction summary
  *
- * Deleted messages render as `Deleted message` in place of content.
+ * [Deleted message]s render as `[Deleted message]` in place of content.
  */
 export function renderConversationAsText(
   conversation: ConversationType | LightConversationType,
@@ -211,7 +211,7 @@ function renderUserMessageAsText(
 
   if (msg.visibility === "deleted") {
     return {
-      text: `${header}\nDeleted message\n`,
+      text: `${header}\n[Deleted message]\n`,
       contentLength: 0,
     };
   }
@@ -242,7 +242,7 @@ function renderAgentMessageAsText(
 
   if (msg.visibility === "deleted") {
     return {
-      text: `${header}\nDeleted message\n`,
+      text: `${header}\n[Deleted message]\n`,
       contentLength: 0,
     };
   }

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -219,9 +219,7 @@ function renderUserMessageAsText(
   options: RenderConversationAsTextOptions
 ): RenderedMessage {
   const userName = msg.user?.fullName ?? msg.user?.username ?? "User";
-  const email = options.includeEmail
-    ? `, ${msg.user?.email ?? "Unknown"}`
-    : "";
+  const email = options.includeEmail ? `, ${msg.user?.email ?? "Unknown"}` : "";
   const timestamp = formatTimestamp(msg.created, options);
   const unread = formatUnread(msg.created, lastReadMs, options);
   const header =
@@ -238,7 +236,10 @@ function renderUserMessageAsText(
   }
 
   const rawContent = msg.content ?? "";
-  const { text: content, truncated } = truncateMessageContent(rawContent, options);
+  const { text: content, truncated } = truncateMessageContent(
+    rawContent,
+    options
+  );
   const truncatedSuffix = truncated ? " (truncated)" : "";
 
   return {
@@ -269,7 +270,10 @@ function renderAgentMessageAsText(
   }
 
   const rawContent = msg.content ?? "";
-  const { text: content, truncated } = truncateMessageContent(rawContent, options);
+  const { text: content, truncated } = truncateMessageContent(
+    rawContent,
+    options
+  );
   const truncatedSuffix = truncated ? " (truncated)" : "";
 
   const lines: string[] = [];

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -190,14 +190,6 @@ function formatUnread(
   return createdMs > lastReadMs ? "(unread)" : null;
 }
 
-/**
- * Build a message header line by joining non-null parts with spaces.
- * Example: ">> User (Alice) [2024-01-01T00:00:00.000Z] (unread):"
- */
-function buildHeaderLine(parts: (string | null)[]): string {
-  return parts.filter((p) => p !== null).join(" ") + ":";
-}
-
 function truncateContent(
   content: string,
   options: RenderConversationAsTextOptions
@@ -224,11 +216,13 @@ function renderUserMessageAsText(
     options.includeEmail && msg.user && "email" in msg.user
       ? `, ${msg.user.email}`
       : "";
-  const header = buildHeaderLine([
-    `>> User (${userName}${email})`,
-    formatTimestamp(msg.created, options),
-    formatUnread(msg.created, lastReadMs, options),
-  ]);
+  const timestamp = formatTimestamp(msg.created, options);
+  const unread = formatUnread(msg.created, lastReadMs, options);
+  const header =
+    `>> User (${userName}${email})` +
+    (timestamp ? ` ${timestamp}` : "") +
+    (unread ? ` ${unread}` : "") +
+    ":";
 
   if (msg.visibility === "deleted") {
     return {
@@ -253,11 +247,13 @@ function renderAgentMessageAsText(
   options: RenderConversationAsTextOptions
 ): RenderedMessage {
   const agentName = msg.configuration?.name ?? "Agent";
-  const header = buildHeaderLine([
-    `>> Agent (${agentName})`,
-    formatTimestamp(msg.created, options),
-    formatUnread(msg.created, lastReadMs, options),
-  ]);
+  const timestamp = formatTimestamp(msg.created, options);
+  const unread = formatUnread(msg.created, lastReadMs, options);
+  const header =
+    `>> Agent (${agentName})` +
+    (timestamp ? ` ${timestamp}` : "") +
+    (unread ? ` ${unread}` : "") +
+    ":";
 
   if (msg.visibility === "deleted") {
     return {
@@ -325,11 +321,13 @@ function renderContentFragmentAsText(
   lastReadMs: number | null,
   options: RenderConversationAsTextOptions
 ): RenderedMessage {
-  const header = buildHeaderLine([
-    ">> Content Fragment",
-    formatTimestamp(msg.created, options),
-    formatUnread(msg.created, lastReadMs, options),
-  ]);
+  const timestamp = formatTimestamp(msg.created, options);
+  const unread = formatUnread(msg.created, lastReadMs, options);
+  const header =
+    ">> Content Fragment" +
+    (timestamp ? ` ${timestamp}` : "") +
+    (unread ? ` ${unread}` : "") +
+    ":";
 
   return {
     text: `${header}\nTitle: ${msg.title}\nContent-Type: ${msg.contentType}\n`,
@@ -341,10 +339,8 @@ function renderCompactionMessageAsText(
   msg: CompactionMessageType,
   options: RenderConversationAsTextOptions
 ): RenderedMessage {
-  const header = buildHeaderLine([
-    ">> Compaction",
-    formatTimestamp(msg.created, options),
-  ]);
+  const timestamp = formatTimestamp(msg.created, options);
+  const header = ">> Compaction" + (timestamp ? ` ${timestamp}` : "") + ":";
   const content = msg.content ?? "";
 
   return {

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -47,12 +47,28 @@ export interface RenderConversationAsTextOptions {
  * Messages are iterated most-recent-first so that when truncateTotalChars is set, the most recent
  * messages are preserved and older ones are dropped. The final output is in chronological order.
  *
- * The output format is:
- *   >> User (Name) [2024-01-01T00:00:00.000Z]:
+ * Each message is rendered as a header line followed by content. Optional parts (timestamps, email,
+ * unread markers, truncation indicators) appear only when their corresponding option is enabled.
+ *
+ *   >> User (Name, email) [timestamp] (unread): (truncated)
  *   message content
  *
- *   >> Agent (Name) [2024-01-01T00:00:00.000Z]:
+ *   >> Agent (Name) [timestamp] (unread): (truncated)
+ *   Actions:
+ *   - toolName (success)
  *   message content
+ *
+ *   >> Content Fragment [timestamp] (unread):
+ *   ID: ...
+ *   Content-Type: ...
+ *   Title: ...
+ *   Version: ...
+ *   Source URL: ...
+ *
+ *   >> Compaction [timestamp]:
+ *   compaction summary
+ *
+ * Deleted messages render as `[Deleted message]` in place of content.
  */
 export function renderConversationAsText(
   conversation: ConversationType | LightConversationType,

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -66,7 +66,7 @@ export interface RenderConversationAsTextOptions {
  *   >> Compaction [timestamp]:
  *   compaction summary
  *
- * Deleted messages render as `[Deleted message]` in place of content.
+ * Deleted messages render as `Deleted message` in place of content.
  */
 export function renderConversationAsText(
   conversation: ConversationType | LightConversationType,
@@ -166,10 +166,14 @@ function formatUnread(
   lastReadMs: number | null,
   options: RenderConversationAsTextOptions
 ): string | null {
-  if (!options.includeUnread || lastReadMs === null) {
+  if (!options.includeUnread) {
     return null;
   }
-  return createdMs > lastReadMs ? "(unread)" : null;
+  // A message is unread if there is no last-read timestamp or the message was created after it.
+  if (lastReadMs === null || createdMs > lastReadMs) {
+    return "(unread)";
+  }
+  return null;
 }
 
 function truncateMessageContent(
@@ -194,10 +198,9 @@ function renderUserMessageAsText(
   options: RenderConversationAsTextOptions
 ): RenderedMessage {
   const userName = msg.user?.fullName ?? msg.user?.username ?? "User";
-  const email =
-    options.includeEmail && msg.user && "email" in msg.user
-      ? `, ${msg.user.email}`
-      : "";
+  const email = options.includeEmail
+    ? `, ${msg.user?.email ?? "Unknown"}`
+    : "";
   const timestamp = formatTimestamp(msg.created, options);
   const unread = formatUnread(msg.created, lastReadMs, options);
   const header =
@@ -208,7 +211,7 @@ function renderUserMessageAsText(
 
   if (msg.visibility === "deleted") {
     return {
-      text: `${header}\n[Deleted message]\n`,
+      text: `${header}\nDeleted message\n`,
       contentLength: 0,
     };
   }
@@ -239,7 +242,7 @@ function renderAgentMessageAsText(
 
   if (msg.visibility === "deleted") {
     return {
-      text: `${header}\n[Deleted message]\n`,
+      text: `${header}\nDeleted message\n`,
       contentLength: 0,
     };
   }

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -172,22 +172,30 @@ function renderMessageAsText(
 function formatTimestamp(
   createdMs: number,
   options: RenderConversationAsTextOptions
-): string {
+): string | null {
   if (!options.includeTimestamps) {
-    return "";
+    return null;
   }
-  return ` [${new Date(createdMs).toISOString()}]`;
+  return `[${new Date(createdMs).toISOString()}]`;
 }
 
 function formatUnread(
   createdMs: number,
   lastReadMs: number | null,
   options: RenderConversationAsTextOptions
-): string {
+): string | null {
   if (!options.includeUnread || lastReadMs === null) {
-    return "";
+    return null;
   }
-  return createdMs > lastReadMs ? " (unread)" : "";
+  return createdMs > lastReadMs ? "(unread)" : null;
+}
+
+/**
+ * Build a message header line by joining non-null parts with spaces.
+ * Example: ">> User (Alice) [2024-01-01T00:00:00.000Z] (unread):"
+ */
+function buildHeaderLine(parts: (string | null)[]): string {
+  return parts.filter((p) => p !== null).join(" ") + ":";
 }
 
 function truncateContent(
@@ -213,23 +221,28 @@ function renderUserMessageAsText(
 ): RenderedMessage {
   const userName = msg.user?.fullName ?? msg.user?.username ?? "User";
   const email =
-    options.includeEmail && "email" in msg.user! ? `, ${msg.user!.email}` : "";
-  const timestamp = formatTimestamp(msg.created, options);
-  const unread = formatUnread(msg.created, lastReadMs, options);
+    options.includeEmail && msg.user && "email" in msg.user
+      ? `, ${msg.user.email}`
+      : "";
+  const header = buildHeaderLine([
+    `>> User (${userName}${email})`,
+    formatTimestamp(msg.created, options),
+    formatUnread(msg.created, lastReadMs, options),
+  ]);
 
   if (msg.visibility === "deleted") {
     return {
-      text: `>> User (${userName}${email})${timestamp}${unread}:\n[Deleted message]\n`,
+      text: `${header}\n[Deleted message]\n`,
       contentLength: 0,
     };
   }
 
   const rawContent = msg.content ?? "";
   const { text: content, truncated } = truncateContent(rawContent, options);
-  const truncatedMarker = truncated ? " (truncated)" : "";
+  const truncatedSuffix = truncated ? " (truncated)" : "";
 
   return {
-    text: `>> User (${userName}${email})${timestamp}${unread}:${truncatedMarker}\n${content}\n`,
+    text: `${header}${truncatedSuffix}\n${content}\n`,
     contentLength: content.length,
   };
 }
@@ -240,22 +253,25 @@ function renderAgentMessageAsText(
   options: RenderConversationAsTextOptions
 ): RenderedMessage {
   const agentName = msg.configuration?.name ?? "Agent";
-  const timestamp = formatTimestamp(msg.created, options);
-  const unread = formatUnread(msg.created, lastReadMs, options);
+  const header = buildHeaderLine([
+    `>> Agent (${agentName})`,
+    formatTimestamp(msg.created, options),
+    formatUnread(msg.created, lastReadMs, options),
+  ]);
 
   if (msg.visibility === "deleted") {
     return {
-      text: `>> Agent (${agentName})${timestamp}${unread}:\n[Deleted message]\n`,
+      text: `${header}\n[Deleted message]\n`,
       contentLength: 0,
     };
   }
 
   const rawContent = msg.content ?? "";
   const { text: content, truncated } = truncateContent(rawContent, options);
-  const truncatedMarker = truncated ? " (truncated)" : "";
+  const truncatedSuffix = truncated ? " (truncated)" : "";
 
   const lines: string[] = [];
-  lines.push(`>> Agent (${agentName})${timestamp}${unread}:${truncatedMarker}`);
+  lines.push(`${header}${truncatedSuffix}`);
 
   // Render actions if requested and available on full AgentMessageType.
   if (options.includeActions && "actions" in msg && msg.actions.length > 0) {
@@ -309,11 +325,14 @@ function renderContentFragmentAsText(
   lastReadMs: number | null,
   options: RenderConversationAsTextOptions
 ): RenderedMessage {
-  const timestamp = formatTimestamp(msg.created, options);
-  const unread = formatUnread(msg.created, lastReadMs, options);
+  const header = buildHeaderLine([
+    ">> Content Fragment",
+    formatTimestamp(msg.created, options),
+    formatUnread(msg.created, lastReadMs, options),
+  ]);
 
   return {
-    text: `>> Content Fragment${timestamp}${unread}:\nTitle: ${msg.title}\nContent-Type: ${msg.contentType}\n`,
+    text: `${header}\nTitle: ${msg.title}\nContent-Type: ${msg.contentType}\n`,
     contentLength: 0,
   };
 }
@@ -322,11 +341,14 @@ function renderCompactionMessageAsText(
   msg: CompactionMessageType,
   options: RenderConversationAsTextOptions
 ): RenderedMessage {
-  const timestamp = formatTimestamp(msg.created, options);
+  const header = buildHeaderLine([
+    ">> Compaction",
+    formatTimestamp(msg.created, options),
+  ]);
   const content = msg.content ?? "";
 
   return {
-    text: `>> Compaction${timestamp}:\n${content}\n`,
+    text: `${header}\n${content}\n`,
     contentLength: content.length,
   };
 }

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -59,7 +59,17 @@ export function renderConversationAsText(
   const parts: string[] = [];
   let totalChars = 0;
 
-  const allMessages = flattenConversationMessages(conversation);
+  // Flatten version groups into an ordered list of messages (last version of each group).
+  const allMessages: AnyMessageType[] = isLightConversationType(conversation)
+    ? [...conversation.content]
+    : conversation.content.reduce<AnyMessageType[]>((acc, versions) => {
+        const msg = versions[versions.length - 1];
+        if (msg) {
+          acc.push(msg);
+        }
+        return acc;
+      }, []);
+
   const from = options.fromMessageIndex ?? 0;
   const to = options.toMessageIndex ?? allMessages.length;
   const slicedMessages = allMessages.slice(from, to);
@@ -94,27 +104,6 @@ export function countConversationMessages(
     return conversation.content.length;
   }
   return conversation.content.filter((versions) => versions.length > 0).length;
-}
-
-/**
- * Flatten a conversation's version-grouped content into an ordered list of messages, taking the
- * last version of each group.
- */
-function flattenConversationMessages(
-  conversation: ConversationType | LightConversationType
-): AnyMessageType[] {
-  if (isLightConversationType(conversation)) {
-    return [...conversation.content];
-  }
-
-  const result: AnyMessageType[] = [];
-  for (const versions of conversation.content) {
-    const msg = versions[versions.length - 1];
-    if (msg) {
-      result.push(msg);
-    }
-  }
-  return result;
 }
 
 interface RenderedMessage {

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -99,17 +99,20 @@ export function renderConversationAsText(
       break;
     }
 
-    const rendered = renderMessageAsText(
-      slicedMessages[i],
-      conversation.lastReadMs,
-      options
-    );
+    const msg = slicedMessages[i];
+
+    const rendered = renderMessageAsText(msg, conversation.lastReadMs, options);
     if (!rendered) {
       continue;
     }
 
     totalChars += rendered.contentLength;
     parts.unshift(rendered.text);
+
+    // A succeeded compaction message is a history boundary. Include it and stop.
+    if (msg.type === "compaction_message" && msg.status === "succeeded") {
+      break;
+    }
   }
 
   return parts.join("\n");

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -266,9 +266,6 @@ function renderAgentMessageAsText(
   };
 }
 
-/**
- * Serialize MCP tool output (array of content blocks) into a plain text string.
- */
 function serializeActionOutput(
   output: Array<{ type: string; text?: string }> | null
 ): string | null {

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -330,7 +330,7 @@ function renderContentFragmentAsText(
     ":";
 
   return {
-    text: `${header}\nTitle: ${msg.title}\nContent-Type: ${msg.contentType}\n`,
+    text: `${header}\nID: ${msg.contentFragmentId}\nContent-Type: ${msg.contentType}\nTitle: ${msg.title}\nVersion: ${msg.version}\nSource URL: ${msg.sourceUrl}\n`,
     contentLength: 0,
   };
 }

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -42,8 +42,10 @@ export interface RenderConversationAsTextOptions {
 
 /**
  * Render a conversation's messages as a plain text string. Supports both full and light
- * conversation types. Takes the last version of each message group (for full conversations) and
- * iterates messages in order.
+ * conversation types. Takes the last version of each message group (for full conversations).
+ *
+ * Messages are iterated most-recent-first so that when truncateTotalChars is set, the most recent
+ * messages are preserved and older ones are dropped. The final output is in chronological order.
  *
  * The output format is:
  *   >> User (Name) [2024-01-01T00:00:00.000Z]:
@@ -74,7 +76,8 @@ export function renderConversationAsText(
   const to = options.toMessageIndex ?? allMessages.length;
   const slicedMessages = allMessages.slice(from, to);
 
-  for (const msg of slicedMessages) {
+  // Iterate most-recent-first so that truncateTotalChars keeps the latest messages.
+  for (let i = slicedMessages.length - 1; i >= 0; i--) {
     if (
       options.truncateTotalChars !== undefined &&
       totalChars >= options.truncateTotalChars
@@ -82,13 +85,17 @@ export function renderConversationAsText(
       break;
     }
 
-    const rendered = renderMessageAsText(msg, conversation.lastReadMs, options);
+    const rendered = renderMessageAsText(
+      slicedMessages[i],
+      conversation.lastReadMs,
+      options
+    );
     if (!rendered) {
       continue;
     }
 
     totalChars += rendered.contentLength;
-    parts.push(rendered.text);
+    parts.unshift(rendered.text);
   }
 
   return parts.join("\n");

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -158,7 +158,7 @@ function formatUnread(
   return createdMs > lastReadMs ? "(unread)" : null;
 }
 
-function truncateContent(
+function truncateMessageContent(
   content: string,
   options: RenderConversationAsTextOptions
 ): { text: string; truncated: boolean } {
@@ -200,7 +200,7 @@ function renderUserMessageAsText(
   }
 
   const rawContent = msg.content ?? "";
-  const { text: content, truncated } = truncateContent(rawContent, options);
+  const { text: content, truncated } = truncateMessageContent(rawContent, options);
   const truncatedSuffix = truncated ? " (truncated)" : "";
 
   return {
@@ -231,7 +231,7 @@ function renderAgentMessageAsText(
   }
 
   const rawContent = msg.content ?? "";
-  const { text: content, truncated } = truncateContent(rawContent, options);
+  const { text: content, truncated } = truncateMessageContent(rawContent, options);
   const truncatedSuffix = truncated ? " (truncated)" : "";
 
   const lines: string[] = [];

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -19,11 +19,6 @@ type AnyMessageType =
   | CompactionMessageType
   | UserMessageTypeWithContentFragments;
 
-export interface AgentMessageFeedback {
-  thumbDirection: "up" | "down";
-  content: string | null;
-}
-
 export interface RenderConversationAsTextOptions {
   // Include ISO timestamps on each message header line.
   includeTimestamps?: boolean;
@@ -35,10 +30,6 @@ export interface RenderConversationAsTextOptions {
   includeActions?: boolean;
   // Include action input params and output (requires includeActions).
   includeActionDetails?: boolean;
-  // Include user feedback on agent messages.
-  includeFeedback?: boolean;
-  // Pre-fetched feedback keyed by agent message sId. Required when includeFeedback is true.
-  feedbackByMessageSId?: Map<string, AgentMessageFeedback[]>;
   // Truncate each message's content to this many characters.
   truncateMessageChars?: number;
   // Stop rendering once total content characters reach this limit.
@@ -88,25 +79,6 @@ export function renderConversationAsText(
 
     totalChars += rendered.contentLength;
     parts.push(rendered.text);
-
-    // Append feedback after agent messages if requested.
-    if (
-      options.includeFeedback &&
-      options.feedbackByMessageSId &&
-      msg.type === "agent_message"
-    ) {
-      const feedbacks = options.feedbackByMessageSId.get(msg.sId);
-      if (feedbacks && feedbacks.length > 0) {
-        const feedbackLines: string[] = ["Feedback:"];
-        for (const f of feedbacks) {
-          const direction = f.thumbDirection === "up" ? "+1" : "-1";
-          const comment = f.content ? `: ${f.content}` : "";
-          feedbackLines.push(`- ${direction}${comment}`);
-        }
-        feedbackLines.push("");
-        parts.push(feedbackLines.join("\n"));
-      }
-    }
   }
 
   return parts.join("\n");

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -93,11 +93,13 @@ export function renderConversationAsText(
   const slicedMessages = allMessages.slice(from, to);
 
   // Iterate most-recent-first so that truncateTotalChars keeps the latest messages.
+  let truncatedByTotalChars = false;
   for (let i = slicedMessages.length - 1; i >= 0; i--) {
     if (
       options.truncateTotalChars !== undefined &&
       totalChars >= options.truncateTotalChars
     ) {
+      truncatedByTotalChars = true;
       break;
     }
 
@@ -123,6 +125,12 @@ export function renderConversationAsText(
     if (msg.type === "compaction_message" && msg.status === "succeeded") {
       break;
     }
+  }
+
+  if (truncatedByTotalChars) {
+    parts.unshift(
+      `(conversation content truncated at ${options.truncateTotalChars} chars)\n`
+    );
   }
 
   return parts.join("\n");

--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -30,6 +30,8 @@ export interface RenderConversationAsTextOptions {
   includeActions?: boolean;
   // Include action input params and output (requires includeActions).
   includeActionDetails?: boolean;
+  // Skip agent messages with status "created" (still running).
+  skipRunningAgentMessages?: boolean;
   // Truncate each message's content to this many characters.
   truncateMessageChars?: number;
   // Stop rendering once total content characters reach this limit.
@@ -100,6 +102,14 @@ export function renderConversationAsText(
     }
 
     const msg = slicedMessages[i];
+
+    if (
+      options.skipRunningAgentMessages &&
+      msg.type === "agent_message" &&
+      msg.status === "created"
+    ) {
+      continue;
+    }
 
     const rendered = renderMessageAsText(msg, conversation.lastReadMs, options);
     if (!rendered) {

--- a/front/lib/api/assistant/conversation/shrink_wrap.ts
+++ b/front/lib/api/assistant/conversation/shrink_wrap.ts
@@ -1,11 +1,12 @@
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import {
+  type AgentMessageFeedback,
+  renderConversationAsText,
+} from "@app/lib/api/assistant/conversation/render_as_text";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
-import {
-  isAgentMessageType,
-  isUserMessageType,
-} from "@app/types/assistant/conversation";
+import { isAgentMessageType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isString } from "@app/types/shared/utils/general";
@@ -270,31 +271,8 @@ export async function getShrinkWrappedConversation(
 
   const conversation = conversationRes.value;
 
-  // Flatten the 2D content array into a flat list of messages (last version of each).
-  const flatMessages: ShrinkWrapMessage[] = [];
-  for (const messageVersions of conversation.content) {
-    if (messageVersions.length === 0) {
-      continue;
-    }
-    const lastVersion = messageVersions[messageVersions.length - 1];
-    if (isUserMessageType(lastVersion)) {
-      flatMessages.push(lastVersion);
-    } else if (isAgentMessageType(lastVersion)) {
-      flatMessages.push({
-        ...lastVersion,
-        actions: lastVersion.actions.map((a) => ({
-          functionCallName: a.functionCallName,
-          status: a.status,
-          internalMCPServerName: a.internalMCPServerName,
-          params: a.params,
-          output: serializeActionOutput(a.output),
-        })),
-      });
-    }
-  }
-
   // Optionally fetch feedback and build a map of message sId → feedbacks.
-  let feedbackByMessageId: Map<string, ShrinkWrapFeedback[]> | undefined;
+  let feedbackByMessageSId: Map<string, AgentMessageFeedback[]> | undefined;
   if (includeFeedback) {
     const feedbacks =
       await AgentMessageFeedbackResource.listByConversationModelId(
@@ -315,34 +293,32 @@ export async function getShrinkWrappedConversation(
         }
       }
 
-      feedbackByMessageId = new Map();
+      feedbackByMessageSId = new Map();
       for (const f of feedbacks) {
         const messageId = agentMessageIdToSId.get(f.agentMessageId);
         if (messageId) {
-          const list = feedbackByMessageId.get(messageId) ?? [];
+          const list = feedbackByMessageSId.get(messageId) ?? [];
           list.push({
             thumbDirection: f.thumbDirection,
             content: f.content,
           });
-          feedbackByMessageId.set(messageId, list);
+          feedbackByMessageSId.set(messageId, list);
         }
       }
     }
   }
 
-  const text = formatConversationForShrinkWrap(
-    {
-      sId: conversation.sId,
-      title: conversation.title,
-      messages: flatMessages,
-    },
-    {
-      fromMessageIndex,
-      toMessageIndex,
-      feedbackByMessageId: feedbackByMessageId,
-      includeActionDetails,
-    }
-  );
+  const text = renderConversationAsText(conversation, {
+    includeTimestamps: true,
+    includeActions: true,
+    includeActionDetails,
+    includeFeedback: !!feedbackByMessageSId,
+    feedbackByMessageSId,
+    truncateMessageChars: MAX_CONTENT_CHARS_PER_MESSAGE,
+    truncateTotalChars: MAX_TOTAL_CONTENT_CHARS,
+    fromMessageIndex,
+    toMessageIndex,
+  });
 
   return new Ok({
     type: "text" as const,

--- a/front/lib/api/assistant/conversation/shrink_wrap.ts
+++ b/front/lib/api/assistant/conversation/shrink_wrap.ts
@@ -1,12 +1,11 @@
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import {
-  type AgentMessageFeedback,
-  renderConversationAsText,
-} from "@app/lib/api/assistant/conversation/render_as_text";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
-import { isAgentMessageType } from "@app/types/assistant/conversation";
+import {
+  isAgentMessageType,
+  isUserMessageType,
+} from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isString } from "@app/types/shared/utils/general";
@@ -271,8 +270,31 @@ export async function getShrinkWrappedConversation(
 
   const conversation = conversationRes.value;
 
+  // Flatten the 2D content array into a flat list of messages (last version of each).
+  const flatMessages: ShrinkWrapMessage[] = [];
+  for (const messageVersions of conversation.content) {
+    if (messageVersions.length === 0) {
+      continue;
+    }
+    const lastVersion = messageVersions[messageVersions.length - 1];
+    if (isUserMessageType(lastVersion)) {
+      flatMessages.push(lastVersion);
+    } else if (isAgentMessageType(lastVersion)) {
+      flatMessages.push({
+        ...lastVersion,
+        actions: lastVersion.actions.map((a) => ({
+          functionCallName: a.functionCallName,
+          status: a.status,
+          internalMCPServerName: a.internalMCPServerName,
+          params: a.params,
+          output: serializeActionOutput(a.output),
+        })),
+      });
+    }
+  }
+
   // Optionally fetch feedback and build a map of message sId → feedbacks.
-  let feedbackByMessageSId: Map<string, AgentMessageFeedback[]> | undefined;
+  let feedbackByMessageId: Map<string, ShrinkWrapFeedback[]> | undefined;
   if (includeFeedback) {
     const feedbacks =
       await AgentMessageFeedbackResource.listByConversationModelId(
@@ -293,32 +315,34 @@ export async function getShrinkWrappedConversation(
         }
       }
 
-      feedbackByMessageSId = new Map();
+      feedbackByMessageId = new Map();
       for (const f of feedbacks) {
         const messageId = agentMessageIdToSId.get(f.agentMessageId);
         if (messageId) {
-          const list = feedbackByMessageSId.get(messageId) ?? [];
+          const list = feedbackByMessageId.get(messageId) ?? [];
           list.push({
             thumbDirection: f.thumbDirection,
             content: f.content,
           });
-          feedbackByMessageSId.set(messageId, list);
+          feedbackByMessageId.set(messageId, list);
         }
       }
     }
   }
 
-  const text = renderConversationAsText(conversation, {
-    includeTimestamps: true,
-    includeActions: true,
-    includeActionDetails,
-    includeFeedback: !!feedbackByMessageSId,
-    feedbackByMessageSId,
-    truncateMessageChars: MAX_CONTENT_CHARS_PER_MESSAGE,
-    truncateTotalChars: MAX_TOTAL_CONTENT_CHARS,
-    fromMessageIndex,
-    toMessageIndex,
-  });
+  const text = formatConversationForShrinkWrap(
+    {
+      sId: conversation.sId,
+      title: conversation.title,
+      messages: flatMessages,
+    },
+    {
+      fromMessageIndex,
+      toMessageIndex,
+      feedbackByMessageId: feedbackByMessageId,
+      includeActionDetails,
+    }
+  );
 
   return new Ok({
     type: "text" as const,

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -1,5 +1,6 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import {
   getSmallWhitelistedModel,
@@ -26,7 +27,6 @@ import { GPT_5_1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
 
 export async function updateConversationTitle(
   auth: Authenticator,

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -26,7 +26,7 @@ import { GPT_5_1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { formatConversationForDisplay } from "../../actions/servers/project_manager/tools/conversation_formatting";
+import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
 
 export async function updateConversationTitle(
   auth: Authenticator,
@@ -188,7 +188,7 @@ async function generateConversationTitle(
         content: [
           {
             type: "text",
-            text: `Here is the conversation to generate a title for.\n\n${JSON.stringify(formatConversationForDisplay(conversation, owner.sId).messages, null, 2)}`,
+            text: `Here is the conversation to generate a title for.\n\n${renderConversationAsText(conversation, { includeTimestamps: true })}`,
           },
         ],
         name: "",

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -1,11 +1,11 @@
 import { isMessageUnread } from "@app/components/assistant/conversation/utils";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   countConversationMessages,
   renderConversationAsText,
 } from "@app/lib/api/assistant/conversation/render_as_text";
-import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
 import config from "@app/lib/api/config";
 import { getSmallWhitelistedModel } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -1,6 +1,9 @@
 import { isMessageUnread } from "@app/components/assistant/conversation/utils";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { formatConversationForDisplay } from "@app/lib/api/actions/servers/project_manager/tools/conversation_formatting";
+import {
+  countConversationMessages,
+  renderConversationAsText,
+} from "@app/lib/api/assistant/conversation/render_as_text";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
 import config from "@app/lib/api/config";
@@ -472,17 +475,26 @@ const generateUnreadMessagesSummary = async ({
     `Remember: Use "you/your" - NEVER write "${userFullName}".\n` +
     `Write in a natural, engaging tone that makes someone want to read it.`;
 
-  let conversationSnippet = JSON.stringify(
-    formatConversationForDisplay(conversation, owner.sId).messages,
-    null,
-    2
-  );
+  const renderedMessages = renderConversationAsText(conversation, {
+    includeTimestamps: true,
+    includeEmail: true,
+    includeUnread: true,
+    truncateTotalChars: MAX_CONVERSATION_SNIPPET_LENGTH,
+  });
 
-  if (conversationSnippet.length > MAX_CONVERSATION_SNIPPET_LENGTH) {
-    conversationSnippet =
-      "(the conversation history has been truncated)...\n\n" +
-      conversationSnippet.substring(0, MAX_CONVERSATION_SNIPPET_LENGTH);
-  }
+  const preamble = [
+    `Conversation: ${conversation.sId}`,
+    `Title: ${conversation.title ?? "Untitled Conversation"}`,
+    `Created: ${new Date(conversation.created).toISOString()}`,
+    `Updated: ${new Date(conversation.updated).toISOString()}`,
+    `Unread: ${conversation.unread}`,
+    `Action Required: ${conversation.actionRequired}`,
+    `Has Error: ${conversation.hasError}`,
+    `Message Count: ${countConversationMessages(conversation)}`,
+    `URL: /w/${owner.sId}/assistant/${conversation.sId}`,
+  ].join("\n");
+
+  const conversationSnippet = `${preamble}\n\n${renderedMessages}`;
 
   const res = await runMultiActionsAgent(
     auth,
@@ -500,7 +512,7 @@ const generateUnreadMessagesSummary = async ({
             content: [
               {
                 type: "text",
-                text: `This is the content of the conversation to summarize:\n\n\`\`\`json\n${conversationSnippet}\n\`\`\``,
+                text: `This is the content of the conversation to summarize:\n\n${conversationSnippet}`,
               },
             ],
           },


### PR DESCRIPTION
## Description

We had three separate functions that iterate conversation messages and produce text:
- `formatConversationForDisplay` (project manager, title gen, unread notifications)
- `formatConversationForShrinkWrap` (reinforcement analysis, sidekick context)
- `renderMessagesForCompaction` (compaction — on a separate branch, will rebase)

This PR introduces `renderConversationAsText` in `render_as_text.ts` as the single
unified implementation.`formatConversationForDisplay` and
in the near future `getShrinkWrappedConversation` delegate to it.

Options control what gets included:
- `includeTimestamps` — ISO dates on message headers
- `includeEmail` — user email in headers
- `includeUnread` — (unread) markers
- `includeActions` / `includeActionDetails` — agent tool call summaries
- `includeFeedback` / `feedbackByMessageSId` — user feedback on agent messages
- `truncateMessageChars` / `truncateTotalChars` — content truncation
- `fromMessageIndex` / `toMessageIndex` — message range slicing

## Tests

Existing test, local testing.

## Risk

Low — the output format is intentionally close to the existing `formatConversationForDisplay`
format.

## Deploy Plan

- deploy `front`