### PR TITLE
feat: build agent loop context for sandbox tool calls

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -89,9 +89,11 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
+import type { OAuthProvider } from "@app/types/oauth/lib";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { slugify } from "@app/types/shared/utils/string_utils";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
@@ -190,7 +192,7 @@ export function getToolExtraFields(
   });
 }
 
-function makeServerSideMCPToolConfigurations(
+export function makeServerSideMCPToolConfigurations(
   config: ServerSideMCPServerConfigurationType,
   tools: ServerSideMCPToolTypeWithStakeAndRetryPolicy[],
   toolsArgumentsRequiringApproval?: Record<string, string[]>
@@ -325,59 +327,73 @@ export async function* tryCallMCPTool(
     workspaceId,
   };
 
-  let connectionParams: MCPConnectionParams;
-  if (isServerSideMCPToolConfiguration(toolConfiguration)) {
-    const mcpServerView = await MCPServerViewResource.fetchById(
-      auth,
-      toolConfiguration.mcpServerViewId
-    );
-    if (!mcpServerView) {
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text",
-            text: "Could not call tool: configuration not found",
-          },
-        ],
-      };
-    }
-    connectionParams = makeServerSideMCPConnectionParams(mcpServerView);
-  } else {
-    connectionParams = makeClientSideMCPConnectionParams(toolConfiguration, {
-      conversationId,
-      messageId,
-    });
-  }
-
   let mcpClient;
   try {
-    const connectionResult = await connectToMCPServer(auth, {
-      params: connectionParams,
-      agentLoopContext: { runContext: agentLoopRunContext },
-    });
-    if (connectionResult.isErr()) {
-      if (
-        connectionResult.error instanceof
-        MCPServerPersonalAuthenticationRequiredError
-      ) {
-        return {
-          // Complex code path, but errors returned here are processed in getExitOrPauseEvents.
-          isError: false,
-          content: makePersonalAuthenticationError(
-            connectionResult.error.provider,
-            connectionResult.error.scope
-          ).content,
-        };
+    if (isServerSideMCPToolConfiguration(toolConfiguration)) {
+      const connResult = await connectServerSideMCP(
+        auth,
+        toolConfiguration,
+        agentLoopRunContext
+      );
+      if (connResult.isErr()) {
+        switch (connResult.error.type) {
+          case "not_found":
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text",
+                  text: "Could not call tool: configuration not found",
+                },
+              ],
+            };
+          case "personal_auth_required":
+            // Complex code path: errors returned here are processed in getExitOrPauseEvents.
+            return {
+              isError: false,
+              content: makePersonalAuthenticationError(
+                connResult.error.provider,
+                connResult.error.scope
+              ).content,
+            };
+          case "admin_auth_required":
+          case "connection_failed":
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text",
+                  text: `The tool execution failed with the following error: ${connResult.error.message}`,
+                },
+              ],
+            };
+          default:
+            assertNever(connResult.error);
+        }
       }
-
-      // Admin auth errors (no connection or expired token) are surfaced as
-      // tool errors — the user cannot fix these in-conversation; an admin
-      // must act in the MCP server settings.
-      if (
-        connectionResult.error instanceof
-        MCPServerRequiresAdminAuthenticationError
-      ) {
+      mcpClient = connResult.value;
+    } else {
+      const connectionParams = makeClientSideMCPConnectionParams(
+        toolConfiguration,
+        { conversationId, messageId }
+      );
+      const connectionResult = await connectToMCPServer(auth, {
+        params: connectionParams,
+        agentLoopContext: { runContext: agentLoopRunContext },
+      });
+      if (connectionResult.isErr()) {
+        if (
+          connectionResult.error instanceof
+          MCPServerPersonalAuthenticationRequiredError
+        ) {
+          return {
+            isError: false,
+            content: makePersonalAuthenticationError(
+              connectionResult.error.provider,
+              connectionResult.error.scope
+            ).content,
+          };
+        }
         return {
           isError: true,
           content: [
@@ -388,18 +404,8 @@ export async function* tryCallMCPTool(
           ],
         };
       }
-
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text",
-            text: `The tool execution failed with the following error: ${connectionResult.error.message}`,
-          },
-        ],
-      };
+      mcpClient = connectionResult.value;
     }
-    mcpClient = connectionResult.value;
 
     heartbeat();
 
@@ -523,58 +529,7 @@ export async function* tryCallMCPTool(
       throw toolError;
     }
 
-    // Type inference is not working here because of them using passthrough in the zod schema.
-    const content: CallToolResult["content"] = (toolCallResult.content ??
-      []) as CallToolResult["content"];
-
-    let serverType;
-    if (isClientSideMCPToolConfiguration(toolConfiguration)) {
-      serverType = "client";
-    } else if (isServerSideMCPToolConfiguration(toolConfiguration)) {
-      serverType = toolConfiguration.internalMCPServerId
-        ? "internal"
-        : "remote";
-    }
-
-    if (serverType === "remote") {
-      const isValid = isWithinRemoteContentLimit(content);
-      if (!isValid) {
-        const contentMetadata = generateRemoteContentMetadata(content);
-        logger.info(
-          { contentMetadata, isValid },
-          "Information on MCP tool result"
-        );
-
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: "The tool execution failed because the tool output exceeds the maximum size limit.",
-            },
-          ],
-        };
-      }
-    }
-    if (serverType === "internal" || serverType === "client") {
-      // The MCP SDK is now stripping extra properties from the tool result (both client and server).
-      // To keep the same behavior as before, we moved the extra properties on the _meta field of each resource item.
-      // We now need to move them back to the resource items root level.
-      content.forEach((item) => {
-        if (item.type === "resource" && item.resource._meta) {
-          item.resource = {
-            ...item.resource,
-            ...item.resource._meta,
-          };
-          delete item.resource._meta;
-        }
-      });
-    }
-
-    return {
-      isError: (toolCallResult.isError as boolean) ?? false,
-      content,
-    };
+    return postProcessMCPToolResult(toolCallResult, toolConfiguration);
   } catch (error) {
     logger.error(
       {
@@ -677,6 +632,281 @@ function makeServerSideMCPConnectionParams(
     oAuthUseCase: mcpServerView.oAuthUseCase,
     oauthScope: mcpServerView.oauthScope,
   };
+}
+
+/**
+ * Tagged union for connection errors from connectServerSideMCP.
+ * Callers handle each case differently:
+ * - Agent loop: personal_auth → isError: false (triggers re-auth UI)
+ * - Sandbox: personal_auth → isError: true (can't re-auth from sandbox)
+ */
+type ServerSideMCPConnectionError =
+  | { type: "not_found" }
+  | { type: "personal_auth_required"; provider: OAuthProvider; scope?: string }
+  | { type: "admin_auth_required"; message: string }
+  | { type: "connection_failed"; message: string };
+
+/**
+ * Connect to a server-side MCP server for tool execution. Returns a typed
+ * error so callers can handle auth scenarios differently. Used by both the
+ * Temporal agent-loop path and the sandbox REST endpoint.
+ */
+async function connectServerSideMCP(
+  auth: Authenticator,
+  toolConfiguration: ServerSideMCPToolConfigurationType,
+  agentLoopRunContext: AgentLoopRunContextType
+): Promise<Result<Client, ServerSideMCPConnectionError>> {
+  const mcpServerView = await MCPServerViewResource.fetchById(
+    auth,
+    toolConfiguration.mcpServerViewId
+  );
+  if (!mcpServerView) {
+    return new Err({ type: "not_found" });
+  }
+
+  const connectionParams = makeServerSideMCPConnectionParams(mcpServerView);
+  const connectionResult = await connectToMCPServer(auth, {
+    params: connectionParams,
+    agentLoopContext: { runContext: agentLoopRunContext },
+  });
+
+  if (connectionResult.isErr()) {
+    if (
+      connectionResult.error instanceof
+      MCPServerPersonalAuthenticationRequiredError
+    ) {
+      return new Err({
+        type: "personal_auth_required",
+        provider: connectionResult.error.provider,
+        scope: connectionResult.error.scope,
+      });
+    }
+    if (
+      connectionResult.error instanceof
+      MCPServerRequiresAdminAuthenticationError
+    ) {
+      return new Err({
+        type: "admin_auth_required",
+        message: connectionResult.error.message,
+      });
+    }
+    return new Err({
+      type: "connection_failed",
+      message: connectionResult.error.message,
+    });
+  }
+
+  return new Ok(connectionResult.value);
+}
+
+/**
+ * Post-process a raw MCP tool result: enforce content limits and normalize
+ * metadata. Shared between the Temporal agent-loop path and the sandbox REST
+ * endpoint.
+ */
+function postProcessMCPToolResult(
+  toolCallResult: Awaited<ReturnType<Client["callTool"]>>,
+  toolConfiguration: MCPToolConfigurationType
+): CallToolResult {
+  // Type inference is not working here because of them using passthrough in the zod schema.
+  const content: CallToolResult["content"] = (toolCallResult.content ??
+    []) as CallToolResult["content"];
+
+  let serverType;
+  if (isClientSideMCPToolConfiguration(toolConfiguration)) {
+    serverType = "client";
+  } else if (isServerSideMCPToolConfiguration(toolConfiguration)) {
+    serverType = toolConfiguration.internalMCPServerId ? "internal" : "remote";
+  }
+
+  if (serverType === "remote") {
+    const isValid = isWithinRemoteContentLimit(content);
+    if (!isValid) {
+      const contentMetadata = generateRemoteContentMetadata(content);
+      logger.info(
+        { contentMetadata, isValid },
+        "Information on MCP tool result"
+      );
+
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "The tool execution failed because the tool output exceeds the maximum size limit.",
+          },
+        ],
+      };
+    }
+  }
+  if (serverType === "internal" || serverType === "client") {
+    // The MCP SDK is now stripping extra properties from the tool result (both client and server).
+    // To keep the same behavior as before, we moved the extra properties on the _meta field of each resource item.
+    // We now need to move them back to the resource items root level.
+    content.forEach((item) => {
+      if (item.type === "resource" && item.resource._meta) {
+        item.resource = {
+          ...item.resource,
+          ...item.resource._meta,
+        };
+        delete item.resource._meta;
+      }
+    });
+  }
+
+  return {
+    isError: toolCallResult.isError === true ? true : false,
+    content,
+  };
+}
+
+/**
+ * Simplified MCP tool caller for REST/sandbox context. No progress
+ * notifications, no heartbeats, no Temporal retry logic. Never throws — all
+ * error paths return a CallToolResult with isError: true.
+ */
+export async function callMCPToolForSandbox(
+  auth: Authenticator,
+  inputs: Record<string, unknown> | undefined,
+  agentLoopRunContext: AgentLoopRunContextType
+): Promise<CallToolResult> {
+  const { toolConfiguration } = agentLoopRunContext;
+
+  if (!isMCPToolConfiguration(toolConfiguration)) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Could not call tool, invalid action configuration: not an MCP action configuration",
+        },
+      ],
+    };
+  }
+
+  if (!isServerSideMCPToolConfiguration(toolConfiguration)) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Sandbox tool calls only support server-side MCP tools.",
+        },
+      ],
+    };
+  }
+
+  const connResult = await connectServerSideMCP(
+    auth,
+    toolConfiguration,
+    agentLoopRunContext
+  );
+  if (connResult.isErr()) {
+    switch (connResult.error.type) {
+      case "not_found":
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "Could not call tool: configuration not found",
+            },
+          ],
+        };
+      case "personal_auth_required":
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "Tool requires personal authentication that cannot be completed from sandbox.",
+            },
+          ],
+        };
+      case "admin_auth_required":
+      case "connection_failed":
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `The tool execution failed with the following error: ${connResult.error.message}`,
+            },
+          ],
+        };
+      default:
+        assertNever(connResult.error);
+    }
+  }
+
+  const mcpClient = connResult.value;
+  try {
+    const toolCallResult = await tracer.trace(
+      "mcp.tool.call",
+      { resource: toolConfiguration.originalName },
+      async () =>
+        mcpClient.callTool(
+          {
+            name: toolConfiguration.originalName,
+            arguments: inputs,
+          },
+          CallToolResultSchema,
+          {
+            timeout:
+              toolConfiguration.timeoutMs ?? DEFAULT_MCP_REQUEST_TIMEOUT_MS,
+          }
+        )
+    );
+
+    return postProcessMCPToolResult(toolCallResult, toolConfiguration);
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        toolName: toolConfiguration.originalName,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Exception calling MCP tool in callMCPToolForSandbox()"
+    );
+
+    if (isMcpTimeoutError(error)) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "The tool execution timed out.",
+          },
+        ],
+      };
+    }
+
+    // OAuth errors during tool execution (e.g., expired token mid-call).
+    // Sandbox can't re-authenticate, so surface as an error.
+    if (error instanceof MCPOAuthProviderError) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "Tool requires re-authentication that cannot be completed from sandbox.",
+          },
+        ],
+      };
+    }
+
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: `The tool execution failed with the following error: ${normalizeError(error).message}`,
+        },
+      ],
+    };
+  } finally {
+    await mcpClient.close();
+  }
 }
 
 function makeClientSideMCPConnectionParams(

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -348,7 +348,9 @@ export async function* tryCallMCPTool(
               ],
             };
           case "personal_auth_required":
-            // Complex code path: errors returned here are processed in getExitOrPauseEvents.
+            // Not a tool error: isError must be false so the content flows through
+            // to getExitOrPauseEvents, which detects the AGENT_PAUSE_TOOL_OUTPUT
+            // resource and pauses the agent to prompt the user to authenticate.
             return {
               isError: false,
               content: makePersonalAuthenticationError(
@@ -383,8 +385,9 @@ export async function* tryCallMCPTool(
       });
       if (connectionResult.isErr()) {
         if (
-          connectionResult.error instanceof
-          MCPServerPersonalAuthenticationRequiredError
+          MCPServerPersonalAuthenticationRequiredError.is(
+            connectionResult.error
+          )
         ) {
           return {
             isError: false,
@@ -672,8 +675,7 @@ async function connectServerSideMCP(
 
   if (connectionResult.isErr()) {
     if (
-      connectionResult.error instanceof
-      MCPServerPersonalAuthenticationRequiredError
+      MCPServerPersonalAuthenticationRequiredError.is(connectionResult.error)
     ) {
       return new Err({
         type: "personal_auth_required",
@@ -681,10 +683,7 @@ async function connectServerSideMCP(
         scope: connectionResult.error.scope,
       });
     }
-    if (
-      connectionResult.error instanceof
-      MCPServerRequiresAdminAuthenticationError
-    ) {
+    if (MCPServerRequiresAdminAuthenticationError.is(connectionResult.error)) {
       return new Err({
         type: "admin_auth_required",
         message: connectionResult.error.message,

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -97,7 +97,8 @@ export function createSandboxTools(
       const conversation = agentLoopContext?.runContext?.conversation;
       const agentConfiguration =
         agentLoopContext?.runContext?.agentConfiguration;
-      if (!conversation || !agentConfiguration) {
+      const agentMessage = agentLoopContext?.runContext?.agentMessage;
+      if (!conversation || !agentConfiguration || !agentMessage) {
         return new Err(new MCPError("No conversation context available."));
       }
 
@@ -145,6 +146,7 @@ export function createSandboxTools(
       const execId = generateExecId();
       const sandboxToken = await generateSandboxExecToken(auth, {
         agentConfiguration,
+        agentMessage,
         conversation,
         sandbox,
         execId,

--- a/front/lib/api/sandbox/access_tokens.test.ts
+++ b/front/lib/api/sandbox/access_tokens.test.ts
@@ -45,15 +45,23 @@ async function setupTest() {
     status: "running",
   });
 
-  return { auth, agentConfig, conversation, sandbox };
+  const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {
+    workspace,
+    conversation,
+    agentConfig,
+  });
+
+  return { auth, agentConfig, agentMessage, conversation, sandbox };
 }
 
 describe("sandbox access tokens", () => {
   it("round-trip: generate → verify → check claims", async () => {
-    const { auth, agentConfig, conversation, sandbox } = await setupTest();
+    const { auth, agentConfig, agentMessage, conversation, sandbox } =
+      await setupTest();
 
     const token = await generateSandboxExecToken(auth, {
       agentConfiguration: agentConfig,
+      agentMessage,
       conversation,
       sandbox,
       execId: "test-exec-id",
@@ -68,14 +76,17 @@ describe("sandbox access tokens", () => {
     expect(payload!.cId).toBe(conversation.sId);
     expect(payload!.uId).toBe(auth.getNonNullableUser().sId);
     expect(payload!.aId).toBe(agentConfig.sId);
+    expect(payload!.mId).toBe(agentMessage.sId);
     expect(payload!.sbId).toBe(sandbox.sId);
   });
 
   it("tampered token is rejected", async () => {
-    const { auth, agentConfig, conversation, sandbox } = await setupTest();
+    const { auth, agentConfig, agentMessage, conversation, sandbox } =
+      await setupTest();
 
     const token = await generateSandboxExecToken(auth, {
       agentConfiguration: agentConfig,
+      agentMessage,
       conversation,
       sandbox,
       execId: "test-exec-id",
@@ -95,10 +106,12 @@ describe("sandbox access tokens", () => {
   });
 
   it("token without sbt- prefix is rejected", async () => {
-    const { auth, agentConfig, conversation, sandbox } = await setupTest();
+    const { auth, agentConfig, agentMessage, conversation, sandbox } =
+      await setupTest();
 
     const token = await generateSandboxExecToken(auth, {
       agentConfiguration: agentConfig,
+      agentMessage,
       conversation,
       sandbox,
       execId: "test-exec-id",

--- a/front/lib/api/sandbox/access_tokens.ts
+++ b/front/lib/api/sandbox/access_tokens.ts
@@ -4,7 +4,10 @@ import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type {
+  AgentMessageType,
+  ConversationType,
+} from "@app/types/assistant/conversation";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import crypto from "crypto";
 import jwt from "jsonwebtoken";
@@ -17,6 +20,7 @@ const SandboxExecTokenPayloadSchema = z.object({
   cId: z.string(),
   uId: z.string(),
   aId: z.string(),
+  mId: z.string(),
   sbId: z.string(),
   execId: z.string(),
 });
@@ -90,12 +94,14 @@ export async function generateSandboxExecToken(
   auth: Authenticator,
   {
     agentConfiguration,
+    agentMessage,
     conversation,
     sandbox,
     execId,
     expiryMs = 2 * 60 * 1000, // Default to 2 minutes
   }: {
     agentConfiguration: AgentConfigurationType;
+    agentMessage: AgentMessageType;
     conversation: ConversationType;
     sandbox: SandboxResource;
     execId: string;
@@ -107,6 +113,7 @@ export async function generateSandboxExecToken(
     cId: conversation.sId,
     uId: auth.getNonNullableUser().sId,
     aId: agentConfiguration.sId,
+    mId: agentMessage.sId,
     sbId: sandbox.sId,
     execId,
   };

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -1,3 +1,4 @@
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
   autoInternalMCPServerNameToSId,
   getServerTypeAndIdFromSId,
@@ -1100,6 +1101,18 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     };
   }
 
+  private get allToolsMetadata(): Attributes<RemoteMCPServerToolMetadataModel>[] {
+    return [
+      ...(this.internalToolsMetadata ?? []),
+      ...(this.remoteToolsMetadata ?? []),
+    ];
+  }
+
+  getToolPermission(toolName: string): MCPToolStakeLevelType | undefined {
+    return this.allToolsMetadata.find((m) => m.toolName === toolName)
+      ?.permission;
+  }
+
   // Serialization.
   toJSON(): MCPServerViewType {
     const server =
@@ -1133,18 +1146,11 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         this.editedByUser,
         this.remoteMCPServer ? this.remoteMCPServer.updatedAt : this.updatedAt
       ),
-      toolsMetadata: [
-        ...(this.internalToolsMetadata ?? []).map((t) => ({
-          toolName: t.toolName,
-          permission: t.permission,
-          enabled: t.enabled,
-        })),
-        ...(this.remoteToolsMetadata ?? []).map((t) => ({
-          toolName: t.toolName,
-          permission: t.permission,
-          enabled: t.enabled,
-        })),
-      ],
+      toolsMetadata: this.allToolsMetadata.map((t) => ({
+        toolName: t.toolName,
+        permission: t.permission,
+        enabled: t.enabled,
+      })),
     };
   }
 }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
@@ -1,16 +1,165 @@
-import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
+import { FALLBACK_MCP_TOOL_STAKE_LEVEL } from "@app/lib/actions/constants";
+import {
+  callMCPToolForSandbox,
+  makeServerSideMCPToolConfigurations,
+} from "@app/lib/actions/mcp_actions";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import {
+  type SandboxExecTokenPayload,
+  verifySandboxExecToken,
+} from "@app/lib/api/sandbox/access_tokens";
+import {
+  type Authenticator,
+  getFeatureFlags,
+  isSandboxTokenPrefix,
+} from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
+import type { AgentMessageType } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { CallMCPToolResponseType } from "@dust-tt/client";
 import { CallMCPToolRequestBodySchema } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+const DEFAULT_SANDBOX_STEP_CONTEXT = {
+  citationsCount: 0,
+  citationsOffset: 0,
+  resumeState: null,
+  retrievalTopK: 10,
+  websearchResultCount: 10,
+} as const;
+
+async function extractSandboxClaims(
+  req: NextApiRequest
+): Promise<SandboxExecTokenPayload | null> {
+  const token = req.headers.authorization?.replace("Bearer ", "");
+  if (!token || !isSandboxTokenPrefix(token)) {
+    return null;
+  }
+  return verifySandboxExecToken(token);
+}
+
+async function buildSandboxAgentLoopContext(
+  auth: Authenticator,
+  claims: SandboxExecTokenPayload,
+  {
+    toolName,
+    view,
+  }: {
+    toolName: string;
+    view: MCPServerViewResource;
+  }
+): Promise<AgentLoopContextType | undefined> {
+  const mcpServerViewId = view.sId;
+  const [agentConfiguration, conversationResult] = await Promise.all([
+    getAgentConfiguration(auth, {
+      agentId: claims.aId,
+      variant: "full",
+    }),
+    getConversation(auth, claims.cId),
+  ]);
+
+  if (!agentConfiguration || conversationResult.isErr()) {
+    return undefined;
+  }
+
+  const conversation = conversationResult.value;
+
+  const agentMessage = conversation.content
+    .flat()
+    .find(
+      (m): m is AgentMessageType =>
+        m.type === "agent_message" && m.sId === claims.mId
+    );
+
+  if (!agentMessage) {
+    return undefined;
+  }
+
+  // Find the matching server-side action config for this server view.
+  // Search agent-configured actions first, then fall back to JIT servers
+  // (tools added via the conversation input bar).
+  let serverSideConfig = agentConfiguration.actions
+    .filter(isServerSideMCPServerConfiguration)
+    .find((a) => a.mcpServerViewId === mcpServerViewId);
+
+  if (!serverSideConfig) {
+    const { servers: jitServers } = await getJITServers(auth, {
+      agentConfiguration,
+      conversation,
+      attachments: [],
+    });
+    serverSideConfig = jitServers.find(
+      (s) => s.mcpServerViewId === mcpServerViewId
+    );
+  }
+
+  if (!serverSideConfig) {
+    return undefined;
+  }
+
+  const actualPermission =
+    view.getToolPermission(toolName) ?? FALLBACK_MCP_TOOL_STAKE_LEVEL;
+
+  const [fullToolConfiguration] = makeServerSideMCPToolConfigurations(
+    serverSideConfig,
+    [
+      {
+        name: toolName,
+        description: "", // Not used — stripped before passing to runtime.
+        availability: "manual",
+        stakeLevel: actualPermission,
+        toolServerId: view.mcpServerId,
+        retryPolicy: DEFAULT_MCP_TOOL_RETRY_POLICY,
+      },
+    ]
+  );
+
+  if (!fullToolConfiguration) {
+    return undefined;
+  }
+
+  // Strip inputSchema and description so the runtime object matches
+  // LightServerSideMCPToolConfigurationType — the isLight type guard checks
+  // !("inputSchema" in arg), so keeping these fields would break downstream
+  // guards (e.g. isLightServerSideMCPToolConfiguration).
+  const {
+    inputSchema: _inputSchema,
+    description: _description,
+    ...toolConfiguration
+  } = fullToolConfiguration;
+
+  // Fetch the parent action's stepContext (the running sandbox bash tool).
+  // There is at most one running sandbox action per agent message.
+  const actions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
+    agentMessage.agentMessageId,
+  ]);
+  const parentAction = actions.find(
+    (a) =>
+      a.status === "running" && a.toolConfiguration.mcpServerName === "sandbox"
+  );
+  const stepContext = parentAction?.stepContext ?? DEFAULT_SANDBOX_STEP_CONTEXT;
+
+  return {
+    runContext: {
+      agentConfiguration,
+      agentMessage,
+      conversation,
+      stepContext,
+      toolConfiguration,
+    },
+  };
+}
 
 /**
  * @ignoreswagger
@@ -83,56 +232,44 @@ async function handler(
 
       const { toolName, arguments: toolArgs } = bodyRes.data;
 
-      const clientRes = await connectToMCPServer(auth, {
-        params: {
-          type: "mcpServerId",
-          mcpServerId: view.mcpServerId,
-          oAuthUseCase: view.oAuthUseCase,
+      const sandboxClaims = await extractSandboxClaims(req);
+      if (!sandboxClaims) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Valid sandbox token required.",
+          },
+        });
+      }
+
+      const agentLoopContext = await buildSandboxAgentLoopContext(
+        auth,
+        sandboxClaims,
+        { toolName, view }
+      );
+
+      const runContext = agentLoopContext?.runContext;
+      if (!runContext) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Could not build agent loop context from sandbox token claims.",
+          },
+        });
+      }
+
+      const result = await callMCPToolForSandbox(auth, toolArgs, runContext);
+
+      return res.status(200).json({
+        success: true,
+        result: {
+          content: result.content,
+          isError: result.isError === true,
         },
       });
-
-      if (clientRes.isErr()) {
-        const err = clientRes.error;
-
-        logger.error({ error: err, svId }, "Failed to connect to MCP server");
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to connect to MCP server.",
-          },
-        });
-      }
-
-      const mcpClient = clientRes.value;
-      try {
-        const result = await mcpClient.callTool({
-          name: toolName,
-          arguments: toolArgs,
-        });
-
-        if (!("content" in result) || !Array.isArray(result.content)) {
-          return apiError(req, res, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Unexpected tool result format.",
-            },
-          });
-        }
-
-        const content = result.content;
-
-        return res.status(200).json({
-          success: true,
-          result: {
-            content,
-            isError: result.isError === true,
-          },
-        });
-      } finally {
-        await mcpClient.close();
-      }
     }
 
     default:


### PR DESCRIPTION
## Problem

When a sandbox (code execution environment) calls an MCP tool via the `call_tool` REST endpoint, it bypasses the agent loop entirely. It connects to the MCP server directly and calls the tool without any of the context (agent configuration, conversation, message, step context, tool configuration) that the normal Temporal agent loop path provides. This means:

1. The sandbox token has no way to identify *which agent message* initiated the sandbox, making it impossible to reconstruct the execution context on the server side.
2. The `call_tool` endpoint can't enforce tool permissions, build proper tool configurations, or pass agent loop context to `connectToMCPServer`.
3. `callMCPToolForSandbox` duplicates connection and error-handling logic from `tryCallMCPTool`, and misses post-processing (content size validation, metadata normalization) that the agent-loop path performs.

## Changes

**1. Add `mId` (agent message sId) to sandbox JWT tokens**

The sandbox token payload now includes the agent message identifier. This allows the `call_tool` endpoint to locate the specific agent message within the conversation and reconstruct the full execution context. Updated the Zod schema, token generation, and all 3 existing test cases.

*Files: `access_tokens.ts`, `access_tokens.test.ts`, `sandbox/tools/index.ts`*

**2. Build `AgentLoopContextType` in the `call_tool` endpoint**

The endpoint now:
- Validates the sandbox JWT and extracts claims (`extractSandboxClaims`)
- Reconstructs the full agent loop context from claims (`buildSandboxAgentLoopContext`):
  - Fetches agent configuration and conversation in parallel
  - Locates the agent message by `mId` within conversation content
  - Finds the matching server-side action config (agent-configured first, then JIT servers as fallback)
  - Looks up actual tool permission from `MCPServerViewResource`
  - Builds a `LightServerSideMCPToolConfigurationType` (stripping `inputSchema`/`description` so downstream `isLight` type guards work correctly)
  - Retrieves `stepContext` from the parent running sandbox action

*File: `call_tool.ts`*

**3. Refactor shared MCP tool-calling logic out of `tryCallMCPTool`**

Both `tryCallMCPTool` and `callMCPToolForSandbox` duplicated two concerns: server-side connection (fetch view, build params, call `connectToMCPServer`, handle auth errors) and result post-processing (content size validation, `_meta` metadata normalization). This extracts them into shared helpers:

- **`connectServerSideMCP`**: returns `Result<Client, ServerSideMCPConnectionError>` where the error is a tagged union (`not_found | personal_auth_required | admin_auth_required | connection_failed`). Callers handle each variant via exhaustive `switch` + `assertNever`: the agent loop treats `personal_auth_required` as non-error (triggers re-auth UI), while the sandbox treats it as error (can't re-auth). Adding a new error variant produces a compile-time error in both callers.

- **`postProcessMCPToolResult`**: enforces remote content size limits and normalizes internal/client `_meta` fields. Previously `callMCPToolForSandbox` skipped this entirely (raw cast on result content), meaning sandbox tool calls could return arbitrarily large results or un-normalized metadata.

`callMCPToolForSandbox` also no longer takes `mcpServerView` as a parameter. `connectServerSideMCP` handles the fetch internally. New signature: `(auth, inputs, agentLoopRunContext)`.

*Files: `mcp_actions.ts`, `call_tool.ts`*

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested the full flow with subsequent PRs.
Tested regular tool calling with this PR, MCP works.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low-medium. Touches the mcp connection code.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.