### PR TITLE
Add POST compactions endpoint

### DIFF
--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/compact.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/compact.ts
@@ -67,6 +67,15 @@ import { isSupportedModel } from "@app/types/assistant/assistant";
 import type { CompactionMessageType } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const PostConversationCompactBodySchema = z.object({
+  model: z.object({
+    providerId: z.string(),
+    modelId: z.string(),
+  }),
+});
 
 export type PostConversationCompactResponseBody = {
   compactionMessage: CompactionMessageType;
@@ -79,16 +88,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (req.method !== "POST") {
-    return apiError(req, res, {
-      status_code: 405,
-      api_error: {
-        type: "method_not_supported_error",
-        message: "The method passed is not supported, POST is expected.",
-      },
-    });
-  }
-
   const { cId } = req.query;
   if (typeof cId !== "string") {
     return apiError(req, res, {
@@ -100,35 +99,62 @@ async function handler(
     });
   }
 
-  const conversationRes = await getConversation(auth, cId);
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
-  }
-  const conversation = conversationRes.value;
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = PostConversationCompactBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${fromError(bodyValidation.error).message}`,
+          },
+        });
+      }
 
-  const { model } = req.body;
-  if (!isSupportedModel(model)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message:
-          "Invalid model. Expected { providerId: string, modelId: string } with a supported model.",
-      },
-    });
-  }
+      const { model } = bodyValidation.data;
+      if (!isSupportedModel(model)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Unsupported model: ${model.providerId}/${model.modelId}.`,
+          },
+        });
+      }
 
-  const result = await compactConversation(auth, { conversation, model });
-  if (result.isErr()) {
-    return apiError(req, res, {
-      status_code: result.error.status_code,
-      api_error: result.error.api_error,
-    });
-  }
+      const conversationRes = await getConversation(auth, cId);
+      if (conversationRes.isErr()) {
+        return apiErrorForConversation(req, res, conversationRes.error);
+      }
 
-  return res.status(200).json({
-    compactionMessage: result.value.compactionMessage,
-  });
+      const result = await compactConversation(auth, {
+        conversation: conversationRes.value,
+        model,
+      });
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: result.error.status_code,
+          api_error: result.error.api_error,
+        });
+      }
+
+      return res.status(200).json({
+        compactionMessage: result.value.compactionMessage,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/compact.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/compact.ts
@@ -1,0 +1,134 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/compact:
+ *   post:
+ *     summary: Compact a conversation
+ *     description: Trigger compaction of a conversation, summarizing older messages into a compaction message. Requires a model to use for summary generation.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - model
+ *             properties:
+ *               model:
+ *                 type: object
+ *                 required:
+ *                   - providerId
+ *                   - modelId
+ *                 properties:
+ *                   providerId:
+ *                     type: string
+ *                   modelId:
+ *                     type: string
+ *     responses:
+ *       200:
+ *         description: Compaction started
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 compactionMessage:
+ *                   $ref: '#/components/schemas/PrivateCompactionMessage'
+ *       409:
+ *         description: Conflict — compaction or agent message is already running
+ *       404:
+ *         description: Conversation not found
+ *       400:
+ *         description: Invalid request body
+ */
+import { compactConversation } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import { isSupportedModel } from "@app/types/assistant/assistant";
+import type { CompactionMessageType } from "@app/types/assistant/conversation";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type PostConversationCompactResponseBody = {
+  compactionMessage: CompactionMessageType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PostConversationCompactResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const { cId } = req.query;
+  if (typeof cId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid conversation ID.",
+      },
+    });
+  }
+
+  const conversationRes = await getConversation(auth, cId);
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+  const conversation = conversationRes.value;
+
+  const { model } = req.body;
+  if (!isSupportedModel(model)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Invalid model. Expected { providerId: string, modelId: string } with a supported model.",
+      },
+    });
+  }
+
+  const result = await compactConversation(auth, { conversation, model });
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: result.error.status_code,
+      api_error: result.error.api_error,
+    });
+  }
+
+  return res.status(200).json({
+    compactionMessage: result.value.compactionMessage,
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -70,7 +70,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-const PostConversationCompactBodySchema = z.object({
+const PostConversationCompactionsBodySchema = z.object({
   model: z.object({
     providerId: z.string(),
     modelId: z.string(),
@@ -99,9 +99,14 @@ async function handler(
     });
   }
 
+  const conversationRes = await getConversation(auth, cId);
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
   switch (req.method) {
     case "POST": {
-      const bodyValidation = PostConversationCompactBodySchema.safeParse(
+      const bodyValidation = PostConversationCompactionsBodySchema.safeParse(
         req.body
       );
       if (!bodyValidation.success) {
@@ -123,11 +128,6 @@ async function handler(
             message: `Unsupported model: ${model.providerId}/${model.modelId}.`,
           },
         });
-      }
-
-      const conversationRes = await getConversation(auth, cId);
-      if (conversationRes.isErr()) {
-        return apiErrorForConversation(req, res, conversationRes.error);
       }
 
       const result = await compactConversation(auth, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -1,6 +1,6 @@
 /**
  * @swagger
- * /api/w/{wId}/assistant/conversations/{cId}/compact:
+ * /api/w/{wId}/assistant/conversations/{cId}/compactions:
  *   post:
  *     summary: Compact a conversation
  *     description: Trigger compaction of a conversation, summarizing older messages into a compaction message. Requires a model to use for summary generation.

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -36,7 +36,6 @@ async function handler(
   switch (req.method) {
     case "GET": {
       const conversation = await ConversationResource.fetchById(auth, cId);
-
       if (!conversation) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -6116,6 +6116,96 @@
         }
       }
     },
+    "/api/w/{wId}/assistant/conversations/{cId}/compactions": {
+      "post": {
+        "summary": "Compact a conversation",
+        "description": "Trigger compaction of a conversation, summarizing older messages into a compaction message. Requires a model to use for summary generation.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "model"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "object",
+                    "required": [
+                      "providerId",
+                      "modelId"
+                    ],
+                    "properties": {
+                      "providerId": {
+                        "type": "string"
+                      },
+                      "modelId": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Compaction started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "compactionMessage": {
+                      "$ref": "#/components/schemas/PrivateCompactionMessage"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "404": {
+            "description": "Conversation not found"
+          },
+          "409": {
+            "description": "Conflict — compaction or agent message is already running"
+          }
+        }
+      }
+    },
     "/api/w/{wId}/assistant/conversations/{cId}/content_fragment": {
       "post": {
         "summary": "Create a content fragment",


### PR DESCRIPTION
## Description

Add `POST /api/w/{wId}/assistant/conversations/{cId}/compactions` endpoint that
triggers conversation compaction.

- Zod body validation for `{ model: { providerId, modelId } }`.
- Validates model with `isSupportedModel`.
- Fetches conversation and calls `compactConversation`.
- Returns the created `CompactionMessageType` (status "created").
- Returns 409 if compaction or agent message is already running.
- Swagger documented.

## Tests

Type-check passes.

## Risk

Low — endpoint is additive, compaction is not triggered automatically.

## Deploy Plan

Regular deploy.