### PR TITLE
Add Reinforced skill notification

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -114,7 +114,9 @@ export const FEEDBACK_DISTRIBUTION_LEGEND = [
 
 export type AnalyticsVisibleOrigin = Exclude<
   UserMessageOrigin,
-  "reinforced_agent_notification" | "reinforcement"
+  | "reinforced_agent_notification"
+  | "reinforced_skill_notification"
+  | "reinforcement"
 >;
 
 export const USER_MESSAGE_ORIGIN_LABELS: Record<

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -148,6 +148,7 @@ export const isHiddenMessage = (message: VirtuosoMessage): boolean => {
       (message.context.origin === "onboarding_conversation" ||
         message.context.origin === "project_kickoff" ||
         message.context.origin === "reinforced_agent_notification" ||
+        message.context.origin === "reinforced_skill_notification" ||
         isSidekickBootstrapMessage(message))) ||
     isHandoverUserMessage(message)
   );

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -522,6 +522,7 @@ export function isUserMessageContextValid(
     case "agent_sidekick":
     case "project_kickoff":
     case "reinforced_agent_notification":
+    case "reinforced_skill_notification":
     case "reinforcement":
     case "web":
       return false;

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -38,7 +38,10 @@ import {
 import type { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import { getAgentBuilderRoute } from "@app/lib/utils/router";
+import {
+  getAgentBuilderRoute,
+  getSkillBuilderRoute,
+} from "@app/lib/utils/router";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
@@ -314,6 +317,19 @@ function buildReinforcedAgentStaticResponse(
   ].join("\n");
 }
 
+function buildReinforcedSkillStaticResponse(
+  workspaceId: string,
+  skillName: string,
+  skillId: string
+): string {
+  const builderUrl = getSkillBuilderRoute(workspaceId, skillId);
+  return [
+    `Dust has analysed your workspace conversations using the ${skillName} skill and found suggestions to improve it.`,
+    `You can view and apply these suggestions by going to the [skill builder](${builderUrl}).`,
+    "Let me know if you have further questions.",
+  ].join("\n");
+}
+
 function _getDustLikeGlobalAgent(
   auth: Authenticator,
   {
@@ -358,11 +374,16 @@ function _getDustLikeGlobalAgent(
     globalAgentContext.userMessageRank <= 1;
   const isReinforcedAgentNotificationFirstTurn =
     isFirstUserMessage && globalAgentContext?.reinforcedAgentNotification;
+  const isReinforcedSkillNotificationFirstTurn =
+    isFirstUserMessage && globalAgentContext?.reinforcedSkillNotification;
+  const isReinforcedNotificationFirstTurn =
+    isReinforcedAgentNotificationFirstTurn ||
+    isReinforcedSkillNotificationFirstTurn;
 
   let isPreferredModel = false;
 
   const modelConfiguration = (() => {
-    if (isReinforcedAgentNotificationFirstTurn) {
+    if (isReinforcedNotificationFirstTurn) {
       return NOOP_MODEL_CONFIG;
     }
 
@@ -382,6 +403,30 @@ function _getDustLikeGlobalAgent(
     return getLargeWhitelistedModel(auth, excludeProviders);
   })();
 
+  const reinforcedStaticResponse = (() => {
+    if (
+      isReinforcedAgentNotificationFirstTurn &&
+      globalAgentContext?.reinforcedAgentNotification
+    ) {
+      return buildReinforcedAgentStaticResponse(
+        owner.sId,
+        globalAgentContext.reinforcedAgentNotification.agentName,
+        globalAgentContext.reinforcedAgentNotification.agentConfigurationId
+      );
+    }
+    if (
+      isReinforcedSkillNotificationFirstTurn &&
+      globalAgentContext?.reinforcedSkillNotification
+    ) {
+      return buildReinforcedSkillStaticResponse(
+        owner.sId,
+        globalAgentContext.reinforcedSkillNotification.skillName,
+        globalAgentContext.reinforcedSkillNotification.skillId
+      );
+    }
+    return undefined;
+  })();
+
   const model: AgentModelConfigurationType = modelConfiguration
     ? {
         providerId: modelConfiguration.providerId,
@@ -391,17 +436,11 @@ function _getDustLikeGlobalAgent(
           isPreferredModel && preferredReasoningEffort
             ? preferredReasoningEffort
             : modelConfiguration.defaultReasoningEffort,
-        ...(isReinforcedAgentNotificationFirstTurn &&
-          globalAgentContext?.reinforcedAgentNotification && {
-            metaData: {
-              staticResponse: buildReinforcedAgentStaticResponse(
-                owner.sId,
-                globalAgentContext.reinforcedAgentNotification.agentName,
-                globalAgentContext.reinforcedAgentNotification
-                  .agentConfigurationId
-              ),
-            },
-          }),
+        ...(reinforcedStaticResponse && {
+          metaData: {
+            staticResponse: reinforcedStaticResponse,
+          },
+        }),
       }
     : dummyModelConfiguration;
 

--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -36,6 +36,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   agent_sidekick: "user",
   project_kickoff: "user",
   reinforced_agent_notification: "user",
+  reinforced_skill_notification: "user",
   reinforcement: "user",
 };
 

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -85,6 +85,7 @@ describe("conversation-unread workflow business logic", () => {
     triggered_programmatic: false,
     zendesk: false,
     reinforced_agent_notification: false,
+    reinforced_skill_notification: false,
     reinforcement: false,
   };
   describe("shouldSendNotificationForAgentAnswer", () => {

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -77,6 +77,7 @@ export const shouldSendNotificationForAgentAnswer = (
     case "onboarding_conversation":
     case "agent_sidekick":
     case "reinforced_agent_notification":
+    case "reinforced_skill_notification":
     case "reinforcement":
       // Internal bootstrap conversations shouldn't trigger unread notifications.
       return false;

--- a/front/lib/notifications/workflows/skill-suggestions-ready.ts
+++ b/front/lib/notifications/workflows/skill-suggestions-ready.ts
@@ -1,0 +1,158 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { DustError } from "@app/lib/error";
+import { getNovuClient } from "@app/lib/notifications";
+import { getSkillBuilderRoute } from "@app/lib/utils/router";
+import logger from "@app/logger/logger";
+import { SKILL_SUGGESTIONS_READY_TRIGGER_ID } from "@app/types/notification_preferences";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { pluralize } from "@app/types/shared/utils/string_utils";
+import type { UserType } from "@app/types/user";
+import { workflow } from "@novu/framework";
+import z from "zod";
+
+const SkillSuggestionsReadyPayloadSchema = z.object({
+  workspaceId: z.string(),
+  skillId: z.string(),
+  skillName: z.string(),
+  suggestionCount: z.number(),
+});
+
+type SkillSuggestionsReadyPayloadType = z.infer<
+  typeof SkillSuggestionsReadyPayloadSchema
+>;
+
+export const skillSuggestionsReadyWorkflow = workflow(
+  SKILL_SUGGESTIONS_READY_TRIGGER_ID,
+  async ({ step, payload }) => {
+    await step.inApp("send-in-app", async () => {
+      return {
+        subject: payload.skillName,
+        body: `${payload.suggestionCount} new improvement suggestion${pluralize(payload.suggestionCount)} ready for review.`,
+        primaryAction: {
+          label: "Review",
+          redirect: {
+            url: getSkillBuilderRoute(payload.workspaceId, payload.skillId),
+          },
+        },
+        data: {
+          skillId: payload.skillId,
+          skillName: payload.skillName,
+        },
+      };
+    });
+  },
+  {
+    payloadSchema: SkillSuggestionsReadyPayloadSchema,
+    tags: ["admin"],
+  }
+);
+
+const triggerSkillSuggestionsReadyNotifications = async (
+  auth: Authenticator,
+  {
+    skillId,
+    skillName,
+    editors,
+    suggestionCount,
+  }: {
+    skillId: string;
+    skillName: string;
+    editors: UserType[];
+    suggestionCount: number;
+  }
+): Promise<Result<void, DustError<"internal_error">>> => {
+  if (suggestionCount === 0) {
+    return new Ok(undefined);
+  }
+
+  if (editors.length === 0) {
+    logger.info(
+      { skillId },
+      "No editors found for skill, skipping suggestions ready notification"
+    );
+    return new Ok(undefined);
+  }
+
+  try {
+    const novuClient = await getNovuClient();
+
+    const payload: SkillSuggestionsReadyPayloadType = {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      skillId,
+      skillName,
+      suggestionCount,
+    };
+
+    const r = await novuClient.triggerBulk({
+      events: editors.map((editor) => ({
+        workflowId: SKILL_SUGGESTIONS_READY_TRIGGER_ID,
+        to: {
+          subscriberId: editor.sId,
+          email: editor.email,
+          firstName: editor.firstName ?? undefined,
+          lastName: editor.lastName ?? undefined,
+        },
+        payload,
+      })),
+    });
+
+    if (r.result.some((res) => !!res.error?.length)) {
+      const eventErrors = r.result
+        .filter((res) => !!res.error?.length)
+        .map(({ error }) => error?.join("; "))
+        .join("; ");
+      return new Err({
+        name: "dust_error",
+        code: "internal_error",
+        message: `Failed to trigger skill suggestions ready notification: ${eventErrors}`,
+      });
+    }
+  } catch (err) {
+    return new Err({
+      name: "dust_error",
+      code: "internal_error",
+      message: "Failed to trigger skill suggestions ready notification",
+      cause: normalizeError(err),
+    });
+  }
+
+  return new Ok(undefined);
+};
+
+/**
+ * Fire-and-forget helper to notify skill editors that reinforcement suggestions are ready.
+ * Errors are logged but don't block the caller.
+ */
+export function notifySkillSuggestionsReady(
+  auth: Authenticator,
+  {
+    skillId,
+    skillName,
+    editors,
+    suggestionCount,
+  }: {
+    skillId: string;
+    skillName: string;
+    editors: UserType[];
+    suggestionCount: number;
+  }
+): void {
+  void triggerSkillSuggestionsReadyNotifications(auth, {
+    skillId,
+    skillName,
+    editors,
+    suggestionCount,
+  }).then((notifRes) => {
+    if (notifRes.isErr()) {
+      logger.error(
+        {
+          error: notifRes.error,
+          skillId,
+        },
+        "Failed to trigger skill suggestions ready notification"
+      );
+    }
+  });
+}

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -11,6 +11,7 @@ import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinf
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -335,12 +336,15 @@ export async function createSkillSuggestionsConversations(
     return;
   }
 
-  for (const editor of editors) {
-    await ConversationResource.upsertParticipation(auth, {
-      conversation,
-      action: "posted",
-      user: editor,
-      lastReadAt: null,
-    });
-  }
+  await concurrentExecutor(
+    editors,
+    (editor) =>
+      ConversationResource.upsertParticipation(auth, {
+        conversation,
+        action: "posted",
+        user: editor,
+        lastReadAt: null,
+      }),
+    { concurrency: 8 }
+  );
 }

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -1,13 +1,22 @@
+import {
+  createConversation,
+  postNewContentFragment,
+  postUserMessage,
+} from "@app/lib/api/assistant/conversation";
+import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { formatSkillContext } from "@app/lib/reinforcement/format_skill_context";
 import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinforced_analysis";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import logger from "@app/logger/logger";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
-import { escapeXml } from "@app/types/shared/utils/string_utils";
+import { escapeXml, pluralize } from "@app/types/shared/utils/string_utils";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+import type { UserType } from "@app/types/user";
 
 const AGGREGATION_ASSEMBLY_ORDER = [
   "primary",
@@ -210,4 +219,128 @@ export async function buildSkillAggregationBatchMap(
   }
 
   return new Map([["aggregation", buildReinforcedSkillsLLMParams(ctx.prompt)]]);
+}
+
+/**
+ * Create a conversation with the pending suggestions for the skill editors.
+ */
+export async function createSkillSuggestionsConversations(
+  auth: Authenticator,
+  skill: SkillResource,
+  editors: UserType[]
+): Promise<void> {
+  if (editors.length === 0) {
+    return;
+  }
+
+  const skillType = skill.toJSON(auth);
+
+  const pendingSuggestions =
+    await SkillSuggestionResource.listBySkillConfigurationId(
+      auth,
+      skillType.sId,
+      { sources: ["reinforcement"], states: ["pending"] }
+    );
+
+  if (pendingSuggestions.length === 0) {
+    return;
+  }
+
+  const formattedSuggestions = formatSuggestions(
+    pendingSuggestions.map((s) => s.toJSON())
+  );
+
+  const conversationTitle = `Reinforced suggestions for ${skillType.name} skill`;
+  const conversation = await createConversation(auth, {
+    title: conversationTitle,
+    visibility: "unlisted",
+    spaceId: null,
+    metadata: {
+      reinforcedSkillNotification: {
+        skillName: skillType.name,
+        skillId: skillType.sId,
+      },
+    },
+  });
+
+  const contentFragmentRes = await toFileContentFragment(auth, {
+    contentFragment: {
+      title: `${pendingSuggestions.length} pending suggestions for ${skillType.name} skill`,
+      content: formattedSuggestions,
+      contentType: "text/plain",
+      url: null,
+    },
+    fileName: "suggestions.txt",
+  });
+
+  if (contentFragmentRes.isErr()) {
+    logger.error(
+      {
+        skillId: skillType.sId,
+        error: contentFragmentRes.error.message,
+      },
+      "ReinforcedSkills: failed to create content fragment for suggestions conversation"
+    );
+    return;
+  }
+
+  const author = editors[0];
+
+  const contentFragmentPostRes = await postNewContentFragment(
+    auth,
+    conversation,
+    contentFragmentRes.value,
+    {
+      username: author.username,
+      fullName: author.fullName,
+      email: author.email,
+      profilePictureUrl: author.image,
+    }
+  );
+
+  if (contentFragmentPostRes.isErr()) {
+    logger.error(
+      {
+        skillId: skillType.sId,
+        error: contentFragmentPostRes.error.message,
+      },
+      "ReinforcedSkills: failed to post content fragment for suggestions conversation"
+    );
+    return;
+  }
+
+  const messageRes = await postUserMessage(auth, {
+    conversation,
+    content: `Here are ${pendingSuggestions.length} pending improvement${pluralize(pendingSuggestions.length)} suggestions for the ${skillType.name} skill.`,
+    mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
+    context: {
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
+      username: author.username,
+      fullName: author.fullName,
+      email: author.email,
+      profilePictureUrl: author.image,
+      origin: "reinforced_skill_notification",
+    },
+    skipToolsValidation: true,
+  });
+
+  if (messageRes.isErr()) {
+    logger.error(
+      {
+        skillId: skillType.sId,
+        error: messageRes.error.api_error.message,
+      },
+      "ReinforcedSkills: failed to post user message for suggestions conversation"
+    );
+    return;
+  }
+
+  for (const editor of editors) {
+    await ConversationResource.upsertParticipation(auth, {
+      conversation,
+      action: "posted",
+      user: editor,
+      lastReadAt: null,
+    });
+  }
 }

--- a/front/pages/api/novu/index.ts
+++ b/front/pages/api/novu/index.ts
@@ -5,6 +5,7 @@ import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/con
 import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/project-added-as-member";
 import { projectNewConversationWorkflow } from "@app/lib/notifications/workflows/project-new-conversation";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
+import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
 import { serve } from "@novu/framework/next";
 
 // This endpoint exposes our code-based notifications workflows to the Novu platform.
@@ -17,6 +18,7 @@ export default serve({
     conversationUnreadWorkflow,
     agentMessageFeedbackWorkflow,
     agentSuggestionsReadyWorkflow,
+    skillSuggestionsReadyWorkflow,
     projectAddedAsMemberWorkflow,
     projectNewConversationWorkflow,
     providerCredentialsHealthUpdatedWorkflow,

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -11,6 +11,7 @@ import type { BatchStatus } from "@app/lib/api/llm/types/batch";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
+import { notifySkillSuggestionsReady } from "@app/lib/notifications/workflows/skill-suggestions-ready";
 import {
   prepareReinforcedToolActions,
   type ReinforcedToolActionInfo,
@@ -23,6 +24,7 @@ import {
 import {
   buildSkillAggregationBatchMap,
   buildSkillAggregationSystemPrompt,
+  createSkillSuggestionsConversations,
   loadSkillAggregationContext,
 } from "@app/lib/reinforcement/aggregate_suggestions";
 import {
@@ -490,6 +492,20 @@ export async function finalizeSkillAggregationActivity({
     throw new Error(`Skill not found: ${skillId}`);
   }
   await skill.recordReinforcementAnalysisCompletion();
+
+  if (suggestionsCreated > 0 && !disableNotifications) {
+    const skillType = skill.toJSON(auth);
+    const editors = (await skill.listEditors(auth)) ?? [];
+    const editorTypes = editors.map((e) => e.toJSON());
+
+    notifySkillSuggestionsReady(auth, {
+      skillId: skillType.sId,
+      skillName: skillType.name,
+      editors: editorTypes,
+      suggestionCount: suggestionsCreated,
+    });
+    await createSkillSuggestionsConversations(auth, skill, editorTypes);
+  }
 
   logger.info(
     {

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -10,7 +10,7 @@ import {
 import type { BatchStatus } from "@app/lib/api/llm/types/batch";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { notifySkillSuggestionsReady } from "@app/lib/notifications/workflows/skill-suggestions-ready";
 import {
   prepareReinforcedToolActions,
@@ -493,7 +493,9 @@ export async function finalizeSkillAggregationActivity({
   }
   await skill.recordReinforcementAnalysisCompletion();
 
-  if (suggestionsCreated > 0 && !disableNotifications) {
+  const hasReinforcementUi = await hasFeatureFlag(auth, "reinforcement_ui");
+
+  if (suggestionsCreated > 0 && !disableNotifications && hasReinforcementUi) {
     const skillType = skill.toJSON(auth);
     const editors = (await skill.listEditors(auth)) ?? [];
     const editorTypes = editors.map((e) => e.toJSON());

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -16,6 +16,7 @@ const UserMessageOriginSchema = t.union([
   t.literal("project_kickoff"),
   t.literal("extension"),
   t.literal("reinforced_agent_notification"),
+  t.literal("reinforced_skill_notification"),
 ]);
 
 export const MessageBaseSchema = t.type({

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -167,6 +167,10 @@ export type GlobalAgentContext = {
     agentName: string;
     agentConfigurationId: string;
   };
+  reinforcedSkillNotification?: {
+    skillName: string;
+    skillId: string;
+  };
 };
 
 export const LightAgentConfigurationSchema = z.object({

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -42,6 +42,20 @@ function isReinforcedAgentNotificationMetadata(
   );
 }
 
+function isReinforcedSkillNotificationMetadata(
+  value: unknown
+): value is { skillName: string; skillId: string } {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  return (
+    "skillName" in value &&
+    typeof value.skillName === "string" &&
+    "skillId" in value &&
+    typeof value.skillId === "string"
+  );
+}
+
 /**
  * Error types for getAgentLoopData that indicate soft-deleted resources.
  * These are safe to ignore in callers since the resource was intentionally deleted.
@@ -328,12 +342,21 @@ export async function getAgentLoopDataWithAuth(
     ? reinforcedMeta
     : undefined;
 
+  const reinforcedSkillMeta =
+    conversation.metadata?.reinforcedSkillNotification;
+  const reinforcedSkillNotification = isReinforcedSkillNotificationMetadata(
+    reinforcedSkillMeta
+  )
+    ? reinforcedSkillMeta
+    : undefined;
+
   const globalAgentContext: GlobalAgentContext = {
     userMessageRank: userMessage.rank,
     sidekickIsNewAgentFromScratch:
       conversation.metadata?.sidekickIsNewAgentFromScratch === true ||
       undefined,
     reinforcedAgentNotification,
+    reinforcedSkillNotification,
   };
 
   // As the agent configuration is never supposed to change during a loop, we can cache it for a long time.

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -81,7 +81,8 @@ export type ClientMessageOrigin =
   | "project_kickoff"
   | "extension"
   | "agent_sidekick"
-  | "reinforced_agent_notification";
+  | "reinforced_agent_notification"
+  | "reinforced_skill_notification";
 
 export type UserMessageOrigin =
   // "api" is Custom API usage, while e.g. extension, gsheets and many other origins

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -119,6 +119,8 @@ export const PROJECT_NEW_CONVERSATION_TRIGGER_ID =
   "project-new-conversation" as const;
 export const AGENT_SUGGESTIONS_READY_TRIGGER_ID =
   "agent-suggestions-ready" as const;
+export const SKILL_SUGGESTIONS_READY_TRIGGER_ID =
+  "skill-suggestions-ready" as const;
 export const PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID =
   "provider-credentials-health-updated" as const;
 export const PROVIDER_CREDENTIALS_HEALTH_UPDATED_TAG =
@@ -129,4 +131,5 @@ export type WorkflowTriggerId =
   | typeof PROJECT_ADDED_AS_MEMBER_TRIGGER_ID
   | typeof PROJECT_NEW_CONVERSATION_TRIGGER_ID
   | typeof AGENT_SUGGESTIONS_READY_TRIGGER_ID
+  | typeof SKILL_SUGGESTIONS_READY_TRIGGER_ID
   | typeof PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -343,6 +343,7 @@ const USER_MESSAGE_ORIGINS = [
   "agent_sidekick",
   "project_kickoff",
   "reinforced_agent_notification",
+  "reinforced_skill_notification",
   "reinforcement",
 ] as const;
 


### PR DESCRIPTION
## Description

- Add notification system for Reinforced skills, matching the existing agent reinforcement notification pattern
- When skill aggregation produces suggestions, skill editors receive a Novu in-app notification and an auto-created conversation with a @Dust static response linking to the skill builder
- The user message in the notification conversation is hidden (matching agent notification behavior)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Under flag

## Deploy Plan

Front