### PR TITLE
Display compaction messages in the conversation UI

### DIFF
--- a/front/components/assistant/conversation/CompactionMessage.tsx
+++ b/front/components/assistant/conversation/CompactionMessage.tsx
@@ -1,16 +1,9 @@
 import type { CompactionVirtuosoMessage } from "@app/components/assistant/conversation/types";
+import { formatTimestring } from "@app/lib/utils/timestamps";
 import { AnimatedText, Spinner } from "@dust-tt/sparkle";
 
 interface CompactionMessageProps {
   message: CompactionVirtuosoMessage;
-}
-
-function formatCompactionTime(timestamp: number): string {
-  return new Date(timestamp).toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
 }
 
 export function CompactionMessage({ message }: CompactionMessageProps) {
@@ -18,7 +11,7 @@ export function CompactionMessage({ message }: CompactionMessageProps) {
     <div className="flex items-center justify-center gap-1.5 py-4">
       {message.status === "succeeded" && (
         <span className="text-base text-muted-foreground">
-          Context compacted · {formatCompactionTime(message.created)}
+          Context compacted · {formatTimestring(message.created)}
         </span>
       )}
       {message.status === "created" && (

--- a/front/components/assistant/conversation/CompactionMessage.tsx
+++ b/front/components/assistant/conversation/CompactionMessage.tsx
@@ -8,7 +8,7 @@ interface CompactionMessageProps {
 
 export function CompactionMessage({ message }: CompactionMessageProps) {
   return (
-    <div className="flex items-center justify-center gap-1.5 py-4">
+    <div className="flex items-center justify-center gap-1.5">
       {message.status === "succeeded" && (
         <span className="text-base text-muted-foreground">
           Context compacted · {formatTimestring(message.created)}

--- a/front/components/assistant/conversation/CompactionMessage.tsx
+++ b/front/components/assistant/conversation/CompactionMessage.tsx
@@ -1,9 +1,9 @@
-import type { CompactionVirtuosoMessage } from "@app/components/assistant/conversation/types";
 import { formatTimestring } from "@app/lib/utils/timestamps";
+import type { CompactionMessageType } from "@app/types/assistant/conversation";
 import { AnimatedText, Spinner } from "@dust-tt/sparkle";
 
 interface CompactionMessageProps {
-  message: CompactionVirtuosoMessage;
+  message: CompactionMessageType;
 }
 
 export function CompactionMessage({ message }: CompactionMessageProps) {

--- a/front/components/assistant/conversation/CompactionMessage.tsx
+++ b/front/components/assistant/conversation/CompactionMessage.tsx
@@ -1,0 +1,34 @@
+import type { CompactionVirtuosoMessage } from "@app/components/assistant/conversation/types";
+import { AnimatedText, Spinner } from "@dust-tt/sparkle";
+
+interface CompactionMessageProps {
+  message: CompactionVirtuosoMessage;
+}
+
+function formatCompactionTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+export function CompactionMessage({ message }: CompactionMessageProps) {
+  return (
+    <div className="flex items-center justify-center gap-1.5 py-4">
+      {message.status === "succeeded" && (
+        <span className="text-base text-muted-foreground">
+          Context compacted · {formatCompactionTime(message.created)}
+        </span>
+      )}
+      {message.status === "created" && (
+        <>
+          <Spinner size="xs" />
+          <AnimatedText variant="muted" className="text-base">
+            Compacting context…
+          </AnimatedText>
+        </>
+      )}
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -22,7 +22,6 @@ import {
   isAgentMessageWithStreaming,
   isCompactionMessage,
   isUserMessage,
-  makeCompactionVirtuosoMessage,
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
 import {
@@ -565,9 +564,7 @@ export const ConversationViewer = ({
             break;
           case "compaction_message_new":
             if (ref.current) {
-              const compactionMessage = makeCompactionVirtuosoMessage(
-                event.message
-              );
+              const compactionMessage = event.message;
               const predicate =
                 getPredicateForRankAndBranch(compactionMessage);
               const exists = ref.current.data.find(predicate);
@@ -589,7 +586,7 @@ export const ConversationViewer = ({
 
           case "compaction_message_done":
             if (ref.current) {
-              const doneMessage = makeCompactionVirtuosoMessage(event.message);
+              const doneMessage = event.message;
               ref.current.data.map((m) =>
                 isCompactionMessage(m) && m.sId === event.messageId
                   ? doneMessage

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -20,7 +20,9 @@ import {
   convertLightMessageTypeToVirtuosoMessages,
   getPredicateForRankAndBranch,
   isAgentMessageWithStreaming,
+  isCompactionMessage,
   isUserMessage,
+  makeCompactionVirtuosoMessage,
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
 import {
@@ -562,8 +564,38 @@ export const ConversationViewer = ({
             void mutateConversationAttachments();
             break;
           case "compaction_message_new":
+            if (ref.current) {
+              const compactionMessage = makeCompactionVirtuosoMessage(
+                event.message
+              );
+              const predicate =
+                getPredicateForRankAndBranch(compactionMessage);
+              const exists = ref.current.data.find(predicate);
+
+              if (!exists) {
+                const currentData = ref.current.data.get();
+                const offset = getBranchedInsertIndex(
+                  currentData,
+                  compactionMessage
+                );
+                if (offset < currentData.length) {
+                  ref.current.data.insert([compactionMessage], offset);
+                } else {
+                  ref.current.data.append([compactionMessage]);
+                }
+              }
+            }
+            break;
+
           case "compaction_message_done":
-            // TODO(compaction): handle compaction events in the UI.
+            if (ref.current) {
+              const doneMessage = makeCompactionVirtuosoMessage(event.message);
+              ref.current.data.map((m) =>
+                isCompactionMessage(m) && m.sId === event.messageId
+                  ? doneMessage
+                  : m
+              );
+            }
             break;
           default:
             ((t: never) => {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -565,8 +565,7 @@ export const ConversationViewer = ({
           case "compaction_message_new":
             if (ref.current) {
               const compactionMessage = event.message;
-              const predicate =
-                getPredicateForRankAndBranch(compactionMessage);
+              const predicate = getPredicateForRankAndBranch(compactionMessage);
               const exists = ref.current.data.find(predicate);
 
               if (!exists) {

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -1,6 +1,7 @@
 import { AgentMessage } from "@app/components/assistant/conversation/AgentMessage";
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
 import { contentFragmentToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
+import { CompactionMessage } from "@app/components/assistant/conversation/CompactionMessage";
 import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { MentionInvalid } from "@app/components/assistant/conversation/MentionInvalid";
 import { MentionValidationRequired } from "@app/components/assistant/conversation/MentionValidationRequired";
@@ -12,6 +13,7 @@ import type {
 import {
   getMessageDate,
   isAgentMessageWithStreaming,
+  isCompactionMessage,
   isHiddenMessage,
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
@@ -48,7 +50,11 @@ function getMessageTopMargin({
   isPreviousAgentMessageSteered: boolean;
 }): string | undefined {
   // Previous message has reactions — add extra space to clear them.
-  if (prevData && prevData.reactions.length > 0) {
+  if (
+    prevData &&
+    !isCompactionMessage(prevData) &&
+    prevData.reactions.length > 0
+  ) {
     return "mt-8";
   }
 
@@ -241,6 +247,18 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       return null;
     }
 
+    if (isCompactionMessage(data) && data.status !== "failed") {
+      // TODO(compaction): handle failed compaction display
+      return (
+        <div
+          ref={ref}
+          className={cn("mx-auto max-w-conversation mt-8", !nextData && "mb-8")}
+        >
+          <CompactionMessage message={data} />
+        </div>
+      );
+    }
+
     // No message without a conversation
     if (!context.conversation) {
       return null;
@@ -300,6 +318,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
             />
           )}
           {data.visibility !== "deleted" &&
+            !isCompactionMessage(data) &&
             data.richMentions.map((mention, index) => {
               // To please the type checker
               if (!context.conversation) {

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -247,6 +247,14 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       return null;
     }
 
+    const topMargin = getMessageTopMargin({
+      data,
+      prevData,
+      isPreviousMessageSameSender,
+      isSteeredAgentMessage,
+      isPreviousAgentMessageSteered,
+    });
+
     if (isCompactionMessage(data)) {
       // TODO(compaction): handle failed compaction display
       if (data.status === "failed") {
@@ -255,7 +263,11 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       return (
         <div
           ref={ref}
-          className={cn("mx-auto max-w-conversation mt-8", !nextData && "mb-8")}
+          className={cn(
+            "mx-auto max-w-conversation",
+            topMargin,
+            !nextData && "mb-8"
+          )}
         >
           <CompactionMessage message={data} />
         </div>
@@ -266,14 +278,6 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
     if (!context.conversation) {
       return null;
     }
-
-    const topMargin = getMessageTopMargin({
-      data,
-      prevData,
-      isPreviousMessageSameSender,
-      isSteeredAgentMessage,
-      isPreviousAgentMessageSteered,
-    });
 
     return (
       <>

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -247,8 +247,11 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       return null;
     }
 
-    if (isCompactionMessage(data) && data.status !== "failed") {
+    if (isCompactionMessage(data)) {
       // TODO(compaction): handle failed compaction display
+      if (data.status === "failed") {
+        return null;
+      }
       return (
         <div
           ref={ref}

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -18,6 +18,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import {
   isCompactionMessageType,
+  isLightAgentMessageType,
   isLightAgentMessageWithActionsType,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
@@ -26,6 +27,7 @@ import type { RichMention } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
@@ -87,12 +89,10 @@ export type AgentMessageStateWithControlEvent =
   | AgentMessageStateEvent
   | { type: "end-of-stream" };
 
-export type CompactionVirtuosoMessage = CompactionMessageType;
-
 export type VirtuosoMessage =
   | AgentMessageWithStreaming
   | UserMessageTypeWithContentFragments
-  | CompactionVirtuosoMessage;
+  | CompactionMessageType;
 
 export type VirtuosoMessageListContext = {
   owner: LightWorkspaceType;
@@ -159,7 +159,7 @@ export const isHiddenMessage = (message: VirtuosoMessage): boolean => {
 
 export const isCompactionMessage = (
   msg: VirtuosoMessage
-): msg is CompactionVirtuosoMessage => msg.type === "compaction_message";
+): msg is CompactionMessageType => msg.type === "compaction_message";
 
 export const isUserMessage = (
   msg: VirtuosoMessage
@@ -201,19 +201,20 @@ export const isSidekickBootstrapMessage = (
   return message.context.origin === "agent_sidekick" && message.rank === 0;
 };
 
-export const makeCompactionVirtuosoMessage = (
-  message: CompactionMessageType
-): CompactionVirtuosoMessage => message;
-
 export const convertLightMessageTypeToVirtuosoMessages = (
   messages: LightMessageType[]
 ): VirtuosoMessage[] =>
   messages.map((message) => {
     if (isCompactionMessageType(message)) {
-      return makeCompactionVirtuosoMessage(message);
-    }
-    if (isUserMessageTypeWithContentFragments(message)) {
       return message;
+    } else if (isUserMessageTypeWithContentFragments(message)) {
+      return message;
+    } else if (isLightAgentMessageWithActionsType(message)) {
+      return makeInitialMessageStreamState(message);
+    } else if (isLightAgentMessageType(message)) {
+      return makeInitialMessageStreamState(message);
+    } else {
+      assertNeverAndIgnore(message);
+      return message; // Non reachable
     }
-    return makeInitialMessageStreamState(message);
   });

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -7,6 +7,7 @@ import type { DustError } from "@app/lib/error";
 import type { AgentMCPActionType } from "@app/types/actions";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
+  CompactionMessageType,
   ConversationWithoutContentType,
   InlineActivityStep,
   LightAgentMessageType,
@@ -86,9 +87,12 @@ export type AgentMessageStateWithControlEvent =
   | AgentMessageStateEvent
   | { type: "end-of-stream" };
 
+export type CompactionVirtuosoMessage = CompactionMessageType;
+
 export type VirtuosoMessage =
   | AgentMessageWithStreaming
-  | UserMessageTypeWithContentFragments;
+  | UserMessageTypeWithContentFragments
+  | CompactionVirtuosoMessage;
 
 export type VirtuosoMessageListContext = {
   owner: LightWorkspaceType;
@@ -153,6 +157,10 @@ export const isHiddenMessage = (message: VirtuosoMessage): boolean => {
   );
 };
 
+export const isCompactionMessage = (
+  msg: VirtuosoMessage
+): msg is CompactionVirtuosoMessage => msg.type === "compaction_message";
+
 export const isUserMessage = (
   msg: VirtuosoMessage
 ): msg is UserMessageTypeWithContentFragments =>
@@ -193,14 +201,19 @@ export const isSidekickBootstrapMessage = (
   return message.context.origin === "agent_sidekick" && message.rank === 0;
 };
 
+export const makeCompactionVirtuosoMessage = (
+  message: CompactionMessageType
+): CompactionVirtuosoMessage => message;
+
 export const convertLightMessageTypeToVirtuosoMessages = (
   messages: LightMessageType[]
-) =>
-  messages
-    // TODO(compaction): Add support for compaction messages in the UI instead of filtering.
-    .filter((message) => !isCompactionMessageType(message))
-    .map((message) =>
-      isUserMessageTypeWithContentFragments(message)
-        ? message
-        : makeInitialMessageStreamState(message)
-    );
+): VirtuosoMessage[] =>
+  messages.map((message) => {
+    if (isCompactionMessageType(message)) {
+      return makeCompactionVirtuosoMessage(message);
+    }
+    if (isUserMessageTypeWithContentFragments(message)) {
+      return message;
+    }
+    return makeInitialMessageStreamState(message);
+  });

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -172,9 +172,9 @@ Make compaction actually affect what the model sees.
 - Show "Earlier messages were summarized" with an expandable summary.
 - Show a loading indicator while `status === "created"`.
 
-### - [ ] PR 5.3 — Disable input bar during compaction
+### - [ ] PR 5.3 — Steering during compaction
 
-- Disable input bar while compaction is in progress (mirror the pending steering UX).
+- Add support for steering (creating pending message) while compaction is running.
 
 ### - [ ] PR 5.4 — Manual compaction trigger
 

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -166,14 +166,17 @@ Make compaction actually affect what the model sees.
 - Display a progress bar or indicator showing context fullness.
 - Show a warning when approaching the compaction threshold.
 
-### - [ ] PR 5.2 — Compaction message rendering in conversation UI
+### - [x] PR 5.2 — Compaction message rendering in conversation UI
 
 - Render `CompactionMessage` as a lightweight separator/divider in the conversation view.
 - Show "Earlier messages were summarized" with an expandable summary.
 - Show a loading indicator while `status === "created"`.
+
+### - [ ] PR 5.3 — Disable input bar during compaction
+
 - Disable input bar while compaction is in progress (mirror the pending steering UX).
 
-### - [ ] PR 5.3 — Manual compaction trigger
+### - [ ] PR 5.4 — Manual compaction trigger
 
 - Add a UI affordance (button in the context usage indicator, or a `/compact` command) that calls
   `compaction`.


### PR DESCRIPTION
## Description

Display compaction messages in the conversation UI. Extends `VirtuosoMessage` to include
`CompactionMessageType`, handles `compaction_message_new`/`compaction_message_done` events in
`ConversationViewer`, and renders a centered status line with animated text while compacting and a
static timestamp once completed.

<img width="681" height="482" alt="Screenshot 2026-04-14 at 15 46 10" src="https://github.com/user-attachments/assets/785db614-6bc4-4d31-992d-cc0591bc3564" />
<img width="658" height="400" alt="Screenshot 2026-04-14 at 15 46 38" src="https://github.com/user-attachments/assets/eacb3904-1d9e-4b6a-8d4c-a97686ed9cdc" />

## Tests

Tested locally

## Risk

N/A compaction messages are not yet created

## Deploy Plan

-deploy `front`