### PR TITLE
Improve error handling of compaction

### DIFF
--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -129,7 +129,15 @@ export async function runCompaction(
   if (summaryRes.isOk()) {
     content = summaryRes.value;
     status = "succeeded";
+
+    logger.info(
+      { workspaceId: owner.sId, conversationId, compactionMessageId, status },
+      "Compaction generation succeeded"
+    );
   } else {
+    content = null;
+    status = "failed";
+
     logger.error(
       {
         workspaceId: owner.sId,
@@ -139,8 +147,6 @@ export async function runCompaction(
       },
       "Compaction generation failed"
     );
-    content = null;
-    status = "failed";
   }
 
   const result = await updateCompactionMessageWithContentAndFinalStatus(auth, {
@@ -161,11 +167,6 @@ export async function runCompaction(
       message: compactionMessage,
     },
     { conversationId }
-  );
-
-  logger.info(
-    { workspaceId: owner.sId, conversationId, compactionMessageId, status },
-    "Compaction completed"
   );
 
   return new Ok(undefined);
@@ -193,6 +194,7 @@ async function generateCompactionSummary(
   // that the current conversation is not exceeding it already.
   // TODO(compaction): We may want to be more mechanical about files available to the model in
   // conversation and projects by including a lsit as part of the summary.
+  // TODO(compaction: We may want to add retries around the LLM call
 
   const conv: ModelConversationTypeMultiActions = {
     messages: [

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -109,9 +109,10 @@ const { ensureConversationTitleActivity } = proxyActivities<
 });
 
 const { compactionActivity } = proxyActivities<typeof compactionActivities>({
-  startToCloseTimeout: "5 minutes",
+  startToCloseTimeout: "10 minutes",
   retry: {
-    maximumAttempts: 3,
+    // Do not retry compaction, the mesage is marked as failed, not idempotent
+    maximumAttempts: 1,
   },
 });
 


### PR DESCRIPTION
## Description

Improve slightly the error handling of compaction + remove retries at temporal level.

- The logger was misplaced
- remove retries at temporal layer since the activity is not idempotent since we could error after the message is marked as failed. We'll revisit retries as we go.

## Tests

Tested locally

## Risk

None

## Deploy Plan

- deploy `front`