### PR TITLE
feat: set project notification preferences

### DIFF
--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -34,6 +34,7 @@ import {
 import type React from "react";
 import type { ReactElement } from "react";
 import { useCallback, useEffect, useState } from "react";
+import { ProjectNotificationMenu } from "./ProjectNotificationMenu";
 
 /**
  * Hook for handling right-click context menu with timing protection
@@ -142,7 +143,6 @@ export function ProjectMenu({
     disabled: shouldWaitBeforeFetching,
     includeAllMembers: true,
   });
-
   const [showRenameDialog, setShowRenameDialog] = useState<boolean>(false);
 
   const shareLink = activeSpaceId
@@ -239,6 +239,11 @@ export function ProjectMenu({
           <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
         )}
         <DropdownMenuContent onFocusOutside={(e) => e.preventDefault()}>
+          <ProjectNotificationMenu
+            activeSpaceId={activeSpaceId}
+            owner={owner}
+            shouldWaitBeforeFetching={shouldWaitBeforeFetching}
+          />
           {canRename && (
             <DropdownMenuItem
               label="Rename"

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -21,7 +21,9 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuPortal,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -239,11 +241,21 @@ export function ProjectMenu({
           <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
         )}
         <DropdownMenuContent onFocusOutside={(e) => e.preventDefault()}>
+          <DropdownMenuLabel label="My settings" />
+          {canLeave && (
+            <DropdownMenuItem
+              label="Leave"
+              onClick={openLeaveDialog}
+              icon={XMarkIcon}
+            />
+          )}
           <ProjectNotificationMenu
             activeSpaceId={activeSpaceId}
             owner={owner}
             shouldWaitBeforeFetching={shouldWaitBeforeFetching}
           />
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel label="Project" />
           {canRename && (
             <DropdownMenuItem
               label="Rename"
@@ -251,41 +263,33 @@ export function ProjectMenu({
               icon={PencilSquareIcon}
             />
           )}
-          {spaceInfo?.members && spaceInfo.members.length > 0 && (
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger
-                icon={ContactsUserIcon}
-                label="Member list"
-              />
-              <DropdownMenuPortal>
-                <DropdownMenuSubContent>
-                  {spaceInfo.members.map((member) => (
-                    <DropdownMenuItem
-                      key={member.sId}
-                      label={member.fullName ?? member.username}
-                      onClick={() => handleSeeUserDetails(member.sId)}
-                      icon={
-                        <Avatar
-                          size="xs"
-                          visual={member.image ?? undefined}
-                          name={member.fullName ?? member.username}
-                          isRounded
-                        />
-                      }
-                      className="!text-foreground dark:!text-foreground-night"
-                    />
-                  ))}
-                </DropdownMenuSubContent>
-              </DropdownMenuPortal>
-            </DropdownMenuSub>
-          )}
-          {shareLink && (
-            <DropdownMenuItem
-              label="Copy link"
-              onClick={copyProjectLink}
-              icon={LinkIcon}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger
+              icon={ContactsUserIcon}
+              disabled={!spaceInfo?.members?.length}
+              label="Member list"
             />
-          )}
+            <DropdownMenuPortal>
+              <DropdownMenuSubContent>
+                {spaceInfo?.members.map((member) => (
+                  <DropdownMenuItem
+                    key={member.sId}
+                    label={member.fullName ?? member.username}
+                    onClick={() => handleSeeUserDetails(member.sId)}
+                    icon={
+                      <Avatar
+                        size="xs"
+                        visual={member.image ?? undefined}
+                        name={member.fullName ?? member.username}
+                        isRounded
+                      />
+                    }
+                    className="!text-foreground dark:!text-foreground-night"
+                  />
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuPortal>
+          </DropdownMenuSub>
           {isProjectEditor && (
             <DropdownMenuItem
               label="Archive"
@@ -294,12 +298,16 @@ export function ProjectMenu({
               variant="warning"
             />
           )}
-          {canLeave && (
-            <DropdownMenuItem
-              label="Leave"
-              onClick={openLeaveDialog}
-              icon={XMarkIcon}
-            />
+          {shareLink && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel label="Share" />
+              <DropdownMenuItem
+                label="Copy link"
+                onClick={copyProjectLink}
+                icon={LinkIcon}
+              />
+            </>
           )}
         </DropdownMenuContent>
       </DropdownMenu>

--- a/front/components/assistant/conversation/ProjectNotificationMenu.tsx
+++ b/front/components/assistant/conversation/ProjectNotificationMenu.tsx
@@ -27,15 +27,17 @@ const NOTIFICATION_CONDITION_LABELS: Record<NotificationCondition, string> = {
   never: "Don't notify me",
 };
 
+interface ProjectNotificationMenuProps {
+  activeSpaceId: string | null;
+  owner: WorkspaceType;
+  shouldWaitBeforeFetching: boolean;
+}
+
 export function ProjectNotificationMenu({
   activeSpaceId,
   owner,
   shouldWaitBeforeFetching,
-}: {
-  activeSpaceId: string | null;
-  owner: WorkspaceType;
-  shouldWaitBeforeFetching: boolean;
-}) {
+}: ProjectNotificationMenuProps) {
   const {
     metadata: defaultNotificationCondition,
     isMetadataLoading: isDefaultNotificationConditionLoading,

--- a/front/components/assistant/conversation/ProjectNotificationMenu.tsx
+++ b/front/components/assistant/conversation/ProjectNotificationMenu.tsx
@@ -22,7 +22,7 @@ import {
 import { useEffect, useState } from "react";
 
 const NOTIFICATION_CONDITION_LABELS: Record<NotificationCondition, string> = {
-  all_messages: "All messages",
+  all_messages: "All activity",
   only_mentions: "Only when mentioned",
   never: "Don't notify me",
 };

--- a/front/components/assistant/conversation/ProjectNotificationMenu.tsx
+++ b/front/components/assistant/conversation/ProjectNotificationMenu.tsx
@@ -1,0 +1,134 @@
+import {
+  useProjectNotificationPreference,
+  useUpdateProjectNotificationPreference,
+} from "@app/lib/swr/spaces";
+import { useUserMetadata } from "@app/lib/swr/user";
+import {
+  CONVERSATION_NOTIFICATION_METADATA_KEYS,
+  DEFAULT_NOTIFICATION_CONDITION,
+  isNotificationCondition,
+  type NotificationCondition,
+} from "@app/types/notification_preferences";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  BellIcon,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+
+const NOTIFICATION_CONDITION_LABELS: Record<NotificationCondition, string> = {
+  all_messages: "All messages",
+  only_mentions: "Only when mentioned",
+  never: "Don't notify me",
+};
+
+export function ProjectNotificationMenu({
+  activeSpaceId,
+  owner,
+  shouldWaitBeforeFetching,
+}: {
+  activeSpaceId: string | null;
+  owner: WorkspaceType;
+  shouldWaitBeforeFetching: boolean;
+}) {
+  const {
+    metadata: defaultNotificationCondition,
+    isMetadataLoading: isDefaultNotificationConditionLoading,
+  } = useUserMetadata(CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition, {
+    disabled: shouldWaitBeforeFetching,
+  });
+
+  const {
+    projectNotificationPreference,
+    isProjectNotificationPreferenceLoading,
+  } = useProjectNotificationPreference({
+    workspaceId: owner.sId,
+    spaceId: activeSpaceId,
+    disabled: shouldWaitBeforeFetching,
+  });
+
+  const isLoading =
+    isDefaultNotificationConditionLoading ||
+    isProjectNotificationPreferenceLoading;
+
+  const updateNotificationPreference = useUpdateProjectNotificationPreference({
+    workspaceId: owner.sId,
+    spaceId: activeSpaceId,
+  });
+
+  const [selectedNotificationPreference, setSelectedNotificationPreference] =
+    useState<NotificationCondition>(() => {
+      if (projectNotificationPreference?.preference) {
+        return projectNotificationPreference.preference;
+      }
+      if (
+        defaultNotificationCondition?.value &&
+        isNotificationCondition(defaultNotificationCondition.value)
+      ) {
+        return defaultNotificationCondition.value;
+      }
+      return DEFAULT_NOTIFICATION_CONDITION;
+    });
+
+  useEffect(() => {
+    if (projectNotificationPreference?.preference) {
+      setSelectedNotificationPreference(
+        projectNotificationPreference.preference
+      );
+      return;
+    }
+    if (
+      defaultNotificationCondition?.value &&
+      isNotificationCondition(defaultNotificationCondition.value)
+    ) {
+      setSelectedNotificationPreference(defaultNotificationCondition.value);
+      return;
+    }
+  }, [projectNotificationPreference, defaultNotificationCondition?.value]);
+
+  const handleNotificationPreferenceChange = (
+    preference: NotificationCondition
+  ) => {
+    setSelectedNotificationPreference(preference);
+    void updateNotificationPreference(preference);
+  };
+
+  const displayedPreferences: NotificationCondition[] = [
+    "never",
+    "only_mentions",
+    "all_messages",
+  ];
+
+  if (!activeSpaceId) {
+    return null;
+  }
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger
+        disabled={isLoading || shouldWaitBeforeFetching}
+        icon={BellIcon}
+        label="Notifications"
+      />
+      <DropdownMenuPortal>
+        <DropdownMenuSubContent>
+          <DropdownMenuRadioGroup value={selectedNotificationPreference}>
+            {displayedPreferences.map((preference) => (
+              <DropdownMenuRadioItem
+                key={preference}
+                label={NOTIFICATION_CONDITION_LABELS[preference]}
+                value={preference}
+                onClick={() => handleNotificationPreferenceChange(preference)}
+              />
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuSubContent>
+      </DropdownMenuPortal>
+    </DropdownMenuSub>
+  );
+}

--- a/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
+++ b/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
@@ -92,12 +92,7 @@ export function ProjectHeaderActions({
                 tooltip="Project options"
               />
             </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <ProjectNotificationMenu
-                activeSpaceId={spaceId}
-                owner={owner}
-                shouldWaitBeforeFetching={false}
-              />
+            <DropdownMenuContent collisionPadding={8}>
               {!canLeaveProject ? (
                 <DropdownTooltipTrigger
                   description="You are the last editor of this project and cannot leave it."
@@ -116,6 +111,11 @@ export function ProjectHeaderActions({
                   onClick={openLeaveDialog}
                 />
               )}
+              <ProjectNotificationMenu
+                activeSpaceId={spaceId}
+                owner={owner}
+                shouldWaitBeforeFetching={false}
+              />
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
+++ b/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
@@ -19,6 +19,7 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { useCallback } from "react";
+import { ProjectNotificationMenu } from "../ProjectNotificationMenu";
 
 interface ProjectHeaderActionsProps {
   isMember: boolean;
@@ -92,6 +93,11 @@ export function ProjectHeaderActions({
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent>
+              <ProjectNotificationMenu
+                activeSpaceId={spaceId}
+                owner={owner}
+                shouldWaitBeforeFetching={false}
+              />
               {!canLeaveProject ? (
                 <DropdownTooltipTrigger
                   description="You are the last editor of this project and cannot leave it."

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -35,6 +35,10 @@ import type {
   GetProjectMetadataResponseBody,
   PatchProjectMetadataResponseBody,
 } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_metadata";
+import type {
+  GetUserProjectNotificationPreferenceResponseBody,
+  PatchUserProjectNotificationPreferenceResponseBody,
+} from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences";
 import type { SpacesLookupResponseBody } from "@app/pages/api/w/[wId]/spaces/projects-lookup";
 import type { PatchProjectMetadataBodyType } from "@app/types/api/internal/spaces";
 import type { DataSourceViewCategoryWithoutApps } from "@app/types/api/public/spaces";
@@ -42,6 +46,10 @@ import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { SearchWarningCode } from "@app/types/core/core_api";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/core_api";
 import type { DataSourceViewType } from "@app/types/data_source_view";
+import type {
+  NotificationCondition,
+  UserProjectNotificationPreference,
+} from "@app/types/notification_preferences";
 import type { ProjectMetadataType } from "@app/types/project_metadata";
 import { isString } from "@app/types/shared/utils/general";
 import type { ProjectType, SpaceKind, SpaceType } from "@app/types/space";
@@ -1035,6 +1043,87 @@ export function useUpdateProjectMetadata({
 
     const response: PatchProjectMetadataResponseBody = await res.json();
     return response.projectMetadata;
+  };
+}
+
+export function useProjectNotificationPreference({
+  workspaceId,
+  spaceId,
+  disabled = false,
+}: {
+  workspaceId: string;
+  spaceId: string | null;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const projectMetadataFetcher: Fetcher<GetUserProjectNotificationPreferenceResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/spaces/${spaceId}/project_notification_preferences`,
+    projectMetadataFetcher,
+    { disabled: disabled || spaceId === null }
+  );
+
+  return {
+    projectNotificationPreference:
+      data?.userProjectNotificationPreference ?? null,
+    isProjectNotificationPreferenceLoading: !error && !data && !disabled,
+    mutateProjectNotificationPreference: mutate,
+  };
+}
+
+export function useUpdateProjectNotificationPreference({
+  workspaceId,
+  spaceId,
+}: {
+  workspaceId: string;
+  spaceId: string | null;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateProjectNotificationPreference } =
+    useProjectNotificationPreference({
+      workspaceId,
+      spaceId,
+      disabled: true,
+    });
+
+  return async (
+    preference: NotificationCondition
+  ): Promise<UserProjectNotificationPreference | null> => {
+    if (!spaceId) {
+      return null;
+    }
+    const url = `/api/w/${workspaceId}/spaces/${spaceId}/project_notification_preferences`;
+
+    const res = await clientFetch(url, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        preference,
+      }),
+    });
+
+    if (!res.ok) {
+      const errorData = await getErrorFromResponse(res);
+      sendNotification({
+        type: "error",
+        title: "Error updating project notification preference",
+        description: `Error: ${errorData.message}`,
+      });
+      return null;
+    }
+
+    void mutateProjectNotificationPreference();
+
+    sendNotification({
+      type: "success",
+      title: "Project notification preference updated",
+    });
+
+    const response: PatchUserProjectNotificationPreferenceResponseBody =
+      await res.json();
+    return response.userProjectNotificationPreference;
   };
 }
 


### PR DESCRIPTION
## Description

This PR updates the project notification preferences dropdown UI layout and labeling.

- Reorganizes the project context menu to group related items with separators (My settings / Project / Share sections)
- Adds the possibility to change the notification preference per project

<img width="233" height="409" alt="Capture d’écran 2026-04-14 à 10 18 24" src="https://github.com/user-attachments/assets/56d913f3-a7f1-4ea3-8ed9-0b34d1c27cf2" />

<img width="364" height="217" alt="Capture d’écran 2026-04-14 à 10 10 27" src="https://github.com/user-attachments/assets/755f5651-a74a-45d0-820e-2b8739e3106d" />

## Tests

Manually

## Risks
Low.

## Deploy Plan

Standard deployment.
