### PR TITLE
chore: fix typos in coding rules

### DIFF
--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -16,19 +16,19 @@ PR).
 
 ### [GEN2] Simple but good is better than perfect but complex
 
-Favor simple and easy to understand approaches vs overly optimized but complex ones.
+Favor simple and easy to understand approaches vs. overly optimized but complex ones.
 
 Reviewer: If you detect an overly optimized or complex solution that can be simplified (at the cost
 of a bit of performance loss or extra code), ask the author to consider the simpler approach.
 
-### [GEN3] Favor types over typescript enums
+### [GEN3] Favor types over TypeScript enums
 
-We do not use typescript enums, we use types instead, eg: `type Color = "red" | "blue";`.
+We do not use TypeScript enums, we use types instead, e.g.: `type Color = "red" | "blue";`.
 
 ### [GEN4] Non type-safe use of `as` is prohibited
 
-The non type-safe uses of `as` are prohibited in the codebase. Use typeguards or other type-safe
-methods instead. There are few exceptions where `as` is type-safe to use (eg, `as const`) and
+The non-type-safe uses of `as` are prohibited in the codebase. Use type guards or other type-safe
+methods instead. There are few exceptions where `as` is type-safe to use (e.g., `as const`) and
 therefore acceptable.
 
 ### [GEN5] No mutation of function parameters
@@ -111,7 +111,7 @@ function handleStreamEvent(event: AgentMessageEvent): State {
 
 ### [GEN7] Avoid loops with quadratic or worse complexity
 
-Loops with quadratic O(n²) or worse cubic O(n³) complexity can severely hurt performance as data
+Loops with quadratic O(n²) or worse, cubic O(n³) complexity can severely hurt performance as data
 sizes grow. Common quadratic patterns include nested loops over related datasets, repeated searches
 within loops, and chained array operations that each iterate over the data.
 
@@ -200,7 +200,7 @@ logger.error({ err: error }, "Failed to fetch data");
 ### [GEN9] Use unit suffixes for money and time variables
 
 Variables representing monetary amounts or time durations must include a unit suffix in their name.
-This prevents conversion errors (e.g., cents vs dollars, milliseconds vs seconds) such as the one
+This prevents conversion errors (e.g., cents vs. dollars, milliseconds vs. seconds) such as the one
 that caused [this incident](https://dust4ai.slack.com/archives/C05B529FHV1/p1764835038528229).
 
 Common suffixes:
@@ -289,12 +289,12 @@ Example:
 Never catch your own errors. `catch` is authorized around external libraries (whose error handling
 we don't control), but otherwise errors that may alter the execution upstream should be returned
 using our `Result<>` pattern. It is OK to throw errors, since we can't catch them these are
-guaranteed to trigger a internal error (and return a 500).
+guaranteed to trigger an internal error (and return a 500).
 
 ### [ERR2] Do not rely on `err as Error`
 
 Never catch and cast what was caught as `Error`. JS allows throwing anything (string, number,
-random object, ...) so the cast may be invalid and hides errors from the logs. Use `normalizeError`
+random object, ...), so the cast may be invalid and hides errors from the logs. Use `normalizeError`
 instead, this function properly checks the content of the caught object and always returns a valid
 `Error` object.
 

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -5,14 +5,14 @@ automatically. This file contains rules specific to the `front` workspace.
 
 ## BACKEND
 
-### [BACK1] No sequelize models in API routes
+### [BACK1] No Sequelize models in API routes
 
-API routes should not interact with sequelize models directly. Use `lib/api/*` interfaces (creating
-them if missing). Direct Resource interaction are acceptable.
+API routes should not interact with Sequelize models directly. Use `lib/api/*` interfaces (creating
+them if missing). Direct Resource interactions are acceptable.
 
-### [BACK2] No sequelize models or ModelId in `lib/api/*` interfaces
+### [BACK2] No Sequelize models or ModelId in `lib/api/*` interfaces
 
-Interfaces in `lib/api/*` should not expose ModelId or sequelize model objects.
+Interfaces in `lib/api/*` should not expose ModelId or Sequelize model objects.
 
 Example:
 
@@ -26,20 +26,20 @@ function doWorkspace({ id }: { id: ModelId }) { }
 function doWorkspace({ workspace }: { workspace: WorkspaceType }) { }
 ```
 
-### [BACK3] Resource invariant: no sequelize models outside of resources
+### [BACK3] Resource invariant: no Sequelize models outside of resources
 
 Any new model should be abstracted to the rest of the codebase through a pre-existing or new
 `Resource`.
 
 ### [BACK4] Resource invariant: no models in interfaces
 
-Resources interface should take Resource or Types but not model objects.
+Resource interfaces should take Resource or Types but not model objects.
 
 ### [BACK5] Resource invariant: `lib/api/*` should use Resources not models
 
 Any newly introduced function in `lib/api/*` should rely on Resources and not models directly.
 
-### [BACK6] Use ConcurrentExecutor vs PQueue
+### [BACK6] Use ConcurrentExecutor vs. PQueue
 
 We are deprecating our use of `PQueue` in favor of `ConcurrentExecutor`. Use `ConcurrentExecutor`
 for all new code and migrate to it from `PQueue` when modifying existing code that involves
@@ -50,7 +50,7 @@ for all new code and migrate to it from `PQueue` when modifying existing code th
 Never use `Promise.all` on anything else than static arrays of promises with a known length (8 max).
 To parallelize asynchronous handling of dynamic arrays, use `ConcurrentExecutor`.
 
-### [BACK8] Favor typeguards over other methods
+### [BACK8] Favor type guards over other methods
 
 When checking types, use explicit typeguards over `typeof`, `instanceof`, etc.
 
@@ -162,10 +162,10 @@ Follow these steps based on the type of change:
 **1. Deleting an endpoint:**
 
 - Do NOT delete the endpoint immediately
-- Mark the endpoint as deprecated in code comments with deprecation date
+- Mark the endpoint as deprecated in code comments with a deprecation date
 - Create the replacement endpoint or functionality first
 - Monitor usage metrics to ensure all clients have migrated
-- Only delete after confirmed all clients have stopped using it
+- Only delete after having confirmed all clients have stopped using it
 - If deletion is urgent, coordinate a synchronized release across all clients
 
 **2. Adding a mandatory input parameter:**
@@ -187,7 +187,7 @@ Follow these steps based on the type of change:
 
 - Do NOT remove fields from responses immediately
 - First: Update all client code to stop using the field
-- Remove the field from backend response only after a period of time
+- Remove the field from the backend response only after a period of time
 - If removal is urgent, create a new endpoint version instead
 
 **5. Adding or removing enum values in responses:**
@@ -198,7 +198,7 @@ Follow these steps based on the type of change:
 - **Removing** an enum value from responses:
   - Do NOT remove enum values immediately
   - First: Update all client code to stop relying on the removed value
-  - Stop returning the enum value from backend only after a period of time
+  - Stop returning the enum value from the backend only after a period of time
 
 ### [BACK13] Foreign key must be indexed
 
@@ -314,7 +314,7 @@ will be default exported.
 
 If a tool in an internal MCP server outputs a custom resource, a `zod` schema that describes the
 output must be defined in `lib/actions/mcp_internal_actions/output_schemas.ts`. This way, when
-processing the tool output, a typeguard that checks the output against the schema
+processing the tool output, a type guard that checks the output against the schema
 can be used to identify this output type. In the code of the internal server the type inferred
 from the `zod` schema should be used to type the tool output.
 
@@ -331,9 +331,9 @@ desired.
 Test state setup should be done through factories. Factories should return Resources whenever
 possible.
 
-### [TEST5] Avoid sequelize models in tests
+### [TEST5] Avoid Sequelize models in tests
 
-Direct use of sequelize models in tests should be avoided in favor of Resources. This includes test
+Direct use of Sequelize models in tests should be avoided in favor of Resources. This includes test
 setup and assertions.
 
 ## REACT
@@ -423,16 +423,16 @@ function MCPServerDetails({ owner, disabled }: MCPServerDetailsProps) {
 <MCPServerDetails owner={owner} disabled={!isOpen} />
 ```
 
-Reviewer: If you see an SWR hook called unconditionally inside a conditionally-visible component,
+Reviewer: If you see an SWR hook called unconditionally inside a conditionally visible component,
 require the author to either add a `disabled` prop forwarded to the hook or justify the prefetch
 with a comment.
 
-In NextJS pages, getServerSideProps should not fetch data and return more that what's
+In NextJS pages, getServerSideProps should not fetch data and return more than what's
 available in authenticator. Rather rely on API endpoint and SWR calls.
 
 ### [REACT3] Any async network operation should have a visual loading state
 
-Any load/async has a visible visual state (spinner, busy state, disabled button, etc), even if the
+Any load/async has a visible visual state (spinner, busy state, disabled button, etc.), even if the
 load time is expected to be small.
 
 ### [REACT4] Stable references on Context provider values


### PR DESCRIPTION
## Description

- This PR fixes a few typos/grammar errors in the coding rules.
- This will be followed by a more focused PR to update the coding rule `[BACK10]`.

## Tests

- N/A.

## Risk

- None.

## Deploy Plan

- No deploy.
