### PR TITLE
Harden egress proxy service lifecycle

### DIFF
--- a/egress-proxy/README.md
+++ b/egress-proxy/README.md
@@ -17,7 +17,6 @@ Current functionality:
 Not implemented yet:
 
 - GCS policy reads
-- production lifecycle hardening around listener supervision and graceful tunnel draining
 - configurable idle or max-lifetime policy for established tunnels
 
 ## Configuration

--- a/egress-proxy/src/server.rs
+++ b/egress-proxy/src/server.rs
@@ -8,9 +8,11 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::signal;
 use tokio::sync::{watch, Semaphore};
+use tokio::task::{JoinError, JoinSet};
 use tokio::time::timeout;
 use tracing::{error, info, warn};
 
+const CONNECTION_DRAIN_TIMEOUT_SECONDS: u64 = 5;
 const TLS_ACCEPT_TIMEOUT_SECONDS: u64 = 5;
 const MAX_CONCURRENT_CONNECTIONS: usize = 1024;
 
@@ -27,7 +29,7 @@ pub async fn run(config: Config) -> Result<()> {
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
     let mut health_handle = tokio::spawn(health::serve(health_listener, shutdown_rx.clone()));
-    let proxy_handle = tokio::spawn(run_proxy_listener(
+    let mut proxy_handle = tokio::spawn(run_proxy_listener(
         listener,
         tls_acceptor,
         state,
@@ -52,6 +54,11 @@ pub async fn run(config: Config) -> Result<()> {
                 return Err(error);
             }
         }
+        proxy_result = &mut proxy_handle => {
+            let _ = shutdown_tx.send(true);
+            proxy_result??;
+            return Err(anyhow!("proxy listener stopped unexpectedly"));
+        }
         health_result = &mut health_handle => {
             let _ = shutdown_tx.send(true);
             health_result??;
@@ -70,6 +77,8 @@ async fn run_proxy_listener(
     connection_slots: Arc<Semaphore>,
     mut shutdown: watch::Receiver<bool>,
 ) -> Result<()> {
+    let mut connection_tasks = JoinSet::new();
+
     loop {
         tokio::select! {
             accept_result = listener.accept() => {
@@ -89,7 +98,7 @@ async fn run_proxy_listener(
                 let tls_acceptor = tls_acceptor.clone();
                 let state = state.clone();
 
-                tokio::spawn(async move {
+                connection_tasks.spawn(async move {
                     let _permit = permit;
                     match timeout(
                         Duration::from_secs(TLS_ACCEPT_TIMEOUT_SECONDS),
@@ -115,6 +124,9 @@ async fn run_proxy_listener(
                     }
                 });
             }
+            join_result = connection_tasks.join_next(), if !connection_tasks.is_empty() => {
+                log_connection_task_result(join_result);
+            }
             changed = shutdown.changed() => {
                 if changed.is_err() || *shutdown.borrow() {
                     break;
@@ -123,9 +135,44 @@ async fn run_proxy_listener(
         }
     }
 
-    // TODO(sandbox-egress): In PR 3, supervise the proxy listener task and give accepted
-    // connections a bounded drain window during shutdown instead of detaching them.
+    drain_connection_tasks(connection_tasks).await;
+
     Ok(())
+}
+
+async fn drain_connection_tasks(mut connection_tasks: JoinSet<()>) {
+    if connection_tasks.is_empty() {
+        return;
+    }
+
+    let drain_timeout = Duration::from_secs(CONNECTION_DRAIN_TIMEOUT_SECONDS);
+    match tokio::time::timeout(drain_timeout, async {
+        while let Some(join_result) = connection_tasks.join_next().await {
+            log_connection_task_result(Some(join_result));
+        }
+    })
+    .await
+    {
+        Ok(()) => {}
+        Err(_) => {
+            let pending_tasks = connection_tasks.len();
+            warn!(
+                pending_tasks,
+                drain_timeout_seconds = CONNECTION_DRAIN_TIMEOUT_SECONDS,
+                "aborting active connections after shutdown drain timeout"
+            );
+            connection_tasks.abort_all();
+            while let Some(join_result) = connection_tasks.join_next().await {
+                log_connection_task_result(Some(join_result));
+            }
+        }
+    }
+}
+
+fn log_connection_task_result(join_result: Option<Result<(), JoinError>>) {
+    if let Some(Err(error)) = join_result {
+        warn!(error = %error, "connection task failed");
+    }
 }
 
 async fn wait_for_shutdown_signal() {

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -265,6 +265,29 @@ async fn unsafe_ssrf_bypass_fails_startup_outside_test_env() -> Result<()> {
     wait_for_startup_failure(&mut child).await
 }
 
+#[tokio::test]
+async fn health_bind_failure_fails_startup() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let certs = generate_test_certs(temp_dir.path())?;
+    let proxy_addr = free_addr()?;
+    let occupied_health_listener = StdTcpListener::bind("127.0.0.1:0")?;
+    let health_addr = occupied_health_listener.local_addr()?;
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_egress-proxy"))
+        .env("EGRESS_PROXY_LISTEN_ADDR", proxy_addr.to_string())
+        .env("EGRESS_PROXY_HEALTH_ADDR", health_addr.to_string())
+        .env("EGRESS_PROXY_TLS_CERT", certs.server_cert_path)
+        .env("EGRESS_PROXY_TLS_KEY", certs.server_key_path)
+        .env("EGRESS_PROXY_JWT_SECRET", SECRET)
+        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "localhost")
+        .env("EGRESS_PROXY_ENV", "production")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    wait_for_startup_failure(&mut child).await
+}
+
 async fn start_proxy(
     allowed_domains: &str,
     unsafe_skip_ssrf_check: bool,


### PR DESCRIPTION
## Description

This PR hardens the egress proxy service lifecycle without changing proxy semantics.

It adds supervision for the proxy listener task, tracks accepted connection tasks, gives active tunnels a bounded drain window during shutdown, and aborts any remaining connection tasks after the drain timeout. It also adds a startup test that verifies the process fails fast when the health listener cannot bind.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- `cargo build`
- `cargo audit -q`
- `docker build -f dockerfiles/egress-proxy.Dockerfile -t dust-egress-proxy-pr3 .`

## Risk

This changes shutdown and task-supervision behavior in the proxy binary. The main risk is around dropping or aborting active tunnels incorrectly during shutdown. That risk is limited by keeping the change scoped to listener supervision and drain behavior, and by covering the new startup failure path in integration tests.

## Deploy Plan

Merge after PR #24142. Deploy with the normal egress proxy rollout. No infra changes or data migrations are required.