### PR TITLE
[front] fix(yaml-export): allow null name and description in actions

### DIFF
--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -308,7 +308,10 @@ export class AgentYAMLConverter {
     action: AgentYAMLAction
   ): Promise<
     Result<
-      | PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"][number]
+      | (PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"][number] & {
+          action?: string | null;
+          description?: string | null;
+        })
       | null,
       Error
     >

--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -309,7 +309,7 @@ export class AgentYAMLConverter {
   ): Promise<
     Result<
       | (PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"][number] & {
-          action?: string | null;
+          name?: string | null;
           description?: string | null;
         })
       | null,

--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -308,13 +308,7 @@ export class AgentYAMLConverter {
     action: AgentYAMLAction
   ): Promise<
     Result<
-      | (Omit<
-          PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"][number],
-          "name" | "description"
-        > & {
-          name?: string | null;
-          description?: string | null;
-        })
+      | PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"][number]
       | null,
       Error
     >
@@ -358,8 +352,8 @@ export class AgentYAMLConverter {
       return new Ok({
         type: "mcp_server_configuration",
         mcpServerViewId: mcpServerView.sId,
-        name: action.name,
-        description: action.description,
+        name: action.name ?? "",
+        description: action.description ?? null,
         dataSources: configuration.data_sources
           ? this.convertDataSources(configuration.data_sources, workspaceId)
           : null,

--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -308,7 +308,10 @@ export class AgentYAMLConverter {
     action: AgentYAMLAction
   ): Promise<
     Result<
-      | (PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"][number] & {
+      | (Omit<
+          PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"][number],
+          "name" | "description"
+        > & {
           name?: string | null;
           description?: string | null;
         })

--- a/front/lib/agent_yaml_converter/schemas.ts
+++ b/front/lib/agent_yaml_converter/schemas.ts
@@ -65,24 +65,24 @@ export const agentYAMLProjectConfigurationSchema = z.object({
 });
 
 export const agentYAMLMCPActionSchema = z.object({
-  name: z.string().min(1, "Action name is required"),
-  description: z.string().min(1, "Action description is required"),
+  name: z.string().nullish(),
+  description: z.string().nullish(),
   type: z.literal("MCP"),
   configuration: z.object({
     mcp_server_name: z.string(),
     data_sources: z
       .record(z.string(), agentYAMLDataSourceConfigurationSchema)
       .optional(),
-    tables: z.array(agentYAMLTableConfigurationSchema).nullable().optional(),
-    child_agent_id: z.string().nullable().optional(),
+    tables: z.array(agentYAMLTableConfigurationSchema).nullish(),
+    child_agent_id: z.string().nullish(),
     time_frame: agentYAMLTimeFrameSchema.optional(),
-    json_schema: z.object({}).nullable().optional(),
+    json_schema: z.object({}).nullish(),
     additional_configuration: additionalConfigurationSchema.optional(),
     dust_app_configuration: agentYAMLDustAppConfigurationSchema
       .nullable()
       .optional(),
-    secret_name: z.string().nullable().optional(),
-    dust_project: agentYAMLProjectConfigurationSchema.nullable().optional(),
+    secret_name: z.string().nullish(),
+    dust_project: agentYAMLProjectConfigurationSchema.nullish(),
   }),
 });
 

--- a/front/lib/agent_yaml_converter/schemas.ts
+++ b/front/lib/agent_yaml_converter/schemas.ts
@@ -65,8 +65,8 @@ export const agentYAMLProjectConfigurationSchema = z.object({
 });
 
 export const agentYAMLMCPActionSchema = z.object({
-  name: z.string().nullish(),
-  description: z.string().nullish(),
+  name: z.string(),
+  description: z.string(),
   type: z.literal("MCP"),
   configuration: z.object({
     mcp_server_name: z.string(),

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -142,7 +142,7 @@ async function importAgentConfiguration(
   return new Ok({
     agentConfiguration: agentConfigurationRes.value,
     skippedActions: skippedActions.map(({ action, reason }) => ({
-      name: action.name,
+      name: action.name ?? "",
       reason,
     })),
   });


### PR DESCRIPTION
## Description

- Fixes the issue reported [here](https://dust4ai.slack.com/archives/C0525Q93AEL/p1776174060183009).
- This PR fixes the schema of the yaml export to allow nullish names and descriptions in actions, which is the case for search actions.
- This is a hotfix, the typing needs to be checked more in-depth.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
