### PR TITLE
Display inline activity timeline alongside tool validation popups

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -6,16 +6,14 @@ import { AgentMessageActions } from "@app/components/assistant/conversation/acti
 import { InlineActivitySteps } from "@app/components/assistant/conversation/actions/inline/InlineActivitySteps";
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
 import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
+import { BlockedAction } from "@app/components/assistant/conversation/BlockedAction";
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { DeletedMessage } from "@app/components/assistant/conversation/DeletedMessage";
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
 import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
-import { GoogleDriveFileAuthorizationRequired } from "@app/components/assistant/conversation/GoogleDriveFileAuthorizationRequired";
 import { useAutoOpenInteractiveContent } from "@app/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent";
-import { MCPServerPersonalAuthenticationRequired } from "@app/components/assistant/conversation/MCPServerPersonalAuthenticationRequired";
-import { MCPToolValidationRequired } from "@app/components/assistant/conversation/MCPToolValidationRequired";
 import type {
   AgentMessageStateWithControlEvent,
   AgentMessageWithStreaming,
@@ -28,7 +26,6 @@ import {
   isUserMessage,
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
-import { UserAnswerRequired } from "@app/components/assistant/conversation/UserAnswerRequired";
 import { ConfirmContext } from "@app/components/Confirm";
 import {
   CitationsContext,
@@ -1184,72 +1181,19 @@ function AgentMessageContent({
     isLastMessage,
   });
 
-  const blockedActionUI = (() => {
-    if (!blockedAction) {
-      return null;
-    }
-    switch (blockedAction.status) {
-      case "blocked_validation_required":
-        return (
-          <MCPToolValidationRequired
-            triggeringUser={triggeringUser}
-            owner={owner}
-            blockedAction={blockedAction}
-            conversationId={conversationId}
-            messageId={sId}
-          />
-        );
+  const blockedActionElement = blockedAction ? (
+    <BlockedAction
+      blockedAction={blockedAction}
+      triggeringUser={triggeringUser}
+      owner={owner}
+      conversationId={conversationId}
+      messageId={sId}
+      retryHandler={retryHandlerWithResetState}
+    />
+  ) : null;
 
-      case "blocked_authentication_required":
-        return (
-          <MCPServerPersonalAuthenticationRequired
-            blockedAction={blockedAction}
-            triggeringUser={triggeringUser}
-            owner={owner}
-            mcpServerId={blockedAction.metadata.mcpServerId}
-            provider={blockedAction.authorizationInfo.provider}
-            scope={blockedAction.authorizationInfo.scope}
-            retryHandler={() =>
-              retryHandlerWithResetState({
-                conversationId: blockedAction.conversationId,
-                messageId: blockedAction.messageId,
-              })
-            }
-          />
-        );
-
-      case "blocked_file_authorization_required":
-        return (
-          <GoogleDriveFileAuthorizationRequired
-            blockedAction={blockedAction}
-            triggeringUser={triggeringUser}
-            owner={owner}
-            fileAuthorizationInfo={blockedAction.fileAuthorizationInfo}
-            mcpServerId={blockedAction.metadata.mcpServerId}
-            retryHandler={() =>
-              retryHandlerWithResetState({
-                conversationId: blockedAction.conversationId,
-                messageId: blockedAction.messageId,
-              })
-            }
-          />
-        );
-
-      case "blocked_user_answer_required":
-        return (
-          <UserAnswerRequired
-            blockedAction={blockedAction}
-            triggeringUser={triggeringUser}
-            owner={owner}
-            conversationId={conversationId}
-            messageId={sId}
-          />
-        );
-    }
-  })();
-
-  if (blockedActionUI && !isInlineActivityEnabled) {
-    return blockedActionUI;
+  if (blockedActionElement && !isInlineActivityEnabled) {
+    return blockedActionElement;
   }
 
   if (agentMessage.status === "created" && !!streamError) {
@@ -1348,7 +1292,7 @@ function AgentMessageContent({
             owner={owner}
           />
         )}
-        {blockedActionUI}
+        {blockedActionElement}
         <AgentMessageInteractiveContentGeneratedFiles
           files={interactiveFiles}
         />

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1184,7 +1184,10 @@ function AgentMessageContent({
     isLastMessage,
   });
 
-  if (blockedAction) {
+  const blockedActionUI = (() => {
+    if (!blockedAction) {
+      return null;
+    }
     switch (blockedAction.status) {
       case "blocked_validation_required":
         return (
@@ -1243,6 +1246,10 @@ function AgentMessageContent({
           />
         );
     }
+  })();
+
+  if (blockedActionUI && !isInlineActivityEnabled) {
+    return blockedActionUI;
   }
 
   if (agentMessage.status === "created" && !!streamError) {
@@ -1330,6 +1337,7 @@ function AgentMessageContent({
             onOpenDetails={onOpenDetails}
             owner={owner}
             isLastMessage={isLastMessage}
+            blockedAction={blockedAction ?? null}
           />
         ) : (
           <AgentMessageActions
@@ -1340,6 +1348,7 @@ function AgentMessageContent({
             owner={owner}
           />
         )}
+        {blockedActionUI}
         <AgentMessageInteractiveContentGeneratedFiles
           files={interactiveFiles}
         />

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1281,7 +1281,6 @@ function AgentMessageContent({
             onOpenDetails={onOpenDetails}
             owner={owner}
             isLastMessage={isLastMessage}
-            blockedAction={blockedAction ?? null}
           />
         ) : (
           <AgentMessageActions

--- a/front/components/assistant/conversation/BlockedAction.tsx
+++ b/front/components/assistant/conversation/BlockedAction.tsx
@@ -1,0 +1,94 @@
+import { GoogleDriveFileAuthorizationRequired } from "@app/components/assistant/conversation/GoogleDriveFileAuthorizationRequired";
+import { MCPServerPersonalAuthenticationRequired } from "@app/components/assistant/conversation/MCPServerPersonalAuthenticationRequired";
+import { MCPToolValidationRequired } from "@app/components/assistant/conversation/MCPToolValidationRequired";
+import { UserAnswerRequired } from "@app/components/assistant/conversation/UserAnswerRequired";
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+
+interface BlockedActionProps {
+  blockedAction: BlockedToolExecution;
+  triggeringUser: UserType | null;
+  owner: LightWorkspaceType;
+  conversationId: string;
+  messageId: string;
+  retryHandler: (params: {
+    conversationId: string;
+    messageId: string;
+  }) => Promise<void>;
+}
+
+export function BlockedAction({
+  blockedAction,
+  triggeringUser,
+  owner,
+  conversationId,
+  messageId,
+  retryHandler,
+}: BlockedActionProps) {
+  switch (blockedAction.status) {
+    case "blocked_validation_required":
+      return (
+        <MCPToolValidationRequired
+          triggeringUser={triggeringUser}
+          owner={owner}
+          blockedAction={blockedAction}
+          conversationId={conversationId}
+          messageId={messageId}
+        />
+      );
+
+    case "blocked_authentication_required":
+      return (
+        <MCPServerPersonalAuthenticationRequired
+          blockedAction={blockedAction}
+          triggeringUser={triggeringUser}
+          owner={owner}
+          mcpServerId={blockedAction.metadata.mcpServerId}
+          provider={blockedAction.authorizationInfo.provider}
+          scope={blockedAction.authorizationInfo.scope}
+          retryHandler={() =>
+            retryHandler({
+              conversationId: blockedAction.conversationId,
+              messageId: blockedAction.messageId,
+            })
+          }
+        />
+      );
+
+    case "blocked_file_authorization_required":
+      return (
+        <GoogleDriveFileAuthorizationRequired
+          blockedAction={blockedAction}
+          triggeringUser={triggeringUser}
+          owner={owner}
+          fileAuthorizationInfo={blockedAction.fileAuthorizationInfo}
+          mcpServerId={blockedAction.metadata.mcpServerId}
+          retryHandler={() =>
+            retryHandler({
+              conversationId: blockedAction.conversationId,
+              messageId: blockedAction.messageId,
+            })
+          }
+        />
+      );
+
+    case "blocked_user_answer_required":
+      return (
+        <UserAnswerRequired
+          blockedAction={blockedAction}
+          triggeringUser={triggeringUser}
+          owner={owner}
+          conversationId={conversationId}
+          messageId={messageId}
+        />
+      );
+
+    case "blocked_child_action_input_required":
+      return null;
+
+    default:
+      assertNeverAndIgnore(blockedAction);
+      return null;
+  }
+}

--- a/front/components/assistant/conversation/BlockedAction.tsx
+++ b/front/components/assistant/conversation/BlockedAction.tsx
@@ -84,6 +84,7 @@ export function BlockedAction({
         />
       );
 
+    // Flattened into child actions by BlockedActionsProvider — never reached here.
     case "blocked_child_action_input_required":
       return null;
 

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -8,6 +8,7 @@ import type {
 } from "@app/components/assistant/conversation/types";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
 import { getInternalMCPServerIconByName } from "@app/lib/actions/mcp_internal_actions/constants";
+import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
 import { getToolCallDisplayLabel } from "@app/lib/actions/tool_display_labels";
 import { getActionOneLineLabel } from "@app/lib/api/assistant/activity_steps";
 import { formatDurationString } from "@app/lib/utils/timestamps";
@@ -309,9 +310,10 @@ export function InlineActivitySteps({
               </div>
             ) : null}
 
-            {/* Active action (tool in progress) */}
+            {/* Active action (tool in progress) — skip blocked actions, handled by BlockedAction */}
             {isActing &&
               activeAction &&
+              !isToolExecutionStatusBlocked(activeAction.status) &&
               renderRunningToolRow({
                 isLast: false,
                 label: getActionOneLineLabel(activeAction, "running"),

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -159,15 +159,13 @@ export function InlineActivitySteps({
     isLast,
     label,
     onClick,
-    icon,
   }: {
     isLast: boolean;
     label: string;
     onClick?: () => void;
-    icon?: React.ComponentType<{ className?: string }>;
   }) => {
     const row = (
-      <TimelineRow spinner={!icon} icon={icon} isLast={isLast}>
+      <TimelineRow spinner isLast={isLast}>
         <span className="text-muted-foreground dark:text-muted-foreground-night flex items-center gap-1">
           {label}
           <Icon

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -7,6 +7,7 @@ import type {
   PendingToolCall,
 } from "@app/components/assistant/conversation/types";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getInternalMCPServerIconByName } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getToolCallDisplayLabel } from "@app/lib/actions/tool_display_labels";
 import { getActionOneLineLabel } from "@app/lib/api/assistant/activity_steps";
@@ -26,12 +27,14 @@ import {
   ChevronRightIcon,
   cn,
   Icon,
+  LockIcon,
   ToolsIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 interface InlineActivityStepsProps {
   agentMessage: LightAgentMessageType | LightAgentMessageWithActionsType;
+  blockedAction: BlockedToolExecution | null;
   lastAgentStateClassification: AgentStateClassification;
   completedSteps: InlineActivityStep[];
   pendingToolCalls: PendingToolCall[];
@@ -73,6 +76,7 @@ function getCollapseAnimationStyle(isCollapsed: boolean): React.CSSProperties {
  */
 export function InlineActivitySteps({
   agentMessage,
+  blockedAction,
   lastAgentStateClassification,
   completedSteps,
   pendingToolCalls,
@@ -148,7 +152,8 @@ export function InlineActivitySteps({
     showActiveThinking ||
     showActiveWriting ||
     activeAction ||
-    showPendingToolCalls;
+    showPendingToolCalls ||
+    blockedAction;
 
   if (!hasContent) {
     return null;
@@ -158,13 +163,15 @@ export function InlineActivitySteps({
     isLast,
     label,
     onClick,
+    icon,
   }: {
     isLast: boolean;
     label: string;
     onClick?: () => void;
+    icon?: React.ComponentType<{ className?: string }>;
   }) => {
     const row = (
-      <TimelineRow spinner isLast={isLast}>
+      <TimelineRow spinner={!icon} icon={icon} isLast={isLast}>
         <span className="text-muted-foreground dark:text-muted-foreground-night flex items-center gap-1">
           {label}
           <Icon
@@ -310,10 +317,19 @@ export function InlineActivitySteps({
             {/* Active action (tool in progress) */}
             {isActing &&
               activeAction &&
+              !blockedAction &&
               renderRunningToolRow({
                 isLast: false,
                 label: getActionOneLineLabel(activeAction, "running"),
                 onClick: () => openBreakdownPanel(activeAction.sId),
+              })}
+
+            {/* Blocked action — waiting on user, not the system */}
+            {blockedAction &&
+              renderRunningToolRow({
+                isLast: true,
+                label: "Waiting for user to continue",
+                icon: LockIcon,
               })}
 
             {latestPendingToolCall &&

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -7,7 +7,6 @@ import type {
   PendingToolCall,
 } from "@app/components/assistant/conversation/types";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
-import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getInternalMCPServerIconByName } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getToolCallDisplayLabel } from "@app/lib/actions/tool_display_labels";
 import { getActionOneLineLabel } from "@app/lib/api/assistant/activity_steps";
@@ -27,14 +26,12 @@ import {
   ChevronRightIcon,
   cn,
   Icon,
-  LockIcon,
   ToolsIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 interface InlineActivityStepsProps {
   agentMessage: LightAgentMessageType | LightAgentMessageWithActionsType;
-  blockedAction: BlockedToolExecution | null;
   lastAgentStateClassification: AgentStateClassification;
   completedSteps: InlineActivityStep[];
   pendingToolCalls: PendingToolCall[];
@@ -76,7 +73,6 @@ function getCollapseAnimationStyle(isCollapsed: boolean): React.CSSProperties {
  */
 export function InlineActivitySteps({
   agentMessage,
-  blockedAction,
   lastAgentStateClassification,
   completedSteps,
   pendingToolCalls,
@@ -152,8 +148,7 @@ export function InlineActivitySteps({
     showActiveThinking ||
     showActiveWriting ||
     activeAction ||
-    showPendingToolCalls ||
-    blockedAction;
+    showPendingToolCalls;
 
   if (!hasContent) {
     return null;
@@ -317,19 +312,10 @@ export function InlineActivitySteps({
             {/* Active action (tool in progress) */}
             {isActing &&
               activeAction &&
-              !blockedAction &&
               renderRunningToolRow({
                 isLast: false,
                 label: getActionOneLineLabel(activeAction, "running"),
                 onClick: () => openBreakdownPanel(activeAction.sId),
-              })}
-
-            {/* Blocked action — waiting on user, not the system */}
-            {blockedAction &&
-              renderRunningToolRow({
-                isLast: true,
-                label: "Waiting for user to continue",
-                icon: LockIcon,
               })}
 
             {latestPendingToolCall &&


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/7365
## Description
When a blocked action exists (tool requiring user approval), show the inline activity timeline with the action row updated to display a lock icon and "Waiting for approval" label, instead of hiding the timeline behind an early return.

I think this looks best since the in progress text with the animation icon makes it seem like work is still happening in the background, swapping the text and icon makes it more clear imo but let me know your thoughts!
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Test with link
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front 

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
