### PR TITLE
feat: move todo and takeways to the new schema for versions

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -103,6 +103,7 @@ import {
   ProjectTodoConversationModel,
   ProjectTodoModel,
   ProjectTodoSourceModel,
+  ProjectTodoVersionModel,
 } from "@app/lib/resources/storage/models/project_todo";
 import { ProjectTodoStateModel } from "@app/lib/resources/storage/models/project_todo_state";
 import { ProjectTodoTakeawaySourcesModel } from "@app/lib/resources/storage/models/project_todo_takeaway_sources";
@@ -115,6 +116,7 @@ import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import {
   TakeawaySourcesModel,
   TakeawaysModel,
+  TakeawaysVersionModel,
 } from "@app/lib/resources/storage/models/takeaways";
 import { TemplateModel } from "@app/lib/resources/storage/models/templates";
 import {
@@ -234,8 +236,10 @@ export function loadAllModels() {
     ProjectTodoConversationModel,
     ProjectTodoSourceModel,
     ProjectTodoStateModel,
+    ProjectTodoVersionModel,
     TakeawaysModel,
     TakeawaySourcesModel,
+    TakeawaysVersionModel,
     ProjectTodoTakeawaySourcesModel,
   ];
 }

--- a/front/lib/api/actions/servers/project_todos/tools/index.ts
+++ b/front/lib/api/actions/servers/project_todos/tools/index.ts
@@ -142,7 +142,6 @@ export function createProjectTodosTools(
           category: category ?? "follow_ups",
           text,
           status: "todo",
-          version: 1,
           doneAt: null,
           actorRationale: null,
         });
@@ -185,7 +184,6 @@ export function createProjectTodosTools(
             category: item.category ?? "follow_ups",
             text: item.text,
             status: "todo",
-            version: 1,
             doneAt: null,
             actorRationale: null,
           });
@@ -235,7 +233,7 @@ export function createProjectTodosTools(
           ]);
         }
 
-        await todo.createVersion(auth, {
+        await todo.updateWithVersion(auth, {
           status: "done",
           doneAt: new Date(),
           markedAsDoneByType: "agent",
@@ -289,7 +287,7 @@ export function createProjectTodosTools(
           ]);
         }
 
-        await todo.createVersion(auth, {
+        await todo.updateWithVersion(auth, {
           status: "todo",
           doneAt: null,
           markedAsDoneByType: null,

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -410,7 +410,6 @@ async function createOrLinkTodos(
         markedAsDoneByType: null,
         markedAsDoneByUserId: null,
         markedAsDoneByAgentConfigurationId: null,
-        version: 1,
       });
 
       await todo.addSource(auth, {
@@ -446,7 +445,7 @@ async function updateTodoIfChanged(
     todo.doneAt?.toISOString() !== blob.doneAt?.toISOString();
 
   if (textChanged || statusChanged || doneAtChanged) {
-    await todo.createVersion(auth, {
+    await todo.updateWithVersion(auth, {
       text: blob.text,
       status: blob.status,
       doneAt: blob.doneAt,

--- a/front/lib/resources/project_todo_resource.test.ts
+++ b/front/lib/resources/project_todo_resource.test.ts
@@ -1,0 +1,244 @@
+import { Authenticator } from "@app/lib/auth";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// Minimal creation blob — all nullable fields set explicitly so TypeScript is
+// happy without the factory abstraction.
+function makeTodoBlob(
+  spaceId: number,
+  userId: number,
+  overrides: { text?: string } = {}
+) {
+  return {
+    spaceId,
+    userId,
+    createdByType: "user" as const,
+    createdByUserId: userId,
+    createdByAgentConfigurationId: null,
+    markedAsDoneByType: null,
+    markedAsDoneByUserId: null,
+    markedAsDoneByAgentConfigurationId: null,
+    category: "follow_ups" as const,
+    text: overrides.text ?? "Test todo",
+    status: "todo" as const,
+    doneAt: null,
+    actorRationale: null,
+  };
+}
+
+describe("ProjectTodoResource", () => {
+  let workspace: LightWorkspaceType;
+  let user: UserResource;
+  let auth: Authenticator;
+  let space: SpaceResource;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({ role: "user" });
+    workspace = setup.workspace;
+    user = setup.user;
+    auth = setup.authenticator;
+    space = setup.globalSpace;
+  });
+
+  describe("makeNew", () => {
+    it("should create a todo with a stable sId starting with 'ptd_'", async () => {
+      const todo = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id, { text: "My todo" })
+      );
+
+      expect(todo.sId).toMatch(/^ptd_/);
+      expect(todo.workspaceId).toBe(workspace.id);
+      expect(todo.userId).toBe(user.id);
+      expect(todo.text).toBe("My todo");
+      expect(todo.status).toBe("todo");
+    });
+
+    it("should compute the same sId as modelIdToSId", async () => {
+      const todo = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id)
+      );
+
+      const computed = ProjectTodoResource.modelIdToSId({
+        id: todo.id,
+        workspaceId: todo.workspaceId,
+      });
+
+      expect(todo.sId).toBe(computed);
+    });
+  });
+
+  describe("fetchBySId", () => {
+    it("should fetch a todo by its stable sId", async () => {
+      const todo = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id, { text: "Fetchable todo" })
+      );
+
+      const fetched = await ProjectTodoResource.fetchBySId(auth, todo.sId);
+
+      expect(fetched).not.toBeNull();
+      expect(fetched?.sId).toBe(todo.sId);
+      expect(fetched?.text).toBe("Fetchable todo");
+    });
+
+    it("should return null for a non-existent sId", async () => {
+      const fetched = await ProjectTodoResource.fetchBySId(
+        auth,
+        "ptd_doesnotexist"
+      );
+      expect(fetched).toBeNull();
+    });
+
+    it("should not fetch a todo that belongs to a different workspace", async () => {
+      const todo = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id)
+      );
+
+      const otherSetup = await createResourceTest({ role: "user" });
+      const fetched = await ProjectTodoResource.fetchBySId(
+        otherSetup.authenticator,
+        todo.sId
+      );
+
+      expect(fetched).toBeNull();
+    });
+  });
+
+  describe("updateWithVersion", () => {
+    it("should update the main row and preserve the sId", async () => {
+      const todo = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id, { text: "Original" })
+      );
+      const originalSId = todo.sId;
+
+      const updated = await todo.updateWithVersion(auth, { text: "Updated" });
+
+      expect(updated.sId).toBe(originalSId);
+      expect(updated.text).toBe("Updated");
+    });
+
+    it("should persist the update so a subsequent fetch returns the new value", async () => {
+      const todo = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id, { text: "Before" })
+      );
+
+      await todo.updateWithVersion(auth, { text: "After" });
+
+      const fetched = await ProjectTodoResource.fetchBySId(auth, todo.sId);
+      expect(fetched?.text).toBe("After");
+    });
+
+    it("should allow multiple successive updates", async () => {
+      const todo = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id)
+      );
+
+      const v1 = await todo.updateWithVersion(auth, { text: "Version 1" });
+      const v2 = await v1.updateWithVersion(auth, { text: "Version 2" });
+
+      expect(v2.text).toBe("Version 2");
+      expect(v2.sId).toBe(todo.sId);
+    });
+
+    it("should support marking a todo as done", async () => {
+      const todo = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id)
+      );
+
+      const updated = await todo.updateWithVersion(auth, {
+        status: "done",
+        markedAsDoneByType: "user",
+        markedAsDoneByUserId: user.id,
+        markedAsDoneByAgentConfigurationId: null,
+      });
+
+      expect(updated.status).toBe("done");
+      expect(updated.markedAsDoneByType).toBe("user");
+      expect(updated.markedAsDoneByUserId).toBe(user.id);
+    });
+  });
+
+  describe("fetchLatestBySpace", () => {
+    it("should return todos belonging to the authenticated user in the space", async () => {
+      await ProjectTodoResource.makeNew(auth, makeTodoBlob(space.id, user.id));
+      await ProjectTodoResource.makeNew(auth, makeTodoBlob(space.id, user.id));
+
+      const todos = await ProjectTodoResource.fetchLatestBySpace(auth, {
+        spaceId: space.id,
+      });
+
+      expect(todos.length).toBeGreaterThanOrEqual(2);
+      for (const t of todos) {
+        expect(t.workspaceId).toBe(workspace.id);
+        expect(t.userId).toBe(user.id);
+      }
+    });
+
+    it("should not return todos from a different user in the same space", async () => {
+      // Create a second user in the same workspace.
+      const otherSetup = await createResourceTest({ role: "user" });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherSetup.user.sId,
+        workspace.sId
+      );
+
+      // Create one todo for user and one for otherUser in the same space.
+      await ProjectTodoResource.makeNew(auth, makeTodoBlob(space.id, user.id));
+      await ProjectTodoResource.makeNew(
+        otherAuth,
+        makeTodoBlob(space.id, otherSetup.user.id)
+      );
+
+      // fetchLatestBySpace is scoped to the current user.
+      const todosForUser = await ProjectTodoResource.fetchLatestBySpace(auth, {
+        spaceId: space.id,
+      });
+
+      for (const t of todosForUser) {
+        expect(t.userId).toBe(user.id);
+      }
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete the todo so fetchBySId returns null afterwards", async () => {
+      const todo = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id)
+      );
+      const sId = todo.sId;
+
+      const result = await todo.delete(auth, {});
+      expect(result.isOk()).toBe(true);
+
+      const fetched = await ProjectTodoResource.fetchBySId(auth, sId);
+      expect(fetched).toBeNull();
+    });
+
+    it("should also delete version snapshots created by updateWithVersion", async () => {
+      const todo = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id)
+      );
+      const updated = await todo.updateWithVersion(auth, { text: "v1" });
+      const sId = updated.sId;
+
+      await updated.delete(auth, {});
+
+      // The main row is gone — no observable version leakage through the public API.
+      const fetched = await ProjectTodoResource.fetchBySId(auth, sId);
+      expect(fetched).toBeNull();
+    });
+  });
+});

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -4,11 +4,13 @@ import {
   ProjectTodoConversationModel,
   ProjectTodoModel,
   ProjectTodoSourceModel,
+  ProjectTodoVersionModel,
 } from "@app/lib/resources/storage/models/project_todo";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   ProjectTodoSourceType,
   ProjectTodoType,
@@ -39,63 +41,112 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     super(ProjectTodoModel, blob);
   }
 
+  // The stable string identifier for this todo, computed from the model's
+  // integer id. External code must use this sId — never the raw model id.
+  get sId(): string {
+    return ProjectTodoResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("project_todo", { id, workspaceId });
+  }
+
   // ── Creation ────────────────────────────────────────────────────────────────
 
   static async makeNew(
     auth: Authenticator,
-    blob: Omit<CreationAttributes<ProjectTodoModel>, "workspaceId" | "sId">,
+    blob: Omit<CreationAttributes<ProjectTodoModel>, "workspaceId">,
     transaction?: Transaction
   ): Promise<ProjectTodoResource> {
-    const todo = await ProjectTodoModel.create(
-      {
-        ...blob,
-        sId: generateRandomModelSId(),
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-      { transaction }
-    );
+    return withTransaction(async (t) => {
+      const todo = await ProjectTodoModel.create(
+        {
+          ...blob,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        { transaction: t }
+      );
 
-    return new this(ProjectTodoModel, todo.get());
+      return new this(ProjectTodoModel, todo.get());
+    }, transaction);
   }
 
-  // Inserts a new version row for this logical todo, copying unchanged fields and
-  // applying the supplied updates. Mirrors the AgentConfiguration update pattern.
-  async createVersion(
+  // Snapshots the current mutable state into the version table, then updates
+  // the main row in place. The version number is determined by the existing
+  // snapshot count + 1.
+  async updateWithVersion(
     auth: Authenticator,
     updates: Partial<
-      Omit<
+      Pick<
         CreationAttributes<ProjectTodoModel>,
-        "workspaceId" | "sId" | "version"
+        | "category"
+        | "text"
+        | "status"
+        | "doneAt"
+        | "actorRationale"
+        | "markedAsDoneByType"
+        | "markedAsDoneByUserId"
+        | "markedAsDoneByAgentConfigurationId"
       >
     >,
     transaction?: Transaction
   ): Promise<ProjectTodoResource> {
-    const newRow = await ProjectTodoModel.create(
+    return withTransaction(async (t) => {
+      await this.saveVersion(t);
+
+      const [, [updated]] = await ProjectTodoModel.update(
+        { ...updates },
+        {
+          where: {
+            id: this.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+          returning: true,
+          transaction: t,
+        }
+      );
+
+      return new ProjectTodoResource(ProjectTodoModel, updated.get());
+    }, transaction);
+  }
+
+  // Saves the current mutable state as a version snapshot. Called before every
+  // in-place update of the main row.
+  private async saveVersion(transaction?: Transaction): Promise<void> {
+    const existingCount = await ProjectTodoVersionModel.count({
+      where: {
+        workspaceId: this.workspaceId,
+        projectTodoId: this.id,
+      },
+      transaction,
+    });
+
+    await ProjectTodoVersionModel.create(
       {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        sId: this.sId,
-        version: this.version + 1,
-        spaceId: this.spaceId,
-        userId: this.userId,
-        createdByType: this.createdByType,
-        createdByUserId: this.createdByUserId ?? null,
-        createdByAgentConfigurationId:
-          this.createdByAgentConfigurationId ?? null,
-        markedAsDoneByType: this.markedAsDoneByType ?? null,
-        markedAsDoneByUserId: this.markedAsDoneByUserId ?? null,
-        markedAsDoneByAgentConfigurationId:
-          this.markedAsDoneByAgentConfigurationId ?? null,
+        workspaceId: this.workspaceId,
+        projectTodoId: this.id,
+        version: existingCount + 1,
         category: this.category,
         text: this.text,
         status: this.status,
         doneAt: this.doneAt ?? null,
         actorRationale: this.actorRationale ?? null,
-        ...updates,
+        markedAsDoneByType: this.markedAsDoneByType ?? null,
+        markedAsDoneByUserId: this.markedAsDoneByUserId ?? null,
+        markedAsDoneByAgentConfigurationId:
+          this.markedAsDoneByAgentConfigurationId ?? null,
       },
       { transaction }
     );
-
-    return new ProjectTodoResource(ProjectTodoModel, newRow.get());
   }
 
   // ── Fetching ─────────────────────────────────────────────────────────────────
@@ -125,17 +176,16 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
   }
 
-  // Fetches the latest version of a todo by its stable sId.
+  // Fetches a todo by its stable string sId.
   static async fetchBySId(
     auth: Authenticator,
     sId: string
   ): Promise<ProjectTodoResource | null> {
-    const results = await this.baseFetch(auth, {
-      where: { sId },
-      order: [["version", "DESC"]],
-      limit: 1,
-    });
-
+    const id = getResourceIdFromSId(sId);
+    if (id === null) {
+      return null;
+    }
+    const results = await this.baseFetch(auth, { where: { id }, limit: 1 });
     return results[0] ?? null;
   }
 
@@ -149,7 +199,8 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
   }
 
-  // Returns only the latest version of each logical todo for the given space.
+  // Returns all todos for the authenticated user in the given space. Each row
+  // in project_todos IS the latest state — no de-duplication needed.
   static async fetchLatestBySpace(
     auth: Authenticator,
     { spaceId }: { spaceId: ModelId }
@@ -160,76 +211,20 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
   }
 
-  // Returns the latest version of each logical todo for an explicit target userId
-  // in the given space. Mirrors fetchLatestBySpace but takes an explicit userId
-  // instead of using auth.user — needed by the merge workflow, which acts on
-  // behalf of specific target users rather than the authenticated principal.
+  // Returns all todos for an explicit target userId in the given space.
+  // Used by the merge workflow which acts on behalf of specific target users.
   static async fetchLatestBySpaceForUser(
     auth: Authenticator,
     { spaceId, userId }: { spaceId: ModelId; userId: ModelId }
   ): Promise<ProjectTodoResource[]> {
-    const all = await this.baseFetch(auth, {
-      where: { spaceId, userId },
-      order: [
-        ["sId", "ASC"],
-        ["version", "DESC"],
-      ],
-    });
-
-    // O(n) deduplication — keep the first occurrence per sId (highest version).
-    const latestBySId = new Map<string, ProjectTodoResource>();
-    for (const todo of all) {
-      if (!latestBySId.has(todo.sId)) {
-        latestBySId.set(todo.sId, todo);
-      }
-    }
-
-    return Array.from(latestBySId.values());
-  }
-
-  // Returns the latest version of each logical todo across ALL users for the given
-  // space. Used by MCP tools that need to list todos for all project members.
-  static async fetchLatestAllBySpace(
-    auth: Authenticator,
-    { spaceId }: { spaceId: ModelId }
-  ): Promise<ProjectTodoResource[]> {
-    const all = await this.baseFetch(auth, {
-      where: { spaceId },
-      order: [
-        ["sId", "ASC"],
-        ["version", "DESC"],
-      ],
-    });
-
-    // O(n) deduplication — keep the first occurrence per sId (highest version).
-    const latestBySId = new Map<string, ProjectTodoResource>();
-    for (const todo of all) {
-      if (!latestBySId.has(todo.sId)) {
-        latestBySId.set(todo.sId, todo);
-      }
-    }
-
-    return Array.from(latestBySId.values());
-  }
-
-  // Returns every version row for (spaceId, userId), across all sIds. Used by the
-  // diff algorithm to reconstruct snapshots at arbitrary cutoff dates.
-  static async fetchAllVersionsBySpace(
-    auth: Authenticator,
-    { spaceId }: { spaceId: ModelId }
-  ): Promise<ProjectTodoResource[]> {
     return this.baseFetch(auth, {
-      where: { spaceId, userId: auth.getNonNullableUser().id },
-      order: [
-        ["sId", "ASC"],
-        ["version", "ASC"],
-      ],
+      where: { spaceId, userId },
+      order: [["createdAt", "DESC"]],
     });
   }
 
-  // Batch variant of fetchBySourceId. Returns a map from `${sourceId}:${userId}`
-  // to the latest version of each matching todo. Replaces per-item lookups in the
-  // merge workflow with three queries total instead of N*(2–3).
+  // Batch variant: fetches the current todo row for each sourceId in one pass.
+  // Returns a map from `${sourceId}:${userId}` to the matching ProjectTodoResource.
   static async fetchBySourceIds(
     auth: Authenticator,
     { sourceIds }: { sourceIds: string[] }
@@ -240,7 +235,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
 
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    // Step 1: Find all source links for the given item IDs in a single query.
+    // Step 1: Find all source links for the given item IDs.
     const sources = await ProjectTodoSourceModel.findAll({
       where: { workspaceId, sourceId: { [Op.in]: sourceIds } },
     });
@@ -248,8 +243,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       return new Map();
     }
 
-    // Step 2: Fetch the linked todo rows (any version) to resolve their stable
-    // sIds — sources point to a specific version's PK, not the sId directly.
+    // Step 2: Fetch the linked todo rows.
     const linkedModelIds = [...new Set(sources.map((s) => s.projectTodoId))];
     const linkedRows = await this.baseFetch(auth, {
       where: { id: { [Op.in]: linkedModelIds } },
@@ -258,39 +252,19 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       return new Map();
     }
 
-    // Step 3: Batch-fetch all versions of those todos and keep the latest per sId.
-    const uniqueSIds = [...new Set(linkedRows.map((t) => t.sId))];
-    const allVersions = await this.baseFetch(auth, {
-      where: { sId: { [Op.in]: uniqueSIds } },
-      order: [
-        ["sId", "ASC"],
-        ["version", "DESC"],
-      ],
-    });
-    const latestBySId = new Map<string, ProjectTodoResource>();
-    for (const todo of allVersions) {
-      if (!latestBySId.has(todo.sId)) {
-        latestBySId.set(todo.sId, todo);
-      }
-    }
-
-    // Build a lookup from linked row model id → sId to bridge sources to latest.
-    const sIdByModelId = new Map<ModelId, string>(
-      linkedRows.map((t) => [t.id, t.sId])
+    // Build a lookup from model id → resource.
+    const rowById = new Map<ModelId, ProjectTodoResource>(
+      linkedRows.map((t) => [t.id, t])
     );
 
-    // Result: `${sourceId}:${userId}` → latest ProjectTodoResource.
+    // Result: `${sourceId}:${userId}` → ProjectTodoResource.
     const result = new Map<string, ProjectTodoResource>();
     for (const source of sources) {
-      const sId = sIdByModelId.get(source.projectTodoId);
-      if (!sId) {
+      const todo = rowById.get(source.projectTodoId);
+      if (!todo) {
         continue;
       }
-      const latest = latestBySId.get(sId);
-      if (!latest) {
-        continue;
-      }
-      result.set(`${source.sourceId}:${latest.userId}`, latest);
+      result.set(`${source.sourceId}:${todo.userId}`, todo);
     }
 
     return result;
@@ -311,48 +285,38 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
 
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    // Get all version row IDs for these logical todos.
-    const allVersions = await ProjectTodoModel.findAll({
-      where: { workspaceId, sId: { [Op.in]: sIds } },
-      attributes: ["id", "sId"],
-    });
+    // Decode each sId to its integer model id.
+    const idToSId = new Map<number, string>();
+    for (const sId of sIds) {
+      const id = getResourceIdFromSId(sId);
+      if (id !== null) {
+        idToSId.set(id, sId);
+      }
+    }
 
-    if (allVersions.length === 0) {
+    if (idToSId.size === 0) {
       return new Map();
     }
 
-    const versionIdToSId = new Map(
-      allVersions.map((v) => [v.id, v.sId] as const)
-    );
-
-    // Fetch sources for all version rows in a single query.
+    // Fetch sources for all logical todos in a single query.
     const sources = await ProjectTodoSourceModel.findAll({
       where: {
         workspaceId,
-        projectTodoId: {
-          [Op.in]: allVersions.map((v) => v.id),
-        },
+        projectTodoId: { [Op.in]: [...idToSId.keys()] },
       },
     });
 
-    // Group by logical todo sId, deduplicating by (sourceType, sourceId).
+    // Group by logical todo sId.
     const result = new Map<
       string,
       Array<{ sourceType: ProjectTodoSourceType; sourceId: string }>
     >();
-    const seen = new Set<string>();
 
     for (const source of sources) {
-      const todoSId = versionIdToSId.get(source.projectTodoId);
+      const todoSId = idToSId.get(source.projectTodoId);
       if (!todoSId) {
         continue;
       }
-
-      const dedupeKey = `${todoSId}:${source.sourceType}:${source.sourceId}`;
-      if (seen.has(dedupeKey)) {
-        continue;
-      }
-      seen.add(dedupeKey);
 
       const existing = result.get(todoSId) ?? [];
       existing.push({
@@ -363,38 +327,6 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     }
 
     return result;
-  }
-
-  // ── Output conversation links (todo => conversation) ────────────────────
-
-  async addOutputConversation(
-    auth: Authenticator,
-    { conversationId }: { conversationId: ModelId },
-    transaction?: Transaction
-  ): Promise<void> {
-    await ProjectTodoConversationModel.create(
-      {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        projectTodoId: this.id,
-        conversationId,
-      },
-      { transaction }
-    );
-  }
-
-  async removeOutputConversation(
-    auth: Authenticator,
-    { conversationId }: { conversationId: ModelId },
-    transaction?: Transaction
-  ): Promise<void> {
-    await ProjectTodoConversationModel.destroy({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        projectTodoId: this.id,
-        conversationId,
-      },
-      transaction,
-    });
   }
 
   // ── Source links (* => todo) ─────────────────────────────────────────────
@@ -421,28 +353,6 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     );
   }
 
-  async removeSource(
-    auth: Authenticator,
-    {
-      sourceType,
-      sourceId,
-    }: {
-      sourceType: ProjectTodoSourceType;
-      sourceId: string;
-    },
-    transaction?: Transaction
-  ): Promise<void> {
-    await ProjectTodoSourceModel.destroy({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        projectTodoId: this.id,
-        sourceType,
-        sourceId,
-      },
-      transaction,
-    });
-  }
-
   // ── Serialization ──────────────────────────────────────────────────────────
 
   toJSON(): ProjectTodoType {
@@ -452,7 +362,6 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       category: this.category,
       text: this.text,
       status: this.status,
-      version: this.version,
       doneAt: this.doneAt,
       actorRationale: this.actorRationale,
       createdByType: this.createdByType,
@@ -472,27 +381,25 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction }
   ): Promise<Result<undefined, Error>> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
     await ProjectTodoConversationModel.destroy({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        projectTodoId: this.id,
-      },
+      where: { workspaceId, projectTodoId: this.id },
       transaction,
     });
 
     await ProjectTodoSourceModel.destroy({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        projectTodoId: this.id,
-      },
+      where: { workspaceId, projectTodoId: this.id },
+      transaction,
+    });
+
+    await ProjectTodoVersionModel.destroy({
+      where: { workspaceId, projectTodoId: this.id },
       transaction,
     });
 
     await this.model.destroy({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        id: this.id,
-      },
+      where: { workspaceId, id: this.id },
       transaction,
     });
 

--- a/front/lib/resources/storage/models/project_todo.ts
+++ b/front/lib/resources/storage/models/project_todo.ts
@@ -12,7 +12,54 @@ import type {
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
+// ── Shared mutable-state attributes ─────────────────────────────────────────
+// Used by both the main table and the version snapshot table.
+
+const PROJECT_TODO_MUTABLE_ATTRIBUTES = {
+  markedAsDoneByType: {
+    type: DataTypes.STRING,
+    allowNull: true,
+    comment: "Actor type that completed this todo: user or agent.",
+  },
+  markedAsDoneByUserId: {
+    type: DataTypes.BIGINT,
+    allowNull: true,
+    comment: "Set when markedAsDoneByType is user.",
+  },
+  markedAsDoneByAgentConfigurationId: {
+    type: DataTypes.STRING,
+    allowNull: true,
+    comment: "sId of the agent configuration when markedAsDoneByType is agent.",
+  },
+  category: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    comment:
+      "Category of the todo: need_attention, key_decisions, follow_ups, notable_updates.",
+  },
+  text: {
+    type: DataTypes.TEXT,
+    allowNull: false,
+  },
+  status: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    defaultValue: "todo",
+  },
+  doneAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+  },
+  actorRationale: {
+    type: DataTypes.TEXT,
+    allowNull: true,
+    comment: "Explanation for why the actor made a change.",
+  },
+} as const;
+
 // ── Main model ──────────────────────────────────────────────────────────────
+// One row per logical todo. The row's `id` is the stable identity used as a
+// foreign key in ProjectTodoVersionModel and all join tables.
 
 export class ProjectTodoModel extends WorkspaceAwareModel<ProjectTodoModel> {
   declare createdAt: CreationOptional<Date>;
@@ -33,12 +80,8 @@ export class ProjectTodoModel extends WorkspaceAwareModel<ProjectTodoModel> {
   declare markedAsDoneByUserId: ForeignKey<UserModel["id"]> | null;
   declare markedAsDoneByAgentConfigurationId: string | null;
 
-  // Stable identity: same sId across all version rows of one logical todo.
-  declare sId: string;
-
   declare category: ProjectTodoCategory;
   declare text: string;
-  declare version: number;
   declare status: ProjectTodoStatus;
   declare doneAt: Date | null;
   declare actorRationale: string | null;
@@ -85,79 +128,12 @@ ProjectTodoModel.init(
       allowNull: true,
       comment: "sId of the agent configuration when createdByType is agent.",
     },
-    markedAsDoneByType: {
-      type: DataTypes.STRING,
-      allowNull: true,
-      comment: "Actor type that completed this todo: user or agent.",
-    },
-    markedAsDoneByUserId: {
-      type: DataTypes.BIGINT,
-      allowNull: true,
-      comment: "Set when markedAsDoneByType is user.",
-    },
-    markedAsDoneByAgentConfigurationId: {
-      type: DataTypes.STRING,
-      allowNull: true,
-      comment:
-        "sId of the agent configuration when markedAsDoneByType is agent.",
-    },
-    sId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      comment:
-        "Stable identifier shared across all version rows of the same logical todo.",
-    },
-    category: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      comment:
-        "Category of the todo: need_attention, key_decisions, follow_ups, notable_updates.",
-    },
-    text: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-    },
-    version: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      defaultValue: 1,
-      comment: "Version number for diff handling.",
-    },
-    status: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      defaultValue: "todo",
-    },
-    doneAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-    },
-    actorRationale: {
-      type: DataTypes.TEXT,
-      allowNull: true,
-      comment: "Explanation for why the actor made a change.",
-    },
+    ...PROJECT_TODO_MUTABLE_ATTRIBUTES,
   },
   {
     modelName: "project_todo",
     sequelize: frontSequelize,
     indexes: [
-      {
-        name: "project_todos_sId_version_unique_idx",
-        fields: ["workspaceId", "sId", "version"],
-        unique: true,
-        concurrently: true,
-      },
-      {
-        name: "project_todos_sId_idx",
-        fields: ["sId"],
-        concurrently: true,
-      },
-      {
-        name: "project_todos_ws_space_user_version_idx",
-        fields: ["workspaceId", "spaceId", "userId", "version"],
-        concurrently: true,
-      },
       {
         name: "project_todos_ws_space_user_idx",
         fields: ["workspaceId", "spaceId", "userId"],
@@ -224,6 +200,77 @@ ProjectTodoModel.init(
     },
   }
 );
+
+// ── Version model ────────────────────────────────────────────────────────────
+// Each save of a logical todo appends a new row here before overwriting the
+// main row, preserving the full history. The `projectTodoId` FK is the stable
+// reference back to the logical todo's identity.
+
+export class ProjectTodoVersionModel extends WorkspaceAwareModel<ProjectTodoVersionModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare projectTodoId: ForeignKey<ProjectTodoModel["id"]>;
+  declare version: number;
+
+  // Snapshot of mutable state at the time of this version.
+  declare markedAsDoneByType: ProjectTodoActorType | null;
+  declare markedAsDoneByUserId: ForeignKey<UserModel["id"]> | null;
+  declare markedAsDoneByAgentConfigurationId: string | null;
+  declare category: ProjectTodoCategory;
+  declare text: string;
+  declare status: ProjectTodoStatus;
+  declare doneAt: Date | null;
+  declare actorRationale: string | null;
+}
+
+ProjectTodoVersionModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    projectTodoId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    version: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      comment: "Monotonically increasing per projectTodoId.",
+    },
+    ...PROJECT_TODO_MUTABLE_ATTRIBUTES,
+  },
+  {
+    modelName: "project_todo_version",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "project_todo_versions_ws_todo_version_unique_idx",
+        fields: ["workspaceId", "projectTodoId", "version"],
+        unique: true,
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+ProjectTodoVersionModel.belongsTo(ProjectTodoModel, {
+  foreignKey: { name: "projectTodoId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "projectTodo",
+});
+
+ProjectTodoModel.hasMany(ProjectTodoVersionModel, {
+  foreignKey: { name: "projectTodoId", allowNull: false },
+  as: "versions",
+});
 
 ProjectTodoModel.belongsTo(SpaceModel, {
   foreignKey: { name: "spaceId", allowNull: false },

--- a/front/lib/resources/storage/models/takeaways.ts
+++ b/front/lib/resources/storage/models/takeaways.ts
@@ -10,10 +10,36 @@ import type {
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
-// ── Takeaways (versioned) ─────────────────────────────────────────────────────
-// Versioned snapshot of butler-extracted takeaways (action items, notable
-// facts, key decisions). Each butler run appends a new row; the sId is stable
-// across all versions of the same logical takeaway.
+// ── Shared content attributes ─────────────────────────────────────────────────
+// Used by both the main takeaway row and its version snapshots.
+
+const TAKEAWAY_CONTENT_ATTRIBUTES = {
+  actionItems: {
+    type: DataTypes.JSONB,
+    allowNull: false,
+    defaultValue: [],
+    comment:
+      "Detected action items with assignee, status, and source message rank.",
+  },
+  notableFacts: {
+    type: DataTypes.JSONB,
+    allowNull: false,
+    defaultValue: [],
+    comment: "Notable facts extracted from the conversation.",
+  },
+  keyDecisions: {
+    type: DataTypes.JSONB,
+    allowNull: false,
+    defaultValue: [],
+    comment: "Key decisions made during the conversation.",
+  },
+} as const;
+
+// ── Takeaways (main) ──────────────────────────────────────────────────────────
+// One row per logical takeaway. The row's `id` is the stable identity used as a
+// foreign key in TakeawaysVersionModel and TakeawaySourcesModel.
+// Each butler run updates this row in place and appends a snapshot to
+// TakeawaysVersionModel for history.
 export class TakeawaysModel extends WorkspaceAwareModel<TakeawaysModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -21,14 +47,7 @@ export class TakeawaysModel extends WorkspaceAwareModel<TakeawaysModel> {
   // The space (project) this takeaway belongs to.
   declare spaceId: ForeignKey<SpaceModel["id"]>;
 
-  // Stable identity: same sId across all version rows of one logical takeaway.
-  declare sId: string;
-
-  // Versioning: each butler run appends a new row. Version is monotonically
-  // increasing per sId, starting at 1.
-  declare version: number;
-
-  // Rolling state — full replacement on each run.
+  // Rolling state — full replacement on each butler run.
   declare actionItems: TodoVersionedActionItem[];
   declare notableFacts: TodoVersionedNotableFact[];
   declare keyDecisions: TodoVersionedKeyDecision[];
@@ -46,61 +65,19 @@ TakeawaysModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    sId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      comment:
-        "Stable identifier shared across all version rows of the same logical takeaway.",
-    },
-    version: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      defaultValue: 1,
-      comment:
-        "Monotonically increasing per sId. Each butler run inserts a new row rather than overwriting.",
-    },
-    actionItems: {
-      type: DataTypes.JSONB,
-      allowNull: false,
-      defaultValue: [],
-      comment:
-        "Detected action items with assignee, status, and source message rank.",
-    },
-    notableFacts: {
-      type: DataTypes.JSONB,
-      allowNull: false,
-      defaultValue: [],
-      comment: "Notable facts extracted from the conversation.",
-    },
-    keyDecisions: {
-      type: DataTypes.JSONB,
-      allowNull: false,
-      defaultValue: [],
-      comment: "Key decisions made during the conversation.",
-    },
     spaceId: {
       type: DataTypes.BIGINT,
       allowNull: false,
       references: { model: "vaults", key: "id" },
       comment: "The space (project) this takeaway belongs to.",
     },
+    ...TAKEAWAY_CONTENT_ATTRIBUTES,
   },
   {
     modelName: "takeaways",
     tableName: "takeaways",
     sequelize: frontSequelize,
     indexes: [
-      {
-        name: "takeaways_ws_sId_version_unique_idx",
-        fields: ["workspaceId", "sId", "version"],
-        unique: true,
-        concurrently: true,
-      },
-      {
-        name: "takeaways_sId_idx",
-        fields: ["sId"],
-        concurrently: true,
-      },
       {
         name: "takeaways_spaceId_idx",
         fields: ["spaceId"],
@@ -115,15 +92,84 @@ TakeawaysModel.belongsTo(SpaceModel, {
   onDelete: "RESTRICT",
 });
 
+// ── Takeaway versions ─────────────────────────────────────────────────────────
+// Each butler run appends a new row here before overwriting the main row,
+// preserving the full history. `takeawaysId` is the FK back to the stable
+// TakeawaysModel row.
+export class TakeawaysVersionModel extends WorkspaceAwareModel<TakeawaysVersionModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare takeawaysId: ForeignKey<TakeawaysModel["id"]>;
+
+  // Monotonically increasing per takeawaysId, starting at 1.
+  declare version: number;
+
+  // Full content snapshot at the time this version was created.
+  declare actionItems: TodoVersionedActionItem[];
+  declare notableFacts: TodoVersionedNotableFact[];
+  declare keyDecisions: TodoVersionedKeyDecision[];
+}
+
+TakeawaysVersionModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    takeawaysId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    version: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      comment:
+        "Monotonically increasing per takeawaysId. Each butler run inserts a new row rather than overwriting.",
+    },
+    ...TAKEAWAY_CONTENT_ATTRIBUTES,
+  },
+  {
+    modelName: "takeaways_version",
+    tableName: "takeaway_versions",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "takeaway_versions_ws_takeawaysId_version_unique_idx",
+        fields: ["workspaceId", "takeawaysId", "version"],
+        unique: true,
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+TakeawaysVersionModel.belongsTo(TakeawaysModel, {
+  foreignKey: { name: "takeawaysId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "takeaways",
+});
+
+TakeawaysModel.hasMany(TakeawaysVersionModel, {
+  foreignKey: { name: "takeawaysId", allowNull: false },
+  as: "versions",
+});
+
 // ── Source takeaways ──────────────────────────────────────────────────────────
 // Content node (conversation, etc.) that triggered the production of a
-// takeaway snapshot, linked to the snapshot by its stable sId.
+// takeaway snapshot, linked to the stable TakeawaysModel row by its id.
 export class TakeawaySourcesModel extends WorkspaceAwareModel<TakeawaySourcesModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  // References the stable sId of the takeaway this source produced.
-  declare takeawaySId: string;
+  // FK to the stable TakeawaysModel row that this source produced.
+  declare takeawaysId: ForeignKey<TakeawaysModel["id"]>;
   declare sourceType: ProjectTodoSourceType;
   declare sourceId: string;
 }
@@ -140,10 +186,10 @@ TakeawaySourcesModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    takeawaySId: {
-      type: DataTypes.STRING,
+    takeawaysId: {
+      type: DataTypes.BIGINT,
       allowNull: false,
-      comment: "Stable sId of the takeaway this source produced.",
+      comment: "FK to the TakeawaysModel row this source produced.",
     },
     sourceType: {
       type: DataTypes.STRING,
@@ -163,8 +209,8 @@ TakeawaySourcesModel.init(
     sequelize: frontSequelize,
     indexes: [
       {
-        name: "takeaway_sources_ws_takeawaySId_idx",
-        fields: ["workspaceId", "takeawaySId"],
+        name: "takeaway_sources_ws_takeawaysId_idx",
+        fields: ["workspaceId", "takeawaysId"],
         concurrently: true,
       },
       {
@@ -175,3 +221,14 @@ TakeawaySourcesModel.init(
     ],
   }
 );
+
+TakeawaySourcesModel.belongsTo(TakeawaysModel, {
+  foreignKey: { name: "takeawaysId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "takeaways",
+});
+
+TakeawaysModel.hasMany(TakeawaySourcesModel, {
+  foreignKey: { name: "takeawaysId", allowNull: false },
+  as: "sources",
+});

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -78,6 +78,10 @@ export const RESOURCES_PREFIX = {
 
   // Project todos.
   project_todo_state: "pts",
+  project_todo: "ptd",
+
+  // Takeaways.
+  takeaways: "tka",
 
   // Conversation branches.
   conversation_branch: "cbr",

--- a/front/lib/resources/takeaways_resource.test.ts
+++ b/front/lib/resources/takeaways_resource.test.ts
@@ -1,0 +1,252 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { TakeawaysResource } from "@app/lib/resources/takeaways_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { TakeawaysFactory } from "@app/tests/utils/TakeawaysFactory";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("TakeawaysResource", () => {
+  let workspace: LightWorkspaceType;
+  let auth: Authenticator;
+  let space: SpaceResource;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({ role: "user" });
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+    space = setup.globalSpace;
+  });
+
+  describe("makeNew", () => {
+    it("should create a takeaway with a stable sId starting with 'tka_'", async () => {
+      const takeaway = await TakeawaysFactory.create(auth, space);
+
+      expect(takeaway.sId).toMatch(/^tka_/);
+      expect(takeaway.workspaceId).toBe(workspace.id);
+      expect(takeaway.actionItems).toEqual([]);
+      expect(takeaway.notableFacts).toEqual([]);
+      expect(takeaway.keyDecisions).toEqual([]);
+    });
+
+    it("should compute the same sId as modelIdToSId", async () => {
+      const takeaway = await TakeawaysFactory.create(auth, space);
+      const computed = TakeawaysResource.modelIdToSId({
+        id: takeaway.id,
+        workspaceId: takeaway.workspaceId,
+      });
+      expect(takeaway.sId).toBe(computed);
+    });
+  });
+
+  describe("updateWithVersion", () => {
+    it("should update the content and preserve the sId", async () => {
+      const takeaway = await TakeawaysFactory.create(auth, space);
+      const originalSId = takeaway.sId;
+
+      const fact = {
+        sId: "fact_001",
+        text: "A notable fact",
+        relevantUserIds: [],
+        sourceMessageRank: 1,
+      };
+      const updated = await takeaway.updateWithVersion(auth, {
+        actionItems: [],
+        notableFacts: [fact],
+        keyDecisions: [],
+      });
+
+      expect(updated.sId).toBe(originalSId);
+      expect(updated.notableFacts).toHaveLength(1);
+      expect(updated.notableFacts[0].text).toBe("A notable fact");
+    });
+
+    it("should allow multiple successive updates", async () => {
+      const takeaway = await TakeawaysFactory.create(auth, space);
+
+      const fact1 = {
+        sId: "fact_001",
+        text: "First fact",
+        relevantUserIds: [],
+        sourceMessageRank: 1,
+      };
+      const fact2 = {
+        sId: "fact_002",
+        text: "Second fact",
+        relevantUserIds: [],
+        sourceMessageRank: 2,
+      };
+
+      const v1 = await takeaway.updateWithVersion(auth, {
+        actionItems: [],
+        notableFacts: [fact1],
+        keyDecisions: [],
+      });
+      const v2 = await v1.updateWithVersion(auth, {
+        actionItems: [],
+        notableFacts: [fact2],
+        keyDecisions: [],
+      });
+
+      expect(v2.sId).toBe(takeaway.sId);
+      expect(v2.notableFacts[0].text).toBe("Second fact");
+    });
+  });
+
+  describe("makeNewForConversation", () => {
+    it("should create a new takeaway on the first call for a conversation", async () => {
+      const conversationId = "conv_testinit";
+
+      const takeaway = await TakeawaysResource.makeNewForConversation(auth, {
+        conversationId,
+        spaceId: space.sId,
+        actionItems: [],
+        notableFacts: [],
+        keyDecisions: [],
+      });
+
+      expect(takeaway.sId).toMatch(/^tka_/);
+      expect(takeaway.workspaceId).toBe(workspace.id);
+    });
+
+    it("should update the existing takeaway on subsequent calls for the same conversation", async () => {
+      const conversationId = "conv_testupdate";
+      const fact = {
+        sId: "fact_001",
+        text: "Updated fact",
+        relevantUserIds: [],
+        sourceMessageRank: 1,
+      };
+
+      const first = await TakeawaysResource.makeNewForConversation(auth, {
+        conversationId,
+        spaceId: space.sId,
+        actionItems: [],
+        notableFacts: [],
+        keyDecisions: [],
+      });
+
+      const second = await TakeawaysResource.makeNewForConversation(auth, {
+        conversationId,
+        spaceId: space.sId,
+        actionItems: [],
+        notableFacts: [fact],
+        keyDecisions: [],
+      });
+
+      // Same stable identity — the main row was updated in place.
+      expect(second.sId).toBe(first.sId);
+      expect(second.notableFacts[0].text).toBe("Updated fact");
+    });
+  });
+
+  describe("fetchLatestByConversationId", () => {
+    it("should return the takeaway linked to the given conversation", async () => {
+      const conversationId = "conv_testfetch";
+
+      const created = await TakeawaysResource.makeNewForConversation(auth, {
+        conversationId,
+        spaceId: space.sId,
+        actionItems: [],
+        notableFacts: [],
+        keyDecisions: [],
+      });
+
+      const fetched = await TakeawaysResource.fetchLatestByConversationId(
+        auth,
+        { conversationId }
+      );
+
+      expect(fetched).not.toBeNull();
+      expect(fetched?.sId).toBe(created.sId);
+    });
+
+    it("should return null when no takeaway exists for the conversation", async () => {
+      const fetched = await TakeawaysResource.fetchLatestByConversationId(
+        auth,
+        { conversationId: "conv_doesnotexist" }
+      );
+      expect(fetched).toBeNull();
+    });
+
+    it("should not return a takeaway from a different workspace", async () => {
+      const conversationId = "conv_testisolation";
+
+      await TakeawaysResource.makeNewForConversation(auth, {
+        conversationId,
+        spaceId: space.sId,
+        actionItems: [],
+        notableFacts: [],
+        keyDecisions: [],
+      });
+
+      const otherSetup = await createResourceTest({ role: "user" });
+      const fetched = await TakeawaysResource.fetchLatestByConversationId(
+        otherSetup.authenticator,
+        { conversationId }
+      );
+
+      expect(fetched).toBeNull();
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete the takeaway and its source link", async () => {
+      const conversationId = "conv_testdelete";
+
+      const takeaway = await TakeawaysResource.makeNewForConversation(auth, {
+        conversationId,
+        spaceId: space.sId,
+        actionItems: [],
+        notableFacts: [],
+        keyDecisions: [],
+      });
+
+      expect(takeaway).not.toBeNull();
+
+      const result = await takeaway.delete(auth, {});
+      expect(result.isOk()).toBe(true);
+
+      // The source link is also deleted, so fetchLatestByConversationId returns null.
+      const fetched = await TakeawaysResource.fetchLatestByConversationId(
+        auth,
+        { conversationId }
+      );
+      expect(fetched).toBeNull();
+    });
+
+    it("should also delete version snapshots created by updateWithVersion", async () => {
+      const conversationId = "conv_testdeletewithversion";
+      const fact = {
+        sId: "fact_001",
+        text: "A fact",
+        relevantUserIds: [],
+        sourceMessageRank: 1,
+      };
+
+      const takeaway = await TakeawaysResource.makeNewForConversation(auth, {
+        conversationId,
+        spaceId: space.sId,
+        actionItems: [],
+        notableFacts: [],
+        keyDecisions: [],
+      });
+
+      // Create a version snapshot.
+      const updated = await takeaway.updateWithVersion(auth, {
+        actionItems: [],
+        notableFacts: [fact],
+        keyDecisions: [],
+      });
+
+      await updated.delete(auth, {});
+
+      // Main row and source are gone.
+      const fetched = await TakeawaysResource.fetchLatestByConversationId(
+        auth,
+        { conversationId }
+      );
+      expect(fetched).toBeNull();
+    });
+  });
+});

--- a/front/lib/resources/takeaways_resource.ts
+++ b/front/lib/resources/takeaways_resource.ts
@@ -1,19 +1,17 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { ProjectTodoTakeawaySourcesModel } from "@app/lib/resources/storage/models/project_todo_takeaway_sources";
 import {
   TakeawaySourcesModel,
   TakeawaysModel,
+  TakeawaysVersionModel,
 } from "@app/lib/resources/storage/models/takeaways";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Ok, type Result } from "@app/types/shared/result";
-import { md5 } from "@app/types/shared/utils/encryption";
 import type {
   TodoVersionedActionItem,
   TodoVersionedKeyDecision,
@@ -25,8 +23,7 @@ import type {
   ModelStatic,
   Transaction,
 } from "sequelize";
-import { col, fn, Op } from "sequelize";
-import { v4 as uuidv4 } from "uuid";
+import { Op } from "sequelize";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -44,63 +41,38 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
     super(TakeawaysModel, blob);
   }
 
-  static async makeNew(
-    auth: Authenticator,
-    blob: Omit<
-      CreationAttributes<TakeawaysModel>,
-      "workspaceId" | "version" | "sId"
-    >,
-    transaction?: Transaction
-  ): Promise<TakeawaysResource> {
-    const row = await TakeawaysModel.create(
-      {
-        ...blob,
-        sId: generateRandomModelSId(),
-        workspaceId: auth.getNonNullableWorkspace().id,
-        version: 1,
-      },
-      { transaction }
-    );
-
-    return new this(TakeawaysModel, row.get());
+  // The stable string identifier for this takeaway, computed from the model's
+  // integer id. External code must use this sId — never the raw model id.
+  get sId(): string {
+    return TakeawaysResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
   }
 
-  // Appends a new version row for the given sId. An advisory lock scoped to the
-  // (workspace, sId) pair is acquired to serialise concurrent butler runs and
-  // prevent version-number races.
-  static async createNewVersion(
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("takeaways", { id, workspaceId });
+  }
+
+  // ── Creation ────────────────────────────────────────────────────────────────
+
+  static async makeNew(
     auth: Authenticator,
-    sId: string,
-    blob: Omit<
-      CreationAttributes<TakeawaysModel>,
-      "workspaceId" | "version" | "sId"
-    >,
+    blob: Omit<CreationAttributes<TakeawaysModel>, "workspaceId">,
     transaction?: Transaction
   ): Promise<TakeawaysResource> {
-    const workspaceId = auth.getNonNullableWorkspace().id;
-
     return withTransaction(async (t) => {
-      const hash = md5(`takeaways_version_${workspaceId}_${sId}`);
-      const lockKey = parseInt(hash, 16) % 9999999999;
-      // biome-ignore lint/plugin/noRawSql: advisory lock requires raw SQL
-      await frontSequelize.query("SELECT pg_advisory_xact_lock(:key)", {
-        transaction: t,
-        replacements: { key: lockKey },
-      });
-
-      const maxVersionResult = await TakeawaysModel.findOne({
-        where: { workspaceId, sId },
-        attributes: [[fn("MAX", col("version")), "maxVersion"]],
-        raw: true,
-        transaction: t,
-      });
-
-      const nextVersion =
-        ((maxVersionResult as { maxVersion: number | null } | null)
-          ?.maxVersion ?? 0) + 1;
-
       const row = await TakeawaysModel.create(
-        { ...blob, sId, workspaceId, version: nextVersion },
+        {
+          ...blob,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
         { transaction: t }
       );
 
@@ -108,82 +80,101 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
     }, transaction);
   }
 
-  // Returns the most recent snapshot for a given sId, or null if none exists.
-  static async fetchLatestBySId(
+  // Saves the current content as a version snapshot, then updates the main row
+  // in place. The version number is determined by the existing snapshot count + 1.
+  async updateWithVersion(
     auth: Authenticator,
-    { sId }: { sId: string },
+    updates: Pick<
+      CreationAttributes<TakeawaysModel>,
+      "actionItems" | "notableFacts" | "keyDecisions"
+    >,
+    transaction?: Transaction
+  ): Promise<TakeawaysResource> {
+    return withTransaction(async (t) => {
+      await this.saveVersion(t);
+
+      const [, [updated]] = await TakeawaysModel.update(
+        { ...updates },
+        {
+          where: {
+            id: this.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+          returning: true,
+          transaction: t,
+        }
+      );
+
+      return new TakeawaysResource(TakeawaysModel, updated.get());
+    }, transaction);
+  }
+
+  // Appends a snapshot of the current content to the version table.
+  // Called before every in-place update of the main row.
+  private async saveVersion(transaction?: Transaction): Promise<void> {
+    const existingCount = await TakeawaysVersionModel.count({
+      where: {
+        workspaceId: this.workspaceId,
+        takeawaysId: this.id,
+      },
+      transaction,
+    });
+
+    await TakeawaysVersionModel.create(
+      {
+        workspaceId: this.workspaceId,
+        takeawaysId: this.id,
+        version: existingCount + 1,
+        actionItems: this.actionItems,
+        notableFacts: this.notableFacts,
+        keyDecisions: this.keyDecisions,
+      },
+      { transaction }
+    );
+  }
+
+  // ── Fetching ─────────────────────────────────────────────────────────────────
+  private static async _fetchById(
+    auth: Authenticator,
+    id: ModelId,
     transaction?: Transaction
   ): Promise<TakeawaysResource | null> {
     const row = await TakeawaysModel.findOne({
       where: {
+        id,
         workspaceId: auth.getNonNullableWorkspace().id,
-        sId,
       },
-      order: [["version", "DESC"]],
       transaction,
     });
 
     return row ? new this(TakeawaysModel, row.get()) : null;
   }
 
-  // Returns all versioned snapshots for a given sId, oldest first.
-  static async fetchAllBySId(
-    auth: Authenticator,
-    { sId }: { sId: string },
-    transaction?: Transaction
-  ): Promise<TakeawaysResource[]> {
-    const rows = await TakeawaysModel.findAll({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        sId,
-      },
-      order: [["version", "ASC"]],
-      transaction,
-    });
-
-    return rows.map((r) => new this(TakeawaysModel, r.get()));
-  }
-
-  // Returns a specific version for a given sId, or null if it does not exist.
-  static async fetchBySIdAndVersion(
-    auth: Authenticator,
-    { sId, version }: { sId: string; version: number },
-    transaction?: Transaction
-  ): Promise<TakeawaysResource | null> {
-    const row = await TakeawaysModel.findOne({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        sId,
-        version,
-      },
-      transaction,
-    });
-
-    return row ? new this(TakeawaysModel, row.get()) : null;
-  }
+  // ── Space-level bulk operations ──────────────────────────────────────────────
 
   // Deletes all takeaway rows for a specific space, along with their source
-  // entries and the join-table rows that reference those sources.
-  // Must be called before deleting project todos for the same space because
-  // ProjectTodoTakeawaySourcesModel holds RESTRICT FKs on both sides.
+  // entries, version snapshots, and the join-table rows that reference those
+  // sources. Must be called before deleting project todos for the same space
+  // because ProjectTodoTakeawaySourcesModel holds RESTRICT FKs on both sides.
   static async deleteAllForSpace(
     auth: Authenticator,
     { spaceModelId }: { spaceModelId: ModelId }
   ): Promise<void> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    const takeaways = await TakeawaysModel.findAll({
-      attributes: ["sId"],
-      where: { workspaceId, spaceId: spaceModelId },
-      raw: true,
-    });
-    const takeawaySIds = [...new Set(takeaways.map((r) => r.sId))];
+    const takeawayIds = (
+      await TakeawaysModel.findAll({
+        attributes: ["id"],
+        where: { workspaceId, spaceId: spaceModelId },
+        raw: true,
+      })
+    ).map((r) => r.id);
 
-    if (takeawaySIds.length > 0) {
+    if (takeawayIds.length > 0) {
       const takeawaySourceIds = (
         await TakeawaySourcesModel.findAll({
           attributes: ["id"],
-          where: { workspaceId, takeawaySId: { [Op.in]: takeawaySIds } },
+          where: { workspaceId, takeawaysId: { [Op.in]: takeawayIds } },
         })
       ).map((r) => r.id);
 
@@ -197,7 +188,11 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
       }
 
       await TakeawaySourcesModel.destroy({
-        where: { workspaceId, takeawaySId: { [Op.in]: takeawaySIds } },
+        where: { workspaceId, takeawaysId: { [Op.in]: takeawayIds } },
+      });
+
+      await TakeawaysVersionModel.destroy({
+        where: { workspaceId, takeawaysId: { [Op.in]: takeawayIds } },
       });
     }
 
@@ -224,6 +219,7 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
     }
 
     await TakeawaySourcesModel.destroy({ where: { workspaceId } });
+    await TakeawaysVersionModel.destroy({ where: { workspaceId } });
     await TakeawaysModel.destroy({ where: { workspaceId } });
   }
 
@@ -231,20 +227,49 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction }
   ): Promise<Result<undefined, Error>> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const takeawaySourceIds = (
+      await TakeawaySourcesModel.findAll({
+        attributes: ["id"],
+        where: { workspaceId, takeawaysId: this.id },
+        transaction,
+      })
+    ).map((r) => r.id);
+
+    if (takeawaySourceIds.length > 0) {
+      await ProjectTodoTakeawaySourcesModel.destroy({
+        where: {
+          workspaceId,
+          takeawaySourceId: { [Op.in]: takeawaySourceIds },
+        },
+        transaction,
+      });
+    }
+
+    await TakeawaySourcesModel.destroy({
+      where: { workspaceId, takeawaysId: this.id },
+      transaction,
+    });
+
+    await TakeawaysVersionModel.destroy({
+      where: { workspaceId, takeawaysId: this.id },
+      transaction,
+    });
+
     await this.model.destroy({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        id: this.id,
-      },
+      where: { workspaceId, id: this.id },
       transaction,
     });
 
     return new Ok(undefined);
   }
 
+  // ── Conversation-scoped helpers ──────────────────────────────────────────────
+
   // Returns the latest takeaway snapshot for every conversation that has
-  // produced a takeaway in the given space. Each entry pairs the most-recent
-  // TakeawaysResource version with the conversation sId that produced it.
+  // produced a takeaway in the given space. Each entry pairs the
+  // TakeawaysResource with the conversation sId that produced it.
   // Used by the merge workflow to iterate over all conversations to process.
   static async fetchLatestBySpaceId(
     auth: Authenticator,
@@ -252,47 +277,32 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
   ): Promise<{ takeaway: TakeawaysResource; conversationSId: string }[]> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    // Fetch all rows for this space ordered so the highest version per sId
-    // comes first — the first occurrence is the latest version.
     const rows = await TakeawaysModel.findAll({
       where: { workspaceId, spaceId: spaceModelId },
-      order: [
-        ["sId", "ASC"],
-        ["version", "DESC"],
-      ],
     });
 
-    // O(n) dedup — keep only the latest version per sId.
-    const latestBySId = new Map<string, TakeawaysModel>();
-    for (const row of rows) {
-      if (!latestBySId.has(row.sId)) {
-        latestBySId.set(row.sId, row);
-      }
-    }
-
-    if (latestBySId.size === 0) {
+    if (rows.length === 0) {
       return [];
     }
 
-    // Batch-fetch source rows to resolve each takeaway sId → conversation sId.
-    const sIds = [...latestBySId.keys()];
+    const takeawayIds = rows.map((r) => r.id);
     const sources = await TakeawaySourcesModel.findAll({
       where: {
         workspaceId,
-        takeawaySId: { [Op.in]: sIds },
+        takeawaysId: { [Op.in]: takeawayIds },
         sourceType: "conversation",
       },
     });
 
-    // One source per takeaway sId (a takeaway is produced by one conversation).
-    const conversationSIdBySId = new Map<string, string>(
-      sources.map((s) => [s.takeawaySId, s.sourceId])
+    // One source per takeaway (a takeaway is produced by one conversation).
+    const conversationSIdById = new Map<ModelId, string>(
+      sources.map((s) => [s.takeawaysId, s.sourceId])
     );
 
     const result: { takeaway: TakeawaysResource; conversationSId: string }[] =
       [];
-    for (const [sId, row] of latestBySId) {
-      const conversationSId = conversationSIdBySId.get(sId);
+    for (const row of rows) {
+      const conversationSId = conversationSIdById.get(row.id);
       if (!conversationSId) {
         // Takeaway exists for this space but has no conversation source — skip.
         continue;
@@ -306,8 +316,8 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
     return result;
   }
 
-  // Returns the most recent snapshot for a conversation, or null if none exists.
-  // Looks up the conversation's stable sId through TakeawaySourcesModel.
+  // Returns the takeaway for a given conversation, or null if none exists.
+  // Looks up the conversation via TakeawaySourcesModel.
   static async fetchLatestByConversationId(
     auth: Authenticator,
     { conversationId }: { conversationId: string },
@@ -323,15 +333,13 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
     if (!source) {
       return null;
     }
-    return TakeawaysResource.fetchLatestBySId(
-      auth,
-      { sId: source.takeawaySId },
-      transaction
-    );
+    return TakeawaysResource._fetchById(auth, source.takeawaysId, transaction);
   }
 
-  // Creates a new versioned snapshot for a conversation. The conversation's
-  // stable takeaway sId is looked up (or created) via TakeawaySourcesModel.
+  // Creates or updates the takeaway for a conversation. If no takeaway exists
+  // for this conversation yet, a new TakeawaysModel row and source link are
+  // created. Otherwise the existing row is updated in place with a version
+  // snapshot appended to TakeawaysVersionModel.
   static async makeNewForConversation(
     auth: Authenticator,
     {
@@ -356,32 +364,46 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
     }
 
     return withTransaction(async (t) => {
-      let source = await TakeawaySourcesModel.findOne({
+      const source = await TakeawaySourcesModel.findOne({
         where: { workspaceId, sourceId: conversationId },
         transaction: t,
       });
 
-      let sId: string;
       if (source) {
-        sId = source.takeawaySId;
-      } else {
-        sId = uuidv4();
-        await TakeawaySourcesModel.create(
-          {
-            workspaceId,
-            takeawaySId: sId,
-            sourceType: "conversation",
-            sourceId: conversationId,
-          },
-          { transaction: t }
+        const existing = await TakeawaysResource._fetchById(
+          auth,
+          source.takeawaysId,
+          t
+        );
+        if (!existing) {
+          throw new Error(
+            `TakeawaysModel row missing for takeawaysId ${source.takeawaysId}`
+          );
+        }
+        return existing.updateWithVersion(
+          auth,
+          { actionItems, notableFacts, keyDecisions },
+          t
         );
       }
 
-      return TakeawaysResource.makeNew(
+      const takeaway = await TakeawaysResource.makeNew(
         auth,
         { spaceId: spaceModelId, actionItems, notableFacts, keyDecisions },
         t
       );
+
+      await TakeawaySourcesModel.create(
+        {
+          workspaceId,
+          takeawaysId: takeaway.id,
+          sourceType: "conversation",
+          sourceId: conversationId,
+        },
+        { transaction: t }
+      );
+
+      return takeaway;
     }, transaction);
   }
 }

--- a/front/migrations/db/migration_579.sql
+++ b/front/migrations/db/migration_579.sql
@@ -1,0 +1,70 @@
+-- Migration created on Apr 14, 2026
+-- Replace the multi-row versioning pattern (sId + version columns in the main
+-- table) with a stable main row + separate version snapshot tables for both
+-- project_todos and takeaways.
+-- Data is NOT migrated — these tables are truncated before schema changes.
+
+BEGIN;
+
+-- ── project_todos: clear data and dependent tables ────────────────────────
+-- Truncate in FK dependency order: join tables first, then parent tables.
+TRUNCATE "project_todo_takeaway_sources";
+TRUNCATE "project_todo_conversations";
+TRUNCATE "project_todo_sources";
+TRUNCATE "project_todos";
+
+-- ── project_todo_versions: new version snapshot table ─────────────────────
+CREATE TABLE IF NOT EXISTS "project_todo_versions"
+(
+    "id"                                 BIGSERIAL PRIMARY KEY,
+    "createdAt"                          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"                          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "workspaceId"                        BIGINT                   NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "projectTodoId"                      BIGINT                   NOT NULL REFERENCES "project_todos" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "version"                            INTEGER                  NOT NULL,
+    "markedAsDoneByType"                 VARCHAR(255),
+    "markedAsDoneByUserId"               BIGINT,
+    "markedAsDoneByAgentConfigurationId" VARCHAR(255),
+    "category"                           VARCHAR(255)             NOT NULL,
+    "text"                               TEXT                     NOT NULL,
+    "status"                             VARCHAR(255)             NOT NULL DEFAULT 'todo',
+    "doneAt"                             TIMESTAMP WITH TIME ZONE,
+    "actorRationale"                     TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "project_todo_versions_ws_todo_version_unique_idx"
+    ON "project_todo_versions" ("workspaceId", "projectTodoId", "version");
+
+-- ── takeaways: clear data ─────────────────────────────────────────────────
+-- takeaway_sources used a plain string reference in the old schema (no proper
+-- FK to takeaways), so it is truncated separately from takeaways.
+-- project_todo_takeaway_sources was already cleared above.
+TRUNCATE "takeaway_sources";
+TRUNCATE "takeaways";
+
+-- ── takeaway_sources: replace string reference with integer FK ─────────────
+ALTER TABLE "takeaway_sources"
+    ADD COLUMN "takeawaysId" BIGINT NOT NULL
+        REFERENCES "takeaways" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX IF NOT EXISTS "takeaway_sources_ws_takeawaysId_idx"
+    ON "takeaway_sources" ("workspaceId", "takeawaysId");
+
+-- ── takeaway_versions: new version snapshot table ─────────────────────────
+CREATE TABLE IF NOT EXISTS "takeaway_versions"
+(
+    "id"           BIGSERIAL PRIMARY KEY,
+    "createdAt"    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "workspaceId"  BIGINT                   NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "takeawaysId"  BIGINT                   NOT NULL REFERENCES "takeaways" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "version"      INTEGER                  NOT NULL,
+    "actionItems"  JSONB                    NOT NULL DEFAULT '[]',
+    "notableFacts" JSONB                    NOT NULL DEFAULT '[]',
+    "keyDecisions" JSONB                    NOT NULL DEFAULT '[]'
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "takeaway_versions_ws_takeawaysId_version_unique_idx"
+    ON "takeaway_versions" ("workspaceId", "takeawaysId", "version");
+
+COMMIT;

--- a/front/migrations/db/migration_580.sql
+++ b/front/migrations/db/migration_580.sql
@@ -1,0 +1,30 @@
+-- Migration created on Apr 14, 2026
+-- Replace the multi-row versioning pattern (sId + version columns in the main
+-- table) with a stable main row + separate version snapshot tables for both
+-- project_todos and takeaways.
+-- Data is NOT migrated — these tables are truncated before schema changes.
+
+-- Drop old versioning indexes (column drop below would remove them anyway, but
+-- explicit drops keep the migration intent clear).
+DROP INDEX CONCURRENTLY IF EXISTS "project_todos_sId_version_unique_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "project_todos_sId_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "project_todos_ws_space_user_version_idx";
+
+ALTER TABLE "project_todos"
+    DROP COLUMN IF EXISTS "sId";
+ALTER TABLE "project_todos"
+    DROP COLUMN IF EXISTS "version";
+
+DROP INDEX CONCURRENTLY IF EXISTS "takeaways_ws_sId_version_unique_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "takeaways_sId_idx";
+
+ALTER TABLE "takeaways"
+    DROP COLUMN IF EXISTS "sId";
+ALTER TABLE "takeaways"
+    DROP COLUMN IF EXISTS "version";
+
+-- ── takeaway_sources: replace string reference with integer FK ─────────────
+DROP INDEX CONCURRENTLY IF EXISTS "takeaway_sources_ws_takeawaySId_idx";
+
+ALTER TABLE "takeaway_sources"
+    DROP COLUMN IF EXISTS "takeawaySId";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.test.ts
@@ -40,7 +40,6 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]", () => {
     const { todo: updated } = res._getJSONData();
     expect(updated.text).toBe("Updated text");
     expect(updated.sId).toBe(todo.sId);
-    expect(updated.version).toBe(2);
   });
 
   it("should mark a todo as done", async () => {
@@ -61,7 +60,6 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]", () => {
     expect(updated.status).toBe("done");
     expect(updated.markedAsDoneByType).toBe("user");
     expect(updated.doneAt).not.toBeNull();
-    expect(updated.version).toBe(2);
   });
 
   it("should allow un-marking a done todo", async () => {
@@ -71,7 +69,7 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]", () => {
     const todo = await ProjectTodoFactory.create(workspace, project, {
       userId: user.id,
     });
-    const doneTodo = await todo.createVersion(auth, {
+    const doneTodo = await todo.updateWithVersion(auth, {
       status: "done",
       markedAsDoneByType: "user",
       markedAsDoneByUserId: user.id,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.ts
@@ -81,7 +81,7 @@ async function handler(
       const { text, status } = parseResult.data;
       const user = auth.getNonNullableUser();
 
-      const updates: Parameters<typeof todo.createVersion>[1] = {};
+      const updates: Parameters<typeof todo.updateWithVersion>[1] = {};
 
       if (text !== undefined) {
         updates.text = text;
@@ -103,7 +103,7 @@ async function handler(
         }
       }
 
-      const updatedTodo = await todo.createVersion(auth, updates);
+      const updatedTodo = await todo.updateWithVersion(auth, updates);
 
       return res.status(200).json({ todo: updatedTodo.toJSON() });
     }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.test.ts
@@ -45,7 +45,7 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_todos", () => {
       text: "First todo",
     });
     // Create a new version of the same todo.
-    await todo.createVersion(auth, { text: "Updated todo" });
+    await todo.updateWithVersion(auth, { text: "Updated todo" });
 
     req.query.spaceId = project.sId;
     await handler(req, res);
@@ -117,7 +117,6 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_todos", () => {
     expect(todo.text).toBe("New todo item");
     expect(todo.category).toBe("follow_ups");
     expect(todo.status).toBe("todo");
-    expect(todo.version).toBe(1);
     expect(typeof todo.sId).toBe("string");
   });
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
@@ -127,7 +127,6 @@ async function handler(
         category,
         text,
         status: "todo",
-        version: 1,
         doneAt: null,
         actorRationale: null,
       });

--- a/front/tests/utils/ProjectTodoFactory.ts
+++ b/front/tests/utils/ProjectTodoFactory.ts
@@ -28,7 +28,6 @@ export class ProjectTodoFactory {
       category: params.category ?? "follow_ups",
       text: params.text ?? "A test todo item.",
       status: "todo",
-      version: 1,
       doneAt: null,
       actorRationale: null,
     });

--- a/front/tests/utils/TakeawaysFactory.ts
+++ b/front/tests/utils/TakeawaysFactory.ts
@@ -1,0 +1,17 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { TakeawaysResource } from "@app/lib/resources/takeaways_resource";
+
+export class TakeawaysFactory {
+  static async create(
+    auth: Authenticator,
+    space: SpaceResource
+  ): Promise<TakeawaysResource> {
+    return TakeawaysResource.makeNew(auth, {
+      spaceId: space.id,
+      actionItems: [],
+      notableFacts: [],
+      keyDecisions: [],
+    });
+  }
+}

--- a/front/types/project_todo.ts
+++ b/front/types/project_todo.ts
@@ -34,7 +34,6 @@ export type ProjectTodoType = {
   category: ProjectTodoCategory;
   text: string;
   status: ProjectTodoStatus;
-  version: number;
   doneAt: Date | null;
   actorRationale: string | null;
   createdByType: ProjectTodoActorType;


### PR DESCRIPTION
## Description

Move the design of "versions" for takeaways and project_todo from a version+sId to a new table (like in skills).

We don't care about the data, so truncate everything.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
