### PR TITLE
feat(triggers): disable trigger when agent becomes inaccessible

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -730,7 +730,7 @@ export async function postUserMessage(
       return new Err({
         status_code: 400,
         api_error: {
-          type: "invalid_request_error",
+          type: "agent_inaccessible",
           message:
             "This agent is either disabled or you don't have access to it.",
         },
@@ -1177,7 +1177,7 @@ export async function editUserMessage(
       return new Err({
         status_code: 400,
         api_error: {
-          type: "invalid_request_error",
+          type: "agent_inaccessible",
           message:
             "This agent is either disabled or you don't have access to it.",
         },

--- a/front/temporal/triggers/common/activities.ts
+++ b/front/temporal/triggers/common/activities.ts
@@ -1,7 +1,3 @@
-import {
-  isServerSideMCPServerConfiguration,
-  isServerSideMCPServerConfigurationWithName,
-} from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import {
   createConversation,
@@ -14,8 +10,6 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
@@ -30,58 +24,6 @@ import { Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import { makeTriggerScheduleId } from "../schedule/client";
-
-/**
- * We want to create individual conversations if the agent outcome will vary from user to user.
- */
-async function shouldCreateIndividualConversations(
-  auth: Authenticator,
-  agentConfiguration: AgentConfigurationType,
-  checkedAgentConfigurationIds: string[] = []
-): Promise<boolean> {
-  // Check if one of the actions is using a personal actions or a run agent action
-  const mcpServerViews = await MCPServerViewResource.listByWorkspace(auth);
-  const mcpServerViewsMap = new Map(
-    mcpServerViews.map((mcpServerView) => [mcpServerView.sId, mcpServerView])
-  );
-  for (const action of agentConfiguration.actions) {
-    if (isServerSideMCPServerConfiguration(action)) {
-      const mcpServerView = mcpServerViewsMap.get(action.mcpServerViewId);
-      if (!mcpServerView) {
-        throw new Error(
-          `MCP server view with ID ${action.mcpServerViewId} not found.`
-        );
-      }
-      if (mcpServerView.oAuthUseCase === "personal_actions") {
-        return true;
-      }
-      // Check the chain of agents
-      if (
-        isServerSideMCPServerConfigurationWithName(action, "run_agent") &&
-        action.childAgentId &&
-        // Avoid infinite loop
-        !checkedAgentConfigurationIds.includes(action.childAgentId)
-      ) {
-        const subAgentConfiguration = await getAgentConfiguration(auth, {
-          agentId: action.childAgentId,
-          variant: "full",
-        });
-        if (subAgentConfiguration) {
-          const subCheck = await shouldCreateIndividualConversations(
-            auth,
-            subAgentConfiguration,
-            [...checkedAgentConfigurationIds, agentConfiguration.sId]
-          );
-          if (subCheck) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-
-  return false;
-}
 
 async function createConversationForAgentConfiguration({
   auth,
@@ -194,6 +136,15 @@ export async function runTriggeredAgentsActivity({
   });
 
   if (!agentConfiguration) {
+    logger.info(
+      {
+        triggerId: trigger.sId,
+        agentConfigurationId: trigger.agentConfigurationId,
+        workspaceId: auth.workspace()?.sId,
+      },
+      "Disabling trigger: agent configuration not found."
+    );
+    await triggerResource.disable(auth);
     throw new TriggerNonRetryableError(
       `Agent configuration with ID ${trigger.agentConfigurationId} not found in workspace ${auth.getNonNullableWorkspace().id}.`
     );
@@ -215,19 +166,9 @@ export async function runTriggeredAgentsActivity({
     },
   });
 
-  const useIndividualConversations = await shouldCreateIndividualConversations(
-    auth,
-    agentConfiguration
-  );
-
   if (triggerResource.status !== "enabled") {
     logger.info({ triggerId: trigger.sId }, "Trigger is disabled.");
     return;
-  }
-
-  const subscribers = await triggerResource.getSubscribers(auth);
-  if (subscribers.isErr()) {
-    throw new TriggerNonRetryableError("Error getting trigger subscribers.");
   }
 
   let lastRunAt: Date | null = null;
@@ -265,86 +206,59 @@ export async function runTriggeredAgentsActivity({
     }
   }
 
-  const subscribersAuths = await Promise.all(
-    subscribers.value.map((s) =>
-      Authenticator.fromUserIdAndWorkspaceId(
-        s.sId,
-        auth.getNonNullableWorkspace().sId
-      )
-    )
-  );
+  // Create a single conversation for the editor.
+  const conversationResult = await createConversationForAgentConfiguration({
+    auth,
+    agentConfiguration,
+    trigger,
+    lastRunAt,
+    contentFragment,
+  });
+  if (conversationResult.isErr()) {
+    const { type: errorType, message: errorMessage } =
+      conversationResult.error.api_error;
+    const isNonRetryable =
+      errorType === "plan_message_limit_exceeded" ||
+      errorType === "model_disabled" ||
+      errorType === "invalid_request_error";
 
-  if (useIndividualConversations) {
-    // Create conversations for the editor and all the subscribers
-    for (const tempAuth of [auth, ...subscribersAuths]) {
-      try {
-        await createConversationForAgentConfiguration({
-          auth: tempAuth,
-          agentConfiguration,
-          trigger,
-          lastRunAt,
-          contentFragment,
-        });
-      } catch (error) {
-        // Might happen if a subscriber do not have the right permissions to use the agent
-        logger.error(
+    if (isNonRetryable) {
+      // If the agent is inaccessible, disable the trigger.
+      if (
+        errorMessage ===
+        "This agent is either disabled or you don't have access to it."
+      ) {
+        logger.info(
           {
-            error,
+            triggerId: trigger.sId,
             agentConfigurationId: trigger.agentConfigurationId,
-            userId: tempAuth.getNonNullableUser().sId,
-            workspaceId: tempAuth.getNonNullableWorkspace().sId,
+            workspaceId: auth.workspace()?.sId,
           },
-          "Error creating conversation for agent configuration."
+          "Disabling trigger: agent is inaccessible."
         );
+        await triggerResource.disable(auth);
       }
-    }
-  } else {
-    // Create a single conversation for the editor
-    const conversationResult = await createConversationForAgentConfiguration({
-      auth,
-      agentConfiguration,
-      trigger,
-      lastRunAt,
-      contentFragment,
-    });
-    if (conversationResult.isErr()) {
-      const { type: errorType, message: errorMessage } =
-        conversationResult.error.api_error;
-      const isNonRetryable =
-        errorType === "plan_message_limit_exceeded" ||
-        errorType === "model_disabled";
 
-      if (isNonRetryable) {
-        if (webhookRequestId && trigger.kind === "webhook") {
-          const webhookRequest =
-            await WebhookRequestResource.fetchByModelIdWithAuth(
-              auth,
-              webhookRequestId
-            );
-          if (webhookRequest) {
-            await webhookRequest.markRelatedTrigger({
-              trigger,
-              status: "workflow_start_failed",
-              errorMessage,
-            });
-          }
+      if (webhookRequestId && trigger.kind === "webhook") {
+        const webhookRequest =
+          await WebhookRequestResource.fetchByModelIdWithAuth(
+            auth,
+            webhookRequestId
+          );
+        if (webhookRequest) {
+          await webhookRequest.markRelatedTrigger({
+            trigger,
+            status: "workflow_start_failed",
+            errorMessage,
+          });
         }
-        // Return without throwing, this is normal behaviour so we don't want an error
-        return;
       }
-
-      throw new Error(`Error creating conversation: ${errorMessage}`, {
-        cause: conversationResult.error,
-      });
+      // Return without throwing, this is normal behaviour so we don't want an error
+      return;
     }
 
-    // Upsert all the subscribers as participants
-    for (const tempAuth of subscribersAuths) {
-      await ConversationResource.upsertParticipation(tempAuth, {
-        conversation: conversationResult.value,
-        action: "subscribed",
-        user: tempAuth.getNonNullableUser().toJSON(),
-      });
-    }
+    throw new Error(`Error creating conversation: ${errorMessage}`, {
+      cause: conversationResult.error,
+    });
   }
 }

--- a/front/temporal/triggers/common/activities.ts
+++ b/front/temporal/triggers/common/activities.ts
@@ -220,14 +220,12 @@ export async function runTriggeredAgentsActivity({
     const isNonRetryable =
       errorType === "plan_message_limit_exceeded" ||
       errorType === "model_disabled" ||
-      errorType === "invalid_request_error";
+      errorType === "invalid_request_error" ||
+      errorType === "agent_inaccessible";
 
     if (isNonRetryable) {
       // If the agent is inaccessible, disable the trigger.
-      if (
-        errorMessage ===
-        "This agent is either disabled or you don't have access to it."
-      ) {
+      if (errorType === "agent_inaccessible") {
         logger.info(
           {
             triggerId: trigger.sId,

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -64,6 +64,7 @@ const API_ERROR_TYPES = [
   "connector_credentials_not_found",
   "connector_operation_in_progress",
   "agent_configuration_not_found",
+  "agent_inaccessible",
   "agent_group_permission_error",
   "agent_message_error",
   "unprocessable_entity",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

 This PR does two things.

1. **It removes the trigger subscribers path.** 

The individual-conversations branching (`shouldCreateIndividualConversations`), subscriber fetching, and per-subscriber conversation creation are not currently used and only add complexity to the activity. 

The activity now follows a single straightforward path: create one conversation for the trigger's editor. 

Subscriber support can be re-introduced cleanly when it's actually needed.

2. **It better handles permanent trigger errors.** 

When a user creates a trigger on an agent they have access to but aren't an editor of, and that agent's permissions later change so the user loses access, the trigger keeps firing and failing with "This agent is either disabled or you don't have access to it." 

Because this error wasn't in the non-retryable list, Temporal retried it indefinitely even though the request would never succeed. We now treat all `invalid_request_error` responses (alongside the existing `plan_message_limit_exceeded` and `model_disabled`) as non-retryable, since 400-class errors from `postUserMessage` on a fresh conversation are permanent by definition.

When the error is specifically about agent inaccessibility, the trigger is also disabled, calling `triggerResource.disable()`, removes the Temporal schedule so it stops firing entirely. The user can re-enable it from the UI if their access is restored.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

By hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front