### PR TITLE
Always use hard cancel instead of graceful stop

### DIFF
--- a/front/hooks/conversations/useCancelMessage.ts
+++ b/front/hooks/conversations/useCancelMessage.ts
@@ -1,5 +1,4 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback } from "react";
@@ -12,8 +11,6 @@ export function useCancelMessage({
   conversationId?: string | null;
 }) {
   const sendNotification = useSendNotification();
-  const { hasFeature } = useFeatureFlags();
-  const isSteeringEnabled = hasFeature("enable_steering");
 
   return useCallback(
     async (messageIds: string[]) => {
@@ -27,7 +24,7 @@ export function useCancelMessage({
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              action: isSteeringEnabled ? "gracefully_stop" : "cancel",
+              action: "cancel",
               messageIds,
             }),
           }
@@ -38,6 +35,6 @@ export function useCancelMessage({
         sendNotification({ type: "error", title: "Failed to cancel message" });
       }
     },
-    [owner.sId, conversationId, sendNotification, isSteeringEnabled]
+    [owner.sId, conversationId, sendNotification]
   );
 }


### PR DESCRIPTION
## Description

The stop button was sending `gracefully_stop` when the `enable_steering` feature flag was set,
which caused the agent to finish its current step before stopping. This changes it back to always
send `cancel` for immediate stop regardless of steering being enabled.

Supersedes https://github.com/dust-tt/dust/pull/24201

## Tests

Manual testing in the browser.

## Risk

Low — restores previous hard-cancel behavior.

## Deploy Plan

Regular deploy.