### PR TITLE
fix: deprecate temporal patch for tool-denial continue loop

### DIFF
--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -30,7 +30,7 @@ import type {
 } from "@temporalio/workflow";
 import {
   CancellationScope,
-  patched,
+  deprecatePatch,
   proxyActivities,
   proxySinks,
   setHandler,
@@ -372,19 +372,12 @@ async function executeStepIteration({
 
   // Generation completed or the loop unpaused and no new tools were generated.
   if (actionBlobs.length === 0) {
+    deprecatePatch("tool-denial-continue-loop");
     return {
       runId,
-      // Patch lifecycle for tool-denial continue loop:
-      // 1. Now: patched() makes new workflows continue the loop when runId is null (all actions
-      //    denied). Old workflows keep the previous behavior (shouldContinue: false).
-      // 2. + a few hours: Replace patched() with deprecatePatch(), remove conditional.
-      // 3. + a few hours: Remove deprecatePatch() entirely.
-
-      // if runId is null that means we unpaused the loop with no new tools (eg: they were all
+      // If runId is null that means we unpaused the loop with no new tools (eg: they were all
       // denied) and no LLM call, so we need to continue as the agent loop is not finished.
-      shouldContinue: patched("tool-denial-continue-loop")
-        ? runId === null
-        : false,
+      shouldContinue: runId === null,
     };
   }
 


### PR DESCRIPTION
## Description

Move the `tool-denial-continue-loop` temporal patch from `patched()` to `deprecatePatch()` now that the initial fix (#24150) has been deployed and all in-flight workflows have completed. This is step 2 of the patch lifecycle — the conditional branch is removed and `shouldContinue: runId === null` is now the only code path.

## Tests

Existing agent loop tests cover tool denial flows. The `deprecatePatch` call ensures replay compatibility with any workflows that saw the `patched()` marker.

## Risk

Low.

## Deploy Plan

- deploy `front`