### PR TITLE
[Sessions] Suffix fork titles with "(forked)"

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -135,7 +135,7 @@ describe("createConversationFork", () => {
 
     const childConversation = result.value;
 
-    expect(childConversation.title).toBe("Parent conversation");
+    expect(childConversation.title).toBe("Parent conversation (forked)");
     expect(childConversation.spaceId).toBe(globalSpace.sId);
     expect(childConversation.depth).toBe(parentConversation.depth + 1);
     expect(childConversation.content).toEqual([]);
@@ -236,6 +236,40 @@ describe("createConversationFork", () => {
     expect(result.value.forkedFrom?.sourceMessageId).toBe(
       firstAgentMessage.sId
     );
+  });
+
+  it("does not duplicate the fork suffix when forking an already forked conversation", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation (forked)",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "Continue from here",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.title).toBe("Parent conversation (forked)");
   });
 
   it("returns invalid_request_error when the source message is not forkable", async () => {

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -238,40 +238,6 @@ describe("createConversationFork", () => {
     );
   });
 
-  it("does not duplicate the fork suffix when forking an already forked conversation", async () => {
-    const { auth } = await createPrivateApiMockRequest();
-
-    const parentConversation = await createConversation(auth, {
-      title: "Parent conversation (forked)",
-      visibility: "unlisted",
-      spaceId: null,
-    });
-
-    const userMessage = await createUserMessage(auth, {
-      conversation: parentConversation,
-      rank: 0,
-      content: "Continue from here",
-    });
-    const sourceMessage = await createAgentMessage(auth, {
-      conversation: parentConversation,
-      rank: 1,
-      parentId: userMessage.id,
-      status: "succeeded",
-    });
-
-    const result = await createConversationFork(auth, {
-      conversationId: parentConversation.sId,
-      sourceMessageId: sourceMessage.sId,
-    });
-
-    expect(result.isErr()).toBe(false);
-    if (result.isErr()) {
-      throw result.error;
-    }
-
-    expect(result.value.title).toBe("Parent conversation (forked)");
-  });
-
   it("returns invalid_request_error when the source message is not forkable", async () => {
     const { auth } = await createPrivateApiMockRequest();
 

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -19,6 +19,20 @@ export type CreateConversationForkErrorCode =
   | "invalid_request_error"
   | "internal_error";
 
+const FORKED_CONVERSATION_TITLE_SUFFIX = " (forked)";
+
+function getForkedConversationTitle(title: string | null): string | null {
+  if (title === null) {
+    return null;
+  }
+
+  if (title.endsWith(FORKED_CONVERSATION_TITLE_SUFFIX)) {
+    return title;
+  }
+
+  return `${title}${FORKED_CONVERSATION_TITLE_SUFFIX}`;
+}
+
 async function copyConversationMCPServerViews(
   auth: Authenticator,
   {
@@ -116,7 +130,7 @@ export async function createConversationFork(
       auth,
       {
         sId: generateRandomModelSId(),
-        title: parentConversation.title,
+        title: getForkedConversationTitle(parentConversation.title),
         visibility: parentConversation.visibility,
         depth: parentConversation.depth + 1,
         triggerId: null,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -144,6 +144,9 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().conversation.title).toBe(
+      "Parent conversation (forked)"
+    );
     expect(res._getJSONData().conversation.forkedFrom).toEqual({
       parentConversationId: parentConversation.sId,
       sourceMessageId: sourceMessage.sId,


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24156 and https://github.com/dust-tt/dust/pull/24181.
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

Appends ` (forked)` to child conversation titles during fork creation, while keeping untitled conversations untitled and avoiding duplicate suffixes when forking an already-forked conversation.

Not doing complex logic at the time to distinguish from multiple forked convos.

## Risks
Blast radius: internal conversation fork creation titles
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/api/assistant/conversation/forks.test.ts pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts`
