### PR TITLE
feat: user project notification preference backend

### DIFF
--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -89,6 +89,9 @@ export const RESOURCES_PREFIX = {
 
   // Provider credentials (BYOK).
   provider_credential: "pcr",
+
+  // User project notification preferences.
+  user_project_notification_preference: "upnp",
 } as const;
 
 export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;

--- a/front/lib/resources/user_project_notification_preferences_resource.ts
+++ b/front/lib/resources/user_project_notification_preferences_resource.ts
@@ -1,19 +1,16 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-import type {
-  NotificationCondition,
-  UserProjectNotificationPreference,
-} from "@app/types/notification_preferences";
+import type { NotificationCondition } from "@app/types/notification_preferences";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Attributes } from "sequelize";
 import { Op } from "sequelize";
 import { SpaceResource } from "./space_resource";
-import type { UserModel } from "./storage/models/user";
 import { UserProjectNotificationPreferenceModel } from "./storage/models/user_project_notification_preferences";
 import { makeSId } from "./string_ids";
+import type { UserResource } from "./user_resource";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface UserProjectNotificationPreferenceResource
@@ -24,12 +21,12 @@ export class UserProjectNotificationPreferenceResource extends BaseResource<User
   static model: typeof UserProjectNotificationPreferenceModel =
     UserProjectNotificationPreferenceModel;
 
-  readonly user: Attributes<UserModel>;
+  readonly user: UserResource;
 
   constructor(
     model: typeof UserProjectNotificationPreferenceModel,
     blob: Attributes<UserProjectNotificationPreferenceModel>,
-    { user }: { user: Attributes<UserModel> }
+    { user }: { user: UserResource }
   ) {
     super(UserProjectNotificationPreferenceModel, blob);
 
@@ -178,8 +175,9 @@ export class UserProjectNotificationPreferenceResource extends BaseResource<User
     }
   }
 
-  toJSON(): UserProjectNotificationPreference {
+  toJSON() {
     return {
+      id: this.id,
       sId: this.sId,
       spaceId: SpaceResource.modelIdToSId({
         id: this.spaceId,

--- a/front/lib/resources/user_project_notification_preferences_resource.ts
+++ b/front/lib/resources/user_project_notification_preferences_resource.ts
@@ -1,0 +1,192 @@
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type {
+  NotificationCondition,
+  UserProjectNotificationPreference,
+} from "@app/types/notification_preferences";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { Attributes } from "sequelize";
+import { Op } from "sequelize";
+import { SpaceResource } from "./space_resource";
+import type { UserModel } from "./storage/models/user";
+import { UserProjectNotificationPreferenceModel } from "./storage/models/user_project_notification_preferences";
+import { makeSId } from "./string_ids";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface UserProjectNotificationPreferenceResource
+  extends ReadonlyAttributesType<UserProjectNotificationPreferenceModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class UserProjectNotificationPreferenceResource extends BaseResource<UserProjectNotificationPreferenceModel> {
+  static model: typeof UserProjectNotificationPreferenceModel =
+    UserProjectNotificationPreferenceModel;
+
+  readonly user: Attributes<UserModel>;
+
+  constructor(
+    model: typeof UserProjectNotificationPreferenceModel,
+    blob: Attributes<UserProjectNotificationPreferenceModel>,
+    { user }: { user: Attributes<UserModel> }
+  ) {
+    super(UserProjectNotificationPreferenceModel, blob);
+
+    this.user = user;
+  }
+
+  get sId(): string {
+    return UserProjectNotificationPreferenceResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("user_project_notification_preference", {
+      id,
+      workspaceId,
+    });
+  }
+
+  static async create(
+    auth: Authenticator,
+    {
+      spaceModelId,
+      preference,
+    }: {
+      spaceModelId: ModelId;
+      preference: NotificationCondition;
+    }
+  ): Promise<UserProjectNotificationPreferenceResource> {
+    const workspace = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
+
+    const entry = await UserProjectNotificationPreferenceModel.create({
+      workspaceId: workspace.id,
+      spaceId: spaceModelId,
+      userId: user.id,
+      preference,
+    });
+
+    return new this(this.model, entry.get(), {
+      user,
+    });
+  }
+
+  static async fetchAllBySpaceAndUsers(
+    auth: Authenticator,
+    {
+      spaceModelId,
+      userModelIds,
+    }: {
+      spaceModelId: ModelId;
+      userModelIds: ModelId[];
+    }
+  ): Promise<Map<ModelId, NotificationCondition>> {
+    const results = await UserProjectNotificationPreferenceModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId: spaceModelId,
+        userId: { [Op.in]: userModelIds },
+      },
+    });
+
+    const preferenceMap = new Map<ModelId, NotificationCondition>();
+    for (const result of results) {
+      preferenceMap.set(result.userId, result.preference);
+    }
+
+    return preferenceMap;
+  }
+
+  static async fetchByProject(
+    auth: Authenticator,
+    spaceModelId: ModelId
+  ): Promise<UserProjectNotificationPreferenceResource | null> {
+    const user = auth.getNonNullableUser();
+    const result = await UserProjectNotificationPreferenceModel.findOne({
+      where: {
+        userId: user.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId: spaceModelId,
+      },
+    });
+
+    return result ? new this(this.model, result.get(), { user }) : null;
+  }
+
+  static async setPreference(
+    auth: Authenticator,
+    {
+      spaceModelId,
+      preference,
+    }: {
+      spaceModelId: ModelId;
+      preference: NotificationCondition;
+    }
+  ): Promise<UserProjectNotificationPreferenceResource> {
+    const workspace = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
+
+    const [entry] = await UserProjectNotificationPreferenceModel.upsert({
+      userId: user.id,
+      workspaceId: workspace.id,
+      spaceId: spaceModelId,
+      preference,
+    });
+
+    return new this(this.model, entry.get(), { user });
+  }
+
+  static async deleteAllBySpace(
+    auth: Authenticator,
+    spaceModelId: ModelId
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await UserProjectNotificationPreferenceModel.destroy({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          spaceId: spaceModelId,
+        },
+      });
+      return new Ok(undefined);
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
+  }
+
+  async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
+    try {
+      await UserProjectNotificationPreferenceModel.destroy({
+        where: {
+          id: this.id,
+          userId: auth.getNonNullableUser().id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      });
+      return new Ok(undefined);
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
+  }
+
+  toJSON(): UserProjectNotificationPreference {
+    return {
+      sId: this.sId,
+      spaceId: SpaceResource.modelIdToSId({
+        id: this.spaceId,
+        workspaceId: this.workspaceId,
+      }),
+      userId: this.user.sId,
+      preference: this.preference,
+    };
+  }
+}

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
@@ -1,3 +1,111 @@
+/**
+ * @swagger
+ * /api/w/{wId}/spaces/{spaceId}/project_notification_preferences:
+ *   get:
+ *     summary: Get project notification preference
+ *     description: Returns the current user's notification preference for a project space.
+ *     tags:
+ *       - Private Spaces
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: spaceId
+ *         required: true
+ *         description: ID of the project space
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 userProjectNotificationPreference:
+ *                   type: object
+ *                   nullable: true
+ *                   properties:
+ *                     sId:
+ *                       type: string
+ *                     spaceId:
+ *                       type: string
+ *                     userId:
+ *                       type: string
+ *                     preference:
+ *                       type: string
+ *                       enum: [all_messages, only_mentions, never]
+ *       400:
+ *         description: Bad request (space is not a project)
+ *       401:
+ *         description: Unauthorized
+ *   patch:
+ *     summary: Set project notification preference
+ *     description: Sets the current user's notification preference for a project space.
+ *     tags:
+ *       - Private Spaces
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: spaceId
+ *         required: true
+ *         description: ID of the project space
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - preference
+ *             properties:
+ *               preference:
+ *                 type: string
+ *                 enum: [all_messages, only_mentions, never]
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 userProjectNotificationPreference:
+ *                   type: object
+ *                   nullable: true
+ *                   properties:
+ *                     sId:
+ *                       type: string
+ *                     spaceId:
+ *                       type: string
+ *                     userId:
+ *                       type: string
+ *                     preference:
+ *                       type: string
+ *                       enum: [all_messages, only_mentions, never]
+ *       400:
+ *         description: Bad request (space is not a project or invalid body)
+ *       401:
+ *         description: Unauthorized
+ *       405:
+ *         description: Method not supported
+ */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
@@ -1,0 +1,109 @@
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import {
+  NOTIFICATION_CONDITION_OPTIONS,
+  type UserProjectNotificationPreference,
+} from "@app/types/notification_preferences";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+export type GetUserProjectNotificationPreferenceResponseBody = {
+  userProjectNotificationPreference: UserProjectNotificationPreference | null;
+};
+
+export type PatchUserProjectNotificationPreferenceResponseBody = {
+  userProjectNotificationPreference: UserProjectNotificationPreference | null;
+};
+
+const PatchUserProjectNotificationPreferenceBodySchema = z.object({
+  preference: z.enum(NOTIFICATION_CONDITION_OPTIONS),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      | GetUserProjectNotificationPreferenceResponseBody
+      | PatchUserProjectNotificationPreferenceResponseBody
+    >
+  >,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  // Only project spaces can have notification preferences
+  if (!space.isProject()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Project notification preferences are only available for project spaces.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const preference =
+        await UserProjectNotificationPreferenceResource.fetchByProject(
+          auth,
+          space.id
+        );
+      return res.status(200).json({
+        userProjectNotificationPreference: preference
+          ? preference.toJSON()
+          : null,
+      });
+    }
+
+    case "PATCH": {
+      const bodyValidation =
+        PatchUserProjectNotificationPreferenceBodySchema.safeParse(req.body);
+
+      if (!bodyValidation.success) {
+        const errorMessage = bodyValidation.error.errors
+          .map((e) => `${e.path.join(".")}: ${e.message}`)
+          .join(", ");
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${errorMessage}`,
+          },
+        });
+      }
+
+      const body = bodyValidation.data;
+
+      const preferenceResource =
+        await UserProjectNotificationPreferenceResource.setPreference(auth, {
+          spaceModelId: space.id,
+          preference: body.preference,
+        });
+
+      return res.status(200).json({
+        userProjectNotificationPreference: preferenceResource.toJSON(),
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET or PATCH expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
+);

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -67,6 +67,7 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { TakeawaysResource } from "@app/lib/resources/takeaways_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
@@ -220,6 +221,11 @@ export async function scrubSpaceActivity({
         }
       },
       { concurrency: 8 }
+    );
+
+    await UserProjectNotificationPreferenceResource.deleteAllBySpace(
+      auth,
+      space.id
     );
   }
 

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -8823,6 +8823,184 @@
         }
       }
     },
+    "/api/w/{wId}/spaces/{spaceId}/project_notification_preferences": {
+      "get": {
+        "summary": "Get project notification preference",
+        "description": "Returns the current user's notification preference for a project space.",
+        "tags": [
+          "Private Spaces"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "spaceId",
+            "required": true,
+            "description": "ID of the project space",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "userProjectNotificationPreference": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "sId": {
+                          "type": "string"
+                        },
+                        "spaceId": {
+                          "type": "string"
+                        },
+                        "userId": {
+                          "type": "string"
+                        },
+                        "preference": {
+                          "type": "string",
+                          "enum": [
+                            "all_messages",
+                            "only_mentions",
+                            "never"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (space is not a project)"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Set project notification preference",
+        "description": "Sets the current user's notification preference for a project space.",
+        "tags": [
+          "Private Spaces"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "spaceId",
+            "required": true,
+            "description": "ID of the project space",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "preference"
+                ],
+                "properties": {
+                  "preference": {
+                    "type": "string",
+                    "enum": [
+                      "all_messages",
+                      "only_mentions",
+                      "never"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "userProjectNotificationPreference": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "sId": {
+                          "type": "string"
+                        },
+                        "spaceId": {
+                          "type": "string"
+                        },
+                        "userId": {
+                          "type": "string"
+                        },
+                        "preference": {
+                          "type": "string",
+                          "enum": [
+                            "all_messages",
+                            "only_mentions",
+                            "never"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request (space is not a project or invalid body)"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "405": {
+            "description": "Method not supported"
+          }
+        }
+      }
+    },
     "/api/w/{wId}/spaces": {
       "get": {
         "summary": "List spaces",

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -71,6 +71,13 @@ export type NotificationCondition =
 export const DEFAULT_NOTIFICATION_CONDITION: NotificationCondition =
   "all_messages";
 
+export type UserProjectNotificationPreference = {
+  sId: string;
+  spaceId: string;
+  userId: string;
+  preference: NotificationCondition;
+};
+
 export const isNotificationCondition = (
   value: unknown
 ): value is NotificationCondition => {


### PR DESCRIPTION
## Description

This PR implements the backend infrastructure for user project notification preferences.

- Adds a new `UserProjectNotificationPreferenceResource` with CRUD operations (create, fetch, update, delete)
- Creates a new API endpoint `GET/PATCH /api/w/[wId]/spaces/[spaceId]/project_notification_preferences` to manage preferences
- Introduces a new resource prefix `upnp` for user project notification preferences
- Adds type definitions for `UserProjectNotificationPreference` with `NotificationCondition` options
- Updates the space scrubbing activity to clean up associated notification preferences when a space is deleted

## Tests

Manually

## Risks

Low risk. This is purely additive backend functionality with no existing dependencies. The changes are isolated to a new resource type and API endpoint.

## Deploy Plan

Standard deployment. No special considerations needed as this is new functionality that doesn't affect existing features.
