### PR TITLE
[Sessions] Copy conversation skills into forks

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -10,11 +10,13 @@ import {
 import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -347,6 +349,59 @@ describe("createConversationFork", () => {
     );
     expect(childMCPServerViews[0].enabled).toBe(true);
     expect(childMCPServerViews[0].source).toBe("conversation");
+  });
+
+  it("copies enabled conversation skills into the child conversation", async () => {
+    const { auth, globalSpace } = await createPrivateApiMockRequest();
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: globalSpace.id,
+    });
+
+    const enabledSkill = await SkillFactory.create(auth, {
+      name: "Enabled skill",
+    });
+    await SkillFactory.create(auth, {
+      name: "Disabled skill",
+    });
+
+    const upsertResult = await SkillResource.upsertConversationSkills(auth, {
+      conversationId: parentConversation.id,
+      skills: [enabledSkill],
+      enabled: true,
+    });
+    expect(upsertResult.isOk()).toBe(true);
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "Continue with the same skills.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childSkills = await SkillResource.listEnabledByConversation(auth, {
+      conversation: result.value,
+    });
+
+    expect(childSkills).toHaveLength(1);
+    expect(childSkills[0].sId).toBe(enabledSkill.sId);
   });
 
   it("inherits the parent's requested spaces so the fork does not broaden visibility", async () => {

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -129,12 +129,15 @@ async function copyConversationSkills(
     return new Ok(undefined);
   }
 
-  const upsertResult = await SkillResource.upsertConversationSkills(auth, {
-    conversationId: childConversation.id,
-    skills: parentSkills,
-    enabled: true,
-    transaction,
-  });
+  const upsertResult = await SkillResource.upsertConversationSkills(
+    auth,
+    {
+      conversationId: childConversation.id,
+      skills: parentSkills,
+      enabled: true,
+    },
+    { transaction }
+  );
 
   if (upsertResult.isErr()) {
     return new Err(

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -5,6 +5,7 @@ import { DustError } from "@app/lib/error";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { withTransaction } from "@app/lib/utils/sql_utils";
@@ -101,6 +102,45 @@ async function copyConversationMCPServerViews(
       new DustError(
         "internal_error",
         "Failed to copy MCP server views into the forked conversation."
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}
+
+async function copyConversationSkills(
+  auth: Authenticator,
+  {
+    parentConversation,
+    childConversation,
+    transaction,
+  }: {
+    parentConversation: ConversationWithoutContentType;
+    childConversation: ConversationWithoutContentType;
+    transaction: Transaction;
+  }
+): Promise<Result<undefined, DustError<CreateConversationForkErrorCode>>> {
+  const parentSkills = await SkillResource.listEnabledByConversation(auth, {
+    conversation: parentConversation,
+  });
+
+  if (parentSkills.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const upsertResult = await SkillResource.upsertConversationSkills(auth, {
+    conversationId: childConversation.id,
+    skills: parentSkills,
+    enabled: true,
+    transaction,
+  });
+
+  if (upsertResult.isErr()) {
+    return new Err(
+      new DustError(
+        "internal_error",
+        "Failed to copy conversation skills into the forked conversation."
       )
     );
   }
@@ -215,6 +255,16 @@ export async function createConversationFork(
 
     if (copyMCPServerViewsResult.isErr()) {
       return copyMCPServerViewsResult;
+    }
+
+    const copySkillsResult = await copyConversationSkills(auth, {
+      parentConversation: parentConversation.toJSON(),
+      childConversation: childConversation.toJSON(),
+      transaction,
+    });
+
+    if (copySkillsResult.isErr()) {
+      return copySkillsResult;
     }
 
     await createForkInitializationMessage(auth, {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1294,9 +1294,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       conversationId,
       enabled,
+      transaction,
     }: {
       conversationId: ModelId;
       enabled: boolean;
+      transaction?: Transaction;
     }
   ): Promise<Result<undefined, Error>> {
     const user = auth.user();
@@ -1313,22 +1315,26 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         conversationId,
         agentConfigurationId: null,
       },
+      transaction,
     });
 
     if (existingConversationSkill && !enabled) {
-      await existingConversationSkill.destroy();
+      await existingConversationSkill.destroy({ transaction });
       return new Ok(undefined);
     }
 
     if (!existingConversationSkill && enabled) {
-      await ConversationSkillModel.create({
-        ...this.skillReference,
-        conversationId,
-        workspaceId: workspace.id,
-        agentConfigurationId: null,
-        source: "conversation",
-        addedByUserId: user.id,
-      } satisfies ConversationSkillCreationAttributes);
+      await ConversationSkillModel.create(
+        {
+          ...this.skillReference,
+          conversationId,
+          workspaceId: workspace.id,
+          agentConfigurationId: null,
+          source: "conversation",
+          addedByUserId: user.id,
+        } satisfies ConversationSkillCreationAttributes,
+        { transaction }
+      );
       return new Ok(undefined);
     }
 
@@ -1341,16 +1347,19 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       conversationId,
       skills,
       enabled,
+      transaction,
     }: {
       conversationId: ModelId;
       skills: SkillResource[];
       enabled: boolean;
+      transaction?: Transaction;
     }
   ): Promise<Result<undefined, Error>> {
     for (const skill of skills) {
       const result = await skill.upsertToConversation(auth, {
         conversationId,
         enabled,
+        transaction,
       });
 
       if (result.isErr()) {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1294,12 +1294,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       conversationId,
       enabled,
-      transaction,
     }: {
       conversationId: ModelId;
       enabled: boolean;
-      transaction?: Transaction;
-    }
+    },
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
     const user = auth.user();
     if (!user) {
@@ -1347,20 +1346,22 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       conversationId,
       skills,
       enabled,
-      transaction,
     }: {
       conversationId: ModelId;
       skills: SkillResource[];
       enabled: boolean;
-      transaction?: Transaction;
-    }
+    },
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
     for (const skill of skills) {
-      const result = await skill.upsertToConversation(auth, {
-        conversationId,
-        enabled,
-        transaction,
-      });
+      const result = await skill.upsertToConversation(
+        auth,
+        {
+          conversationId,
+          enabled,
+        },
+        { transaction }
+      );
 
       if (result.isErr()) {
         return result;


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24156 and https://github.com/dust-tt/dust/pull/24181.
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

Copies enabled conversation-level skills from the parent into the child during fork creation.

As with conversation MCP server views, the copy runs inside the fork transaction. This PR also threads `transaction` support through conversation-skill upserts so the copied skill rows stay atomic with child conversation creation.

## Risks
Blast radius: internal conversation fork creation for conversations with conversation-scoped skills
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/api/assistant/conversation/forks.test.ts pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts`
