### PR TITLE
fix: hide title scrollbar

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -85,7 +85,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
         className="grid h-full min-w-0 max-w-full grid-cols-[1fr,auto] items-center gap-3"
         onContextMenu={handleRightClick}
       >
-        <div className="min-w-0 overflow-scroll">
+        <div className="min-w-0 overflow-x-auto scrollbar-hide">
           <Breadcrumbs
             items={breadcrumbItems}
             className="dd-privacy-mask"


### PR DESCRIPTION
## Description

This PR fixes the visibility of the scrollbar in conversation titles by hiding it while maintaining scroll functionality.

- Changed the title container from `overflow-scroll` to `overflow-x-auto scrollbar-hide` to prevent the scrollbar from appearing visually while keeping horizontal scrolling enabled

## Tests

Manually tested

## Risks

Low risk - This is a minor UI change affecting only the visual appearance of the scrollbar in conversation titles. The scrolling functionality is preserved.

## Deploy Plan

No special deployment.