### PR TITLE
[sessions] no auto scroll for steering

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -674,14 +674,16 @@ export const ConversationViewer = ({
           }
         }
 
-        // An agent will answer immediately only if it is explicitely mentioned.
+        // An agent will answer immediately only if it is explicitly mentioned.
         // In that case, we want to scroll to put the user message at the top.
+        // But when steering (agent already running), don't auto-scroll — let the
+        // user keep their current scroll position.
         const isMentioningAgent = mentions.some(isRichAgentMention);
 
         const nbMessages = ref.current.data.get().length;
         ref.current.data.append(
           [placeholderUserMsg, ...placeholderAgentMessages],
-          isMentioningAgent
+          isMentioningAgent && !hasRunningAgent
             ? () => {
                 return {
                   index: nbMessages, // Avoid jumping around when the agent message is generated.


### PR DESCRIPTION
## Description
This PR is to avoid auto scrolling the conversation to the last user message when it's steering so that users will be able to see the inline activity. The currently auto scrolling doesn't work reliably but it sometimes works so we fix it when it works 🙃
 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
