### PR TITLE
[Sessions] Refresh sidebar conversations after branching

### DIFF
--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -1,12 +1,13 @@
+import { useConversations } from "@app/hooks/conversations/useConversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { PostConversationForkResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/forks";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
-import { useSWRConfig } from "swr";
 
 export function useBranchConversation({
   owner,
@@ -17,7 +18,7 @@ export function useBranchConversation({
 }) {
   const sendNotification = useSendNotification();
   const router = useAppRouter();
-  const { mutate } = useSWRConfig();
+  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
 
   const [isBranching, setIsBranching] = useState(false);
 
@@ -63,11 +64,24 @@ export function useBranchConversation({
         }
       );
 
-      const conversationPathPrefix = `/api/w/${owner.sId}/assistant/conversations`;
-      void mutate(
-        (key) =>
-          typeof key === "string" && key.startsWith(conversationPathPrefix)
-      );
+      if (!conversation.spaceId) {
+        void mutateConversations(
+          (
+            currentConversations: ConversationWithoutContentType[] | undefined
+          ) =>
+            currentConversations
+              ? [
+                  conversation,
+                  ...currentConversations.filter(
+                    (currentConversation) =>
+                      currentConversation.sId !== conversation.sId
+                  ),
+                ]
+              : currentConversations
+        );
+      } else {
+        void mutateConversations();
+      }
 
       return true;
     } catch {
@@ -80,7 +94,13 @@ export function useBranchConversation({
     } finally {
       setIsBranching(false);
     }
-  }, [conversationId, mutate, owner.sId, router, sendNotification]);
+  }, [
+    conversationId,
+    mutateConversations,
+    owner.sId,
+    router,
+    sendNotification,
+  ]);
 
   return {
     branchConversation,


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24178.

Uses `useConversations().mutateConversations()` in the branch flow instead of global SWR mutation so the sidebar conversation list updates immediately after creating a child conversation.

## Risks
Blast radius: sidebar conversation list refresh after branching.
Risk: low

## Deploy Plan
- pmrr (small follow-up)
- deploy front
