### PR TITLE
[front] fix(triggers): filter user-own triggers on agent duplication

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -263,6 +263,9 @@ export default function AgentBuilder({
     const currentValues = form.getValues();
 
     const defaultModel = getDefaultModel(availableModels);
+    const userOwnedTriggers = triggers.filter(
+      (trigger) => trigger.editor === user.id
+    );
 
     form.reset({
       ...currentValues,
@@ -270,14 +273,14 @@ export default function AgentBuilder({
       skills: processedSkills,
       additionalSpaces: computedAdditionalSpaces,
       triggersToCreate: duplicateAgentId
-        ? triggers.map((trigger) => ({
-            ...trigger,
-            editor: user.id,
-          }))
+        ? userOwnedTriggers.map((trigger) => ({
+              ...trigger,
+              editor: user.id,
+            }))
         : [],
       triggersToUpdate: duplicateAgentId
         ? []
-        : triggers.filter((t) => t.editor === user.id),
+        : userOwnedTriggers,
       triggersToDelete: [],
       agentSettings: {
         ...currentValues.agentSettings,

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -272,9 +272,7 @@ export default function AgentBuilder({
       actions: processedActions,
       skills: processedSkills,
       additionalSpaces: computedAdditionalSpaces,
-      triggersToCreate: duplicateAgentId
-        ? userOwnedTriggers
-        : [],
+      triggersToCreate: duplicateAgentId ? userOwnedTriggers : [],
       triggersToUpdate: duplicateAgentId ? [] : userOwnedTriggers,
       triggersToDelete: [],
       agentSettings: {

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -274,13 +274,11 @@ export default function AgentBuilder({
       additionalSpaces: computedAdditionalSpaces,
       triggersToCreate: duplicateAgentId
         ? userOwnedTriggers.map((trigger) => ({
-              ...trigger,
-              editor: user.id,
-            }))
+            ...trigger,
+            editor: user.id,
+          }))
         : [],
-      triggersToUpdate: duplicateAgentId
-        ? []
-        : userOwnedTriggers,
+      triggersToUpdate: duplicateAgentId ? [] : userOwnedTriggers,
       triggersToDelete: [],
       agentSettings: {
         ...currentValues.agentSettings,

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -273,10 +273,7 @@ export default function AgentBuilder({
       skills: processedSkills,
       additionalSpaces: computedAdditionalSpaces,
       triggersToCreate: duplicateAgentId
-        ? userOwnedTriggers.map((trigger) => ({
-            ...trigger,
-            editor: user.id,
-          }))
+        ? userOwnedTriggers
         : [],
       triggersToUpdate: duplicateAgentId ? [] : userOwnedTriggers,
       triggersToDelete: [],


### PR DESCRIPTION
## Description

- When duplicating an agent we currently pull triggers coming from every user on the agent and reassign them to the currently authenticated user.
- This PR fixes that to only port the current user's triggers.
- Reported [here](https://dust4ai.slack.com/archives/C066R3PMUAU/p1775843321821529).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
