### PR TITLE
Fix the time shown for each skill version

### DIFF
--- a/front/components/skill_builder/SkillVersionHistory.tsx
+++ b/front/components/skill_builder/SkillVersionHistory.tsx
@@ -62,8 +62,8 @@ export function SkillVersionHistory({
   }, [editedByLookupMembers]);
 
   function formatVersionLabel(config: SkillWithVersionType): string {
-    return config.createdAt
-      ? format(config.createdAt, "Pp")
+    return config.updatedAt
+      ? format(config.updatedAt, "Pp")
       : `Version ${config.version}`;
   }
 


### PR DESCRIPTION
## Description

The createdAt on each version is being copied from the original skill configuration (so all versions shared the same creation time), while updatedAt reflects when each version was actually saved.

<img width="452" height="456" alt="Screenshot 2026-04-13 at 16 52 31" src="https://github.com/user-attachments/assets/cb6f00fc-83dd-46f6-8128-2e3eff04c288" />


## Tests

Manual

## Risk

Low

## Deploy Plan

Front