### PR TITLE
Add support for array length > 1 and object in tool approval args.

### DIFF
--- a/front/lib/actions/tool_status.test.ts
+++ b/front/lib/actions/tool_status.test.ts
@@ -1,0 +1,80 @@
+import { extractArgRequiringApprovalValues } from "@app/lib/actions/tool_status";
+import { describe, expect, it } from "vitest";
+
+describe("extractArgRequiringApprovalValues", () => {
+  it("keeps existing behavior for primitive and single-element array values", () => {
+    const values = extractArgRequiringApprovalValues(
+      ["recipient", "retries", "dryRun", "email"],
+      {
+        recipient: "team@dust.tt",
+        retries: 3,
+        dryRun: false,
+        email: ["adrien@dust.tt"],
+      }
+    );
+
+    expect(values).toEqual({
+      recipient: "team@dust.tt",
+      retries: "3",
+      dryRun: "false",
+      email: "adrien@dust.tt",
+    });
+  });
+
+  it("serializes multi-element arrays", () => {
+    const values = extractArgRequiringApprovalValues(["emails", "ids"], {
+      emails: ["first@dust.tt", "second@dust.tt"],
+      ids: [2, 1],
+    });
+
+    expect(values).toEqual({
+      emails: '["first@dust.tt","second@dust.tt"]',
+      ids: "[2,1]",
+    });
+  });
+
+  it("serializes objects with stable key ordering, including nested objects", () => {
+    const values = extractArgRequiringApprovalValues(["payload"], {
+      payload: {
+        z: 1,
+        nested: {
+          b: "two",
+          a: "one",
+        },
+        a: true,
+      },
+    });
+
+    expect(values).toEqual({
+      payload: '{"a":true,"nested":{"a":"one","b":"two"},"z":1}',
+    });
+  });
+
+  it("returns identical strings for equivalent objects with different key order", () => {
+    const first = extractArgRequiringApprovalValues(["payload"], {
+      payload: {
+        z: 1,
+        nested: {
+          c: [3, 2, 1],
+          b: "two",
+          a: "one",
+        },
+        a: true,
+      },
+    });
+
+    const second = extractArgRequiringApprovalValues(["payload"], {
+      payload: {
+        a: true,
+        nested: {
+          a: "one",
+          c: [3, 2, 1],
+          b: "two",
+        },
+        z: 1,
+      },
+    });
+
+    expect(first.payload).toEqual(second.payload);
+  });
+});

--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -169,12 +169,56 @@ export function extractArgRequiringApprovalValues(
       // Handle single-element arrays (e.g., ["adrien@dust.tt"]).
       result[argName] = value[0].toString();
     } else {
-      // For objects/arrays with multiple elements, we do not support approval. Skip them.
-      // In fact, it's very unlikely the model will infer two times the same
-      // object/array as identical, so storing the approval would be useless.
-      continue;
+      const stableValue = stableStringify(value);
+      if (stableValue !== null) {
+        result[argName] = stableValue;
+      }
     }
   }
 
   return result;
+}
+
+function stableStringify(value: unknown): string | null {
+  const normalizedValue = normalizeForStableStringify(value);
+  if (normalizedValue === undefined) {
+    return null;
+  }
+
+  return JSON.stringify(normalizedValue);
+}
+
+function normalizeForStableStringify(value: unknown): unknown {
+  if (value === null || isString(value) || isNumberOrBoolean(value)) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeForStableStringify(entry));
+  }
+
+  if (isPlainObject(value)) {
+    const sortedKeys = Object.keys(value).sort();
+    const normalizedObject: Record<string, unknown> = {};
+
+    for (const key of sortedKeys) {
+      const normalizedProperty = normalizeForStableStringify(value[key]);
+      if (normalizedProperty !== undefined) {
+        normalizedObject[key] = normalizedProperty;
+      }
+    }
+
+    return normalizedObject;
+  }
+
+  return undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }


### PR DESCRIPTION
## Description

`extractArgRequiringApprovalValues` previously skipped multi-element arrays and objects entirely, making approval impossible for tools like `create_conversation` whose `dustProject` argument is an object. This meant the approval cache was never populated for those args, so the confirmation prompt would fire every time even after the user already approved. Actually, it was even worse than that, the approval would fire the first time and if you always accepted the arg, it would never ask again, even for different args.

- Replace the `continue` skip with `stableStringify` — a recursive serializer that normalizes plain objects (sorted keys, deeply) and arrays before `JSON.stringify`, producing a stable string regardless of key insertion order
- Single-element arrays and primitives keep their existing behavior
- Add `isPlainObject` guard to exclude class instances and other non-POJO values (returned as `null`)
- Add tests covering primitives, single-element arrays, multi-element arrays, nested objects, and key-order stability

## Tests

Local + green (new tests added)

## Risk

Low

## Deploy Plan

Deploy `front`
