### PR TITLE
Add isProviderWhitelisted check to compaction

### DIFF
--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -61,6 +61,7 @@ import { compactConversation } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { isProviderWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import { isSupportedModel } from "@app/types/assistant/assistant";
@@ -126,6 +127,16 @@ async function handler(
           api_error: {
             type: "invalid_request_error",
             message: `Unsupported model: ${model.providerId}/${model.modelId}.`,
+          },
+        });
+      }
+
+      if (!isProviderWhitelisted(auth, model.providerId)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "model_disabled",
+            message: `The model provider ${model.providerId} has been disabled by your workspace admin.`,
           },
         });
       }

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -5,6 +5,7 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
+import { isProviderWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type {
@@ -116,6 +117,14 @@ export async function runCompaction(
 
   if (!compactionMessage) {
     return new Err(new Error("Compaction message not found"));
+  }
+
+  if (!isProviderWhitelisted(auth, model.providerId)) {
+    return new Err(
+      new Error(
+        `The model provider ${model.providerId} has been disabled by your workspace admin.`
+      )
+    );
   }
 
   const summaryRes = await generateCompactionSummary(auth, {


### PR DESCRIPTION
## Description

Follow-up from [#24111 review comment](https://github.com/dust-tt/dust/pull/24111/files#r3080381457).

Validates that the model provider is whitelisted before triggering compaction:
- **API endpoint** (`compactions.ts`): returns 400 `model_disabled` if the provider is not whitelisted.
- **Temporal workflow** (`compaction.ts`): fails the compaction with an error if the provider was disabled between the API call and workflow execution.

## Tests

Existing tests, manual verification.

## Risk

None

## Deploy Plan

- deploy `front`