### PR TITLE
[front] fix: use Markdown when rendering non-streaming thinking content inline

### DIFF
--- a/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
+++ b/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
@@ -1,5 +1,4 @@
 import { TimelineRow } from "@app/components/assistant/conversation/actions/inline/TimelineRow";
-import { stripMarkdown } from "@app/types/shared/utils/string_utils";
 import { cn, Markdown } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -46,12 +45,9 @@ export function ThinkingStep({
     );
   }
 
-  const collapsedTextContent = stripMarkdown(content).trim();
   const needsTruncation =
-    isMessageDone && collapsedTextContent.length > MAX_THINKING_DISPLAY_LENGTH;
-
-  const collapsedPreviewContent =
-    collapsedTextContent.slice(0, MAX_THINKING_DISPLAY_LENGTH) + "…";
+    isMessageDone && content.length > MAX_THINKING_DISPLAY_LENGTH;
+  const isCollapsed = needsTruncation && !isExpanded;
 
   return (
     <div
@@ -63,14 +59,13 @@ export function ThinkingStep({
       }
     >
       <TimelineRow icon="circle" isLast={isLast}>
-        <div className="min-w-0 flex-1">
-          {needsTruncation && !isExpanded ? (
-            <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              {collapsedPreviewContent}
-            </span>
-          ) : (
-            markdown
+        <div
+          className={cn(
+            "min-w-0 flex-1",
+            isCollapsed && "line-clamp-3"
           )}
+        >
+          {markdown}
         </div>
       </TimelineRow>
     </div>

--- a/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
+++ b/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
@@ -1,4 +1,5 @@
 import { TimelineRow } from "@app/components/assistant/conversation/actions/inline/TimelineRow";
+import { stripMarkdown } from "@app/types/shared/utils/string_utils";
 import { cn, Markdown } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -19,6 +20,20 @@ export function ThinkingStep({
 }: ThinkingStepProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
+  const markdown = content ? (
+    <Markdown
+      content={content}
+      isStreaming={isStreaming}
+      streamingState={isStreaming ? "streaming" : "none"}
+      enableAnimation={isStreaming}
+      animationDurationSeconds={0.3}
+      delimiter=" "
+      forcedTextSize="text-sm"
+      textColor="text-muted-foreground dark:text-muted-foreground-night"
+      isLastMessage={false}
+    />
+  ) : null;
+
   if (isStreaming) {
     return (
       <TimelineRow
@@ -26,42 +41,37 @@ export function ThinkingStep({
         spinner={!content}
         isLast={isLast}
       >
-        {content ? (
-          <Markdown
-            content={content}
-            isStreaming={false}
-            streamingState="streaming"
-            enableAnimation
-            animationDurationSeconds={0.3}
-            delimiter=" "
-            forcedTextSize="text-sm"
-            textColor="text-muted-foreground dark:text-muted-foreground-night"
-            isLastMessage={false}
-          />
-        ) : null}
+        {markdown}
       </TimelineRow>
     );
   }
 
+  const collapsedTextContent = stripMarkdown(content).trim();
   const needsTruncation =
-    isMessageDone && content.length > MAX_THINKING_DISPLAY_LENGTH;
+    isMessageDone && collapsedTextContent.length > MAX_THINKING_DISPLAY_LENGTH;
 
-  const displayContent =
-    needsTruncation && !isExpanded
-      ? content.slice(0, MAX_THINKING_DISPLAY_LENGTH) + "\u2026"
-      : content;
+  const collapsedPreviewContent = collapsedTextContent.slice(0, MAX_THINKING_DISPLAY_LENGTH) + "…";
 
   return (
-    <TimelineRow icon="circle" isLast={isLast}>
-      <span
-        className={cn(
-          "text-sm text-muted-foreground dark:text-muted-foreground-night",
-          needsTruncation && "cursor-pointer"
-        )}
-        onClick={needsTruncation ? () => setIsExpanded((v) => !v) : undefined}
-      >
-        {displayContent}
-      </span>
-    </TimelineRow>
+    <div
+      className={cn(needsTruncation && "cursor-pointer")}
+      onClick={
+        needsTruncation
+          ? () => setIsExpanded((expanded) => !expanded)
+          : undefined
+      }
+    >
+      <TimelineRow icon="circle" isLast={isLast}>
+        <div className="min-w-0 flex-1">
+          {needsTruncation && !isExpanded ? (
+            <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              {collapsedPreviewContent}
+            </span>
+          ) : (
+            markdown
+          )}
+        </div>
+      </TimelineRow>
+    </div>
   );
 }

--- a/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
+++ b/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
@@ -31,7 +31,6 @@ export function ThinkingStep({
       forcedTextSize="text-sm"
       textColor="text-muted-foreground dark:text-muted-foreground-night"
       isLastMessage={false}
-      compactSpacing
     />
   ) : null;
 

--- a/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
+++ b/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
@@ -50,7 +50,8 @@ export function ThinkingStep({
   const needsTruncation =
     isMessageDone && collapsedTextContent.length > MAX_THINKING_DISPLAY_LENGTH;
 
-  const collapsedPreviewContent = collapsedTextContent.slice(0, MAX_THINKING_DISPLAY_LENGTH) + "…";
+  const collapsedPreviewContent =
+    collapsedTextContent.slice(0, MAX_THINKING_DISPLAY_LENGTH) + "…";
 
   return (
     <div

--- a/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
+++ b/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
@@ -3,7 +3,7 @@ import { cn, Markdown } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 const MAX_THINKING_DISPLAY_LENGTH = 250;
-const COLLAPSED_THINKING_MAX_HEIGHT_CLASS = "max-h-20";
+const COLLAPSED_THINKING_MAX_HEIGHT_CLASS = "max-h-16";
 
 interface ThinkingStepProps {
   content: string;
@@ -75,9 +75,13 @@ export function ThinkingStep({
           </div>
 
           {isCollapsed ? (
-            <div className={cn("pointer-events-none absolute inset-x-0 bottom-0 h-10",
-              "bg-gradient-to-t from-background via-background/80 to-transparent",
-              "dark:from-background-night dark:via-background-night/80")} />
+            <div
+              className={cn(
+                "pointer-events-none absolute inset-x-0 bottom-0 h-6",
+                "bg-gradient-to-t from-background via-background/90 via-10% to-transparent",
+                "dark:from-background-night dark:via-background-night/90"
+              )}
+            />
           ) : null}
         </div>
       </TimelineRow>

--- a/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
+++ b/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
@@ -77,8 +77,8 @@ export function ThinkingStep({
             <div
               className={cn(
                 "pointer-events-none absolute inset-x-0 bottom-0 h-6",
-                "bg-gradient-to-t from-background via-background/90 via-10% to-transparent",
-                "dark:from-background-night dark:via-background-night/90"
+                "bg-gradient-to-t from-background via-background/70 via-10% to-transparent",
+                "dark:from-background-night dark:via-background-night/70"
               )}
             />
           ) : null}

--- a/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
+++ b/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
@@ -59,12 +59,7 @@ export function ThinkingStep({
       }
     >
       <TimelineRow icon="circle" isLast={isLast}>
-        <div
-          className={cn(
-            "min-w-0 flex-1",
-            isCollapsed && "line-clamp-3"
-          )}
-        >
+        <div className={cn("min-w-0 flex-1", isCollapsed && "line-clamp-3")}>
           {markdown}
         </div>
       </TimelineRow>

--- a/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
+++ b/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
@@ -3,6 +3,7 @@ import { cn, Markdown } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 const MAX_THINKING_DISPLAY_LENGTH = 250;
+const COLLAPSED_THINKING_MAX_HEIGHT_CLASS = "max-h-20";
 
 interface ThinkingStepProps {
   content: string;
@@ -60,8 +61,24 @@ export function ThinkingStep({
       }
     >
       <TimelineRow icon="circle" isLast={isLast}>
-        <div className={cn("min-w-0 flex-1", isCollapsed && "line-clamp-3")}>
-          {markdown}
+        <div className="relative min-w-0 flex-1">
+          <div
+            className={cn(
+              "min-w-0",
+              isCollapsed && [
+                COLLAPSED_THINKING_MAX_HEIGHT_CLASS,
+                "overflow-hidden",
+              ]
+            )}
+          >
+            {markdown}
+          </div>
+
+          {isCollapsed ? (
+            <div className={cn("pointer-events-none absolute inset-x-0 bottom-0 h-10",
+              "bg-gradient-to-t from-background via-background/80 to-transparent",
+              "dark:from-background-night dark:via-background-night/80")} />
+          ) : null}
         </div>
       </TimelineRow>
     </div>

--- a/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
+++ b/front/components/assistant/conversation/actions/inline/ThinkingStep.tsx
@@ -30,6 +30,7 @@ export function ThinkingStep({
       forcedTextSize="text-sm"
       textColor="text-muted-foreground dark:text-muted-foreground-night"
       isLastMessage={false}
+      compactSpacing
     />
   ) : null;
 


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/7535.
- Example of issue fixed by this PR [here](https://app.dust.tt/w/0ec9852c2f/conversation/y2vCAPCJzD): the Markdown in the thinking content in the inline activity is not rendered, we see literal ** for bold content.
- This PR renders the Markdown in expanded and collapsed mode after streaming: the collapsed content has a max height and a gradient to indicate truncation.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
