### PR TITLE
feat: check project preference for notification

### DIFF
--- a/front/lib/notifications/triggers/project-new-conversation.test.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.test.ts
@@ -1,31 +1,41 @@
+import { Authenticator } from "@app/lib/auth";
 import { filterMembersByNotifyCondition } from "@app/lib/notifications/triggers/project-new-conversation";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import {
   CONVERSATION_NOTIFICATION_METADATA_KEYS,
   DEFAULT_NOTIFICATION_CONDITION,
   type NotificationCondition,
 } from "@app/types/notification_preferences";
-import type { WorkspaceType } from "@app/types/user";
+import type { LightWorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, test } from "vitest";
 
 describe("filterMembersByNotifyCondition", () => {
-  let workspace: WorkspaceType;
+  let workspace: LightWorkspaceType;
+  let auth: Authenticator;
+  let space: SpaceResource;
   let user1: UserResource;
   let user2: UserResource;
   let user3: UserResource;
 
   beforeEach(async () => {
-    workspace = await WorkspaceFactory.basic();
-    user1 = await UserFactory.basic();
+    const result = await createResourceTest({ role: "admin" });
+    workspace = result.workspace;
+    user1 = result.user;
+    auth = result.authenticator;
+
     user2 = await UserFactory.basic();
     user3 = await UserFactory.basic();
 
-    await MembershipFactory.associate(workspace, user1, { role: "user" });
     await MembershipFactory.associate(workspace, user2, { role: "user" });
     await MembershipFactory.associate(workspace, user3, { role: "user" });
+
+    space = await SpaceFactory.project(workspace);
   });
 
   test("should include user with 'all_messages' preference", async () => {
@@ -36,7 +46,11 @@ describe("filterMembersByNotifyCondition", () => {
     );
 
     const members = [user1];
-    const result = await filterMembersByNotifyCondition(members);
+    const result = await filterMembersByNotifyCondition(
+      auth,
+      members,
+      space.id
+    );
 
     expect(result).toHaveLength(1);
     expect(result[0].sId).toBe(user1.sId);
@@ -50,7 +64,11 @@ describe("filterMembersByNotifyCondition", () => {
     );
 
     const members = [user1];
-    const result = await filterMembersByNotifyCondition(members);
+    const result = await filterMembersByNotifyCondition(
+      auth,
+      members,
+      space.id
+    );
 
     expect(result).toHaveLength(0);
   });
@@ -63,7 +81,11 @@ describe("filterMembersByNotifyCondition", () => {
     );
 
     const members = [user1];
-    const result = await filterMembersByNotifyCondition(members);
+    const result = await filterMembersByNotifyCondition(
+      auth,
+      members,
+      space.id
+    );
 
     expect(result).toHaveLength(0);
   });
@@ -71,7 +93,11 @@ describe("filterMembersByNotifyCondition", () => {
   test("should default to 'all_messages' when no preference stored", async () => {
     // No preference set for user1
     const members = [user1];
-    const result = await filterMembersByNotifyCondition(members);
+    const result = await filterMembersByNotifyCondition(
+      auth,
+      members,
+      space.id
+    );
 
     expect(result).toHaveLength(1);
     expect(result[0].sId).toBe(user1.sId);
@@ -92,7 +118,11 @@ describe("filterMembersByNotifyCondition", () => {
     // user3 has no preference (should default to "all_messages")
 
     const members = [user1, user2, user3];
-    const result = await filterMembersByNotifyCondition(members);
+    const result = await filterMembersByNotifyCondition(
+      auth,
+      members,
+      space.id
+    );
 
     expect(result).toHaveLength(2);
     expect(result.map((p) => p.sId).sort()).toEqual(
@@ -107,7 +137,11 @@ describe("filterMembersByNotifyCondition", () => {
     );
 
     const members = [user1];
-    const result = await filterMembersByNotifyCondition(members);
+    const result = await filterMembersByNotifyCondition(
+      auth,
+      members,
+      space.id
+    );
 
     expect(result).toHaveLength(1);
     expect(result[0].sId).toBe(user1.sId);
@@ -115,12 +149,118 @@ describe("filterMembersByNotifyCondition", () => {
 
   test("should handle empty members array", async () => {
     const members: UserResource[] = [];
-    const result = await filterMembersByNotifyCondition(members);
+    const result = await filterMembersByNotifyCondition(
+      auth,
+      members,
+      space.id
+    );
 
     expect(result).toHaveLength(0);
   });
 
   test("should verify default condition is 'all_messages'", () => {
     expect(DEFAULT_NOTIFICATION_CONDITION).toBe("all_messages");
+  });
+
+  describe("project-level preference overrides", () => {
+    async function setProjectPreference(
+      user: UserResource,
+      preference: NotificationCondition
+    ) {
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+      await UserProjectNotificationPreferenceResource.setPreference(userAuth, {
+        spaceModelId: space.id,
+        preference,
+      });
+    }
+
+    test("should override general 'all_messages' with project 'never'", async () => {
+      await user1.setMetadata(
+        CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+        "all_messages"
+      );
+      await setProjectPreference(user1, "never");
+
+      const members = [user1];
+      const result = await filterMembersByNotifyCondition(
+        auth,
+        members,
+        space.id
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    test("should override general 'never' with project 'all_messages'", async () => {
+      await user1.setMetadata(
+        CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+        "never"
+      );
+      await setProjectPreference(user1, "all_messages");
+
+      const members = [user1];
+      const result = await filterMembersByNotifyCondition(
+        auth,
+        members,
+        space.id
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].sId).toBe(user1.sId);
+    });
+
+    test("should fall back to general preference when no project preference exists", async () => {
+      await user1.setMetadata(
+        CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+        "never"
+      );
+      // No project-level preference set
+
+      const members = [user1];
+      const result = await filterMembersByNotifyCondition(
+        auth,
+        members,
+        space.id
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    test("should handle mixed general and project preferences across users", async () => {
+      // user1: general=never, project=all_messages -> should be included
+      await user1.setMetadata(
+        CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+        "never"
+      );
+      await setProjectPreference(user1, "all_messages");
+
+      // user2: general=all_messages, no project pref -> should be included
+      await user2.setMetadata(
+        CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+        "all_messages"
+      );
+
+      // user3: general=all_messages, project=only_mentions -> should be excluded
+      await user3.setMetadata(
+        CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+        "all_messages"
+      );
+      await setProjectPreference(user3, "only_mentions");
+
+      const members = [user1, user2, user3];
+      const result = await filterMembersByNotifyCondition(
+        auth,
+        members,
+        space.id
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.map((p) => p.sId).sort()).toEqual(
+        [user1.sId, user2.sId].sort()
+      );
+    });
   });
 });

--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -4,6 +4,7 @@ import { getNovuClient } from "@app/lib/notifications";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
+import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -16,6 +17,7 @@ import {
   isNotificationCondition,
   type NotificationCondition,
 } from "@app/types/notification_preferences";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -26,12 +28,14 @@ import { Op } from "sequelize";
 const NOTIFICATION_DELAY_MS = 15_000; // 15 seconds
 
 export const filterMembersByNotifyCondition = async (
-  members: UserResource[]
+  auth: Authenticator,
+  members: UserResource[],
+  spaceModelId: ModelId
 ): Promise<UserResource[]> => {
   const userModelIds = members.map((p) => p.id);
 
-  // Bulk query for all preferences.
-  const preferences = await UserMetadataModel.findAll({
+  // Bulk query for general and project-level preferences.
+  const generalPreferences = await UserMetadataModel.findAll({
     where: {
       userId: { [Op.in]: userModelIds },
       key: CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
@@ -39,16 +43,28 @@ export const filterMembersByNotifyCondition = async (
     attributes: ["userId", "value"],
   });
 
-  const preferenceMap = new Map<number, NotificationCondition>();
-  for (const pref of preferences) {
+  const projectPreferenceMap =
+    await UserProjectNotificationPreferenceResource.fetchAllBySpaceAndUsers(
+      auth,
+      {
+        spaceModelId,
+        userModelIds,
+      }
+    );
+
+  const generalPreferenceMap = new Map<number, NotificationCondition>();
+  for (const pref of generalPreferences) {
     if (isNotificationCondition(pref.value)) {
-      preferenceMap.set(pref.userId, pref.value);
+      generalPreferenceMap.set(pref.userId, pref.value);
     }
   }
 
   return members.filter((member) => {
+    // Project-level preference overrides the general one if present.
     const notifyCondition =
-      preferenceMap.get(member.id) ?? DEFAULT_NOTIFICATION_CONDITION;
+      projectPreferenceMap.get(member.id) ??
+      generalPreferenceMap.get(member.id) ??
+      DEFAULT_NOTIFICATION_CONDITION;
     switch (notifyCondition) {
       case "all_messages":
         return true;
@@ -128,8 +144,11 @@ const triggerProjectNewConversationNotifications = async (
     (member) => member.sId !== userThatCreatedConversation.sId
   );
 
-  const usersToNotify =
-    await filterMembersByNotifyCondition(otherProjectMembers);
+  const usersToNotify = await filterMembersByNotifyCondition(
+    auth,
+    otherProjectMembers,
+    space.id
+  );
 
   if (usersToNotify.length === 0) {
     return new Ok(undefined);

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -62,6 +62,7 @@ vi.mock("@app/lib/api/assistant/conversation_rendering", () => ({
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 
 describe("conversation-unread workflow business logic", () => {
@@ -365,9 +366,6 @@ describe("conversation-unread workflow business logic", () => {
         user: UserResource,
         preference: "all_messages" | "only_mentions" | "never"
       ) {
-        const { UserProjectNotificationPreferenceResource } = await import(
-          "@app/lib/resources/user_project_notification_preferences_resource"
-        );
         const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
           user.sId,
           workspace.sId

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -168,20 +168,26 @@ describe("conversation-unread workflow business logic", () => {
   });
 
   describe("filterParticipantsByNotifyCondition", () => {
-    let workspace: WorkspaceType;
+    let workspace: LightWorkspaceType;
+    let auth: Authenticator;
+    let space: SpaceResource;
     let user1: UserResource;
     let user2: UserResource;
     let user3: UserResource;
 
     beforeEach(async () => {
-      workspace = await WorkspaceFactory.basic();
-      user1 = await UserFactory.basic();
+      const result = await createResourceTest({ role: "admin" });
+      workspace = result.workspace;
+      user1 = result.user;
+      auth = result.authenticator;
+
       user2 = await UserFactory.basic();
       user3 = await UserFactory.basic();
 
-      await MembershipFactory.associate(workspace, user1, { role: "user" });
       await MembershipFactory.associate(workspace, user2, { role: "user" });
       await MembershipFactory.associate(workspace, user3, { role: "user" });
+
+      space = await SpaceFactory.project(workspace);
     });
 
     const makeParticipant = (
@@ -200,9 +206,11 @@ describe("conversation-unread workflow business logic", () => {
 
       const participants = [makeParticipant(user1)];
       const result = await filterParticipantsByNotifyCondition({
+        auth,
         participants,
         mentionedUserIds: new Set(),
         totalParticipantCount: 5,
+        spaceModelId: space.id,
       });
 
       expect(result).toHaveLength(1);
@@ -217,9 +225,11 @@ describe("conversation-unread workflow business logic", () => {
 
       const participants = [makeParticipant(user1)];
       const result = await filterParticipantsByNotifyCondition({
+        auth,
         participants,
         mentionedUserIds: new Set([user1.sId]),
         totalParticipantCount: 5,
+        spaceModelId: space.id,
       });
 
       expect(result).toHaveLength(1);
@@ -234,9 +244,11 @@ describe("conversation-unread workflow business logic", () => {
 
       const participants = [makeParticipant(user1)];
       const result = await filterParticipantsByNotifyCondition({
+        auth,
         participants,
         mentionedUserIds: new Set(),
         totalParticipantCount: 5,
+        spaceModelId: space.id,
       });
 
       expect(result).toHaveLength(0);
@@ -250,9 +262,11 @@ describe("conversation-unread workflow business logic", () => {
 
       const participants = [makeParticipant(user1)];
       const result = await filterParticipantsByNotifyCondition({
+        auth,
         participants,
         mentionedUserIds: new Set(),
         totalParticipantCount: 1, // Single participant exception
+        spaceModelId: space.id,
       });
 
       expect(result).toHaveLength(1);
@@ -267,9 +281,11 @@ describe("conversation-unread workflow business logic", () => {
 
       const participants = [makeParticipant(user1)];
       const result = await filterParticipantsByNotifyCondition({
+        auth,
         participants,
         mentionedUserIds: new Set([user1.sId]),
         totalParticipantCount: 1,
+        spaceModelId: space.id,
       });
 
       expect(result).toHaveLength(0);
@@ -279,9 +295,11 @@ describe("conversation-unread workflow business logic", () => {
       // No preference set for user1
       const participants = [makeParticipant(user1)];
       const result = await filterParticipantsByNotifyCondition({
+        auth,
         participants,
         mentionedUserIds: new Set(),
         totalParticipantCount: 5,
+        spaceModelId: space.id,
       });
 
       expect(result).toHaveLength(1);
@@ -310,15 +328,173 @@ describe("conversation-unread workflow business logic", () => {
       ];
 
       const result = await filterParticipantsByNotifyCondition({
+        auth,
         participants,
         mentionedUserIds: new Set([user2.sId]), // Only user2 is mentioned
         totalParticipantCount: 3,
+        spaceModelId: space.id,
       });
 
       expect(result).toHaveLength(2);
       expect(result.map((p) => p.sId).sort()).toEqual(
         [user1.sId, user2.sId].sort()
       );
+    });
+
+    it("should handle null spaceModelId (no project preferences)", async () => {
+      await user1.setMetadata(
+        CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+        "all_messages"
+      );
+
+      const participants = [makeParticipant(user1)];
+      const result = await filterParticipantsByNotifyCondition({
+        auth,
+        participants,
+        mentionedUserIds: new Set(),
+        totalParticipantCount: 5,
+        spaceModelId: null,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].sId).toBe(user1.sId);
+    });
+
+    describe("project-level preference overrides", () => {
+      async function setProjectPreference(
+        user: UserResource,
+        preference: "all_messages" | "only_mentions" | "never"
+      ) {
+        const { UserProjectNotificationPreferenceResource } = await import(
+          "@app/lib/resources/user_project_notification_preferences_resource"
+        );
+        const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+          user.sId,
+          workspace.sId
+        );
+        await UserProjectNotificationPreferenceResource.setPreference(
+          userAuth,
+          { spaceModelId: space.id, preference }
+        );
+      }
+
+      it("should override general 'all_messages' with project 'never'", async () => {
+        await user1.setMetadata(
+          CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+          "all_messages"
+        );
+        await setProjectPreference(user1, "never");
+
+        const participants = [makeParticipant(user1)];
+        const result = await filterParticipantsByNotifyCondition({
+          auth,
+          participants,
+          mentionedUserIds: new Set(),
+          totalParticipantCount: 5,
+          spaceModelId: space.id,
+        });
+
+        expect(result).toHaveLength(0);
+      });
+
+      it("should override general 'never' with project 'all_messages'", async () => {
+        await user1.setMetadata(
+          CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+          "never"
+        );
+        await setProjectPreference(user1, "all_messages");
+
+        const participants = [makeParticipant(user1)];
+        const result = await filterParticipantsByNotifyCondition({
+          auth,
+          participants,
+          mentionedUserIds: new Set(),
+          totalParticipantCount: 5,
+          spaceModelId: space.id,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].sId).toBe(user1.sId);
+      });
+
+      it("should fall back to general preference when no project preference exists", async () => {
+        await user1.setMetadata(
+          CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+          "never"
+        );
+
+        const participants = [makeParticipant(user1)];
+        const result = await filterParticipantsByNotifyCondition({
+          auth,
+          participants,
+          mentionedUserIds: new Set(),
+          totalParticipantCount: 5,
+          spaceModelId: space.id,
+        });
+
+        expect(result).toHaveLength(0);
+      });
+
+      it("should override general 'only_mentions' with project 'all_messages'", async () => {
+        await user1.setMetadata(
+          CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+          "only_mentions"
+        );
+        await setProjectPreference(user1, "all_messages");
+
+        const participants = [makeParticipant(user1)];
+        const result = await filterParticipantsByNotifyCondition({
+          auth,
+          participants,
+          mentionedUserIds: new Set(), // Not mentioned
+          totalParticipantCount: 5,
+          spaceModelId: space.id,
+        });
+
+        // Would be excluded by general "only_mentions", but project overrides to "all_messages"
+        expect(result).toHaveLength(1);
+        expect(result[0].sId).toBe(user1.sId);
+      });
+
+      it("should handle mixed general and project preferences across users", async () => {
+        // user1: general=never, project=all_messages -> included
+        await user1.setMetadata(
+          CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+          "never"
+        );
+        await setProjectPreference(user1, "all_messages");
+
+        // user2: general=all_messages, no project pref -> included
+        await user2.setMetadata(
+          CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+          "all_messages"
+        );
+
+        // user3: general=all_messages, project=never -> excluded
+        await user3.setMetadata(
+          CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
+          "all_messages"
+        );
+        await setProjectPreference(user3, "never");
+
+        const participants = [
+          makeParticipant(user1),
+          makeParticipant(user2),
+          makeParticipant(user3),
+        ];
+        const result = await filterParticipantsByNotifyCondition({
+          auth,
+          participants,
+          mentionedUserIds: new Set(),
+          totalParticipantCount: 3,
+          spaceModelId: space.id,
+        });
+
+        expect(result).toHaveLength(2);
+        expect(result.map((p) => p.sId).sort()).toEqual(
+          [user1.sId, user2.sId].sort()
+        );
+      });
     });
   });
 

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -24,6 +24,7 @@ import { renderEmail } from "@app/lib/notifications/email-templates/conversation
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
+import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
@@ -46,6 +47,7 @@ import {
   NOTIFICATION_PREFERENCES_DELAYS,
 } from "@app/types/notification_preferences";
 import { isDevelopment } from "@app/types/shared/env";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -1072,18 +1074,21 @@ export const conversationUnreadWorkflow = workflow(
  * always notified regardless of their preference.
  */
 export const filterParticipantsByNotifyCondition = async ({
+  auth,
   participants,
   mentionedUserIds,
   totalParticipantCount,
+  spaceModelId,
 }: {
+  auth: Authenticator;
   participants: (UserType & { lastReadAt: Date | null })[];
   mentionedUserIds: Set<string>;
   totalParticipantCount: number;
+  spaceModelId: ModelId | null;
 }): Promise<(UserType & { lastReadAt: Date | null })[]> => {
   const userModelIds = participants.map((p) => p.id);
 
-  // Bulk query for all preferences.
-  const preferences = await UserMetadataModel.findAll({
+  const generalPreferences = await UserMetadataModel.findAll({
     where: {
       userId: { [Op.in]: userModelIds },
       key: CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition,
@@ -1091,16 +1096,26 @@ export const filterParticipantsByNotifyCondition = async ({
     attributes: ["userId", "value"],
   });
 
-  const preferenceMap = new Map<number, NotificationCondition>();
-  for (const pref of preferences) {
+  const generalPreferenceMap = new Map<number, NotificationCondition>();
+  for (const pref of generalPreferences) {
     if (isNotificationCondition(pref.value)) {
-      preferenceMap.set(pref.userId, pref.value);
+      generalPreferenceMap.set(pref.userId, pref.value);
     }
   }
 
+  const projectPreferenceMap = spaceModelId
+    ? await UserProjectNotificationPreferenceResource.fetchAllBySpaceAndUsers(
+        auth,
+        { spaceModelId, userModelIds }
+      )
+    : new Map<ModelId, NotificationCondition>();
+
   return participants.filter((participant) => {
+    // Project-level preference overrides the general one if present.
     const notifyCondition =
-      preferenceMap.get(participant.id) ?? DEFAULT_NOTIFICATION_CONDITION;
+      projectPreferenceMap.get(participant.id) ??
+      generalPreferenceMap.get(participant.id) ??
+      DEFAULT_NOTIFICATION_CONDITION;
     switch (notifyCondition) {
       case "all_messages":
         return true;
@@ -1178,9 +1193,11 @@ export const triggerConversationUnreadNotifications = async (
 
   // Filter participants based on their notification condition preference.
   const participants = await filterParticipantsByNotifyCondition({
+    auth,
     participants: allParticipants,
     mentionedUserIds: new Set(detailsResult.value.mentionedUserIds),
     totalParticipantCount: totalParticipants.length,
+    spaceModelId: conversation.spaceId,
   });
 
   if (participants.length === 0) {


### PR DESCRIPTION
## Description

This PR implements project-level notification preference checking in the notification workflow triggers.

- Updated `filterMembersByNotifyCondition` and `filterParticipantsByNotifyCondition` to apply project-level notification preferences that override general user preferences
- Added comprehensive test coverage for project-level preference override scenarios including mixed preference combinations across multiple users

## Tests

- Added extensive unit tests for both triggers.

## Risks

Low risk. The changes add a new layer of preference checking that takes precedence over existing general preferences, maintaining backward compatibility by falling back to general preferences when no project-level preference is set.

## Deploy Plan

Standard deployment. No special deployment steps required.
