### PR TITLE
feat: project about page ui

### DIFF
--- a/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
+++ b/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
@@ -14,11 +14,11 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  Input,
   Spinner,
   TrashIcon,
 } from "@dust-tt/sparkle";
-// biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { useCallback, useState } from "react";
+import { type ChangeEvent, useCallback, useState } from "react";
 
 interface DeleteSpaceDialogProps {
   owner: LightWorkspaceType;
@@ -28,6 +28,7 @@ interface DeleteSpaceDialogProps {
 export function DeleteSpaceDialog({ owner, space }: DeleteSpaceDialogProps) {
   const router = useAppRouter();
   const [isDeleting, setIsDeleting] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
   const doDelete = useDeleteSpace({ owner, force: true });
   const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
     workspaceId: owner.sId,
@@ -45,15 +46,21 @@ export function DeleteSpaceDialog({ owner, space }: DeleteSpaceDialogProps) {
   }, [doDelete, space, mutateSpaceSummary, owner.sId, router]);
 
   return (
-    <Dialog>
+    <Dialog
+      onOpenChange={(open) => {
+        if (!open) {
+          setConfirmText("");
+        }
+      }}
+    >
       <DialogTrigger asChild>
         <div className="flex w-full flex-col items-start">
           <Button icon={TrashIcon} variant="warning" label="Delete project" />
         </div>
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent size="md">
         <DialogHeader>
-          <DialogTitle>{`Delete ${getSpaceName(space)}`}</DialogTitle>
+          <DialogTitle>{`Delete ${getSpaceName(space)}?`}</DialogTitle>
         </DialogHeader>
         {isDeleting ? (
           <div className="flex justify-center py-8">
@@ -61,14 +68,20 @@ export function DeleteSpaceDialog({ owner, space }: DeleteSpaceDialogProps) {
           </div>
         ) : (
           <>
-            <DialogContainer className="space-y-4">
-              <div>
-                <p className="text-sm text-muted-foreground">
-                  Are you sure you want to permanently delete project{" "}
-                  <strong>{getSpaceName(space)}</strong>? This action cannot be
-                  undone.
-                </p>
-              </div>
+            <DialogContainer className="flex flex-col gap-4">
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                Type <strong>delete</strong> below to confirm. This permanently
+                removes all project content and cannot be undone.
+              </p>
+              <Input
+                name="delete-confirm"
+                value={confirmText}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setConfirmText(e.target.value)
+                }
+                placeholder="Type delete to confirm"
+                containerClassName="w-full"
+              />
             </DialogContainer>
             <DialogFooter
               leftButtonProps={{
@@ -76,8 +89,9 @@ export function DeleteSpaceDialog({ owner, space }: DeleteSpaceDialogProps) {
                 variant: "outline",
               }}
               rightButtonProps={{
-                label: "Delete",
+                label: "Delete permanently",
                 variant: "warning",
+                disabled: confirmText.trim().toLowerCase() !== "delete",
                 onClick: async () => {
                   void onDelete();
                 },

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -10,21 +10,20 @@ import {
   useUpdateProjectMetadata,
   useUpdateSpace,
 } from "@app/lib/swr/spaces";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { PatchProjectMetadataBodyType } from "@app/types/api/internal/spaces";
 import { PatchProjectMetadataBodySchema } from "@app/types/api/internal/spaces";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
+  ArchiveIcon,
+  ArrowUpOnSquareIcon,
   Button,
   ContentMessage,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  EmptyCTA,
-  EmptyCTAButton,
-  EyeIcon,
-  EyeSlashIcon,
   Input,
   MoreIcon,
   ScrollArea,
@@ -218,46 +217,39 @@ export function SpaceAboutTab({
 
   return (
     <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-y-auto px-6">
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 py-8">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 py-8">
         <div className="flex gap-2">
           <h2 className="heading-2xl flex-1 text-foreground dark:text-foreground-night">
             Settings
           </h2>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" icon={MoreIcon} />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuItem
-                icon={projectMetadata?.archivedAt ? EyeIcon : EyeSlashIcon}
-                label={
-                  projectMetadata?.archivedAt
-                    ? "Unarchive project"
-                    : "Archive project"
-                }
-                variant="warning"
-                onClick={handleArchiveToggle}
-              />
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {isProjectEditor && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" icon={MoreIcon} />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                {projectMetadata?.archivedAt ? (
+                  <DropdownMenuItem
+                    icon={ArrowUpOnSquareIcon}
+                    label="Unarchive project"
+                    onClick={handleArchiveToggle}
+                  />
+                ) : (
+                  <DropdownMenuItem
+                    icon={ArchiveIcon}
+                    label="Archive project"
+                    variant="warning"
+                    onClick={handleArchiveToggle}
+                  />
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
         {space.archivedAt && (
-          <EmptyCTA
-            action={
-              <EmptyCTAButton
-                icon={EyeIcon}
-                label="Unarchive"
-                onClick={handleArchiveToggle}
-                disabled={!isProjectEditor}
-                tooltip={
-                  !isProjectEditor
-                    ? "You need to be an editor to unarchive this project."
-                    : undefined
-                }
-              />
-            }
-            message="This project has been archived. Unarchive it to continue creating new conversations."
-          />
+          <ContentMessage variant="info" size="lg">
+            This project has been archived.
+          </ContentMessage>
         )}
         <div className="flex w-full flex-col gap-2">
           <div className="heading-lg">Name</div>
@@ -360,55 +352,88 @@ export function SpaceAboutTab({
           </div>
         </div>
 
-        <div className="flex items-center gap-2">
-          <h3 className="heading-lg flex-1">Members</h3>
-          {isProjectEditor && onOpenMembersPanel && (
-            <Button
-              label="Manage"
-              variant="outline"
-              icon={UserGroupIcon}
-              onClick={onOpenMembersPanel}
-            />
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <h3 className="heading-lg flex-1">Members</h3>
+            {isProjectEditor && onOpenMembersPanel && (
+              <Button
+                label="Manage"
+                variant="outline"
+                icon={UserGroupIcon}
+                onClick={onOpenMembersPanel}
+              />
+            )}
+          </div>
+          {projectMembers.length > 0 && (
+            <>
+              <SearchInput
+                name="search"
+                placeholder="Search (email)"
+                value={searchSelectedMembers}
+                onChange={setSearchSelectedMembers}
+              />
+              <ScrollArea className="h-full" orientation="horizontal">
+                <MembersTable
+                  owner={owner}
+                  space={space}
+                  selectedMembers={projectMembers}
+                  searchSelectedMembers={searchSelectedMembers}
+                  isEditor={isProjectEditor}
+                  mutateSpaceInfo={() =>
+                    mutateSpaceInfoRegardlessOfQueryParams()
+                  }
+                />
+              </ScrollArea>
+            </>
           )}
         </div>
-        {projectMembers.length > 0 && (
-          <>
-            <SearchInput
-              name="search"
-              placeholder="Search (email)"
-              value={searchSelectedMembers}
-              onChange={setSearchSelectedMembers}
-            />
-            <ScrollArea className="h-full" orientation="horizontal">
-              <MembersTable
-                owner={owner}
-                space={space}
-                selectedMembers={projectMembers}
-                searchSelectedMembers={searchSelectedMembers}
-                isEditor={isProjectEditor}
-                mutateSpaceInfo={() => mutateSpaceInfoRegardlessOfQueryParams()}
-              />
-            </ScrollArea>
-          </>
-        )}
 
         {isProjectEditor && (
-          <div className="flex w-full flex-col items-center gap-y-4 border-t pt-8">
-            <ContentMessage
-              variant="warning"
-              title="Danger Zone"
-              className="flex w-full"
-            >
-              <div className="flex flex-col gap-y-4">
+          <div className="flex w-full flex-col gap-3 border-t border-border pt-8 dark:border-border-night">
+            <h3 className="heading-lg">Danger Zone</h3>
+            <h4 className="heading-base">Archive</h4>
+            {projectMetadata?.archivedAt ? (
+              <div className="flex flex-col gap-3">
                 <p className="text-sm text-foreground dark:text-foreground-night">
-                  Deleting this project will permanently remove all its content,
-                  including conversations, folders, websites, and data sources.
-                  This action cannot be undone. All assistants using tools that
-                  depend on this project will be impacted.
+                  Archived on{" "}
+                  <span className="font-medium">
+                    {formatTimestampToFriendlyDate(
+                      projectMetadata.archivedAt,
+                      "short"
+                    )}
+                  </span>
+                  .
                 </p>
-                <DeleteSpaceDialog owner={owner} space={space} />
+                <Button
+                  icon={ArrowUpOnSquareIcon}
+                  variant="outline"
+                  label="Unarchive"
+                  onClick={handleArchiveToggle}
+                  className="w-fit"
+                />
               </div>
-            </ContentMessage>
+            ) : (
+              <>
+                <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                  This project will be removed from the sidebar. Its data stays
+                  intact and can still be used as a data source.
+                </p>
+                <Button
+                  icon={ArchiveIcon}
+                  variant="warning-secondary"
+                  label="Archive"
+                  onClick={handleArchiveToggle}
+                  className="w-fit"
+                />
+              </>
+            )}
+            <h4 className="heading-base">Delete</h4>
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              This permanently removes all content—conversations, folders,
+              websites, and data sources. Assistants using this project's tools
+              will be impacted. This cannot be undone.
+            </p>
+            <DeleteSpaceDialog owner={owner} space={space} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7516

This PR updates the UI of the project about page (settings page) to match the new design for the danger zone.

- Refactored the delete project dialog to require explicit confirmation by typing "delete" instead of just clicking a button
- Reorganized the "Danger Zone" section with separate subsections for Archive and Delete actions

<img width="1119" height="326" alt="Capture d’écran 2026-04-14 à 16 23 24" src="https://github.com/user-attachments/assets/3ae71d81-0b0f-4ebf-a927-617aabd06dc3" />

<img width="1119" height="326" alt="Capture d’écran 2026-04-14 à 16 23 28" src="https://github.com/user-attachments/assets/1d3a7a54-5e92-43e8-9992-03c1f05a0d8e" />

<img width="561" height="281" alt="Capture d’écran 2026-04-14 à 16 23 36" src="https://github.com/user-attachments/assets/7c7b0df5-a441-46af-9bc0-c8c53026c555" />

<img width="1014" height="281" alt="Capture d’écran 2026-04-14 à 16 23 47" src="https://github.com/user-attachments/assets/dd650fb8-0a94-4675-afc6-b4c48af7c903" />


## Tests

Manually

## Risks

Low - UI improvements only, no changes to business logic.

## Deploy Plan

Standard deployment.
