### PR TITLE
Show nice label for tool args approval

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -270,6 +270,7 @@ export function AgentMessage({
                 userId: eventPayload.data.userId,
                 argumentsRequiringApproval:
                   eventPayload.data.argumentsRequiringApproval,
+                approvalArgsLabel: eventPayload.data.approvalArgsLabel,
               },
             });
             break;

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -133,6 +133,10 @@ export function MCPToolValidationRequired({
         blockedAction.inputs
       );
     }
+
+    if (blockedAction.approvalArgsLabel) {
+      return blockedAction.approvalArgsLabel;
+    }
     const args = blockedAction.argumentsRequiringApproval ?? [];
     const argValues = args
       .filter((arg) => blockedAction.inputs[arg] != null)

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -24,6 +24,8 @@ export interface ToolExecution<
 
   // For medium-stake tools: which arguments will be saved for future auto-approval.
   argumentsRequiringApproval?: string[];
+  // Human-readable label for the "always allow" approval checkbox.
+  approvalArgsLabel?: string;
 }
 
 type ToolPersonalAuthError = {

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -202,6 +202,9 @@ export type DustProjectConfigurationType = z.infer<
   (typeof ConfigurableToolInputSchemas)[typeof INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT]
 >;
 
+export const DustProjectConfigurationSchema =
+  ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT];
+
 /**
  * Mapping between the mime types we used to identify a configurable resource
  * and the JSON schema resulting from the Zod schema defined above.

--- a/front/lib/actions/tool_approval_labels.test.ts
+++ b/front/lib/actions/tool_approval_labels.test.ts
@@ -1,0 +1,66 @@
+import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { describe, expect, it, vi } from "vitest";
+
+describe("getApprovalArgsLabel", () => {
+  it("returns a label with project URI when space cannot be resolved", async () => {
+    const fetchByIdSpy = vi
+      .spyOn(SpaceResource, "fetchById")
+      .mockResolvedValue(null);
+
+    const auth = {
+      getNonNullableWorkspace: () => ({ sId: "ws123" }),
+    } as never;
+
+    await expect(
+      getApprovalArgsLabel({
+        auth,
+        internalMCPServerName: "project_manager",
+        toolName: "create_conversation",
+        agentName: "assistant",
+        inputs: {
+          dustProject: {
+            uri: "project://dust/w/ws123/projects/prj456",
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT,
+          },
+        },
+        argumentsRequiringApproval: ["dustProject"],
+      })
+    ).resolves.toBe(
+      'Always allow @assistant to Create Conversation in "project://dust/w/ws123/projects/prj456".'
+    );
+
+    expect(fetchByIdSpy).toHaveBeenCalledWith(auth, "prj456");
+  });
+
+  it("returns a label with resolved space name", async () => {
+    const fetchByIdSpy = vi
+      .spyOn(SpaceResource, "fetchById")
+      .mockResolvedValue({ name: "Revenue Ops" } as never);
+
+    const auth = {
+      getNonNullableWorkspace: () => ({ sId: "ws123" }),
+    } as never;
+
+    await expect(
+      getApprovalArgsLabel({
+        auth,
+        internalMCPServerName: "project_manager",
+        toolName: "create_conversation",
+        agentName: "assistant",
+        inputs: {
+          dustProject: {
+            uri: "project://dust/w/ws123/projects/prj456",
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT,
+          },
+        },
+        argumentsRequiringApproval: ["dustProject"],
+      })
+    ).resolves.toBe(
+      'Always allow @assistant to Create Conversation in "Revenue Ops".'
+    );
+
+    expect(fetchByIdSpy).toHaveBeenCalledWith(auth, "prj456");
+  });
+});

--- a/front/lib/actions/tool_approval_labels.ts
+++ b/front/lib/actions/tool_approval_labels.ts
@@ -1,0 +1,58 @@
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { DustProjectConfigurationSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { parseProjectConfigurationURI } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { isString } from "@app/types/shared/utils/general";
+import { asDisplayName } from "@app/types/shared/utils/string_utils";
+
+export async function getApprovalArgsLabel({
+  auth,
+  toolName,
+  agentName,
+  inputs,
+  argumentsRequiringApproval,
+}: {
+  auth: Authenticator;
+  internalMCPServerName: InternalMCPServerNameType | null | undefined;
+  toolName: string;
+  agentName: string;
+  inputs: Record<string, unknown>;
+  argumentsRequiringApproval: string[];
+}): Promise<string | undefined> {
+  for (const [inputName, inputValue] of Object.entries(inputs)) {
+    if (!argumentsRequiringApproval.includes(inputName)) {
+      continue;
+    }
+
+    // Check if the input is a Dust project configuration
+    const parsed = DustProjectConfigurationSchema.safeParse(inputValue);
+    if (parsed.success) {
+      const parsedProject = parseProjectConfigurationURI(parsed.data.uri);
+      if (parsedProject.isOk()) {
+        const { workspaceId, projectId } = parsedProject.value;
+        if (workspaceId !== auth.getNonNullableWorkspace().sId) {
+          return `Always allow @${agentName} to ${asDisplayName(toolName)} in project ${parsed.data.uri}`;
+        }
+
+        const space = await SpaceResource.fetchById(auth, projectId);
+        return `Always allow @${agentName} to ${asDisplayName(toolName)} in "${space?.name ?? parsed.data.uri}".`;
+      }
+    }
+
+    // Check if the input is a file (a bit naive)
+    if (
+      inputName.toLowerCase().includes("fileid") &&
+      isString(inputValue) &&
+      inputValue.startsWith("fil_")
+    ) {
+      const file = await FileResource.fetchById(auth, inputValue);
+      if (file) {
+        return `Always allow @${agentName} to ${asDisplayName(toolName)} for file ${file?.fileName ?? inputValue}.`;
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -316,7 +316,7 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
 
 const PROJECT_MANAGER_INSTRUCTIONS =
   "Project files and metadata are shared across all conversations in this project. " +
-  "Only text-based files are supported for adding/updating. " +
+  "You can add all sorts of files but only text-based files are supported for updating. " +
   "You can add/update files by providing text content directly, or by copying from existing files (like those you've generated). " +
   "You can also attach an existing project context file to the current conversation without recreating it. " +
   "Use list_projects to discover projects you can access and obtain the dustProject uri for other tools. " +

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -10,6 +10,7 @@ import {
   isToolExecutionStatusBlocked,
   TOOL_EXECUTION_BLOCKED_STATUSES,
 } from "@app/lib/actions/statuses";
+import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
 import {
   getToolDisplayLabels,
   getToolNameFromFunctionCallName,
@@ -391,6 +392,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         BlockedToolExecution,
         "status" | "authorizationInfo"
       > = {
+        // Compute approval labels from persisted configuration + stored inputs.
+        // This keeps resumed conversations consistent with streamed events.
         messageId: agentMessage.message.sId,
         userId: parentUserMessage.userMessage?.user?.sId,
         conversationId: conversation.sId,
@@ -410,6 +413,19 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         },
         argumentsRequiringApproval:
           action.toolConfiguration.argumentsRequiringApproval,
+        approvalArgsLabel: await getApprovalArgsLabel({
+          auth,
+          internalMCPServerName: action.toolConfiguration.toolServerId
+            ? getInternalMCPServerNameFromSId(
+                action.toolConfiguration.toolServerId
+              )
+            : null,
+          toolName: action.toolConfiguration.originalName,
+          agentName: agentConfiguration.name,
+          inputs: action.augmentedInputs,
+          argumentsRequiringApproval:
+            action.toolConfiguration.argumentsRequiringApproval ?? [],
+        }),
       };
 
       if (action.status === "blocked_authentication_required") {

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -1,8 +1,10 @@
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
+import { getInternalMCPServerNameFromSId } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
 import type { ToolInputContext } from "@app/lib/actions/tool_status";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import type { StepContext } from "@app/lib/actions/types";
@@ -151,6 +153,8 @@ async function createActionForTool(
   );
 
   const rawInputs = JSON.parse(stepContent.value.value.arguments);
+  const argumentsRequiringApproval =
+    actionConfiguration.argumentsRequiringApproval ?? [];
 
   // Build context for medium stake per-argument approval checks
   const mediumStakeContext: ToolInputContext = {
@@ -258,8 +262,17 @@ async function createActionForTool(
               agentName: agentConfiguration.name,
               icon: actionConfiguration.icon,
             },
-            argumentsRequiringApproval:
-              actionConfiguration.argumentsRequiringApproval,
+            argumentsRequiringApproval,
+            approvalArgsLabel: await getApprovalArgsLabel({
+              auth,
+              internalMCPServerName: getInternalMCPServerNameFromSId(
+                actionConfiguration.toolServerId
+              ),
+              toolName: actionConfiguration.originalName,
+              agentName: agentConfiguration.name,
+              inputs: rawInputs,
+              argumentsRequiringApproval,
+            }),
           }
         : undefined,
   };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1358,6 +1358,8 @@ const ToolExecutionMetadataSchema = z.object({
     mcpServerDisplayName: z.string().optional(),
     mcpServerId: z.string().optional(),
   }),
+  argumentsRequiringApproval: z.array(z.string()).optional(),
+  approvalArgsLabel: z.string().optional(),
 });
 
 const BlockedActionExecutionSchema = ToolExecutionMetadataSchema.extend({


### PR DESCRIPTION
## Description

The "always allow" checkbox in the tool approval prompt was showing a raw serialized argument value (e.g. a `dustProject` URI or a file ID) instead of something human-readable. This was particularly jarring for project tools where the approval label showed a raw URI rather than the project name.

- Add `getApprovalArgsLabel` in a new `tool_approval_labels.ts` — inspects the args requiring approval and returns a friendly string when it recognises a known pattern:
  - `dustProject` URI → resolves the project `spaceId` to its name via `SpaceResource.fetchById`, falls back to the raw URI if unresolvable
  - `fileId`-shaped args → resolves the filename via `FileResource.fetchById`
- Pipe `approvalArgsLabel` through the stream event (`ToolExecution`, `BlockedActionExecutionSchema`) and display it in `MCPToolValidationRequired` when present, ahead of the existing arg-value fallback
- Call `getApprovalArgsLabel` both at stream time (in `createActionForTool`) and when rebuilding blocked actions from persistence (in `AgentMCPActionResource`) so resumed conversations show the same label
- Update `project_manager` instructions: all file types can be added, only text-based ones can be updated
- Add tests for `getApprovalArgsLabel` (resolved name, unresolvable fallback)

## Tests

Before, after
<img width="510" height="218" alt="image" src="https://github.com/user-attachments/assets/e76476cd-fbaa-4b0a-b9de-fba1a53337af" />
<img width="521" height="166" alt="image" src="https://github.com/user-attachments/assets/5ce8409a-5dad-42ed-91f5-e50c9b9025ac" />


Local + green (new tests added)

## Risk

Low

## Deploy Plan

Deploy `front`
