### PR TITLE
Remove check on plan for SSO

### DIFF
--- a/front/components/pages/onboarding/LoginErrorPage.tsx
+++ b/front/components/pages/onboarding/LoginErrorPage.tsx
@@ -142,18 +142,6 @@ function getErrorMessage(domain: string | null, reason: string | null) {
         </>
       );
 
-    case "sso-not-allowed":
-      return (
-        <>
-          {headerNode}
-          <p className={defaultErrorMessageClassName}>
-            SSO login is not available for this workspace.
-            <br />
-            Please contact your workspace administrator for assistance.
-          </p>
-        </>
-      );
-
     default:
       return (
         <>

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -128,7 +128,6 @@ import { Authenticator, getSession } from "@app/lib/auth";
 import { DUST_HAS_SESSION } from "@app/lib/cookies";
 import { fetchUserFromSession } from "@app/lib/iam/users";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
-import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getClientIp } from "@app/lib/utils/request";
@@ -419,25 +418,6 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
 
     if (!sealedSession) {
       throw new Error("Sealed session not found");
-    }
-
-    // If login was via SSO, verify the workspace's plan still allows SSO.
-    if (authenticationMethod?.toLowerCase() === "sso" && organizationId) {
-      const workspace =
-        await WorkspaceResource.fetchByWorkOSOrganizationId(organizationId);
-      if (workspace) {
-        const subscription =
-          await SubscriptionResource.fetchActiveByWorkspaceModelId(
-            workspace.id
-          );
-        if (!subscription?.getPlan().limits.users.isSSOAllowed) {
-          logger.warn(
-            { workspaceId: workspace.sId, organizationId },
-            "SSO login blocked: workspace plan does not allow SSO"
-          );
-          return redirectTo(res, "/login-error?reason=sso-not-allowed");
-        }
-      }
     }
 
     // Decode and inspect JWT content


### PR DESCRIPTION
## Description

For people who have access to multiplw workspaces and logged with SSO on one of them, we should not block access to other workspaces.

Blocking SSO was only for enterprise workspaces which were downgraded ( as we don't delete SSO connection automatically anymore) . We should rather have a check/alert when we have workos connectionns on downgraded workspaces.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
