### PR TITLE
fix: agent loop stuck after tool denial during resume

### DIFF
--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -37,6 +37,10 @@ import assert from "assert";
 export type RunModelAndCreateActionsResult = {
   actionBlobs: ActionBlob[];
   runId: string | null;
+  // Set when resuming from tool validation and all actions at the step already reached a final
+  // state (e.g., all denied). The step is complete but the loop must continue so the model can see
+  // the results and generate a follow-up response or try alternatives.
+  stepAlreadyComplete?: boolean;
 };
 
 const AGENT_LOOP_COST_CAP_ERROR_CODE = "agent_loop_cost_cap_exceeded";
@@ -234,6 +238,10 @@ async function _runModelAndCreateActionsActivity({
       return {
         actionBlobs: existingData.actionBlobs,
         runId: null,
+        // When all actions already reached a final state (e.g., all denied by the user), the step
+        // is done but the loop must continue to the next step so the model sees the denied results
+        // and can generate a follow-up response or try alternatives.
+        stepAlreadyComplete: existingData.actionBlobs.length === 0,
       };
     }
   }

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -37,10 +37,6 @@ import assert from "assert";
 export type RunModelAndCreateActionsResult = {
   actionBlobs: ActionBlob[];
   runId: string | null;
-  // Set when resuming from tool validation and all actions at the step already reached a final
-  // state (e.g., all denied). The step is complete but the loop must continue so the model can see
-  // the results and generate a follow-up response or try alternatives.
-  stepAlreadyComplete?: boolean;
 };
 
 const AGENT_LOOP_COST_CAP_ERROR_CODE = "agent_loop_cost_cap_exceeded";
@@ -238,10 +234,6 @@ async function _runModelAndCreateActionsActivity({
       return {
         actionBlobs: existingData.actionBlobs,
         runId: null,
-        // When all actions already reached a final state (e.g., all denied by the user), the step
-        // is done but the loop must continue to the next step so the model sees the denied results
-        // and can generate a follow-up response or try alternatives.
-        stepAlreadyComplete: existingData.actionBlobs.length === 0,
       };
     }
   }

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -373,7 +373,10 @@ async function executeStepIteration({
   if (actionBlobs.length === 0) {
     return {
       runId,
-      shouldContinue: false,
+      // If the step was already complete (e.g., all actions denied during tool validation), the
+      // loop must continue to the next step so the model sees the denied results and can generate a
+      // follow-up response or try alternatives.
+      shouldContinue: result.stepAlreadyComplete === true,
     };
   }
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -30,6 +30,7 @@ import type {
 } from "@temporalio/workflow";
 import {
   CancellationScope,
+  patched,
   proxyActivities,
   proxySinks,
   setHandler,
@@ -369,14 +370,18 @@ async function executeStepIteration({
 
   const { runId, actionBlobs } = result;
 
-  // Generation completed (text response, no tool calls).
+  // Generation completed or the loop unpaused and no new tools were generated.
   if (actionBlobs.length === 0) {
     return {
       runId,
-      // If the step was already complete (e.g., all actions denied during tool validation), the
-      // loop must continue to the next step so the model sees the denied results and can generate a
-      // follow-up response or try alternatives.
-      shouldContinue: result.stepAlreadyComplete === true,
+      // Patch lifecycle for tool-denial continue loop:
+      // 1. Now: patched() makes new workflows continue the loop when runId is null (all actions
+      //    denied). Old workflows keep the previous behavior (shouldContinue: false).
+      // 2. + a few hours: Replace patched() with deprecatePatch(), remove conditional.
+      // 3. + a few hours: Remove deprecatePatch() entirely.
+      shouldContinue: patched("tool-denial-continue-loop")
+        ? runId === null
+        : false,
     };
   }
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -379,6 +379,9 @@ async function executeStepIteration({
       //    denied). Old workflows keep the previous behavior (shouldContinue: false).
       // 2. + a few hours: Replace patched() with deprecatePatch(), remove conditional.
       // 3. + a few hours: Remove deprecatePatch() entirely.
+
+      // if runId is null that means we unpaused the loop with no new tools (eg: they were all
+      // denied) and no LLM call, so we need to continue as the agent loop is not finished.
       shouldContinue: patched("tool-denial-continue-loop")
         ? runId === null
         : false,


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/7470

When a user rejects a tool action and the agent loop resumes, `getExistingActionsAndBlobs` finds the denied actions (in final state) and returns `{ actionBlobs: [] }`. The workflow interprets empty `actionBlobs` as "generation completed" and exits with `shouldContinue: false`. The model never runs, so `agent_message_success` is never emitted and the agent message stays at `created` forever. Any pending steering messages are also stuck since `updateAgentMessageWithFinalStatus` is never called.

Fix: add a `stepAlreadyComplete` flag to the `RunModelAndCreateActionsResult` type. When resuming and all actions at the step are already in a final state (e.g., all denied), the flag signals the workflow to continue to the next step where the model sees the denied results and can generate a follow-up response or try alternatives.

## Tests

Issue reproduced in dev and fixed with diff.

## Risk

Medium. Somewhat edge-case but touches the main agent loop.

## Deploy Plan

I don't believe we are exposed to NonDeterminism error here since we don't change the call graph per se we just change the behavior of one branching. Additionally this new branching behavior is pretty rare which limits the exposure anyway here.

- deploy `front`