### PR TITLE
feat: archived projects in project browse popover

### DIFF
--- a/front/components/assistant/conversation/sidebar/ProjectsBrowsePopover.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsBrowsePopover.tsx
@@ -7,6 +7,7 @@ import type { ProjectType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
+  Chip,
   Icon,
   LoadingBlock,
   MoreIcon,
@@ -58,7 +59,12 @@ function ProjectBrowseItem({ space, onClick }: ProjectBrowseItemProps) {
         className="mt-0.5 shrink-0"
       />
       <div className="min-w-0 flex-1">
-        <div className="truncate font-medium">{space.name}</div>
+        <div className="flex flex-row items-center justify-between gap-1.5">
+          <div className="truncate font-medium">{space.name}</div>
+          {space.archivedAt && (
+            <Chip size="mini" color="primary" label="Archived" />
+          )}
+        </div>
         {space.description && (
           <Tooltip
             label={space.description}
@@ -89,7 +95,9 @@ export function ProjectsBrowsePopover({ owner }: ProjectsBrowsePopoverProps) {
     });
 
   const filteredProjects = useMemo(() => {
-    return projects.filter(({ isMember }) => !isMember);
+    return projects.filter(
+      ({ isMember, archivedAt }) => (!isMember && !archivedAt) || archivedAt
+    );
   }, [projects]);
 
   return (


### PR DESCRIPTION
## Description

This PR improves archived projects display in the project browse popover.

- Display an "Archived" chip next to archived project names
- Updated the project filtering logic to include all archived projects in the browse list (previously only non-member projects were shown)

<img width="365" height="556" alt="Capture d’écran 2026-04-14 à 15 35 14" src="https://github.com/user-attachments/assets/de2e1fff-f52a-4614-b7e7-78f166624770" />


## Tests

Manually

## Risks

Low risk. This is a UI-only change that affects the project browse popover. The change makes archived projects visible where they were previously hidden.

## Deploy Plan

Standard deployment - no special considerations needed.
