### PR TITLE
Reinforcement: improve suggestions on how to use tools by adding MCP to describe tool in details

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -20,6 +20,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_agent_info": "never_ask",
   },
   "agent_sidekick_context": {
+    "describe_mcp": "never_ask",
     "get_agent_feedback": "never_ask",
     "get_agent_insights": "never_ask",
     "get_agent_template": "never_ask",

--- a/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
@@ -2743,4 +2743,94 @@ describe("agent_sidekick_context tools", () => {
       }
     });
   });
+
+  describe("describe_mcp", () => {
+    it("returns tool details for an accessible MCP server", async () => {
+      const { workspace, globalSpace, authenticator } =
+        await createResourceTest({ role: "user" });
+
+      const server = await RemoteMCPServerFactory.create(workspace, {
+        name: "LinkedIn",
+        description: "Search and enrich LinkedIn profiles",
+        tools: [
+          {
+            name: "search_user",
+            description: "Search for a person by name",
+            inputSchema: {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string",
+                  description: "Full name to search for",
+                },
+              },
+              required: ["name"],
+            },
+          },
+          {
+            name: "enrich_user",
+            description: "Get detailed profile data for a person",
+            inputSchema: {
+              type: "object",
+              properties: {
+                user_id: {
+                  type: "string",
+                  description: "The LinkedIn user identifier",
+                },
+              },
+              required: ["user_id"],
+            },
+          },
+        ],
+      });
+
+      const view = await MCPServerViewFactory.create(
+        workspace,
+        server.sId,
+        globalSpace
+      );
+
+      const tool = getToolByName("describe_mcp");
+      const result = await tool.handler(
+        { mcpId: view.sId },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          expect(content.text).toContain("LinkedIn");
+          expect(content.text).toContain("Search and enrich LinkedIn profiles");
+          expect(content.text).toContain("search_user");
+          expect(content.text).toContain("Search for a person by name");
+          expect(content.text).toContain("name (string)");
+          expect(content.text).toContain("Full name to search for");
+          expect(content.text).toContain("enrich_user");
+          expect(content.text).toContain("user_id (string)");
+        }
+      }
+    });
+
+    it("returns a not-found message for an unknown MCP id", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      const tool = getToolByName("describe_mcp");
+      const result = await tool.handler(
+        { mcpId: "mcp_does_not_exist" },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          expect(content.text).toContain("not found");
+          expect(content.text).toContain("mcp_does_not_exist");
+        }
+      }
+    });
+  });
 });

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -7,6 +7,7 @@ import {
   MAX_PENDING_SUB_AGENT_SUGGESTIONS,
   MAX_PENDING_TOOLS_SUGGESTIONS,
 } from "@app/lib/api/actions/servers/agent_sidekick_context/constants";
+import { DESCRIBE_MCP_TOOL_NAME } from "@app/lib/reinforcement/types";
 import { MODEL_IDS } from "@app/types/assistant/models/models";
 import { REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 import {
@@ -153,6 +154,18 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Listing available tools",
       done: "List available tools",
+    },
+  },
+  [DESCRIBE_MCP_TOOL_NAME]: {
+    description:
+      "Get detailed information about a specific MCP server: its description, and each tool's name, description, and input parameters.",
+    schema: {
+      mcpId: z.string().describe("The sId of the MCP server to describe"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Describing MCP server",
+      done: "Describe MCP server",
     },
   },
   get_available_agents: {

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -535,12 +535,15 @@ import {
   formatAvailableModels,
   formatAvailableSkills,
   formatAvailableTools,
+  formatMcpDescription,
 } from "@app/lib/api/assistant/global_agents/sidekick_context";
 import {
+  describeMcpServer,
   getAvailableModelsForWorkspace,
   listAvailableSkills,
   listAvailableTools,
 } from "@app/lib/api/assistant/workspace_capabilities";
+import { DESCRIBE_MCP_TOOL_NAME } from "@app/lib/reinforcement/types";
 import type { z } from "zod";
 
 /**
@@ -703,6 +706,18 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
         type: "text" as const,
         text: formatAvailableTools(toolList),
       },
+    ]);
+  },
+
+  [DESCRIBE_MCP_TOOL_NAME]: async ({ mcpId }, { auth }) => {
+    const server = await describeMcpServer(auth, mcpId);
+    if (!server) {
+      return new Ok([
+        { type: "text" as const, text: `MCP server not found: ${mcpId}` },
+      ]);
+    }
+    return new Ok([
+      { type: "text" as const, text: formatMcpDescription(mcpId, server) },
     ]);
   },
 

--- a/front/lib/api/assistant/global_agents/sidekick_context.ts
+++ b/front/lib/api/assistant/global_agents/sidekick_context.ts
@@ -85,6 +85,74 @@ export function formatAvailableTools(tools: AvailableTool[]): string {
   return `<available_tools>\n${blocks.join("\n")}\n</available_tools>`;
 }
 
+function formatInputParams(
+  inputSchema: Record<string, unknown> | undefined
+): string {
+  if (!inputSchema || inputSchema["type"] !== "object") {
+    return "  Input parameters: none";
+  }
+  const properties = inputSchema["properties"];
+  if (!properties || typeof properties !== "object") {
+    return "  Input parameters: none";
+  }
+  const required = new Set(
+    Array.isArray(inputSchema["required"]) ? inputSchema["required"] : []
+  );
+  const entries = Object.entries(
+    properties as Record<string, Record<string, unknown>>
+  );
+  if (entries.length === 0) {
+    return "  Input parameters: none";
+  }
+  const params = entries
+    .map(([name, prop]) => {
+      const type = typeof prop["type"] === "string" ? prop["type"] : "any";
+      const optStr = required.has(name) ? "" : " (optional)";
+      const descStr =
+        typeof prop["description"] === "string"
+          ? `: ${prop["description"]}`
+          : "";
+      return `    - ${name} (${type}${optStr})${descStr}`;
+    })
+    .join("\n");
+  return `  Input parameters:\n${params}`;
+}
+
+export function formatMcpDescription(
+  mcpId: string,
+  server: {
+    name: string;
+    description: string;
+    tools: {
+      name: string;
+      description: string;
+      inputSchema?: Record<string, unknown>;
+    }[];
+  }
+): string {
+  const lines: string[] = [
+    `MCP: ${server.name} (${mcpId})`,
+    `Description: ${server.description}`,
+    "",
+  ];
+  if (server.tools.length === 0) {
+    lines.push("Tools: none");
+  } else {
+    lines.push("Tools:");
+    for (const tool of server.tools) {
+      lines.push(`- ${tool.name}`);
+      lines.push(`  Description: ${tool.description}`);
+      lines.push(
+        formatInputParams(
+          tool.inputSchema as Record<string, unknown> | undefined
+        )
+      );
+      lines.push("");
+    }
+  }
+  return lines.join("\n");
+}
+
 async function fetchSidekickUserMetadata(
   auth: Authenticator
 ): Promise<SidekickUserMetadata | null> {

--- a/front/lib/api/assistant/global_agents/sidekick_context.ts
+++ b/front/lib/api/assistant/global_agents/sidekick_context.ts
@@ -85,32 +85,39 @@ export function formatAvailableTools(tools: AvailableTool[]): string {
   return `<available_tools>\n${blocks.join("\n")}\n</available_tools>`;
 }
 
+interface InputParamSchema {
+  type?: string | string[];
+  properties?: Record<string, unknown>;
+  required?: string[];
+}
+
 function formatInputParams(
-  inputSchema: Record<string, unknown> | undefined
+  inputSchema: InputParamSchema | undefined
 ): string {
-  if (!inputSchema || inputSchema["type"] !== "object") {
+  if (inputSchema?.type !== "object" || !inputSchema.properties) {
     return "  Input parameters: none";
   }
-  const properties = inputSchema["properties"];
-  if (!properties || typeof properties !== "object") {
-    return "  Input parameters: none";
-  }
-  const required = new Set(
-    Array.isArray(inputSchema["required"]) ? inputSchema["required"] : []
-  );
-  const entries = Object.entries(
-    properties as Record<string, Record<string, unknown>>
-  );
+  const required = new Set(inputSchema.required ?? []);
+  const entries = Object.entries(inputSchema.properties);
   if (entries.length === 0) {
     return "  Input parameters: none";
   }
   const params = entries
     .map(([name, prop]) => {
-      const type = typeof prop["type"] === "string" ? prop["type"] : "any";
+      const type =
+        prop !== null &&
+        typeof prop === "object" &&
+        "type" in prop &&
+        typeof prop.type === "string"
+          ? prop.type
+          : "any";
       const optStr = required.has(name) ? "" : " (optional)";
       const descStr =
-        typeof prop["description"] === "string"
-          ? `: ${prop["description"]}`
+        prop !== null &&
+        typeof prop === "object" &&
+        "description" in prop &&
+        typeof prop.description === "string"
+          ? `: ${prop.description}`
           : "";
       return `    - ${name} (${type}${optStr})${descStr}`;
     })
@@ -126,7 +133,7 @@ export function formatMcpDescription(
     tools: {
       name: string;
       description: string;
-      inputSchema?: Record<string, unknown>;
+      inputSchema?: InputParamSchema;
     }[];
   }
 ): string {
@@ -144,7 +151,7 @@ export function formatMcpDescription(
       lines.push(`  Description: ${tool.description}`);
       lines.push(
         formatInputParams(
-          tool.inputSchema as Record<string, unknown> | undefined
+          tool.inputSchema
         )
       );
       lines.push("");

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -4,7 +4,7 @@ import {
   getMcpServerViewDisplayName,
   isToolWithKnowledge,
 } from "@app/lib/actions/mcp_helper";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { filterCustomAvailableAndWhitelistedModels } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -104,4 +104,16 @@ export async function listAvailableSkills(
     icon: skill.icon,
     toolIds: skill.mcpServerViews.map((v) => v.sId),
   }));
+}
+
+/**
+ * Fetch detailed information about a specific MCP server by its sId.
+ * Returns the MCPServerType (including its tools list) or null if not found.
+ */
+export async function describeMcpServer(
+  auth: Authenticator,
+  mcpId: string
+): Promise<MCPServerType | null> {
+  const [view] = await MCPServerViewResource.fetchByIds(auth, [mcpId]);
+  return view?.toJSON()?.server ?? null;
 }

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -33,6 +33,7 @@ Propose configuration changes only when <analysis_workflow> yields concrete evid
 
 ## Exploration tools (optional — use these if you need more context)
 - get_available_tools: Lists all tools (MCP servers) available in the workspace. Use this to discover tools you could suggest adding or to verify that suggested tools exist.
+- describe_mcp: Returns detailed information about a specific MCP server: its tools, each tool's description, and input parameters. ALWAYS call this before suggesting instruction changes that reference specific tool names or workflows for a given MCP — you need to know the exact tool names and their inputs to write accurate instructions.
 `,
 
   skill_usage_analysis: `In <skill_context>, you have received all custom skills that were enabled in the conversation.
@@ -99,7 +100,8 @@ ONLY make suggestions that will affect the skill behavior. NEVER suggest cosmeti
 - Discover available tools by calling get_available_tools.
 - Only suggest adding a tool if there is clear evidence from the conversation that the skill needed a capability it did not have.
 - Only suggest removing a tool if there is clear evidence the tool is causing confusion or is unused and cluttering the skill configuration.
-- When suggesting a tool addition, ensure the tool exists in the workspace by checking available tools first.`,
+- When suggesting a tool addition, ensure the tool exists in the workspace by checking available tools first.
+- When the conversation involves a tool call that failed or produced unexpected results, call describe_mcp for the relevant MCP to understand the full list of available tools and their correct usage before suggesting instruction changes.`,
 };
 
 export function buildSkillAnalysisSystemPrompt(): string {

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -10,6 +10,7 @@ import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import {
   ALL_TOOLS,
+  DESCRIBE_MCP_TOOL_NAME,
   type ExploratoryToolCallInfo,
   getReinforcedSkillsMetadata,
   isExploratoryToolName,
@@ -44,6 +45,13 @@ const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
     description:
       "Get the list of available tools (MCP servers) that can be added to skills.",
     schema: {},
+  },
+  [DESCRIBE_MCP_TOOL_NAME]: {
+    description:
+      "Get detailed information about a specific MCP server: its description, and each tool's name, description, and input parameters. Use this to understand what a tool can do before suggesting instruction changes that reference it.",
+    schema: {
+      mcpId: z.string().describe("The sId of the MCP server to describe"),
+    },
   },
   edit_skill: {
     description:

--- a/front/lib/reinforcement/types.ts
+++ b/front/lib/reinforcement/types.ts
@@ -1,13 +1,20 @@
 import type { ToolCallEvent } from "@app/lib/api/llm/types/events";
 import { z } from "zod";
 
-export type ExploratoryToolName = "get_available_tools";
+export const DESCRIBE_MCP_TOOL_NAME = "describe_mcp" as const;
+
+export type ExploratoryToolName =
+  | "get_available_tools"
+  | typeof DESCRIBE_MCP_TOOL_NAME;
 
 export type TerminalToolName = "edit_skill";
 
 export const TERMINAL_TOOLS: TerminalToolName[] = ["edit_skill"];
 
-export const EXPLORATORY_TOOLS: ExploratoryToolName[] = ["get_available_tools"];
+export const EXPLORATORY_TOOLS: ExploratoryToolName[] = [
+  "get_available_tools",
+  DESCRIBE_MCP_TOOL_NAME,
+];
 
 export const ALL_TOOLS = [...TERMINAL_TOOLS, ...EXPLORATORY_TOOLS];
 

--- a/front/tests/reinforcement-evals/lib/assertions.ts
+++ b/front/tests/reinforcement-evals/lib/assertions.ts
@@ -1,3 +1,4 @@
+import { DESCRIBE_MCP_TOOL_NAME } from "@app/lib/reinforcement/types";
 import type {
   ToolCall,
   ToolCallAssertion,
@@ -148,6 +149,21 @@ export function validateToolCallAssertion(
             error: `Expected no suggestions, but edit_skill was called with ${instructionEdits.length} instructionEdit(s) and ${toolEdits.length} toolEdit(s)`,
           };
         }
+      }
+      return { success: true };
+    }
+    case "calledDescribeMcp": {
+      const called = toolCalls.some(
+        (tc) =>
+          tc.name === DESCRIBE_MCP_TOOL_NAME &&
+          isString(tc.arguments["mcpId"]) &&
+          tc.arguments["mcpId"] === assertion.mcpId
+      );
+      if (!called) {
+        return {
+          success: false,
+          error: `Expected ${DESCRIBE_MCP_TOOL_NAME} to be called with mcpId "${assertion.mcpId}", but it was not`,
+        };
       }
       return { success: true };
     }

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -1,4 +1,7 @@
-import { formatAvailableTools } from "@app/lib/api/assistant/global_agents/sidekick_context";
+import {
+  formatAvailableTools,
+  formatMcpDescription,
+} from "@app/lib/api/assistant/global_agents/sidekick_context";
 import { getLLM } from "@app/lib/api/llm";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { BatchResultWithRunIds } from "@app/lib/api/llm/types/batch";
@@ -15,21 +18,25 @@ import {
   buildReinforcedSkillsLLMParams,
   classifySkillToolCalls,
 } from "@app/lib/reinforcement/run_reinforced_analysis";
+import { DESCRIBE_MCP_TOOL_NAME } from "@app/lib/reinforcement/types";
 import {
   BATCH_POLL_INTERVAL_MS,
   MODEL_ID,
+  VERBOSE,
 } from "@app/tests/reinforcement-evals/lib/config";
 import {
   buildConversationText,
   type CategorizedTestCase,
   type ExecutionResult,
   isAnalysisTestCase,
+  type MockMcpDescription,
   type MockSkillConfig,
   type TestCase,
   type ToolCall,
   type WorkspaceContext,
 } from "@app/tests/reinforcement-evals/lib/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { isString } from "@app/types/shared/utils/general";
 
 function makeSkillType(config: MockSkillConfig): SkillType {
   return {
@@ -127,12 +134,70 @@ function extractFromEvents(events: LLMEvent[]): ExecutionResult {
   return { toolCalls, responseText };
 }
 
+function mockDescriptionToFormatInput(
+  mcpName: string,
+  desc: MockMcpDescription
+) {
+  return {
+    name: mcpName,
+    description: desc.description,
+    tools: (desc.tools ?? []).map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema:
+        t.inputs && t.inputs.length > 0
+          ? {
+              type: "object",
+              properties: Object.fromEntries(
+                t.inputs.map((i) => [
+                  i.name,
+                  {
+                    type: i.type,
+                    ...(i.description ? { description: i.description } : {}),
+                  },
+                ])
+              ),
+              required: t.inputs
+                .filter((i) => i.required !== false)
+                .map((i) => i.name),
+            }
+          : undefined,
+    })),
+  };
+}
+
 /**
  * Simulate an exploratory tool call using the test case's workspace context.
  */
-function simulateExploratoryTool(workspaceContext: WorkspaceContext): string {
-  // The skills pipeline only has one exploratory tool: get_available_tools.
-  return formatAvailableTools(workspaceContext.tools);
+function simulateExploratoryTool(
+  toolName: string,
+  args: Record<string, unknown>,
+  workspaceContext: WorkspaceContext
+): string {
+  switch (toolName) {
+    case "get_available_tools":
+      return formatAvailableTools(workspaceContext.tools);
+    case DESCRIBE_MCP_TOOL_NAME: {
+      const mcpId = args["mcpId"];
+      if (!isString(mcpId)) {
+        return "Error: mcpId parameter is required";
+      }
+      const desc = workspaceContext.mcpDescriptions?.find(
+        (d) => d.sId === mcpId
+      );
+      if (!desc) {
+        return `MCP server not found: ${mcpId}`;
+      }
+      const mcpName =
+        workspaceContext.tools.find((t) => t.sId === mcpId)?.name ?? mcpId;
+      return formatMcpDescription(
+        mcpId,
+        mockDescriptionToFormatInput(mcpName, desc)
+      );
+    }
+    default:
+      return `Unknown exploratory tool: ${toolName}`;
+  }
 }
 
 /**
@@ -143,7 +208,8 @@ function simulateExploratoryTool(workspaceContext: WorkspaceContext): string {
 async function executeMultiStep(
   llm: LLM,
   initialParams: LLMStreamParameters,
-  workspaceContext: WorkspaceContext
+  workspaceContext: WorkspaceContext,
+  scenarioId: string
 ): Promise<ExecutionResult> {
   const allToolCalls: ToolCall[] = [];
   let lastResponseText = "";
@@ -160,6 +226,12 @@ async function executeMultiStep(
     lastResponseText = stepResult.responseText;
 
     const { exploratoryToolCalls } = classifySkillToolCalls(events);
+    if (VERBOSE && exploratoryToolCalls.length > 0) {
+      console.log(
+        `[${scenarioId}] Exploratory tool calls input:`,
+        JSON.stringify(exploratoryToolCalls, null, 2)
+      );
+    }
 
     // If no exploratory tools were called, we're done.
     if (exploratoryToolCalls.length === 0) {
@@ -169,7 +241,17 @@ async function executeMultiStep(
     // Simulate exploratory tool responses from workspace context.
     const toolResults: Record<string, string> = {};
     for (const tc of exploratoryToolCalls) {
-      toolResults[tc.id] = simulateExploratoryTool(workspaceContext);
+      toolResults[tc.id] = simulateExploratoryTool(
+        tc.name,
+        tc.arguments,
+        workspaceContext
+      );
+    }
+    if (VERBOSE && exploratoryToolCalls.length > 0) {
+      console.log(
+        `[${scenarioId}] Exploratory tool calls output:`,
+        JSON.stringify(toolResults, null, 2)
+      );
     }
 
     // Build continuation messages and extend conversation.
@@ -220,7 +302,12 @@ export async function executeReinforced(
   const prompt = buildPromptForTestCase(testCase);
   const params = buildReinforcedSkillsLLMParams(prompt);
 
-  return executeMultiStep(llm, params, testCase.workspaceContext);
+  return executeMultiStep(
+    llm,
+    params,
+    testCase.workspaceContext,
+    testCase.scenarioId
+  );
 }
 
 function sleep(ms: number): Promise<void> {
@@ -289,12 +376,26 @@ export async function executeBatch(
           responseText: stepResult.responseText,
         });
       } else {
+        if (VERBOSE) {
+          console.log(
+            `[${scenarioId}] Exploratory tool calls inputs:`,
+            JSON.stringify(exploratoryToolCalls, null, 2)
+          );
+        }
         // Simulate tool responses and prepare continuation params.
         const tc = testCaseById.get(scenarioId)!;
         const toolResultsMap: Record<string, string> = {};
         for (const toolCall of exploratoryToolCalls) {
           toolResultsMap[toolCall.id] = simulateExploratoryTool(
+            toolCall.name,
+            toolCall.arguments,
             tc.workspaceContext
+          );
+        }
+        if (VERBOSE) {
+          console.log(
+            `[${scenarioId}] Exploratory tool calls results:`,
+            JSON.stringify(toolResultsMap, null, 2)
           );
         }
 

--- a/front/tests/reinforcement-evals/lib/types.ts
+++ b/front/tests/reinforcement-evals/lib/types.ts
@@ -6,8 +6,30 @@ import {
 import type { AvailableTool } from "@app/lib/api/assistant/workspace_capabilities";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 
+export interface MockMcpToolInput {
+  name: string;
+  type: string;
+  description?: string;
+  /** Defaults to true if omitted. */
+  required?: boolean;
+}
+
+export interface MockMcpTool {
+  name: string;
+  description: string;
+  inputs?: MockMcpToolInput[];
+}
+
+export interface MockMcpDescription {
+  sId: string;
+  description: string;
+  tools: MockMcpTool[];
+}
+
 export interface WorkspaceContext {
   tools: AvailableTool[];
+  /** Optional MCP details returned when describe_mcp is called during eval. */
+  mcpDescriptions?: MockMcpDescription[];
 }
 
 function slugify(name: string): string {
@@ -192,7 +214,8 @@ export type ToolCallAssertion =
   | { type: "editSkillWithInstructions"; skillId: string }
   | { type: "editSkillWithTool"; skillId: string; toolId: string }
   | { type: "editSkill"; skillId: string }
-  | { type: "noSuggestion" };
+  | { type: "noSuggestion" }
+  | { type: "calledDescribeMcp"; mcpId: string };
 
 /** Expects an edit_skill call with instructionEdits for the given skill. */
 export function editSkillWithInstructions(skillId: string): ToolCallAssertion {
@@ -214,6 +237,11 @@ export function editSkill(skillId: string): ToolCallAssertion {
 
 export function noSuggestion(): ToolCallAssertion {
   return { type: "noSuggestion" };
+}
+
+/** Expects describe_mcp to have been called with the given mcpId. */
+export function calledDescribeMcp(mcpId: string): ToolCallAssertion {
+  return { type: "calledDescribeMcp", mcpId };
 }
 
 export interface JudgeResult {

--- a/front/tests/reinforcement-evals/reinforcement-eval.test.ts
+++ b/front/tests/reinforcement-evals/reinforcement-eval.test.ts
@@ -157,6 +157,13 @@ describe.skipIf(!RUN_REINFORCEMENT_EVAL)(
                 JUDGE_RUNS
               );
 
+              if (VERBOSE) {
+                console.log(
+                  `[${scenarioId}] Judge Result:`,
+                  JSON.stringify(judgeResult, null, 2)
+                );
+              }
+
               const passedJudge = judgeResult.finalScore >= PASS_THRESHOLD;
               const toolCallsSummary = formatToolCalls(toolCalls);
 

--- a/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
@@ -1,13 +1,68 @@
 import {
+  calledDescribeMcp,
   editSkillWithInstructions,
   editSkillWithTool,
+  type MockMcpDescription,
   mockTool,
   noSuggestion,
   type TestSuite,
   type WorkspaceContext,
 } from "@app/tests/reinforcement-evals/lib/types";
 
+const LINKEDIN_MCP_DESCRIPTION: MockMcpDescription = {
+  sId: "mcp_linkedin",
+  description: "Search and enrich company and people profiles from LinkedIn",
+  tools: [
+    {
+      name: "search_company",
+      description: "Search for a company on LinkedIn by name",
+      inputs: [
+        {
+          name: "company_name",
+          type: "string",
+          description: "The name of the company to search for",
+        },
+      ],
+    },
+    {
+      name: "search_user",
+      description: "Search for a person on LinkedIn by name",
+      inputs: [
+        {
+          name: "name",
+          type: "string",
+          description: "The full name of the person to search for",
+        },
+      ],
+    },
+    {
+      name: "enrich_company_data",
+      description: "Get detailed profile data for a company",
+      inputs: [
+        {
+          name: "company_id",
+          type: "string",
+          description:
+            "The LinkedIn company identifier returned by search_company",
+        },
+      ],
+    },
+    {
+      name: "enrich_user",
+      description: "Get detailed profile data for a person",
+      inputs: [
+        {
+          name: "user_id",
+          type: "string",
+          description: "The LinkedIn user identifier returned by search_user",
+        },
+      ],
+    },
+  ],
+};
+
 const WORKSPACE_CONTEXT: WorkspaceContext = {
+  mcpDescriptions: [LINKEDIN_MCP_DESCRIPTION],
   tools: [
     mockTool("Slack", "Read and send Slack messages"),
     mockTool("Notion", "Search Notion workspace"),
@@ -20,6 +75,10 @@ const WORKSPACE_CONTEXT: WorkspaceContext = {
     mockTool(
       "Calendar",
       "Manage calendar events, check availability, and schedule meetings"
+    ),
+    mockTool(
+      "LinkedIn",
+      "Search and enrich company and people profiles from LinkedIn"
     ),
   ],
 };
@@ -360,6 +419,57 @@ Score 0 if no edit_skill with instructionEdits call is made.
 Score 0-1 if the suggestion is generic and doesn't address the specific feedback points.
 Score 2 if the suggestion addresses tone but misses the remedy guidance (or vice versa).
 Score 3 if the suggestion addresses both brand voice and remedy guidance with a clear analysis.`,
+    },
+    {
+      scenarioId: "wrong-tool-order-linkedin-enrich",
+      type: "analysis",
+      skillConfigs: [
+        {
+          name: "Enrich user info with LinkedIn",
+          sId: "skill_linkedin_enrich",
+          description:
+            "Enriches company and people profiles using LinkedIn data",
+          instructions:
+            "Use the LinkedIn tool to enrich user and company information when requested. Call enrich_user to get detailed profile data for a person, or enrich_company_data for company information.",
+          tools: [{ name: "LinkedIn", sId: "mcp_linkedin" }],
+        },
+      ],
+      conversation: [
+        {
+          role: "user",
+          content:
+            "Can you enrich the profile of René Cotty who works at Acme Corp?",
+        },
+        {
+          role: "agent",
+          content:
+            "I wasn't able to find René Cotty's profile. The LinkedIn enrichment returned no results for the ID I tried.",
+          actions: [
+            {
+              functionCallName: "enrich_user",
+              status: "succeeded",
+              params: { user_id: "rene-cotty" },
+              output: "User not found",
+            },
+          ],
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [
+        calledDescribeMcp("mcp_linkedin"),
+        editSkillWithInstructions("skill_linkedin_enrich"),
+      ],
+      judgeCriteria: `The analyst MUST call describe_mcp with mcpId "mcp_linkedin" AND call edit_skill with instructionEdits for skill "skill_linkedin_enrich".
+Adding instructions about how to form the user_id is not enough and will never work — the suggestion MUST be about using the search_user tool to look up the correct ID first.
+The suggestion should:
+- Add a step to first call search_user (or search_company) to retrieve the correct LinkedIn ID before calling enrich_user (or enrich_company_data)
+- Reference the enrich_user call returning "User not found" as the signal
+- Preserve the skill's purpose of enriching profiles
+
+Score 0 if describe_mcp("mcp_linkedin") was not called.
+Score 0 if no edit_skill with instructionEdits call is made.
+Score 1 if the analysis correctly identifies the root failure but does not add an instruction about using search_user.
+Score 3 if describe_mcp was called, and the suggestion clearly instructs to search first to obtain the correct ID, then call enrich with that ID.`,
     },
     {
       scenarioId: "multi-skill-targeted-feedback",


### PR DESCRIPTION
## Description

 - Add new MCP tools to describe a MCP in details (params, types and descriptions)
 - Add new reinforcement eval test to make it can correctly suggest improvment in tool usage

This is an example output of the new tool call
```
MCP: LinkedIn (mcp_linkedin)
Description: Search and enrich company and people profiles from LinkedIn

Tools:
- search_company
  Description: Search for a company on LinkedIn by name
  Input parameters:
    - company_name (string): The name of the company to search for
    
- search_user
  Description: Search for a person on LinkedIn by name
  Input parameters:
    - name (string): The full name of the person to search for
    
- enrich_company_data
  Description: Get detailed profile data for a company
  Input parameters:
    - company_id (string): The LinkedIn company identifier returned by search_company

- enrich_user
  Description: Get detailed profile data for a person
  Input parameters:
    - user_id (string): The LinkedIn user identifier returned by search_user
```

## Tests

```
 ✓ tests/reinforcement-evals/reinforcement-eval.test.ts (1 test) 26101ms
   ✓ Reinforced Skills Evaluation Tests (1)
     ✓ analyze-conversation (1)
       ✓ wrong-tool-order-linkedin-enrich  25792ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  16:59:16
   Duration  36.86s (transform 4.33s, setup 571ms, import 9.45s, tests 26.10s, environment 587ms)
```

## Risk

low

## Deploy Plan

deploy front
