### PR TITLE
[Sessions] Copy conversation MCP server views into forks

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -12,7 +12,9 @@ import { ConversationBranchResource } from "@app/lib/resources/conversation_bran
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -266,6 +268,86 @@ describe("createConversationFork", () => {
     expect(result.isErr() ? result.error.code : "").toBe(
       "invalid_request_error"
     );
+  });
+
+  it("copies enabled conversation MCP server views into the child conversation", async () => {
+    const { auth, globalSpace, workspace } =
+      await createPrivateApiMockRequest();
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: globalSpace.id,
+    });
+
+    const enabledRemoteServer = await RemoteMCPServerFactory.create(workspace);
+    const enabledMCPServerView = await MCPServerViewFactory.create(
+      workspace,
+      enabledRemoteServer.sId,
+      globalSpace
+    );
+    const disabledRemoteServer = await RemoteMCPServerFactory.create(workspace);
+    const disabledMCPServerView = await MCPServerViewFactory.create(
+      workspace,
+      disabledRemoteServer.sId,
+      globalSpace
+    );
+
+    const enabledUpsertResult = await ConversationResource.upsertMCPServerViews(
+      auth,
+      {
+        conversation: parentConversation,
+        mcpServerViews: [enabledMCPServerView],
+        enabled: true,
+        source: "conversation",
+        agentConfigurationId: null,
+      }
+    );
+    expect(enabledUpsertResult.isOk()).toBe(true);
+
+    const disabledUpsertResult =
+      await ConversationResource.upsertMCPServerViews(auth, {
+        conversation: parentConversation,
+        mcpServerViews: [disabledMCPServerView],
+        enabled: false,
+        source: "conversation",
+        agentConfigurationId: null,
+      });
+    expect(disabledUpsertResult.isOk()).toBe(true);
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "Continue with the same tools.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childMCPServerViews = await ConversationResource.fetchMCPServerViews(
+      auth,
+      result.value
+    );
+
+    expect(childMCPServerViews).toHaveLength(1);
+    expect(childMCPServerViews[0].mcpServerViewId).toBe(
+      enabledMCPServerView.id
+    );
+    expect(childMCPServerViews[0].enabled).toBe(true);
+    expect(childMCPServerViews[0].source).toBe("conversation");
   });
 
   it("inherits the parent's requested spaces so the fork does not broaden visibility", async () => {

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -3,16 +3,73 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type {
+  ConversationType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import type { Transaction } from "sequelize";
 
 export type CreateConversationForkErrorCode =
   | "conversation_not_found"
   | "invalid_request_error"
   | "internal_error";
+
+async function copyConversationMCPServerViews(
+  auth: Authenticator,
+  {
+    parentConversation,
+    childConversation,
+    transaction,
+  }: {
+    parentConversation: ConversationWithoutContentType;
+    childConversation: ConversationWithoutContentType;
+    transaction: Transaction;
+  }
+): Promise<Result<undefined, DustError<CreateConversationForkErrorCode>>> {
+  const parentMCPServerViews = await ConversationResource.fetchMCPServerViews(
+    auth,
+    parentConversation,
+    { onlyEnabled: true }
+  );
+
+  if (parentMCPServerViews.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const readableMCPServerViews = await MCPServerViewResource.fetchByModelIds(
+    auth,
+    parentMCPServerViews.map((view) => view.mcpServerViewId)
+  );
+
+  if (readableMCPServerViews.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const upsertResult = await ConversationResource.upsertMCPServerViews(auth, {
+    conversation: childConversation,
+    mcpServerViews: readableMCPServerViews,
+    enabled: true,
+    source: "conversation",
+    agentConfigurationId: null,
+    transaction,
+  });
+
+  if (upsertResult.isErr()) {
+    return new Err(
+      new DustError(
+        "internal_error",
+        "Failed to copy MCP server views into the forked conversation."
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}
 
 export async function createConversationFork(
   auth: Authenticator,
@@ -70,6 +127,19 @@ export async function createConversationFork(
       parentConversation.space,
       { transaction }
     );
+
+    const copyMCPServerViewsResult = await copyConversationMCPServerViews(
+      auth,
+      {
+        parentConversation: parentConversation.toJSON(),
+        childConversation: childConversation.toJSON(),
+        transaction,
+      }
+    );
+
+    if (copyMCPServerViewsResult.isErr()) {
+      return copyMCPServerViewsResult;
+    }
 
     await ConversationResource.upsertParticipation(auth, {
       conversation: childConversation.toJSON(),

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2410,10 +2410,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       enabled,
       source,
       agentConfigurationId,
+      transaction,
     }: {
       conversation: ConversationWithoutContentType;
       mcpServerViews: MCPServerViewResource[];
       enabled: boolean;
+      transaction?: Transaction;
     } & (
       | { source: "agent_enabled"; agentConfigurationId: string }
       | { source: "conversation"; agentConfigurationId: null }
@@ -2443,6 +2445,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           conversationId: conversation.id,
           agentConfigurationId: agentConfigurationId ?? null,
         },
+        transaction,
       });
 
     // Cycle through the mcpServerViewIds and create or update the conversationMCPServerView
@@ -2465,18 +2468,22 @@ export class ConversationResource extends BaseResource<ConversationModel> {
               workspaceId: auth.getNonNullableWorkspace().id,
               conversationId: conversation.id,
             },
+            transaction,
           }
         );
       } else {
-        await ConversationMCPServerViewModel.create({
-          conversationId: conversation.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
-          mcpServerViewId: mcpServerView.id,
-          userId: auth.getNonNullableUser().id,
-          enabled,
-          source,
-          agentConfigurationId,
-        });
+        await ConversationMCPServerViewModel.create(
+          {
+            conversationId: conversation.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+            mcpServerViewId: mcpServerView.id,
+            userId: auth.getNonNullableUser().id,
+            enabled,
+            source,
+            agentConfigurationId,
+          },
+          { transaction }
+        );
       }
     }
 


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24060, https://github.com/dust-tt/dust/pull/24112, and https://github.com/dust-tt/dust/pull/24156.
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

Copies enabled conversation-scoped MCP server views from the parent into the child during fork creation.

The copy runs inside the fork transaction, so the child conversation and its conversation-level MCP view rows stay in sync.

## Risks
Blast radius: internal conversation fork creation for conversations with conversation-scoped MCP tools
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/api/assistant/conversation/forks.test.ts pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts`
