### PR TITLE
Add V2 homepage for Series B announcement

### DIFF
--- a/front/components/home/content/V2/AgentsImproveSection.tsx
+++ b/front/components/home/content/V2/AgentsImproveSection.tsx
@@ -1,0 +1,141 @@
+import { H2, P } from "@app/components/home/ContentComponents";
+
+const CAPABILITY_CARDS = [
+  {
+    icon: "📚",
+    title: "Knows your company",
+    description:
+      "Connects to all your tools and data sources. Context flows automatically.",
+    bg: "bg-amber-100",
+  },
+  {
+    icon: "🤝",
+    title: "AI is a team sport",
+    description:
+      "Built for collaboration across departments. One builds, everyone benefits.",
+    bg: "bg-blue-100",
+  },
+  {
+    icon: "⚡",
+    title: "Always the best model",
+    description:
+      "Switch between OpenAI, Anthropic, Google, Mistral. Always use what's best.",
+    bg: "bg-emerald-100",
+  },
+  {
+    icon: "📈",
+    title: "Compounds across the org",
+    description:
+      "Value grows with every team that joins. Skills spread, intelligence compounds.",
+    bg: "bg-rose-100",
+  },
+];
+
+const SOURCES = [
+  "Slack",
+  "Salesforce",
+  "Notion",
+  "GitHub",
+  "Zendesk",
+  "Linear",
+];
+
+export function AgentsImproveSection() {
+  return (
+    <section className="py-16 lg:py-24">
+      <div className="rounded-3xl bg-emerald-50/50 p-8 md:p-12 lg:p-16">
+        <p className="mb-4 text-xs font-semibold uppercase tracking-[0.15em] text-emerald-700">
+          🔄 How Dust Agents Improve with You
+        </p>
+        <div className="grid grid-cols-1 gap-12 lg:grid-cols-2 lg:gap-16">
+          <div className="flex flex-col gap-8">
+            <div>
+              <H2 mono className="mb-6 text-left">
+                Agents that understand how you work and get smarter
+                over&nbsp;time.
+              </H2>
+              <P size="lg" className="text-muted-foreground">
+                Dust agents don&rsquo;t just search your data; your teams encode
+                how you work in agents. With Skills and reinforcement
+                capabilities, agents learn and evolve through repeated use. Best
+                practices consolidate into shared skills, improvements spread to
+                every agent automatically, and your fiftieth workflow is easier to
+                build than your fifth.
+              </P>
+            </div>
+
+            <div className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+              <p className="mb-4 italic leading-relaxed text-muted-foreground">
+                &ldquo;We used to do the work. Now we build the agents that do
+                it.&rdquo;
+              </p>
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-purple-100 text-sm font-bold text-purple-700">
+                  SK
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-foreground">
+                    Shashank Khanna
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Founder in Residence, GTM Innovation at Vanta
+                  </p>
+                </div>
+                <span className="ml-auto rounded-full bg-purple-50 px-3 py-1 text-xs font-medium text-purple-700">
+                  ~400h saved/week
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {CAPABILITY_CARDS.map((card) => (
+              <div
+                key={card.title}
+                className="rounded-2xl border border-border bg-white p-6 shadow-sm"
+              >
+                <div
+                  className={`mb-4 flex h-10 w-10 items-center justify-center rounded-xl text-lg ${card.bg}`}
+                >
+                  {card.icon}
+                </div>
+                <h4 className="mb-2 font-semibold text-foreground">
+                  {card.title}
+                </h4>
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  {card.description}
+                </p>
+              </div>
+            ))}
+
+            <div className="rounded-2xl border border-border bg-white p-6 shadow-sm sm:col-span-2">
+              <p className="mb-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Connected Sources
+              </p>
+              <div className="grid grid-cols-3 gap-3">
+                {SOURCES.map((source) => (
+                  <div
+                    key={source}
+                    className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2"
+                  >
+                    <div className="h-2 w-2 rounded-full bg-emerald-400" />
+                    <span className="text-xs font-medium text-foreground">
+                      {source}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-4 rounded-lg bg-gray-50 px-3 py-2">
+                <p className="text-xs text-muted-foreground">Agent Memory</p>
+                <p className="text-sm text-foreground">
+                  Remembers context from{" "}
+                  <span className="font-semibold">847</span> past conversations
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/front/components/home/content/V2/ClosingCtaSection.tsx
+++ b/front/components/home/content/V2/ClosingCtaSection.tsx
@@ -1,0 +1,46 @@
+import { Button } from "@dust-tt/sparkle";
+import Link from "next/link";
+
+export function ClosingCtaSection() {
+  return (
+    <section className="py-16 lg:py-24">
+      <div className="rounded-3xl bg-emerald-950 px-8 py-16 text-center md:px-16 md:py-20 lg:px-24 lg:py-24">
+        <h2 className="mx-auto mb-6 max-w-3xl font-objektiv text-3xl font-medium tracking-tight text-white md:text-4xl lg:text-5xl">
+          The best teams aren&rsquo;t just using&nbsp;AI — they&rsquo;re
+          running&nbsp;it.
+        </h2>
+        <p className="mx-auto mb-8 max-w-2xl text-lg leading-relaxed text-emerald-200">
+          There&rsquo;s a new kind of person emerging in fast-moving companies —
+          someone who doesn&rsquo;t wait for an AI tool to be handed to them.
+          They build it, deploy it, and run it for their whole team. We call them
+          AI operators.
+        </p>
+        <p className="mx-auto mb-10 max-w-2xl text-base leading-relaxed text-emerald-300">
+          At companies like Datadog, 1Password, Cursor, Vanta, Persona, Clay,
+          and Qonto, thousands of AI operators have deployed over 300,000 agents.
+          They&rsquo;ve rewired how their teams work, achieved 70% weekly active
+          usage, and expanded every single renewal.
+        </p>
+        <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <Link href="https://dust.tt/home/signup">
+            <Button
+              label="Become an AI operator"
+              variant="highlight"
+              size="lg"
+            />
+          </Link>
+        </div>
+        <p className="mt-6 text-sm text-emerald-400">
+          We&rsquo;re hiring across engineering, marketing, sales, and customer
+          success.{" "}
+          <Link
+            href="https://dust.tt/jobs"
+            className="underline underline-offset-4 transition hover:text-emerald-200"
+          >
+            &rarr; dust.tt/jobs
+          </Link>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/front/components/home/content/V2/CollaborationSection.module.css
+++ b/front/components/home/content/V2/CollaborationSection.module.css
@@ -1,0 +1,72 @@
+/* Cursor movement paths */
+@keyframes cursor-sarah {
+  0% { transform: translate(0, 0); }
+  15% { transform: translate(40px, 20px); }
+  30% { transform: translate(10px, 60px); }
+  50% { transform: translate(60px, 30px); }
+  70% { transform: translate(20px, -10px); }
+  85% { transform: translate(50px, 50px); }
+  100% { transform: translate(0, 0); }
+}
+@keyframes cursor-marcus {
+  0% { transform: translate(0, 0); }
+  20% { transform: translate(30px, -15px); }
+  40% { transform: translate(70px, 10px); }
+  60% { transform: translate(40px, 40px); }
+  80% { transform: translate(-10px, 20px); }
+  100% { transform: translate(0, 0); }
+}
+@keyframes cursor-priya {
+  0% { transform: translate(0, 0); }
+  25% { transform: translate(-20px, -30px); }
+  50% { transform: translate(30px, -10px); }
+  75% { transform: translate(-10px, 20px); }
+  100% { transform: translate(0, 0); }
+}
+
+.cursorSarah { animation: cursor-sarah 12s ease-in-out infinite; }
+.cursorMarcus { animation: cursor-marcus 10s ease-in-out infinite; }
+.cursorPriya { animation: cursor-priya 14s ease-in-out infinite; }
+
+/* Message appear animation */
+@keyframes msg-appear {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.msgAppear {
+  opacity: 0;
+  animation: msg-appear 0.6s ease-out forwards;
+}
+
+/* Handoff pulse */
+@keyframes handoff-pulse {
+  0%, 100% { opacity: 0.3; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.05); }
+}
+.handoffPulse { animation: handoff-pulse 2s ease-in-out infinite 4.6s; }
+
+/* Live ping */
+@keyframes live-ping {
+  0% { transform: scale(1); opacity: 1; }
+  75% { transform: scale(2.5); opacity: 0; }
+  100% { transform: scale(2.5); opacity: 0; }
+}
+.livePing { position: relative; }
+.livePing::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: #34d399;
+  animation: live-ping 2s ease-out infinite;
+}
+
+/* Canvas replay loop */
+@keyframes canvas-loop {
+  0% { opacity: 0; }
+  4% { opacity: 1; }
+  85% { opacity: 1; }
+  95% { opacity: 0; }
+  100% { opacity: 0; }
+}
+.canvasLoop { animation: canvas-loop 16s ease-in-out infinite; }

--- a/front/components/home/content/V2/CollaborationSection.tsx
+++ b/front/components/home/content/V2/CollaborationSection.tsx
@@ -1,0 +1,289 @@
+import { H2, P } from "@app/components/home/ContentComponents";
+
+import styles from "./CollaborationSection.module.css";
+
+function CursorTag({
+  name,
+  color,
+  className,
+}: {
+  name: string;
+  color: string;
+  className: string;
+}) {
+  return (
+    <div className={`pointer-events-none absolute z-10 ${className}`}>
+      <div
+        className={`flex items-center gap-1 rounded-full ${color} px-1.5 py-0.5 text-[9px] font-semibold text-white shadow-lg`}
+      >
+        <svg className="h-2.5 w-2.5" viewBox="0 0 10 10">
+          <polygon points="0,0 10,4 2,6" fill="white" />
+        </svg>
+        {name}
+      </div>
+    </div>
+  );
+}
+
+export function CollaborationSection() {
+  return (
+    <section className="py-16 lg:py-24">
+      <div className="rounded-3xl bg-blue-50/50 p-8 md:p-12 lg:p-16">
+        <p className="mb-4 text-xs font-semibold uppercase tracking-[0.15em] text-blue-700">
+          👥 How Your Team Collaborates with Dust
+        </p>
+        <div className="grid grid-cols-1 gap-12 lg:grid-cols-2 lg:gap-16">
+          {/* Left: Collaboration visual */}
+          <div className="flex items-center justify-center">
+            <div className="relative w-full max-w-lg overflow-hidden rounded-2xl border border-border bg-white shadow-lg">
+              {/* Canvas header */}
+              <div className="flex items-center justify-between border-b border-border/50 px-6 py-3">
+                <div className="flex items-center gap-2.5">
+                  <div className="relative h-2 w-2">
+                    <div
+                      className={`h-2 w-2 rounded-full bg-emerald-400 ${styles.livePing}`}
+                    />
+                  </div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Live — Q2 Deal Pipeline
+                  </p>
+                </div>
+                <div className="flex -space-x-1.5">
+                  <div className="flex h-5 w-5 items-center justify-center rounded-full border-2 border-white bg-blue-500 text-[8px] font-bold text-white">
+                    M
+                  </div>
+                  <div className="flex h-5 w-5 items-center justify-center rounded-full border-2 border-white bg-rose-500 text-[8px] font-bold text-white">
+                    S
+                  </div>
+                  <div className="flex h-5 w-5 items-center justify-center rounded-full border-2 border-white bg-amber-500 text-[8px] font-bold text-white">
+                    P
+                  </div>
+                  <div className="flex h-5 w-5 items-center justify-center rounded-full border-2 border-white bg-emerald-600">
+                    <div className="flex gap-0.5">
+                      <div className="h-1 w-1 rounded-full bg-white" />
+                      <div className="h-1 w-1 rounded-full bg-white" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Animated message feed */}
+              <div
+                className={`relative space-y-2.5 p-5 ${styles.canvasLoop}`}
+                style={{ minHeight: 460 }}
+              >
+                {/* Sarah → Marcus (Human ↔ Human) */}
+                <div
+                  className={`rounded-xl border border-rose-100 bg-rose-50 p-3.5 ${styles.msgAppear}`}
+                  style={{ animationDelay: "0.3s" }}
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-rose-200 text-[10px] font-bold text-rose-700">
+                      SA
+                    </div>
+                    <div>
+                      <p className="mb-0.5 text-[10px] font-semibold text-rose-600">
+                        Sarah · Sales
+                      </p>
+                      <p className="text-xs leading-relaxed text-foreground">
+                        <span className="font-semibold text-blue-700">
+                          @Marcus
+                        </span>{" "}
+                        I built a Deal Prep agent that pulls from Salesforce +
+                        call transcripts. Try it on the Acme renewal — saved me
+                        2h this week.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Marcus → Agent (Human ↔ Agent) */}
+                <div
+                  className={`rounded-xl border border-blue-100 bg-blue-50 p-3.5 ${styles.msgAppear}`}
+                  style={{ animationDelay: "1.8s" }}
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-200 text-[10px] font-bold text-blue-700">
+                      MA
+                    </div>
+                    <div>
+                      <p className="mb-0.5 text-[10px] font-semibold text-blue-600">
+                        Marcus · RevOps
+                      </p>
+                      <p className="text-xs leading-relaxed text-foreground">
+                        <span className="font-semibold text-emerald-700">
+                          @Deal Prep Agent
+                        </span>{" "}
+                        Run full analysis on Acme Corp renewal — include
+                        competitor intel and expansion signals.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Deal Prep Agent response */}
+                <div
+                  className={`rounded-xl border border-border bg-gray-50 p-3.5 ${styles.msgAppear}`}
+                  style={{ animationDelay: "3.5s" }}
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-emerald-600 text-white">
+                      <div className="h-2 w-2 rounded-full bg-white" />
+                    </div>
+                    <div className="flex-1">
+                      <p className="mb-1.5 text-[10px] font-semibold text-emerald-700">
+                        Deal Prep Agent
+                      </p>
+                      <div className="space-y-1.5 text-xs leading-relaxed text-foreground">
+                        <p>
+                          ✓ Pulled 14 Salesforce records + 3 Gong transcripts
+                        </p>
+                        <p>
+                          ✓ Key risk: champion left in Q1. New contact
+                          identified.
+                        </p>
+                        <p className={styles.handoffPulse}>
+                          ☞ Handing off to{" "}
+                          <span className="font-semibold text-purple-700">
+                            @Competitive Intel Agent
+                          </span>
+                          …
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Competitive Intel Agent (Agent ↔ Agent) */}
+                <div
+                  className={`rounded-xl border border-purple-100 bg-purple-50 p-3.5 ${styles.msgAppear}`}
+                  style={{ animationDelay: "5.5s" }}
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-purple-600 text-white">
+                      <div className="h-2 w-2 rounded-full bg-white" />
+                    </div>
+                    <div className="flex-1">
+                      <p className="mb-1.5 text-[10px] font-semibold text-purple-700">
+                        Competitive Intel Agent
+                      </p>
+                      <div className="space-y-1.5 text-xs leading-relaxed text-foreground">
+                        <p>
+                          ✓ Battlecard generated: Acme vs. 3 competitors
+                        </p>
+                        <p>
+                          ✓ Pricing intel updated from latest G2 reviews
+                        </p>
+                        <p>
+                          ☞ Notifying{" "}
+                          <span className="font-semibold text-blue-700">
+                            @Marcus
+                          </span>{" "}
+                          and{" "}
+                          <span className="font-semibold text-rose-700">
+                            @Sarah
+                          </span>{" "}
+                          — ready for review
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Animated cursors */}
+                <CursorTag
+                  name="Sarah"
+                  color="bg-rose-500"
+                  className={`right-8 top-16 ${styles.cursorSarah}`}
+                />
+                <CursorTag
+                  name="Marcus"
+                  color="bg-blue-500"
+                  className={`left-6 top-32 ${styles.cursorMarcus}`}
+                />
+                <CursorTag
+                  name="Priya"
+                  color="bg-amber-500"
+                  className={`bottom-8 right-12 ${styles.cursorPriya}`}
+                />
+              </div>
+
+              {/* Legend bar */}
+              <div className="flex items-center gap-5 border-t border-border/50 px-5 py-2.5 text-[10px] text-muted-foreground">
+                <div className="flex items-center gap-1.5">
+                  <div className="flex -space-x-1">
+                    <div className="h-3 w-3 rounded-full border border-white bg-rose-300" />
+                    <div className="h-3 w-3 rounded-full border border-white bg-blue-300" />
+                  </div>
+                  Human ↔ Human
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <div className="flex -space-x-1">
+                    <div className="h-3 w-3 rounded-full border border-white bg-blue-300" />
+                    <div className="h-3 w-3 rounded-lg border border-white bg-emerald-400" />
+                  </div>
+                  Human ↔ Agent
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <div className="flex -space-x-1">
+                    <div className="h-3 w-3 rounded-lg border border-white bg-emerald-400" />
+                    <div className="h-3 w-3 rounded-lg border border-white bg-purple-400" />
+                  </div>
+                  Agent ↔ Agent
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Right: text + quote */}
+          <div className="flex flex-col gap-8">
+            <div>
+              <H2 mono className="mb-6 text-left">
+                Anyone can build sophisticated AI agents in minutes. The real
+                power? Everyone else gets to use them.
+              </H2>
+              <P size="lg" className="text-muted-foreground">
+                AI is a team sport. AI Operators build agents and skills that
+                immediately benefit their entire team. Sales builds something
+                useful, Support is already using it by Tuesday. With Projects,
+                people, agents, and context come together in shared hubs where
+                intelligence compounds. Not single-player productivity —
+                multiplayer AI for the enterprise.
+              </P>
+            </div>
+
+            <div className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+              <p className="mb-4 italic leading-relaxed text-muted-foreground">
+                &ldquo;We made a bet on Dust because we knew the team was
+                exceptional. What we didn&rsquo;t expect was how quickly it would
+                transform how we work. Dust became the connective tissue that
+                amplifies what each team does best.&rdquo;
+              </p>
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-700">
+                  RW
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-foreground">
+                    Ryan Wang
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    CEO at Assembled
+                  </p>
+                </div>
+                <div className="ml-auto flex gap-2">
+                  <span className="rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
+                    95% adoption
+                  </span>
+                  <span className="rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
+                    120+ employees
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/front/components/home/content/V2/EnterpriseSection.tsx
+++ b/front/components/home/content/V2/EnterpriseSection.tsx
@@ -1,0 +1,101 @@
+import { H2, P } from "@app/components/home/ContentComponents";
+
+interface FeatureColumnProps {
+  icon: string;
+  iconBg: string;
+  title: string;
+  items: string[];
+}
+
+function FeatureColumn({ icon, iconBg, title, items }: FeatureColumnProps) {
+  return (
+    <div className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+      <div
+        className={`mb-4 flex h-10 w-10 items-center justify-center rounded-xl text-lg ${iconBg}`}
+      >
+        {icon}
+      </div>
+      <h3 className="mb-4 text-lg font-semibold text-foreground">{title}</h3>
+      <ul className="space-y-2.5 text-sm text-muted-foreground">
+        {items.map((item) => (
+          <li key={item} className="flex items-start gap-2">
+            <span className="mt-0.5 text-emerald-500">✓</span>
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+const COLUMNS: FeatureColumnProps[] = [
+  {
+    icon: "🛡",
+    iconBg: "bg-rose-100",
+    title: "Security & compliance",
+    items: [
+      "SOC 2 Type II certified",
+      "GDPR compliant (EU data residency)",
+      "HIPAA-ready deployment",
+      "SSO (SAML, OIDC) + SCIM",
+      "Audit logs (365-day retention)",
+      "RBAC + dual-layer permissions",
+      "AES-256 at rest, TLS 1.3 in transit",
+      "Zero model training on your data",
+    ],
+  },
+  {
+    icon: "⚡",
+    iconBg: "bg-amber-100",
+    title: "Performance & scale",
+    items: [
+      "99.9% uptime SLA",
+      "Supports 10,000+ users per workspace",
+      "Concurrent agent execution",
+      "Sub-2s agent response time (p95)",
+      "CDN-backed global deployment",
+    ],
+  },
+  {
+    icon: "🔗",
+    iconBg: "bg-blue-100",
+    title: "Integration architecture",
+    items: [
+      "RESTful API for custom integrations",
+      "MCP for proprietary systems",
+      "Webhook support for event-driven workflows",
+      "OAuth2 for third-party permissions",
+      "Bi-directional sync (read + write)",
+      "Incremental data refresh",
+      "100+ production connectors",
+    ],
+  },
+];
+
+export function EnterpriseSection() {
+  return (
+    <section className="py-16 lg:py-24">
+      <div className="mb-12">
+        <p className="mb-4 text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+          🔒 Enterprise Ready, Obviously
+        </p>
+        <H2 mono className="mb-6 max-w-3xl text-left">
+          When AI has access to your company&rsquo;s knowledge, &ldquo;mostly
+          secure&rdquo; doesn&rsquo;t cut&nbsp;it.
+        </H2>
+        <P size="lg" className="max-w-3xl text-muted-foreground">
+          Your operators build fast. Your data stays locked down. Dust&rsquo;s
+          dual-layer permission model separates what agents can access from who
+          can use them, with SCIM-synced groups, admin-gated overrides, and zero
+          privilege escalation.
+        </P>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+        {COLUMNS.map((col) => (
+          <FeatureColumn key={col.title} {...col} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/front/components/home/content/V2/HeroSection.tsx
+++ b/front/components/home/content/V2/HeroSection.tsx
@@ -1,0 +1,38 @@
+import { H1, P } from "@app/components/home/ContentComponents";
+import { Button } from "@dust-tt/sparkle";
+import Link from "next/link";
+
+export function HeroSection() {
+  return (
+    <div className="w-full pt-12 sm:pt-18 lg:pt-36">
+      <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 px-4 text-center">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-highlight">
+          The Platform for AI Operators
+        </p>
+        <H1
+          mono
+          className="text-center text-5xl font-medium md:text-6xl lg:text-7xl"
+        >
+          AI for the people
+          <br />
+          who run the&nbsp;work.
+        </H1>
+        <P size="lg" className="max-w-2xl text-base text-muted-foreground">
+          Turn scattered knowledge and tools into coordinated execution with AI
+          agents that fast-moving teams build, own, and run themselves.
+        </P>
+        <div className="mt-4 flex flex-col items-center gap-4 sm:flex-row">
+          <Link href="https://dust.tt/home/signup">
+            <Button label="Try Dust" variant="highlight" size="md" />
+          </Link>
+          <Link
+            href="/home/product"
+            className="font-medium text-highlight hover:underline"
+          >
+            See how it works &rarr;
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/components/home/content/V2/HowAgentsWorkSection.tsx
+++ b/front/components/home/content/V2/HowAgentsWorkSection.tsx
@@ -1,0 +1,112 @@
+import { H2, P } from "@app/components/home/ContentComponents";
+
+const ACTIVITY_STEPS = [
+  {
+    color: "bg-blue-400",
+    title: "Zendesk ticket received",
+    detail: "Customer: Acme Corp · Priority: High",
+    pulse: true,
+  },
+  {
+    color: "bg-amber-400",
+    title: "Agent classifies & drafts response",
+    detail: "Category: Billing · Sentiment: Frustrated",
+    pulse: true,
+  },
+  {
+    color: "bg-emerald-400",
+    title: "CRM updated automatically",
+    detail: "Salesforce · Contact record synced",
+    pulse: true,
+  },
+  {
+    color: "bg-emerald-600",
+    title: "Reply sent to customer",
+    detail: "Via Zendesk · Resolution time: 2m 14s",
+    pulse: false,
+  },
+];
+
+export function HowAgentsWorkSection() {
+  return (
+    <section className="py-16 lg:py-24">
+      <div className="rounded-3xl bg-amber-50/50 p-8 md:p-12 lg:p-16">
+        <p className="mb-4 text-xs font-semibold uppercase tracking-[0.15em] text-amber-700">
+          ✦ How Dust Agents Work
+        </p>
+        <div className="grid grid-cols-1 gap-12 lg:grid-cols-2 lg:gap-16">
+          <div className="flex flex-col gap-8">
+            <div>
+              <H2 mono className="mb-6 text-left">
+                Turn scattered knowledge and tools into coordinated execution.
+              </H2>
+              <P size="lg" className="text-muted-foreground">
+                Your team runs on dozens of tools and knowledge sources operating
+                in isolation. Dust connects across all of them, pulling the right
+                context from the right source and taking action in the right
+                place, at the right time. Not a chatbot sitting on top of your
+                stack — a coordination layer running through it.
+              </P>
+            </div>
+
+            <div className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+              <p className="mb-4 italic leading-relaxed text-muted-foreground">
+                &ldquo;Dust is the most impactful software we&rsquo;ve adopted
+                since building Clay. It delivers immediate value while
+                continuously getting smarter and more valuable over time.&rdquo;
+              </p>
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-sm font-bold text-emerald-700">
+                  EB
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-foreground">
+                    Everett Berry
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Head of GTM Engineering at Clay
+                  </p>
+                </div>
+                <div className="ml-auto flex gap-2">
+                  <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700">
+                    100% adoption
+                  </span>
+                  <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700">
+                    58h saved/mo
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-start justify-center">
+            <div className="w-full max-w-md rounded-2xl border border-border bg-white shadow-sm">
+              <div className="border-b border-border/50 px-6 py-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Live Agent Activity
+                </p>
+              </div>
+              <div className="flex flex-col gap-4 p-6">
+                {ACTIVITY_STEPS.map((step, i) => (
+                  <div key={i} className="flex items-start gap-3">
+                    <div
+                      className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${step.color} ${step.pulse ? "animate-pulse" : ""}`}
+                    />
+                    <div>
+                      <p className="text-sm font-medium text-foreground">
+                        {step.title}
+                      </p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        {step.detail}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/front/components/home/content/V2/SocialProofBar.tsx
+++ b/front/components/home/content/V2/SocialProofBar.tsx
@@ -1,0 +1,79 @@
+import Image from "next/image";
+
+const LOGOS = [
+  { src: "/static/landing/logos/gray/clay.svg", alt: "Clay", height: 24 },
+  { src: "/static/landing/logos/gray/cursor.svg", alt: "Cursor", height: 24 },
+  {
+    src: "/static/landing/logos/gray/watershed.svg",
+    alt: "Watershed",
+    height: 20,
+  },
+  {
+    src: "/static/landing/logos/gray/persona.svg",
+    alt: "Persona",
+    height: 20,
+  },
+  { src: "/static/landing/logos/gray/qonto.svg", alt: "Qonto", height: 24 },
+  { src: "/static/landing/logos/gray/mirakl.svg", alt: "Mirakl", height: 20 },
+  {
+    src: "/static/landing/logos/gray/spendesk.svg",
+    alt: "Spendesk",
+    height: 20,
+  },
+  {
+    src: "/static/landing/logos/gray/1password.svg",
+    alt: "1Password",
+    height: 24,
+  },
+];
+
+const STATS = [
+  { value: "300,000+", label: "agents deployed" },
+  { value: "12M", label: "conversations" },
+  { value: "70%", label: "weekly active users" },
+];
+
+export function SocialProofBar() {
+  return (
+    <section className="py-12 lg:py-16">
+      <div className="mb-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          Trusted among AI operators at{" "}
+          <span className="font-semibold text-foreground">5,000+</span> global
+          organizations
+        </p>
+      </div>
+
+      <div className="mb-10 flex flex-wrap items-center justify-center gap-x-8 gap-y-4 opacity-60">
+        {LOGOS.map((logo) => (
+          <Image
+            key={logo.alt}
+            src={logo.src}
+            alt={logo.alt}
+            width={logo.height * 4}
+            height={logo.height}
+            className="object-contain"
+            style={{ height: logo.height }}
+          />
+        ))}
+        <span className="text-sm font-semibold tracking-wide text-muted-foreground">
+          Datadog
+        </span>
+        <span className="text-sm font-semibold tracking-wide text-muted-foreground">
+          Criteo
+        </span>
+      </div>
+
+      <div className="mx-auto grid max-w-2xl grid-cols-3 gap-8 text-center">
+        {STATS.map((stat) => (
+          <div key={stat.label}>
+            <p className="font-objektiv text-3xl font-bold text-highlight md:text-4xl">
+              {stat.value}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">{stat.label}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/front/components/home/content/V2/TeamUseCasesSection.tsx
+++ b/front/components/home/content/V2/TeamUseCasesSection.tsx
@@ -1,0 +1,196 @@
+import { H2 } from "@app/components/home/ContentComponents";
+import { classNames } from "@app/lib/utils";
+import { useState } from "react";
+
+interface UseCase {
+  title: string;
+  description: string;
+}
+
+interface Tab {
+  id: string;
+  label: string;
+  useCases: UseCase[];
+}
+
+const TABS: Tab[] = [
+  {
+    id: "engineering",
+    label: "Engineering",
+    useCases: [
+      {
+        title: "Incident response",
+        description:
+          "Agents pull context from PagerDuty, Datadog, and Slack to auto-triage incidents, draft runbooks, and coordinate across teams.",
+      },
+      {
+        title: "Code review & debugging",
+        description:
+          "Agents review PRs against your team's standards, flag security issues, and suggest fixes grounded in your codebase context.",
+      },
+      {
+        title: "Documentation",
+        description:
+          "Auto-generate and update technical docs, API references, and architecture decision records from code changes.",
+      },
+      {
+        title: "Knowledge retrieval",
+        description:
+          "Search across Confluence, Notion, GitHub, and Slack to find answers instantly instead of interrupting senior engineers.",
+      },
+    ],
+  },
+  {
+    id: "support",
+    label: "Customer Support",
+    useCases: [
+      {
+        title: "Ticket classification & routing",
+        description:
+          "Automatically categorize, prioritize, and route support tickets to the right team with full context attached.",
+      },
+      {
+        title: "Response drafting",
+        description:
+          "Generate accurate, on-brand responses grounded in your knowledge base. Agents learn your tone and escalation patterns.",
+      },
+      {
+        title: "Trend analysis",
+        description:
+          "Identify recurring issues, extract actionable insights from ticket patterns, and flag product bugs automatically.",
+      },
+      {
+        title: "Quality assurance",
+        description:
+          "Review agent-drafted responses for accuracy and compliance before they reach customers. Maintain consistency at scale.",
+      },
+    ],
+  },
+  {
+    id: "sales",
+    label: "Sales",
+    useCases: [
+      {
+        title: "Prospect research",
+        description:
+          "Automatically compile company profiles, key contacts, and competitive intelligence before every meeting.",
+      },
+      {
+        title: "RFP & proposal generation",
+        description:
+          "Draft responses grounded in past wins, product docs, and pricing. Cut RFP turnaround from days to hours.",
+      },
+      {
+        title: "Deal summaries",
+        description:
+          "Generate pipeline reviews, QBR prep, and deal updates automatically from CRM data and call transcripts.",
+      },
+      {
+        title: "Competitive intelligence",
+        description:
+          "Track competitor moves, build battlecards, and surface relevant context during live sales conversations.",
+      },
+    ],
+  },
+  {
+    id: "marketing",
+    label: "Marketing & Content",
+    useCases: [
+      {
+        title: "Brand content creation",
+        description:
+          "Generate on-brand copy, blog drafts, and social content grounded in your style guide and past campaigns.",
+      },
+      {
+        title: "Localization & translation",
+        description:
+          "Translate and adapt content across languages while maintaining brand voice, terminology, and regional nuance.",
+      },
+      {
+        title: "Campaign analysis",
+        description:
+          "Pull data from HubSpot, Google Analytics, and LinkedIn to generate performance reports and optimization recommendations.",
+      },
+      {
+        title: "Customer feedback synthesis",
+        description:
+          "Extract actionable insights from reviews, NPS surveys, and support conversations to inform messaging strategy.",
+      },
+    ],
+  },
+  {
+    id: "data",
+    label: "Data & Analytics",
+    useCases: [
+      {
+        title: "Data querying & exploration",
+        description:
+          "Ask questions in natural language and get SQL queries, visualizations, and insights from your data warehouse.",
+      },
+      {
+        title: "Automated reporting",
+        description:
+          "Generate recurring reports, dashboards, and executive summaries from live data sources on schedule.",
+      },
+      {
+        title: "Anomaly detection",
+        description:
+          "Monitor metrics across systems and alert teams when patterns deviate from expected behavior.",
+      },
+      {
+        title: "Cross-system analysis",
+        description:
+          "Connect data from Salesforce, Stripe, Mixpanel, and more to answer questions that span multiple systems.",
+      },
+    ],
+  },
+];
+
+export function TeamUseCasesSection() {
+  const [activeTab, setActiveTab] = useState("engineering");
+  const activeContent = TABS.find((t) => t.id === activeTab);
+
+  return (
+    <section className="py-16 lg:py-24">
+      <p className="mb-4 text-xs font-semibold uppercase tracking-[0.15em] text-highlight">
+        💼 How Every Team Uses Dust
+      </p>
+      <H2 mono className="mb-10 text-left">
+        One platform, every team, compounding&nbsp;value.
+      </H2>
+
+      <div className="mb-8 flex gap-1 overflow-x-auto border-b border-border">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={classNames(
+              "whitespace-nowrap px-4 py-3 text-sm transition",
+              activeTab === tab.id
+                ? "border-b-2 border-highlight font-semibold text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {activeContent && (
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+          {activeContent.useCases.map((uc) => (
+            <div
+              key={uc.title}
+              className="rounded-2xl border border-border bg-white p-6 shadow-sm"
+            >
+              <h4 className="mb-3 font-semibold text-foreground">{uc.title}</h4>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {uc.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/front/components/home/content/V2/TestimonialsSection.tsx
+++ b/front/components/home/content/V2/TestimonialsSection.tsx
@@ -1,0 +1,148 @@
+import { H2 } from "@app/components/home/ContentComponents";
+import { Button } from "@dust-tt/sparkle";
+import Image from "next/image";
+import Link from "next/link";
+
+interface StatCardProps {
+  logo: string;
+  logoAlt: string;
+  value: string;
+  label: string;
+}
+
+function StatCard({ logo, logoAlt, value, label }: StatCardProps) {
+  return (
+    <div className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+      <Image
+        src={logo}
+        alt={logoAlt}
+        width={96}
+        height={24}
+        className="mb-4 opacity-70"
+        style={{ height: 24 }}
+      />
+      <p className="mb-1 font-objektiv text-4xl font-bold text-highlight">
+        {value}
+      </p>
+      <p className="text-sm text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+const STATS: StatCardProps[] = [
+  {
+    logo: "/static/landing/logos/color/malt.png",
+    logoAlt: "Malt",
+    value: "100%",
+    label: "of CX team uses Dust daily",
+  },
+  {
+    logo: "/static/landing/logos/color/doctolib.png",
+    logoAlt: "Doctolib",
+    value: "95%",
+    label: "adoption across 3,000 employees",
+  },
+  {
+    logo: "/static/landing/logos/color/qonto.png",
+    logoAlt: "Qonto",
+    value: "x4",
+    label: "support tickets cut · +50k hours saved/year",
+  },
+  {
+    logo: "/static/landing/logos/color/fleet.png",
+    logoAlt: "Fleet",
+    value: "70%",
+    label: "reduction in translation bottleneck",
+  },
+];
+
+const TRUST_LOGOS = [
+  { src: "/static/landing/logos/gray/vanta.svg", alt: "Vanta" },
+  { src: "/static/landing/logos/gray/assembled.svg", alt: "Assembled" },
+  { src: "/static/landing/logos/gray/clay.svg", alt: "Clay" },
+  { src: "/static/landing/logos/gray/cursor.svg", alt: "Cursor" },
+  { src: "/static/landing/logos/gray/doctolib.svg", alt: "Doctolib" },
+  { src: "/static/landing/logos/gray/mirakl.svg", alt: "Mirakl" },
+  { src: "/static/landing/logos/gray/qonto.svg", alt: "Qonto" },
+  { src: "/static/landing/logos/gray/persona.svg", alt: "Persona" },
+  { src: "/static/landing/logos/gray/spendesk.svg", alt: "Spendesk" },
+  { src: "/static/landing/logos/gray/1password.svg", alt: "1Password" },
+  { src: "/static/landing/logos/gray/fleet.svg", alt: "Fleet" },
+  { src: "/static/landing/logos/gray/watershed.svg", alt: "Watershed" },
+];
+
+export function TestimonialsSection() {
+  return (
+    <section className="py-16 lg:py-24">
+      <p className="mb-4 text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+        📊 Don&rsquo;t Take Our Word for It
+      </p>
+      <H2 mono className="mb-10 text-left">
+        The numbers speak for themselves.
+      </H2>
+
+      <div className="mb-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {STATS.map((stat) => (
+          <StatCard key={stat.logoAlt} {...stat} />
+        ))}
+
+        {/* Clay quote card */}
+        <div className="rounded-2xl border border-border bg-white p-6 shadow-sm sm:col-span-2">
+          <Image
+            src="/static/landing/logos/color/clay.png"
+            alt="Clay"
+            width={96}
+            height={24}
+            className="mb-4 opacity-70"
+            style={{ height: 24 }}
+          />
+          <p className="italic leading-relaxed text-muted-foreground">
+            &ldquo;Dust is the most impactful software we&rsquo;ve adopted since
+            building Clay.&rdquo;
+          </p>
+        </div>
+
+        {/* PayFit */}
+        <StatCard
+          logo="/static/landing/logos/color/payfit.png"
+          logoAlt="PayFit"
+          value="50%"
+          label="faster legal task completion"
+        />
+
+        {/* Alan */}
+        <StatCard
+          logo="/static/landing/logos/color/alan.png"
+          logoAlt="Alan"
+          value="84%"
+          label="weekly active users"
+        />
+      </div>
+
+      {/* Trust bar */}
+      <div className="text-center">
+        <p className="mb-6 text-sm text-muted-foreground">
+          Trusted by{" "}
+          <span className="font-semibold text-foreground">5,000+</span>{" "}
+          organizations
+        </p>
+        <div className="mb-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-3 opacity-50">
+          {TRUST_LOGOS.map((logo) => (
+            <Image
+              key={logo.alt}
+              src={logo.src}
+              alt={logo.alt}
+              width={80}
+              height={20}
+              className="object-contain"
+              style={{ height: 20 }}
+            />
+          ))}
+        </div>
+        <Link href="https://dust.tt/home/signup">
+          <Button label="Join them" variant="highlight" size="md" />
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/front/pages/home/v2.tsx
+++ b/front/pages/home/v2.tsx
@@ -1,0 +1,55 @@
+import { AgentsImproveSection } from "@app/components/home/content/V2/AgentsImproveSection";
+import { ClosingCtaSection } from "@app/components/home/content/V2/ClosingCtaSection";
+import { CollaborationSection } from "@app/components/home/content/V2/CollaborationSection";
+import { EnterpriseSection } from "@app/components/home/content/V2/EnterpriseSection";
+import { HeroSection } from "@app/components/home/content/V2/HeroSection";
+import { HowAgentsWorkSection } from "@app/components/home/content/V2/HowAgentsWorkSection";
+import { SocialProofBar } from "@app/components/home/content/V2/SocialProofBar";
+import { TeamUseCasesSection } from "@app/components/home/content/V2/TeamUseCasesSection";
+import { TestimonialsSection } from "@app/components/home/content/V2/TestimonialsSection";
+import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
+import LandingLayout from "@app/components/home/LandingLayout";
+import { PageMetadata } from "@app/components/home/PageMetadata";
+import { useRouter } from "next/router";
+import type { ReactElement } from "react";
+
+export async function getStaticProps() {
+  return {
+    props: {
+      shape: 0,
+      gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+    },
+  };
+}
+
+export function HomeV2() {
+  const router = useRouter();
+
+  return (
+    <>
+      <PageMetadata
+        title="Dust — AI for the People Who Run the Work"
+        description="Turn scattered knowledge and tools into coordinated execution with AI agents that fast-moving teams build, own, and run themselves."
+        pathname={router.asPath}
+      />
+      <HeroSection />
+      <SocialProofBar />
+      <HowAgentsWorkSection />
+      <CollaborationSection />
+      <AgentsImproveSection />
+      <EnterpriseSection />
+      <TeamUseCasesSection />
+      <TestimonialsSection />
+      <ClosingCtaSection />
+    </>
+  );
+}
+
+// biome-ignore lint/plugin/nextjsPageComponentNaming: v2 homepage
+export default function Home() {
+  return <HomeV2 />;
+}
+
+Home.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {
+  return <LandingLayout pageProps={pageProps}>{page}</LandingLayout>;
+};

--- a/front/preview/index.html
+++ b/front/preview/index.html
@@ -1,0 +1,1015 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dust Homepage V2 — Series B Preview</title>
+  <link rel="stylesheet" href="https://use.typekit.net/lzv1deb.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['darkmode-off-cc', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono: ['darkmode-on-cc', 'ui-monospace', 'monospace'],
+          },
+        },
+      },
+    }
+  </script>
+  <style>
+    /* Smooth scroll */
+    html { scroll-behavior: smooth; }
+
+    /* Animated gradient for the Live Agent Activity card */
+    @keyframes pulse-dot {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.4; }
+    }
+    .pulse-dot { animation: pulse-dot 2s ease-in-out infinite; }
+
+    /* Tab active state */
+    .tab-active {
+      border-bottom: 2px solid #059669;
+      color: #1c1917;
+      font-weight: 600;
+    }
+
+    /* === COLLABORATION SECTION ANIMATIONS === */
+
+    /* Cursor movement paths — each cursor traces a unique path across the canvas */
+    @keyframes cursor-sarah {
+      0%   { transform: translate(0, 0); }
+      15%  { transform: translate(40px, 20px); }
+      30%  { transform: translate(10px, 60px); }
+      50%  { transform: translate(60px, 30px); }
+      70%  { transform: translate(20px, -10px); }
+      85%  { transform: translate(50px, 50px); }
+      100% { transform: translate(0, 0); }
+    }
+    @keyframes cursor-marcus {
+      0%   { transform: translate(0, 0); }
+      20%  { transform: translate(-30px, 40px); }
+      40%  { transform: translate(20px, 80px); }
+      60%  { transform: translate(-10px, 20px); }
+      80%  { transform: translate(30px, 60px); }
+      100% { transform: translate(0, 0); }
+    }
+    @keyframes cursor-priya {
+      0%   { transform: translate(0, 0); }
+      25%  { transform: translate(-20px, -15px); }
+      50%  { transform: translate(15px, 25px); }
+      75%  { transform: translate(-30px, 10px); }
+      100% { transform: translate(0, 0); }
+    }
+    .cursor-sarah { animation: cursor-sarah 12s ease-in-out infinite; }
+    .cursor-marcus { animation: cursor-marcus 10s ease-in-out infinite; }
+    .cursor-priya { animation: cursor-priya 14s ease-in-out infinite; }
+
+    /* Messages fade in sequentially with staggered delays */
+    .collab-msg {
+      opacity: 0;
+      transform: translateY(12px);
+      animation: msg-appear 0.6s ease-out forwards;
+    }
+    @keyframes msg-appear {
+      to { opacity: 1; transform: translateY(0); }
+    }
+    .collab-msg:nth-child(1) { animation-delay: 0.3s; }
+    .collab-msg:nth-child(2) { animation-delay: 1.8s; }
+    .collab-msg:nth-child(3) { animation-delay: 3.5s; }
+    .collab-msg:nth-child(4) { animation-delay: 5.5s; }
+
+    /* Typing indicator dots */
+    @keyframes typing-bounce {
+      0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+      30% { transform: translateY(-4px); opacity: 1; }
+    }
+    .typing-dot {
+      display: inline-block;
+      width: 4px; height: 4px;
+      border-radius: 50%;
+      background: #94a3b8;
+      animation: typing-bounce 1.4s ease-in-out infinite;
+    }
+    .typing-dot:nth-child(2) { animation-delay: 0.15s; }
+    .typing-dot:nth-child(3) { animation-delay: 0.3s; }
+
+    /* Typing indicator container — appears between messages then fades */
+    .typing-indicator-1 {
+      animation: typing-show 1.5s ease-in-out 1.0s forwards;
+      opacity: 0;
+    }
+    .typing-indicator-2 {
+      animation: typing-show 2s ease-in-out 2.8s forwards;
+      opacity: 0;
+    }
+    .typing-indicator-3 {
+      animation: typing-show 2s ease-in-out 4.5s forwards;
+      opacity: 0;
+    }
+    @keyframes typing-show {
+      0%   { opacity: 0; }
+      15%  { opacity: 1; }
+      85%  { opacity: 1; }
+      100% { opacity: 0; }
+    }
+
+    /* Agent work progress animation — checkmarks appear one by one */
+    .agent-line {
+      opacity: 0;
+      animation: line-appear 0.4s ease-out forwards;
+    }
+    .agent-line:nth-child(1) { animation-delay: 3.8s; }
+    .agent-line:nth-child(2) { animation-delay: 4.3s; }
+    .agent-line:nth-child(3) { animation-delay: 4.8s; }
+    .agent-line-2:nth-child(1) { animation-delay: 5.8s; }
+    .agent-line-2:nth-child(2) { animation-delay: 6.3s; }
+    .agent-line-2:nth-child(3) { animation-delay: 6.8s; }
+    @keyframes line-appear {
+      from { opacity: 0; transform: translateX(-8px); }
+      to   { opacity: 1; transform: translateX(0); }
+    }
+
+    /* Handoff arrow pulse between agents */
+    @keyframes handoff-pulse {
+      0%, 100% { opacity: 0.3; transform: scale(1); }
+      50% { opacity: 1; transform: scale(1.15); }
+    }
+    .handoff-pulse { animation: handoff-pulse 2s ease-in-out infinite 4.6s; }
+
+    /* Live dot pulse */
+    @keyframes live-ping {
+      0%   { transform: scale(1); opacity: 1; }
+      75%  { transform: scale(2.5); opacity: 0; }
+      100% { transform: scale(2.5); opacity: 0; }
+    }
+    .live-ping::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: 50%;
+      background: #34d399;
+      animation: live-ping 2s ease-out infinite;
+    }
+
+    /* Replay loop — whole conversation fades out and restarts */
+    .collab-canvas-inner {
+      animation: canvas-loop 16s ease-in-out infinite;
+    }
+    @keyframes canvas-loop {
+      0%   { opacity: 0; }
+      4%   { opacity: 1; }
+      85%  { opacity: 1; }
+      95%  { opacity: 0; }
+      100% { opacity: 0; }
+    }
+  </style>
+</head>
+<body class="bg-[#FAFAF8] text-stone-900 font-sans antialiased">
+
+  <!-- ============================================ -->
+  <!-- HEADER / NAVIGATION                          -->
+  <!-- ============================================ -->
+  <header class="fixed top-0 w-full z-50 bg-white/80 backdrop-blur-lg border-b border-stone-200">
+    <div class="max-w-7xl mx-auto px-6 lg:px-8 flex items-center justify-between h-16">
+      <!-- Logo -->
+      <div class="flex items-center gap-8">
+        <a href="#" class="flex items-center gap-2">
+          <svg width="80" height="24" viewBox="0 0 80 24" fill="none">
+            <text x="0" y="18" font-family="darkmode-on-cc, monospace" font-size="20" font-weight="700" fill="#1c1917">Dust</text>
+          </svg>
+        </a>
+        <nav class="hidden md:flex items-center gap-6 text-sm text-stone-600">
+          <a href="#" class="hover:text-stone-900 transition">Product</a>
+          <a href="#" class="hover:text-stone-900 transition">Solutions</a>
+          <a href="#" class="hover:text-stone-900 transition">Resources</a>
+          <a href="#" class="hover:text-stone-900 transition">Trust</a>
+          <a href="#" class="hover:text-stone-900 transition">Pricing</a>
+        </nav>
+      </div>
+      <div class="flex items-center gap-3">
+        <a href="#" class="hidden sm:inline text-sm text-stone-600 hover:text-stone-900 transition">Sign in</a>
+        <a href="#" class="inline-flex items-center px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium rounded-full transition">
+          Get started
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main class="max-w-7xl mx-auto px-6 lg:px-8">
+
+    <!-- ============================================ -->
+    <!-- SECTION 1 — HERO                             -->
+    <!-- ============================================ -->
+    <section class="pt-32 pb-8 lg:pt-44 lg:pb-12">
+      <div class="max-w-4xl mx-auto text-center flex flex-col items-center gap-6">
+        <p class="text-xs font-semibold tracking-[0.2em] uppercase text-emerald-700">
+          The Platform for AI Operators
+        </p>
+        <h1 class="font-mono text-5xl md:text-6xl lg:text-7xl font-medium tracking-tight leading-[1.1]">
+          AI for the people<br>who run the&nbsp;work.
+        </h1>
+        <p class="text-lg md:text-xl text-stone-600 max-w-2xl leading-relaxed">
+          Turn scattered knowledge and tools into coordinated execution with AI agents that fast-moving teams build, own, and run themselves.
+        </p>
+        <div class="flex flex-col sm:flex-row items-center gap-4 mt-4">
+          <a href="#" class="inline-flex items-center px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-full transition text-base">
+            Try Dust
+            <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+          </a>
+          <a href="#" class="text-emerald-700 font-medium hover:underline underline-offset-4 transition">
+            See how it works &rarr;
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================ -->
+    <!-- SECTION 2 — SOCIAL PROOF BAR                 -->
+    <!-- ============================================ -->
+    <section class="py-12 lg:py-16">
+      <div class="text-center mb-8">
+        <p class="text-sm text-stone-500">
+          Trusted among AI operators at <span class="font-semibold text-stone-700">5,000+</span> global organizations
+        </p>
+      </div>
+
+      <!-- Logo row -->
+      <div class="flex flex-wrap justify-center items-center gap-x-8 gap-y-4 mb-10 opacity-60">
+        <img src="../public/static/landing/logos/gray/clay.svg" alt="Clay" class="h-6">
+        <img src="../public/static/landing/logos/gray/cursor.svg" alt="Cursor" class="h-6">
+        <img src="../public/static/landing/logos/gray/watershed.svg" alt="Watershed" class="h-5">
+        <img src="../public/static/landing/logos/gray/persona.svg" alt="Persona" class="h-5">
+        <img src="../public/static/landing/logos/gray/qonto.svg" alt="Qonto" class="h-6">
+        <img src="../public/static/landing/logos/gray/mirakl.svg" alt="Mirakl" class="h-5">
+        <img src="../public/static/landing/logos/gray/spendesk.svg" alt="Spendesk" class="h-5">
+        <img src="../public/static/landing/logos/gray/1password.svg" alt="1Password" class="h-6">
+        <!-- Datadog & Criteo — text placeholders since SVGs don't exist -->
+        <span class="text-stone-400 font-semibold text-sm tracking-wide">Datadog</span>
+        <span class="text-stone-400 font-semibold text-sm tracking-wide">Criteo</span>
+      </div>
+
+      <!-- Stats row -->
+      <div class="grid grid-cols-3 gap-8 max-w-2xl mx-auto text-center">
+        <div>
+          <p class="text-3xl md:text-4xl font-mono font-bold text-emerald-700">300,000+</p>
+          <p class="text-sm text-stone-500 mt-1">agents deployed</p>
+        </div>
+        <div>
+          <p class="text-3xl md:text-4xl font-mono font-bold text-emerald-700">12M</p>
+          <p class="text-sm text-stone-500 mt-1">conversations</p>
+        </div>
+        <div>
+          <p class="text-3xl md:text-4xl font-mono font-bold text-emerald-700">70%</p>
+          <p class="text-sm text-stone-500 mt-1">weekly active users</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================ -->
+    <!-- SECTION 3 — HOW DUST AGENTS WORK             -->
+    <!-- ============================================ -->
+    <section class="py-16 lg:py-24">
+      <div class="bg-[#FDF9F3] rounded-3xl p-8 md:p-12 lg:p-16">
+        <p class="text-xs font-semibold tracking-[0.15em] uppercase text-amber-700 mb-4">
+          &#10022; How Dust Agents Work
+        </p>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16">
+          <!-- Left: text + quote -->
+          <div class="flex flex-col gap-8">
+            <div>
+              <h2 class="font-mono text-3xl md:text-4xl lg:text-5xl font-medium tracking-tight leading-tight mb-6">
+                Turn scattered knowledge and tools into coordinated execution.
+              </h2>
+              <p class="text-stone-600 text-lg leading-relaxed">
+                Your team runs on dozens of tools and knowledge sources operating in isolation. Dust connects across all of them, pulling the right context from the right source and taking action in the right place, at the right time. Not a chatbot sitting on top of your stack &mdash; a coordination layer running through it.
+              </p>
+            </div>
+
+            <!-- Customer quote: Clay -->
+            <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+              <p class="text-stone-600 italic leading-relaxed mb-4">
+                &ldquo;Dust is the most impactful software we&rsquo;ve adopted since building Clay. It delivers immediate value while continuously getting smarter and more valuable over time.&rdquo;
+              </p>
+              <div class="flex items-center gap-3">
+                <div class="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center text-emerald-700 font-bold text-sm">EB</div>
+                <div>
+                  <p class="font-semibold text-stone-900 text-sm">Everett Berry</p>
+                  <p class="text-stone-500 text-xs">Head of GTM Engineering at Clay</p>
+                </div>
+                <div class="ml-auto flex gap-2">
+                  <span class="bg-emerald-50 text-emerald-700 text-xs font-medium rounded-full px-3 py-1">100% adoption</span>
+                  <span class="bg-emerald-50 text-emerald-700 text-xs font-medium rounded-full px-3 py-1">58h saved/mo</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Right: Live Agent Activity card -->
+          <div class="flex items-start justify-center">
+            <div class="bg-white rounded-2xl border border-stone-200 shadow-sm w-full max-w-md">
+              <div class="px-6 py-4 border-b border-stone-100">
+                <p class="text-xs font-semibold tracking-wide uppercase text-stone-400">Live Agent Activity</p>
+              </div>
+              <div class="p-6 flex flex-col gap-4">
+                <div class="flex items-start gap-3">
+                  <div class="w-2.5 h-2.5 rounded-full bg-blue-400 mt-1.5 shrink-0 pulse-dot"></div>
+                  <div>
+                    <p class="text-sm font-medium text-stone-900">Zendesk ticket received</p>
+                    <p class="text-xs text-stone-400 mt-0.5">Customer: Acme Corp &middot; Priority: High</p>
+                  </div>
+                </div>
+                <div class="flex items-start gap-3">
+                  <div class="w-2.5 h-2.5 rounded-full bg-amber-400 mt-1.5 shrink-0 pulse-dot" style="animation-delay: 0.3s"></div>
+                  <div>
+                    <p class="text-sm font-medium text-stone-900">Agent classifies &amp; drafts response</p>
+                    <p class="text-xs text-stone-400 mt-0.5">Category: Billing &middot; Sentiment: Frustrated</p>
+                  </div>
+                </div>
+                <div class="flex items-start gap-3">
+                  <div class="w-2.5 h-2.5 rounded-full bg-emerald-400 mt-1.5 shrink-0 pulse-dot" style="animation-delay: 0.6s"></div>
+                  <div>
+                    <p class="text-sm font-medium text-stone-900">CRM updated automatically</p>
+                    <p class="text-xs text-stone-400 mt-0.5">Salesforce &middot; Contact record synced</p>
+                  </div>
+                </div>
+                <div class="flex items-start gap-3">
+                  <div class="w-2.5 h-2.5 rounded-full bg-emerald-600 mt-1.5 shrink-0"></div>
+                  <div>
+                    <p class="text-sm font-medium text-stone-900">Reply sent to customer</p>
+                    <p class="text-xs text-stone-400 mt-0.5">Via Zendesk &middot; Resolution time: 2m 14s</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================ -->
+    <!-- SECTION 4 — HOW YOUR TEAM COLLABORATES       -->
+    <!-- ============================================ -->
+    <section class="py-16 lg:py-24">
+      <div class="bg-[#F5F7FA] rounded-3xl p-8 md:p-12 lg:p-16">
+        <p class="text-xs font-semibold tracking-[0.15em] uppercase text-blue-700 mb-4">
+          &#128101; How Your Team Collaborates with Dust
+        </p>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16">
+          <!-- Left: Collaboration visual — animated live workspace canvas -->
+          <div class="flex items-center justify-center">
+            <div class="bg-white rounded-2xl border border-stone-200 shadow-lg w-full max-w-lg relative overflow-hidden" style="min-height: 540px;">
+
+              <!-- Canvas header with live indicator -->
+              <div class="px-6 py-3 border-b border-stone-100 flex items-center justify-between">
+                <div class="flex items-center gap-2.5">
+                  <div class="relative w-2 h-2">
+                    <div class="w-2 h-2 rounded-full bg-emerald-400 relative live-ping"></div>
+                  </div>
+                  <p class="text-xs font-semibold tracking-wide uppercase text-stone-400">Live &mdash; Q2 Deal Pipeline</p>
+                </div>
+                <div class="flex -space-x-1.5">
+                  <div class="w-5 h-5 rounded-full bg-blue-500 border-2 border-white text-[8px] text-white flex items-center justify-center font-bold">M</div>
+                  <div class="w-5 h-5 rounded-full bg-rose-500 border-2 border-white text-[8px] text-white flex items-center justify-center font-bold">S</div>
+                  <div class="w-5 h-5 rounded-full bg-amber-500 border-2 border-white text-[8px] text-white flex items-center justify-center font-bold">P</div>
+                  <div class="w-5 h-5 rounded-full bg-emerald-600 border-2 border-white flex items-center justify-center">
+                    <div class="flex gap-0.5"><div class="w-1 h-1 rounded-full bg-white"></div><div class="w-1 h-1 rounded-full bg-white"></div></div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Animated message feed -->
+              <div class="p-5 space-y-2.5 collab-canvas-inner relative">
+
+                <!-- MSG 1: HUMAN ↔ HUMAN — Sarah shares with Marcus -->
+                <div class="collab-msg relative bg-rose-50 rounded-xl p-3.5 border border-rose-100">
+                  <div class="flex items-start gap-3">
+                    <div class="w-7 h-7 rounded-full bg-rose-200 flex items-center justify-center text-rose-700 text-[10px] font-bold shrink-0">SA</div>
+                    <div>
+                      <p class="text-[10px] font-semibold text-rose-600 mb-0.5">Sarah &middot; Sales</p>
+                      <div class="text-xs text-stone-700 leading-relaxed">
+                        <span class="font-semibold text-blue-700">@Marcus</span> I built a Deal Prep agent that pulls from Salesforce + call transcripts. Try it on the Acme renewal &mdash; saved me 2h this week.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Typing indicator: Marcus is typing... -->
+                <div class="typing-indicator-1 flex items-center gap-2 px-4 py-2">
+                  <div class="w-5 h-5 rounded-full bg-blue-200 flex items-center justify-center text-blue-700 text-[8px] font-bold">MA</div>
+                  <div class="flex gap-1"><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div>
+                </div>
+
+                <!-- MSG 2: HUMAN ↔ AGENT — Marcus triggers agent -->
+                <div class="collab-msg relative bg-blue-50 rounded-xl p-3.5 border border-blue-100">
+                  <div class="flex items-start gap-3">
+                    <div class="w-7 h-7 rounded-full bg-blue-200 flex items-center justify-center text-blue-700 text-[10px] font-bold shrink-0">MA</div>
+                    <div>
+                      <p class="text-[10px] font-semibold text-blue-600 mb-0.5">Marcus &middot; RevOps</p>
+                      <div class="text-xs text-stone-700 leading-relaxed">
+                        <span class="font-semibold text-emerald-700">@Deal Prep Agent</span> Run full analysis on Acme Corp renewal &mdash; include competitor intel and expansion signals.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Typing indicator: Agent is working... -->
+                <div class="typing-indicator-2 flex items-center gap-2 px-4 py-2">
+                  <div class="w-5 h-5 rounded-lg bg-emerald-600 flex items-center justify-center"><div class="w-1.5 h-1.5 rounded-full bg-white"></div></div>
+                  <div class="flex gap-1"><span class="typing-dot" style="background:#059669"></span><span class="typing-dot" style="background:#059669"></span><span class="typing-dot" style="background:#059669"></span></div>
+                  <span class="text-[10px] text-stone-400">Querying 3 data sources&hellip;</span>
+                </div>
+
+                <!-- MSG 3: AGENT ↔ HUMAN — Deal Prep Agent responds -->
+                <div class="collab-msg relative bg-stone-50 rounded-xl p-3.5 border border-stone-200">
+                  <div class="flex items-start gap-3">
+                    <div class="w-7 h-7 rounded-lg bg-emerald-600 flex items-center justify-center text-white shrink-0"><div class="w-2 h-2 rounded-full bg-white"></div></div>
+                    <div class="flex-1">
+                      <p class="text-[10px] font-semibold text-emerald-700 mb-1.5">Deal Prep Agent</p>
+                      <div class="text-xs text-stone-700 leading-relaxed space-y-1.5">
+                        <p class="agent-line">&#10003; Pulled 14 Salesforce records + 3 Gong transcripts</p>
+                        <p class="agent-line">&#10003; Key risk: champion left in Q1. New contact identified.</p>
+                        <p class="agent-line handoff-pulse">&#9758; Handing off to <span class="font-semibold text-purple-700">@Competitive Intel Agent</span>&hellip;</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Typing indicator: Second agent activating... -->
+                <div class="typing-indicator-3 flex items-center gap-2 px-4 py-2">
+                  <div class="w-5 h-5 rounded-lg bg-purple-600 flex items-center justify-center"><div class="w-1.5 h-1.5 rounded-full bg-white"></div></div>
+                  <div class="flex gap-1"><span class="typing-dot" style="background:#7c3aed"></span><span class="typing-dot" style="background:#7c3aed"></span><span class="typing-dot" style="background:#7c3aed"></span></div>
+                  <span class="text-[10px] text-stone-400">Generating battlecard&hellip;</span>
+                </div>
+
+                <!-- MSG 4: AGENT ↔ AGENT — Competitive Intel Agent -->
+                <div class="collab-msg relative bg-purple-50 rounded-xl p-3.5 border border-purple-100">
+                  <div class="flex items-start gap-3">
+                    <div class="w-7 h-7 rounded-lg bg-purple-600 flex items-center justify-center text-white shrink-0"><div class="w-2 h-2 rounded-full bg-white"></div></div>
+                    <div class="flex-1">
+                      <p class="text-[10px] font-semibold text-purple-700 mb-1.5">Competitive Intel Agent</p>
+                      <div class="text-xs text-stone-700 leading-relaxed space-y-1.5">
+                        <p class="agent-line-2">&#10003; Battlecard generated: Acme vs. 3 competitors</p>
+                        <p class="agent-line-2">&#10003; Pricing intel updated from latest G2 reviews</p>
+                        <p class="agent-line-2">&#9758; Notifying <span class="font-semibold text-blue-700">@Marcus</span> and <span class="font-semibold text-rose-700">@Sarah</span> &mdash; ready for review</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Animated cursors moving across the canvas -->
+                <div class="absolute top-16 right-8 cursor-sarah pointer-events-none z-10">
+                  <div class="flex items-center gap-1 bg-rose-500 text-white text-[9px] font-semibold px-1.5 py-0.5 rounded-full shadow-lg">
+                    <svg class="w-2.5 h-2.5" viewBox="0 0 10 10"><polygon points="0,0 10,4 2,6" fill="white"/></svg>
+                    Sarah
+                  </div>
+                </div>
+                <div class="absolute top-32 left-6 cursor-marcus pointer-events-none z-10">
+                  <div class="flex items-center gap-1 bg-blue-500 text-white text-[9px] font-semibold px-1.5 py-0.5 rounded-full shadow-lg">
+                    <svg class="w-2.5 h-2.5" viewBox="0 0 10 10"><polygon points="0,0 10,4 2,6" fill="white"/></svg>
+                    Marcus
+                  </div>
+                </div>
+                <div class="absolute bottom-8 right-12 cursor-priya pointer-events-none z-10">
+                  <div class="flex items-center gap-1 bg-amber-500 text-white text-[9px] font-semibold px-1.5 py-0.5 rounded-full shadow-lg">
+                    <svg class="w-2.5 h-2.5" viewBox="0 0 10 10"><polygon points="0,0 10,4 2,6" fill="white"/></svg>
+                    Priya
+                  </div>
+                </div>
+
+              </div>
+
+              <!-- Bottom bar: interaction legend -->
+              <div class="px-5 py-2.5 border-t border-stone-100 flex items-center gap-5 text-[10px] text-stone-400">
+                <div class="flex items-center gap-1.5">
+                  <div class="flex -space-x-1"><div class="w-3 h-3 rounded-full bg-rose-300 border border-white"></div><div class="w-3 h-3 rounded-full bg-blue-300 border border-white"></div></div>
+                  Human &harr; Human
+                </div>
+                <div class="flex items-center gap-1.5">
+                  <div class="flex -space-x-1"><div class="w-3 h-3 rounded-full bg-blue-300 border border-white"></div><div class="w-3 h-3 rounded-lg bg-emerald-400 border border-white"></div></div>
+                  Human &harr; Agent
+                </div>
+                <div class="flex items-center gap-1.5">
+                  <div class="flex -space-x-1"><div class="w-3 h-3 rounded-lg bg-emerald-400 border border-white"></div><div class="w-3 h-3 rounded-lg bg-purple-400 border border-white"></div></div>
+                  Agent &harr; Agent
+                </div>
+              </div>
+
+            </div>
+          </div>
+
+          <!-- Right: text + quote -->
+          <div class="flex flex-col gap-8">
+            <div>
+              <h2 class="font-mono text-3xl md:text-4xl lg:text-5xl font-medium tracking-tight leading-tight mb-6">
+                Anyone can build sophisticated AI agents in minutes. The real power? Everyone else gets to use them.
+              </h2>
+              <p class="text-stone-600 text-lg leading-relaxed">
+                AI is a team sport. AI Operators build agents and skills that immediately benefit their entire team. Sales builds something useful, Support is already using it by Tuesday. With Projects, people, agents, and context come together in shared hubs where intelligence compounds. Not single-player productivity &mdash; multiplayer AI for the enterprise.
+              </p>
+            </div>
+
+            <!-- Customer quote: Assembled -->
+            <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+              <p class="text-stone-600 italic leading-relaxed mb-4">
+                &ldquo;We made a bet on Dust because we knew the team was exceptional. What we didn&rsquo;t expect was how quickly it would transform how we work. Dust became the connective tissue that amplifies what each team does best.&rdquo;
+              </p>
+              <div class="flex items-center gap-3">
+                <div class="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center text-blue-700 font-bold text-sm">RW</div>
+                <div>
+                  <p class="font-semibold text-stone-900 text-sm">Ryan Wang</p>
+                  <p class="text-stone-500 text-xs">CEO at Assembled</p>
+                </div>
+                <div class="ml-auto flex gap-2">
+                  <span class="bg-blue-50 text-blue-700 text-xs font-medium rounded-full px-3 py-1">95% adoption</span>
+                  <span class="bg-blue-50 text-blue-700 text-xs font-medium rounded-full px-3 py-1">120+ employees</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================ -->
+    <!-- SECTION 5 — HOW DUST AGENTS IMPROVE          -->
+    <!-- ============================================ -->
+    <section class="py-16 lg:py-24">
+      <div class="bg-[#F3F7F4] rounded-3xl p-8 md:p-12 lg:p-16">
+        <p class="text-xs font-semibold tracking-[0.15em] uppercase text-emerald-700 mb-4">
+          &#128260; How Dust Agents Improve with You
+        </p>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16">
+          <!-- Left: text + quote -->
+          <div class="flex flex-col gap-8">
+            <div>
+              <h2 class="font-mono text-3xl md:text-4xl lg:text-5xl font-medium tracking-tight leading-tight mb-6">
+                Agents that understand how you work and get smarter over&nbsp;time.
+              </h2>
+              <p class="text-stone-600 text-lg leading-relaxed">
+                Dust agents don&rsquo;t just search your data; your teams encode how you work in agents. With Skills and reinforcement capabilities, agents learn and evolve through repeated use. Best practices consolidate into shared skills, improvements spread to every agent automatically, and your fiftieth workflow is easier to build than your fifth.
+              </p>
+            </div>
+
+            <!-- Customer quote: Vanta -->
+            <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+              <p class="text-stone-600 italic leading-relaxed mb-4">
+                &ldquo;We used to do the work. Now we build the agents that do it.&rdquo;
+              </p>
+              <div class="flex items-center gap-3">
+                <div class="w-10 h-10 rounded-full bg-purple-100 flex items-center justify-center text-purple-700 font-bold text-sm">SK</div>
+                <div>
+                  <p class="font-semibold text-stone-900 text-sm">Shashank Khanna</p>
+                  <p class="text-stone-500 text-xs">Founder in Residence, GTM Innovation at Vanta</p>
+                </div>
+                <span class="ml-auto bg-purple-50 text-purple-700 text-xs font-medium rounded-full px-3 py-1">~400h saved/week</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Right: 2x2 grid of capability cards -->
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <!-- Card 1 -->
+            <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+              <div class="w-10 h-10 rounded-xl bg-amber-100 flex items-center justify-center text-lg mb-4">&#128218;</div>
+              <h4 class="font-semibold text-stone-900 mb-2">Knows your company</h4>
+              <p class="text-sm text-stone-500 leading-relaxed">Connects to all your tools and data sources. Context flows automatically.</p>
+            </div>
+            <!-- Card 2 -->
+            <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+              <div class="w-10 h-10 rounded-xl bg-blue-100 flex items-center justify-center text-lg mb-4">&#129309;</div>
+              <h4 class="font-semibold text-stone-900 mb-2">AI is a team sport</h4>
+              <p class="text-sm text-stone-500 leading-relaxed">Built for collaboration across departments. One builds, everyone benefits.</p>
+            </div>
+            <!-- Card 3 -->
+            <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+              <div class="w-10 h-10 rounded-xl bg-emerald-100 flex items-center justify-center text-lg mb-4">&#9889;</div>
+              <h4 class="font-semibold text-stone-900 mb-2">Always the best model</h4>
+              <p class="text-sm text-stone-500 leading-relaxed">Switch between OpenAI, Anthropic, Google, Mistral. Always use what&rsquo;s best.</p>
+            </div>
+            <!-- Card 4 -->
+            <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+              <div class="w-10 h-10 rounded-xl bg-rose-100 flex items-center justify-center text-lg mb-4">&#128200;</div>
+              <h4 class="font-semibold text-stone-900 mb-2">Compounds across the org</h4>
+              <p class="text-sm text-stone-500 leading-relaxed">Value grows with every team that joins. Skills spread, intelligence compounds.</p>
+            </div>
+
+            <!-- Connected Sources mini-card -->
+            <div class="sm:col-span-2 bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+              <p class="text-xs font-semibold tracking-wide uppercase text-stone-400 mb-4">Connected Sources</p>
+              <div class="grid grid-cols-3 gap-3">
+                <div class="flex items-center gap-2 bg-stone-50 rounded-lg px-3 py-2">
+                  <div class="w-2 h-2 rounded-full bg-emerald-400"></div>
+                  <span class="text-xs font-medium text-stone-700">Slack</span>
+                </div>
+                <div class="flex items-center gap-2 bg-stone-50 rounded-lg px-3 py-2">
+                  <div class="w-2 h-2 rounded-full bg-emerald-400"></div>
+                  <span class="text-xs font-medium text-stone-700">Salesforce</span>
+                </div>
+                <div class="flex items-center gap-2 bg-stone-50 rounded-lg px-3 py-2">
+                  <div class="w-2 h-2 rounded-full bg-emerald-400"></div>
+                  <span class="text-xs font-medium text-stone-700">Notion</span>
+                </div>
+                <div class="flex items-center gap-2 bg-stone-50 rounded-lg px-3 py-2">
+                  <div class="w-2 h-2 rounded-full bg-emerald-400"></div>
+                  <span class="text-xs font-medium text-stone-700">GitHub</span>
+                </div>
+                <div class="flex items-center gap-2 bg-stone-50 rounded-lg px-3 py-2">
+                  <div class="w-2 h-2 rounded-full bg-emerald-400"></div>
+                  <span class="text-xs font-medium text-stone-700">Zendesk</span>
+                </div>
+                <div class="flex items-center gap-2 bg-stone-50 rounded-lg px-3 py-2">
+                  <div class="w-2 h-2 rounded-full bg-emerald-400"></div>
+                  <span class="text-xs font-medium text-stone-700">Linear</span>
+                </div>
+              </div>
+              <div class="mt-4 bg-stone-50 rounded-lg px-3 py-2">
+                <p class="text-xs text-stone-400 mb-1">Agent Memory</p>
+                <p class="text-sm text-stone-700">Remembers context from <span class="font-semibold">847</span> past conversations</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================ -->
+    <!-- SECTION 6 — ENTERPRISE READY                 -->
+    <!-- ============================================ -->
+    <section class="py-16 lg:py-24">
+      <div class="mb-12">
+        <p class="text-xs font-semibold tracking-[0.15em] uppercase text-stone-500 mb-4">
+          &#128274; Enterprise Ready, Obviously
+        </p>
+        <h2 class="font-mono text-3xl md:text-4xl lg:text-5xl font-medium tracking-tight leading-tight mb-6 max-w-3xl">
+          When AI has access to your company&rsquo;s knowledge, &ldquo;mostly secure&rdquo; doesn&rsquo;t cut&nbsp;it.
+        </h2>
+        <p class="text-stone-600 text-lg leading-relaxed max-w-3xl">
+          Your operators build fast. Your data stays locked down. Dust&rsquo;s dual-layer permission model separates what agents can access from who can use them, with SCIM-synced groups, admin-gated overrides, and zero privilege escalation.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <!-- Security & Compliance -->
+        <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+          <div class="w-10 h-10 rounded-xl bg-rose-100 flex items-center justify-center text-lg mb-4">&#128737;</div>
+          <h3 class="font-semibold text-stone-900 text-lg mb-4">Security &amp; compliance</h3>
+          <ul class="space-y-2.5 text-sm text-stone-600">
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> SOC 2 Type II certified</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> GDPR compliant (EU data residency)</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> HIPAA-ready deployment</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> SSO (SAML, OIDC) + SCIM</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> Audit logs (365-day retention)</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> RBAC + dual-layer permissions</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> AES-256 at rest, TLS 1.3 in transit</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> Zero model training on your data</li>
+          </ul>
+        </div>
+
+        <!-- Performance & Scale -->
+        <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+          <div class="w-10 h-10 rounded-xl bg-amber-100 flex items-center justify-center text-lg mb-4">&#9889;</div>
+          <h3 class="font-semibold text-stone-900 text-lg mb-4">Performance &amp; scale</h3>
+          <ul class="space-y-2.5 text-sm text-stone-600">
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> 99.9% uptime SLA</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> Supports 10,000+ users per workspace</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> Concurrent agent execution</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> Sub-2s agent response time (p95)</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> CDN-backed global deployment</li>
+          </ul>
+        </div>
+
+        <!-- Integration Architecture -->
+        <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+          <div class="w-10 h-10 rounded-xl bg-blue-100 flex items-center justify-center text-lg mb-4">&#128279;</div>
+          <h3 class="font-semibold text-stone-900 text-lg mb-4">Integration architecture</h3>
+          <ul class="space-y-2.5 text-sm text-stone-600">
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> RESTful API for custom integrations</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> MCP for proprietary systems</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> Webhook support for event-driven workflows</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> OAuth2 for third-party permissions</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> Bi-directional sync (read + write)</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> Incremental data refresh</li>
+            <li class="flex items-start gap-2"><span class="text-emerald-500 mt-0.5">&#10003;</span> 100+ production connectors</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================ -->
+    <!-- SECTION 7 — HOW EVERY TEAM USES DUST         -->
+    <!-- ============================================ -->
+    <section class="py-16 lg:py-24">
+      <p class="text-xs font-semibold tracking-[0.15em] uppercase text-emerald-700 mb-4">
+        &#128188; How Every Team Uses Dust
+      </p>
+      <h2 class="font-mono text-3xl md:text-4xl lg:text-5xl font-medium tracking-tight leading-tight mb-10">
+        One platform, every team, compounding&nbsp;value.
+      </h2>
+
+      <!-- Tab bar -->
+      <div class="flex gap-1 border-b border-stone-200 mb-8 overflow-x-auto">
+        <button onclick="switchTab('engineering')" id="tab-engineering" class="px-4 py-3 text-sm whitespace-nowrap tab-active transition">Engineering</button>
+        <button onclick="switchTab('support')" id="tab-support" class="px-4 py-3 text-sm whitespace-nowrap text-stone-500 hover:text-stone-700 transition">Customer Support</button>
+        <button onclick="switchTab('sales')" id="tab-sales" class="px-4 py-3 text-sm whitespace-nowrap text-stone-500 hover:text-stone-700 transition">Sales</button>
+        <button onclick="switchTab('marketing')" id="tab-marketing" class="px-4 py-3 text-sm whitespace-nowrap text-stone-500 hover:text-stone-700 transition">Marketing &amp; Content</button>
+        <button onclick="switchTab('data')" id="tab-data" class="px-4 py-3 text-sm whitespace-nowrap text-stone-500 hover:text-stone-700 transition">Data &amp; Analytics</button>
+      </div>
+
+      <!-- Tab content -->
+      <div id="content-engineering" class="tab-content">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Incident response</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Agents pull context from PagerDuty, Datadog, and Slack to auto-triage incidents, draft runbooks, and coordinate across teams.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Code review &amp; debugging</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Agents review PRs against your team&rsquo;s standards, flag security issues, and suggest fixes grounded in your codebase context.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Documentation</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Auto-generate and update technical docs, API references, and architecture decision records from code changes.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Knowledge retrieval</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Search across Confluence, Notion, GitHub, and Slack to find answers instantly instead of interrupting senior engineers.</p>
+          </div>
+        </div>
+      </div>
+
+      <div id="content-support" class="tab-content hidden">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Ticket classification &amp; routing</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Automatically categorize, prioritize, and route support tickets to the right team with full context attached.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Response drafting</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Generate accurate, on-brand responses grounded in your knowledge base. Agents learn your tone and escalation patterns.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Trend analysis</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Identify recurring issues, extract actionable insights from ticket patterns, and flag product bugs automatically.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Quality assurance</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Review agent-drafted responses for accuracy and compliance before they reach customers. Maintain consistency at scale.</p>
+          </div>
+        </div>
+      </div>
+
+      <div id="content-sales" class="tab-content hidden">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Prospect research</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Automatically compile company profiles, key contacts, and competitive intelligence before every meeting.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">RFP &amp; proposal generation</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Draft responses grounded in past wins, product docs, and pricing. Cut RFP turnaround from days to hours.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Deal summaries</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Generate pipeline reviews, QBR prep, and deal updates automatically from CRM data and call transcripts.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Competitive intelligence</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Track competitor moves, build battlecards, and surface relevant context during live sales conversations.</p>
+          </div>
+        </div>
+      </div>
+
+      <div id="content-marketing" class="tab-content hidden">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Brand content creation</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Generate on-brand copy, blog drafts, and social content grounded in your style guide and past campaigns.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Localization &amp; translation</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Translate and adapt content across languages while maintaining brand voice, terminology, and regional nuance.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Campaign analysis</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Pull data from HubSpot, Google Analytics, and LinkedIn to generate performance reports and optimization recommendations.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Customer feedback synthesis</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Extract actionable insights from reviews, NPS surveys, and support conversations to inform messaging strategy.</p>
+          </div>
+        </div>
+      </div>
+
+      <div id="content-data" class="tab-content hidden">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Data querying &amp; exploration</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Ask questions in natural language and get SQL queries, visualizations, and insights from your data warehouse.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Automated reporting</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Generate recurring reports, dashboards, and executive summaries from live data sources on schedule.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Anomaly detection</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Monitor metrics across systems and alert teams when patterns deviate from expected behavior.</p>
+          </div>
+          <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+            <h4 class="font-semibold text-stone-900 mb-3">Cross-system analysis</h4>
+            <p class="text-sm text-stone-600 leading-relaxed">Connect data from Salesforce, Stripe, Mixpanel, and more to answer questions that span multiple systems.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================ -->
+    <!-- SECTION 8 — DON'T TAKE OUR WORD FOR IT       -->
+    <!-- ============================================ -->
+    <section class="py-16 lg:py-24">
+      <p class="text-xs font-semibold tracking-[0.15em] uppercase text-stone-500 mb-4">
+        &#128202; Don&rsquo;t Take Our Word for It
+      </p>
+      <h2 class="font-mono text-3xl md:text-4xl lg:text-5xl font-medium tracking-tight leading-tight mb-10">
+        The numbers speak for themselves.
+      </h2>
+
+      <!-- Stats grid -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-12">
+        <!-- Malt -->
+        <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+          <img src="../public/static/landing/logos/color/malt.png" alt="Malt" class="h-6 mb-4 opacity-70">
+          <p class="text-4xl font-mono font-bold text-emerald-700 mb-1">100%</p>
+          <p class="text-sm text-stone-500">of CX team uses Dust daily</p>
+        </div>
+
+        <!-- Doctolib -->
+        <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+          <img src="../public/static/landing/logos/color/doctolib.png" alt="Doctolib" class="h-6 mb-4 opacity-70">
+          <p class="text-4xl font-mono font-bold text-emerald-700 mb-1">95%</p>
+          <p class="text-sm text-stone-500">adoption across 3,000 employees</p>
+        </div>
+
+        <!-- Qonto -->
+        <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+          <img src="../public/static/landing/logos/color/qonto.png" alt="Qonto" class="h-6 mb-4 opacity-70">
+          <p class="text-4xl font-mono font-bold text-emerald-700 mb-1">x4</p>
+          <p class="text-sm text-stone-500">support tickets cut &middot; +50k hours saved/year</p>
+        </div>
+
+        <!-- Fleet -->
+        <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+          <img src="../public/static/landing/logos/color/fleet.png" alt="Fleet" class="h-6 mb-4 opacity-70">
+          <p class="text-4xl font-mono font-bold text-emerald-700 mb-1">70%</p>
+          <p class="text-sm text-stone-500">reduction in translation bottleneck</p>
+        </div>
+
+        <!-- Clay -->
+        <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm sm:col-span-2">
+          <img src="../public/static/landing/logos/color/clay.png" alt="Clay" class="h-6 mb-4 opacity-70">
+          <p class="text-stone-600 italic leading-relaxed">&ldquo;Dust is the most impactful software we&rsquo;ve adopted since building Clay.&rdquo;</p>
+        </div>
+
+        <!-- PayFit -->
+        <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+          <img src="../public/static/landing/logos/color/payfit.png" alt="PayFit" class="h-6 mb-4 opacity-70">
+          <p class="text-4xl font-mono font-bold text-emerald-700 mb-1">50%</p>
+          <p class="text-sm text-stone-500">faster legal task completion</p>
+        </div>
+
+        <!-- Alan -->
+        <div class="bg-white rounded-2xl border border-stone-200 p-6 shadow-sm">
+          <img src="../public/static/landing/logos/color/alan.png" alt="Alan" class="h-6 mb-4 opacity-70">
+          <p class="text-4xl font-mono font-bold text-emerald-700 mb-1">84%</p>
+          <p class="text-sm text-stone-500">weekly active users</p>
+        </div>
+      </div>
+
+      <!-- Trust bar -->
+      <div class="text-center">
+        <p class="text-sm text-stone-500 mb-6">
+          Trusted by <span class="font-semibold text-stone-700">5,000+</span> organizations
+        </p>
+        <div class="flex flex-wrap justify-center items-center gap-x-6 gap-y-3 mb-8 opacity-50">
+          <img src="../public/static/landing/logos/gray/vanta.svg" alt="Vanta" class="h-5">
+          <img src="../public/static/landing/logos/gray/assembled.svg" alt="Assembled" class="h-5">
+          <img src="../public/static/landing/logos/gray/clay.svg" alt="Clay" class="h-5">
+          <img src="../public/static/landing/logos/gray/cursor.svg" alt="Cursor" class="h-5">
+          <img src="../public/static/landing/logos/gray/doctolib.svg" alt="Doctolib" class="h-5">
+          <img src="../public/static/landing/logos/gray/mirakl.svg" alt="Mirakl" class="h-5">
+          <img src="../public/static/landing/logos/gray/qonto.svg" alt="Qonto" class="h-5">
+          <img src="../public/static/landing/logos/gray/persona.svg" alt="Persona" class="h-5">
+          <img src="../public/static/landing/logos/gray/spendesk.svg" alt="Spendesk" class="h-5">
+          <img src="../public/static/landing/logos/gray/1password.svg" alt="1Password" class="h-5">
+          <img src="../public/static/landing/logos/gray/fleet.svg" alt="Fleet" class="h-5">
+          <img src="../public/static/landing/logos/gray/watershed.svg" alt="Watershed" class="h-5">
+        </div>
+        <a href="#" class="inline-flex items-center px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-full transition">
+          Join them
+          <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+        </a>
+      </div>
+    </section>
+
+    <!-- ============================================ -->
+    <!-- SECTION 9 — CLOSING CTA                      -->
+    <!-- ============================================ -->
+    <section class="py-16 lg:py-24">
+      <div class="bg-emerald-950 rounded-3xl px-8 py-16 md:px-16 md:py-20 lg:px-24 lg:py-24 text-center">
+        <h2 class="font-mono text-3xl md:text-4xl lg:text-5xl font-medium tracking-tight leading-tight text-white mb-6 max-w-3xl mx-auto">
+          The best teams aren&rsquo;t just using&nbsp;AI &mdash; they&rsquo;re running&nbsp;it.
+        </h2>
+        <p class="text-emerald-200 text-lg leading-relaxed max-w-2xl mx-auto mb-8">
+          There&rsquo;s a new kind of person emerging in fast-moving companies &mdash; someone who doesn&rsquo;t wait for an AI tool to be handed to them. They build it, deploy it, and run it for their whole team. We call them AI operators.
+        </p>
+        <p class="text-emerald-300 text-base leading-relaxed max-w-2xl mx-auto mb-10">
+          At companies like Datadog, 1Password, Cursor, Vanta, Persona, Clay, and Qonto, thousands of AI operators have deployed over 300,000 agents. They&rsquo;ve rewired how their teams work, achieved 70% weekly active usage, and expanded every single renewal.
+        </p>
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a href="#" class="inline-flex items-center px-8 py-4 bg-emerald-500 hover:bg-emerald-400 text-white font-semibold rounded-full transition text-lg">
+            Become an AI operator
+            <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+          </a>
+        </div>
+        <p class="mt-6 text-emerald-400 text-sm">
+          We&rsquo;re hiring across engineering, marketing, sales, and customer success.
+          <a href="#" class="underline underline-offset-4 hover:text-emerald-200 transition">&rarr; dust.tt/jobs</a>
+        </p>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ============================================ -->
+  <!-- FOOTER                                       -->
+  <!-- ============================================ -->
+  <footer class="bg-stone-100 border-t border-stone-200 mt-8">
+    <div class="max-w-7xl mx-auto px-6 lg:px-8 py-12">
+      <div class="grid grid-cols-2 md:grid-cols-5 gap-8 text-sm">
+        <div>
+          <p class="font-semibold text-stone-900 mb-3">Product</p>
+          <ul class="space-y-2 text-stone-500">
+            <li><a href="#" class="hover:text-stone-700 transition">Product</a></li>
+            <li><a href="#" class="hover:text-stone-700 transition">Pricing</a></li>
+            <li><a href="#" class="hover:text-stone-700 transition">Security</a></li>
+          </ul>
+        </div>
+        <div>
+          <p class="font-semibold text-stone-900 mb-3">Solutions</p>
+          <ul class="space-y-2 text-stone-500">
+            <li><a href="#" class="hover:text-stone-700 transition">Customer Support</a></li>
+            <li><a href="#" class="hover:text-stone-700 transition">Engineering</a></li>
+            <li><a href="#" class="hover:text-stone-700 transition">Sales</a></li>
+            <li><a href="#" class="hover:text-stone-700 transition">Marketing</a></li>
+          </ul>
+        </div>
+        <div>
+          <p class="font-semibold text-stone-900 mb-3">Developers</p>
+          <ul class="space-y-2 text-stone-500">
+            <li><a href="#" class="hover:text-stone-700 transition">Platform Documentation</a></li>
+            <li><a href="#" class="hover:text-stone-700 transition">GitHub Repo</a></li>
+          </ul>
+        </div>
+        <div>
+          <p class="font-semibold text-stone-900 mb-3">Company</p>
+          <ul class="space-y-2 text-stone-500">
+            <li><a href="#" class="hover:text-stone-700 transition">Blog</a></li>
+            <li><a href="#" class="hover:text-stone-700 transition">Jobs</a></li>
+          </ul>
+        </div>
+        <div>
+          <p class="font-semibold text-stone-900 mb-3">Legal</p>
+          <ul class="space-y-2 text-stone-500">
+            <li><a href="#" class="hover:text-stone-700 transition">Terms &amp; Policies</a></li>
+            <li><a href="#" class="hover:text-stone-700 transition">Privacy Policy</a></li>
+            <li><a href="#" class="hover:text-stone-700 transition">Trust Center</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="mt-8 pt-8 border-t border-stone-200 text-sm text-stone-400">
+        &copy; 2026 Dust. All rights reserved.
+      </div>
+    </div>
+  </footer>
+
+  <!-- Tab switching script -->
+  <script>
+    function switchTab(tabName) {
+      // Hide all content
+      document.querySelectorAll('.tab-content').forEach(el => el.classList.add('hidden'));
+      // Show selected content
+      document.getElementById('content-' + tabName).classList.remove('hidden');
+      // Update tab styles
+      document.querySelectorAll('[id^="tab-"]').forEach(el => {
+        el.classList.remove('tab-active');
+        el.classList.add('text-stone-500');
+      });
+      document.getElementById('tab-' + tabName).classList.add('tab-active');
+      document.getElementById('tab-' + tabName).classList.remove('text-stone-500');
+    }
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New homepage at `/home/v2` with 9 sections centered on "AI operators" positioning for Series B announcement
- Includes Hero, Social Proof (logos + stats), How Agents Work, Collaboration visual (animated), Agents Improve, Enterprise Security, Team Use Cases (tabbed), Testimonials, and Closing CTA
- Standalone HTML preview at `front/preview/index.html` for design iteration

## Test plan
- [ ] Navigate to `/home/v2` and verify all 9 sections render
- [ ] Check responsive layout at mobile/tablet/desktop
- [ ] Verify animations in collaboration section
- [ ] Confirm existing pages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)