### PR TITLE
fix: description alignment members table

### DIFF
--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -1136,7 +1136,10 @@ DataTable.CellContent = function CellContent({
         />
       )}
       <div
-        className={cn("s-flex s-shrink s-truncate", grow ? "s-flex-grow" : "")}
+        className={cn(
+          "s-flex s-shrink s-truncate s-items-center",
+          grow ? "s-flex-grow" : ""
+        )}
       >
         <div
           className={cn(


### PR DESCRIPTION
## Description

This PR fixes a vertical alignment regression in the `MemberSelectionTable` component that cause the email to be not aligned.

Root cause: PR #23995  changed avatar rendering in `MemberSelectionTable` from the `avatarUrl` prop to a custom `children` div with the `Avatar` component inside, making `children` taller than the `description` span. This exposed a missing `s-items-center` on the inner flex wrapper that holds `children` and the `description` span side by side. 

Fix: Add `s-items-center` to the inner wrapper in `DataTable.CellContent`.

Why this only affects `MemberSelectionTable`: The `description` prop is currently used only in the `MemberSelectionTable`. The alignment fix only has a visual effect when both `children` and `description` are present. For single-child cases (all other tables), the flex container collapses to the child's natural height, making `items-center` vs nothing visually identical.

Before:
<img width="556" height="673" alt="Capture d’écran 2026-04-13 à 12 42 28" src="https://github.com/user-attachments/assets/94c2368d-df62-414b-8332-d77e7eadc16a" />

After:
<img width="556" height="673" alt="Capture d’écran 2026-04-13 à 12 38 05" src="https://github.com/user-attachments/assets/b51529a6-3ebd-419e-b51a-3ca36ce4b9bb" />

## Tests

Manually

## Risks

Low - minor UI change to improve visual alignment

## Deploy Plan

Standard deployment
