### PR TITLE
[front] fix(mcp): remove limit on number of output items

### DIFF
--- a/front/lib/actions/action_output_limits.ts
+++ b/front/lib/actions/action_output_limits.ts
@@ -14,6 +14,8 @@ export const FILE_OFFLOAD_SNIPPET_LENGTH = 8_000; // Approximately 2K tokens.
 export const REMOTE_MAX_TEXT_SIZE_BYTES = 2 * 1024 * 1024; // 2MB.
 export const REMOTE_MAX_IMAGE_SIZE_BYTES = 2 * 1024 * 1024; // 2MB.
 export const REMOTE_MAX_RESOURCE_SIZE_BYTES = 20 * 1024 * 1024; // 20MB.
+// Hard limit on the entire array of tool outputs.
+export const REMOTE_MAX_TOOL_RESULT_SIZE_BYTES = 50 * 1024 * 1024; // 50MB.
 
 export function computeTextByteSize(text: string): number {
   return Buffer.byteLength(text, "utf8");
@@ -41,7 +43,7 @@ export function getRemoteContentMaxSize(
   }
 }
 
-export function calculateContentSize(
+export function computeContentSize(
   item: CallToolResult["content"][number]
 ): number {
   switch (item.type) {
@@ -75,7 +77,16 @@ export function calculateContentSize(
 export function isWithinRemoteContentLimit(
   content: CallToolResult["content"]
 ): boolean {
-  return !content.some(
-    (item) => calculateContentSize(item) > getRemoteContentMaxSize(item)
-  );
+  let totalOutputSize = 0;
+  for (const item of content) {
+    const itemSize = computeContentSize(item);
+    if (itemSize > getRemoteContentMaxSize(item)) {
+      return false;
+    }
+    totalOutputSize += itemSize;
+    if (totalOutputSize > REMOTE_MAX_TOOL_RESULT_SIZE_BYTES) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -108,8 +108,6 @@ import tracer from "dd-trace";
 import EventEmitter from "events";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
-const MAX_OUTPUT_ITEMS = 128;
-
 const MCP_NOTIFICATION_EVENT_NAME = "mcp-notification";
 const MCP_TOOL_DONE_EVENT_NAME = "TOOL_DONE" as const;
 const MCP_TOOL_ERROR_EVENT_NAME = "TOOL_ERROR" as const;
@@ -528,20 +526,6 @@ export async function* tryCallMCPTool(
     // Type inference is not working here because of them using passthrough in the zod schema.
     const content: CallToolResult["content"] = (toolCallResult.content ??
       []) as CallToolResult["content"];
-
-    if (content.length >= MAX_OUTPUT_ITEMS) {
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text",
-            text:
-              "The tool execution failed because of too many output items: " +
-              `${content.length} (max is ${MAX_OUTPUT_ITEMS})`,
-          },
-        ],
-      };
-    }
 
     let serverType;
     if (isClientSideMCPToolConfiguration(toolConfiguration)) {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -1,7 +1,7 @@
 // All mime types are okay to use from the public API.
 
 import {
-  calculateContentSize,
+  computeContentSize,
   getRemoteContentMaxSize,
   isWithinRemoteContentLimit,
 } from "@app/lib/actions/action_output_limits";
@@ -266,7 +266,7 @@ function generateRemoteContentMetadata(content: CallToolResult["content"]): {
 }[] {
   const result = [];
   for (const item of content) {
-    const byteSize = calculateContentSize(item);
+    const byteSize = computeContentSize(item);
     const maxSize = getRemoteContentMaxSize(item);
 
     result.push({ type: item.type, byteSize, maxSize });
@@ -550,9 +550,7 @@ export async function* tryCallMCPTool(
           content: [
             {
               type: "text",
-              text:
-                "The tool execution failed because of a tool result content size exceeding " +
-                "the maximum limit.",
+              text: "The tool execution failed because the tool output exceeds the maximum size limit.",
             },
           ],
         };


### PR DESCRIPTION
## Description

- This PR removes the hard cap on the number of output items (number of elements in the array of results in the MCP format) from a single tool call.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
