### PR TITLE
[connectors] handle SharePoint object values

### DIFF
--- a/connectors/src/connectors/microsoft/lib/utils.ts
+++ b/connectors/src/connectors/microsoft/lib/utils.ts
@@ -120,6 +120,50 @@ export async function _getListColumns({
   return res.value.filter(isCustomColumn);
 }
 
+/**
+ * Extract a display string from a SharePoint field value.
+ * Graph API returns objects for taxonomy terms, lookups, and person/group
+ * fields — interpolating them directly produces "[object Object]".
+ */
+function formatFieldValue(v: unknown): string | null {
+  if (v === null || v === undefined) {
+    return null;
+  }
+
+  if (Array.isArray(v)) {
+    const parts = v.map(formatFieldValue).filter((s) => s !== null);
+    return parts.length > 0 ? parts.join(", ") : null;
+  }
+
+  if (typeof v === "object") {
+    const obj = v as Record<string, unknown>;
+    // Taxonomy / managed-metadata fields.
+    if (typeof obj.Label === "string") {
+      return obj.Label;
+    }
+    // Lookup fields.
+    if (typeof obj.LookupValue === "string") {
+      return obj.LookupValue;
+    }
+    // Person / group fields (and some lookup variants).
+    // Person / group fields.
+    if (typeof obj.displayName === "string") {
+      return obj.displayName;
+    }
+    if (typeof obj.Email === "string") {
+      return obj.Email;
+    }
+    if (typeof obj.Title === "string") {
+      return obj.Title;
+    }
+
+    // Fallback: JSON-serialize so we never produce "[object Object]".
+    return JSON.stringify(v);
+  }
+
+  return String(v);
+}
+
 // Turn the labels into a string array of formatted string such as column.displayName:value
 export const getColumnsFromListItem = async (
   file: DriveItem,
@@ -151,7 +195,10 @@ export const getColumnsFromListItem = async (
     for (const [k, v] of Object.entries(fields as Record<string, unknown>)) {
       const column = columns.find((column) => column.name === k);
       if (column) {
-        columnsList.push(`${column.displayName}:${v}`);
+        const formatted = formatFieldValue(v);
+        if (formatted !== null) {
+          columnsList.push(`${column.displayName}:${formatted}`);
+        }
       }
     }
 


### PR DESCRIPTION
## Description
This PR is to fix the broken display `[object object]` when data coming from Sharepoint. From what I understood: Microsoft Graph API returns complex JSON objects for several column types, and right now we call `toString()`  for any values here: https://github.com/dust-tt/dust/blob/765fd6ef5fea61de3a04a3f1564c6c5409cd41bc/connectors/src/connectors/microsoft/lib/utils.ts#L154

and now we add formatted version. I'm not sure how I can test it but at least this should not break anything so it should be safe to try?

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
