### PR TITLE
feat(sbx): expose skill MCP servers in sandbox tools endpoint

### DIFF
--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -6,9 +6,13 @@ import type { Authenticator } from "@app/lib/auth";
 import { isRemoteDatabase } from "@app/lib/data_sources";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  AgentConfigurationType,
+  LightAgentConfigurationType,
+} from "@app/types/assistant/agent";
+import type { ConversationType } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 const SKILL_KNOWLEDGE_FILE_SYSTEM_SERVER_NAME = "skill_knowledge_file_system";
@@ -41,7 +45,7 @@ export async function getSkillServers(
     (v) => !isRemoteDatabase(v.dataSource)
   );
 
-  return skills.flatMap((skill) =>
+  const mcpServers = skills.flatMap((skill) =>
     [
       ...skill.mcpServerConfigurations,
       ...(skill.extendedSkill?.mcpServerConfigurations ?? []),
@@ -76,6 +80,26 @@ export async function getSkillServers(
       });
     })
   );
+
+  // Add knowledge servers (file system / data warehouse) from skills with attached data sources.
+  const {
+    documentDataSourceConfigurations,
+    warehouseDataSourceConfigurations,
+  } = await getSkillDataSourceConfigurations(auth, { skills });
+
+  const [fileSystemServer, dataWarehouseServer] = await Promise.all([
+    createSkillKnowledgeFileSystemServer(auth, {
+      dataSourceConfigurations: documentDataSourceConfigurations,
+    }),
+    createSkillKnowledgeDataWarehouseServer(auth, {
+      dataSourceConfigurations: warehouseDataSourceConfigurations,
+    }),
+  ]);
+
+  return [
+    ...mcpServers,
+    ...removeNulls([fileSystemServer, dataWarehouseServer]),
+  ];
 }
 
 /**
@@ -192,7 +216,7 @@ export async function getSkillDataSourceConfigurations(
  * Creates a file system server configuration scoped to the provided data source configurations.
  * Returns null if no configurations are provided or the server view doesn't exist.
  */
-export async function createSkillKnowledgeFileSystemServer(
+async function createSkillKnowledgeFileSystemServer(
   auth: Authenticator,
   {
     dataSourceConfigurations,
@@ -225,7 +249,7 @@ export async function createSkillKnowledgeFileSystemServer(
  * Creates a data warehouse server configuration scoped to the provided data source configurations.
  * Returns null if no configurations are provided or the server view doesn't exist.
  */
-export async function createSkillKnowledgeDataWarehouseServer(
+async function createSkillKnowledgeDataWarehouseServer(
   auth: Authenticator,
   {
     dataSourceConfigurations,
@@ -251,5 +275,33 @@ export async function createSkillKnowledgeDataWarehouseServer(
     mcpServerView,
     dataSources: dataSourceConfigurations,
     serverNameOverride: SKILL_KNOWLEDGE_DATA_WAREHOUSE_SERVER_NAME,
+  });
+}
+
+/**
+ * Resolves all skill-based MCP servers for an agent in a conversation.
+ */
+export async function resolveSkillMCPServers(
+  auth: Authenticator,
+  {
+    agentConfiguration,
+    conversation,
+  }: {
+    agentConfiguration: AgentConfigurationType;
+    conversation: ConversationType;
+  }
+): Promise<MCPServerConfigurationType[]> {
+  const { enabledSkills } = await SkillResource.listForAgentLoop(auth, {
+    agentConfiguration,
+    conversation,
+  });
+
+  if (enabledSkills.length === 0) {
+    return [];
+  }
+
+  return getSkillServers(auth, {
+    agentConfiguration,
+    skills: enabledSkills,
   });
 }

--- a/front/pages/api/v1/w/[wId]/sandbox/tools.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/tools.ts
@@ -97,19 +97,16 @@ async function handler(
       }
 
       const conversation = conversationResult.value;
-      const [{ servers: jitServers }, skillServers] = await Promise.all([
-        listAttachments(auth, { conversation }).then((attachments) =>
-          getJITServers(auth, {
-            agentConfiguration: agentConfig,
-            conversation,
-            attachments,
-          })
-        ),
-        resolveSkillMCPServers(auth, {
-          agentConfiguration: agentConfig,
-          conversation,
-        }),
-      ]);
+      const attachments = await listAttachments(auth, { conversation });
+      const { servers: jitServers } = await getJITServers(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+        attachments,
+      });
+      const skillServers = await resolveSkillMCPServers(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
       for (const srv of jitServers) {
         viewIds.add(srv.mcpServerViewId);
       }

--- a/front/pages/api/v1/w/[wId]/sandbox/tools.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/tools.ts
@@ -7,6 +7,7 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
@@ -96,14 +97,26 @@ async function handler(
       }
 
       const conversation = conversationResult.value;
-      const attachments = await listAttachments(auth, { conversation });
-      const { servers: jitServers } = await getJITServers(auth, {
-        agentConfiguration: agentConfig,
-        conversation,
-        attachments,
-      });
+      const [{ servers: jitServers }, skillServers] = await Promise.all([
+        listAttachments(auth, { conversation }).then((attachments) =>
+          getJITServers(auth, {
+            agentConfiguration: agentConfig,
+            conversation,
+            attachments,
+          })
+        ),
+        resolveSkillMCPServers(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+        }),
+      ]);
       for (const srv of jitServers) {
         viewIds.add(srv.mcpServerViewId);
+      }
+      for (const srv of skillServers) {
+        if (isServerSideMCPServerConfiguration(srv)) {
+          viewIds.add(srv.mcpServerViewId);
+        }
       }
 
       if (viewIds.size === 0) {

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -7,12 +7,7 @@ import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mc
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
-import {
-  createSkillKnowledgeDataWarehouseServer,
-  createSkillKnowledgeFileSystemServer,
-  getSkillDataSourceConfigurations,
-  getSkillServers,
-} from "@app/lib/api/assistant/skill_actions";
+import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -182,27 +177,6 @@ async function listAvailableTools(
     agentConfiguration,
     skills: enabledSkills,
   });
-
-  const {
-    documentDataSourceConfigurations,
-    warehouseDataSourceConfigurations,
-  } = await getSkillDataSourceConfigurations(auth, { skills: enabledSkills });
-
-  const fileSystemServer = await createSkillKnowledgeFileSystemServer(auth, {
-    dataSourceConfigurations: documentDataSourceConfigurations,
-  });
-  const dataWarehouseServer = await createSkillKnowledgeDataWarehouseServer(
-    auth,
-    {
-      dataSourceConfigurations: warehouseDataSourceConfigurations,
-    }
-  );
-  if (fileSystemServer) {
-    skillServers.push(fileSystemServer);
-  }
-  if (dataWarehouseServer) {
-    skillServers.push(dataWarehouseServer);
-  }
 
   const { serverToolsAndInstructions: mcpActions } = await tryListMCPTools(
     auth,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -30,12 +30,7 @@ import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { isLegacyAgentConfiguration } from "@app/lib/api/assistant/legacy_agent";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
-import {
-  createSkillKnowledgeDataWarehouseServer,
-  createSkillKnowledgeFileSystemServer,
-  getSkillDataSourceConfigurations,
-  getSkillServers,
-} from "@app/lib/api/assistant/skill_actions";
+import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
 import { getLLM } from "@app/lib/api/llm";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import {
@@ -251,30 +246,6 @@ export async function runModel(
       agentConfiguration,
       skills: enabledSkills,
     });
-
-    // Add file system / data warehouse servers if skills have attached knowledge.
-    const {
-      documentDataSourceConfigurations,
-      warehouseDataSourceConfigurations,
-    } = await getSkillDataSourceConfigurations(auth, {
-      skills: enabledSkills,
-    });
-
-    const fileSystemServer = await createSkillKnowledgeFileSystemServer(auth, {
-      dataSourceConfigurations: documentDataSourceConfigurations,
-    });
-    const dataWarehouseServer = await createSkillKnowledgeDataWarehouseServer(
-      auth,
-      {
-        dataSourceConfigurations: warehouseDataSourceConfigurations,
-      }
-    );
-    if (fileSystemServer) {
-      skillServers.push(fileSystemServer);
-    }
-    if (dataWarehouseServer) {
-      skillServers.push(dataWarehouseServer);
-    }
 
     const {
       serverToolsAndInstructions: mcpActions,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

- Add `resolveSkillMCPServers` helper to resolve skill-based MCP servers for an agent in a conversation context
- Expose skill servers alongside JIT servers in the sandbox tools endpoint (`/api/v1/w/[wId]/sandbox/tools`)
- Consolidate knowledge server creation (file system / data warehouse) into `getSkillServers`, removing duplicated logic from `prompt_commands.ts` and `run_model.ts`

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

By hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front