### PR TITLE
fix(connectors): sanitize Snowflake identifiers in SQL queries

### DIFF
--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -87,7 +87,7 @@ export const fetchAvailableChildrenInSnowflake = async ({
 
     const allSchemasRes = await fetchSchemas({
       credentials,
-      fromDatabase: parentInternalId,
+      fromDatabase: databaseName,
     });
     if (allSchemasRes.isErr()) {
       return new Err(allSchemasRes.error);
@@ -124,7 +124,8 @@ export const fetchAvailableChildrenInSnowflake = async ({
 
     const allTablesRes = await fetchTables({
       credentials,
-      fromSchema: parentInternalId,
+      fromDatabase: databaseName,
+      fromSchema: schemaName,
     });
     if (allTablesRes.isErr()) {
       return new Err(allTablesRes.error);

--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -30,6 +30,14 @@ import type {
 } from "snowflake-sdk";
 import snowflake from "snowflake-sdk";
 
+/**
+ * Quote a Snowflake identifier for safe use in SQL.
+ * Wraps in double quotes and doubles any internal double-quote characters.
+ */
+function sanitizeSnowflakeIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SnowflakeRow = Record<string, any>;
 type SnowflakeRows = Array<SnowflakeRow>;
@@ -371,7 +379,7 @@ export const fetchSchemas = async ({
   fromDatabase: string;
   connection?: Connection;
 }): Promise<Result<Array<RemoteDBSchema>, Error>> => {
-  const query = `SHOW SCHEMAS IN DATABASE ${fromDatabase}`;
+  const query = `SHOW SCHEMAS IN DATABASE ${sanitizeSnowflakeIdentifier(fromDatabase)}`;
   return _fetchRows<RemoteDBSchema>({
     credentials,
     query,
@@ -395,12 +403,14 @@ export const fetchTables = async ({
   connection?: Connection;
 }): Promise<Result<Array<RemoteDBTable>, Error>> => {
   // We fetch the tables in the schema provided if defined, otherwise in the database provided if
-  // defined, otherwise globally.
-  const query = fromSchema
-    ? `SHOW TABLES IN SCHEMA ${fromSchema}`
-    : fromDatabase
-      ? `SHOW TABLES IN DATABASE ${fromDatabase}`
-      : "SHOW TABLES";
+  // defined, otherwise globally. When both fromDatabase and fromSchema are set, we build a fully
+  // qualified schema reference.
+  const query =
+    fromSchema && fromDatabase
+      ? `SHOW TABLES IN SCHEMA ${sanitizeSnowflakeIdentifier(fromDatabase)}.${sanitizeSnowflakeIdentifier(fromSchema)}`
+      : fromDatabase
+        ? `SHOW TABLES IN DATABASE ${sanitizeSnowflakeIdentifier(fromDatabase)}`
+        : "SHOW TABLES";
 
   return _fetchRows<RemoteDBTable>({
     credentials,
@@ -526,7 +536,10 @@ export const useWarehouse = async ({
   connection: Connection;
 }): Promise<Result<void, Error>> => {
   const warehouse = credentials.warehouse;
-  const res = await _executeQuery(connection, `USE WAREHOUSE ${warehouse}`);
+  const res = await _executeQuery(
+    connection,
+    `USE WAREHOUSE ${sanitizeSnowflakeIdentifier(warehouse)}`
+  );
   if (res.isErr()) {
     const e = normalizeError(res.error);
 
@@ -573,7 +586,7 @@ async function _checkRoleGrants(
   // Check current grants
   const currentGrantsRes = await _fetchRows<SnowflakeGrant>({
     credentials,
-    query: `SHOW GRANTS TO ${isDbRole ? "DATABASE ROLE" : "ROLE"} ${roleName}`,
+    query: `SHOW GRANTS TO ${isDbRole ? "DATABASE ROLE" : "ROLE"} ${sanitizeSnowflakeIdentifier(roleName)}`,
     codec: snowflakeGrantCodec,
     connection,
   });
@@ -588,7 +601,7 @@ async function _checkRoleGrants(
     // Check future grants
     futureGrantsRes = await _fetchRows<SnowflakeFutureGrant>({
       credentials,
-      query: `SHOW FUTURE GRANTS TO ROLE ${roleName}`,
+      query: `SHOW FUTURE GRANTS TO ROLE ${sanitizeSnowflakeIdentifier(roleName)}`,
       codec: snowflakeFutureGrantCodec,
       connection,
     });


### PR DESCRIPTION
## Description

Database, schema, warehouse, and role names containing special characters (like @ or .) cause SQL compilation errors when interpolated unquoted into Snowflake queries.

A first fix was attempted in #24077 but had to be rolled back because it broke the permissions endpoint. The problem was that permissions.ts was passing internal  IDs (like ADK_PROD_DB.DATA_ANALYSIS) directly to fetchSchemas and fetchTables, where the dot acts as a database/schema separator. Quoting the whole string as "ADK_PROD_DB.DATA_ANALYSIS" made Snowflake look for a single object with that literal name instead of database.schema.

This PR fixes both issues. It adds a sanitizeSnowflakeIdentifier helper that wraps identifiers in double quotes (with internal " escaped as ""), and it fixes permissions.ts to pass the already-parsed databaseName and schemaName instead of the raw internal ID. fetchTables now accepts separate database and schema params and builds a properly qualified "db"."schema" reference.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
