### PR TITLE
Global agents: janitorial clean-up

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/anthropic.ts
+++ b/front/lib/api/assistant/global_agents/configurations/anthropic.ts
@@ -16,8 +16,8 @@ import {
   CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG,
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
-  CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
   CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 
 /**
@@ -330,11 +330,11 @@ export function _getClaude4_5SonnetGlobalAgent({
     scope: "global",
     userFavorite: false,
     model: {
-      providerId: CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG.providerId,
-      modelId: CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG.modelId,
+      providerId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.providerId,
+      modelId: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.modelId,
       temperature: 0.7,
       reasoningEffort:
-        CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
+        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
     },
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({

--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -334,11 +334,7 @@ export function _getGPT5NanoGlobalAgent({
   settings: GlobalAgentSettingsModel | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
-  let status: AgentConfigurationStatus = "active";
-
-  if (settings) {
-    status = settings.status;
-  }
+  let status = settings?.status ?? "disabled_by_admin";
   if (!auth.isUpgraded()) {
     status = "disabled_free_workspace";
   }

--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -395,11 +395,7 @@ export function _getO3MiniGlobalAgent({
   settings: GlobalAgentSettingsModel | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
-  let status: AgentConfigurationStatus = "active";
-
-  if (settings) {
-    status = settings.status;
-  }
+  let status = settings?.status ?? "disabled_by_admin";
   if (!auth.isUpgraded()) {
     status = "disabled_free_workspace";
   }

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -10,8 +10,8 @@ import {
   CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG,
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
-  CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
   CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import { GEMINI_2_5_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 import {
@@ -160,8 +160,8 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
     case GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET:
       return {
         sId: GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET,
-        name: "claude-4.5-sonnet",
-        description: CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG.description,
+        name: "claude-sonnet",
+        description: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.description,
         pictureUrl:
           "https://dust.tt/static/systemavatar/claude_avatar_full.png",
       };

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -168,7 +168,7 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
     case GLOBAL_AGENTS_SID.CLAUDE_4_5_HAIKU:
       return {
         sId: GLOBAL_AGENTS_SID.CLAUDE_4_5_HAIKU,
-        name: "claude-4.5-haiku",
+        name: "claude-haiku",
         description: CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG.description,
         pictureUrl:
           "https://dust.tt/static/systemavatar/claude_avatar_full.png",

--- a/front/types/assistant/models/mistral.ts
+++ b/front/types/assistant/models/mistral.ts
@@ -18,7 +18,7 @@ export const MISTRAL_LARGE_MODEL_CONFIG: ModelConfigurationType = {
   recommendedTopK: 16,
   recommendedExhaustiveTopK: 56, // 28_672
   largeModel: true,
-  description: "Mistral's `large 3` model (256k context).",
+  description: "Mistral's `large` model (256k context).",
   shortDescription: "Mistral's large model.",
   isLegacy: false,
   isLatest: true,


### PR DESCRIPTION
## Description

- Rename "claude-4.5-sonnet" global agent to "claude-sonnet" and upgrade its underlying model from Claude 4.5 Sonnet (`claude-sonnet-4-5-20250929`) to Claude Sonnet 4.6 (`claude-sonnet-4-6`).
- Default o3-mini global agent to `disabled_by_admin` (agent kept for backward compat with existing conversations).

## Tests

N/A, tested locally

## Risk

Low. Model upgrade for claude-sonnet, disable for o3-mini.

## Deploy Plan

- deploy `front`