### PR TITLE
[Microsoft Teams] List messages in threads

### DIFF
--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -101,12 +101,18 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
   },
   list_messages: {
     description:
-      "List all messages (and their replies) in a specific channel. Returns thread messages with their replies. Supports pagination to retrieve all results and filtering by date range.",
+      "List messages in a specific channel. Without messageId, returns top-level messages only (thread starters, where replyToId is null) — thread replies are NOT included. To read a full thread, call this tool again with the messageId of the top-level message to fetch its replies via the /replies endpoint. Supports pagination to retrieve all results and filtering by date range.",
     schema: {
       teamId: z.string().describe("The ID of the team containing the channel."),
       channelId: z
         .string()
-        .describe("The ID of the channel to list threads from."),
+        .describe("The ID of the channel to list messages from."),
+      messageId: z
+        .string()
+        .optional()
+        .describe(
+          "When provided, fetches replies to this top-level message instead of listing channel messages. Use the ID of a top-level message obtained from a previous call to list_messages (without messageId)."
+        ),
       fromDate: z
         .string()
         .optional()

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -211,7 +211,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
   },
 
   list_messages: async (
-    { teamId, channelId, fromDate, toDate },
+    { teamId, channelId, messageId, fromDate, toDate },
     { authInfo }
   ) => {
     const client = await getGraphClient(authInfo);
@@ -248,11 +248,12 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
         );
       };
 
+      const baseEndpoint = messageId
+        ? `/teams/${teamId}/channels/${channelId}/messages/${messageId}/replies`
+        : `/teams/${teamId}/channels/${channelId}/messages`;
+
       // First page
-      let response = await client
-        .api(`/teams/${teamId}/channels/${channelId}/messages`)
-        .top(50)
-        .get();
+      let response = await client.api(baseEndpoint).top(50).get();
 
       let shouldContinue = processMessages(response.value);
 


### PR DESCRIPTION
## Description

The `list_messages` tool now supports reading full thread conversations in Microsoft Teams channels. Previously, the tool would return only top-level messages. 

This change adds an optional `messageId` parameter. When omitted, the tool lists only top-level channel messages (where `replyToId` is null). When provided with a top-level message ID, the tool fetches all replies to that specific thread using the `/replies` endpoint. This matches the pattern used in Slack's thread handling.

## Tests

Tested manually with Microsoft Teams channels containing threaded conversations.

## Risk

Low.

## Deploy Plan

Deploy front.