### PR TITLE
Another snowflake fix

### DIFF
--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -31,10 +31,21 @@ import type {
 import snowflake from "snowflake-sdk";
 
 /**
- * Quote a Snowflake identifier for safe use in SQL.
- * Wraps in double quotes and doubles any internal double-quote characters.
+ * Conditionally quote a Snowflake identifier for safe use in SQL.
+ *
+ * Snowflake resolves unquoted identifiers case-insensitively (uppercased), so
+ * simple identifiers (letters, digits, _, $) are left unquoted to preserve that
+ * behavior. This matters because user-provided values (role, warehouse) are
+ * often typed lowercase but stored uppercase.
+ *
+ * Identifiers with special characters (dots, spaces, etc.) are wrapped in
+ * double quotes. These were necessarily created with quotes in Snowflake, so
+ * SHOW commands return them in their original case.
  */
-function sanitizeSnowflakeIdentifier(identifier: string): string {
+function quoteSnowflakeIdentifier(identifier: string): string {
+  if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(identifier)) {
+    return identifier;
+  }
   return `"${identifier.replace(/"/g, '""')}"`;
 }
 
@@ -379,7 +390,7 @@ export const fetchSchemas = async ({
   fromDatabase: string;
   connection?: Connection;
 }): Promise<Result<Array<RemoteDBSchema>, Error>> => {
-  const query = `SHOW SCHEMAS IN DATABASE ${sanitizeSnowflakeIdentifier(fromDatabase)}`;
+  const query = `SHOW SCHEMAS IN DATABASE ${quoteSnowflakeIdentifier(fromDatabase)}`;
   return _fetchRows<RemoteDBSchema>({
     credentials,
     query,
@@ -407,9 +418,9 @@ export const fetchTables = async ({
   // qualified schema reference.
   const query =
     fromSchema && fromDatabase
-      ? `SHOW TABLES IN SCHEMA ${sanitizeSnowflakeIdentifier(fromDatabase)}.${sanitizeSnowflakeIdentifier(fromSchema)}`
+      ? `SHOW TABLES IN SCHEMA ${quoteSnowflakeIdentifier(fromDatabase)}.${quoteSnowflakeIdentifier(fromSchema)}`
       : fromDatabase
-        ? `SHOW TABLES IN DATABASE ${sanitizeSnowflakeIdentifier(fromDatabase)}`
+        ? `SHOW TABLES IN DATABASE ${quoteSnowflakeIdentifier(fromDatabase)}`
         : "SHOW TABLES";
 
   return _fetchRows<RemoteDBTable>({
@@ -538,7 +549,7 @@ export const useWarehouse = async ({
   const warehouse = credentials.warehouse;
   const res = await _executeQuery(
     connection,
-    `USE WAREHOUSE ${sanitizeSnowflakeIdentifier(warehouse)}`
+    `USE WAREHOUSE ${quoteSnowflakeIdentifier(warehouse)}`
   );
   if (res.isErr()) {
     const e = normalizeError(res.error);
@@ -586,7 +597,9 @@ async function _checkRoleGrants(
   // Check current grants
   const currentGrantsRes = await _fetchRows<SnowflakeGrant>({
     credentials,
-    query: `SHOW GRANTS TO ${isDbRole ? "DATABASE ROLE" : "ROLE"} ${sanitizeSnowflakeIdentifier(roleName)}`,
+    // Database role names from SHOW GRANTS are already qualified as "database.role"
+    // where the dot is a structural separator. They must stay unquoted.
+    query: `SHOW GRANTS TO ${isDbRole ? "DATABASE ROLE" : "ROLE"} ${isDbRole ? roleName : quoteSnowflakeIdentifier(roleName)}`,
     codec: snowflakeGrantCodec,
     connection,
   });
@@ -601,7 +614,7 @@ async function _checkRoleGrants(
     // Check future grants
     futureGrantsRes = await _fetchRows<SnowflakeFutureGrant>({
       credentials,
-      query: `SHOW FUTURE GRANTS TO ROLE ${sanitizeSnowflakeIdentifier(roleName)}`,
+      query: `SHOW FUTURE GRANTS TO ROLE ${quoteSnowflakeIdentifier(roleName)}`,
       codec: snowflakeFutureGrantCodec,
       connection,
     });

--- a/connectors/src/lib/remote_databases/utils.test.ts
+++ b/connectors/src/lib/remote_databases/utils.test.ts
@@ -38,6 +38,13 @@ describe("Remote Database Utils", () => {
         "my__DUST_DOT__database.public__DUST_DOT__schema.user__DUST_DOT__table"
       );
     });
+
+    it("should handle multiple dots in a single name", () => {
+      const result = buildInternalId({
+        databaseName: "foo.bar.baz",
+      });
+      expect(result).toBe("foo__DUST_DOT__bar__DUST_DOT__baz");
+    });
   });
 
   describe("parseInternalId", () => {
@@ -92,6 +99,17 @@ describe("Remote Database Utils", () => {
         databaseName: "my.database",
         schemaName: "public.schema",
         tableName: "user.table",
+      };
+      const built = buildInternalId(original);
+      const parsed = parseInternalId(built);
+      expect(parsed).toEqual(original);
+    });
+
+    it("should correctly roundtrip internal IDs with multiple dots in names", () => {
+      const original = {
+        databaseName: "foo.bar.baz",
+        schemaName: "a.b.c",
+        tableName: "x.y",
       };
       const built = buildInternalId(original);
       const parsed = parseInternalId(built);

--- a/connectors/src/lib/remote_databases/utils.ts
+++ b/connectors/src/lib/remote_databases/utils.ts
@@ -292,7 +292,7 @@ export const buildInternalId = ({
 }) => {
   return [databaseName, schemaName, tableName]
     .filter((name) => name !== undefined)
-    .map((name) => name!.replace(".", "__DUST_DOT__"))
+    .map((name) => name!.replaceAll(".", "__DUST_DOT__"))
     .join(".");
 };
 
@@ -309,7 +309,7 @@ export const parseInternalId = (
 } => {
   const [databaseName, schemaName, tableName] = internalId
     .split(".")
-    .map((name) => name.replace("__DUST_DOT__", "."));
+    .map((name) => name.replaceAll("__DUST_DOT__", "."));
   if (!databaseName) {
     throw new Error(
       "Invalid internal ID, it requires at least a database name: " + internalId


### PR DESCRIPTION
## Description

PR #24146 introduced double-quote wrapping for all Snowflake identifiers in SQL queries to fix a bug where database names containing dots (e.g. SWAN.IO) broke SQL parsing. This caused two regressions in production:

1. Role names like dust_role were quoted as "dust_role", making Snowflake do a case-sensitive lookup. Since unquoted identifiers are stored uppercase (DUST_ROLE), the quoted lowercase form was not found.
2. Database role names like MY_DB.MY_ROLE were quoted as a single identifier "MY_DB.MY_ROLE", but the dot is a structural separator between database and role. Snowflake requires a current database context to resolve single-identifier database roles, which the session does not have.

The fix replaces the always-quote approach with conditional quoting: simple identifiers (letters, digits, underscores, $) are left unquoted so Snowflake's default case-insensitive resolution works. Identifiers containing special characters (dots, spaces, etc.) are wrapped in double quotes.

Database role names from SHOW GRANTS output are always left unquoted since their dot is a separator, not part of the name.

Additionally, buildInternalId and parseInternalId in utils.ts used String.replace() which only replaces the first occurrence. Names with multiple dots (e.g. foo.bar.baz) were incorrectly encoded. Changed to replaceAll with corresponding test coverage.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
