### PR TITLE
fix(project-todo): fix takeaway version bloat and push dedup queries to DB

### DIFF
--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -18,6 +18,8 @@ import { Ok, type Result } from "@app/types/shared/result";
 import {
   type Attributes,
   type CreationAttributes,
+  col,
+  fn,
   type ModelStatic,
   Op,
   type Transaction,
@@ -168,23 +170,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     auth: Authenticator,
     { spaceId, userId }: { spaceId: ModelId; userId: ModelId }
   ): Promise<ProjectTodoResource[]> {
-    const all = await this.baseFetch(auth, {
-      where: { spaceId, userId },
-      order: [
-        ["sId", "ASC"],
-        ["version", "DESC"],
-      ],
-    });
-
-    // O(n) deduplication — keep the first occurrence per sId (highest version).
-    const latestBySId = new Map<string, ProjectTodoResource>();
-    for (const todo of all) {
-      if (!latestBySId.has(todo.sId)) {
-        latestBySId.set(todo.sId, todo);
-      }
-    }
-
-    return Array.from(latestBySId.values());
+    return this.fetchLatestBySpaceInternal(auth, { spaceId, userId });
   }
 
   // Returns the latest version of each logical todo across ALL users for the given
@@ -193,23 +179,42 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     auth: Authenticator,
     { spaceId }: { spaceId: ModelId }
   ): Promise<ProjectTodoResource[]> {
-    const all = await this.baseFetch(auth, {
-      where: { spaceId },
-      order: [
-        ["sId", "ASC"],
-        ["version", "DESC"],
-      ],
-    });
+    return this.fetchLatestBySpaceInternal(auth, { spaceId });
+  }
 
-    // O(n) deduplication — keep the first occurrence per sId (highest version).
-    const latestBySId = new Map<string, ProjectTodoResource>();
-    for (const todo of all) {
-      if (!latestBySId.has(todo.sId)) {
-        latestBySId.set(todo.sId, todo);
-      }
+  // Shared implementation: pushes dedup to the DB with a two-query strategy.
+  // Query 1: GROUP BY sId to fetch (sId, MAX(version)) pairs.
+  // Query 2: Fetch the actual rows that match those (sId, version) pairs.
+  // This avoids loading every historical version row into memory.
+  private static async fetchLatestBySpaceInternal(
+    auth: Authenticator,
+    where: { spaceId: ModelId; userId?: ModelId }
+  ): Promise<ProjectTodoResource[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const maxVersionRows = (await ProjectTodoModel.findAll({
+      attributes: ["sId", [fn("MAX", col("version")), "maxVersion"]],
+      where: { workspaceId, ...where },
+      group: ["sId"],
+      raw: true,
+    })) as unknown as { sId: string; maxVersion: number }[];
+
+    if (maxVersionRows.length === 0) {
+      return [];
     }
 
-    return Array.from(latestBySId.values());
+    const todos = await ProjectTodoModel.findAll({
+      where: {
+        workspaceId,
+        ...where,
+        [Op.or]: maxVersionRows.map(({ sId, maxVersion }) => ({
+          sId,
+          version: maxVersion,
+        })),
+      },
+    });
+
+    return todos.map((t) => new this(ProjectTodoModel, t.get()));
   }
 
   // Returns every version row for (spaceId, userId), across all sIds. Used by the

--- a/front/lib/resources/takeaways_resource.ts
+++ b/front/lib/resources/takeaways_resource.ts
@@ -25,7 +25,7 @@ import type {
   ModelStatic,
   Transaction,
 } from "sequelize";
-import { col, fn, Op } from "sequelize";
+import { col, fn, Op, type WhereOptions } from "sequelize";
 import { v4 as uuidv4 } from "uuid";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -252,23 +252,34 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
   ): Promise<{ takeaway: TakeawaysResource; conversationSId: string }[]> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    // Fetch all rows for this space ordered so the highest version per sId
-    // comes first — the first occurrence is the latest version.
+    // Query 1: get the maximum version per sId for this space — avoids loading
+    // all historical version rows into memory.
+    const maxVersionRows = (await TakeawaysModel.findAll({
+      attributes: ["sId", [fn("MAX", col("version")), "maxVersion"]],
+      where: { workspaceId, spaceId: spaceModelId } as WhereOptions,
+      group: ["sId"],
+      raw: true,
+    })) as unknown as { sId: string; maxVersion: number }[];
+
+    if (maxVersionRows.length === 0) {
+      return [];
+    }
+
+    // Query 2: fetch only the rows that match each (sId, maxVersion) pair.
     const rows = await TakeawaysModel.findAll({
-      where: { workspaceId, spaceId: spaceModelId },
-      order: [
-        ["sId", "ASC"],
-        ["version", "DESC"],
-      ],
+      where: {
+        workspaceId,
+        spaceId: spaceModelId,
+        [Op.or]: maxVersionRows.map(({ sId, maxVersion }) => ({
+          sId,
+          version: maxVersion,
+        })),
+      } as WhereOptions,
     });
 
-    // O(n) dedup — keep only the latest version per sId.
-    const latestBySId = new Map<string, TakeawaysModel>();
-    for (const row of rows) {
-      if (!latestBySId.has(row.sId)) {
-        latestBySId.set(row.sId, row);
-      }
-    }
+    const latestBySId = new Map<string, TakeawaysModel>(
+      rows.map((r) => [r.sId, r])
+    );
 
     if (latestBySId.size === 0) {
       return [];
@@ -356,26 +367,31 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
     }
 
     return withTransaction(async (t) => {
-      let source = await TakeawaySourcesModel.findOne({
+      const source = await TakeawaySourcesModel.findOne({
         where: { workspaceId, sourceId: conversationId },
         transaction: t,
       });
 
-      let sId: string;
       if (source) {
-        sId = source.takeawaySId;
-      } else {
-        sId = uuidv4();
-        await TakeawaySourcesModel.create(
-          {
-            workspaceId,
-            takeawaySId: sId,
-            sourceType: "conversation",
-            sourceId: conversationId,
-          },
-          { transaction: t }
+        // Conversation already has a takeaway — append a new version.
+        return TakeawaysResource.createNewVersion(
+          auth,
+          source.takeawaySId,
+          { spaceId: spaceModelId, actionItems, notableFacts, keyDecisions },
+          t
         );
       }
+
+      const sId = uuidv4();
+      await TakeawaySourcesModel.create(
+        {
+          workspaceId,
+          takeawaySId: sId,
+          sourceType: "conversation",
+          sourceId: conversationId,
+        },
+        { transaction: t }
+      );
 
       return TakeawaysResource.makeNew(
         auth,


### PR DESCRIPTION
## Description

Two bugs fixed in the project-todo / takeaways resource layer.

**1. Takeaway version bloat (`makeNewForConversation`)**
`makeNewForConversation` always called `makeNew`, which generates a fresh random `sId` at version 1
regardless of whether a `TakeawaySourcesModel` row already existed for the conversation.
Re-processing the same conversation created orphaned version-1 rows instead of appending a new
version to the stable `sId` that is linked to the conversation source.
Fix: when a source row is found, delegate to `createNewVersion` with the existing `sId` so the
versioned history stays attached to the correct logical takeaway.

**2. Full version-history scan in `fetchLatestBySpace*` / `fetchLatestBySpaceId`**
Both `ProjectTodoResource` and `TakeawaysResource` were loading every version row for a space into
memory and deduplicating with a `Map`. As todos accumulate versions the amount of data transferred
from the DB scaled with `todos × versions`.
Fix: replace with a two-query strategy that never loads stale history rows:
- Query 1: `GROUP BY sId` + `MAX(version)` to get the latest version number per logical todo.
- Query 2: fetch only the exact rows matching those `(sId, version)` pairs.

## Tests

Covered by existing endpoint-level tests for project todos and takeaways.

## Risk

Low — the `makeNewForConversation` fix is purely corrective (it was always writing wrong data); the
fetch changes are query-shape refactors with identical return semantics. Both changes are safe to
rollback.
