### PR TITLE
[Sessions] Seed forks with an initialization message

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -11,7 +11,6 @@ import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
-import { getConversationRoute } from "@app/lib/utils/router";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -135,20 +134,10 @@ describe("createConversationFork", () => {
     }
 
     const childConversation = result.value;
-    const expectedInitializationMessage =
-      "The conversation was forked from " +
-      `[Parent conversation](${getConversationRoute(auth.getNonNullableWorkspace().sId, parentConversation.sId)}).`;
 
     expect(childConversation.title).toBe("Parent conversation (forked)");
     expect(childConversation.spaceId).toBe(globalSpace.sId);
     expect(childConversation.depth).toBe(parentConversation.depth + 1);
-    expect(childConversation.content).toHaveLength(1);
-    expect(childConversation.content[0]).toHaveLength(1);
-    expect(childConversation.content[0][0]).toMatchObject({
-      type: "user_message",
-      content: expectedInitializationMessage,
-      mentions: [],
-    });
     expect(childConversation.forkedFrom).toEqual({
       parentConversationId: parentConversation.sId,
       sourceMessageId: sourceMessage.sId,

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -11,6 +11,7 @@ import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { getConversationRoute } from "@app/lib/utils/router";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -134,11 +135,20 @@ describe("createConversationFork", () => {
     }
 
     const childConversation = result.value;
+    const expectedInitializationMessage =
+      "The conversation was forked from " +
+      `[Parent conversation](${getConversationRoute(auth.getNonNullableWorkspace().sId, parentConversation.sId)}).`;
 
     expect(childConversation.title).toBe("Parent conversation (forked)");
     expect(childConversation.spaceId).toBe(globalSpace.sId);
     expect(childConversation.depth).toBe(parentConversation.depth + 1);
-    expect(childConversation.content).toEqual([]);
+    expect(childConversation.content).toHaveLength(1);
+    expect(childConversation.content[0]).toHaveLength(1);
+    expect(childConversation.content[0][0]).toMatchObject({
+      type: "user_message",
+      content: expectedInitializationMessage,
+      mentions: [],
+    });
     expect(childConversation.forkedFrom).toEqual({
       parentConversationId: parentConversation.sId,
       sourceMessageId: sourceMessage.sId,

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -120,6 +120,8 @@ async function createForkInitializationMessage(
     transaction: Transaction;
   }
 ) {
+  // TODO(sessions): Replace this placeholder user message with a compaction message once
+  // compaction messages are rendered in the main conversation UI.
   const user = auth.getNonNullableUser();
 
   await createUserMessage(auth, {

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -1,10 +1,12 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { createUserMessage } from "@app/lib/api/assistant/conversation/messages";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { getConversationRoute } from "@app/lib/utils/router";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   ConversationType,
@@ -20,6 +22,8 @@ export type CreateConversationForkErrorCode =
   | "internal_error";
 
 const FORKED_CONVERSATION_TITLE_SUFFIX = " (forked)";
+const FORK_INITIALIZATION_MESSAGE_RANK = 0;
+const UNTITLED_CONVERSATION_TITLE = "Untitled conversation";
 
 function getForkedConversationTitle(title: string | null): string | null {
   if (title === null) {
@@ -31,6 +35,25 @@ function getForkedConversationTitle(title: string | null): string | null {
   }
 
   return `${title}${FORKED_CONVERSATION_TITLE_SUFFIX}`;
+}
+
+function escapeMarkdownLinkText(text: string): string {
+  return text.replace(/[\\[\]]/g, "\\$&");
+}
+
+function getForkInitializationMessageContent(
+  workspaceId: string,
+  parentConversation: ConversationWithoutContentType
+): string {
+  const parentConversationTitle = escapeMarkdownLinkText(
+    parentConversation.title ?? UNTITLED_CONVERSATION_TITLE
+  );
+  const parentConversationUrl = getConversationRoute(
+    workspaceId,
+    parentConversation.sId
+  );
+
+  return `The conversation was forked from [${parentConversationTitle}](${parentConversationUrl}).`;
 }
 
 async function copyConversationMCPServerViews(
@@ -83,6 +106,43 @@ async function copyConversationMCPServerViews(
   }
 
   return new Ok(undefined);
+}
+
+async function createForkInitializationMessage(
+  auth: Authenticator,
+  {
+    parentConversation,
+    childConversation,
+    transaction,
+  }: {
+    parentConversation: ConversationWithoutContentType;
+    childConversation: ConversationWithoutContentType;
+    transaction: Transaction;
+  }
+) {
+  const user = auth.getNonNullableUser();
+
+  await createUserMessage(auth, {
+    conversation: childConversation,
+    content: getForkInitializationMessageContent(
+      auth.getNonNullableWorkspace().sId,
+      parentConversation
+    ),
+    metadata: {
+      type: "create",
+      user: user.toJSON(),
+      rank: FORK_INITIALIZATION_MESSAGE_RANK,
+      context: {
+        username: user.username,
+        fullName: user.fullName(),
+        email: user.email,
+        profilePictureUrl: user.imageUrl,
+        timezone: "UTC",
+        origin: "api",
+      },
+    },
+    transaction,
+  });
 }
 
 export async function createConversationFork(
@@ -155,12 +215,18 @@ export async function createConversationFork(
       return copyMCPServerViewsResult;
     }
 
+    await createForkInitializationMessage(auth, {
+      parentConversation: parentConversation.toJSON(),
+      childConversation: childConversation.toJSON(),
+      transaction,
+    });
+
     await ConversationResource.upsertParticipation(auth, {
       conversation: childConversation.toJSON(),
       action: "subscribed",
       user: auth.getNonNullableUser().toJSON(),
       transaction,
-      lastReadAt: branchedAt,
+      lastReadAt: new Date(),
     });
 
     await ConversationForkResource.makeNew(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -5,6 +5,7 @@ import {
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { getConversationRoute } from "@app/lib/utils/router";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -143,6 +144,10 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
 
     await handler(req, res);
 
+    const expectedInitializationMessage =
+      "The conversation was forked from " +
+      `[Parent conversation](${getConversationRoute(auth.getNonNullableWorkspace().sId, parentConversation.sId)}).`;
+
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData().conversation.title).toBe(
       "Parent conversation (forked)"
@@ -155,7 +160,13 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
     });
     expect(res._getJSONData().conversation.depth).toBe(1);
     expect(res._getJSONData().conversation.spaceId).toBe(globalSpace.sId);
-    expect(res._getJSONData().conversation.content).toEqual([]);
+    expect(res._getJSONData().conversation.content).toHaveLength(1);
+    expect(res._getJSONData().conversation.content[0]).toHaveLength(1);
+    expect(res._getJSONData().conversation.content[0][0]).toMatchObject({
+      type: "user_message",
+      content: expectedInitializationMessage,
+      mentions: [],
+    });
   });
 
   it("returns 400 when the source message cannot be forked", async () => {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -5,7 +5,6 @@ import {
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
-import { getConversationRoute } from "@app/lib/utils/router";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -144,10 +143,6 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
 
     await handler(req, res);
 
-    const expectedInitializationMessage =
-      "The conversation was forked from " +
-      `[Parent conversation](${getConversationRoute(auth.getNonNullableWorkspace().sId, parentConversation.sId)}).`;
-
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData().conversation.title).toBe(
       "Parent conversation (forked)"
@@ -160,13 +155,6 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
     });
     expect(res._getJSONData().conversation.depth).toBe(1);
     expect(res._getJSONData().conversation.spaceId).toBe(globalSpace.sId);
-    expect(res._getJSONData().conversation.content).toHaveLength(1);
-    expect(res._getJSONData().conversation.content[0]).toHaveLength(1);
-    expect(res._getJSONData().conversation.content[0][0]).toMatchObject({
-      type: "user_message",
-      content: expectedInitializationMessage,
-      mentions: [],
-    });
   });
 
   it("returns 400 when the source message cannot be forked", async () => {


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24156, https://github.com/dust-tt/dust/pull/24181, and https://github.com/dust-tt/dust/pull/24186.
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

Adds a visible placeholder message when creating a forked conversation: `The conversation was forked from [Conversation title](conversation link)`.

Compaction messages already exist in the backend, but they are not rendered in the main conversation UI yet. As a temporary stub, this PR uses a regular user message with no agent mention to guarantee immediate UI rendering.

<img width="1957" height="480" alt="image" src="https://github.com/user-attachments/assets/b58425b2-91da-47cc-aec6-e8314a6b11c2" />


## Risks
Blast radius: internal conversation fork creation rendering
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/api/assistant/conversation/forks.test.ts pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts`
