### PR TITLE
Fix migration script

### DIFF
--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -742,7 +742,7 @@ const PACKAGES: PackageDef[] = [
   {
     name: "Legacy Enterprise USD",
     aliases: [{ name: "legacy-enterprise" }],
-    rate_card_name: "Legacy Enterprise USD",
+    rate_card_name: "Legacy Enterprise MAU USD",
     ...BILLING_CYCLE_CONFIG,
   },
   // EUR variants
@@ -770,7 +770,7 @@ const PACKAGES: PackageDef[] = [
   {
     name: "Legacy Enterprise EUR",
     aliases: [{ name: "legacy-enterprise-eur" }],
-    rate_card_name: "Legacy Enterprise EUR",
+    rate_card_name: "Legacy Enterprise MAU EUR",
     ...BILLING_CYCLE_CONFIG,
   },
 ];
@@ -1366,6 +1366,12 @@ interface ExistingPackage {
 function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
   // Check rate card cascade
   if (recreated.rateCards.has(desired.rate_card_name)) {
+    return false;
+  }
+
+  // Check rate card ID matches the expected one.
+  const expectedRateCardId = ids.rateCards[desired.rate_card_name];
+  if (expectedRateCardId && ex.rate_card_id !== expectedRateCardId) {
     return false;
   }
 

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -22,6 +22,7 @@ import {
   getMetronomeClient,
 } from "@app/lib/metronome/client";
 import {
+  applyEnterpriseOverrides,
   buildEnterpriseOverrides,
   type EnterprisePricingCents,
   extractEnterprisePricing,
@@ -353,12 +354,12 @@ async function migrateWorkspace(
     );
   }
 
-  // Create new contract with enterprise overrides (if any).
+  // Create new contract, then apply enterprise overrides if needed.
+  // Metronome does not allow overrides in v1.contracts.create when using a package.
   const newContract = await client.v1.contracts.create({
     customer_id: metronomeCustomerId,
     package_alias: targetAlias,
     starting_at: subInfo.startDate,
-    ...enterpriseOverrides,
   });
   const newContractId = newContract.data.id;
 
@@ -366,6 +367,17 @@ async function migrateWorkspace(
     { workspaceId: workspace.sId, contractId: newContractId, targetAlias },
     "New contract created"
   );
+
+  if (enterpriseOverrides) {
+    await applyEnterpriseOverrides({
+      metronomeCustomerId,
+      contractId: newContractId,
+      pricing: subInfo.enterprisePricing!,
+      startDate: subInfo.startDate,
+      overrideLogger: logger,
+      workspaceId: workspace.sId,
+    });
+  }
 
   // Sync subscriptions: seats for pro/business, MAU for enterprise.
   if (isEnterprise) {


### PR DESCRIPTION
## Summary

Fix migration script: Metronome does not allow `overrides` or `recurring_commits` in `v1.contracts.create` when a `package_alias` is provided. The API returns:

> "When package_id or package_alias is provided, only customer_id, starting_at, package_id, package_alias, uniqueness_key, transition are allowed."

Changed to a two-step approach: create the contract first, then apply enterprise overrides via `v2.contracts.edit`.

The dry-run logging still uses `buildEnterpriseOverrides` to show what will be applied.

## Test plan

- [ ] Dry-run migration script on sandbox — verify overrides logged correctly
- [ ] Execute on a single enterprise workspace — verify contract created and overrides applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)