### PR TITLE
Remove redundant JWT claim checks

### DIFF
--- a/egress-proxy/src/jwt.rs
+++ b/egress-proxy/src/jwt.rs
@@ -30,8 +30,6 @@ pub enum JwtValidationError {
 struct Claims {
     #[serde(rename = "sbId")]
     sb_id: String,
-    iss: String,
-    aud: String,
     exp: usize,
 }
 
@@ -67,11 +65,7 @@ fn claims_to_validated_token(
 ) -> Result<ValidatedSandboxToken, JwtValidationError> {
     let claims = token.claims;
     let now_seconds = current_unix_timestamp_seconds()?;
-    if claims.sb_id.trim().is_empty()
-        || claims.iss != EXPECTED_ISSUER
-        || claims.aud != EXPECTED_AUDIENCE
-        || claims.exp == 0
-    {
+    if claims.sb_id.trim().is_empty() || claims.exp == 0 {
         return Err(JwtValidationError::InvalidClaims);
     }
 


### PR DESCRIPTION
## Description

This removes redundant issuer and audience checks from the egress proxy JWT validator.

The jsonwebtoken validation config already enforces the expected issuer and audience before we reach `claims_to_validated_token`, so the extra post-decode comparisons were duplicating the same validation. This also lets us drop the unused `iss` and `aud` fields from the typed claims.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`

## Risk

Low. This does not relax validation behavior because issuer and audience are still enforced by the jsonwebtoken validation config. The change only removes duplicate checks after decode.

## Deploy Plan

Merge normally. No deploy sequencing or config changes are required.