### PR TITLE
[front] fix sub agent streaming in `AgentSingleActionPanel`

### DIFF
--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -384,6 +384,7 @@ function AgentActionsPanelContent({
 interface AgentSingleActionPanelProps extends AgentActionsPanelProps {
   messageId: string;
   actionId: string;
+  virtuosoMsg: AgentMessageWithStreaming | null;
   closeIcon?: React.ComponentType;
   onClose: () => void;
 }
@@ -393,6 +394,7 @@ function AgentSingleActionPanel({
   owner,
   messageId,
   actionId,
+  virtuosoMsg,
   closeIcon = XMarkIcon,
   onClose,
 }: AgentSingleActionPanelProps) {
@@ -403,6 +405,13 @@ function AgentSingleActionPanel({
       messageId,
       actionId,
     });
+
+  // Extract streaming progress for the action from the Virtuoso message state.
+  const lastNotification =
+    action && virtuosoMsg?.sId === messageId && virtuosoMsg.status === "created"
+      ? (virtuosoMsg.streaming.actionProgress.get(action.id)?.progress ??
+          null)
+      : null;
 
   if (isActionLoading) {
     return (
@@ -445,7 +454,7 @@ function AgentSingleActionPanel({
         <MCPActionDetails
           displayContext="sidebar-single-action"
           action={action}
-          lastNotification={null}
+          lastNotification={lastNotification}
           owner={owner}
           messageStatus={messageStatus}
         />
@@ -558,6 +567,7 @@ export function AgentActionsPanel({
         owner={owner}
         messageId={messageId}
         actionId={actionId}
+        virtuosoMsg={virtuosoMsg}
         onClose={onPanelClosed}
       />
     );

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -409,8 +409,7 @@ function AgentSingleActionPanel({
   // Extract streaming progress for the action from the Virtuoso message state.
   const lastNotification =
     action && virtuosoMsg?.sId === messageId && virtuosoMsg.status === "created"
-      ? (virtuosoMsg.streaming.actionProgress.get(action.id)?.progress ??
-          null)
+      ? (virtuosoMsg.streaming.actionProgress.get(action.id)?.progress ?? null)
       : null;
 
   if (isActionLoading) {


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/7541.
- This PR fixes the streaming of sub agent answers in the action panel with the steering feature flag.
- The streaming currently never kicks off because we fail to detect the very first notification that sends the `conversationId` and `agentMessageId` to connect to.
- For context: the main agent stream only sends one event (converted from a notification in the `run_agent` tool) to convey the `conversationId` and `agentMessageId`, which is then used to connect to the sub agent's stream.

## Tests

- Tested locally.

## Risk

- Low. Well scoped to the action panel and specific to the feature flag.

## Deploy Plan

- Deploy front.
