### PR TITLE
[sessions] change side of agent picker seleciton

### DIFF
--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -24,6 +24,7 @@ interface AgentPickerProps {
   pickerButton?: React.ReactNode;
   showDropdownArrow?: boolean;
   showFooterButtons?: boolean;
+  side?: "top" | "bottom";
   size?: "xs" | "sm" | "md";
   isLoading?: boolean;
   disabled?: boolean;
@@ -38,6 +39,7 @@ export function AgentPicker({
   pickerButton,
   showDropdownArrow = true,
   showFooterButtons = true,
+  side,
   size = "md",
   isLoading = false,
   disabled = false,
@@ -74,6 +76,7 @@ export function AgentPicker({
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="h-96 w-80"
+        side={side}
         align="start"
         dropdownHeaders={
           <>

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -96,6 +96,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       }}
       agents={allAgents}
       showDropdownArrow={false}
+      side={conversation ? "bottom" : "top"}
       showFooterButtons={
         actions.includes("agents-list-with-actions") &&
         clientType !== "extension"

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -96,7 +96,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       }}
       agents={allAgents}
       showDropdownArrow={false}
-      side={conversation ? "bottom" : "top"}
+      side={conversation ? "top" : "bottom"}
       showFooterButtons={
         actions.includes("agents-list-with-actions") &&
         clientType !== "extension"


### PR DESCRIPTION
## Description
This PR is to fix the issue we sometimes render the agent selector in the bottom on mobile. Since this is what we want to do on desktop too, I changed the side to bottom if a conversation exists. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
