### PR TITLE
[front] update authorization url for google

### DIFF
--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -101,6 +101,15 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
       authUrl.searchParams.set("resource", resource);
     }
 
+    // Google OAuth requires `access_type=offline` to issue a refresh token and
+    // `prompt=consent` to ensure it is returned on subsequent authorizations.
+    // Without these, Google only issues a short-lived access token (~1 hour)
+    // causing MCP connections to drop when the token expires.
+    if (authUrl.hostname === "accounts.google.com") {
+      authUrl.searchParams.set("access_type", "offline");
+      authUrl.searchParams.set("prompt", "consent");
+    }
+
     return authUrl.toString();
   }
 


### PR DESCRIPTION
## Description
This PR is to fix https://github.com/dust-tt/tasks/issues/7448. From what I understood, Google OAuth only issues a short-lived
  access token (~1 hour) and no refresh token if you don't pass `access_type=offline`.  We already do this for Gmail and GDrive so it looks legitimate? 
https://github.com/dust-tt/dust/blob/c90468d781992212c0d2aca76b95b4e218780f81/front/lib/api/oauth/providers/google_drive.ts#L40-L41

```
If you are not using a client library, you need to set the access_type HTTP query parameter to offline when [redirecting the user to Google's OAuth 2.0 server](https://developers.google.com/identity/protocols/oauth2/web-server#redirecting). In that case, Google's authorization server returns a refresh token when you [exchange an authorization code](https://developers.google.com/identity/protocols/oauth2/web-server#exchange-authorization-code) for an access token. Then, if the access token expires (or at any other time), you can use a refresh token to obtain a new access token.
```
https://developers.google.com/identity/protocols/oauth2/web-server 


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
