### PR TITLE
feat: add command palette (Cmd+K) v0 - silent ship

### DIFF
--- a/front/components/assistant/conversation/sidebar/SidebarSearch.tsx
+++ b/front/components/assistant/conversation/sidebar/SidebarSearch.tsx
@@ -14,11 +14,6 @@ export function SidebarSearch({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        e.stopPropagation();
-        searchInputRef.current?.focus();
-      }
       if (
         e.key === "Escape" &&
         document.activeElement === searchInputRef.current

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -8,7 +8,7 @@ import { SkillDetailsSheetById } from "@app/components/command_palette/SkillDeta
 import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useSkills } from "@app/lib/swr/skill_configurations";
-import { filterAndSortAgents } from "@app/lib/utils";
+import { filterAndSortAgents, subFilter } from "@app/lib/utils";
 import {
   getAgentBuilderRoute,
   getConversationRoute,
@@ -88,7 +88,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
       return skills;
     }
     const lowerQuery = debouncedQuery.toLowerCase();
-    return skills.filter((s) => s.name.toLowerCase().includes(lowerQuery));
+    return skills.filter((s) => subFilter(lowerQuery, s.name.toLowerCase()));
   }, [skills, debouncedQuery]);
 
   const isLoading =

--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -1,0 +1,217 @@
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
+import type { CommandPaletteAction } from "@app/components/command_palette/CommandPaletteActionPhase";
+import { CommandPaletteActionPhase } from "@app/components/command_palette/CommandPaletteActionPhase";
+import { useCommandPalette } from "@app/components/command_palette/CommandPaletteContext";
+import type { CommandPaletteItem } from "@app/components/command_palette/CommandPaletteSearchPhase";
+import { CommandPaletteSearchPhase } from "@app/components/command_palette/CommandPaletteSearchPhase";
+import { SkillDetailsSheetById } from "@app/components/command_palette/SkillDetailsSheetById";
+import { useAppRouter } from "@app/lib/platform";
+import { useAgentConfigurations } from "@app/lib/swr/assistants";
+import { useSkills } from "@app/lib/swr/skill_configurations";
+import { filterAndSortAgents } from "@app/lib/utils";
+import {
+  getAgentBuilderRoute,
+  getConversationRoute,
+  getSkillBuilderRoute,
+} from "@app/lib/utils/router";
+import { compareAgentsForSort } from "@app/types/assistant/assistant";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+import { Dialog, DialogContent } from "@dust-tt/sparkle";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+interface CommandPaletteProps {
+  owner: LightWorkspaceType;
+  user: UserType;
+}
+
+export function CommandPalette({ owner, user }: CommandPaletteProps) {
+  const { isOpen, close } = useCommandPalette();
+  const router = useAppRouter();
+
+  // Dialog state.
+  const [searchQuery, setSearchQuery] = useState("");
+  const [phase, setPhase] = useState<"search" | "action">("search");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedItem, setSelectedItem] = useState<CommandPaletteItem | null>(
+    null
+  );
+
+  // Detail sheet state (lives outside the dialog lifecycle).
+  const [agentDetailsId, setAgentDetailsId] = useState<string | null>(null);
+  const [skillDetailsId, setSkillDetailsId] = useState<string | null>(null);
+
+  // Fetch agents and skills only when the palette is open.
+  const { agentConfigurations, isAgentConfigurationsLoading } =
+    useAgentConfigurations({
+      workspaceId: owner.sId,
+      agentsGetView: "list",
+      disabled: !isOpen,
+    });
+
+  const { skills, isSkillsLoading } = useSkills({
+    owner,
+    disabled: !isOpen,
+    status: "active",
+  });
+
+  // Debounce the search query to avoid expensive fuzzy filtering on every keystroke.
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const trimmed = searchQuery.trim();
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+    debounceTimerRef.current = setTimeout(() => {
+      setDebouncedQuery(trimmed);
+    }, 150);
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [searchQuery]);
+
+  const isDebouncing = searchQuery.trim() !== debouncedQuery;
+
+  const filteredAgents = useMemo(
+    () =>
+      debouncedQuery
+        ? filterAndSortAgents(agentConfigurations, debouncedQuery)
+        : [...agentConfigurations].sort(compareAgentsForSort),
+    [agentConfigurations, debouncedQuery]
+  );
+
+  const filteredSkills = useMemo(() => {
+    if (!debouncedQuery) {
+      return skills;
+    }
+    const lowerQuery = debouncedQuery.toLowerCase();
+    return skills.filter((s) => s.name.toLowerCase().includes(lowerQuery));
+  }, [skills, debouncedQuery]);
+
+  const isLoading =
+    isAgentConfigurationsLoading || isSkillsLoading || isDebouncing;
+
+  // Reset state when dialog opens/closes.
+  useEffect(() => {
+    if (isOpen) {
+      setSearchQuery("");
+      setDebouncedQuery("");
+      setPhase("search");
+      setSelectedIndex(0);
+      setSelectedItem(null);
+    }
+  }, [isOpen]);
+
+  const executeAction = useCallback(
+    (item: CommandPaletteItem, action: CommandPaletteAction) => {
+      close();
+
+      switch (action) {
+        case "chat_with":
+          if (item.kind === "agent") {
+            void router.push(
+              getConversationRoute(owner.sId, "new", `agent=${item.agent.sId}`)
+            );
+          }
+          break;
+        case "view_details":
+          if (item.kind === "agent") {
+            setAgentDetailsId(item.agent.sId);
+          } else {
+            setSkillDetailsId(item.skill.sId);
+          }
+          break;
+        case "edit":
+          if (item.kind === "agent") {
+            void router.push(getAgentBuilderRoute(owner.sId, item.agent.sId));
+          } else {
+            void router.push(getSkillBuilderRoute(owner.sId, item.skill.sId));
+          }
+          break;
+      }
+    },
+    [close, router, owner.sId]
+  );
+
+  const handleItemSelect = useCallback(
+    (item: CommandPaletteItem) => {
+      // Skills without write access have only one action (view details).
+      if (item.kind === "skill" && !item.skill.canWrite) {
+        executeAction(item, "view_details");
+      } else {
+        setSelectedItem(item);
+        setPhase("action");
+      }
+    },
+    [executeAction]
+  );
+
+  const handleBack = useCallback(() => {
+    setPhase("search");
+    setSelectedItem(null);
+  }, []);
+
+  const handleAction = useCallback(
+    (action: CommandPaletteAction) => {
+      if (selectedItem) {
+        executeAction(selectedItem, action);
+      }
+    },
+    [selectedItem, executeAction]
+  );
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        close();
+      }
+    },
+    [close]
+  );
+
+  return (
+    <>
+      <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+        <DialogContent size="lg" variant="command" trapFocusScope>
+          {phase === "search" ? (
+            <CommandPaletteSearchPhase
+              searchQuery={searchQuery}
+              onSearchQueryChange={setSearchQuery}
+              agents={filteredAgents}
+              skills={filteredSkills}
+              isLoading={isLoading}
+              selectedIndex={selectedIndex}
+              onSelectedIndexChange={setSelectedIndex}
+              onItemSelect={handleItemSelect}
+              onClose={close}
+            />
+          ) : selectedItem ? (
+            <CommandPaletteActionPhase
+              item={selectedItem}
+              onAction={handleAction}
+              onBack={handleBack}
+              onClose={close}
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+
+      <AgentDetailsSheet
+        owner={owner}
+        user={user}
+        agentId={agentDetailsId}
+        onClose={() => setAgentDetailsId(null)}
+      />
+
+      <SkillDetailsSheetById
+        owner={owner}
+        user={user}
+        skillId={skillDetailsId}
+        onClose={() => setSkillDetailsId(null)}
+      />
+    </>
+  );
+}

--- a/front/components/command_palette/CommandPaletteActionPhase.tsx
+++ b/front/components/command_palette/CommandPaletteActionPhase.tsx
@@ -172,7 +172,7 @@ export function CommandPaletteActionPhase({
         hints={[
           { keys: ["↑", "↓"], label: "Navigate" },
           { keys: ["↵"], label: "Select" },
-          { keys: ["←"], label: "Back" },
+          { keys: ["⌫"], label: "Back", textSize: "text-base" },
           { keys: ["Esc"], label: "Close" },
         ]}
       />

--- a/front/components/command_palette/CommandPaletteActionPhase.tsx
+++ b/front/components/command_palette/CommandPaletteActionPhase.tsx
@@ -1,0 +1,181 @@
+import { KeyboardHints } from "@app/components/command_palette/CommandPaletteItems";
+import type { CommandPaletteItem } from "@app/components/command_palette/CommandPaletteSearchPhase";
+import { getSkillAvatarIcon } from "@app/lib/skill";
+import {
+  ArrowLeftIcon,
+  Avatar,
+  ChatBubbleBottomCenterTextIcon,
+  cn,
+  EyeIcon,
+  Icon,
+  PencilSquareIcon,
+} from "@dust-tt/sparkle";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+export type CommandPaletteAction = "view_details" | "edit" | "chat_with";
+
+interface CommandPaletteActionPhaseProps {
+  item: CommandPaletteItem;
+  onAction: (action: CommandPaletteAction) => void;
+  onBack: () => void;
+  onClose: () => void;
+}
+
+interface ActionDefinition {
+  action: CommandPaletteAction;
+  label: string;
+  description: string;
+  icon: typeof EyeIcon;
+}
+
+function canEdit(item: CommandPaletteItem): boolean {
+  switch (item.kind) {
+    case "agent":
+      return item.agent.canEdit;
+    case "skill":
+      return item.skill.canWrite;
+  }
+}
+
+export function CommandPaletteActionPhase({
+  item,
+  onAction,
+  onBack,
+  onClose,
+}: CommandPaletteActionPhaseProps) {
+  const actions = useMemo(() => {
+    const result: ActionDefinition[] = [];
+    if (item.kind === "agent") {
+      result.push({
+        action: "chat_with",
+        label: "New conversation",
+        description: "Open a new conversation",
+        icon: ChatBubbleBottomCenterTextIcon,
+      });
+    }
+    result.push({
+      action: "view_details",
+      label: "Details",
+      description: "View description and settings",
+      icon: EyeIcon,
+    });
+    if (canEdit(item)) {
+      result.push({
+        action: "edit",
+        label: "Edit",
+        description: "Change instructions and settings",
+        icon: PencilSquareIcon,
+      });
+    }
+    return result;
+  }, [item]);
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
+
+  // Reset selection when the available actions change (e.g., switching between items).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: actions is an intentional trigger
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [actions]);
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev + 1) % actions.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setSelectedIndex(
+          (prev) => (prev - 1 + actions.length) % actions.length
+        );
+        break;
+      case "Enter":
+        e.preventDefault();
+        onAction(actions[selectedIndex].action);
+        break;
+      case "Backspace":
+        e.preventDefault();
+        onBack();
+        break;
+      case "Escape":
+        e.preventDefault();
+        onClose();
+        break;
+    }
+  }
+
+  const itemName =
+    item.kind === "agent" ? `@${item.agent.name}` : item.skill.name;
+
+  const itemAvatar =
+    item.kind === "agent" ? (
+      <Avatar visual={item.agent.pictureUrl} size="xs" />
+    ) : (
+      React.createElement(getSkillAvatarIcon(item.skill.icon), { size: "xs" })
+    );
+
+  return (
+    <div
+      ref={containerRef}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      className="flex flex-col outline-none"
+    >
+      <button
+        className={cn(
+          "flex items-center gap-2 border-b px-4 py-3",
+          "border-separator dark:border-separator-night",
+          "text-sm text-muted-foreground dark:text-muted-foreground-night",
+          "transition-colors duration-100",
+          "hover:text-foreground dark:hover:text-foreground-night"
+        )}
+        onClick={onBack}
+      >
+        <Icon visual={ArrowLeftIcon} size="sm" />
+        {itemAvatar}
+        <span className="font-medium text-foreground dark:text-foreground-night">
+          {itemName}
+        </span>
+      </button>
+
+      <div className="p-1.5">
+        {actions.map(({ action, label, description, icon }, i) => (
+          <div
+            key={action}
+            className={cn(
+              "flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 transition-colors duration-100",
+              "text-foreground dark:text-foreground-night",
+              selectedIndex === i
+                ? "bg-primary-100 dark:bg-primary-100-night"
+                : "hover:bg-muted-background dark:hover:bg-muted-background-night"
+            )}
+            onClick={() => onAction(action)}
+            onMouseEnter={() => setSelectedIndex(i)}
+          >
+            <Icon visual={icon} size="sm" className="shrink-0" />
+            <div className="flex flex-col">
+              <span className="text-sm font-medium">{label}</span>
+              <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                {description}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <KeyboardHints
+        hints={[
+          { keys: ["↑", "↓"], label: "Navigate" },
+          { keys: ["↵"], label: "Select" },
+          { keys: ["←"], label: "Back" },
+          { keys: ["Esc"], label: "Close" },
+        ]}
+      />
+    </div>
+  );
+}

--- a/front/components/command_palette/CommandPaletteContext.tsx
+++ b/front/components/command_palette/CommandPaletteContext.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+interface CommandPaletteContextType {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+const CommandPaletteContext = createContext<CommandPaletteContextType | null>(
+  null
+);
+
+interface CommandPaletteProviderProps {
+  children: ReactNode;
+}
+
+export function CommandPaletteProvider({
+  children,
+}: CommandPaletteProviderProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      isOpen,
+      open,
+      close,
+    }),
+    [isOpen, open, close]
+  );
+
+  return (
+    <CommandPaletteContext.Provider value={value}>
+      {children}
+    </CommandPaletteContext.Provider>
+  );
+}
+
+export function useCommandPalette() {
+  const context = useContext(CommandPaletteContext);
+  if (!context) {
+    throw new Error(
+      "useCommandPalette must be used within a CommandPaletteProvider"
+    );
+  }
+  return context;
+}

--- a/front/components/command_palette/CommandPaletteItems.tsx
+++ b/front/components/command_palette/CommandPaletteItems.tsx
@@ -1,0 +1,89 @@
+import { cn } from "@dust-tt/sparkle";
+import React from "react";
+
+interface ItemRowProps {
+  isSelected: boolean;
+  onClick: () => void;
+  onMouseEnter: () => void;
+  children: React.ReactNode;
+}
+
+export const ItemRow = React.forwardRef<HTMLDivElement, ItemRowProps>(
+  function ItemRow({ isSelected, onClick, onMouseEnter, children }, ref) {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex cursor-pointer items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm transition-colors duration-100",
+          "text-foreground dark:text-foreground-night",
+          isSelected
+            ? "bg-primary-100 dark:bg-primary-100-night"
+            : "hover:bg-muted-background dark:hover:bg-muted-background-night"
+        )}
+        onClick={onClick}
+        onMouseEnter={onMouseEnter}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+interface ItemTitleProps {
+  children: React.ReactNode;
+}
+
+export function ItemTitle({ children }: ItemTitleProps) {
+  return (
+    <div className="px-3 pb-1.5 pt-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
+      {children}
+    </div>
+  );
+}
+
+interface ItemEmptyStateProps {
+  children: React.ReactNode;
+}
+
+export function ItemEmptyState({ children }: ItemEmptyStateProps) {
+  return (
+    <div className="px-3 py-8 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+      {children}
+    </div>
+  );
+}
+
+interface KeyboardHint {
+  keys: string[];
+  label: string;
+}
+
+export function KeyboardHints({ hints }: { hints: KeyboardHint[] }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-end gap-4 border-t px-4 py-2",
+        "border-separator dark:border-separator-night",
+        "text-xs text-muted-foreground dark:text-muted-foreground-night"
+      )}
+    >
+      {hints.map((hint) => (
+        <div key={hint.label} className="flex items-center gap-1.5">
+          {hint.keys.map((key) => (
+            <kbd
+              key={key}
+              className={cn(
+                "inline-flex h-5 min-w-5 items-center justify-center rounded border px-1",
+                "border-separator",
+                "dark:border-separator-night"
+              )}
+            >
+              {key}
+            </kbd>
+          ))}
+          <span>{hint.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/front/components/command_palette/CommandPaletteItems.tsx
+++ b/front/components/command_palette/CommandPaletteItems.tsx
@@ -56,6 +56,7 @@ export function ItemEmptyState({ children }: ItemEmptyStateProps) {
 interface KeyboardHint {
   keys: string[];
   label: string;
+  textSize?: "text-xs" | "text-sm" | "text-base";
 }
 
 export function KeyboardHints({ hints }: { hints: KeyboardHint[] }) {
@@ -73,9 +74,9 @@ export function KeyboardHints({ hints }: { hints: KeyboardHint[] }) {
             <kbd
               key={key}
               className={cn(
-                "inline-flex h-5 min-w-5 items-center justify-center rounded border px-1",
-                "border-separator",
-                "dark:border-separator-night"
+                "inline-flex h-6 min-w-6 items-center justify-center rounded border px-1",
+                "border-separator dark:border-separator-night",
+                hint.textSize ?? "text-xs"
               )}
             >
               {key}

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -116,7 +116,7 @@ export function CommandPaletteSearchPhase({
           isLoading={isLoading}
         />
       </div>
-      <div className="flex max-h-[480px] flex-col gap-2 overflow-y-auto p-1.5">
+      <div className="flex max-h-125 flex-col gap-2 overflow-y-auto p-1.5">
         {isLoading && flatItems.length === 0 && (
           <div className="flex flex-col gap-1 p-1">
             {Array.from({ length: 9 }, (_, i) => (

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -1,0 +1,209 @@
+import {
+  ItemEmptyState,
+  ItemRow,
+  ItemTitle,
+  KeyboardHints,
+} from "@app/components/command_palette/CommandPaletteItems";
+import { getSkillAvatarIcon } from "@app/lib/skill";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { Avatar, SearchInput } from "@dust-tt/sparkle";
+import { useEffect, useMemo, useRef } from "react";
+
+export type CommandPaletteItem =
+  | { kind: "agent"; agent: LightAgentConfigurationType }
+  | { kind: "skill"; skill: SkillType };
+
+interface CommandPaletteSearchPhaseProps {
+  searchQuery: string;
+  onSearchQueryChange: (query: string) => void;
+  agents: LightAgentConfigurationType[];
+  skills: SkillType[];
+  isLoading: boolean;
+  selectedIndex: number;
+  onSelectedIndexChange: (index: number) => void;
+  onItemSelect: (item: CommandPaletteItem) => void;
+  onClose: () => void;
+}
+
+function getFlatItems(
+  agents: LightAgentConfigurationType[],
+  skills: SkillType[]
+): CommandPaletteItem[] {
+  return [
+    ...agents.map((agent): CommandPaletteItem => ({ kind: "agent", agent })),
+    ...skills.map((skill): CommandPaletteItem => ({ kind: "skill", skill })),
+  ];
+}
+
+export function CommandPaletteSearchPhase({
+  searchQuery,
+  onSearchQueryChange,
+  agents,
+  skills,
+  isLoading,
+  selectedIndex,
+  onSelectedIndexChange,
+  onItemSelect,
+  onClose,
+}: CommandPaletteSearchPhaseProps) {
+  const flatItems = useMemo(
+    () => getFlatItems(agents, skills),
+    [agents, skills]
+  );
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus the search input on mount. Deferred with requestAnimationFrame
+  // to run after Radix FocusScope has finished trapping focus.
+  useEffect(() => {
+    const frameId = requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(frameId);
+  }, []);
+
+  // Scroll selected item into view.
+  useEffect(() => {
+    itemRefs.current[selectedIndex]?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  // Reset selection when the number of results changes (e.g., after typing).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: agents.length and skills.length are intentional triggers
+  useEffect(() => {
+    onSelectedIndexChange(0);
+  }, [agents.length, skills.length, onSelectedIndexChange]);
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    const totalItems = flatItems.length;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        if (totalItems > 0) {
+          onSelectedIndexChange((selectedIndex + 1) % totalItems);
+        }
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        if (totalItems > 0) {
+          onSelectedIndexChange((selectedIndex - 1 + totalItems) % totalItems);
+        }
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (flatItems[selectedIndex]) {
+          onItemSelect(flatItems[selectedIndex]);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        onClose();
+        break;
+    }
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="p-3">
+        <SearchInput
+          ref={searchInputRef}
+          name="command-palette-search"
+          placeholder="Search agents and skills…"
+          value={searchQuery}
+          onChange={onSearchQueryChange}
+          onKeyDown={handleKeyDown}
+          isLoading={isLoading}
+        />
+      </div>
+      <div className="flex max-h-[480px] flex-col gap-2 overflow-y-auto p-1.5">
+        {isLoading && flatItems.length === 0 && (
+          <div className="flex flex-col gap-1 p-1">
+            {Array.from({ length: 9 }, (_, i) => (
+              <div key={i} className="flex items-center gap-2.5 px-3 py-2.5">
+                <div className="h-6 w-6 shrink-0 animate-pulse rounded-full bg-muted-background dark:bg-muted-background-night" />
+                <div
+                  className="h-4 animate-pulse rounded bg-muted-background dark:bg-muted-background-night"
+                  style={{ width: `${30 + (i % 3) * 20}%` }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+        {!isLoading && flatItems.length === 0 && searchQuery.length > 0 && (
+          <ItemEmptyState>No results found.</ItemEmptyState>
+        )}
+        {!isLoading && flatItems.length === 0 && searchQuery.length === 0 && (
+          <ItemEmptyState>Type to search agents and skills.</ItemEmptyState>
+        )}
+
+        {agents.length > 0 && (
+          <div>
+            <ItemTitle>Agents</ItemTitle>
+            {agents.map((agent, i) => (
+              <ItemRow
+                key={agent.sId}
+                ref={(el) => {
+                  itemRefs.current[i] = el;
+                }}
+                isSelected={selectedIndex === i}
+                onClick={() => onItemSelect({ kind: "agent", agent })}
+                onMouseEnter={() => onSelectedIndexChange(i)}
+              >
+                <Avatar visual={agent.pictureUrl} size="xs" />
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span className="shrink-0 font-medium">@{agent.name}</span>
+                  <span className="shrink-0 text-muted-foreground dark:text-muted-foreground-night">
+                    -
+                  </span>
+                  <span className="min-w-0 truncate text-muted-foreground dark:text-muted-foreground-night">
+                    {agent.description}
+                  </span>
+                </div>
+              </ItemRow>
+            ))}
+          </div>
+        )}
+
+        {skills.length > 0 && (
+          <div>
+            <ItemTitle>Skills</ItemTitle>
+            {skills.map((skill, i) => {
+              const globalIndex = agents.length + i;
+              const SkillAvatar = getSkillAvatarIcon(skill.icon);
+              return (
+                <ItemRow
+                  key={skill.sId}
+                  ref={(el) => {
+                    itemRefs.current[globalIndex] = el;
+                  }}
+                  isSelected={selectedIndex === globalIndex}
+                  onClick={() => onItemSelect({ kind: "skill", skill })}
+                  onMouseEnter={() => onSelectedIndexChange(globalIndex)}
+                >
+                  <SkillAvatar size="xs" />
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <span className="shrink-0 font-medium">{skill.name}</span>
+                    <span className="shrink-0 text-muted-foreground dark:text-muted-foreground-night">
+                      -
+                    </span>
+                    <span className="min-w-0 truncate text-muted-foreground dark:text-muted-foreground-night">
+                      {skill.userFacingDescription}
+                    </span>
+                  </div>
+                </ItemRow>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      <KeyboardHints
+        hints={[
+          { keys: ["↑", "↓"], label: "Navigate" },
+          { keys: ["↵"], label: "Select" },
+          { keys: ["Esc"], label: "Close" },
+        ]}
+      />
+    </div>
+  );
+}

--- a/front/components/command_palette/SkillDetailsSheetById.tsx
+++ b/front/components/command_palette/SkillDetailsSheetById.tsx
@@ -1,0 +1,33 @@
+import { SkillDetailsSheet } from "@app/components/skills/SkillDetailsSheet";
+import { useSkill } from "@app/lib/swr/skill_configurations";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+
+interface SkillDetailsSheetByIdProps {
+  owner: LightWorkspaceType;
+  user: UserType;
+  skillId: string | null;
+  onClose: () => void;
+}
+
+export function SkillDetailsSheetById({
+  owner,
+  user,
+  skillId,
+  onClose,
+}: SkillDetailsSheetByIdProps) {
+  const { skill } = useSkill({
+    workspaceId: owner.sId,
+    skillId,
+    withRelations: true,
+    disabled: !skillId,
+  });
+
+  return (
+    <SkillDetailsSheet
+      skill={skill ?? null}
+      owner={owner}
+      user={user}
+      onClose={onClose}
+    />
+  );
+}

--- a/front/components/pages/conversation/ConversationPage.tsx
+++ b/front/components/pages/conversation/ConversationPage.tsx
@@ -1,12 +1,10 @@
 import { ConversationContainerVirtuoso } from "@app/components/assistant/conversation/ConversationContainer";
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
+import { useAgentFromSearchParam } from "@app/hooks/useAgentFromSearchParam";
 import { useOnboardingConversation } from "@app/hooks/useOnboardingConversation";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
-import { useAgentConfiguration } from "@app/lib/swr/assistants";
-import { toRichAgentMentionType } from "@app/types/assistant/mentions";
-import { useContext, useEffect } from "react";
+import { useEffect } from "react";
 
 export function ConversationPage() {
   const router = useAppRouter();
@@ -37,19 +35,8 @@ export function ConversationPage() {
     conversationId: activeConversationId,
   });
 
-  const { setSelectedAgent } = useContext(InputBarContext);
-
-  const { agentConfiguration: selectedAgentConfiguration } =
-    useAgentConfiguration({
-      workspaceId: owner.sId,
-      agentConfigurationId: agent,
-    });
-
-  useEffect(() => {
-    if (selectedAgentConfiguration) {
-      setSelectedAgent(toRichAgentMentionType(selectedAgentConfiguration));
-    }
-  }, [selectedAgentConfiguration, setSelectedAgent]);
+  // Consume ?agent= param: fetch agent, set it in input bar, clean up URL.
+  useAgentFromSearchParam(owner.sId);
 
   return (
     <ConversationContainerVirtuoso

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -1,3 +1,4 @@
+import { CommandPalette } from "@app/components/command_palette/CommandPalette";
 import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigationContext";
 import { Navigation } from "@app/components/navigation/Navigation";
 import { SubscriptionEndBanner } from "@app/components/navigation/TrialBanner";
@@ -16,7 +17,7 @@ interface AppContentLayoutProps {
 
 export function AppContentLayout({ children }: AppContentLayoutProps) {
   const owner = useWorkspace();
-  const { subscription } = useAuth();
+  const { subscription, user } = useAuth();
   const {
     contentClassName,
     contentWidth,
@@ -124,6 +125,7 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
           </div>
         )}
       </div>
+      <CommandPalette owner={owner} user={user} />
     </div>
   );
 }

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -1,5 +1,6 @@
 import { InputBarProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { WelcomeTourGuideProvider } from "@app/components/assistant/WelcomeTourGuideProvider";
+import { CommandPaletteProvider } from "@app/components/command_palette/CommandPaletteContext";
 import { DesktopNavigationProvider } from "@app/components/navigation/DesktopNavigationContext";
 import { QuickStartGuide } from "@app/components/QuickStartGuide";
 import { useAppHeadSetup } from "@app/hooks/useAppHeadSetup";
@@ -20,12 +21,14 @@ export default function AppRootLayout({
   return (
     <ClientTypeProvider value="web">
       <WelcomeTourGuideProvider>
-        <DesktopNavigationProvider>
-          <InputBarProvider>
-            {children}
-            <QuickStartGuide />
-          </InputBarProvider>
-        </DesktopNavigationProvider>
+        <CommandPaletteProvider>
+          <DesktopNavigationProvider>
+            <InputBarProvider>
+              {children}
+              <QuickStartGuide />
+            </InputBarProvider>
+          </DesktopNavigationProvider>
+        </CommandPaletteProvider>
       </WelcomeTourGuideProvider>
     </ClientTypeProvider>
   );

--- a/front/hooks/useAgentFromSearchParam.ts
+++ b/front/hooks/useAgentFromSearchParam.ts
@@ -1,0 +1,40 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useSearchParam } from "@app/lib/platform";
+import { useAgentConfiguration } from "@app/lib/swr/assistants";
+import { toRichAgentMentionType } from "@app/types/assistant/mentions";
+import { useContext, useEffect } from "react";
+
+/**
+ * Reads the ?agent= search param, fetches the corresponding agent configuration,
+ * sets it as the selected agent in the input bar, and cleans up the param from the
+ * URL so it doesn't persist across manual agent changes or page refreshes.
+ */
+export function useAgentFromSearchParam(workspaceId: string) {
+  const agent = useSearchParam("agent");
+  const { setSelectedAgent } = useContext(InputBarContext);
+
+  const { agentConfiguration } = useAgentConfiguration({
+    workspaceId,
+    agentConfigurationId: agent,
+    disabled: !agent,
+  });
+
+  useEffect(() => {
+    if (!agentConfiguration) {
+      return;
+    }
+
+    setSelectedAgent(toRichAgentMentionType(agentConfiguration));
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("agent")) {
+      params.delete("agent");
+      const qs = params.toString();
+      window.history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}${qs ? `?${qs}` : ""}${window.location.hash}`
+      );
+    }
+  }, [agentConfiguration, setSelectedAgent]);
+}

--- a/front/hooks/useAppKeyboardShortcuts.ts
+++ b/front/hooks/useAppKeyboardShortcuts.ts
@@ -1,3 +1,4 @@
+import { useCommandPalette } from "@app/components/command_palette/CommandPaletteContext";
 import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigationContext";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -6,6 +7,7 @@ import { useEffect } from "react";
 
 export function useAppKeyboardShortcuts(owner: LightWorkspaceType) {
   const { toggleNavigationBar } = useDesktopNavigation();
+  const { open: openCommandPalette } = useCommandPalette();
 
   const router = useAppRouter();
 
@@ -29,11 +31,15 @@ export function useAppKeyboardShortcuts(owner: LightWorkspaceType) {
               shallow: true,
             });
             break;
+          case "k":
+            event.preventDefault();
+            openCommandPalette();
+            break;
         }
       }
     }
 
     window.addEventListener("keydown", handleKeyboardShortcuts);
     return () => window.removeEventListener("keydown", handleKeyboardShortcuts);
-  }, [owner.sId, router, toggleNavigationBar]);
+  }, [owner.sId, router, toggleNavigationBar, openCommandPalette]);
 }

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -51,9 +51,24 @@ const heightClasses: Record<DialogHeightType, string> = {
   "2xl": "sm:s-h-2xl",
 };
 
+const DIALOG_VARIANTS = ["default", "command"] as const;
+type DialogVariantType = (typeof DIALOG_VARIANTS)[number];
+
+const variantClasses: Record<DialogVariantType, string> = {
+  default: cn(
+    "s-top-[50%] s-translate-y-[-50%] s-duration-200",
+    "data-[state=open]:s-animate-in data-[state=closed]:s-animate-out",
+    "data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0",
+    "data-[state=closed]:s-zoom-out-95 data-[state=open]:s-zoom-in-95",
+    "data-[state=closed]:s-slide-out-to-left-1/2 data-[state=closed]:s-slide-out-to-top-[48%]",
+    "data-[state=open]:s-slide-in-from-left-1/2 data-[state=open]:s-slide-in-from-top-[48%]"
+  ),
+  command: "s-top-[20%]",
+};
+
 const dialogVariants = cva(
   cn(
-    "s-fixed s-left-[50%] s-top-[50%] s-z-50 s-overflow-hidden s-translate-x-[-50%] s-translate-y-[-50%] s-duration-200 data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0 data-[state=closed]:s-zoom-out-95 data-[state=open]:s-zoom-in-95 data-[state=closed]:s-slide-out-to-left-1/2 data-[state=closed]:s-slide-out-to-top-[48%] data-[state=open]:s-slide-in-from-left-1/2 data-[state=open]:s-slide-in-from-top-[48%]",
+    "s-fixed s-left-[50%] s-z-50 s-overflow-hidden s-translate-x-[-50%]",
     "s-rounded-2xl s-flex s-flex-col s-w-full s-max-w-[calc(100vw-2rem)] s-border s-border s-shadow-lg s-sm:rounded-lg",
     "s-bg-background dark:s-bg-background-night",
     "s-border-border dark:s-border-border-night",
@@ -63,9 +78,11 @@ const dialogVariants = cva(
     variants: {
       size: sizeClasses,
       height: heightClasses,
+      variant: variantClasses,
     },
     defaultVariants: {
       size: "md",
+      variant: "default",
     },
   }
 );
@@ -74,6 +91,7 @@ interface DialogContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   size?: DialogSizeType;
   height?: DialogHeightType;
+  variant?: DialogVariantType;
   trapFocusScope?: boolean;
   isAlertDialog?: boolean;
   preventAutoFocusOnClose?: boolean;
@@ -90,6 +108,7 @@ const DialogContent = React.forwardRef<
       children,
       size,
       height,
+      variant,
       trapFocusScope,
       isAlertDialog,
       preventAutoFocusOnClose = true,
@@ -115,7 +134,7 @@ const DialogContent = React.forwardRef<
         <FocusScope trapped={trapFocusScope} asChild>
           <DialogPrimitive.Content
             ref={ref}
-            className={cn(dialogVariants({ size, height }), className)}
+            className={cn(dialogVariants({ size, height, variant }), className)}
             onInteractOutside={
               isAlertDialog
                 ? (e) => e.preventDefault()


### PR DESCRIPTION
## Description

Adds a global command palette accessible via Cmd+K on all user-facing pages. Users can search across agents and skills using fuzzy matching, then take actions on them.

For agents, the available actions are: start a new conversation, view details (opens the sidebar sheet), and edit (navigates to the builder, if the user has permissions). For skills, the actions are view details and edit. When only one action is available (e.g. a global skill the user cannot edit), selecting the item executes it directly without showing the action sub-menu.

Search uses the same fuzzy matching and sort order as the input bar agent picker. Results are debounced (150ms) for performance on large workspaces. Data is fetched via existing SWR hooks with disabled flags so no network calls happen until the palette is opened.

On the Sparkle side, this adds a command variant to DialogContent that anchors the dialog at 20% from the top of the viewport instead of vertically centering it, so the search input stays stable as results change.

Also extracts useAgentFromSearchParam, a hook that consumes the ?agent= query param (used by the "new conversation" action and other existing callers), sets the agent in the input bar, and cleans up the param from the URL so it does not persist across manual agent changes.

This is a v0: the palette is available to all users but not discoverable (no visible UI hint, only Cmd+K). This lets us ship silently, gather feedback, and iterate before making it prominent. Example of thing we'll want before showing the shortcut is some kind of Quick Actions, such as showing 3/4 recently used agents .

<kbd>
<img width="698" height="691" alt="Screenshot 2026-04-15 at 11 44 36" src="https://github.com/user-attachments/assets/bb650e46-96dd-43ca-b34e-a7273de7adaa" />
</kbd>

## Tests

Manual, locally / on a review app. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 