### PR TITLE
[Agent Loop] Abort tool activities on worker shutdown

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -87,6 +87,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { isInShutdown } from "@app/lib/shutdown_signal";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
@@ -115,6 +116,9 @@ const MCP_NOTIFICATION_EVENT_NAME = "mcp-notification";
 const MCP_TOOL_DONE_EVENT_NAME = "TOOL_DONE" as const;
 const MCP_TOOL_ERROR_EVENT_NAME = "TOOL_ERROR" as const;
 const MCP_TOOL_HEARTBEAT_EVENT_NAME = "TOOL_HEARTBEAT" as const;
+const TOOL_EXECUTION_CANCELLED_MESSAGE = "The tool execution was cancelled.";
+const TOOL_EXECUTION_INTERRUPTED_MESSAGE =
+  "A tool was interrupted before Dust could confirm the result. Please check whether it completed, then retry.";
 
 const EMPTY_INPUT_SCHEMA: JSONSchema = {
   properties: {},
@@ -528,7 +532,9 @@ export async function* tryCallMCPTool(
     } catch (toolError) {
       if (abortSignal?.aborted) {
         return makeMCPToolExit({
-          message: "The tool execution was cancelled.",
+          message: isInShutdown()
+            ? TOOL_EXECUTION_INTERRUPTED_MESSAGE
+            : TOOL_EXECUTION_CANCELLED_MESSAGE,
           isError: true,
         });
       }

--- a/front/lib/shutdown_signal.ts
+++ b/front/lib/shutdown_signal.ts
@@ -2,8 +2,9 @@
  * Global shutdown signal for coordinating graceful pod termination.
  *
  * This module tracks whether the pod is shutting down to coordinate between:
- * - The prestop hook
- * - The readiness probe
+ * - The prestop hook (which signals shutdown)
+ * - The readiness probe (which should fail when shutting down)
+ * - Connection draining (which needs the pod to stay alive)
  * - Worker shutdown handlers
  */
 
@@ -14,6 +15,10 @@ const shutdownController = new AbortController();
  * Marks the pod as shutting down.
  */
 export function markShuttingDown(): void {
+  if (isShuttingDown) {
+    return;
+  }
+
   isShuttingDown = true;
   shutdownController.abort();
 }

--- a/front/lib/shutdown_signal.ts
+++ b/front/lib/shutdown_signal.ts
@@ -2,19 +2,20 @@
  * Global shutdown signal for coordinating graceful pod termination.
  *
  * This module tracks whether the pod is shutting down to coordinate between:
- * - The prestop hook (which signals shutdown)
- * - The readiness probe (which should fail when shutting down)
- * - Connection draining (which needs the pod to stay alive)
+ * - The prestop hook
+ * - The readiness probe
+ * - Worker shutdown handlers
  */
 
 let isShuttingDown = false;
+const shutdownController = new AbortController();
 
 /**
  * Marks the pod as shutting down.
- * This should be called by the prestop hook to signal that the pod is terminating.
  */
 export function markShuttingDown(): void {
   isShuttingDown = true;
+  shutdownController.abort();
 }
 
 /**
@@ -23,4 +24,8 @@ export function markShuttingDown(): void {
  */
 export function isInShutdown(): boolean {
   return isShuttingDown;
+}
+
+export function getShutdownSignal(): AbortSignal {
+  return shutdownController.signal;
 }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -68,27 +68,6 @@ function extractDataSourceIds(
   return result;
 }
 
-function mergeAbortSignals(...signals: AbortSignal[]): AbortSignal {
-  const controller = new AbortController();
-
-  for (const signal of signals) {
-    if (signal.aborted) {
-      controller.abort(signal.reason);
-      return controller.signal;
-    }
-
-    signal.addEventListener(
-      "abort",
-      () => {
-        controller.abort(signal.reason);
-      },
-      { once: true }
-    );
-  }
-
-  return controller.signal;
-}
-
 export async function runToolActivity(
   authType: AuthenticatorType,
   {
@@ -214,10 +193,10 @@ async function executeToolStreaming(
     step: number;
   }
 ): Promise<ToolExecutionResult> {
-  const abortSignal = mergeAbortSignals(
+  const abortSignal = AbortSignal.any([
     Context.current().cancellationSignal,
-    getShutdownSignal()
-  );
+    getShutdownSignal(),
+  ]);
 
   const eventStream = runToolWithStreaming(
     auth,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -9,6 +9,7 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { getShutdownSignal } from "@app/lib/shutdown_signal";
 import logger from "@app/logger/logger";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
@@ -65,6 +66,27 @@ function extractDataSourceIds(
       .join(",");
   }
   return result;
+}
+
+function mergeAbortSignals(...signals: AbortSignal[]): AbortSignal {
+  const controller = new AbortController();
+
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      return controller.signal;
+    }
+
+    signal.addEventListener(
+      "abort",
+      () => {
+        controller.abort(signal.reason);
+      },
+      { once: true }
+    );
+  }
+
+  return controller.signal;
 }
 
 export async function runToolActivity(
@@ -192,7 +214,10 @@ async function executeToolStreaming(
     step: number;
   }
 ): Promise<ToolExecutionResult> {
-  const abortSignal = Context.current().cancellationSignal;
+  const abortSignal = mergeAbortSignals(
+    Context.current().cancellationSignal,
+    getShutdownSignal()
+  );
 
   const eventStream = runToolWithStreaming(
     auth,

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -3,6 +3,7 @@ import {
   resource,
 } from "@app/lib/api/instrumentation/init";
 import { NoopSpanExporter } from "@app/lib/api/instrumentation/noop_span_exporter";
+import { markShuttingDown } from "@app/lib/shutdown_signal";
 import { getTemporalAgentWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
@@ -106,7 +107,10 @@ export async function runAgentLoopWorker() {
   });
 
   // TODO(2025-11-12 INSTRUMENTATION): Drain Langfuse data before shutdown.
-  process.on("SIGTERM", () => worker.shutdown());
+  process.on("SIGTERM", () => {
+    markShuttingDown();
+    void worker.shutdown();
+  });
 
   try {
     await worker.run(); // this resolves after shutdown completes


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7458
Follows https://github.com/dust-tt/dust/pull/24165 and https://github.com/dust-tt/dust/pull/24169

Marks the shared shutdown signal on agent-loop worker SIGTERM and merges it into runToolActivity's abort signal, so deploy-time pod termination can abort in-flight tool calls before the pod is killed.

When the abort comes from worker shutdown, the tool returns an in-band interruption message instead of falling through to a heartbeat-timeout workflow failure.

## Risks
Blast radius: agent-loop tool executions interrupted by front-agent-loop-worker deploys or pod shutdowns.
Risk: low

## Deploy Plan
- pmrr
- deploy front