### PR TITLE
db: user project notification preference table

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -124,6 +124,7 @@ import {
   UserModel,
   UserToolApprovalModel,
 } from "@app/lib/resources/storage/models/user";
+import { UserProjectNotificationPreferenceModel } from "@app/lib/resources/storage/models/user_project_notification_preferences";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
 import { WorkspaceVerificationAttemptModel } from "@app/lib/resources/storage/models/workspace_verification_attempt";
@@ -241,6 +242,7 @@ export function loadAllModels() {
     TakeawaySourcesModel,
     TakeawaysVersionModel,
     ProjectTodoTakeawaySourcesModel,
+    UserProjectNotificationPreferenceModel,
   ];
 }
 

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1600,6 +1600,7 @@ const KNOWN_SPACE_RELATED_MODELS = [
   "takeaways",
   "takeaways_version",
   "webhook_sources_view",
+  "user_project_notification_preferences",
 ];
 
 describe("SpaceResource cleanup on delete", () => {

--- a/front/lib/resources/storage/models/user_project_notification_preferences.ts
+++ b/front/lib/resources/storage/models/user_project_notification_preferences.ts
@@ -1,0 +1,71 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import {
+  NOTIFICATION_CONDITION_OPTIONS,
+  type NotificationCondition,
+} from "@app/types/notification_preferences";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
+
+export class UserProjectNotificationPreferenceModel extends WorkspaceAwareModel<UserProjectNotificationPreferenceModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare userId: ForeignKey<UserModel["id"]>;
+  declare spaceId: ForeignKey<SpaceModel["id"]>;
+  declare preference: NotificationCondition;
+}
+
+UserProjectNotificationPreferenceModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    preference: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        isIn: [NOTIFICATION_CONDITION_OPTIONS],
+      },
+    },
+  },
+  {
+    modelName: "user_project_notification_preferences",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "user_project_notif_pref_workspace_user_space_unique",
+        fields: ["workspaceId", "userId", "spaceId"],
+        unique: true,
+        concurrently: true,
+      },
+      { fields: ["userId"], concurrently: true },
+      { fields: ["spaceId"], concurrently: true },
+    ],
+  }
+);
+
+UserModel.hasMany(UserProjectNotificationPreferenceModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});
+UserProjectNotificationPreferenceModel.belongsTo(UserModel, {
+  foreignKey: { allowNull: false },
+});
+
+SpaceModel.hasMany(UserProjectNotificationPreferenceModel, {
+  foreignKey: { allowNull: false, name: "spaceId" },
+  onDelete: "RESTRICT",
+});
+UserProjectNotificationPreferenceModel.belongsTo(SpaceModel, {
+  foreignKey: { allowNull: false, name: "spaceId" },
+});

--- a/front/migrations/db/migration_584.sql
+++ b/front/migrations/db/migration_584.sql
@@ -1,0 +1,5 @@
+-- Migration created on avr. 13, 2026
+CREATE TABLE IF NOT EXISTS "user_project_notification_preferences" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "preference" VARCHAR(255) NOT NULL, "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , "userId" BIGINT NOT NULL REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "spaceId" BIGINT NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, PRIMARY KEY ("id"));
+CREATE UNIQUE INDEX CONCURRENTLY "user_project_notif_pref_workspace_user_space_unique" ON "user_project_notification_preferences" ("workspaceId", "userId", "spaceId");
+CREATE INDEX CONCURRENTLY "user_project_notification_preferences_user_id" ON "user_project_notification_preferences" ("userId");
+CREATE INDEX CONCURRENTLY "user_project_notification_preferences_space_id" ON "user_project_notification_preferences" ("spaceId");


### PR DESCRIPTION
## Description

This PR adds a new table to store user notification preferences at the project level.

- Creates a new `user_project_notification_preferences` table 
- Adds a Sequelize model `UserProjectNotificationPreferenceModel` with relationships to `UserModel` and `SpaceModel` (projects)
- Implements validation for the `preference` field using `NOTIFICATION_CONDITION_OPTIONS`
- Registers the new model in the database initialization

## Tests

Manually

## Risks

Low - This PR only adds a new table without modifying existing functionality.

## Deploy Plan

Run migration 577 before deployment.

