### PR TITLE
Adapt frame sharing sheet to workspace_only policy

### DIFF
--- a/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
+++ b/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
@@ -19,10 +19,12 @@ import {
   Button,
   ClipboardCheckIcon,
   ClipboardIcon,
+  ContentMessage,
   ContextItem,
   GlobeAltIcon,
   Icon,
   IconButton,
+  InformationCircleIcon,
   Input,
   Label,
   LockIcon,
@@ -43,38 +45,47 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-const SCOPE_OPTIONS: {
+function getScopeOptions(sharingPolicy: WorkspaceSharingPolicy): {
   icon: typeof LockIcon;
   label: string;
   description: string;
   value: FileShareScope;
-}[] = [
-  {
-    icon: LockIcon,
-    label: "Email invites only",
-    description: "Only people you invite by email can view this",
-    value: "emails_only",
-  },
-  {
-    icon: UserGroupIcon,
-    label: "Workspace members and email invites",
-    description: "Everyone in your workspace, plus anyone you invite by email",
-    value: "workspace_and_emails",
-  },
-  {
-    icon: GlobeAltIcon,
-    label: "Anyone with the link",
-    description: "No sign-in required",
-    value: "public",
-  },
-];
+}[] {
+  const externalOff = sharingPolicy === "workspace_only";
+  return [
+    {
+      icon: LockIcon,
+      label: externalOff ? "Specific members" : "Invite only",
+      description: externalOff
+        ? "Only the workspace members you invite"
+        : "Only the people you invite",
+      value: "emails_only",
+    },
+    {
+      icon: UserGroupIcon,
+      label: externalOff
+        ? "All workspace members + specific members"
+        : "All workspace members + invites",
+      description: externalOff
+        ? "Everyone in your workspace, plus members you invite individually"
+        : "Everyone in your workspace, plus anyone you invite",
+      value: "workspace_and_emails",
+    },
+    {
+      icon: GlobeAltIcon,
+      label: "Anyone with the link",
+      description: "No sign-in required",
+      value: "public",
+    },
+  ];
+}
 
 // Scopes allowed by each workspace sharing policy.
 const ALLOWED_SCOPES_BY_POLICY: Record<
   WorkspaceSharingPolicy,
   FileShareScope[]
 > = {
-  workspace_only: ["workspace_and_emails"],
+  workspace_only: ["emails_only", "workspace_and_emails"],
   workspace_and_emails: ["emails_only", "workspace_and_emails"],
   all_scopes: ["emails_only", "workspace_and_emails", "public"],
 };
@@ -146,13 +157,12 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
   const shareURL = fileShare?.shareUrl ?? "";
 
   const allowedScopes = ALLOWED_SCOPES_BY_POLICY[owner.sharingPolicy];
-  const availableScopeOptions = SCOPE_OPTIONS.filter((o) =>
-    allowedScopes.includes(o.value)
+  const availableScopeOptions = getScopeOptions(owner.sharingPolicy).filter(
+    (o) => allowedScopes.includes(o.value)
   );
 
   const showEmailSection =
-    owner.sharingPolicy !== "workspace_only" &&
-    (currentScope === "emails_only" || currentScope === "workspace_and_emails");
+    currentScope === "emails_only" || currentScope === "workspace_and_emails";
 
   const onInviteSubmit = async (data: InviteFormValues) => {
     const emails = data.emailsRaw
@@ -216,6 +226,16 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
               </div>
             ) : (
               <div className="flex flex-col gap-6">
+                {owner.sharingPolicy === "workspace_only" && (
+                  <ContentMessage
+                    icon={InformationCircleIcon}
+                    variant="info"
+                    title="Only workspace members can be added"
+                  >
+                    Your admin has disabled external sharing. You can only share with people already
+                    in your workspace.
+                  </ContentMessage>
+                )}
                 <fieldset className="flex flex-col gap-2 border-none p-0">
                   <legend className="text-sm font-semibold text-foreground dark:text-foreground-night mb-2">
                     Who has access
@@ -300,13 +320,32 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
                       </p>
                     ) : (
                       <ScrollArea className="max-h-96">
-                        {grants.map((grant) => (
-                          <GrantRow
-                            key={grant.id}
-                            grant={grant}
-                            onRevoke={() => handleRevoke(grant)}
-                          />
-                        ))}
+                        {grants
+                          .filter((g) => !g.blockedByPolicy)
+                          .map((grant) => (
+                            <GrantRow
+                              key={grant.id}
+                              grant={grant}
+                              onRevoke={() => handleRevoke(grant)}
+                            />
+                          ))}
+                        {grants.some((g) => g.blockedByPolicy) && (
+                          <>
+                            <p className="pb-2 pt-6 text-xs font-medium text-warning-500 dark:text-warning-500-night">
+                              No longer have access · not in your workspace
+                            </p>
+                            {grants
+                              .filter((g) => g.blockedByPolicy)
+                              .map((grant) => (
+                                <GrantRow
+                                  key={grant.id}
+                                  grant={grant}
+                                  onRevoke={() => handleRevoke(grant)}
+                                  blocked
+                                />
+                              ))}
+                          </>
+                        )}
                       </ScrollArea>
                     )}
                   </div>
@@ -323,9 +362,10 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
 interface GrantRowProps {
   grant: SharingGrantType;
   onRevoke: () => void;
+  blocked?: boolean;
 }
 
-function GrantRow({ grant, onRevoke }: GrantRowProps) {
+function GrantRow({ grant, onRevoke, blocked = false }: GrantRowProps) {
   const now = new Date();
   const invitedBy = grant.grantedBy?.fullName ?? grant.grantedBy?.email;
   const grantedAgo = intlFormatDistance(new Date(grant.grantedAt), now);
@@ -342,7 +382,14 @@ function GrantRow({ grant, onRevoke }: GrantRowProps) {
   return (
     <ContextItem
       title={grant.email}
-      visual={<Avatar size="xs" name={grant.email} isRounded />}
+      visual={
+        <Avatar
+          size="xs"
+          name={grant.email}
+          isRounded
+          className={blocked ? "opacity-40" : undefined}
+        />
+      }
       hasSeparator={false}
       action={
         <IconButton
@@ -353,6 +400,7 @@ function GrantRow({ grant, onRevoke }: GrantRowProps) {
         />
       }
       hoverAction
+      className={blocked ? "opacity-60" : undefined}
     >
       <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
         {invitedLabel} · {viewedLabel}

--- a/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
+++ b/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
@@ -55,7 +55,7 @@ function getScopeOptions(sharingPolicy: WorkspaceSharingPolicy): {
   return [
     {
       icon: LockIcon,
-      label: externalOff ? "Specific members" : "Invite only",
+      label: externalOff ? "Invited members only" : "Invite only",
       description: externalOff
         ? "Only the workspace members you invite"
         : "Only the people you invite",
@@ -64,7 +64,7 @@ function getScopeOptions(sharingPolicy: WorkspaceSharingPolicy): {
     {
       icon: UserGroupIcon,
       label: externalOff
-        ? "All workspace members + specific members"
+        ? "All workspace members + invited members"
         : "All workspace members + invites",
       description: externalOff
         ? "Everyone in your workspace, plus members you invite individually"
@@ -163,6 +163,14 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
 
   const showEmailSection =
     currentScope === "emails_only" || currentScope === "workspace_and_emails";
+
+  const activeGrants = grants
+    .filter((g) => !g.blockedByPolicy)
+    .sort((a, b) => a.email.localeCompare(b.email));
+
+  const blockedGrants = grants
+    .filter((g) => g.blockedByPolicy)
+    .sort((a, b) => a.email.localeCompare(b.email));
 
   const onInviteSubmit = async (data: InviteFormValues) => {
     const emails = data.emailsRaw
@@ -320,32 +328,27 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
                       </p>
                     ) : (
                       <ScrollArea className="max-h-96">
-                        {grants
-                          .filter((g) => !g.blockedByPolicy)
-                          .sort((a, b) => a.email.localeCompare(b.email))
-                          .map((grant) => (
-                            <GrantRow
-                              key={grant.id}
-                              grant={grant}
-                              onRevoke={() => handleRevoke(grant)}
-                            />
-                          ))}
-                        {grants.some((g) => g.blockedByPolicy) && (
+                        {activeGrants.map((grant) => (
+                          <GrantRow
+                            key={grant.id}
+                            grant={grant}
+                            onRevoke={() => handleRevoke(grant)}
+                          />
+                        ))}
+                        {blockedGrants.length > 0 && (
                           <>
                             <p className="pb-2 pt-6 text-xs font-medium text-warning-500 dark:text-warning-500-night">
-                              No longer have access · not in your workspace
+                              No longer have access since they are not in your
+                              workspace
                             </p>
-                            {grants
-                              .filter((g) => g.blockedByPolicy)
-                              .sort((a, b) => a.email.localeCompare(b.email))
-                              .map((grant) => (
-                                <GrantRow
-                                  key={grant.id}
-                                  grant={grant}
-                                  onRevoke={() => handleRevoke(grant)}
-                                  blocked
-                                />
-                              ))}
+                            {blockedGrants.map((grant) => (
+                              <GrantRow
+                                key={grant.id}
+                                grant={grant}
+                                onRevoke={() => handleRevoke(grant)}
+                                blocked
+                              />
+                            ))}
                           </>
                         )}
                       </ScrollArea>

--- a/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
+++ b/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
@@ -232,8 +232,8 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
                     variant="info"
                     title="Only workspace members can be added"
                   >
-                    Your admin has disabled external sharing. You can only share with people already
-                    in your workspace.
+                    Your admin has disabled external sharing. You can only share
+                    with people already in your workspace.
                   </ContentMessage>
                 )}
                 <fieldset className="flex flex-col gap-2 border-none p-0">
@@ -322,6 +322,7 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
                       <ScrollArea className="max-h-96">
                         {grants
                           .filter((g) => !g.blockedByPolicy)
+                          .sort((a, b) => a.email.localeCompare(b.email))
                           .map((grant) => (
                             <GrantRow
                               key={grant.id}
@@ -336,6 +337,7 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
                             </p>
                             {grants
                               .filter((g) => g.blockedByPolicy)
+                              .sort((a, b) => a.email.localeCompare(b.email))
                               .map((grant) => (
                                 <GrantRow
                                   key={grant.id}

--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -66,13 +66,21 @@ export function InteractiveContentSharingToggle({
   );
 
   const handlePolicyChange = (newPolicy: WorkspaceSharingPolicy) => {
-    // Downgrading from all_scopes requires confirmation (revokes public links).
-    if (sharingPolicy === "all_scopes" && newPolicy !== "all_scopes") {
+    // Downgrading from all_scopes (revokes public links) or switching to
+    // workspace_only (blocks existing email invitees) requires confirmation.
+    if (
+      (sharingPolicy === "all_scopes" && newPolicy !== "all_scopes") ||
+      newPolicy === "workspace_only"
+    ) {
       setPendingPolicy(newPolicy);
     } else {
       void doUpdateSharingPolicy(newPolicy);
     }
   };
+
+  const isRestrictingToWorkspaceOnly = pendingPolicy === "workspace_only";
+  const isDowngradingFromAllScopes =
+    sharingPolicy === "all_scopes" && pendingPolicy !== null;
 
   return (
     <>
@@ -121,10 +129,26 @@ export function InteractiveContentSharingToggle({
       >
         <DialogContent size="md" isAlertDialog>
           <DialogHeader hideButton>
-            <DialogTitle>Restrict Frame sharing</DialogTitle>
+            <DialogTitle>
+              {isRestrictingToWorkspaceOnly
+                ? "Block external access"
+                : "Restrict Frame sharing"}
+            </DialogTitle>
             <DialogDescription>
-              This will revoke public access to all currently shared Frames in
-              this workspace. Existing public links will stop working.
+              {isRestrictingToWorkspaceOnly ? (
+                <>
+                  Non-workspace members with email invites will immediately lose access to all
+                  frames in this workspace. Their invites are preserved and will resume if you
+                  change this setting later.
+                  {isDowngradingFromAllScopes &&
+                    " Public links will also stop working."}
+                </>
+              ) : (
+                <>
+                  This will revoke public access to all currently shared frames in this workspace.
+                  Existing public links will stop working.
+                </>
+              )}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter
@@ -134,7 +158,9 @@ export function InteractiveContentSharingToggle({
               variant: "outline",
             }}
             rightButtonProps={{
-              label: "Restrict sharing",
+              label: isRestrictingToWorkspaceOnly
+                ? "Block external access"
+                : "Restrict sharing",
               disabled: isChanging,
               variant: "warning",
               onClick: async () => {

--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -137,16 +137,16 @@ export function InteractiveContentSharingToggle({
             <DialogDescription>
               {isRestrictingToWorkspaceOnly ? (
                 <>
-                  Non-workspace members with email invites will immediately lose access to all
-                  frames in this workspace. Their invites are preserved and will resume if you
-                  change this setting later.
+                  Non-workspace members with email invites will immediately lose
+                  access to all frames in this workspace. Their invites are
+                  preserved and will resume if you change this setting later.
                   {isDowngradingFromAllScopes &&
                     " Public links will also stop working."}
                 </>
               ) : (
                 <>
-                  This will revoke public access to all currently shared frames in this workspace.
-                  Existing public links will stop working.
+                  This will revoke public access to all currently shared frames
+                  in this workspace. Existing public links will stop working.
                 </>
               )}
             </DialogDescription>

--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -137,7 +137,7 @@ export function InteractiveContentSharingToggle({
             <DialogDescription>
               {isRestrictingToWorkspaceOnly ? (
                 <>
-                  Non-workspace members with email invites will immediately lose
+                  Non-workspace members with email invites will lose
                   access to all frames in this workspace. Their invites are
                   preserved and will resume if you change this setting later.
                   {isDowngradingFromAllScopes &&

--- a/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
+++ b/front/components/workspace/settings/InteractiveContentSharingToggle.tsx
@@ -137,9 +137,9 @@ export function InteractiveContentSharingToggle({
             <DialogDescription>
               {isRestrictingToWorkspaceOnly ? (
                 <>
-                  Non-workspace members with email invites will lose
-                  access to all frames in this workspace. Their invites are
-                  preserved and will resume if you change this setting later.
+                  Non-workspace members with email invites will lose access to
+                  all frames in this workspace. Their invites are preserved and
+                  will resume if you change this setting later.
                   {isDowngradingFromAllScopes &&
                     " Public links will also stop working."}
                 </>

--- a/front/pages/api/w/[wId]/files/[fileId]/share/grants.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share/grants.test.ts
@@ -1,6 +1,9 @@
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { frameContentType } from "@app/types/files";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
@@ -252,6 +255,177 @@ describe("sharing grants endpoint", () => {
 
       expect(listRes._getStatusCode()).toBe(200);
       expect(listRes._getJSONData().grants).toEqual([]);
+    });
+
+    describe("workspace_only sharing policy", () => {
+      it("blocks inviting an external email", async () => {
+        const { req, res, auth, user, workspace } =
+          await createPrivateApiMockRequest({ method: "POST", role: "user" });
+
+        await FeatureFlagFactory.basic(auth, "email_restricted_sharing");
+        await WorkspaceModel.update(
+          { sharingPolicy: "workspace_only" },
+          { where: { sId: workspace.sId } }
+        );
+
+        const file = await FileFactory.create(auth, user, {
+          contentType: frameContentType,
+          fileName: "test-frame.tsx",
+          fileSize: 1024,
+          status: "ready",
+          useCase: "conversation",
+        });
+        req.query = { ...req.query, fileId: file.sId };
+        req.body = { emails: ["external@example.com"] };
+
+        await handler(req, res);
+
+        expect(res._getStatusCode()).toBe(403);
+      });
+
+      it("allows inviting a workspace member", async () => {
+        const { req, res, auth, user, workspace } =
+          await createPrivateApiMockRequest({ method: "POST", role: "user" });
+
+        await FeatureFlagFactory.basic(auth, "email_restricted_sharing");
+        await WorkspaceModel.update(
+          { sharingPolicy: "workspace_only" },
+          { where: { sId: workspace.sId } }
+        );
+
+        // Create a second workspace member to invite.
+        const member = await UserFactory.basic();
+        await MembershipFactory.associate(workspace, member, { role: "user" });
+
+        const file = await FileFactory.create(auth, user, {
+          contentType: frameContentType,
+          fileName: "test-frame.tsx",
+          fileSize: 1024,
+          status: "ready",
+          useCase: "conversation",
+        });
+        req.query = { ...req.query, fileId: file.sId };
+        req.body = { emails: [member.email] };
+
+        await handler(req, res);
+
+        expect(res._getStatusCode()).toBe(200);
+        expect(res._getJSONData().grants).toHaveLength(1);
+        expect(res._getJSONData().grants[0].email).toBe(
+          member.email.toLowerCase()
+        );
+      });
+
+      it("marks existing external grants as blockedByPolicy on GET", async () => {
+        const { auth, user, workspace } = await createPrivateApiMockRequest({
+          method: "POST",
+          role: "user",
+        });
+
+        await FeatureFlagFactory.basic(auth, "email_restricted_sharing");
+
+        const file = await FileFactory.create(auth, user, {
+          contentType: frameContentType,
+          fileName: "test-frame.tsx",
+          fileSize: 1024,
+          status: "ready",
+          useCase: "conversation",
+        });
+
+        // Add a grant while policy is still permissive.
+        await file.addSharingGrants(auth, { emails: ["external@example.com"] });
+
+        // Now restrict to workspace_only.
+        await WorkspaceModel.update(
+          { sharingPolicy: "workspace_only" },
+          { where: { sId: workspace.sId } }
+        );
+
+        // GET should return the grant with blockedByPolicy: true.
+        const { req: getReq, res: getRes } = createMocks<
+          NextApiRequest,
+          NextApiResponse
+        >({
+          method: "GET",
+          query: { wId: workspace.sId, fileId: file.sId },
+        });
+        await handler(getReq, getRes);
+
+        expect(getRes._getStatusCode()).toBe(200);
+        const { grants } = getRes._getJSONData();
+        expect(grants).toHaveLength(1);
+        expect(grants[0].email).toBe("external@example.com");
+        expect(grants[0].blockedByPolicy).toBe(true);
+      });
+
+      it("does not mark workspace member grants as blockedByPolicy on GET", async () => {
+        const { auth, user, workspace } = await createPrivateApiMockRequest({
+          method: "POST",
+          role: "user",
+        });
+
+        await FeatureFlagFactory.basic(auth, "email_restricted_sharing");
+
+        const member = await UserFactory.basic();
+        await MembershipFactory.associate(workspace, member, { role: "user" });
+
+        const file = await FileFactory.create(auth, user, {
+          contentType: frameContentType,
+          fileName: "test-frame.tsx",
+          fileSize: 1024,
+          status: "ready",
+          useCase: "conversation",
+        });
+
+        await file.addSharingGrants(auth, { emails: [member.email] });
+
+        await WorkspaceModel.update(
+          { sharingPolicy: "workspace_only" },
+          { where: { sId: workspace.sId } }
+        );
+
+        const { req: getReq, res: getRes } = createMocks<
+          NextApiRequest,
+          NextApiResponse
+        >({
+          method: "GET",
+          query: { wId: workspace.sId, fileId: file.sId },
+        });
+        await handler(getReq, getRes);
+
+        expect(getRes._getStatusCode()).toBe(200);
+        const { grants } = getRes._getJSONData();
+        expect(grants).toHaveLength(1);
+        expect(grants[0].blockedByPolicy).toBe(false);
+      });
+
+      it("blocks if any email in the batch is not a workspace member", async () => {
+        const { req, res, auth, user, workspace } =
+          await createPrivateApiMockRequest({ method: "POST", role: "user" });
+
+        await FeatureFlagFactory.basic(auth, "email_restricted_sharing");
+        await WorkspaceModel.update(
+          { sharingPolicy: "workspace_only" },
+          { where: { sId: workspace.sId } }
+        );
+
+        const member = await UserFactory.basic();
+        await MembershipFactory.associate(workspace, member, { role: "user" });
+
+        const file = await FileFactory.create(auth, user, {
+          contentType: frameContentType,
+          fileName: "test-frame.tsx",
+          fileSize: 1024,
+          status: "ready",
+          useCase: "conversation",
+        });
+        req.query = { ...req.query, fileId: file.sId };
+        req.body = { emails: [member.email, "external@example.com"] };
+
+        await handler(req, res);
+
+        expect(res._getStatusCode()).toBe(403);
+      });
     });
 
     it("should return 404 when revoking a non-existent grant", async () => {

--- a/front/pages/api/w/[wId]/files/[fileId]/share/grants.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share/grants.test.ts
@@ -1,9 +1,9 @@
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
-import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { frameContentType } from "@app/types/files";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";

--- a/front/pages/api/w/[wId]/files/[fileId]/share/grants.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share/grants.ts
@@ -165,8 +165,8 @@ async function handler(
           memberships.map((m) => userIdToEmail.get(m.userId)).filter(Boolean)
         );
 
-        const nonMemberEmails = emails.filter((e) => !memberEmails.has(e));
-        if (nonMemberEmails.length > 0) {
+        const hasNonMemberEmails = emails.some((e) => !memberEmails.has(e));
+        if (hasNonMemberEmails) {
           return apiError(req, res, {
             status_code: 403,
             api_error: {

--- a/front/pages/api/w/[wId]/files/[fileId]/share/grants.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share/grants.ts
@@ -4,6 +4,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { SharingGrantType } from "@app/types/files";
@@ -104,6 +106,32 @@ async function handler(
     case "GET": {
       const grants = await file.listActiveSharingGrants();
 
+      const workspace = auth.getNonNullableWorkspace();
+      if (workspace.sharingPolicy === "workspace_only" && grants.length > 0) {
+        const emails = grants.map((g) => g.email.toLowerCase());
+        const users = await UserResource.fetchByEmails(emails);
+
+        const userIdToEmail = new Map(
+          users.map((u) => [u.id, u.email.toLowerCase()])
+        );
+
+        const { memberships } = await MembershipResource.getActiveMemberships({
+          users,
+          workspace,
+        });
+
+        const memberEmails = new Set(
+          memberships.map((m) => userIdToEmail.get(m.userId)).filter(Boolean)
+        );
+
+        return res.status(200).json({
+          grants: grants.map((g) => ({
+            ...g,
+            blockedByPolicy: !memberEmails.has(g.email.toLowerCase()),
+          })),
+        });
+      }
+
       return res.status(200).json({ grants });
     }
 
@@ -117,6 +145,37 @@ async function handler(
             message: `Invalid request body: ${parseResult.error.message}`,
           },
         });
+      }
+
+      const workspace = auth.getNonNullableWorkspace();
+      if (workspace.sharingPolicy === "workspace_only") {
+        const emails = parseResult.data.emails.map((e) => e.toLowerCase());
+        const users = await UserResource.fetchByEmails(emails);
+
+        const userIdToEmail = new Map(
+          users.map((u) => [u.id, u.email.toLowerCase()])
+        );
+
+        const { memberships } = await MembershipResource.getActiveMemberships({
+          users,
+          workspace,
+        });
+
+        const memberEmails = new Set(
+          memberships.map((m) => userIdToEmail.get(m.userId)).filter(Boolean)
+        );
+
+        const nonMemberEmails = emails.filter((e) => !memberEmails.has(e));
+        if (nonMemberEmails.length > 0) {
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Only workspace members can be invited when external sharing is disabled.",
+            },
+          });
+        }
       }
 
       const grants = await file.addSharingGrants(auth, {

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -67,6 +67,8 @@ export interface SharingGrantType {
   grantedBy: UserType | null;
   expiresAt: Date | null;
   lastViewedAt: Date | null;
+  // True when the workspace policy prevents this grant from granting access.
+  blockedByPolicy?: boolean;
 }
 
 export interface FileType {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When a workspace is restricted to members only, the share sheet now reflects this. Labels update to drop any mention of external people, a banner explains the constraint, and inviting a non-member email is rejected by the API.

Existing external grants are not revoked. They stay in the DB but are blocked at the API level. The share sheet groups them separately at the bottom so frame owners can see who's affected and clean up if they want. If the policy is relaxed later, access naturally resumes.

**With workspace policy enabled**
<img width="573" height="1040" alt="image" src="https://github.com/user-attachments/assets/c0b4dc93-fc03-4450-846e-d16135640c8d" />

**Without workspace policy**
<img width="573" height="1040" alt="image" src="https://github.com/user-attachments/assets/f78fdcd0-cbb2-456e-a903-e779dd420631" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
