### PR TITLE
Fix: count of allowed results for search / inclusion.

### DIFF
--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -35,14 +35,17 @@ export function getRetrievalTopK({
   const searchActions = stepActions.filter(
     (tool) =>
       isServerSideMCPToolConfigurationWithName(tool, "search") ||
-      isServerSideMCPToolConfigurationWithName(tool, "conversation_files") ||
-      isServerSideMCPToolConfigurationWithName(tool, "project_manager")
+      (isServerSideMCPToolConfigurationWithName(tool, "conversation_files") &&
+        tool.originalName === "semantic_search") ||
+      (isServerSideMCPToolConfigurationWithName(tool, "project_manager") &&
+        tool.originalName === "semantic_search")
   );
 
   const includeActions = stepActions.filter(
     (tool) =>
       isServerSideMCPToolConfigurationWithName(tool, "include_data") ||
-      isServerSideMCPToolConfigurationWithName(tool, "project_manager")
+      (isServerSideMCPToolConfigurationWithName(tool, "project_manager") &&
+        tool.originalName === "retrieve_recent_documents")
   );
   const dsFsActions = stepActions.filter((tool) =>
     isServerSideMCPToolConfigurationWithName(tool, "data_sources_file_system")


### PR DESCRIPTION
## Description

`getRetrievalTopK` was counting any `project_manager` tool call as both a search action and an include action, regardless of which specific tool was being invoked. Since `project_manager` now hosts many tools (`create_conversation`, `list_projects`, `semantic_search`, `retrieve_recent_documents`, etc.), this inflated both counters on every project tool use and incorrectly shrunk the topK budget for actual search and include results.

- Narrow the search filter to only count `project_manager` and `conversation_files` calls where `originalName === "semantic_search"`
- Narrow the include filter to only count `project_manager` calls where `originalName === "retrieve_recent_documents"`

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`
