### PR TITLE
[Email] Route failed agent replies through error path

### DIFF
--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -205,6 +205,15 @@ export async function sendEmailReplyOnCompletion(
       return;
     }
 
+    if (agentMessage.status === "failed") {
+      await sendEmailReplyOnError(
+        authType,
+        agentLoopArgs,
+        agentMessage.error?.message ?? "Agent execution failed."
+      );
+      return;
+    }
+
     // Check if blocked on tool validation — send validation email instead.
     const blocked = await handleBlockedValidation(
       auth,


### PR DESCRIPTION
## Description
Context: https://github.com/dust-tt/tasks/issues/7458
Fixes regression in https://github.com/dust-tt/dust/pull/24169

If an email-originated agent message already ended in `failed`, `sendEmailReplyOnCompletion()` now routes it through the error email path instead of sending the normal completion email. Previously, these in-band failures could still email the normal completion template, using partial or empty agent content. This stays behind the existing email-agents workspace check.

## Risks
Blast radius: email replies for failed agent-loop messages
Risk: low

## Deploy Plan
- deploy front
