### PR TITLE
[Agent Loop] Add runModel heartbeat details

### DIFF
--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -17,6 +17,7 @@ import {
 import { RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS } from "@app/temporal/agent_loop/config";
 import type { ActionBlob } from "@app/temporal/agent_loop/lib/create_tool_actions";
 import { createToolActionsActivity } from "@app/temporal/agent_loop/lib/create_tool_actions";
+import { heartbeatRunModelAndCreateActionsActivity } from "@app/temporal/agent_loop/lib/heartbeat_details";
 import { handlePromptCommand } from "@app/temporal/agent_loop/lib/prompt_commands";
 import { runModel } from "@app/temporal/agent_loop/lib/run_model";
 import { getMaxActionsPerStep } from "@app/types/assistant/agent";
@@ -101,6 +102,11 @@ async function _runModelAndCreateActionsActivity({
 }): Promise<RunModelAndCreateActionsResult | null> {
   const activityTimeoutDeadlineMs = getActivityTimeoutDeadlineMs();
 
+  heartbeatRunModelAndCreateActionsActivity({
+    step,
+    phase: "loading_agent_loop_data",
+  });
+
   const runAgentDataRes = await startActiveObservation(
     "get-agent-loop-data",
     () => getAgentLoopData(authType, runAgentArgs)
@@ -124,6 +130,11 @@ async function _runModelAndCreateActionsActivity({
   const durationRecorder = DurationRecorder.create([
     `workspace:${auth.getNonNullableWorkspace().sId}`,
   ]);
+
+  heartbeatRunModelAndCreateActionsActivity({
+    step,
+    phase: "checking_guardrails",
+  });
 
   // Intentionally check at step start (not step end) to early exit if dollar amount too high.
   // This can miss thresholds crossed on the final step.
@@ -214,6 +225,10 @@ async function _runModelAndCreateActionsActivity({
   }
 
   // Tool test run: bypass LLM and directly execute tool commands.
+  heartbeatRunModelAndCreateActionsActivity({
+    step,
+    phase: "checking_prompt_command",
+  });
   const featureFlags = await getFeatureFlags(auth);
   if (featureFlags.includes("run_tools_from_prompt")) {
     const result = await handlePromptCommand(auth, runAgentData, step, runIds);
@@ -223,6 +238,11 @@ async function _runModelAndCreateActionsActivity({
   }
 
   if (checkForResume) {
+    heartbeatRunModelAndCreateActionsActivity({
+      step,
+      phase: "checking_resume",
+    });
+
     // Check if actions already exist for this step. If so, we are resuming from tool validation.
     const existingData = await getExistingActionsAndBlobs(
       auth,
@@ -280,6 +300,10 @@ async function _runModelAndCreateActionsActivity({
   // 2. Create tool actions.
   // Include the new runId in the runIds array when creating actions
   const currentRunIds = runId ? [...runIds, runId] : runIds;
+  heartbeatRunModelAndCreateActionsActivity({
+    step,
+    phase: "creating_actions",
+  });
   const createResult = await startActiveObservation("create-tool-actions", () =>
     createToolActionsActivity(auth, {
       runAgentData,
@@ -293,6 +317,10 @@ async function _runModelAndCreateActionsActivity({
 
   const needsApproval = createResult.actionBlobs.some((a) => a.needsApproval);
   if (needsApproval) {
+    heartbeatRunModelAndCreateActionsActivity({
+      step,
+      phase: "marking_action_required",
+    });
     await ConversationResource.markAsActionRequired(auth, {
       conversation: runAgentData.conversation,
     });

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -1,8 +1,10 @@
 import type { LLM } from "@app/lib/api/llm/llm";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import { parseResponseFormatSchema } from "@app/lib/api/llm/utils";
 import { config as regionsConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
+import { heartbeatRunModelAndCreateActionsActivity } from "@app/temporal/agent_loop/lib/heartbeat_details";
 import type {
   GetOutputRequestParams,
   GetOutputResponse,
@@ -11,7 +13,7 @@ import type {
 import type { ModelIdType } from "@app/types/assistant/models/types";
 import { Err, Ok } from "@app/types/shared/result";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
-import { CancelledFailure, heartbeat, sleep } from "@temporalio/activity";
+import { CancelledFailure, sleep } from "@temporalio/activity";
 
 const LLM_HEARTBEAT_INTERVAL_MS = 10_000;
 // Log heartbeat status periodically to track long-waiting LLM calls.
@@ -87,21 +89,22 @@ function makeLLMTimeoutResponse(kind: LLMStreamTimeoutKind): GetOutputResponse {
 
 // Wraps an async iterator and ensures heartbeat() is called at regular intervals
 // even when the source is slow to yield values.
-async function* withPeriodicHeartbeat<T>(
-  stream: AsyncIterator<T>,
+async function* withPeriodicHeartbeat(
+  stream: AsyncIterator<LLMEvent>,
   activityTimeoutDeadlineMs: number,
-  logContext?: {
+  logContext: {
     workspaceId: string;
     conversationId: string;
     step: number;
     modelId: ModelIdType;
   }
-): AsyncGenerator<T> {
+): AsyncGenerator<LLMEvent> {
   let nextPromise = stream.next();
   let streamExhausted = false;
   let heartbeatCount = 0;
   const streamStartTimeMs = Date.now();
   let lastEventTimeMs = Date.now();
+  let lastEventType: LLMEvent["type"] | undefined;
 
   let heartbeatTimer: NodeJS.Timeout | undefined;
 
@@ -143,12 +146,19 @@ async function* withPeriodicHeartbeat<T>(
       // Clear the heartbeat timer if the stream event won the race.
       clearTimeout(heartbeatTimer);
 
-      heartbeat();
-
       if (result.type === "heartbeat") {
         heartbeatCount++;
         const now = Date.now();
-        const elapsedMs = now - lastEventTimeMs;
+        const timeSinceLastEventMs = now - lastEventTimeMs;
+
+        heartbeatRunModelAndCreateActionsActivity({
+          step: logContext.step,
+          phase: "waiting_model_event",
+          elapsedMs: now - streamStartTimeMs,
+          heartbeatCount,
+          lastEventType,
+          timeSinceLastEventMs,
+        });
 
         if (now >= activityTimeoutDeadlineMs) {
           logger.error(
@@ -167,17 +177,21 @@ async function* withPeriodicHeartbeat<T>(
         }
 
         // Check for timeout waiting on event.
-        if (elapsedMs >= LLM_EVENT_TIMEOUT_MS) {
+        if (timeSinceLastEventMs >= LLM_EVENT_TIMEOUT_MS) {
           logger.error(
             {
               ...logContext,
               heartbeatCount,
-              elapsedMs,
+              elapsedMs: timeSinceLastEventMs,
               timeoutMinutes: LLM_EVENT_TIMEOUT_MINUTES,
             },
             "[LLM stream] timeout - no event received"
           );
-          throw new LLMStreamTimeoutError("event", elapsedMs, logContext);
+          throw new LLMStreamTimeoutError(
+            "event",
+            timeSinceLastEventMs,
+            logContext
+          );
         }
 
         // Log every minute to track long-waiting LLM calls.
@@ -186,7 +200,7 @@ async function* withPeriodicHeartbeat<T>(
             {
               ...logContext,
               heartbeatCount,
-              elapsedMs,
+              elapsedMs: timeSinceLastEventMs,
             },
             "[LLM stream] heartbeat - still waiting for event"
           );
@@ -203,6 +217,16 @@ async function* withPeriodicHeartbeat<T>(
         streamExhausted = true;
         break;
       }
+
+      const now = Date.now();
+      lastEventType = streamResult.value.type;
+      heartbeatRunModelAndCreateActionsActivity({
+        step: logContext.step,
+        phase: "processing_model_event",
+        elapsedMs: now - streamStartTimeMs,
+        lastEventType,
+        timeSinceLastEventMs: now - lastEventTimeMs,
+      });
 
       yield streamResult.value;
       nextPromise = stream.next();

--- a/front/temporal/agent_loop/lib/heartbeat_details.ts
+++ b/front/temporal/agent_loop/lib/heartbeat_details.ts
@@ -1,0 +1,65 @@
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import { Context, heartbeat } from "@temporalio/activity";
+
+const RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME =
+  "runModelAndCreateActionsActivity";
+
+export type RunModelAndCreateActionsHeartbeatPhase =
+  | "loading_agent_loop_data"
+  | "checking_guardrails"
+  | "checking_prompt_command"
+  | "checking_resume"
+  | "resolving_tools"
+  | "rendering_conversation"
+  | "preparing_model_call"
+  | "starting_model_stream"
+  | "waiting_model_event"
+  | "processing_model_event"
+  | "persisting_model_output"
+  | "creating_actions"
+  | "marking_action_required";
+
+export type RunModelAndCreateActionsHeartbeatDetails = {
+  activity: typeof RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME;
+  attempt: number;
+  step: number;
+  phase: RunModelAndCreateActionsHeartbeatPhase;
+  elapsedMs?: number;
+  heartbeatCount?: number;
+  lastEventType?: LLMEvent["type"];
+  timeSinceLastEventMs?: number;
+};
+
+export function heartbeatRunModelAndCreateActionsActivity({
+  step,
+  phase,
+  elapsedMs,
+  heartbeatCount,
+  lastEventType,
+  timeSinceLastEventMs,
+}: Omit<
+  RunModelAndCreateActionsHeartbeatDetails,
+  "activity" | "attempt"
+>): void {
+  const details: RunModelAndCreateActionsHeartbeatDetails = {
+    activity: RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME,
+    attempt: Context.current().info.attempt,
+    step,
+    phase,
+  };
+
+  if (elapsedMs !== undefined) {
+    details.elapsedMs = Math.round(elapsedMs);
+  }
+  if (heartbeatCount !== undefined) {
+    details.heartbeatCount = heartbeatCount;
+  }
+  if (lastEventType !== undefined) {
+    details.lastEventType = lastEventType;
+  }
+  if (timeSinceLastEventMs !== undefined) {
+    details.timeSinceLastEventMs = Math.round(timeSinceLastEventMs);
+  }
+
+  heartbeat(details);
+}

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -69,6 +69,7 @@ import {
 import { METRICS } from "@app/temporal/agent_loop/activities/instrumentation";
 import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
 import { getOutputFromLLMStream } from "@app/temporal/agent_loop/lib/get_output_from_llm";
+import { heartbeatRunModelAndCreateActionsActivity } from "@app/temporal/agent_loop/lib/heartbeat_details";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import type { AgentActionsEvent } from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
@@ -82,7 +83,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { startActiveObservation } from "@langfuse/tracing";
-import { Context, heartbeat } from "@temporalio/activity";
+import { Context } from "@temporalio/activity";
 import assert from "assert";
 
 // Concatenate two content strings, ensuring at least one whitespace character
@@ -222,6 +223,11 @@ export async function runModel(
     });
     return null;
   }
+
+  heartbeatRunModelAndCreateActionsActivity({
+    step,
+    phase: "resolving_tools",
+  });
 
   const {
     enabledSkills,
@@ -429,6 +435,10 @@ export async function runModel(
 
   // Turn the conversation into a digest that can be presented to the model.
   const promptText = systemPromptToText(prompt);
+  heartbeatRunModelAndCreateActionsActivity({
+    step,
+    phase: "rendering_conversation",
+  });
   const modelConversationRes = await startActiveObservation(
     "render-conversation",
     () =>
@@ -518,6 +528,11 @@ export async function runModel(
     workspaceId: conversation.owner.sId,
   };
 
+  heartbeatRunModelAndCreateActionsActivity({
+    step,
+    phase: "preparing_model_call",
+  });
+
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
   });
@@ -566,7 +581,10 @@ export async function runModel(
   // Heartbeat before starting the LLM stream to ensure the activity is still
   // considered alive after potentially long setup operations (MCP tools
   // listing, conversation rendering, etc.).
-  heartbeat();
+  heartbeatRunModelAndCreateActionsActivity({
+    step,
+    phase: "starting_model_stream",
+  });
 
   localLogger.info(
     {
@@ -677,6 +695,11 @@ export async function runModel(
 
   const { dustRunId, nativeChainOfThought, output } =
     getOutputFromActionResponse.value;
+
+  heartbeatRunModelAndCreateActionsActivity({
+    step,
+    phase: "persisting_model_output",
+  });
 
   // Create a new object to avoid mutation
   const updatedFunctionCallStepContentIds = { ...functionCallStepContentIds };


### PR DESCRIPTION
## Description
Context: https://github.com/dust-tt/tasks/issues/7458
Follows https://github.com/dust-tt/dust/pull/24169

Adds structured heartbeat details to `runModelAndCreateActionsActivity` so Temporal timeouts show the current phase, step, attempt, and last streamed event instead of `lastHeartbeatDetails: [null]`.

## Risks
Blast radius: agent loop activity observability and Temporal heartbeat payloads
Risk: low

## Deploy Plan
- deploy front
