### PR TITLE
Exclude deleted conversations from fetchByModelIds

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -187,11 +187,16 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const workspace = auth.getNonNullableWorkspace();
 
+    const excludedVisibilities: ConversationVisibility[] = ["deleted"];
+    if (excludeTest) {
+      excludedVisibilities.push("test");
+    }
+
     const conversations = await this.model.findAll({
       where: {
         workspaceId: workspace.id,
         id: ids,
-        ...(excludeTest ? { visibility: { [Op.ne]: "test" } } : {}),
+        visibility: { [Op.notIn]: excludedVisibilities },
         ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
       } as WhereOptions<ConversationModel>,
       include: this.getForkedFromInclude(),


### PR DESCRIPTION
## Description

Right now only caller is reinforced skills, which doesn't want to look at deleted convos. We could make that optional via param if we need the flexibility.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front