### PR TITLE
Provision enterprise contracts on poke upgrade

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -33,6 +33,11 @@ export function floorToHourISO(date: Date): string {
   return new Date(Math.floor(date.getTime() / HOUR_MS) * HOUR_MS).toISOString();
 }
 
+/** Convert an epoch-seconds timestamp (e.g. from Stripe) to an hour-floored ISO string. */
+export function epochSecondsToFloorHourISO(epochSeconds: number): string {
+  return floorToHourISO(new Date(epochSeconds * 1000));
+}
+
 export function ceilToHourISO(date: Date): string {
   return new Date(Math.ceil(date.getTime() / HOUR_MS) * HOUR_MS).toISOString();
 }

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -1,0 +1,521 @@
+import type { EnterprisePricingCents } from "@app/lib/metronome/contracts";
+import {
+  buildEnterpriseOverrides,
+  extractEnterprisePricing,
+} from "@app/lib/metronome/contracts";
+import type Stripe from "stripe";
+import { describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { mockPrices } = vi.hoisted(() => {
+  const mockPrices = { retrieve: vi.fn() };
+  return { mockPrices };
+});
+
+vi.mock("@app/lib/plans/stripe", () => ({
+  getStripeClient: () => ({ prices: mockPrices }),
+}));
+
+vi.mock("@app/lib/metronome/constants", () => ({
+  CURRENCY_TO_CREDIT_TYPE_ID: {
+    usd: "usd-credit-type",
+    eur: "eur-credit-type",
+  },
+  getProductWorkspaceMau1Id: () => "mau1-product",
+  getProductWorkspaceMau5Id: () => "mau5-product",
+  getProductWorkspaceMau10Id: () => "mau10-product",
+  getProductPrepaidCommitId: () => "prepaid-commit-product",
+}));
+
+const noopLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as any;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSubscription(
+  items: Array<{
+    priceId: string;
+    currency: string;
+    metadata?: Record<string, string>;
+    unitAmount?: number | null;
+  }>
+): Stripe.Subscription {
+  return {
+    items: {
+      data: items.map((item) => ({
+        price: {
+          id: item.priceId,
+          currency: item.currency,
+          metadata: item.metadata ?? {},
+          unit_amount: item.unitAmount ?? null,
+        },
+      })),
+    },
+  } as unknown as Stripe.Subscription;
+}
+
+const START_DATE = "2026-04-01T00:00:00.000Z";
+
+// ---------------------------------------------------------------------------
+// extractEnterprisePricing
+// ---------------------------------------------------------------------------
+
+describe("extractEnterprisePricing", () => {
+  it("extracts FIXED pricing", async () => {
+    const sub = makeSubscription([
+      {
+        priceId: "price_fixed",
+        currency: "usd",
+        metadata: { REPORT_USAGE: "FIXED" },
+        unitAmount: 500000,
+      },
+    ]);
+
+    const result = await extractEnterprisePricing(sub, noopLogger);
+
+    expect(result).toEqual({
+      currency: "usd",
+      billingMode: "FIXED",
+      tiers: [],
+      floorCents: 500000,
+    });
+  });
+
+  it("extracts 2-tier MAU pricing (floor + overage)", async () => {
+    const sub = makeSubscription([
+      {
+        priceId: "price_mau",
+        currency: "usd",
+        metadata: { REPORT_USAGE: "MAU_1" },
+      },
+    ]);
+    mockPrices.retrieve.mockResolvedValue({
+      currency: "usd",
+      tiers: [
+        { up_to: 100, unit_amount: 0, flat_amount: 450000 },
+        { up_to: null, unit_amount: 4500, flat_amount: null },
+      ],
+    });
+
+    const result = await extractEnterprisePricing(sub, noopLogger);
+
+    expect(result).toEqual({
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 100, unitAmountCents: 0, flatAmountCents: 450000 },
+        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
+      ],
+      floorCents: 450000,
+    });
+  });
+
+  it("extracts multi-tier MAU pricing (5 tiers)", async () => {
+    const sub = makeSubscription([
+      {
+        priceId: "price_mau_multi",
+        currency: "usd",
+        metadata: { REPORT_USAGE: "MAU_1" },
+      },
+    ]);
+    mockPrices.retrieve.mockResolvedValue({
+      currency: "usd",
+      tiers: [
+        { up_to: 70, unit_amount: null, flat_amount: 315000 },
+        { up_to: 100, unit_amount: 4500, flat_amount: null },
+        { up_to: 200, unit_amount: 4200, flat_amount: null },
+        { up_to: 500, unit_amount: 4000, flat_amount: null },
+        { up_to: null, unit_amount: 3700, flat_amount: null },
+      ],
+    });
+
+    const result = await extractEnterprisePricing(sub, noopLogger);
+
+    expect(result).toEqual({
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 70, unitAmountCents: 0, flatAmountCents: 315000 },
+        { upTo: 100, unitAmountCents: 4500, flatAmountCents: 0 },
+        { upTo: 200, unitAmountCents: 4200, flatAmountCents: 0 },
+        { upTo: 500, unitAmountCents: 4000, flatAmountCents: 0 },
+        { upTo: undefined, unitAmountCents: 3700, flatAmountCents: 0 },
+      ],
+      floorCents: 315000,
+    });
+  });
+
+  it("extracts single-tier MAU pricing (flat rate)", async () => {
+    const sub = makeSubscription([
+      {
+        priceId: "price_single",
+        currency: "usd",
+        metadata: { REPORT_USAGE: "MAU_1" },
+      },
+    ]);
+    mockPrices.retrieve.mockResolvedValue({
+      currency: "usd",
+      tiers: [{ up_to: null, unit_amount: 2000, flat_amount: null }],
+    });
+
+    const result = await extractEnterprisePricing(sub, noopLogger);
+
+    expect(result).toEqual({
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [{ upTo: undefined, unitAmountCents: 2000, flatAmountCents: 0 }],
+      floorCents: 0,
+    });
+  });
+
+  it("extracts no-floor pricing (free included seats)", async () => {
+    const sub = makeSubscription([
+      {
+        priceId: "price_no_floor",
+        currency: "usd",
+        metadata: { REPORT_USAGE: "MAU_1" },
+      },
+    ]);
+    mockPrices.retrieve.mockResolvedValue({
+      currency: "usd",
+      tiers: [
+        { up_to: 100, unit_amount: 0, flat_amount: 0 },
+        { up_to: null, unit_amount: 4500, flat_amount: null },
+      ],
+    });
+
+    const result = await extractEnterprisePricing(sub, noopLogger);
+
+    expect(result).toEqual({
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 100, unitAmountCents: 0, flatAmountCents: 0 },
+        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
+      ],
+      floorCents: 0,
+    });
+  });
+
+  it("extracts MAU_5 billing mode", async () => {
+    const sub = makeSubscription([
+      {
+        priceId: "price_mau5",
+        currency: "eur",
+        metadata: { REPORT_USAGE: "MAU_5" },
+      },
+    ]);
+    mockPrices.retrieve.mockResolvedValue({
+      currency: "eur",
+      tiers: [
+        { up_to: 50, unit_amount: 0, flat_amount: 225000 },
+        { up_to: null, unit_amount: 4500, flat_amount: null },
+      ],
+    });
+
+    const result = await extractEnterprisePricing(sub, noopLogger);
+
+    expect(result?.billingMode).toBe("MAU_5");
+    expect(result?.currency).toBe("eur");
+  });
+
+  it("returns undefined when no enterprise pricing item found", async () => {
+    const sub = makeSubscription([
+      {
+        priceId: "price_pro",
+        currency: "usd",
+        metadata: { REPORT_USAGE: "PER_SEAT" },
+      },
+    ]);
+
+    const result = await extractEnterprisePricing(sub, noopLogger);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when tiers are empty", async () => {
+    const sub = makeSubscription([
+      {
+        priceId: "price_empty",
+        currency: "usd",
+        metadata: { REPORT_USAGE: "MAU_1" },
+      },
+    ]);
+    mockPrices.retrieve.mockResolvedValue({
+      currency: "usd",
+      tiers: [],
+    });
+
+    const result = await extractEnterprisePricing(sub, noopLogger);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildEnterpriseOverrides
+// ---------------------------------------------------------------------------
+
+describe("buildEnterpriseOverrides", () => {
+  it("FIXED: disables all MAU products", () => {
+    const pricing: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "FIXED",
+      tiers: [],
+      floorCents: 500000,
+    };
+
+    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+
+    expect(result.overrides).toHaveLength(3);
+    expect(result.overrides.map((o) => o.product_id)).toEqual([
+      "mau1-product",
+      "mau5-product",
+      "mau10-product",
+    ]);
+    for (const o of result.overrides) {
+      expect(o.entitled).toBe(false);
+      expect(o.overwrite_rate.rate_type).toBe("FLAT");
+      expect(o.overwrite_rate.price).toBe(0);
+    }
+    expect(result.recurring_commits).toBeUndefined();
+  });
+
+  it("Pattern A: floor + overage (2-tier)", () => {
+    // Stripe: [{flat: 450000, unit: 0, up_to: 100}, {unit: 4500, up_to: null}]
+    const pricing: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 100, unitAmountCents: 0, flatAmountCents: 450000 },
+        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
+      ],
+      floorCents: 450000,
+    };
+
+    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+
+    // Single override: tiered rate on MAU_1 product.
+    const mauOverride = result.overrides.find(
+      (o) => o.product_id === "mau1-product"
+    );
+    expect(mauOverride?.entitled).toBe(true);
+    expect(mauOverride?.overwrite_rate.rate_type).toBe("TIERED");
+    expect(mauOverride?.overwrite_rate.tiers).toEqual([
+      { price: 4500, size: 100 }, // 450000 / 100 = 4500
+      { price: 4500 },
+    ]);
+
+    // Recurring commit for the floor.
+    expect(result.recurring_commits).toHaveLength(1);
+    expect(result.recurring_commits![0].access_amount.unit_price).toBe(450000);
+  });
+
+  it("Pattern B: no floor, free included seats", () => {
+    // Stripe: [{flat: 0, unit: 0, up_to: 100}, {unit: 4500, up_to: null}]
+    const pricing: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 100, unitAmountCents: 0, flatAmountCents: 0 },
+        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
+      ],
+      floorCents: 0,
+    };
+
+    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+
+    const mauOverride = result.overrides.find(
+      (o) => o.product_id === "mau1-product"
+    );
+    expect(mauOverride?.overwrite_rate.tiers).toEqual([
+      { price: 0, size: 100 },
+      { price: 4500 },
+    ]);
+    // No floor → no recurring commit.
+    expect(result.recurring_commits).toBeUndefined();
+  });
+
+  it("Pattern C: no floor, paid from first seat", () => {
+    // Stripe: [{flat: null, unit: 4000, up_to: 120}, {unit: 4500, up_to: null}]
+    const pricing: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 120, unitAmountCents: 4000, flatAmountCents: 0 },
+        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
+      ],
+      floorCents: 0,
+    };
+
+    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+
+    const mauOverride = result.overrides.find(
+      (o) => o.product_id === "mau1-product"
+    );
+    expect(mauOverride?.overwrite_rate.tiers).toEqual([
+      { price: 4000, size: 120 },
+      { price: 4500 },
+    ]);
+    expect(result.recurring_commits).toBeUndefined();
+  });
+
+  it("Pattern D: multi-tier (5 tiers)", () => {
+    // Stripe: [{flat: 315000, up_to: 70}, {unit: 4500, up_to: 100}, {unit: 4200, up_to: 200},
+    //          {unit: 4000, up_to: 500}, {unit: 3700, up_to: null}]
+    const pricing: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 70, unitAmountCents: 0, flatAmountCents: 315000 },
+        { upTo: 100, unitAmountCents: 4500, flatAmountCents: 0 },
+        { upTo: 200, unitAmountCents: 4200, flatAmountCents: 0 },
+        { upTo: 500, unitAmountCents: 4000, flatAmountCents: 0 },
+        { upTo: undefined, unitAmountCents: 3700, flatAmountCents: 0 },
+      ],
+      floorCents: 315000,
+    };
+
+    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+
+    const mauOverride = result.overrides.find(
+      (o) => o.product_id === "mau1-product"
+    );
+    expect(mauOverride?.overwrite_rate.tiers).toEqual([
+      { price: 4500, size: 70 }, // 315000 / 70 = 4500
+      { price: 4500, size: 30 }, // 100 - 70
+      { price: 4200, size: 100 }, // 200 - 100
+      { price: 4000, size: 300 }, // 500 - 200
+      { price: 3700 },
+    ]);
+
+    expect(result.recurring_commits).toHaveLength(1);
+    expect(result.recurring_commits![0].access_amount.unit_price).toBe(315000);
+  });
+
+  it("Pattern E: single-tier flat rate", () => {
+    // Stripe: [{unit: 2000, up_to: null}]
+    const pricing: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [{ upTo: undefined, unitAmountCents: 2000, flatAmountCents: 0 }],
+      floorCents: 0,
+    };
+
+    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+
+    const mauOverride = result.overrides.find(
+      (o) => o.product_id === "mau1-product"
+    );
+    expect(mauOverride?.overwrite_rate.tiers).toEqual([{ price: 2000 }]);
+    expect(result.recurring_commits).toBeUndefined();
+  });
+
+  it("MAU_5: disables MAU_1 and enables MAU_5", () => {
+    const pricing: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_5",
+      tiers: [
+        { upTo: 50, unitAmountCents: 0, flatAmountCents: 225000 },
+        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
+      ],
+      floorCents: 225000,
+    };
+
+    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+
+    // MAU_1 disabled.
+    const mau1Override = result.overrides.find(
+      (o) => o.product_id === "mau1-product"
+    );
+    expect(mau1Override?.entitled).toBe(false);
+
+    // MAU_5 enabled with tiered rate.
+    const mau5Override = result.overrides.find(
+      (o) => o.product_id === "mau5-product"
+    );
+    expect(mau5Override?.entitled).toBe(true);
+    expect(mau5Override?.overwrite_rate.rate_type).toBe("TIERED");
+  });
+
+  it("MAU_10: disables MAU_1 and enables MAU_10", () => {
+    const pricing: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_10",
+      tiers: [
+        { upTo: 30, unitAmountCents: 0, flatAmountCents: 135000 },
+        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
+      ],
+      floorCents: 135000,
+    };
+
+    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+
+    const mau1Override = result.overrides.find(
+      (o) => o.product_id === "mau1-product"
+    );
+    expect(mau1Override?.entitled).toBe(false);
+
+    const mau10Override = result.overrides.find(
+      (o) => o.product_id === "mau10-product"
+    );
+    expect(mau10Override?.entitled).toBe(true);
+  });
+
+  it("EUR currency uses EUR credit type", () => {
+    const pricing: EnterprisePricingCents = {
+      currency: "eur",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 30, unitAmountCents: 0, flatAmountCents: 120000 },
+        { upTo: undefined, unitAmountCents: 4000, flatAmountCents: 0 },
+      ],
+      floorCents: 120000,
+    };
+
+    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+
+    const mauOverride = result.overrides.find(
+      (o) => o.product_id === "mau1-product"
+    );
+    expect(mauOverride?.overwrite_rate.credit_type_id).toBe("eur-credit-type");
+    expect(result.recurring_commits![0].access_amount.credit_type_id).toBe(
+      "eur-credit-type"
+    );
+  });
+
+  it("3-tier with floor: floor + 2 overage tiers", () => {
+    // Stripe: [{flat: 325000, unit: 0, up_to: 100}, {unit: 3000, up_to: 200}, {unit: 2500, up_to: null}]
+    const pricing: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 100, unitAmountCents: 0, flatAmountCents: 325000 },
+        { upTo: 200, unitAmountCents: 3000, flatAmountCents: 0 },
+        { upTo: undefined, unitAmountCents: 2500, flatAmountCents: 0 },
+      ],
+      floorCents: 325000,
+    };
+
+    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+
+    const mauOverride = result.overrides.find(
+      (o) => o.product_id === "mau1-product"
+    );
+    expect(mauOverride?.overwrite_rate.tiers).toEqual([
+      { price: 3250, size: 100 }, // 325000 / 100
+      { price: 3000, size: 100 }, // 200 - 100
+      { price: 2500 },
+    ]);
+
+    expect(result.recurring_commits![0].access_amount.unit_price).toBe(325000);
+  });
+});

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -2,15 +2,35 @@ import {
   ceilToHourISO,
   createMetronomeContract,
   createMetronomeCustomer,
+  epochSecondsToFloorHourISO,
   findMetronomeCustomerByAlias,
+  getMetronomeClient,
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
+import {
+  CURRENCY_TO_CREDIT_TYPE_ID,
+  getProductPrepaidCommitId,
+  getProductWorkspaceMau1Id,
+  getProductWorkspaceMau5Id,
+  getProductWorkspaceMau10Id,
+} from "@app/lib/metronome/constants";
 import { syncMauCount } from "@app/lib/metronome/mau_sync";
 import { syncSeatCount } from "@app/lib/metronome/seats";
+import { LEGACY_ENTERPRISE_PACKAGE_ALIAS } from "@app/lib/metronome/types";
+import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
+import { getStripeClient } from "@app/lib/plans/stripe";
+import {
+  isEnterpriseReportUsage,
+  type SupportedEnterpriseReportUsage,
+} from "@app/lib/plans/usage/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Logger } from "@app/logger/logger";
+import logger from "@app/logger/logger";
+import { isSupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
+import type Stripe from "stripe";
 
 /**
  * Switch a Metronome contract to a different package (end old + create new).
@@ -145,4 +165,416 @@ export async function provisionMetronomeCustomerAndContract({
     metronomeCustomerId,
     metronomeContractId,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Enterprise contract provisioning from Stripe pricing
+// ---------------------------------------------------------------------------
+
+/** A single pricing tier extracted from Stripe's graduated tiered price. */
+export interface StripeTierCents {
+  /** Max units in this tier (undefined = unlimited / last tier). */
+  upTo: number | undefined;
+  /** Per-unit price in cents. */
+  unitAmountCents: number;
+  /** Flat amount in cents (typically only on the first tier as a floor). */
+  flatAmountCents: number;
+}
+
+/**
+ * Enterprise pricing extracted from a Stripe subscription.
+ *
+ * For MAU-based plans: graduated tiered pricing with optional floor.
+ * For FIXED plans: flat monthly price, no MAU counting.
+ */
+export interface EnterprisePricingCents {
+  /** Currency of the Stripe price (e.g. "usd", "eur"). */
+  currency: string;
+  /** Billing mode: MAU_1/5/10 for MAU-based, FIXED for flat price. */
+  billingMode: SupportedEnterpriseReportUsage;
+  /** All pricing tiers from Stripe (empty for FIXED). */
+  tiers: StripeTierCents[];
+  /** Monthly floor amount in cents (flat_amount on first tier, or unit_amount for FIXED). */
+  floorCents: number;
+}
+
+function getMauProductId(mode: "MAU_1" | "MAU_5" | "MAU_10"): string {
+  switch (mode) {
+    case "MAU_1":
+      return getProductWorkspaceMau1Id();
+    case "MAU_5":
+      return getProductWorkspaceMau5Id();
+    case "MAU_10":
+      return getProductWorkspaceMau10Id();
+  }
+}
+
+/**
+ * Extract enterprise pricing from a Stripe subscription.
+ *
+ * Supports two enterprise billing modes:
+ * - MAU-based (REPORT_USAGE=MAU_1/5/10): metered, tiered price with floor + per-MAU overage.
+ *   Tier 1: up_to=N, flat_amount=floor, unit_amount=0 (included seats)
+ *   Tier 2: up_to=inf, unit_amount=per_mau_price (overage)
+ * - FIXED (REPORT_USAGE=FIXED): licensed, flat monthly price, no MAU counting.
+ *
+ * Returns undefined if no enterprise pricing item is found.
+ */
+export async function extractEnterprisePricing(
+  stripeSubscription: Stripe.Subscription,
+  pricingLogger: Logger
+): Promise<EnterprisePricingCents | undefined> {
+  const stripe = getStripeClient();
+
+  for (const item of stripeSubscription.items.data) {
+    const reportUsage = item.price.metadata?.REPORT_USAGE;
+    if (!isEnterpriseReportUsage(reportUsage)) {
+      continue;
+    }
+
+    // FIXED pricing: flat monthly fee, no MAU.
+    if (reportUsage === "FIXED") {
+      return {
+        currency: item.price.currency,
+        billingMode: reportUsage,
+        tiers: [],
+        floorCents: item.price.unit_amount ?? 0,
+      };
+    }
+
+    // MAU-based pricing: graduated tiered price.
+    // Stripe doesn't include tiers in the subscription item by default.
+    const price = await stripe.prices.retrieve(item.price.id, {
+      expand: ["tiers"],
+    });
+
+    if (!price.tiers || price.tiers.length === 0) {
+      pricingLogger.warn(
+        { priceId: price.id, tiersCount: price.tiers?.length },
+        "Enterprise price missing tiers"
+      );
+      return undefined;
+    }
+
+    // Single tier (e.g. [{unit: 2000, up_to: null}]) = flat per-MAU rate.
+    if (price.tiers.length === 1) {
+      const tier = price.tiers[0];
+      return {
+        currency: price.currency,
+        billingMode: reportUsage,
+        tiers: [
+          {
+            upTo: undefined,
+            unitAmountCents: tier.unit_amount ?? 0,
+            flatAmountCents: 0,
+          },
+        ],
+        floorCents: 0,
+      };
+    }
+
+    const tiers: StripeTierCents[] = price.tiers.map((t) => ({
+      upTo: t.up_to ?? undefined,
+      unitAmountCents: t.unit_amount ?? 0,
+      flatAmountCents: t.flat_amount ?? 0,
+    }));
+
+    return {
+      currency: price.currency,
+      billingMode: reportUsage,
+      tiers,
+      floorCents: tiers[0].flatAmountCents,
+    };
+  }
+
+  return undefined;
+}
+
+/** Metronome tiered rate tier: price per unit, size = number of units in tier (omit for last). */
+interface MetronomeTier {
+  price: number;
+  size?: number;
+}
+
+interface OverrideEntry {
+  product_id: string;
+  starting_at: string;
+  type: "OVERWRITE";
+  entitled: boolean;
+  overwrite_rate: {
+    rate_type: "FLAT" | "TIERED";
+    price?: number;
+    credit_type_id?: string;
+    tiers?: MetronomeTier[];
+  };
+}
+
+export interface EnterpriseOverridesPayload {
+  overrides: OverrideEntry[];
+  recurring_commits?: Array<{
+    product_id: string;
+    name: string;
+    starting_at: string;
+    rate_type: "LIST_RATE";
+    priority: number;
+    access_amount: {
+      credit_type_id: string;
+      unit_price: number;
+      quantity: number;
+    };
+    commit_duration: { value: number; unit: "PERIODS" };
+    recurrence_frequency: "MONTHLY";
+    applicable_product_ids: string[];
+  }>;
+}
+
+/**
+ * Convert Stripe graduated tiers to Metronome TIERED rate tiers.
+ *
+ * Stripe tiers are graduated (each tier has up_to, unit_amount, flat_amount).
+ * Metronome tiers use { price, size? } where size = number of units in that tier.
+ *
+ * The first tier's unit_amount in Stripe is typically $0 (included in the floor).
+ * In Metronome, we set the first tier's price to flat_amount / up_to so that
+ * the recurring commit draws down at this rate and covers exactly the included units.
+ *
+ * Example — Stripe:
+ *   [{ up_to: 100, unit: 0, flat: 325000 }, { up_to: 200, unit: 3000 }, { up_to: inf, unit: 2500 }]
+ * Metronome tiers:
+ *   [{ price: 3250, size: 100 }, { price: 3000, size: 100 }, { price: 2500 }]
+ * + recurring commit of 325000 (draws down at list rate = 3250/MAU → covers 100 MAUs)
+ */
+function stripeTiersToMetronomeTiers(
+  tiers: StripeTierCents[]
+): MetronomeTier[] {
+  let previousUpTo = 0;
+  return tiers.map((tier, index) => {
+    const tierSize = tier.upTo ? tier.upTo - previousUpTo : undefined;
+    previousUpTo = tier.upTo ?? previousUpTo;
+
+    // First tier: derive per-unit price from flat_amount / tier size.
+    // This ensures the recurring commit covers exactly the included units.
+    let price = tier.unitAmountCents;
+    if (index === 0 && tier.flatAmountCents > 0 && tierSize) {
+      price = Math.round(tier.flatAmountCents / tierSize);
+    }
+
+    return {
+      price,
+      ...(tierSize !== undefined ? { size: tierSize } : {}),
+    };
+  });
+}
+
+/**
+ * Build the Metronome contract edit payload for enterprise pricing overrides.
+ *
+ * For MAU-based plans (MAU_1/5/10):
+ * - TIERED rate override matching Stripe's graduated tiers.
+ * - Recurring prepaid commit for the floor (if any).
+ * - Disables MAU-1 if using MAU-5 or MAU-10.
+ *
+ * For FIXED plans:
+ * - Disables all MAU products (billing is a flat Stripe fee).
+ */
+export function buildEnterpriseOverrides({
+  pricing,
+  startDate,
+}: {
+  pricing: EnterprisePricingCents;
+  startDate: string;
+}): EnterpriseOverridesPayload {
+  const disableOverride = (productId: string): OverrideEntry => ({
+    product_id: productId,
+    starting_at: startDate,
+    type: "OVERWRITE" as const,
+    entitled: false,
+    overwrite_rate: { rate_type: "FLAT" as const, price: 0 },
+  });
+
+  // FIXED: disable all MAU products — billing is a flat Stripe fee.
+  if (pricing.billingMode === "FIXED") {
+    return {
+      overrides: [
+        disableOverride(getProductWorkspaceMau1Id()),
+        disableOverride(getProductWorkspaceMau5Id()),
+        disableOverride(getProductWorkspaceMau10Id()),
+      ],
+    };
+  }
+
+  // MAU-based: apply tiered rate override + floor commit.
+  const targetProductId = getMauProductId(pricing.billingMode);
+
+  const creditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[pricing.currency];
+  if (!creditTypeId) {
+    throw new Error(
+      `Unsupported currency "${pricing.currency}" for enterprise pricing — add it to CURRENCY_TO_CREDIT_TYPE_ID`
+    );
+  }
+
+  const overrides: OverrideEntry[] = [];
+
+  if (pricing.billingMode !== "MAU_1") {
+    overrides.push(disableOverride(getProductWorkspaceMau1Id()));
+  }
+
+  // Convert Stripe graduated tiers to Metronome tiered rate.
+  const metronomeTiers = stripeTiersToMetronomeTiers(pricing.tiers);
+
+  overrides.push({
+    product_id: targetProductId,
+    starting_at: startDate,
+    type: "OVERWRITE" as const,
+    entitled: true,
+    overwrite_rate: {
+      rate_type: "TIERED" as const,
+      credit_type_id: creditTypeId,
+      tiers: metronomeTiers,
+    },
+  });
+
+  // Recurring commit for the floor (flat_amount on first tier).
+  const recurringCommits =
+    pricing.floorCents > 0
+      ? [
+          {
+            product_id: getProductPrepaidCommitId(),
+            name: "MAU Floor (monthly minimum)",
+            starting_at: startDate,
+            rate_type: "LIST_RATE" as const,
+            priority: 100,
+            access_amount: {
+              credit_type_id: creditTypeId,
+              unit_price: pricing.floorCents,
+              quantity: 1,
+            },
+            commit_duration: { value: 1, unit: "PERIODS" as const },
+            recurrence_frequency: "MONTHLY" as const,
+            applicable_product_ids: [targetProductId],
+          },
+        ]
+      : undefined;
+
+  return {
+    overrides,
+    ...(recurringCommits ? { recurring_commits: recurringCommits } : {}),
+  };
+}
+
+/**
+ * Apply enterprise pricing overrides on a Metronome contract.
+ * Uses buildEnterpriseOverrides to construct the payload, then sends it.
+ */
+export async function applyEnterpriseOverrides({
+  metronomeCustomerId,
+  contractId,
+  pricing,
+  startDate,
+  overrideLogger,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  pricing: EnterprisePricingCents;
+  startDate: string;
+  overrideLogger: Logger;
+  workspaceId: string;
+}): Promise<void> {
+  const payload = buildEnterpriseOverrides({ pricing, startDate });
+
+  overrideLogger.info(
+    { workspaceId, contractId, ...payload },
+    `Applying enterprise overrides (${pricing.billingMode})`
+  );
+
+  await getMetronomeClient().v2.contracts.edit({
+    customer_id: metronomeCustomerId,
+    contract_id: contractId,
+    add_overrides: payload.overrides,
+    ...(payload.recurring_commits
+      ? { add_recurring_commits: payload.recurring_commits }
+      : {}),
+  });
+
+  overrideLogger.info(
+    { workspaceId, contractId, billingMode: pricing.billingMode },
+    "Enterprise overrides applied"
+  );
+}
+
+/**
+ * Provision a Metronome customer + contract for an enterprise workspace,
+ * extract MAU pricing from the Stripe subscription, and apply overrides.
+ *
+ * Seats and MAU are synced by provisionMetronomeCustomerAndContract.
+ */
+export async function provisionEnterpriseMetronomeContract({
+  workspace,
+  stripeSubscription,
+}: {
+  workspace: LightWorkspaceType;
+  stripeSubscription: Stripe.Subscription;
+}): Promise<
+  Result<{ metronomeCustomerId: string; metronomeContractId: string }, Error>
+> {
+  const stripeCustomerId = stripeSubscription.customer;
+  if (!stripeCustomerId || typeof stripeCustomerId !== "string") {
+    return new Err(
+      new Error(
+        `No stripeCustomerId found on subscription ${stripeSubscription.id}`
+      )
+    );
+  }
+
+  // Extract MAU pricing from the Stripe subscription tiers.
+  const enterprisePricing = await extractEnterprisePricing(
+    stripeSubscription,
+    logger
+  );
+  if (!enterprisePricing) {
+    return new Err(
+      new Error(
+        `No MAU pricing found in Stripe subscription ${stripeSubscription.id}`
+      )
+    );
+  }
+
+  // Resolve the package alias based on the subscription currency.
+  const packageAlias = resolvePackageAliasForCurrency(
+    LEGACY_ENTERPRISE_PACKAGE_ALIAS,
+    isSupportedCurrency(enterprisePricing.currency)
+      ? enterprisePricing.currency
+      : "usd"
+  );
+
+  // Provision Metronome customer and contract (also syncs seats + MAU).
+  const provisionResult = await provisionMetronomeCustomerAndContract({
+    workspace,
+    stripeCustomerId,
+    packageAlias,
+    uniquenessKey: stripeSubscription.id,
+  });
+  if (provisionResult.isErr()) {
+    return new Err(provisionResult.error);
+  }
+
+  const { metronomeCustomerId, metronomeContractId } = provisionResult.value;
+
+  // Use current billing period start, rounded to hour boundary.
+  const startDate = epochSecondsToFloorHourISO(
+    stripeSubscription.current_period_start
+  );
+
+  // Apply MAU rate overrides + floor commit.
+  await applyEnterpriseOverrides({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+    pricing: enterprisePricing,
+    startDate,
+    overrideLogger: logger,
+    workspaceId: workspace.sId,
+  });
+
+  return new Ok({ metronomeCustomerId, metronomeContractId });
 }

--- a/front/lib/plans/usage/types.ts
+++ b/front/lib/plans/usage/types.ts
@@ -11,7 +11,7 @@ export const SUPPORTED_ENTERPRISE_REPORT_USAGE = [
   "MAU_10",
   "FIXED",
 ] as const;
-type SupportedEnterpriseReportUsage =
+export type SupportedEnterpriseReportUsage =
   (typeof SUPPORTED_ENTERPRISE_REPORT_USAGE)[number];
 
 export const SUPPORTED_REPORT_USAGE = [

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -8,7 +8,10 @@ import {
   getMetronomeContractPackageAliases,
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
-import { switchMetronomeContractPackage } from "@app/lib/metronome/contracts";
+import {
+  provisionEnterpriseMetronomeContract,
+  switchMetronomeContractPackage,
+} from "@app/lib/metronome/contracts";
 import {
   LEGACY_BUSINESS_PACKAGE_ALIAS,
   LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
@@ -50,7 +53,7 @@ import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
-import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
   cacheWithRedis,
@@ -724,7 +727,8 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
 
   static async pokeUpgradeWorkspaceToEnterprise(
     auth: Authenticator,
-    enterpriseDetails: EnterpriseUpgradeFormType
+    enterpriseDetails: EnterpriseUpgradeFormType,
+    stripeSubscription: Stripe.Subscription
   ) {
     const owner = auth.getNonNullableWorkspace();
 
@@ -733,14 +737,48 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     }
 
     const plan = await this.findPlanOrThrow(enterpriseDetails.planCode);
-    // TODO(pricing): provision Metronome contract for enterprise plans.
     // End the current subscription if any.
-    await this.internalSubscribeWorkspaceToFreePlan({
+    const newSubscription = await this.internalSubscribeWorkspaceToFreePlan({
       workspaceId: owner.sId,
       planCode: plan.code,
       stripeSubscriptionId: enterpriseDetails.stripeSubscriptionId,
       endDate: null,
     });
+
+    // Provision Metronome customer + contract with enterprise overrides.
+    const workspaceResource = await WorkspaceResource.fetchById(owner.sId);
+    if (!workspaceResource) {
+      throw new Error(`Workspace not found: ${owner.sId}`);
+    }
+
+    const metronomeResult = await provisionEnterpriseMetronomeContract({
+      workspace: renderLightWorkspaceType({ workspace: workspaceResource }),
+      stripeSubscription,
+    });
+    if (metronomeResult.isErr()) {
+      // Shadow-billed: Stripe owns billing, Metronome failure is not critical.
+      logger.error(
+        {
+          workspaceId: owner.sId,
+          error: metronomeResult.error.message,
+        },
+        "Failed to provision Metronome contract for enterprise upgrade"
+      );
+      return;
+    }
+
+    const { metronomeCustomerId, metronomeContractId } = metronomeResult.value;
+
+    if (!workspaceResource.metronomeCustomerId) {
+      await WorkspaceResource.updateMetronomeCustomerId(
+        workspaceResource.id,
+        metronomeCustomerId
+      );
+    }
+    await SubscriptionResource.updateMetronomeContractId(
+      newSubscription.id,
+      metronomeContractId
+    );
   }
 
   /**

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -203,7 +203,11 @@ async function handler(
       }
 
       try {
-        await SubscriptionResource.pokeUpgradeWorkspaceToEnterprise(auth, body);
+        await SubscriptionResource.pokeUpgradeWorkspaceToEnterprise(
+          auth,
+          body,
+          stripeSubscription
+        );
         // Restore workspace functionality after subscription upgrade
         await restoreWorkspaceAfterSubscription(auth);
 

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -16,14 +16,17 @@
  * Without --execute, runs in dry-run mode (logs what would happen, no changes).
  */
 
-import { getMetronomeClient } from "@app/lib/metronome/client";
 import {
-  CURRENCY_TO_CREDIT_TYPE_ID,
-  getProductPrepaidCommitId,
-  getProductWorkspaceMau1Id,
-  getProductWorkspaceMau5Id,
-  getProductWorkspaceMau10Id,
-} from "@app/lib/metronome/constants";
+  ceilToHourISO,
+  epochSecondsToFloorHourISO,
+  getMetronomeClient,
+} from "@app/lib/metronome/client";
+import {
+  buildEnterpriseOverrides,
+  type EnterprisePricingCents,
+  extractEnterprisePricing,
+} from "@app/lib/metronome/contracts";
+import { syncMauCount } from "@app/lib/metronome/mau_sync";
 import { syncSeatCount } from "@app/lib/metronome/seats";
 import {
   LEGACY_BUSINESS_PACKAGE_ALIAS,
@@ -38,253 +41,18 @@ import {
   PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
-import { getStripeClient, getStripeSubscription } from "@app/lib/plans/stripe";
-import { isMauReportUsage } from "@app/lib/plans/usage/types";
+import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
 import { isSupportedCurrency } from "@app/types/currency";
 import type { LightWorkspaceType } from "@app/types/user";
-import type Stripe from "stripe";
 import { makeScript } from "./helpers";
 import { runOnAllWorkspaces } from "./workspace_helpers";
 
-// Map from old alias → current alias.
-const ALIAS_MIGRATION: Record<string, string> = {
-  "shadow-pro-29": LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
-  "shadow-business-39": LEGACY_BUSINESS_PACKAGE_ALIAS,
-  "legacy-pro-29": LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
-  "legacy-business-39": LEGACY_BUSINESS_PACKAGE_ALIAS,
-  "legacy-business-45": LEGACY_BUSINESS_PACKAGE_ALIAS,
-  "legacy-pro-27-annual": LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
-};
-
-// ---------------------------------------------------------------------------
-// Enterprise Stripe pricing extraction
-// ---------------------------------------------------------------------------
-
-/** MAU threshold from Stripe metadata REPORT_USAGE (e.g. "MAU_1", "MAU_5", "MAU_10"). */
-type MauThreshold = "MAU_1" | "MAU_5" | "MAU_10";
-
-/**
- * Enterprise pricing extracted from Stripe's tiered price.
- * All amounts in cents (USD or EUR).
- */
-interface EnterprisePricingCents {
-  /** Currency of the Stripe price (e.g. "usd", "eur"). */
-  currency: string;
-  /** Per-MAU overage price in cents (from the last tier's unit_amount). */
-  mauPriceCents: number;
-  /** Monthly floor amount in cents (flat_amount on the first tier, 0 if none). */
-  floorCents: number;
-  /** Number of included seats (up_to on the first tier). */
-  includedSeats: number;
-  /** Which MAU threshold this price uses (MAU_1, MAU_5, MAU_10). */
-  mauThreshold: MauThreshold;
-}
-
-function getMauProductId(threshold: MauThreshold): string {
-  switch (threshold) {
-    case "MAU_1":
-      return getProductWorkspaceMau1Id();
-    case "MAU_5":
-      return getProductWorkspaceMau5Id();
-    case "MAU_10":
-      return getProductWorkspaceMau10Id();
-  }
-}
-
-/**
- * Extract enterprise MAU pricing from a Stripe subscription.
- *
- * Enterprise subscriptions on prod_PsyrjK1wsV9vgW have a metered, tiered price
- * with metadata REPORT_USAGE=MAU_1. The tiered structure is:
- *   - Tier 1: up_to=N, flat_amount=floor, unit_amount=0 (included seats)
- *   - Tier 2: up_to=inf, unit_amount=per_mau_price (overage)
- *
- * Returns undefined if the subscription has no MAU price item.
- */
-async function extractEnterprisePricing(
-  stripeSubscription: Stripe.Subscription,
-  logger: Logger
-): Promise<EnterprisePricingCents | undefined> {
-  const stripe = getStripeClient();
-
-  for (const item of stripeSubscription.items.data) {
-    const reportUsage = item.price.metadata?.REPORT_USAGE;
-    if (!isMauReportUsage(reportUsage)) {
-      continue;
-    }
-
-    // Validate it's one of our known MAU thresholds.
-    if (
-      reportUsage !== "MAU_1" &&
-      reportUsage !== "MAU_5" &&
-      reportUsage !== "MAU_10"
-    ) {
-      logger.warn(
-        { reportUsage, priceId: item.price.id },
-        "Unknown MAU threshold — skipping"
-      );
-      continue;
-    }
-
-    // For tiered prices, Stripe doesn't include tiers in the subscription item
-    // by default. Retrieve the full price with tiers expanded.
-    const price = await stripe.prices.retrieve(item.price.id, {
-      expand: ["tiers"],
-    });
-
-    if (!price.tiers || price.tiers.length < 2) {
-      logger.warn(
-        { priceId: price.id, tiersCount: price.tiers?.length },
-        "Enterprise price missing expected tiers"
-      );
-      return undefined;
-    }
-
-    const firstTier = price.tiers[0];
-    const lastTier = price.tiers[price.tiers.length - 1];
-
-    return {
-      currency: price.currency,
-      mauPriceCents: lastTier.unit_amount ?? 0,
-      floorCents: firstTier.flat_amount ?? 0,
-      includedSeats: firstTier.up_to ?? 0,
-      mauThreshold: reportUsage,
-    };
-  }
-
-  return undefined;
-}
-
-/**
- * Apply enterprise pricing on a Metronome contract to match Stripe's tiered pricing.
- *
- * Uses a recurring prepaid commit to model the floor + included seats:
- * 1. A monthly recurring commit of `floorCents` with rate_type COMMIT_RATE.
- *    Usage draws down the commit at the per-MAU commit rate, so the commit
- *    covers `floor / mauPrice` MAUs (the included seats).
- * 2. A commit-specific override sets the commit rate to the per-MAU price.
- * 3. The list rate (overage beyond the commit) is set to the same per-MAU price.
- *
- * Result: single invoice per period with the floor as the minimum charge,
- * included seats consumed from the commit, and overage billed at the list rate.
- *
- * If the customer uses MAU-5 or MAU-10 instead of MAU-1, disables the default
- * MAU-1 product and enables the correct one.
- */
-async function applyEnterpriseOverrides({
-  metronomeCustomerId,
-  contractId,
-  pricing,
-  startDate,
-  logger,
-  workspaceId,
-}: {
-  metronomeCustomerId: string;
-  contractId: string;
-  pricing: EnterprisePricingCents;
-  startDate: string;
-  logger: Logger;
-  workspaceId: string;
-}): Promise<void> {
-  const client = getMetronomeClient();
-  const targetProductId = getMauProductId(pricing.mauThreshold);
-
-  const creditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[pricing.currency];
-  if (!creditTypeId) {
-    throw new Error(
-      `Unsupported currency "${pricing.currency}" for enterprise pricing — add it to CURRENCY_TO_CREDIT_TYPE_ID`
-    );
-  }
-
-  logger.info(
-    {
-      workspaceId,
-      contractId,
-      mauThreshold: pricing.mauThreshold,
-      mauPriceCents: pricing.mauPriceCents,
-      floorCents: pricing.floorCents,
-      includedSeats: pricing.includedSeats,
-      currency: pricing.currency,
-    },
-    `Applying enterprise overrides for MAU Billing (${pricing.mauThreshold})`
-  );
-
-  // --- Build overrides ---
-  const overrides = [];
-
-  if (pricing.mauThreshold !== "MAU_1") {
-    // Disable the default MAU-1 product (base package includes it at $45).
-    overrides.push({
-      product_id: getProductWorkspaceMau1Id(),
-      starting_at: startDate,
-      type: "OVERWRITE" as const,
-      entitled: false,
-      overwrite_rate: { rate_type: "FLAT" as const, price: 0 },
-    });
-  }
-
-  // List rate override: per-MAU price in the customer's currency.
-  // Also used by the recurring commit (rate_type: LIST_RATE) to determine
-  // drawdown rate, so floor / mauPrice = included seats.
-  overrides.push({
-    product_id: targetProductId,
-    starting_at: startDate,
-    type: "OVERWRITE" as const,
-    entitled: true,
-    overwrite_rate: {
-      rate_type: "FLAT" as const,
-      price: pricing.mauPriceCents,
-      credit_type_id: creditTypeId,
-    },
-  });
-
-  // --- Build recurring commit for the floor ---
-  const recurringCommits =
-    pricing.floorCents > 0
-      ? [
-          {
-            product_id: getProductPrepaidCommitId(),
-            name: "MAU Floor (monthly minimum)",
-            starting_at: startDate,
-            // LIST_RATE: drawdown uses the list rate override (per-MAU price),
-            // so floor / mauPrice = number of included MAUs.
-            rate_type: "LIST_RATE" as const,
-            priority: 100,
-            access_amount: {
-              credit_type_id: creditTypeId,
-              unit_price: pricing.floorCents,
-              quantity: 1,
-            },
-            commit_duration: { value: 1, unit: "PERIODS" as const },
-            recurrence_frequency: "MONTHLY" as const,
-            applicable_product_ids: [targetProductId],
-          },
-        ]
-      : [];
-
-  await client.v2.contracts.edit({
-    customer_id: metronomeCustomerId,
-    contract_id: contractId,
-    add_overrides: overrides,
-    ...(recurringCommits.length > 0
-      ? { add_recurring_commits: recurringCommits }
-      : {}),
-  });
-
-  logger.info(
-    {
-      workspaceId,
-      contractId,
-      mauThreshold: pricing.mauThreshold,
-      hasFloor: pricing.floorCents > 0,
-    },
-    "Enterprise overrides applied"
-  );
-}
+// Enterprise pricing extraction and override logic lives in
+// lib/metronome/stripe_migration.ts — imported at the top of this file.
 
 /**
  * Get the current package IDs for the latest versions (by listing packages and
@@ -364,7 +132,7 @@ async function getPackageInfo(): Promise<{
  * so it can be applied as a rate override on the Metronome contract.
  */
 async function getSubscriptionInfo(
-  workspaceId: number,
+  workspace: LightWorkspaceType,
   logger: Logger
 ): Promise<
   | {
@@ -375,8 +143,9 @@ async function getSubscriptionInfo(
     }
   | undefined
 > {
-  const subscription =
-    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspaceId);
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
 
   if (!subscription?.stripeSubscriptionId) {
     return undefined;
@@ -393,10 +162,9 @@ async function getSubscriptionInfo(
 
   // Use current billing period start — not the original subscription start date.
   // This ensures the Metronome contract aligns with the current billing cycle.
-  const startTimestamp = stripeSubscription.current_period_start;
-  // Round to hour boundary (Metronome requirement).
-  const rounded = Math.floor(startTimestamp / 3600) * 3600;
-  const startDate = new Date(rounded * 1000).toISOString();
+  const startDate = epochSecondsToFloorHourISO(
+    stripeSubscription.current_period_start
+  );
   const stripeCurrency = stripeSubscription.currency;
 
   // Detect annual billing from the Stripe price interval.
@@ -418,7 +186,7 @@ async function getSubscriptionInfo(
     );
     if (!enterprisePricing) {
       logger.warn(
-        { workspaceId, planCode },
+        { workspaceId: workspace.sId, planCode },
         "Enterprise plan but no MAU pricing found in Stripe — skipping"
       );
       return undefined;
@@ -481,144 +249,49 @@ async function migrateWorkspace(
 
   const metronomeCustomerId = workspaceResource.metronomeCustomerId;
 
+  // Get subscription info (needed for package alias, start date, enterprise pricing).
+  const subInfo = await getSubscriptionInfo(workspace, logger);
+  if (!subInfo) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "No subscription found, skipping."
+    );
+    return;
+  }
+
+  // Apply package alias filter if set.
+  if (packageAliasFilter && subInfo.packageAlias !== packageAliasFilter) {
+    return;
+  }
+
+  const targetPackageId = packageInfo.aliasToPackageId[subInfo.packageAlias];
+  if (!targetPackageId) {
+    logger.error(
+      { workspaceId: workspace.sId, alias: subInfo.packageAlias },
+      "Target package not found — run metronome_setup.ts first"
+    );
+    return;
+  }
+
+  const targetAlias = subInfo.packageAlias;
+  const isEnterprise =
+    targetAlias === LEGACY_ENTERPRISE_PACKAGE_ALIAS ||
+    targetAlias === LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS;
+
   // List active contracts for this customer.
   const contractsResponse = await client.v2.contracts.list({
     customer_id: metronomeCustomerId,
   });
-
-  const contracts = contractsResponse.data;
-
-  // Filter to active contracts (not archived, not ended).
-  const activeContracts = contracts.filter(
+  const activeContracts = contractsResponse.data.filter(
     (c) => !c.archived_at && !c.ending_before
   );
 
-  // No active contracts — create a new one from the subscription.
-  if (activeContracts.length === 0) {
-    const subInfo = await getSubscriptionInfo(workspace.id, logger);
-    if (!subInfo) {
-      logger.info(
-        { workspaceId: workspace.sId },
-        "No subscription found, skipping."
-      );
-      return; // No paid subscription — skip.
-    }
-
-    // Apply package alias filter if set.
-    if (packageAliasFilter && subInfo.packageAlias !== packageAliasFilter) {
-      return;
-    }
-
-    const targetPackageId = packageInfo.aliasToPackageId[subInfo.packageAlias];
-    if (!targetPackageId) {
-      logger.error(
-        { workspaceId: workspace.sId, alias: subInfo.packageAlias },
-        "Target package not found — run metronome_setup.ts first"
-      );
-      return;
-    }
-
-    const targetPackageAlias = subInfo.packageAlias;
-    const isEnterprise =
-      targetPackageAlias === LEGACY_ENTERPRISE_PACKAGE_ALIAS ||
-      targetPackageAlias === LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS;
-
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        workspaceName: workspace.name,
-        metronomeCustomerId,
-        packageAlias: targetPackageAlias,
-        targetPackageId,
-        startDate: subInfo.startDate,
-        subscriptionModelId: subInfo.subscriptionModelId,
-        ...(isEnterprise && subInfo.enterprisePricing
-          ? {
-              enterprisePricing: subInfo.enterprisePricing,
-            }
-          : {}),
-        action: "CREATE_NEW",
-      },
-      `${execute ? "" : "[DRYRUN] "}Creating new contract (no existing contract)`
-    );
-
-    if (!execute) {
-      return;
-    }
-
-    const newContract = await client.v1.contracts.create({
-      customer_id: metronomeCustomerId,
-      package_alias: subInfo.packageAlias,
-      starting_at: subInfo.startDate,
-    });
-
-    const newContractId = newContract.data.id;
-
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        contractId: newContractId,
-        packageAlias: subInfo.packageAlias,
-        startDate: subInfo.startDate,
-      },
-      "New contract created (aligned to Stripe subscription start)"
-    );
-
-    // For enterprise contracts, apply rate overrides to match Stripe pricing.
-    if (isEnterprise && subInfo.enterprisePricing) {
-      await applyEnterpriseOverrides({
-        metronomeCustomerId,
-        contractId: newContractId,
-        pricing: subInfo.enterprisePricing,
-        startDate: subInfo.startDate,
-        logger,
-        workspaceId: workspace.sId,
-      });
-    }
-
-    // Provision seats for all existing members (for seat-based plans).
-    if (!isEnterprise) {
-      const seatResult = await syncSeatCount({
-        metronomeCustomerId,
-        contractId: newContractId,
-        workspace,
-        startingAt: subInfo.startDate,
-      });
-      if (seatResult.isErr()) {
-        logger.error(
-          {
-            workspaceId: workspace.sId,
-            contractId: newContractId,
-            error: seatResult.error.message,
-          },
-          "Failed to provision seats on new contract"
-        );
-      }
-    }
-
-    // Update metronomeContractId on the subscription.
-    await SubscriptionResource.updateMetronomeContractId(
-      subInfo.subscriptionModelId,
-      newContractId
-    );
-
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        subscriptionId: subInfo.subscriptionModelId,
-        newContractId,
-      },
-      "Updated metronomeContractId on subscription"
-    );
-
-    return;
-  }
-
+  // Resolve old contract info (if any) for logging and alias migration.
+  let oldContractId: string | undefined;
+  let oldAlias: string | undefined;
   for (const contract of activeContracts) {
-    // V2 API returns package_id but the SDK type doesn't declare it.
     const contractPackageId = (contract as unknown as { package_id?: string })
       .package_id;
-
     if (!contractPackageId) {
       logger.info(
         { workspaceId: workspace.sId, contractId: contract.id },
@@ -626,183 +299,124 @@ async function migrateWorkspace(
       );
       continue;
     }
+    oldAlias = packageInfo.packageIdToAlias[contractPackageId];
+    oldContractId = contract.id;
+    break;
+  }
 
-    // Look up the alias for this contract's package (includes archived packages).
-    const currentAlias =
-      packageInfo.packageIdToAlias[contractPackageId] ?? undefined;
+  // Build enterprise overrides for both logging and contract creation.
+  const enterpriseOverrides =
+    isEnterprise && subInfo.enterprisePricing
+      ? buildEnterpriseOverrides({
+          pricing: subInfo.enterprisePricing,
+          startDate: subInfo.startDate,
+        })
+      : undefined;
 
-    // Determine target alias (map shadow aliases to current ones).
-    if (!currentAlias) {
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          contractId: contract.id,
-          packageId: contractPackageId,
-        },
-        "Contract's package not found in current packages — skipping"
-      );
-      continue;
-    }
-    const targetAlias = ALIAS_MIGRATION[currentAlias] ?? currentAlias;
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      workspaceName: workspace.name,
+      metronomeCustomerId,
+      targetAlias,
+      targetPackageId,
+      startDate: subInfo.startDate,
+      ...(oldContractId
+        ? { oldContractId, oldAlias, action: "MIGRATE" }
+        : { action: "CREATE_NEW" }),
+      ...(enterpriseOverrides
+        ? { metronomeOverrides: enterpriseOverrides }
+        : {}),
+    },
+    `${execute ? "" : "[DRYRUN] "}${oldContractId ? "Migrating contract" : "Creating new contract"}`
+  );
 
-    // If a package alias filter is set, skip contracts that don't match.
-    if (packageAliasFilter && targetAlias !== packageAliasFilter) {
-      continue;
-    }
+  if (!execute) {
+    return;
+  }
 
-    const targetPackageId = packageInfo.aliasToPackageId[targetAlias];
-    if (!targetPackageId) {
-      logger.error(
-        {
-          workspaceId: workspace.sId,
-          contractId: contract.id,
-          targetAlias,
-        },
-        "Target package not found in Metronome — run metronome_setup.ts first"
-      );
-      continue;
-    }
-
-    if (contractPackageId === targetPackageId) {
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          contractId: contract.id,
-          targetAlias,
-        },
-        "Contract already on target package — will recreate"
-      );
-    }
-
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        workspaceName: workspace.name,
-        metronomeCustomerId,
-        oldContractId: contract.id,
-        oldPackageId: contractPackageId,
-        oldAlias: currentAlias,
-        targetAlias,
-        targetPackageId,
-        contractStartDate: contract.starting_at,
-        transitionType: "SUPERSEDE",
-        action: "MIGRATE",
-      },
-      `${execute ? "" : "[DRYRUN] "}Migrating contract to latest package`
-    );
-
-    if (!execute) {
-      continue;
-    }
-
-    // Metronome does not support SUPERSEDE for package-based contracts.
-    // Approach: end old contract, create new with same starting_at (preserves billing
-    // anchor/cycle), transfer remaining credit/commit balances.
-    const now = new Date(
-      Math.floor(Date.now() / 3_600_000) * 3_600_000
-    ).toISOString();
-
-    // 1. End the old contract.
+  // End old contract if one exists.
+  if (oldContractId) {
+    const now = ceilToHourISO(new Date());
     await client.v1.contracts.updateEndDate({
       customer_id: metronomeCustomerId,
-      contract_id: contract.id,
+      contract_id: oldContractId,
       ending_before: now,
     });
-
     logger.info(
       {
         workspaceId: workspace.sId,
-        contractId: contract.id,
+        contractId: oldContractId,
         endingBefore: now,
       },
       "Old contract ended"
     );
+  }
 
-    // 2. Create new contract with same starting_at (preserves billing cycle anchor).
-    const newContract = await client.v1.contracts.create({
-      customer_id: metronomeCustomerId,
-      package_alias: targetAlias,
-      starting_at: contract.starting_at,
+  // Create new contract with enterprise overrides (if any).
+  const newContract = await client.v1.contracts.create({
+    customer_id: metronomeCustomerId,
+    package_alias: targetAlias,
+    starting_at: subInfo.startDate,
+    ...enterpriseOverrides,
+  });
+  const newContractId = newContract.data.id;
+
+  logger.info(
+    { workspaceId: workspace.sId, contractId: newContractId, targetAlias },
+    "New contract created"
+  );
+
+  // Sync subscriptions: seats for pro/business, MAU for enterprise.
+  if (isEnterprise) {
+    const mauResult = await syncMauCount({
+      metronomeCustomerId,
+      contractId: newContractId,
+      workspace,
+      startingAt: subInfo.startDate,
     });
-
-    const newContractId = newContract.data.id;
-
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        oldContractId: contract.id,
-        newContractId,
-        targetAlias,
-      },
-      "New contract created (same starting_at as old)"
-    );
-
-    // 3. For enterprise contracts migrating to the enterprise package, apply overrides.
-    if (
-      targetAlias === LEGACY_ENTERPRISE_PACKAGE_ALIAS ||
-      targetAlias === LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS
-    ) {
-      const subInfo = await getSubscriptionInfo(workspace.id, logger);
-      if (subInfo?.enterprisePricing) {
-        await applyEnterpriseOverrides({
-          metronomeCustomerId,
-          contractId: newContractId,
-          pricing: subInfo.enterprisePricing,
-          startDate: contract.starting_at,
-          logger,
-          workspaceId: workspace.sId,
-        });
-      }
-    }
-
-    // 4. Provision seats on the new contract (for seat-based plans).
-    if (
-      targetAlias !== LEGACY_ENTERPRISE_PACKAGE_ALIAS &&
-      targetAlias !== LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS
-    ) {
-      const seatResult2 = await syncSeatCount({
-        metronomeCustomerId,
-        contractId: newContractId,
-        workspace,
-        startingAt: contract.starting_at,
-      });
-      if (seatResult2.isErr()) {
-        logger.error(
-          {
-            workspaceId: workspace.sId,
-            contractId: newContractId,
-            error: seatResult2.error.message,
-          },
-          "Failed to provision seats on new contract"
-        );
-      }
-    }
-
-    // 5. Update metronomeContractId on the active subscription.
-    const activeSubscription =
-      await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
-
-    if (activeSubscription) {
-      await SubscriptionResource.updateMetronomeContractId(
-        activeSubscription.id,
-        newContractId
-      );
-
-      logger.info(
+    if (mauResult.isErr()) {
+      logger.error(
         {
           workspaceId: workspace.sId,
-          subscriptionId: activeSubscription.id,
-          newContractId,
+          contractId: newContractId,
+          error: mauResult.error.message,
         },
-        "Updated metronomeContractId on subscription"
+        "Failed to sync MAU on new contract"
       );
-    } else {
-      logger.warn(
-        { workspaceId: workspace.sId },
-        "No active subscription found — metronomeContractId not updated"
+    }
+  } else {
+    const seatResult = await syncSeatCount({
+      metronomeCustomerId,
+      contractId: newContractId,
+      workspace,
+      startingAt: subInfo.startDate,
+    });
+    if (seatResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          contractId: newContractId,
+          error: seatResult.error.message,
+        },
+        "Failed to provision seats on new contract"
       );
     }
   }
+
+  // Update metronomeContractId on the subscription.
+  await SubscriptionResource.updateMetronomeContractId(
+    subInfo.subscriptionModelId,
+    newContractId
+  );
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      subscriptionId: subInfo.subscriptionModelId,
+      newContractId,
+    },
+    "Updated metronomeContractId on subscription"
+  );
 }
 
 makeScript(


### PR DESCRIPTION
## Summary

Refactor enterprise Metronome contract provisioning into shared, reusable code and wire it into the Poke enterprise upgrade flow.

### Shared enterprise provisioning in `lib/metronome/contracts.ts`
- `extractEnterprisePricing()` — extracts pricing from a Stripe subscription (MAU tiered or FIXED)
- `buildEnterpriseOverrides()` — builds the Metronome contract overrides payload. Used for both contract creation and dry-run logging
- `applyEnterpriseOverrides()` — sends overrides via `v2.contracts.edit` (used by Poke upgrade flow)
- `provisionEnterpriseMetronomeContract()` — full orchestration: provision customer+contract, extract Stripe pricing, apply overrides
- `stripeTiersToMetronomeTiers()` — converts Stripe graduated tiers to Metronome tiered rate format
- `epochSecondsToFloorHourISO()` — helper to convert Stripe epoch-seconds to Metronome hour-boundary ISO strings
- Uses `SupportedEnterpriseReportUsage` type from `usage/types.ts`

### Stripe tiering → Metronome tiering

Supports all enterprise Stripe pricing patterns found in production:

**Pattern A: Floor + overage (most common)**
Stripe: `[{flat: $3,250, up_to: 100}, {unit: $45, up_to: null}]`
→ Metronome: TIERED rate `[{price: 3250, size: 100}, {price: 4500}]` + recurring commit of $3,250

**Pattern B: No floor, free included seats**
Stripe: `[{flat: $0, unit: $0, up_to: 100}, {unit: $45, up_to: null}]`
→ Metronome: TIERED rate `[{price: 0, size: 100}, {price: 4500}]`, no commit

**Pattern C: No floor, paid from first seat**
Stripe: `[{unit: $40, up_to: 120}, {unit: $45, up_to: null}]`
→ Metronome: TIERED rate `[{price: 4000, size: 120}, {price: 4500}]`, no commit

**Pattern D: Multi-tier (3-5 tiers)**
Stripe: `[{flat: $3,150, up_to: 70}, {unit: $45, up_to: 100}, {unit: $42, up_to: 200}, {unit: $40, up_to: 500}, {unit: $37}]`
→ Metronome: TIERED rate `[{price: 4500, size: 70}, {price: 4500, size: 30}, {price: 4200, size: 100}, {price: 4000, size: 300}, {price: 3700}]` + recurring commit of $3,150

**Pattern E: Single-tier flat rate**
Stripe: `[{unit: $20, up_to: null}]`
→ Metronome: TIERED rate `[{price: 2000}]`, no commit

**FIXED billing mode**
Stripe: `REPORT_USAGE=FIXED`, licensed price with quantity=1
→ Metronome: disables all MAU products (billing is a flat Stripe fee)

For all MAU patterns, the first tier's Metronome price is derived from `flat_amount / tier_size` so the recurring commit draws down at the correct rate and covers exactly the included MAUs.

### Poke enterprise upgrade (`upgrade_enterprise.ts` + `subscription_resource.ts`)
- `pokeUpgradeWorkspaceToEnterprise()` now provisions the Metronome contract internally (resolves TODO), consistent with how other subscription methods handle Metronome
- Accepts the Stripe subscription object to avoid redundant API calls
- Sets `metronomeCustomerId` on workspace (if not already set) and `metronomeContractId` on subscription

### Migration script (`migrate_metronome_contracts.ts`)
- Merged the two separate paths (CREATE_NEW / MIGRATE) into a single unified flow
- Enterprise overrides are passed directly to `v1.contracts.create` instead of a separate edit call
- Dry-run logs the exact Metronome overrides payload that will be applied
- Added `syncMauCount` for enterprise contracts (previously only synced seats for pro/business)

## Test plan

- [ ] Dry-run `migrate_metronome_contracts.ts` on sandbox — verify contracts are detected, overrides logged with correct tiered pricing
- [ ] Execute migration on a single sandbox workspace — verify contract created with correct tiered overrides and recurring commit
- [ ] Test Poke enterprise upgrade on sandbox — verify Metronome customer, contract, and overrides are created
- [ ] Test with MAU-based (2-tier, multi-tier) and FIXED enterprise Stripe subscriptions
- [ ] Verify tiering math: for a floor of $3,250 with 100 included seats, confirm Metronome tier 1 price = 3250 ($32.50/MAU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)