### PR TITLE
[Sessions] Add backend conversation fork creation endpoint

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -1,8 +1,9 @@
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { createConversationFork } from "@app/lib/api/assistant/conversation/forks";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
+  ConversationModel,
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
@@ -11,6 +12,9 @@ import { ConversationBranchResource } from "@app/lib/resources/conversation_bran
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -262,5 +266,79 @@ describe("createConversationFork", () => {
     expect(result.isErr() ? result.error.code : "").toBe(
       "invalid_request_error"
     );
+  });
+
+  it("inherits the parent's requested spaces so the fork does not broaden visibility", async () => {
+    const {
+      auth: initialAuth,
+      globalSpace,
+      user,
+      workspace,
+    } = await createPrivateApiMockRequest({ role: "admin" });
+
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const addMembersRes = await restrictedSpace.addMembers(initialAuth, {
+      userIds: [user.sId],
+    });
+    expect(addMembersRes.isOk()).toBe(true);
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: globalSpace.id,
+    });
+    await ConversationModel.update(
+      { requestedSpaceIds: [globalSpace.id, restrictedSpace.id] },
+      {
+        where: {
+          id: parentConversation.id,
+          workspaceId: workspace.id,
+        },
+      }
+    );
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "Continue from the restricted state.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.requestedSpaceIds).toEqual([
+      globalSpace.sId,
+      restrictedSpace.sId,
+    ]);
+
+    const childConversationForOtherUser = await ConversationResource.fetchById(
+      otherAuth,
+      result.value.sId
+    );
+    expect(childConversationForOtherUser).toBeNull();
   });
 });

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -1,0 +1,266 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { createConversationFork } from "@app/lib/api/assistant/conversation/forks";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
+import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
+import { describe, expect, it } from "vitest";
+
+async function createUserMessage(
+  auth: Authenticator,
+  {
+    conversation,
+    rank,
+    content,
+    branchId = null,
+  }: {
+    conversation: ConversationWithoutContentType;
+    rank: number;
+    content: string;
+    branchId?: ModelId | null;
+  }
+): Promise<MessageModel> {
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+
+  const userMessage = await UserMessageModel.create({
+    userId: user.id,
+    workspaceId: workspace.id,
+    content,
+    userContextUsername: user.username,
+    userContextTimezone: "UTC",
+    userContextFullName: user.fullName(),
+    userContextEmail: user.email,
+    userContextProfilePictureUrl: user.imageUrl,
+    userContextOrigin: "web",
+    clientSideMCPServerIds: [],
+  });
+
+  return MessageModel.create({
+    workspaceId: workspace.id,
+    sId: generateRandomModelSId(),
+    rank,
+    conversationId: conversation.id,
+    branchId,
+    parentId: null,
+    userMessageId: userMessage.id,
+  });
+}
+
+async function createAgentMessage(
+  auth: Authenticator,
+  {
+    conversation,
+    rank,
+    parentId,
+    status,
+    branchId = null,
+  }: {
+    conversation: ConversationWithoutContentType;
+    rank: number;
+    parentId: ModelId;
+    status: "created" | "succeeded";
+    branchId?: ModelId | null;
+  }
+): Promise<MessageModel> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const agentMessage = await AgentMessageModel.create({
+    workspaceId: workspace.id,
+    status,
+    agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    agentConfigurationVersion: 0,
+    skipToolsValidation: false,
+    completedAt: status === "created" ? null : new Date(),
+  });
+
+  return MessageModel.create({
+    workspaceId: workspace.id,
+    sId: generateRandomModelSId(),
+    rank,
+    conversationId: conversation.id,
+    branchId,
+    parentId,
+    agentMessageId: agentMessage.id,
+  });
+}
+
+describe("createConversationFork", () => {
+  it("creates the child conversation, sole participant, and lineage row", async () => {
+    const { auth, globalSpace, user } = await createPrivateApiMockRequest();
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: globalSpace.id,
+    });
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "How should I continue this?",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childConversation = result.value;
+
+    expect(childConversation.title).toBe("Parent conversation");
+    expect(childConversation.spaceId).toBe(globalSpace.sId);
+    expect(childConversation.depth).toBe(parentConversation.depth + 1);
+    expect(childConversation.content).toEqual([]);
+    expect(childConversation.forkedFrom).toEqual({
+      parentConversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+      branchedAt: expect.any(Number),
+      user: user.toJSON(),
+    });
+
+    const forkRow = await ConversationForkModel.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        childConversationId: childConversation.id,
+      },
+    });
+
+    expect(forkRow).not.toBeNull();
+    expect(forkRow?.parentConversationId).toBe(parentConversation.id);
+    expect(forkRow?.sourceMessageId).toBe(sourceMessage.id);
+    expect(forkRow?.createdByUserId).toBe(user.id);
+
+    const participants = await ConversationResource.listParticipantDetails(
+      auth,
+      childConversation
+    );
+    expect(participants).toEqual([
+      {
+        userId: user.id,
+        action: "subscribed",
+      },
+    ]);
+  });
+
+  it("resolves the latest completed main-thread agent message when no source is provided", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const firstUserMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "First turn",
+    });
+    const firstAgentMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      parentId: firstUserMessage.id,
+      status: "succeeded",
+    });
+
+    const secondUserMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 2,
+      content: "Second turn",
+    });
+    await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 3,
+      parentId: secondUserMessage.id,
+      status: "created",
+    });
+
+    const branch = await ConversationBranchResource.makeNew(auth, {
+      state: "open",
+      previousMessageId: firstAgentMessage.id,
+      conversationId: parentConversation.id,
+      userId: auth.getNonNullableUser().id,
+    });
+
+    const branchUserMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 10,
+      content: "Branch turn",
+      branchId: branch.id,
+    });
+    await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 11,
+      parentId: branchUserMessage.id,
+      status: "succeeded",
+      branchId: branch.id,
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.forkedFrom?.sourceMessageId).toBe(
+      firstAgentMessage.sId
+    );
+  });
+
+  it("returns invalid_request_error when the source message is not forkable", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "Still waiting for the model",
+    });
+    const pendingAgentMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      parentId: userMessage.id,
+      status: "created",
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: pendingAgentMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() ? result.error.code : "").toBe(
+      "invalid_request_error"
+    );
+  });
+});

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -64,9 +64,7 @@ export async function createConversationFork(
         depth: parentConversation.depth + 1,
         triggerId: null,
         spaceId: parentConversation.space?.id ?? null,
-        requestedSpaceIds: parentConversation.space
-          ? [parentConversation.space.id]
-          : [],
+        requestedSpaceIds: [...parentConversation.requestedSpaceIds],
         metadata: {},
       },
       parentConversation.space,

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -1,0 +1,196 @@
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
+import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { Transaction, WhereOptions } from "sequelize";
+import { Op } from "sequelize";
+
+export type CreateConversationForkErrorCode =
+  | "conversation_not_found"
+  | "invalid_request_error"
+  | "internal_error";
+
+async function resolveForkSourceMessage(
+  auth: Authenticator,
+  {
+    parentConversationId,
+    sourceMessageId,
+    transaction,
+  }: {
+    parentConversationId: number;
+    sourceMessageId?: string;
+    transaction?: Transaction;
+  }
+): Promise<Result<MessageModel, DustError<CreateConversationForkErrorCode>>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const where: WhereOptions<MessageModel> = {
+    workspaceId: workspace.id,
+    conversationId: parentConversationId,
+    visibility: { [Op.ne]: "deleted" },
+    agentMessageId: { [Op.ne]: null },
+  };
+
+  if (sourceMessageId) {
+    where.sId = sourceMessageId;
+  } else {
+    where.branchId = { [Op.is]: null };
+  }
+
+  const sourceMessage = await MessageModel.findOne({
+    where,
+    include: [
+      {
+        model: AgentMessageModel,
+        as: "agentMessage",
+        required: true,
+        attributes: ["status"],
+        where: {
+          status: { [Op.ne]: "created" },
+        },
+      },
+    ],
+    order: sourceMessageId
+      ? undefined
+      : [
+          ["rank", "DESC"],
+          ["version", "DESC"],
+        ],
+    transaction,
+  });
+
+  if (!sourceMessage) {
+    return new Err(
+      new DustError(
+        "invalid_request_error",
+        sourceMessageId
+          ? "The source message is missing or cannot be used for forking."
+          : "The conversation has no completed agent message to fork from."
+      )
+    );
+  }
+
+  if (sourceMessage.branchId !== null) {
+    const [branch] = await ConversationBranchResource.fetchByModelIds(auth, [
+      sourceMessage.branchId,
+    ]);
+
+    if (!branch || !branch.canRead(auth)) {
+      return new Err(
+        new DustError(
+          "invalid_request_error",
+          "The source message is missing or cannot be used for forking."
+        )
+      );
+    }
+  }
+
+  return new Ok(sourceMessage);
+}
+
+export async function createConversationFork(
+  auth: Authenticator,
+  {
+    conversationId,
+    sourceMessageId,
+  }: {
+    conversationId: string;
+    sourceMessageId?: string;
+  }
+): Promise<
+  Result<ConversationType, DustError<CreateConversationForkErrorCode>>
+> {
+  const parentConversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+
+  if (!parentConversation) {
+    return new Err(
+      new DustError("conversation_not_found", "Conversation not found.")
+    );
+  }
+
+  const branchedAt = new Date();
+
+  const childConversationId = await withTransaction(async (transaction) => {
+    const sourceMessage = await resolveForkSourceMessage(auth, {
+      parentConversationId: parentConversation.id,
+      sourceMessageId,
+      transaction,
+    });
+
+    if (sourceMessage.isErr()) {
+      return sourceMessage;
+    }
+
+    const childConversation = await ConversationResource.makeNew(
+      auth,
+      {
+        sId: generateRandomModelSId(),
+        title: parentConversation.title,
+        visibility: parentConversation.visibility,
+        depth: parentConversation.depth + 1,
+        triggerId: null,
+        spaceId: parentConversation.space?.id ?? null,
+        requestedSpaceIds: parentConversation.space
+          ? [parentConversation.space.id]
+          : [],
+        metadata: {},
+      },
+      parentConversation.space,
+      { transaction }
+    );
+
+    await ConversationResource.upsertParticipation(auth, {
+      conversation: childConversation.toJSON(),
+      action: "subscribed",
+      user: auth.getNonNullableUser().toJSON(),
+      transaction,
+      lastReadAt: branchedAt,
+    });
+
+    await ConversationForkResource.makeNew(
+      auth,
+      {
+        parentConversation,
+        childConversation,
+        sourceMessageModelId: sourceMessage.value.id,
+        branchedAt,
+      },
+      { transaction }
+    );
+
+    return new Ok(childConversation.sId);
+  });
+
+  if (childConversationId.isErr()) {
+    return childConversationId;
+  }
+
+  const childConversation = await getConversation(
+    auth,
+    childConversationId.value
+  );
+  if (childConversation.isErr()) {
+    return new Err(
+      new DustError(
+        "internal_error",
+        "The forked conversation could not be loaded after creation."
+      )
+    );
+  }
+
+  return childConversation;
+}

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -1,11 +1,6 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import {
-  AgentMessageModel,
-  MessageModel,
-} from "@app/lib/models/agent/conversation";
-import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -13,91 +8,11 @@ import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { Transaction, WhereOptions } from "sequelize";
-import { Op } from "sequelize";
 
 export type CreateConversationForkErrorCode =
   | "conversation_not_found"
   | "invalid_request_error"
   | "internal_error";
-
-async function resolveForkSourceMessage(
-  auth: Authenticator,
-  {
-    parentConversationId,
-    sourceMessageId,
-    transaction,
-  }: {
-    parentConversationId: number;
-    sourceMessageId?: string;
-    transaction?: Transaction;
-  }
-): Promise<Result<MessageModel, DustError<CreateConversationForkErrorCode>>> {
-  const workspace = auth.getNonNullableWorkspace();
-
-  const where: WhereOptions<MessageModel> = {
-    workspaceId: workspace.id,
-    conversationId: parentConversationId,
-    visibility: { [Op.ne]: "deleted" },
-    agentMessageId: { [Op.ne]: null },
-  };
-
-  if (sourceMessageId) {
-    where.sId = sourceMessageId;
-  } else {
-    where.branchId = { [Op.is]: null };
-  }
-
-  const sourceMessage = await MessageModel.findOne({
-    where,
-    include: [
-      {
-        model: AgentMessageModel,
-        as: "agentMessage",
-        required: true,
-        attributes: ["status"],
-        where: {
-          status: { [Op.ne]: "created" },
-        },
-      },
-    ],
-    order: sourceMessageId
-      ? undefined
-      : [
-          ["rank", "DESC"],
-          ["version", "DESC"],
-        ],
-    transaction,
-  });
-
-  if (!sourceMessage) {
-    return new Err(
-      new DustError(
-        "invalid_request_error",
-        sourceMessageId
-          ? "The source message is missing or cannot be used for forking."
-          : "The conversation has no completed agent message to fork from."
-      )
-    );
-  }
-
-  if (sourceMessage.branchId !== null) {
-    const [branch] = await ConversationBranchResource.fetchByModelIds(auth, [
-      sourceMessage.branchId,
-    ]);
-
-    if (!branch || !branch.canRead(auth)) {
-      return new Err(
-        new DustError(
-          "invalid_request_error",
-          "The source message is missing or cannot be used for forking."
-        )
-      );
-    }
-  }
-
-  return new Ok(sourceMessage);
-}
 
 export async function createConversationFork(
   auth: Authenticator,
@@ -125,14 +40,19 @@ export async function createConversationFork(
   const branchedAt = new Date();
 
   const childConversationId = await withTransaction(async (transaction) => {
-    const sourceMessage = await resolveForkSourceMessage(auth, {
-      parentConversationId: parentConversation.id,
-      sourceMessageId,
-      transaction,
-    });
+    const sourceMessage = await ConversationResource.resolveForkSourceMessage(
+      auth,
+      {
+        conversationId: parentConversation.id,
+        sourceMessageId,
+        transaction,
+      }
+    );
 
     if (sourceMessage.isErr()) {
-      return sourceMessage;
+      return new Err(
+        new DustError("invalid_request_error", sourceMessage.error.message)
+      );
     }
 
     const childConversation = await ConversationResource.makeNew(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -218,7 +218,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   static async makeNew(
     auth: Authenticator,
     blob: Omit<CreationAttributes<ConversationModel>, "workspaceId">,
-    space: SpaceResource | null
+    space: SpaceResource | null,
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<ConversationResource> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -242,10 +243,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       blob.requestedSpaceIds.push(space.id);
     }
 
-    const conversation = await this.model.create({
-      ...blob,
-      workspaceId: workspace.id,
-    });
+    const conversation = await this.model.create(
+      {
+        ...blob,
+        workspaceId: workspace.id,
+      },
+      { transaction }
+    );
 
     return new ConversationResource(
       ConversationResource.model,

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -238,14 +238,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       );
     }
 
-    // Add spaceId to the requestedSpaceIds if it is not already part of the requestedSpaceIds.
-    if (space && !blob.requestedSpaceIds.includes(space.id)) {
-      blob.requestedSpaceIds.push(space.id);
-    }
+    const requestedSpaceIds =
+      space && !blob.requestedSpaceIds.includes(space.id)
+        ? [...blob.requestedSpaceIds, space.id]
+        : blob.requestedSpaceIds;
 
     const conversation = await this.model.create(
       {
         ...blob,
+        requestedSpaceIds,
         workspaceId: workspace.id,
       },
       { transaction }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2041,6 +2041,83 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return RunResource.fetchByDustRunId(auth, { dustRunId: lastRunId });
   }
 
+  static async resolveForkSourceMessage(
+    auth: Authenticator,
+    {
+      conversationId,
+      sourceMessageId,
+      transaction,
+    }: {
+      conversationId: ModelId;
+      sourceMessageId?: string;
+      transaction?: Transaction;
+    }
+  ): Promise<Result<MessageModel, Error>> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const where: WhereOptions<MessageModel> = {
+      workspaceId,
+      conversationId,
+      visibility: { [Op.ne]: "deleted" },
+      agentMessageId: { [Op.ne]: null },
+    };
+
+    if (sourceMessageId) {
+      where.sId = sourceMessageId;
+    } else {
+      where.branchId = { [Op.is]: null };
+    }
+
+    // Keep the lookup scoped to a single conversation/workspace; ordering by rank/version only
+    // applies within that slice when choosing the latest main-thread agent message.
+    const sourceMessage = await MessageModel.findOne({
+      where,
+      include: [
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          required: true,
+          attributes: ["status"],
+          where: {
+            status: { [Op.ne]: "created" },
+          },
+        },
+      ],
+      order: sourceMessageId
+        ? undefined
+        : [
+            ["rank", "DESC"],
+            ["version", "DESC"],
+          ],
+      transaction,
+    });
+
+    if (!sourceMessage) {
+      return new Err(
+        new Error(
+          sourceMessageId
+            ? "The source message is missing or cannot be used for forking."
+            : "The conversation has no completed agent message to fork from."
+        )
+      );
+    }
+
+    if (sourceMessage.branchId !== null) {
+      const [branch] = await ConversationBranchResource.fetchByModelIds(auth, [
+        sourceMessage.branchId,
+      ]);
+
+      if (!branch || !branch.canRead(auth)) {
+        return new Err(
+          new Error(
+            "The source message is missing or cannot be used for forking."
+          )
+        );
+      }
+    }
+
+    return new Ok(sourceMessage);
+  }
+
   static async getMessageByIdInConversation(
     auth: Authenticator,
     conversation: ConversationWithoutContentType,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -1,0 +1,185 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import {
+  AgentMessageModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { describe, expect, it } from "vitest";
+
+import handler from "./index";
+
+async function createUserMessage(
+  auth: Awaited<ReturnType<typeof createPrivateApiMockRequest>>["auth"],
+  {
+    conversation,
+    rank,
+    content,
+  }: {
+    conversation: ConversationWithoutContentType;
+    rank: number;
+    content: string;
+  }
+): Promise<MessageModel> {
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+
+  const userMessage = await UserMessageModel.create({
+    userId: user.id,
+    workspaceId: workspace.id,
+    content,
+    userContextUsername: user.username,
+    userContextTimezone: "UTC",
+    userContextFullName: user.fullName(),
+    userContextEmail: user.email,
+    userContextProfilePictureUrl: user.imageUrl,
+    userContextOrigin: "web",
+    clientSideMCPServerIds: [],
+  });
+
+  return MessageModel.create({
+    workspaceId: workspace.id,
+    sId: generateRandomModelSId(),
+    rank,
+    conversationId: conversation.id,
+    parentId: null,
+    userMessageId: userMessage.id,
+  });
+}
+
+async function createAgentMessage(
+  auth: Awaited<ReturnType<typeof createPrivateApiMockRequest>>["auth"],
+  {
+    conversation,
+    rank,
+    parentId,
+    status,
+  }: {
+    conversation: ConversationWithoutContentType;
+    rank: number;
+    parentId: number;
+    status: "created" | "succeeded";
+  }
+): Promise<MessageModel> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const agentMessage = await AgentMessageModel.create({
+    workspaceId: workspace.id,
+    status,
+    agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    agentConfigurationVersion: 0,
+    skipToolsValidation: false,
+    completedAt: status === "created" ? null : new Date(),
+  });
+
+  return MessageModel.create({
+    workspaceId: workspace.id,
+    sId: generateRandomModelSId(),
+    rank,
+    conversationId: conversation.id,
+    parentId,
+    agentMessageId: agentMessage.id,
+  });
+}
+
+describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
+  it("returns 405 for non-POST methods", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+
+    req.query.cId = "conv_test";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+
+  it("returns 403 when the sessions branching feature flag is disabled", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+
+    req.query.cId = "conv_test";
+    req.body = {};
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error.type).toBe("feature_flag_not_found");
+  });
+
+  it("creates a fork and returns the child conversation", async () => {
+    const { req, res, auth, globalSpace } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+
+    await FeatureFlagFactory.basic(auth, "sessions_branching");
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: globalSpace.id,
+    });
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "Please continue from here.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    req.query.cId = parentConversation.sId;
+    req.body = { sourceMessageId: sourceMessage.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().conversation.forkedFrom).toEqual({
+      parentConversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+      branchedAt: expect.any(Number),
+      user: auth.getNonNullableUser().toJSON(),
+    });
+    expect(res._getJSONData().conversation.depth).toBe(1);
+    expect(res._getJSONData().conversation.spaceId).toBe(globalSpace.sId);
+    expect(res._getJSONData().conversation.content).toEqual([]);
+  });
+
+  it("returns 400 when the source message cannot be forked", async () => {
+    const { req, res, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+
+    await FeatureFlagFactory.basic(auth, "sessions_branching");
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "Please continue from here.",
+    });
+
+    req.query.cId = parentConversation.sId;
+    req.body = { sourceMessageId: userMessage.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
@@ -1,0 +1,117 @@
+/** @ignoreswagger */
+import { createConversationFork } from "@app/lib/api/assistant/conversation/forks";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const PostConversationForkBodySchema = t.partial({
+  sourceMessageId: t.string,
+});
+
+export type PostConversationForkResponseBody = {
+  conversation: ConversationType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PostConversationForkResponseBody | void>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const { cId } = req.query;
+
+  if (!isString(cId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("sessions_branching")) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "feature_flag_not_found",
+        message: "The feature is not enabled for this workspace.",
+      },
+    });
+  }
+
+  const bodyValidation = PostConversationForkBodySchema.decode(req.body ?? {});
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+    });
+  }
+
+  const createRes = await createConversationFork(auth, {
+    conversationId: cId,
+    sourceMessageId: bodyValidation.right.sourceMessageId,
+  });
+
+  if (createRes.isErr()) {
+    switch (createRes.error.code) {
+      case "conversation_not_found":
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "conversation_not_found",
+            message: createRes.error.message,
+          },
+        });
+      case "invalid_request_error":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: createRes.error.message,
+          },
+        });
+      case "internal_error":
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: createRes.error.message,
+          },
+        });
+      default:
+        assertNever(createRes.error.code);
+    }
+  }
+
+  return res.status(200).json({
+    conversation: createRes.value,
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24060 and https://github.com/dust-tt/dust/pull/24112.
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

Adds the first backend fork-creation slice behind `sessions_branching`:
- a private `POST /api/w/{wId}/assistant/conversations/{cId}/forks` endpoint
- a transactional creation flow that creates the child conversation, adds the forking user as the sole participant, and persists the lineage row
- source resolution from an explicit agent message or, when omitted, the latest completed main-thread agent message

This intentionally does not copy conversation setup, seed the compaction placeholder, or copy filesystem state yet.

## Risks
Blast radius: private conversation creation and the new internal fork endpoint
Risk: standard

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/api/assistant/conversation/forks.test.ts pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts`