### PR TITLE
Wire egress-proxy into image build/publish pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ on:
           - oauth
           - viz
           - dante
+          - egress-proxy
       check_deployment_blocked:
         description: "Check #deployment locks or force deploy"
         required: true
@@ -211,7 +212,10 @@ jobs:
 
   deploy:
     needs: [prepare, notify-start, build, deploy-app, deploy-poke, ensure-sandbox-images]
-    if: ${{ !failure() && !cancelled() && (needs.ensure-sandbox-images.result == 'success' || needs.ensure-sandbox-images.result == 'skipped') }}
+    # egress-proxy has no dust-infra helm release yet; this workflow is used as a
+    # build-and-publish-only path until the chart lands. Drop this guard once the
+    # release exists.
+    if: ${{ !failure() && !cancelled() && inputs.component != 'egress-proxy' && (needs.ensure-sandbox-images.result == 'success' || needs.ensure-sandbox-images.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Description

Wires `egress-proxy` into the `Deploy` workflow so we can publish its image to Artifact Registry.

- Adds `egress-proxy` to the `component` choice list.
- Guards the `deploy` job with `inputs.component != 'egress-proxy'` so the `dust-infra` rollout dispatch is skipped until the helm chart lands. Guard is commented and temporary.

The crate, Dockerfile, and PR-side CI already landed in #24094, #24123, #24125, #24142, #24143, #24147 — this is the last wire.

## Tests

Manual after merge: dispatch `Deploy` with `component=egress-proxy`, `regions=all`, confirm images appear in both regional registries and the `deploy` job is skipped.

## Risk

Low. Workflow-only change, additive `if:` clause, existing components unaffected. Rollback is a revert.

## Deploy Plan

1. Merge.
2. Dispatch `Deploy` → `egress-proxy`, `all`.
3. Use the resulting `<sha>` tag in the upcoming `dust-infra` PR.
4. Drop the guard in a follow-up once the helm release exists.