### PR TITLE
Add skill suggestion first UI

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -9,6 +9,7 @@ import {
 import { SkillBuilderInstructionsSection } from "@app/components/skill_builder/SkillBuilderInstructionsSection";
 import { SkillBuilderRequestedSpacesSection } from "@app/components/skill_builder/SkillBuilderRequestedSpacesSection";
 import { SkillBuilderSettingsSection } from "@app/components/skill_builder/SkillBuilderSettingsSection";
+import { SkillBuilderSuggestionsPanel } from "@app/components/skill_builder/SkillBuilderSuggestionsPanel";
 import { SkillBuilderToolsSection } from "@app/components/skill_builder/SkillBuilderToolsSection";
 import { SkillVersionHistoryPicker } from "@app/components/skill_builder/SkillBuilderVersionComparisonBanner";
 import { SkillBuilderVersionComparisonFooter } from "@app/components/skill_builder/SkillBuilderVersionComparisonFooter";
@@ -24,11 +25,13 @@ import { submitSkillBuilderForm } from "@app/components/skill_builder/submitSkil
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useSkillSuggestions } from "@app/hooks/useSkillSuggestions";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { getSkillIcon } from "@app/lib/skill";
 import { useSkillHistory } from "@app/lib/swr/skill_configurations";
 import { useSkillEditors } from "@app/lib/swr/skill_editors";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import {
@@ -38,6 +41,10 @@ import {
   ContentMessage,
   cn,
   InformationCircleIcon,
+  LightbulbIcon,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
   ScrollArea,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -60,6 +67,7 @@ export default function SkillBuilder({
   const router = useAppRouter();
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);
+  const isMobile = useIsMobile();
 
   const { editors } = useSkillEditors({
     owner,
@@ -72,6 +80,15 @@ export default function SkillBuilder({
     disabled: !skill,
     limit: 30,
   });
+
+  const { suggestions } = useSkillSuggestions({
+    skillId: skill?.sId ?? null,
+    states: ["pending"],
+    workspaceId: owner.sId,
+    disabled: !skill,
+  });
+
+  const hasPendingSuggestions = suggestions.length > 0;
 
   const defaultValues = useMemo(() => {
     if (skill) {
@@ -160,6 +177,108 @@ export default function SkillBuilder({
     void form.handleSubmit(handleSubmit)();
   };
 
+  const [isSuggestionsPanelOpen, setIsSuggestionsPanelOpen] = useState(false);
+
+  useEffect(() => {
+    if (hasPendingSuggestions) {
+      setIsSuggestionsPanelOpen(true);
+    }
+  }, [hasPendingSuggestions]);
+
+  const showSuggestionsPanel = skill && !isMobile;
+
+  const leftPanel = (
+    <div className="flex h-full w-full flex-col">
+      <BarHeader
+        variant="default"
+        className="mx-4"
+        title={skill ? `Edit skill ${skill.name}` : "Create new skill"}
+        centerActions={
+          skill && skillHistory ? (
+            <SkillVersionHistoryPicker
+              skill={skill}
+              skillHistory={skillHistory}
+            />
+          ) : undefined
+        }
+        rightActions={
+          <div className="flex items-center gap-2">
+            {showSuggestionsPanel && (
+              <Button
+                icon={LightbulbIcon}
+                size="sm"
+                variant={
+                  isSuggestionsPanelOpen ? "highlight" : "ghost-secondary"
+                }
+                tooltip={
+                  isSuggestionsPanelOpen
+                    ? "Hide suggestions"
+                    : "Show suggestions"
+                }
+                onClick={() => setIsSuggestionsPanelOpen((prev) => !prev)}
+              />
+            )}
+            <BarHeader.ButtonBar variant="close" onClose={handleCancel} />
+          </div>
+        }
+      />
+
+      <ScrollArea className="flex-1">
+        <div className="mx-auto space-y-10 p-8 2xl:max-w-5xl">
+          {extendedSkill && (
+            <ContentMessage
+              title={`Built on ${extendedSkill.name}`}
+              variant="highlight"
+              icon={getSkillIcon(extendedSkill.icon)}
+              size="lg"
+            >
+              A customized version of {extendedSkill.name} with your own
+              guidelines and tools.
+            </ContentMessage>
+          )}
+          {skill?.status === "suggested" && (
+            <ContentMessage
+              title="This is a generated skill suggestion"
+              variant="primary"
+              icon={InformationCircleIcon}
+              size="lg"
+            >
+              This skill was automatically generated based on your workspace's
+              configuration. We recommend reviewing and editing it to match your
+              specific needs before saving.
+            </ContentMessage>
+          )}
+          <SkillBuilderRequestedSpacesSection />
+          <SkillBuilderAgentFacingDescriptionSection />
+          <SkillBuilderInstructionsSection />
+          {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
+          <SkillBuilderToolsSection extendedSkill={extendedSkill} />
+          <SkillBuilderSettingsOrComparisonFooter />
+        </div>
+      </ScrollArea>
+      <BarFooter
+        variant="default"
+        className="mx-4 justify-between"
+        leftActions={
+          <Button
+            variant="outline"
+            label="Cancel"
+            onClick={handleCancel}
+            type="button"
+          />
+        }
+        rightActions={
+          <Button
+            variant="highlight"
+            label={isSaving ? "Saving..." : "Save"}
+            onClick={handleSave}
+            disabled={isSaving}
+          />
+        }
+      />
+    </div>
+  );
+
   return (
     <SkillBuilderFormContext.Provider value={form}>
       <FormProvider form={form} asForm={false}>
@@ -171,78 +290,36 @@ export default function SkillBuilder({
               "dark:bg-background-night dark:text-foreground-night"
             )}
           >
-            <div className="flex h-full w-full flex-col">
-              <BarHeader
-                variant="default"
-                className="mx-4"
-                title={skill ? `Edit skill ${skill.name}` : "Create new skill"}
-                centerActions={
-                  skill && skillHistory ? (
-                    <SkillVersionHistoryPicker
-                      skill={skill}
-                      skillHistory={skillHistory}
-                    />
-                  ) : undefined
-                }
-                rightActions={
-                  <BarHeader.ButtonBar variant="close" onClose={handleCancel} />
-                }
-              />
+            {showSuggestionsPanel ? (
+              <ResizablePanelGroup
+                id="skill-builder-layout"
+                direction="horizontal"
+                className="h-full w-full"
+              >
+                <ResizablePanel defaultSize={65} minSize={40}>
+                  <div className="h-full w-full overflow-y-auto">
+                    {leftPanel}
+                  </div>
+                </ResizablePanel>
 
-              <ScrollArea className="flex-1">
-                <div className="mx-auto space-y-10 p-8 2xl:max-w-5xl">
-                  {extendedSkill && (
-                    <ContentMessage
-                      title={`Built on ${extendedSkill.name}`}
-                      variant="highlight"
-                      icon={getSkillIcon(extendedSkill.icon)}
-                      size="lg"
+                {isSuggestionsPanelOpen && (
+                  <>
+                    <ResizableHandle withHandle />
+                    <ResizablePanel
+                      defaultSize={35}
+                      minSize={20}
+                      maxSize={50}
                     >
-                      A customized version of {extendedSkill.name} with your own
-                      guidelines and tools.
-                    </ContentMessage>
-                  )}
-                  {skill?.status === "suggested" && (
-                    <ContentMessage
-                      title="This is a generated skill suggestion"
-                      variant="primary"
-                      icon={InformationCircleIcon}
-                      size="lg"
-                    >
-                      This skill was automatically generated based on your
-                      workspace's configuration. We recommend reviewing and
-                      editing it to match your specific needs before saving.
-                    </ContentMessage>
-                  )}
-                  <SkillBuilderRequestedSpacesSection />
-                  <SkillBuilderAgentFacingDescriptionSection />
-                  <SkillBuilderInstructionsSection />
-                  {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
-                  <SkillBuilderToolsSection extendedSkill={extendedSkill} />
-                  <SkillBuilderSettingsOrComparisonFooter />
-                </div>
-              </ScrollArea>
-              <BarFooter
-                variant="default"
-                className="mx-4 justify-between"
-                leftActions={
-                  <Button
-                    variant="outline"
-                    label="Cancel"
-                    onClick={handleCancel}
-                    type="button"
-                  />
-                }
-                rightActions={
-                  <Button
-                    variant="highlight"
-                    label={isSaving ? "Saving..." : "Save"}
-                    onClick={handleSave}
-                    disabled={isSaving}
-                  />
-                }
-              />
-            </div>
+                      <div className="h-full w-full overflow-y-auto">
+                        <SkillBuilderSuggestionsPanel />
+                      </div>
+                    </ResizablePanel>
+                  </>
+                )}
+              </ResizablePanelGroup>
+            ) : (
+              leftPanel
+            )}
           </div>
         </SkillVersionComparisonProvider>
       </FormProvider>

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -81,11 +81,13 @@ export default function SkillBuilder({
     limit: 30,
   });
 
+  const hasReinforcedAgents = hasFeature("reinforced_agents");
+
   const { suggestions } = useSkillSuggestions({
     skillId: skill?.sId ?? null,
     states: ["pending"],
     workspaceId: owner.sId,
-    disabled: !skill,
+    disabled: !skill || !hasReinforcedAgents,
   });
 
   const hasPendingSuggestions = suggestions.length > 0;
@@ -185,7 +187,7 @@ export default function SkillBuilder({
     }
   }, [hasPendingSuggestions]);
 
-  const showSuggestionsPanel = skill && !isMobile;
+  const showSuggestionsPanel = skill && !isMobile && hasReinforcedAgents;
 
   const leftPanel = (
     <div className="flex h-full w-full flex-col">
@@ -305,11 +307,7 @@ export default function SkillBuilder({
                 {isSuggestionsPanelOpen && (
                   <>
                     <ResizableHandle withHandle />
-                    <ResizablePanel
-                      defaultSize={35}
-                      minSize={20}
-                      maxSize={50}
-                    >
+                    <ResizablePanel defaultSize={35} minSize={20} maxSize={50}>
                       <div className="h-full w-full overflow-y-auto">
                         <SkillBuilderSuggestionsPanel />
                       </div>

--- a/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
+++ b/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
@@ -1,5 +1,8 @@
+import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import { SkillSuggestionCard } from "@app/components/skill_builder/SkillSuggestionCard";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import {
   usePatchSkillSuggestions,
   useSkillSuggestions,
@@ -7,9 +10,12 @@ import {
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import { LightbulbIcon, ScrollArea, Spinner } from "@dust-tt/sparkle";
 import { useCallback } from "react";
+import { useFormContext } from "react-hook-form";
 
 export function SkillBuilderSuggestionsPanel() {
   const { owner, skillId } = useSkillBuilderContext();
+  const { getValues, setValue } = useFormContext<SkillBuilderFormData>();
+  const { mcpServerViews } = useMCPServerViewsContext();
 
   const { suggestions, isSuggestionsLoading, mutateSuggestions } =
     useSkillSuggestions({
@@ -24,14 +30,47 @@ export function SkillBuilderSuggestionsPanel() {
     workspaceId: owner.sId,
   });
 
+  const applyToolEdits = useCallback(
+    (suggestion: SkillSuggestionType) => {
+      const { toolEdits } = suggestion.suggestion;
+      if (!toolEdits || toolEdits.length === 0) {
+        return;
+      }
+
+      let currentTools = getValues("tools");
+
+      for (const edit of toolEdits) {
+        if (edit.action === "add") {
+          const alreadyAdded = currentTools.some(
+            (t) => t.configuration.mcpServerViewId === edit.toolId
+          );
+          if (!alreadyAdded) {
+            const view = mcpServerViews.find((v) => v.sId === edit.toolId);
+            if (view) {
+              currentTools = [...currentTools, getDefaultMCPAction(view)];
+            }
+          }
+        } else {
+          currentTools = currentTools.filter(
+            (t) => t.configuration.mcpServerViewId !== edit.toolId
+          );
+        }
+      }
+
+      setValue("tools", currentTools, { shouldDirty: true });
+    },
+    [getValues, setValue, mcpServerViews]
+  );
+
   const handleAccept = useCallback(
     async (suggestion: SkillSuggestionType) => {
       const result = await patchSuggestions([suggestion.sId], "approved");
       if (result) {
+        applyToolEdits(suggestion);
         await mutateSuggestions();
       }
     },
-    [patchSuggestions, mutateSuggestions]
+    [patchSuggestions, mutateSuggestions, applyToolEdits]
   );
 
   const handleDecline = useCallback(

--- a/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
+++ b/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
@@ -1,0 +1,87 @@
+import { SkillSuggestionCard } from "@app/components/skill_builder/SkillSuggestionCard";
+import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
+import {
+  usePatchSkillSuggestions,
+  useSkillSuggestions,
+} from "@app/hooks/useSkillSuggestions";
+import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+import { LightbulbIcon, ScrollArea, Spinner } from "@dust-tt/sparkle";
+import { useCallback } from "react";
+
+export function SkillBuilderSuggestionsPanel() {
+  const { owner, skillId } = useSkillBuilderContext();
+
+  const { suggestions, isSuggestionsLoading, mutateSuggestions } =
+    useSkillSuggestions({
+      skillId,
+      states: ["pending"],
+      workspaceId: owner.sId,
+      disabled: !skillId,
+    });
+
+  const { patchSuggestions } = usePatchSkillSuggestions({
+    skillId,
+    workspaceId: owner.sId,
+  });
+
+  const handleAccept = useCallback(
+    async (suggestion: SkillSuggestionType) => {
+      const result = await patchSuggestions([suggestion.sId], "approved");
+      if (result) {
+        await mutateSuggestions();
+      }
+    },
+    [patchSuggestions, mutateSuggestions]
+  );
+
+  const handleDecline = useCallback(
+    async (suggestion: SkillSuggestionType) => {
+      const result = await patchSuggestions([suggestion.sId], "rejected");
+      if (result) {
+        await mutateSuggestions();
+      }
+    },
+    [patchSuggestions, mutateSuggestions]
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-col gap-1 px-4 pb-3 pt-4">
+        <h2 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
+          Suggestions
+        </h2>
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          Dust has analysed conversations using this skill and has generated
+          this list of suggestions to improve it.
+        </p>
+      </div>
+
+      <ScrollArea className="flex-1">
+        <div className="space-y-3 p-4">
+          {isSuggestionsLoading ? (
+            <div className="flex h-40 items-center justify-center">
+              <Spinner />
+            </div>
+          ) : suggestions.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 py-12 text-center">
+              <LightbulbIcon className="text-muted-foreground dark:text-muted-foreground-night" />
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                Dust will continuously analyse conversations using this skill to
+                try to suggest improvements.
+              </p>
+            </div>
+          ) : (
+            suggestions.map((suggestion) => (
+              <SkillSuggestionCard
+                key={suggestion.sId}
+                suggestion={suggestion}
+                onAccept={handleAccept}
+                onDecline={handleDecline}
+              />
+            ))
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
+++ b/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
@@ -1,8 +1,8 @@
 import { getDefaultMCPAction } from "@app/components/agent_builder/types";
-import { SkillSuggestionCard } from "@app/components/skill_builder/SkillSuggestionCard";
+import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
-import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { SkillSuggestionCard } from "@app/components/skill_builder/SkillSuggestionCard";
 import {
   usePatchSkillSuggestions,
   useSkillSuggestions,
@@ -29,6 +29,27 @@ export function SkillBuilderSuggestionsPanel() {
     skillId,
     workspaceId: owner.sId,
   });
+
+  const applyInstructionEdits = useCallback(
+    (suggestion: SkillSuggestionType) => {
+      const { instructionEdits } = suggestion.suggestion;
+      if (!instructionEdits || instructionEdits.length === 0) {
+        return;
+      }
+
+      let instructions = getValues("instructions");
+
+      for (const edit of instructionEdits) {
+        instructions = instructions.replaceAll(
+          edit.old_string,
+          edit.new_string
+        );
+      }
+
+      setValue("instructions", instructions, { shouldDirty: true });
+    },
+    [getValues, setValue]
+  );
 
   const applyToolEdits = useCallback(
     (suggestion: SkillSuggestionType) => {
@@ -66,11 +87,12 @@ export function SkillBuilderSuggestionsPanel() {
     async (suggestion: SkillSuggestionType) => {
       const result = await patchSuggestions([suggestion.sId], "approved");
       if (result) {
+        applyInstructionEdits(suggestion);
         applyToolEdits(suggestion);
         await mutateSuggestions();
       }
     },
-    [patchSuggestions, mutateSuggestions, applyToolEdits]
+    [patchSuggestions, mutateSuggestions, applyInstructionEdits, applyToolEdits]
   );
 
   const handleDecline = useCallback(
@@ -90,8 +112,8 @@ export function SkillBuilderSuggestionsPanel() {
           Suggestions
         </h2>
         <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Dust has analysed conversations using this skill and has generated
-          this list of suggestions to improve it.
+          Dust continuously analyses conversations using this skill to suggest
+          improvements.
         </p>
       </div>
 
@@ -105,8 +127,7 @@ export function SkillBuilderSuggestionsPanel() {
             <div className="flex flex-col items-center gap-3 py-12 text-center">
               <LightbulbIcon className="text-muted-foreground dark:text-muted-foreground-night" />
               <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                Dust will continuously analyse conversations using this skill to
-                try to suggest improvements.
+                No pending suggestions.
               </p>
             </div>
           ) : (

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -1,0 +1,129 @@
+import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import type {
+  SkillInstructionEditItemType,
+  SkillSuggestionType,
+  SkillToolEditItemType,
+} from "@app/types/suggestions/skill_suggestion";
+import {
+  Button,
+  Card,
+  Chip,
+  DiffBlock,
+  PlusIcon,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import { useMemo } from "react";
+
+function useToolDisplayName(toolId: string): string {
+  const { mcpServerViews } = useMCPServerViewsContext();
+
+  return useMemo(() => {
+    const view = mcpServerViews.find((v) => v.sId === toolId);
+    if (!view) {
+      return toolId;
+    }
+    return getMcpServerViewDisplayName(view);
+  }, [mcpServerViews, toolId]);
+}
+
+interface ToolEditChipProps {
+  toolEdit: SkillToolEditItemType;
+}
+
+function ToolEditChip({ toolEdit }: ToolEditChipProps) {
+  const displayName = useToolDisplayName(toolEdit.toolId);
+  const isAdd = toolEdit.action === "add";
+
+  return (
+    <Chip
+      size="sm"
+      color={isAdd ? "highlight" : "warning"}
+      icon={isAdd ? PlusIcon : XMarkIcon}
+      label={displayName}
+    />
+  );
+}
+
+interface InstructionEditBlockProps {
+  edit: SkillInstructionEditItemType;
+}
+
+function InstructionEditBlock({ edit }: InstructionEditBlockProps) {
+  const changes = [
+    {
+      old: edit.old_string,
+      new: edit.new_string || undefined,
+    },
+  ];
+
+  return <DiffBlock changes={changes} />;
+}
+
+interface SkillSuggestionCardProps {
+  suggestion: SkillSuggestionType;
+  onAccept: (suggestion: SkillSuggestionType) => void;
+  onDecline: (suggestion: SkillSuggestionType) => void;
+}
+
+export function SkillSuggestionCard({
+  suggestion,
+  onAccept,
+  onDecline,
+}: SkillSuggestionCardProps) {
+  const { instructionEdits, toolEdits } = suggestion.suggestion;
+
+  return (
+    <Card variant="primary" size="md" className="flex-col gap-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="heading-base text-foreground dark:text-foreground-night">
+          Suggestion
+        </span>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            label="Decline"
+            onClick={() => onDecline(suggestion)}
+          />
+          <Button
+            variant="highlight"
+            size="sm"
+            label="Accept"
+            onClick={() => onAccept(suggestion)}
+          />
+        </div>
+      </div>
+
+      {suggestion.analysis && (
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {suggestion.analysis}
+        </p>
+      )}
+
+      {toolEdits && toolEdits.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+            Tools
+          </span>
+          <div className="flex flex-wrap gap-2">
+            {toolEdits.map((toolEdit, index) => (
+              <ToolEditChip key={index} toolEdit={toolEdit} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {instructionEdits && instructionEdits.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+            Instruction changes
+          </span>
+          {instructionEdits.map((edit, index) => (
+            <InstructionEditBlock key={index} edit={edit} />
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -5,43 +5,74 @@ import type {
   SkillSuggestionType,
   SkillToolEditItemType,
 } from "@app/types/suggestions/skill_suggestion";
-import {
-  Button,
-  Card,
-  Chip,
-  DiffBlock,
-  PlusIcon,
-  XMarkIcon,
-} from "@dust-tt/sparkle";
+import { Button, Card, Chip, DiffBlock } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
-function useToolDisplayName(toolId: string): string {
+function useToolDisplayNames(
+  toolEdits: SkillToolEditItemType[]
+): Map<string, string> {
   const { mcpServerViews } = useMCPServerViewsContext();
 
   return useMemo(() => {
-    const view = mcpServerViews.find((v) => v.sId === toolId);
-    if (!view) {
-      return toolId;
+    const map = new Map<string, string>();
+    for (const edit of toolEdits) {
+      const view = mcpServerViews.find((v) => v.sId === edit.toolId);
+      map.set(
+        edit.toolId,
+        view ? getMcpServerViewDisplayName(view) : edit.toolId
+      );
     }
-    return getMcpServerViewDisplayName(view);
-  }, [mcpServerViews, toolId]);
+    return map;
+  }, [toolEdits, mcpServerViews]);
 }
 
-interface ToolEditChipProps {
-  toolEdit: SkillToolEditItemType;
+interface ToolEditsSectionProps {
+  toolEdits: SkillToolEditItemType[];
 }
 
-function ToolEditChip({ toolEdit }: ToolEditChipProps) {
-  const displayName = useToolDisplayName(toolEdit.toolId);
-  const isAdd = toolEdit.action === "add";
+function ToolEditsSection({ toolEdits }: ToolEditsSectionProps) {
+  const displayNames = useToolDisplayNames(toolEdits);
+
+  const toolsToAdd = toolEdits.filter((e) => e.action === "add");
+  const toolsToRemove = toolEdits.filter((e) => e.action === "remove");
 
   return (
-    <Chip
-      size="sm"
-      color={isAdd ? "highlight" : "warning"}
-      icon={isAdd ? PlusIcon : XMarkIcon}
-      label={displayName}
-    />
+    <div className="flex flex-col gap-2">
+      {toolsToAdd.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+            Tools to add
+          </span>
+          <div className="flex flex-wrap gap-2">
+            {toolsToAdd.map((edit) => (
+              <Chip
+                key={edit.toolId}
+                size="sm"
+                color="highlight"
+                label={displayNames.get(edit.toolId) ?? edit.toolId}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+      {toolsToRemove.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+            Tools to remove
+          </span>
+          <div className="flex flex-wrap gap-2">
+            {toolsToRemove.map((edit) => (
+              <Chip
+                key={edit.toolId}
+                size="sm"
+                color="warning"
+                label={displayNames.get(edit.toolId) ?? edit.toolId}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -102,16 +133,7 @@ export function SkillSuggestionCard({
       )}
 
       {toolEdits && toolEdits.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <span className="text-sm font-medium text-foreground dark:text-foreground-night">
-            Tools
-          </span>
-          <div className="flex flex-wrap gap-2">
-            {toolEdits.map((toolEdit, index) => (
-              <ToolEditChip key={index} toolEdit={toolEdit} />
-            ))}
-          </div>
-        </div>
+        <ToolEditsSection toolEdits={toolEdits} />
       )}
 
       {instructionEdits && instructionEdits.length > 0 && (


### PR DESCRIPTION
## Description

Add UI to display skill suggestions, this is a temporary base solution until we have HTML support and the defenitive UI

 - Only displayed if feature flag is enabled
 - Shows one big card per suggestion
 - can be accepted/rejected -> update the visual state + the state in DB
 - accepted/rejected cards disappear for now
 - No diff display in the editor so far, only the card
 - No handling of conflict if the prompt has change and the edit is not applicable anymore
 - 

<img width="3438" height="1754" alt="image" src="https://github.com/user-attachments/assets/dde29529-ef07-4f66-ae1e-df956c081aca" />


## Tests

Tested locally

## Risk

Low, all is behind feature flag

## Deploy Plan

deploy front
