### PR TITLE
Outlook MCP Enhancements

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -426,6 +426,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_contacts": "never_ask",
     "get_drafts": "never_ask",
     "get_messages": "never_ask",
+    "send_mail": "high",
     "update_contact": "high",
   },
   "outlook_calendar": {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -492,6 +492,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_arguments_requiring_approval: {
       create_draft: ["to"],
+      send_mail: ["to"],
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -147,6 +147,39 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       done: "Create reply draft",
     },
   },
+  send_mail: {
+    description: `Send an email directly via Outlook.
+- The email will be sent immediately without creating a draft.
+- Use this when all required fields are known.`,
+    schema: {
+      to: z
+        .array(z.string())
+        .min(1)
+        .describe("The email addresses of the recipients"),
+      cc: z.array(z.string()).optional().describe("The email addresses to CC"),
+      bcc: z
+        .array(z.string())
+        .optional()
+        .describe("The email addresses to BCC"),
+      subject: z.string().describe("The subject line of the email"),
+      contentType: z
+        .enum(["text", "html"])
+        .default("text")
+        .describe("The content type of the email body (text or html)."),
+      body: z.string().describe("The body of the email"),
+      saveToSentItems: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether to save the sent email to the Sent Items folder. Defaults to true."
+        ),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Sending email",
+      done: "Send email",
+    },
+  },
   get_contacts: {
     description:
       "Get contacts from Outlook. Supports search queries to filter contacts.",
@@ -255,9 +288,9 @@ export const OUTLOOK_MAIL_SERVER = {
     description: "Read emails, manage drafts and contacts.",
     authorization: {
       provider: "microsoft_tools",
-      supported_use_cases: ["personal_actions"],
+      supported_use_cases: ["personal_actions", "platform_actions"],
       scope:
-        "Mail.ReadWrite.Shared Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read offline_access",
+        "Mail.ReadWrite.Shared Mail.Send Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read offline_access",
       availableScopes: [
         {
           value: "Mail.ReadWrite",
@@ -271,6 +304,12 @@ export const OUTLOOK_MAIL_SERVER = {
           label: "Read & write shared mail",
           description: "Access shared and delegated mailboxes.",
           fallbackScope: "Mail.ReadWrite",
+        },
+        {
+          value: "Mail.Send",
+          label: "Send mail",
+          description: "Send emails on behalf of the signed-in user.",
+          required: true,
         },
         {
           value: "Contacts.ReadWrite",

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -309,7 +309,6 @@ export const OUTLOOK_MAIL_SERVER = {
           value: "Mail.Send",
           label: "Send mail",
           description: "Send emails on behalf of the signed-in user.",
-          required: true,
         },
         {
           value: "Contacts.ReadWrite",

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -288,7 +288,7 @@ export const OUTLOOK_MAIL_SERVER = {
     description: "Read emails, manage drafts and contacts.",
     authorization: {
       provider: "microsoft_tools",
-      supported_use_cases: ["personal_actions", "platform_actions"],
+      supported_use_cases: ["personal_actions"],
       scope:
         "Mail.ReadWrite.Shared Mail.Send Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read offline_access",
       availableScopes: [

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -485,6 +485,69 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     ]);
   },
 
+  send_mail: async (
+    {
+      to,
+      cc,
+      bcc,
+      subject,
+      contentType = "text",
+      body,
+      saveToSentItems = true,
+    },
+    { authInfo }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Authentication required"));
+    }
+
+    const message: Record<string, unknown> = {
+      subject,
+      body: {
+        contentType,
+        content: body,
+      },
+      toRecipients: to.map((email) => ({
+        emailAddress: { address: email },
+      })),
+    };
+
+    if (cc && cc.length > 0) {
+      message.ccRecipients = cc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+
+    if (bcc && bcc.length > 0) {
+      message.bccRecipients = bcc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+
+    const response = await fetchFromOutlook("/me/sendMail", accessToken, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message,
+        saveToSentItems,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await getErrorText(response);
+      return new Err(
+        new MCPError(
+          `Failed to send email: ${response.status} ${response.statusText} - ${errorText}`
+        )
+      );
+    }
+
+    return new Ok([{ type: "text" as const, text: "Email sent successfully" }]);
+  },
+
   get_contacts: async (
     { search, top = 20, skip = 0, select },
     { authInfo }

--- a/front/migrations/20260414_disable_send_mail_for_existing_outlook_instances.ts
+++ b/front/migrations/20260414_disable_send_mail_for_existing_outlook_instances.ts
@@ -1,0 +1,193 @@
+import { Op } from "sequelize";
+
+import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { Logger } from "@app/logger/logger";
+import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
+import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { ModelId } from "@app/types/shared/model_id";
+
+const TOOL_NAME = "send_mail";
+const INTERNAL_MCP_SERVER_NAME = "outlook";
+const PERMISSION_LEVEL = "high";
+
+async function disableSendMailForWorkspace(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+): Promise<{ processedCount: number }> {
+  const connections = await MCPServerConnectionModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      serverType: "internal",
+      internalMCPServerId: {
+        [Op.ne]: null,
+      },
+    },
+    attributes: ["id", "workspaceId", "internalMCPServerId", "createdAt"],
+  });
+
+  const uniqueInstancesMap = new Map<
+    string,
+    {
+      workspaceId: ModelId;
+      internalMCPServerId: string;
+      createdAt: Date;
+      mcpServerConnectionId: ModelId;
+    }
+  >();
+
+  for (const conn of connections) {
+    if (!conn.internalMCPServerId) {
+      continue;
+    }
+
+    const parsed = getInternalMCPServerNameAndWorkspaceId(
+      conn.internalMCPServerId
+    );
+    if (parsed.isOk() && parsed.value.name === INTERNAL_MCP_SERVER_NAME) {
+      if (!uniqueInstancesMap.has(conn.internalMCPServerId)) {
+        uniqueInstancesMap.set(conn.internalMCPServerId, {
+          workspaceId: conn.workspaceId,
+          internalMCPServerId: conn.internalMCPServerId,
+          createdAt: conn.createdAt,
+          mcpServerConnectionId: conn.id,
+        });
+      }
+    }
+  }
+
+  const existingInstances = Array.from(uniqueInstancesMap.values());
+  if (existingInstances.length === 0) {
+    logger.info(
+      { workspaceSId: workspace.sId },
+      "No existing Outlook instances found in workspace."
+    );
+    return { processedCount: 0 };
+  }
+
+  logger.info(
+    {
+      workspaceSId: workspace.sId,
+      instancesCount: existingInstances.length,
+    },
+    "Found Outlook instances to disable send_mail in workspace."
+  );
+
+  let processedCount = 0;
+  for (const instance of existingInstances) {
+    const instanceLogger = logger.child({
+      workspaceSId: workspace.sId,
+      internalMCPServerId: instance.internalMCPServerId,
+      mcpServerConnectionId: instance.mcpServerConnectionId,
+      instanceCreatedAt: instance.createdAt.toISOString(),
+    });
+
+    if (execute) {
+      const existingToolMetadata =
+        await RemoteMCPServerToolMetadataModel.findOne({
+          where: {
+            workspaceId: instance.workspaceId,
+            internalMCPServerId: instance.internalMCPServerId,
+            toolName: TOOL_NAME,
+          },
+        });
+      if (existingToolMetadata) {
+        if (existingToolMetadata.enabled) {
+          await existingToolMetadata.update({
+            enabled: false,
+          });
+        }
+      } else {
+        await RemoteMCPServerToolMetadataModel.create({
+          workspaceId: instance.workspaceId,
+          internalMCPServerId: instance.internalMCPServerId,
+          toolName: TOOL_NAME,
+          permission: PERMISSION_LEVEL,
+          enabled: false,
+        });
+      }
+
+      processedCount++;
+
+      instanceLogger.info(
+        "Forced send_mail disabled for existing Outlook instance."
+      );
+    } else {
+      processedCount++;
+
+      instanceLogger.info(
+        "Would force send_mail disabled for existing Outlook instance."
+      );
+    }
+  }
+
+  return { processedCount };
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description:
+        "Optional workspace sId to process (processes all if omitted)",
+      required: false,
+    },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    logger.info(
+      {
+        workspaceId: workspaceId || "all",
+        toolName: TOOL_NAME,
+        serverName: INTERNAL_MCP_SERVER_NAME,
+      },
+      "Starting send_mail disabling migration for existing Outlook instances."
+    );
+
+    let totalProcessed = 0;
+
+    if (workspaceId) {
+      const workspaceResource = await WorkspaceResource.fetchById(workspaceId);
+      if (!workspaceResource) {
+        throw new Error(`Workspace not found: ${workspaceId}`);
+      }
+
+      const workspace = renderLightWorkspaceType({
+        workspace: workspaceResource,
+      });
+
+      const { processedCount } = await disableSendMailForWorkspace(
+        workspace,
+        execute,
+        logger
+      );
+      totalProcessed = processedCount;
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          const { processedCount } = await disableSendMailForWorkspace(
+            workspace,
+            execute,
+            logger
+          );
+          totalProcessed += processedCount;
+        },
+        { concurrency: 8 }
+      );
+    }
+
+    logger.info(
+      {
+        workspaceId: workspaceId || "all",
+        processedCount: totalProcessed,
+      },
+      execute
+        ? "Migration completed successfully."
+        : "Dry-run completed. Use --execute to apply changes."
+    );
+  }
+);


### PR DESCRIPTION
## Description

1. Enable send_mail on Outlook MCP
2. Enable shared workspace credentials
3. Disable send_mail (via migration) for existing tool instances

## Tests

- Updated snapshot
- Tested manually locally

## Risk

- Enabling send_mail on existing instances might inadvertently lead to agents sending instead of creating drafts. The migration addresses this.

## Deploy Plan

- Deploy the change
- Run the migration
- Update workspace admins to alert them to the existence of the tool