### PR TITLE
[Sessions] Add branch conversation action to conversation menu

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -3,6 +3,7 @@ import { EditConversationTitleDialog } from "@app/components/assistant/conversat
 import { LeaveConversationDialog } from "@app/components/assistant/conversation/LeaveConversationDialog";
 import { ConfirmContext } from "@app/components/Confirm";
 import {
+  useBranchConversation,
   useConversationParticipants,
   useConversationParticipationOptions,
   useJoinConversation,
@@ -14,11 +15,9 @@ import { useURLSheet } from "@app/hooks/useURLSheet";
 import config from "@app/lib/api/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
-import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useSpaces } from "@app/lib/swr/spaces";
-import { getErrorFromResponse } from "@app/lib/swr/swr";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import {
   getAgentBuilderRoute,
@@ -26,10 +25,7 @@ import {
   getProjectRoute,
   setQueryParam,
 } from "@app/lib/utils/router";
-import type {
-  ConversationType,
-  ConversationWithoutContentType,
-} from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isProjectConversation } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
 import { isBuilder } from "@app/types/user";
@@ -58,7 +54,6 @@ import {
 import type React from "react";
 import type { ReactElement } from "react";
 import { useCallback, useContext, useEffect, useState } from "react";
-import { useSWRConfig } from "swr";
 
 /**
  * Hook for handling right-click context menu with timing protection
@@ -160,7 +155,6 @@ export function ConversationMenu({
   const clientType = useClientType();
 
   const router = useAppRouter();
-  const { mutate } = useSWRConfig();
 
   const isRestrictedFromAgentCreation =
     featureFlags.includes("disallow_agent_creation_to_users") &&
@@ -235,8 +229,10 @@ export function ConversationMenu({
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
   const [showLeaveDialog, setShowLeaveDialog] = useState<boolean>(false);
   const [showRenameDialog, setShowRenameDialog] = useState<boolean>(false);
-  const [isBranchingConversation, setIsBranchingConversation] =
-    useState<boolean>(false);
+  const { branchConversation, isBranching } = useBranchConversation({
+    owner,
+    conversationId: activeConversationId,
+  });
 
   const conversationLink = getConversationRoute(
     owner.sId,
@@ -268,56 +264,6 @@ export function ConversationMenu({
   const openConversationInBrowser = () => {
     window.open(conversationLink, "_blank");
   };
-
-  const branchConversation = useCallback(async () => {
-    if (!activeConversationId) {
-      return;
-    }
-
-    setIsBranchingConversation(true);
-
-    try {
-      const res = await clientFetch(
-        `/api/w/${owner.sId}/assistant/conversations/${activeConversationId}/forks`,
-        {
-          method: "POST",
-        }
-      );
-
-      if (!res.ok) {
-        const errorData = await getErrorFromResponse(res);
-
-        sendNotification({
-          type: "error",
-          title: "Failed to branch conversation",
-          description: errorData.message,
-        });
-        return;
-      }
-
-      const { conversation: forkedConversation } = (await res.json()) as {
-        conversation: ConversationType;
-      };
-
-      await router.push(
-        getConversationRoute(owner.sId, forkedConversation.sId),
-        undefined,
-        { shallow: true }
-      );
-      void mutate(
-        (key) =>
-          typeof key === "string" &&
-          key.startsWith(`/api/w/${owner.sId}/assistant/conversations?`)
-      );
-    } catch {
-      sendNotification({
-        type: "error",
-        title: "Failed to branch conversation",
-      });
-    } finally {
-      setIsBranchingConversation(false);
-    }
-  }, [activeConversationId, mutate, owner.sId, router, sendNotification]);
 
   if (!activeConversationId) {
     return null;
@@ -390,7 +336,7 @@ export function ConversationMenu({
                 label="Branch conversation"
                 onClick={branchConversation}
                 icon={ActionGitBranchIcon}
-                disabled={isBranchingConversation}
+                disabled={isBranching}
               />
               <DropdownMenuSeparator />
             </>

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -58,6 +58,7 @@ import {
 import type React from "react";
 import type { ReactElement } from "react";
 import { useCallback, useContext, useEffect, useState } from "react";
+import { useSWRConfig } from "swr";
 
 /**
  * Hook for handling right-click context menu with timing protection
@@ -159,6 +160,7 @@ export function ConversationMenu({
   const clientType = useClientType();
 
   const router = useAppRouter();
+  const { mutate } = useSWRConfig();
 
   const isRestrictedFromAgentCreation =
     featureFlags.includes("disallow_agent_creation_to_users") &&
@@ -298,7 +300,14 @@ export function ConversationMenu({
       };
 
       await router.push(
-        getConversationRoute(owner.sId, forkedConversation.sId)
+        getConversationRoute(owner.sId, forkedConversation.sId),
+        undefined,
+        { shallow: true }
+      );
+      void mutate(
+        (key) =>
+          typeof key === "string" &&
+          key.startsWith(`/api/w/${owner.sId}/assistant/conversations?`)
       );
     } catch {
       sendNotification({
@@ -308,7 +317,7 @@ export function ConversationMenu({
     } finally {
       setIsBranchingConversation(false);
     }
-  }, [activeConversationId, owner.sId, router, sendNotification]);
+  }, [activeConversationId, mutate, owner.sId, router, sendNotification]);
 
   if (!activeConversationId) {
     return null;

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -14,9 +14,11 @@ import { useURLSheet } from "@app/hooks/useURLSheet";
 import config from "@app/lib/api/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
+import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useSpaces } from "@app/lib/swr/spaces";
+import { getErrorFromResponse } from "@app/lib/swr/swr";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import {
   getAgentBuilderRoute,
@@ -24,11 +26,15 @@ import {
   getProjectRoute,
   setQueryParam,
 } from "@app/lib/utils/router";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type {
+  ConversationType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import { isProjectConversation } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
 import { isBuilder } from "@app/types/user";
 import {
+  ActionGitBranchIcon,
   ArrowRightIcon,
   Avatar,
   ContactsUserIcon,
@@ -227,6 +233,8 @@ export function ConversationMenu({
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
   const [showLeaveDialog, setShowLeaveDialog] = useState<boolean>(false);
   const [showRenameDialog, setShowRenameDialog] = useState<boolean>(false);
+  const [isBranchingConversation, setIsBranchingConversation] =
+    useState<boolean>(false);
 
   const conversationLink = getConversationRoute(
     owner.sId,
@@ -258,6 +266,49 @@ export function ConversationMenu({
   const openConversationInBrowser = () => {
     window.open(conversationLink, "_blank");
   };
+
+  const branchConversation = useCallback(async () => {
+    if (!activeConversationId) {
+      return;
+    }
+
+    setIsBranchingConversation(true);
+
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/assistant/conversations/${activeConversationId}/forks`,
+        {
+          method: "POST",
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+
+        sendNotification({
+          type: "error",
+          title: "Failed to branch conversation",
+          description: errorData.message,
+        });
+        return;
+      }
+
+      const { conversation: forkedConversation } = (await res.json()) as {
+        conversation: ConversationType;
+      };
+
+      await router.push(
+        getConversationRoute(owner.sId, forkedConversation.sId)
+      );
+    } catch {
+      sendNotification({
+        type: "error",
+        title: "Failed to branch conversation",
+      });
+    } finally {
+      setIsBranchingConversation(false);
+    }
+  }, [activeConversationId, owner.sId, router, sendNotification]);
 
   if (!activeConversationId) {
     return null;
@@ -324,6 +375,17 @@ export function ConversationMenu({
             onClick={() => setShowRenameDialog(true)}
             icon={PencilSquareIcon}
           />
+          {hasFeature("sessions_branching") && (
+            <>
+              <DropdownMenuItem
+                label="Branch conversation"
+                onClick={branchConversation}
+                icon={ActionGitBranchIcon}
+                disabled={isBranchingConversation}
+              />
+              <DropdownMenuSeparator />
+            </>
+          )}
           {hasFeature("projects") && (
             <DropdownMenuSub>
               <DropdownMenuSubTrigger

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -1,5 +1,6 @@
 export { useAgentMessageSkills } from "./useAgentMessageSkills";
 export { useAgentMessageTools } from "./useAgentMessageTools";
+export { useBranchConversation } from "./useBranchConversation";
 export { useCancelMessage } from "./useCancelMessage";
 export { useConversation } from "./useConversation";
 export { useConversationBranchActions } from "./useConversationBranchActions";

--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -1,0 +1,89 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { useAppRouter } from "@app/lib/platform";
+import { getErrorFromResponse } from "@app/lib/swr/swr";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { PostConversationForkResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/forks";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useState } from "react";
+import { useSWRConfig } from "swr";
+
+export function useBranchConversation({
+  owner,
+  conversationId,
+}: {
+  owner: LightWorkspaceType;
+  conversationId?: string | null;
+}) {
+  const sendNotification = useSendNotification();
+  const router = useAppRouter();
+  const { mutate } = useSWRConfig();
+
+  const [isBranching, setIsBranching] = useState(false);
+
+  const branchConversation = useCallback(async (): Promise<boolean> => {
+    if (!conversationId) {
+      return false;
+    }
+
+    setIsBranching(true);
+
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/assistant/conversations/${conversationId}/forks`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({}),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+
+        sendNotification({
+          type: "error",
+          title: "Failed to branch conversation",
+          description: errorData.message,
+        });
+
+        return false;
+      }
+
+      const { conversation }: PostConversationForkResponseBody =
+        await res.json();
+
+      await router.push(
+        getConversationRoute(owner.sId, conversation.sId),
+        undefined,
+        {
+          shallow: true,
+        }
+      );
+
+      const conversationPathPrefix = `/api/w/${owner.sId}/assistant/conversations`;
+      void mutate(
+        (key) =>
+          typeof key === "string" && key.startsWith(conversationPathPrefix)
+      );
+
+      return true;
+    } catch {
+      sendNotification({
+        type: "error",
+        title: "Failed to branch conversation",
+      });
+
+      return false;
+    } finally {
+      setIsBranching(false);
+    }
+  }, [conversationId, mutate, owner.sId, router, sendNotification]);
+
+  return {
+    branchConversation,
+    isBranching,
+  };
+}

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -157,6 +157,45 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
     expect(res._getJSONData().conversation.spaceId).toBe(globalSpace.sId);
   });
 
+  it("accepts an empty string body and resolves the latest source message", async () => {
+    const { req, res, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+
+    await FeatureFlagFactory.basic(auth, "sessions_branching");
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "Please continue from here.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    req.query.cId = parentConversation.sId;
+    req.body = "";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().conversation.forkedFrom).toEqual({
+      parentConversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+      branchedAt: expect.any(Number),
+      user: auth.getNonNullableUser().toJSON(),
+    });
+  });
+
   it("returns 400 when the source message cannot be forked", async () => {
     const { req, res, auth } = await createPrivateApiMockRequest({
       method: "POST",

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
@@ -61,7 +61,9 @@ async function handler(
     });
   }
 
-  const bodyValidation = PostConversationForkBodySchema.decode(req.body ?? {});
+  const requestBody = req.body === "" ? {} : (req.body ?? {});
+
+  const bodyValidation = PostConversationForkBodySchema.decode(requestBody);
   if (isLeft(bodyValidation)) {
     const pathError = reporter.formatValidationErrors(bodyValidation.left);
     return apiError(req, res, {


### PR DESCRIPTION
## Description
Context: https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=5347-9855&t=uWJaIVJ4CZsDIcN0-0

Adds the conversation-level `Branch conversation` action behind `sessions_branching`.
It calls the existing fork endpoint from the conversation menu and redirects to the new child conversation on success.

<img width="1455" height="551" alt="image" src="https://github.com/user-attachments/assets/ef77a9b8-5b09-4527-9887-45592fea6cf2" />


## Risks
Blast radius: conversation menu actions for workspaces with `sessions_branching` enabled.
Risk: low

## Deploy Plan
- pmrr
- deploy front