### PR TITLE
[front] fix: Strip more corrupted unicode sequences

### DIFF
--- a/front/lib/api/llm/utils/tool_arguments.test.ts
+++ b/front/lib/api/llm/utils/tool_arguments.test.ts
@@ -136,9 +136,9 @@ describe("parseToolArguments", () => {
     });
 
     describe("range boundaries", () => {
-      it("should fix U+0080 (first character in Latin-1 Supplement)", () => {
+      it("should strip U+0080 (C1 control character, not a printable Latin-1 char)", () => {
         const result = parseToolArguments('{"text":"\\u000080"}', "test");
-        expect(result).toEqual({ text: "\u0080" });
+        expect(result).toEqual({ text: "" });
       });
 
       it("should fix ÿ (U+00FF) (last character in Latin-1 Supplement)", () => {
@@ -215,19 +215,18 @@ describe("parseToolArguments", () => {
   });
 
   describe("ASCII range protection", () => {
-    it("should NOT fix \\u0000 followed by ASCII range hex (0x00-0x7F)", () => {
-      // These should NOT be fixed because they're in ASCII range
+    it("should strip \\u0000 followed by ASCII range hex (control chars are stripped)", () => {
       const result = parseToolArguments(
         '{"a":"\\u000000","b":"\\u000020","c":"\\u000041","d":"\\u000061","e":"\\u00007f"}',
         "test"
       );
-      // These should remain as null bytes + hex in the parsed result
+      // Control characters and their trailing orphan digits are stripped
       expect(result).toEqual({
-        a: "\u000000",
-        b: "\u000020",
-        c: "\u000041",
-        d: "\u000061",
-        e: "\u00007f",
+        a: "",
+        b: "",
+        c: "",
+        d: "",
+        e: "f",
       });
     });
   });
@@ -283,6 +282,32 @@ describe("parseToolArguments", () => {
       expect(result).toEqual({
         text: "Léducation nationale française est très précise sur la qualité de léducation à fournir. Les élèves doivent être bien préparés.",
       });
+    });
+  });
+
+  describe("control character stripping (GPT-5 ETX corruption)", () => {
+    it("should strip \\u0003 + orphan digits from pré-autorisation", () => {
+      const result = parseToolArguments(
+        String.raw`{"query":"pr\u00033\u00033-autorisation"}`,
+        "test"
+      );
+      expect(result).toEqual({ query: "pr-autorisation" });
+    });
+
+    it("should strip mixed \\u0003 patterns from téléconsultation", () => {
+      const result = parseToolArguments(
+        String.raw`{"query":"t\u00033l\u0003\u00003consultation"}`,
+        "test"
+      );
+      expect(result).toEqual({ query: "tlconsultation" });
+    });
+
+    it("should strip \\u0003 before a regular character from honorée", () => {
+      const result = parseToolArguments(
+        String.raw`{"query":"honor\u0003e"}`,
+        "test"
+      );
+      expect(result).toEqual({ query: "honore" });
     });
   });
 

--- a/front/lib/api/llm/utils/tool_arguments.ts
+++ b/front/lib/api/llm/utils/tool_arguments.ts
@@ -30,7 +30,15 @@ function fixCorruptedUnicodeInJSON(jsonString: string): string {
   );
 
   // Strip remaining standalone \u0000 not followed by two hex digits (those are handled above).
-  return fixed.replace(/\\u0000(?![0-9a-fA-F]{2})/g, "");
+  const stripped = fixed.replace(/\\u0000(?![0-9a-fA-F]{2})/g, "");
+
+  // Strip JSON-escaped control characters (U+0000–U+001F, U+007F–U+009F) and any trailing
+  // orphan digits left by the corruption. This runs after the Latin-1 fix above, so recoverable
+  // characters (0x80–0xFF) have already been rescued — only true control chars remain.
+  return stripped.replace(
+    /\\u00(0[0-9a-fA-F]|1[0-9a-fA-F]|7[fF]|[89][0-9a-fA-F])[0-9]*/gi,
+    ""
+  );
 }
 
 export const parseToolArguments = (


### PR DESCRIPTION
## Description

- Currently we try to fix corrupted unicode sequences outputted by gpt5 while trying to preserve ascii range.
- Unfortunately, that leads to some edge cases (see the tests) where the corrupted sequence is left untouched.
- After many tests with LLMs, they operate seamlessly with stripped strings like "prélèvement" => "prlvement", they get it. 
- So I decided to just strip anything that did not get fixed by the sanitisation attempt, even if we think it's ASCII

## Tests

Tested locally.

## Risk

Low
Blast radius: GPT5 conversations

## Deploy Plan

- [ ] Deploy front