### PR TITLE
feat(todo): add Langfuse startActiveObservation tracing to project TODO LLM calls

### DIFF
--- a/front/lib/project_todo/analyze_conversation/index.ts
+++ b/front/lib/project_todo/analyze_conversation/index.ts
@@ -28,6 +28,7 @@ import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import { startActiveObservation } from "@langfuse/tracing";
 
 // Calls the LLM with a forced extract_action_items tool call and parses the result.
 // Returns null if the call fails, produces no tool call, or the output fails parsing.
@@ -48,27 +49,31 @@ async function callExtractActionItemsLLM(
   }
 ): Promise<ExtractionResult | null> {
   const owner = auth.getNonNullableWorkspace();
-  const res = await runMultiActionsAgent(
-    auth,
-    {
-      providerId: model.providerId,
-      modelId: model.modelId,
-      functionCall: specification.name,
-      useCache: false,
-    },
-    {
-      conversation: conv,
-      prompt,
-      specifications: [specification],
-      forceToolCall: specification.name,
-    },
-    {
-      context: {
-        operationType: "project_todo_analyze_conversation",
-        conversationId: conversation.sId,
-        workspaceId: owner.sId,
-      },
-    }
+  const res = await startActiveObservation(
+    "project-todo-analyze-conversation",
+    () =>
+      runMultiActionsAgent(
+        auth,
+        {
+          providerId: model.providerId,
+          modelId: model.modelId,
+          functionCall: specification.name,
+          useCache: false,
+        },
+        {
+          conversation: conv,
+          prompt,
+          specifications: [specification],
+          forceToolCall: specification.name,
+        },
+        {
+          context: {
+            operationType: "project_todo_analyze_conversation",
+            conversationId: conversation.sId,
+            workspaceId: owner.sId,
+          },
+        }
+      )
   );
   if (res.isErr()) {
     logger.error(

--- a/front/lib/project_todo/deduplicate_candidates.ts
+++ b/front/lib/project_todo/deduplicate_candidates.ts
@@ -19,6 +19,7 @@ import type { ModelConversationTypeMultiActions } from "@app/types/assistant/gen
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { ProjectTodoCategory } from "@app/types/project_todo";
 import type { ModelId } from "@app/types/shared/model_id";
+import { startActiveObservation } from "@langfuse/tracing";
 import { z } from "zod";
 
 // ── Public types ──────────────────────────────────────────────────────────────
@@ -164,27 +165,31 @@ async function runDeduplicationLLMCall(
     ],
   };
 
-  const res = await runMultiActionsAgent(
-    auth,
-    {
-      providerId: model.providerId,
-      modelId: model.modelId,
-      functionCall: specification.name,
-      useCache: false,
-    },
-    {
-      conversation: conv,
-      prompt:
-        "You are a TODO deduplication assistant identifying semantic duplicates.",
-      specifications: [specification],
-      forceToolCall: specification.name,
-    },
-    {
-      context: {
-        operationType: "project_todo_deduplicate_candidates",
-        workspaceId: owner.sId,
-      },
-    }
+  const res = await startActiveObservation(
+    "project-todo-deduplicate-candidates",
+    () =>
+      runMultiActionsAgent(
+        auth,
+        {
+          providerId: model.providerId,
+          modelId: model.modelId,
+          functionCall: specification.name,
+          useCache: false,
+        },
+        {
+          conversation: conv,
+          prompt:
+            "You are a TODO deduplication assistant identifying semantic duplicates.",
+          specifications: [specification],
+          forceToolCall: specification.name,
+        },
+        {
+          context: {
+            operationType: "project_todo_deduplicate_candidates",
+            workspaceId: owner.sId,
+          },
+        }
+      )
   );
 
   if (res.isErr()) {


### PR DESCRIPTION
## Description

Add langfuse active tracing, so we can get some metrics and traces on those LLMs calls in langfuse. Saying differently, it's datadog APM but for those calls.

This is _not_ about prompts, regression tests, etc. It's just ease debugging

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
