### PR TITLE
Use instructionHtml behind FF

### DIFF
--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -87,6 +87,8 @@ function useEditorService(editor: Editor | null) {
 
 interface UseSkillInstructionsEditorProps {
   content: string;
+  htmlContent?: string;
+  withDocumentExtensions?: boolean;
   isReadOnly: boolean;
   onUpdate?: (props: { editor: Editor; transaction: Transaction }) => void;
   onBlur?: () => void;
@@ -108,6 +110,8 @@ const skillInstructionsEditableExtensions = [
 
 export function useSkillInstructionsEditor({
   content,
+  htmlContent,
+  withDocumentExtensions = false,
   isReadOnly,
   onUpdate,
   onBlur,
@@ -117,9 +121,10 @@ export function useSkillInstructionsEditor({
     () =>
       buildSkillInstructionsExtensions(
         isReadOnly,
-        skillInstructionsEditableExtensions
+        skillInstructionsEditableExtensions,
+        { withDocumentExtensions }
       ),
-    [isReadOnly]
+    [isReadOnly, withDocumentExtensions]
   );
 
   // Track if initial content has been set
@@ -139,11 +144,12 @@ export function useSkillInstructionsEditor({
 
   const editorService = useEditorService(editor);
 
-  // Set initial content after editor is created (markdown must be set via setContent)
+  // Set initial content after editor is created
   useEffect(() => {
+    const hasContent = htmlContent || content;
     if (
       editor &&
-      content &&
+      hasContent &&
       !initialContentSetRef.current &&
       !editor.isDestroyed
     ) {
@@ -151,15 +157,19 @@ export function useSkillInstructionsEditor({
       // This fixes Safari crashes where docView is accessed before render
       requestAnimationFrame(() => {
         if (editor && !editor.isDestroyed) {
-          editor.commands.setContent(preprocessMarkdownForEditor(content), {
-            emitUpdate: false,
-            contentType: "markdown",
-          });
+          if (htmlContent) {
+            editor.commands.setContent(htmlContent, { emitUpdate: false });
+          } else {
+            editor.commands.setContent(preprocessMarkdownForEditor(content), {
+              emitUpdate: false,
+              contentType: "markdown",
+            });
+          }
           initialContentSetRef.current = true;
         }
       });
     }
-  }, [editor, content]);
+  }, [editor, content, htmlContent]);
 
   return { editor, editorService };
 }

--- a/front/components/editor/extensions/skill_builder/KnowledgeNode.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNode.tsx
@@ -85,7 +85,7 @@ export const KnowledgeNode = Node.create<{}>({
           // Primary path: deserialization from renderHTML (span with JSON data).
           const data = element.getAttribute("data-selected-items");
           if (data) {
-            return JSON.parse(data);
+            return JSON.parse(decodeURIComponent(data));
           }
 
           // Fallback path: deserialization from a <knowledge> HTML element.
@@ -113,7 +113,9 @@ export const KnowledgeNode = Node.create<{}>({
           return [];
         },
         renderHTML: (attributes) => ({
-          "data-selected-items": JSON.stringify(attributes.selectedItems),
+          "data-selected-items": encodeURIComponent(
+            JSON.stringify(attributes.selectedItems)
+          ),
         }),
       },
     };

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -32,6 +32,7 @@ export const skillBuilderFormSchema = z.object({
     ),
   userFacingDescription: z.string().min(1, "Skill description is required"),
   instructions: z.string().min(1, "Skill instructions are required"),
+  instructionsHtml: z.string(),
   editors: z.array(editorUserSchema),
   tools: z.array(actionSchema),
   icon: z.string().nullable(),

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,6 +1,7 @@
 import { editorVariants } from "@app/components/editor/editorStyles";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
+import { stripHtmlAttributes } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import {
   SkillInstructionsEditorContent,
   useSkillInstructionsEditor,
@@ -8,6 +9,7 @@ import {
 import { SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT } from "@app/components/skill_builder/events";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   postProcessMarkdown,
   preprocessMarkdownForEditor,
@@ -20,6 +22,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 const INSTRUCTIONS_FIELD_NAME = "instructions";
+const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
 const ATTACHED_KNOWLEDGE_FIELD_NAME = "attachedKnowledge";
 
 function collectKnowledgeItems(editor: Editor): KnowledgeItem[] {
@@ -55,11 +58,20 @@ export function SkillBuilderInstructionsEditor({
 }: SkillBuilderInstructionsEditorProps) {
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
   const { setValue } = useFormContext<SkillBuilderFormData>();
+  const { hasFeature } = useFeatureFlags();
+  const useHtmlInstructions = hasFeature("skill_builder_instructions_html");
 
   const { field: instructionsField, fieldState: instructionsFieldState } =
     useController<SkillBuilderFormData, typeof INSTRUCTIONS_FIELD_NAME>({
       name: INSTRUCTIONS_FIELD_NAME,
     });
+
+  const { field: instructionsHtmlField } = useController<
+    SkillBuilderFormData,
+    typeof INSTRUCTIONS_HTML_FIELD_NAME
+  >({
+    name: INSTRUCTIONS_HTML_FIELD_NAME,
+  });
 
   const { fieldState: attachedKnowledgeFieldState } = useController<
     SkillBuilderFormData,
@@ -80,6 +92,13 @@ export function SkillBuilderInstructionsEditor({
             postProcessMarkdown(editor.getMarkdown()).trim(),
             { shouldDirty: true }
           );
+          if (useHtmlInstructions) {
+            setValue(
+              INSTRUCTIONS_HTML_FIELD_NAME,
+              stripHtmlAttributes(editor.getHTML()),
+              { shouldDirty: true }
+            );
+          }
           setValue(
             ATTACHED_KNOWLEDGE_FIELD_NAME,
             toAttachedKnowledge(collectKnowledgeItems(editor)),
@@ -87,7 +106,7 @@ export function SkillBuilderInstructionsEditor({
           );
         }
       }, 250),
-    [isDiffMode, setValue]
+    [isDiffMode, setValue, useHtmlInstructions]
   );
 
   const handleUpdate = useCallback(
@@ -118,6 +137,11 @@ export function SkillBuilderInstructionsEditor({
 
   const { editor } = useSkillInstructionsEditor({
     content: instructionsField.value ?? "",
+    htmlContent:
+      useHtmlInstructions && instructionsHtmlField.value
+        ? instructionsHtmlField.value
+        : undefined,
+    withDocumentExtensions: useHtmlInstructions,
     isReadOnly: false,
     onUpdate: handleUpdate,
     onBlur: handleBlur,
@@ -188,7 +212,12 @@ export function SkillBuilderInstructionsEditor({
 
   // Sync external changes to the editor content
   useEffect(() => {
-    if (!editor || instructionsField.value === undefined) {
+    if (
+      !editor ||
+      (useHtmlInstructions
+        ? !instructionsHtmlField.value
+        : instructionsField.value === undefined)
+    ) {
       return;
     }
 
@@ -201,19 +230,33 @@ export function SkillBuilderInstructionsEditor({
     ) {
       return;
     }
-    const currentContent = postProcessMarkdown(editor.getMarkdown());
-    if (currentContent !== instructionsField.value) {
-      setTimeout(() => {
-        editor.commands.setContent(
-          preprocessMarkdownForEditor(instructionsField.value),
-          {
-            emitUpdate: false,
-            contentType: "markdown",
-          }
-        );
-      }, 0);
+
+    if (useHtmlInstructions) {
+      const incomingHtml = instructionsHtmlField.value;
+      const currentHtml = stripHtmlAttributes(editor.getHTML());
+      if (currentHtml !== incomingHtml) {
+        setTimeout(() => {
+          editor.commands.setContent(incomingHtml, { emitUpdate: false });
+        }, 0);
+      }
+    } else {
+      const incomingMarkdown = instructionsField.value;
+      const currentContent = postProcessMarkdown(editor.getMarkdown());
+      if (currentContent !== incomingMarkdown) {
+        setTimeout(() => {
+          editor.commands.setContent(
+            preprocessMarkdownForEditor(incomingMarkdown),
+            { emitUpdate: false, contentType: "markdown" }
+          );
+        }, 0);
+      }
     }
-  }, [editor, instructionsField.value]);
+  }, [
+    editor,
+    instructionsField.value,
+    instructionsHtmlField.value,
+    useHtmlInstructions,
+  ]);
 
   useEffect(() => {
     if (!editor) {

--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -15,6 +15,7 @@ export function transformSkillTypeToFormData(
     agentFacingDescription: skill.agentFacingDescription,
     userFacingDescription: skill.userFacingDescription,
     instructions: skill.instructions ?? "",
+    instructionsHtml: skill.instructionsHtml ?? "",
     editors: [], // Will be populated reactively from useEditors hook
     tools: skill.tools.map(getDefaultMCPAction),
     fileAttachments: skill.fileAttachments,
@@ -39,6 +40,7 @@ export function getDefaultSkillFormData({
     agentFacingDescription: "",
     userFacingDescription: "",
     instructions: "",
+    instructionsHtml: "",
     editors: [user],
     tools: [],
     fileAttachments: [],

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -40,6 +40,10 @@ export async function submitSkillBuilderForm({
         agentFacingDescription: formData.agentFacingDescription,
         userFacingDescription: formData.userFacingDescription,
         instructions: formData.instructions,
+        instructionsHtml:
+          formData.instructionsHtml.trim() === ""
+            ? null
+            : formData.instructionsHtml,
         icon: formData.icon,
         extendedSkillId: formData.extendedSkillId,
         isDefault: formData.isDefault,

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -113,6 +113,7 @@ export function SkillInfoTab({
           </div>
           <SkillInstructionsReadOnlyEditor
             content={skill.instructions}
+            htmlContent={skill.instructionsHtml ?? ""}
             owner={owner}
             onKnowledgeItemsChange={handleKnowledgeItemsChange}
             className="max-h-150 overflow-y-auto"

--- a/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
+++ b/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
@@ -9,6 +9,7 @@ import { useEffect } from "react";
 
 interface SkillInstructionsReadOnlyEditorProps {
   content: string;
+  htmlContent?: string;
   owner: LightWorkspaceType;
   onKnowledgeItemsChange?: (items: KnowledgeItem[]) => void;
   className?: string;
@@ -16,12 +17,18 @@ interface SkillInstructionsReadOnlyEditorProps {
 
 export function SkillInstructionsReadOnlyEditor({
   content,
+  htmlContent,
   owner,
   onKnowledgeItemsChange,
   className,
 }: SkillInstructionsReadOnlyEditorProps) {
+  const htmlForEditor =
+    htmlContent && htmlContent.trim() !== "" ? htmlContent : undefined;
+
   const { editor, editorService } = useSkillInstructionsEditor({
     content,
+    htmlContent: htmlForEditor,
+    withDocumentExtensions: Boolean(htmlForEditor),
     isReadOnly: true,
   });
 

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -19,23 +19,23 @@ export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
  *
  * @param isReadOnly - When true, interactive editing extensions are omitted.
  * @param editableExtensions - Extensions appended when `isReadOnly` is false.
- * @param serverSide - When true, includes InstructionsDocumentExtension,
- *   InstructionsRootExtension, and BlockIdExtension for server-side HTML
+ * @param withDocumentExtensions - When true, includes InstructionsDocumentExtension,
+ *   InstructionsRootExtension, and BlockIdExtension (document + block IDs).
  */
 export function buildSkillInstructionsExtensions(
   isReadOnly: boolean,
   editableExtensions: Extensions = [],
-  { serverSide = false }: { serverSide?: boolean } = {}
+  { withDocumentExtensions = false }: { withDocumentExtensions?: boolean } = {}
 ): Extensions {
   const baseExtensions: Extensions = [
-    ...(serverSide
+    ...(withDocumentExtensions
       ? [InstructionsDocumentExtension, InstructionsRootExtension]
       : []),
-    Markdown,
+    Markdown.configure(),
     StarterKit.configure({
       // document: false is required when InstructionsDocumentExtension is present
       // (it replaces StarterKit's default Document node).
-      ...(serverSide ? { document: false } : {}),
+      ...(withDocumentExtensions ? { document: false } : {}),
       orderedList: {
         HTMLAttributes: {
           class: markdownStyles.orderedList(),
@@ -77,7 +77,7 @@ export function buildSkillInstructionsExtensions(
         class: "mt-4 mb-3",
       },
     }),
-    ...(serverSide ? [BlockIdExtension] : []),
+    ...(withDocumentExtensions ? [BlockIdExtension] : []),
     KnowledgeNode,
     RawMarkdownBlock,
     ...rawMarkdownBlockParsers,

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -72,7 +72,7 @@ export function buildSkillInstructionsExtensions(
       },
     }),
     HeadingExtension.configure({
-      levels: [1, 2, 3],
+      levels: [1, 2, 3, 4, 5, 6],
       HTMLAttributes: {
         class: "mt-4 mb-3",
       },

--- a/front/lib/editor/skill_instructions_html.ts
+++ b/front/lib/editor/skill_instructions_html.ts
@@ -17,7 +17,7 @@ import { renderToHTMLString } from "@tiptap/static-renderer/pm/html-string";
 import * as cheerio from "cheerio";
 
 const SKILL_EDITOR_EXTENSIONS = buildSkillInstructionsExtensions(true, [], {
-  serverSide: true,
+  withDocumentExtensions: true,
 });
 const MARKDOWN_MANAGER = new MarkdownManager({
   extensions: SKILL_EDITOR_EXTENSIONS,

--- a/front/lib/editor/skill_instructions_preprocessing.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.ts
@@ -3,15 +3,31 @@ import { unescape } from "html-escaper";
 const ZWS = "\u200B";
 
 /**
+ * Escape emphasis delimiters (_ and *) inside $$ ... $$ math blocks so
+ * marked.js does not parse them as italic/bold markers.
+ */
+function escapeMathEmphasis(markdown: string): string {
+  return markdown.replace(/\$\$([\s\S]*?)\$\$/g, (block) =>
+    block.replace(/(?<!\\)_/g, "\\_").replace(/(?<!\\)\*/g, "\\*")
+  );
+}
+
+/**
  * Preprocess markdown before loading it into the TipTap editor.
  */
 export function preprocessMarkdownForEditor(markdown: string): string {
-  return markdown.replace(/<(?!\/?knowledge[\s>/])(\/?\w)/g, `<${ZWS}$1`);
+  return escapeMathEmphasis(
+    markdown.replace(/<(?!\/?knowledge[\s>/])(\/?\w)/g, `<${ZWS}$1`)
+  );
 }
 
 /**
  * Normalize markdown serialized out of the TipTap editor before saving.
  */
 export function postProcessMarkdown(markdown: string): string {
-  return unescape(markdown).replace(new RegExp(ZWS, "g"), "");
+  return unescape(markdown)
+    .replace(new RegExp(ZWS, "g"), "")
+    .replace(/\$\$([\s\S]*?)\$\$/g, (block) =>
+      block.replace(/\\_/g, "_").replace(/\\\*/g, "*")
+    );
 }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1806,6 +1806,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       fileAttachments,
       icon,
       instructions,
+      instructionsHtml,
       isDefault,
       mcpServerViews,
       name,
@@ -1820,6 +1821,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       fileAttachments?: FileResource[];
       icon: string | null;
       instructions: string;
+      instructionsHtml?: string | null;
       isDefault?: boolean;
       mcpServerViews: MCPServerViewResource[];
       name: string;
@@ -1847,6 +1849,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           agentFacingDescription,
           userFacingDescription,
           instructions,
+          ...(instructionsHtml !== undefined
+            ? { instructionsHtml: instructionsHtml ?? null }
+            : {}),
           icon,
           requestedSpaceIds,
           editedBy,

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -64,6 +64,7 @@ const PatchSkillRequestBodySchema = t.intersection([
   t.partial({
     fileAttachments: t.array(t.type({ fileId: t.string })),
     isDefault: t.boolean,
+    instructionsHtml: t.union([t.string, t.null]),
   }),
 ]);
 
@@ -318,6 +319,7 @@ async function handler(
         fileAttachments: files,
         icon: body.icon,
         instructions: body.instructions,
+        instructionsHtml: body.instructionsHtml,
         isDefault: body.isDefault,
         mcpServerViews,
         name,

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -68,6 +68,7 @@ const PostSkillRequestBodySchema = t.intersection([
   t.partial({
     fileAttachments: t.array(t.type({ fileId: t.string })),
     isDefault: t.boolean,
+    instructionsHtml: t.union([t.string, t.null]),
   }),
   t.union([
     t.type({
@@ -354,6 +355,7 @@ async function handler(
           agentFacingDescription: body.agentFacingDescription,
           userFacingDescription: body.userFacingDescription,
           instructions: body.instructions,
+          instructionsHtml: body.instructionsHtml ?? null,
           editedBy: user.id,
           requestedSpaceIds,
           extendedSkillId: body.extendedSkillId,

--- a/front/scripts/migrate_skill_instructions_html.ts
+++ b/front/scripts/migrate_skill_instructions_html.ts
@@ -18,7 +18,6 @@ import {
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { unescape } from "html-escaper";
 import { Op } from "sequelize";
@@ -41,6 +40,9 @@ function normalizeForComparison(s: string): string {
 
   const normalized = unescape(withPlaceholders)
     .replace(new RegExp(ZWS, "g"), "")
+    // Normalize non-breaking spaces to nothing — they are cosmetically
+    // equivalent to regular spaces and are not meaningful in instructions.
+    .replace(/\u00A0/g, "")
     // Normalize italic: _text_ → *text* (cosmetically equivalent)
     .replace(/(?<!\w)_([^_\n]+?)_(?!\w)/g, "*$1*")
     // Normalize bold: __text__ → **text** (cosmetically equivalent)
@@ -50,8 +52,14 @@ function normalizeForComparison(s: string): string {
     // content is preserved, so treat the difference as acceptable.
     .replace(/^- \[[ xX]\] /gm, "- ")
     // Normalize null link titles injected by TipTap's MarkdownManager:
-    // [text](url "null") → [text](url)
-    .replace(/(\[[^\]]*\]\([^)\s]+) "null"\)/g, "$1)")
+    // [text](url "null") → [text](url). Use non-greedy [^)]*? to handle
+    // URLs that contain spaces or other whitespace before the title.
+    .replace(/(\[[^\]]*\]\([^)]*?) "null"\)/g, "$1)")
+    // Normalize auto-linked bare URLs: [url](url) → url. marked.js
+    // auto-links plain URLs/emails even when the original is plain text.
+    .replace(/\[([^\]]+)\]\(\1(?:\s+"[^"]*")?\)/g, "$1")
+    // Normalize auto-linked emails: [addr](mailto:addr) → addr.
+    .replace(/\[([^\]]+)\]\(mailto:[^)]+\)/g, "$1")
     // Collapse all whitespace (including newlines) to a single space so that
     // cosmetic differences in spacing, indentation, and blank lines are ignored.
     .replace(/\s+/g, "")
@@ -66,19 +74,49 @@ function normalizeForComparison(s: string): string {
   );
 }
 
-type ConversionError = { kind: "conversion-failed"; message: string };
+const ROUND_TRIP_DIFF_CONTEXT_CHARS = 40;
+
+type RoundTripMismatchDiff = {
+  position: number;
+  normalizedOriginalWindow: string;
+  normalizedRoundTripWindow: string;
+};
+
+function roundTripMismatchDiff(
+  normalizedOriginal: string,
+  normalizedRoundTrip: string
+): RoundTripMismatchDiff {
+  let i = 0;
+  const minLen = Math.min(
+    normalizedOriginal.length,
+    normalizedRoundTrip.length
+  );
+  while (i < minLen && normalizedOriginal[i] === normalizedRoundTrip[i]) {
+    i++;
+  }
+
+  const ctx = ROUND_TRIP_DIFF_CONTEXT_CHARS;
+  const start = Math.max(0, i - ctx);
+  const end = i + ctx;
+
+  return {
+    position: i,
+    normalizedOriginalWindow: normalizedOriginal.slice(start, end),
+    normalizedRoundTripWindow: normalizedRoundTrip.slice(start, end),
+  };
+}
+
 type RoundTripError = {
   kind: "round-trip-mismatch";
-  diff: string;
+  diff: RoundTripMismatchDiff;
 };
-type SkillError = ConversionError | RoundTripError;
+type SkillError = RoundTripError;
 
 interface SkillResult {
   skillId: number;
   skillName: string;
   workspaceSId: string;
   error: SkillError | null;
-  /** The generated HTML, present only when conversion succeeded. */
   html: string | null;
 }
 
@@ -88,49 +126,22 @@ function convertSkill(
 ): SkillResult {
   const { instructions } = skill;
 
-  let html: string;
-  try {
-    html = convertMarkdownToBlockHtml(instructions);
-  } catch (err) {
-    const error = normalizeError(err);
-    return {
-      skillId: skill.id,
-      skillName: skill.name,
-      workspaceSId,
-      error: { kind: "conversion-failed", message: error.message },
-      html: null,
-    };
-  }
+  const html = convertMarkdownToBlockHtml(instructions);
 
   // Round-trip check: html → markdown, compare against original instructions.
-  let roundTripMarkdown: string;
-  try {
-    roundTripMarkdown = convertBlockHtmlToMarkdown(html);
-  } catch (err) {
-    const error = normalizeError(err);
-    return {
-      skillId: skill.id,
-      skillName: skill.name,
-      workspaceSId,
-      error: {
-        kind: "conversion-failed",
-        message: `round-trip threw: ${error.message}`,
-      },
-      html: null,
-    };
-  }
+  const roundTripMarkdown = convertBlockHtmlToMarkdown(html);
 
-  if (
-    normalizeForComparison(instructions) !==
-    normalizeForComparison(roundTripMarkdown)
-  ) {
+  const normalizedOriginal = normalizeForComparison(instructions);
+  const normalizedRoundTrip = normalizeForComparison(roundTripMarkdown);
+
+  if (normalizedOriginal !== normalizedRoundTrip) {
     return {
       skillId: skill.id,
       skillName: skill.name,
       workspaceSId,
       error: {
         kind: "round-trip-mismatch",
-        diff: `original: "${instructions.slice(0, 300)}" | round-tripped: "${roundTripMarkdown.slice(0, 300)}"`,
+        diff: roundTripMismatchDiff(normalizedOriginal, normalizedRoundTrip),
       },
       html,
     };
@@ -164,11 +175,7 @@ async function processSkillsForWorkspace(
     const result = convertSkill(skill, workspace.sId);
     results.push(result);
 
-    if (
-      execute &&
-      result.error?.kind !== "conversion-failed" &&
-      result.html !== null
-    ) {
+    if (execute && result.error === null && result.html !== null) {
       await skill.update({ instructionsHtml: result.html });
     }
   }
@@ -229,9 +236,7 @@ makeScript(
             workspaceSId: r.workspaceSId,
             error: r.error,
           },
-          r.error?.kind === "round-trip-mismatch"
-            ? "Skill instructions round-trip mismatch"
-            : "Skill instructions conversion failed"
+          "Skill instructions round-trip mismatch"
         );
       }
     }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -1,4 +1,9 @@
 export const WHITELISTABLE_FEATURES_CONFIG = {
+  skill_builder_instructions_html: {
+    description:
+      "Enable HTML-backed instructions in the skill builder (block IDs, HTML round-trip storage)",
+    stage: "dust_only",
+  },
   advanced_notion_management: {
     description:
       "Advanced features for Notion workspace management shown to admins",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -731,6 +731,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "sandbox_tools"
   | "self_created_slack_app_connector_rollout"
   | "show_debug_tools"
+  | "skill_builder_instructions_html"
   | "slack_bot_mcp"
   | "slack_enhanced_default_agent"
   | "slack_message_splitting"


### PR DESCRIPTION
## Description

* Behind FF, save/load instruction HTML and use instruction root block extensions

## Tests

* Loaded in our prod workspace into my local env, ran migration, validated they could be loaded normally

## Risk

* Risk mitigated by putting everything behind FF

## Deploy Plan

1. Deploy front
2. Migrate only our workspace
3. Enable FF on only our workspace
Wait and validate