### PR TITLE
[front] fix dark mode for custom input in `UserAnswerRequired`

### DIFF
--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -183,7 +183,8 @@ export function UserAnswerRequired({
                 "h-auto w-full rounded-none border-transparent bg-transparent",
                 "px-0 py-0 text-sm shadow-none",
                 "dark:border-transparent dark:bg-transparent",
-                "focus-visible:border-transparent focus-visible:ring-0"
+                "focus-visible:border-transparent focus-visible:ring-0",
+                "dark:focus-visible:border-transparent dark:focus-visible:ring-0"
               )}
               placeholder="Type something else"
               value={customResponse}

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -182,6 +182,7 @@ export function UserAnswerRequired({
               className={cn(
                 "h-auto w-full rounded-none border-transparent bg-transparent",
                 "px-0 py-0 text-sm shadow-none",
+                "dark:border-transparent dark:bg-transparent",
                 "focus-visible:border-transparent focus-visible:ring-0"
               )}
               placeholder="Type something else"


### PR DESCRIPTION
## Description

- This PR fixes the dark mode for the custom input in the ask user question tool as reported [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1776169489227979).

<img width="815" height="609" alt="Screenshot 2026-04-14 at 5 09 57 PM" src="https://github.com/user-attachments/assets/35be94ee-6d84-477f-a796-acf14d28ba81" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
