### PR TITLE
feat: add project TODO mcp

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -486,6 +486,13 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "semantic_search": "never_ask",
     "update_file": "medium",
   },
+  "project_todos": {
+    "create_todo": "low",
+    "create_todos_batch": "low",
+    "list_todos": "never_ask",
+    "mark_todo_done": "low",
+    "reopen_todo": "low",
+  },
   "query_tables_v2": {
     "execute_database_query": "never_ask",
     "get_database_schema": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -60,6 +60,10 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "skill_management", id: 1019 },
       { name: "schedules_management", id: 1020 },
       { name: "project_manager", id: 1021 },
+      {
+        name: "project_todos",
+        id: 1029,
+      },
       { name: "agent_sidekick_context", id: 1022 },
       { name: "agent_sidekick_agent_state", id: 1023 },
       { name: "sandbox", id: 1024 },

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -53,6 +53,7 @@ import { PRIMITIVE_TYPES_DEBUGGER_SERVER } from "@app/lib/api/actions/servers/pr
 import { PRODUCTBOARD_SERVER } from "@app/lib/api/actions/servers/productboard/metadata";
 import { PROJECT_CONVERSATION_SERVER } from "@app/lib/api/actions/servers/project_conversation/metadata";
 import { PROJECT_MANAGER_SERVER } from "@app/lib/api/actions/servers/project_manager/metadata";
+import { PROJECT_TODOS_SERVER } from "@app/lib/api/actions/servers/project_todos/metadata";
 import {
   QUERY_TABLES_V2_SERVER,
   TABLE_QUERY_V2_SERVER_NAME,
@@ -203,6 +204,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "skill_management",
   "schedules_management",
   "project_manager",
+  "project_todos",
   "poke",
   "project_conversation",
   "sandbox",
@@ -1018,6 +1020,19 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: PROJECT_MANAGER_SERVER,
+  },
+  project_todos: {
+    id: 1029,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isPreview: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("projects");
+    },
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: PROJECT_TODOS_SERVER,
   },
   agent_sidekick_context: {
     id: 1022,

--- a/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
+++ b/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
@@ -265,7 +265,7 @@ describe("MCP Servers Metadata Snapshot", () => {
     } catch (error) {
       const hint =
         "\n\nTool stakes changed. Review the diff above and run:\n" +
-        "  NODE_ENV=test npm test -- --update lib/actions/" +
+        "  NODE_ENV=test npm test -w front -- --update lib/actions/" +
         "mcp_internal_actions/mcp_servers_metadata.test.ts\n" +
         "to update the snapshot.";
 

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -51,6 +51,7 @@ import { default as primitiveTypesDebuggerServer } from "@app/lib/api/actions/se
 import { default as productboardServer } from "@app/lib/api/actions/servers/productboard";
 import { default as projectConversationServer } from "@app/lib/api/actions/servers/project_conversation";
 import { default as projectManagerServer } from "@app/lib/api/actions/servers/project_manager";
+import { default as projectTodosServer } from "@app/lib/api/actions/servers/project_todos";
 import { default as tablesQueryServerV2 } from "@app/lib/api/actions/servers/query_tables_v2";
 import { default as runAgentServer } from "@app/lib/api/actions/servers/run_agent";
 import { default as dustAppServer } from "@app/lib/api/actions/servers/run_dust_app";
@@ -244,6 +245,8 @@ export async function getInternalMCPServer(
       return productboardServer(auth, agentLoopContext);
     case "project_manager":
       return projectManagerServer(auth, agentLoopContext);
+    case "project_todos":
+      return projectTodosServer(auth, agentLoopContext);
     case "poke":
       return pokeServer(auth, agentLoopContext);
     case "project_conversation":

--- a/front/lib/api/actions/servers/project_todos/index.ts
+++ b/front/lib/api/actions/servers/project_todos/index.ts
@@ -1,0 +1,25 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { PROJECT_TODOS_SERVER_NAME } from "@app/lib/api/actions/servers/project_todos/metadata";
+import { createProjectTodosTools } from "@app/lib/api/actions/servers/project_todos/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer(PROJECT_TODOS_SERVER_NAME);
+
+  const tools = createProjectTodosTools(auth, agentLoopContext);
+  for (const tool of tools) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: PROJECT_TODOS_SERVER_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/project_todos/metadata.ts
+++ b/front/lib/api/actions/servers/project_todos/metadata.ts
@@ -1,0 +1,170 @@
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { PROJECT_TODO_CATEGORIES } from "@app/types/project_todo";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const PROJECT_TODOS_SERVER_NAME = "project_todos" as const;
+
+export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
+  list_todos: {
+    description:
+      "List the current user's TODOs in the project. " +
+      "Defaults to open (todo + in_progress) items. " +
+      "Use status='done' to see completed items, or status='all' for everything.",
+    schema: {
+      status: z
+        .enum(["open", "done", "all"])
+        .optional()
+        .describe(
+          "Which TODOs to return. 'open' = todo + in_progress (default); 'done' = completed; 'all' = everything."
+        ),
+      daysAgo: z
+        .number()
+        .min(1)
+        .max(90)
+        .optional()
+        .describe(
+          "When status is 'done' or 'all', limit completed TODOs to this many days back. Defaults to 7."
+        ),
+      category: z
+        .enum(PROJECT_TODO_CATEGORIES)
+        .optional()
+        .describe("Filter by category."),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to list TODOs from, will fallback to the conversation's project."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing TODOs",
+      done: "List TODOs",
+    },
+  },
+  create_todo: {
+    description: "Create a new TODO for the current user in the project.",
+    schema: {
+      text: z.string().min(1).describe("The TODO description."),
+      category: z
+        .enum(PROJECT_TODO_CATEGORIES)
+        .optional()
+        .describe(
+          "Category. Defaults to 'follow_ups'. " +
+            "need_attention: urgent items requiring immediate action; " +
+            "key_decisions: decisions to track or make; " +
+            "follow_ups: action items to follow up on; " +
+            "notable_updates: things to note or remember."
+        ),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to create the TODO in, will fallback to the conversation's project."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Creating TODO",
+      done: "Create TODO",
+    },
+  },
+  create_todos_batch: {
+    description:
+      "Create multiple TODOs at once for the current user in the project. " +
+      "Useful for extracting action items from meeting notes or conversation summaries.",
+    schema: {
+      todos: z
+        .array(
+          z.object({
+            text: z.string().min(1).describe("The TODO description."),
+            category: z
+              .enum(PROJECT_TODO_CATEGORIES)
+              .optional()
+              .describe("Category. Defaults to 'follow_ups'."),
+          })
+        )
+        .min(1)
+        .max(20)
+        .describe("List of TODOs to create (max 20)."),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to create the TODOs in, will fallback to the conversation's project."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Creating TODOs",
+      done: "Create TODOs",
+    },
+  },
+  mark_todo_done: {
+    description: "Mark one of the current user's TODOs as done.",
+    schema: {
+      todoId: z.string().describe("The sId of the TODO to mark as done."),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to look up the TODO in, will fallback to the conversation's project."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Marking TODO as done",
+      done: "Mark TODO as done",
+    },
+  },
+  reopen_todo: {
+    description:
+      "Reopen one of the current user's completed TODOs, moving it back to open status.",
+    schema: {
+      todoId: z.string().describe("The sId of the TODO to reopen."),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to look up the TODO in, will fallback to the conversation's project."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Reopening TODO",
+      done: "Reopen TODO",
+    },
+  },
+});
+
+export const PROJECT_TODOS_SERVER = {
+  serverInfo: {
+    name: PROJECT_TODOS_SERVER_NAME,
+    version: "1.0.0",
+    description:
+      "Manage the current user's project TODOs: list, create, and complete personal action items.",
+    icon: "ActionDocumentTextIcon",
+    authorization: null,
+    documentationUrl: null,
+    instructions: null,
+  },
+  tools: Object.values(PROJECT_TODOS_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(PROJECT_TODOS_TOOLS_METADATA).map((t) => [t.name, t.stake])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/project_todos/tools/index.ts
+++ b/front/lib/api/actions/servers/project_todos/tools/index.ts
@@ -1,0 +1,311 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type {
+  ToolDefinition,
+  ToolHandlers,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import {
+  getProjectSpace,
+  withErrorHandling,
+} from "@app/lib/api/actions/servers/project_manager/helpers";
+import { PROJECT_TODOS_TOOLS_METADATA } from "@app/lib/api/actions/servers/project_todos/metadata";
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import type { ProjectTodoCategory } from "@app/types/project_todo";
+import { Err, Ok } from "@app/types/shared/result";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function formatTodo(todo: ProjectTodoResource): string {
+  const lines = [
+    `- [${todo.sId}] (${todo.category}) ${todo.text}`,
+    `  Status: ${todo.status} | Created: ${todo.createdAt.toISOString().slice(0, 10)}`,
+  ];
+  if (todo.doneAt) {
+    lines.push(`  Done: ${todo.doneAt.toISOString().slice(0, 10)}`);
+  }
+  return lines.join("\n");
+}
+
+export function createProjectTodosTools(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): ToolDefinition[] {
+  const handlers: ToolHandlers<typeof PROJECT_TODOS_TOOLS_METADATA> = {
+    list_todos: async ({
+      status = "open",
+      daysAgo = 7,
+      category,
+      dustProject,
+    }) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getProjectSpace(auth, {
+          agentLoopContext,
+          dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+        const { space } = contextRes.value;
+
+        let todos = await ProjectTodoResource.fetchLatestBySpace(auth, {
+          spaceId: space.id,
+        });
+
+        const cutoff = new Date(Date.now() - daysAgo * MS_PER_DAY);
+
+        if (status === "open") {
+          todos = todos.filter((t) => t.status !== "done");
+        } else if (status === "done") {
+          todos = todos.filter(
+            (t) =>
+              t.status === "done" && t.doneAt !== null && t.doneAt >= cutoff
+          );
+        } else {
+          // "all": keep open items as-is; limit done items by daysAgo.
+          todos = todos.filter(
+            (t) =>
+              t.status !== "done" || (t.doneAt !== null && t.doneAt >= cutoff)
+          );
+        }
+
+        if (category) {
+          todos = todos.filter((t) => t.category === category);
+        }
+
+        if (todos.length === 0) {
+          return new Ok([{ type: "text" as const, text: "No TODOs found." }]);
+        }
+
+        if (status === "done") {
+          todos.sort(
+            (a, b) => (b.doneAt?.getTime() ?? 0) - (a.doneAt?.getTime() ?? 0)
+          );
+          const lines: string[] = [
+            `Found ${todos.length} completed TODO(s) in the last ${daysAgo} day(s):\n`,
+          ];
+          for (const todo of todos) {
+            lines.push(formatTodo(todo));
+          }
+          return new Ok([{ type: "text" as const, text: lines.join("\n") }]);
+        }
+
+        // "open" or "all": group by category.
+        const grouped = new Map<ProjectTodoCategory, ProjectTodoResource[]>();
+        for (const todo of todos) {
+          const list = grouped.get(todo.category) ?? [];
+          list.push(todo);
+          grouped.set(todo.category, list);
+        }
+
+        const label =
+          status === "open"
+            ? `Found ${todos.length} open TODO(s):\n`
+            : `Found ${todos.length} TODO(s):\n`;
+        const lines: string[] = [label];
+        for (const [cat, items] of grouped) {
+          lines.push(`### ${cat}`);
+          for (const todo of items) {
+            lines.push(formatTodo(todo));
+          }
+          lines.push("");
+        }
+
+        return new Ok([{ type: "text" as const, text: lines.join("\n") }]);
+      }, "Failed to list TODOs");
+    },
+
+    create_todo: async ({ text, category, dustProject }) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getProjectSpace(auth, {
+          agentLoopContext,
+          dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+        const { space } = contextRes.value;
+
+        const currentUser = auth.getNonNullableUser();
+
+        const todo = await ProjectTodoResource.makeNew(auth, {
+          spaceId: space.id,
+          userId: currentUser.id,
+          createdByType: "agent",
+          createdByUserId: currentUser.id,
+          createdByAgentConfigurationId:
+            agentLoopContext?.runContext?.agentConfiguration?.sId ?? null,
+          markedAsDoneByType: null,
+          markedAsDoneByUserId: null,
+          markedAsDoneByAgentConfigurationId: null,
+          category: category ?? "follow_ups",
+          text,
+          status: "todo",
+          version: 1,
+          doneAt: null,
+          actorRationale: null,
+        });
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `TODO created (${todo.sId}): "${text}" [${todo.category}]`,
+          },
+        ]);
+      }, "Failed to create TODO");
+    },
+
+    create_todos_batch: async ({ todos, dustProject }) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getProjectSpace(auth, {
+          agentLoopContext,
+          dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+        const { space } = contextRes.value;
+
+        const currentUser = auth.getNonNullableUser();
+        const agentConfigId =
+          agentLoopContext?.runContext?.agentConfiguration?.sId ?? null;
+
+        const created: string[] = [];
+        for (const item of todos) {
+          const todo = await ProjectTodoResource.makeNew(auth, {
+            spaceId: space.id,
+            userId: currentUser.id,
+            createdByType: "agent",
+            createdByUserId: currentUser.id,
+            createdByAgentConfigurationId: agentConfigId,
+            markedAsDoneByType: null,
+            markedAsDoneByUserId: null,
+            markedAsDoneByAgentConfigurationId: null,
+            category: item.category ?? "follow_ups",
+            text: item.text,
+            status: "todo",
+            version: 1,
+            doneAt: null,
+            actorRationale: null,
+          });
+
+          created.push(`- [${todo.sId}] (${todo.category}) "${item.text}"`);
+        }
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Created ${created.length} TODO(s):\n${created.join("\n")}`,
+          },
+        ]);
+      }, "Failed to create TODOs");
+    },
+
+    mark_todo_done: async ({ todoId, dustProject }) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getProjectSpace(auth, {
+          agentLoopContext,
+          dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const currentUser = auth.getNonNullableUser();
+        const todo = await ProjectTodoResource.fetchBySId(auth, todoId);
+
+        if (!todo) {
+          return new Err(
+            new MCPError(`TODO not found: ${todoId}`, { tracked: false })
+          );
+        }
+
+        if (todo.userId !== currentUser.id) {
+          return new Err(
+            new MCPError("You can only mark your own TODOs as done.", {
+              tracked: false,
+            })
+          );
+        }
+
+        if (todo.status === "done") {
+          return new Ok([
+            { type: "text" as const, text: `TODO ${todoId} is already done.` },
+          ]);
+        }
+
+        await todo.createVersion(auth, {
+          status: "done",
+          doneAt: new Date(),
+          markedAsDoneByType: "agent",
+          markedAsDoneByUserId: currentUser.id,
+          markedAsDoneByAgentConfigurationId:
+            agentLoopContext?.runContext?.agentConfiguration?.sId ?? null,
+        });
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `TODO marked as done: "${todo.text}"`,
+          },
+        ]);
+      }, "Failed to mark TODO as done");
+    },
+
+    reopen_todo: async ({ todoId, dustProject }) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getProjectSpace(auth, {
+          agentLoopContext,
+          dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const currentUser = auth.getNonNullableUser();
+        const todo = await ProjectTodoResource.fetchBySId(auth, todoId);
+
+        if (!todo) {
+          return new Err(
+            new MCPError(`TODO not found: ${todoId}`, { tracked: false })
+          );
+        }
+
+        if (todo.userId !== currentUser.id) {
+          return new Err(
+            new MCPError("You can only reopen your own TODOs.", {
+              tracked: false,
+            })
+          );
+        }
+
+        if (todo.status !== "done") {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: `TODO ${todoId} is not done (current status: ${todo.status}).`,
+            },
+          ]);
+        }
+
+        await todo.createVersion(auth, {
+          status: "todo",
+          doneAt: null,
+          markedAsDoneByType: null,
+          markedAsDoneByUserId: null,
+          markedAsDoneByAgentConfigurationId: null,
+        });
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `TODO reopened: "${todo.text}"`,
+          },
+        ]);
+      }, "Failed to reopen TODO");
+    },
+  };
+
+  return buildTools(PROJECT_TODOS_TOOLS_METADATA, handlers);
+}

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -133,6 +133,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
   skill_management: "platform",
   schedules_management: "platform",
   project_manager: "platform",
+  project_todos: "platform",
   poke: "platform",
   project_conversation: "platform",
   sandbox: "platform",

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -202,6 +202,31 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     return Array.from(latestBySId.values());
   }
 
+  // Returns the latest version of each logical todo across ALL users for the given
+  // space. Used by MCP tools that need to list todos for all project members.
+  static async fetchLatestAllBySpace(
+    auth: Authenticator,
+    { spaceId }: { spaceId: ModelId }
+  ): Promise<ProjectTodoResource[]> {
+    const all = await this.baseFetch(auth, {
+      where: { spaceId },
+      order: [
+        ["sId", "ASC"],
+        ["version", "DESC"],
+      ],
+    });
+
+    // O(n) deduplication — keep the first occurrence per sId (highest version).
+    const latestBySId = new Map<string, ProjectTodoResource>();
+    for (const todo of all) {
+      if (!latestBySId.has(todo.sId)) {
+        latestBySId.set(todo.sId, todo);
+      }
+    }
+
+    return Array.from(latestBySId.values());
+  }
+
   // Returns every version row for (spaceId, userId), across all sIds. Used by the
   // diff algorithm to reconstruct snapshots at arbitrary cutoff dates.
   static async fetchAllVersionsBySpace(


### PR DESCRIPTION
## Description

Add TODO mcp server, based on project manager:
* list TODOs for current user
* create TODOs for current user
* batch create
* mark_todo_done
* reopen_todo (unsure about this one to be honest)

"Inject" `dustProject` like other MCP servers

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
