### PR TITLE
Move todo workflow to a schedule.

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -95,10 +95,6 @@ import {
   launchAgentLoopWorkflow,
   launchCompactionWorkflow,
 } from "@app/temporal/agent_loop/client";
-import {
-  launchOrSignalProjectTodoWorkflow,
-  signalProjectTodoComplete,
-} from "@app/temporal/project_todo/client";
 import type {
   ContentFragmentInputWithContentNode,
   ContentFragmentInputWithFileIdType,
@@ -1059,23 +1055,6 @@ export async function postUserMessage(
       : Promise.resolve(undefined),
   ]);
 
-  if (isPartOfProject) {
-    const projectTodoParams = {
-      authType: auth.toJSON(),
-      spaceId: conversation.spaceId,
-      conversationId: conversation.sId,
-      messageId: userMessage.sId,
-    };
-
-    if (featureFlags.includes("project_todo")) {
-      void launchOrSignalProjectTodoWorkflow(projectTodoParams);
-
-      if (agentMessages.length === 0) {
-        void signalProjectTodoComplete(projectTodoParams);
-      }
-    }
-  }
-
   return new Ok({
     userMessage,
     agentMessages,
@@ -1391,24 +1370,6 @@ export async function editUserMessage(
     },
     agentMessages
   );
-
-  const featureFlags = await getFeatureFlags(auth);
-  if (isProjectConversation(conversation)) {
-    const projectTodoParams = {
-      authType: auth.toJSON(),
-      spaceId: conversation.spaceId,
-      conversationId: conversation.sId,
-      messageId: userMessage.sId,
-    };
-
-    if (featureFlags.includes("project_todo")) {
-      void launchOrSignalProjectTodoWorkflow(projectTodoParams);
-
-      if (agentMessages.length === 0) {
-        void signalProjectTodoComplete(projectTodoParams);
-      }
-    }
-  }
 
   return new Ok({
     userMessage,
@@ -1890,20 +1851,6 @@ export async function retryAgentMessage(
     startStep: 0,
   });
 
-  const featureFlags = await getFeatureFlags(auth);
-  if (isProjectConversation(conversation)) {
-    const projectTodoParams = {
-      authType: auth.toJSON(),
-      spaceId: conversation.spaceId,
-      conversationId: conversation.sId,
-      messageId: agentMessage.sId,
-    };
-
-    if (featureFlags.includes("project_todo")) {
-      void launchOrSignalProjectTodoWorkflow(projectTodoParams);
-    }
-  }
-
   // TODO(DURABLE-AGENTS 2025-07-17): Publish message events to all open tabs to maintain
   // conversation state synchronization in multiplex mode. This is a temporary solution -
   // we should move this to a dedicated real-time sync mechanism.
@@ -2115,21 +2062,6 @@ export async function postNewContentFragment(
     conversationId: conversation.sId,
     message: messageRow,
   });
-
-  const featureFlags = await getFeatureFlags(auth);
-  if (isProjectConversation(conversation)) {
-    const projectTodoParams = {
-      authType: auth.toJSON(),
-      spaceId: conversation.spaceId,
-      conversationId: conversation.sId,
-      messageId,
-    };
-
-    if (featureFlags.includes("project_todo")) {
-      void launchOrSignalProjectTodoWorkflow(projectTodoParams);
-      void signalProjectTodoComplete(projectTodoParams);
-    }
-  }
 
   return new Ok(render);
 }

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -2,7 +2,7 @@ import { hardDeleteApp } from "@app/lib/api/apps";
 import { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent_requirements";
 import { createDataSourceAndConnectorForProject } from "@app/lib/api/projects/connector";
 import { getWorkspaceAdministrationVersionLock } from "@app/lib/api/workspace";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -24,6 +24,10 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import { launchScrubSpaceWorkflow } from "@app/poke/temporal/client";
+import {
+  launchOrSignalProjectTodoWorkflow,
+  stopProjectTodoWorkflow,
+} from "@app/temporal/project_todo/client";
 import type { AgentsUsageType } from "@app/types/data_source";
 import {
   PROJECT_EDITOR_GROUP_PREFIX,
@@ -267,6 +271,17 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
     await launchScrubSpaceWorkflow(auth, space);
   });
 
+  if (space.isProject()) {
+    const featureFlags = await getFeatureFlags(auth);
+    if (featureFlags.includes("project_todo")) {
+      void stopProjectTodoWorkflow({
+        authType: auth.toJSON(),
+        spaceId: space.sId,
+        stopReason: "project deleted",
+      });
+    }
+  }
+
   return new Ok(undefined);
 }
 
@@ -351,6 +366,17 @@ export async function hardDeleteSpace(
       throw res.error;
     }
   });
+
+  if (space.isProject()) {
+    const featureFlags = await getFeatureFlags(auth);
+    if (featureFlags.includes("project_todo")) {
+      void stopProjectTodoWorkflow({
+        authType: auth.toJSON(),
+        spaceId: space.sId,
+        stopReason: "project hard deleted",
+      });
+    }
+  }
 
   return new Ok(undefined);
 }
@@ -601,6 +627,14 @@ export async function createSpaceAndGroup(
         );
         // Don't fail space creation if connector creation fails
         // The connector can be created later if needed
+      }
+
+      const featureFlags = await getFeatureFlags(auth);
+      if (featureFlags.includes("project_todo")) {
+        void launchOrSignalProjectTodoWorkflow({
+          authType: auth.toJSON(),
+          spaceId: space.sId,
+        });
       }
     }
   }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -1,10 +1,26 @@
 import { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockLaunchOrSignalProjectTodoWorkflow, mockStopProjectTodoWorkflow } =
+  vi.hoisted(() => ({
+    mockLaunchOrSignalProjectTodoWorkflow: vi.fn(),
+    mockStopProjectTodoWorkflow: vi.fn(),
+  }));
+
+vi.mock("@app/temporal/project_todo/client", () => ({
+  launchOrSignalProjectTodoWorkflow: mockLaunchOrSignalProjectTodoWorkflow,
+  stopProjectTodoWorkflow: mockStopProjectTodoWorkflow,
+}));
 
 import handler from "./project_metadata";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("GET /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
   it("returns metadata for project spaces", async () => {
@@ -85,6 +101,64 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(403);
+  });
+
+  it("stops project todo workflow when archiving a project", async () => {
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    await FeatureFlagFactory.basic(auth, "project_todo");
+
+    const projectSpace = await SpaceFactory.project(workspace);
+    await ProjectMetadataResource.makeNew(auth, projectSpace, {
+      description: "Test description",
+      archivedAt: null,
+    });
+
+    req.query.spaceId = projectSpace.sId;
+    req.body = { archive: true };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockStopProjectTodoWorkflow).toHaveBeenCalledTimes(1);
+    expect(mockStopProjectTodoWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spaceId: projectSpace.sId,
+      })
+    );
+    expect(mockLaunchOrSignalProjectTodoWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("restarts project todo workflow when unarchiving a project", async () => {
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    await FeatureFlagFactory.basic(auth, "project_todo");
+
+    const projectSpace = await SpaceFactory.project(workspace);
+    await ProjectMetadataResource.makeNew(auth, projectSpace, {
+      description: "Test description",
+      archivedAt: new Date(),
+    });
+
+    req.query.spaceId = projectSpace.sId;
+    req.body = { archive: false };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockLaunchOrSignalProjectTodoWorkflow).toHaveBeenCalledTimes(1);
+    expect(mockLaunchOrSignalProjectTodoWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spaceId: projectSpace.sId,
+      })
+    );
+    expect(mockStopProjectTodoWorkflow).not.toHaveBeenCalled();
   });
 });
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,10 +1,14 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
+import {
+  launchOrSignalProjectTodoWorkflow,
+  stopProjectTodoWorkflow,
+} from "@app/temporal/project_todo/client";
 import { PatchProjectMetadataBodySchema } from "@app/types/api/internal/spaces";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ProjectMetadataType } from "@app/types/project_metadata";
@@ -75,6 +79,8 @@ async function handler(
       const body = bodyValidation.data;
 
       let metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+      const featureFlags = await getFeatureFlags(auth);
+      const projectTodoEnabled = featureFlags.includes("project_todo");
 
       if (!metadata) {
         // Create new metadata
@@ -82,13 +88,31 @@ async function handler(
           description: body.description ?? null,
           archivedAt: body.archive ? new Date() : null,
         });
+        if (!body.archive && projectTodoEnabled) {
+          void launchOrSignalProjectTodoWorkflow({
+            authType: auth.toJSON(),
+            spaceId: space.sId,
+          });
+        }
       } else {
         // Update existing metadata
         if (body.archive !== undefined) {
           if (body.archive) {
             await metadata.archive();
+            if (projectTodoEnabled) {
+              void stopProjectTodoWorkflow({
+                authType: auth.toJSON(),
+                spaceId: space.sId,
+              });
+            }
           } else {
             await metadata.unarchive();
+            if (projectTodoEnabled) {
+              void launchOrSignalProjectTodoWorkflow({
+                authType: auth.toJSON(),
+                spaceId: space.sId,
+              });
+            }
           }
         }
         if (body.description !== undefined) {

--- a/front/scripts/start_project_todo_workflows_for_projects_workspaces.ts
+++ b/front/scripts/start_project_todo_workflows_for_projects_workspaces.ts
@@ -1,0 +1,138 @@
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { FeatureFlagModel } from "@app/lib/models/feature_flag";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import { launchOrSignalProjectTodoWorkflow } from "@app/temporal/project_todo/client";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import type { LightWorkspaceType } from "@app/types/user";
+
+const PROJECTS_FEATURE_FLAG =
+  "projects" as const satisfies WhitelistableFeature;
+
+async function listWorkspacesWithProjectsFeatureFlag(): Promise<
+  LightWorkspaceType[]
+> {
+  const flags = await FeatureFlagModel.findAll({
+    where: { name: PROJECTS_FEATURE_FLAG },
+    attributes: ["workspaceId"],
+    // WORKSPACE_ISOLATION_BYPASS: list workspace IDs with the projects flag for this admin-only backfill script.
+    // @ts-expect-error -- Script operates across all workspaces.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+
+  const workspaceIds = [...new Set(flags.map((f) => f.workspaceId))];
+  if (workspaceIds.length === 0) {
+    return [];
+  }
+
+  const workspaces = await WorkspaceResource.fetchByModelIds(workspaceIds);
+  return workspaces.map((workspace) => renderLightWorkspaceType({ workspace }));
+}
+
+makeScript(
+  {
+    wId: {
+      type: "string",
+      describe: "Optional workspace sId to process a single workspace.",
+    },
+    requireProjectTodo: {
+      type: "boolean",
+      describe:
+        "If true, only start workflows when the workspace also has the project_todo feature flag.",
+      default: true,
+    },
+  },
+  async ({ execute, wId, requireProjectTodo }, logger) => {
+    const processWorkspace = async (workspace: LightWorkspaceType) => {
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      if (requireProjectTodo) {
+        const flags = await getFeatureFlags(auth);
+        if (!flags.includes("project_todo")) {
+          logger.info(
+            { workspaceId: workspace.sId },
+            "Skipping workspace: project_todo feature flag not enabled"
+          );
+          return;
+        }
+      }
+
+      const projectSpaces = await SpaceResource.listProjectSpaces(auth);
+      let started = 0;
+      let skippedArchived = 0;
+
+      for (const space of projectSpaces) {
+        const metadata = await ProjectMetadataResource.fetchBySpace(
+          auth,
+          space
+        );
+        if (metadata?.archivedAt) {
+          skippedArchived += 1;
+          continue;
+        }
+
+        if (execute) {
+          await launchOrSignalProjectTodoWorkflow({
+            authType: auth.toJSON(),
+            spaceId: space.sId,
+          });
+        }
+        started += 1;
+      }
+
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          projectSpaceCount: projectSpaces.length,
+          wouldStartOrStarted: started,
+          skippedArchived,
+          execute,
+        },
+        execute
+          ? "Started project todo workflows for workspace project spaces"
+          : "Dry run: would start project todo workflows for workspace project spaces"
+      );
+    };
+
+    if (wId) {
+      const workspace = await WorkspaceResource.fetchById(wId);
+      if (!workspace) {
+        throw new Error(`Workspace not found: ${wId}`);
+      }
+
+      const hasProjectsFlag = await FeatureFlagModel.findOne({
+        where: {
+          workspaceId: workspace.id,
+          name: PROJECTS_FEATURE_FLAG,
+        },
+      });
+
+      if (!hasProjectsFlag) {
+        throw new Error(
+          `Workspace ${wId} does not have the workspace-level "${PROJECTS_FEATURE_FLAG}" feature flag.`
+        );
+      }
+
+      await processWorkspace(renderLightWorkspaceType({ workspace }));
+      return;
+    }
+
+    const workspaces = await listWorkspacesWithProjectsFeatureFlag();
+    logger.info(
+      { workspaceCount: workspaces.length, requireProjectTodo },
+      "Workspaces with projects feature flag"
+    );
+
+    if (workspaces.length === 0) {
+      logger.info("No workspaces to process.");
+      return;
+    }
+
+    await concurrentExecutor(workspaces, processWorkspace, { concurrency: 2 });
+  }
+);

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -2,12 +2,7 @@ import {
   sendEmailReplyOnCompletion,
   sendEmailReplyOnError,
 } from "@app/lib/api/assistant/email/email_reply";
-import {
-  Authenticator,
-  type AuthenticatorType,
-  getFeatureFlags,
-} from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
 import { launchAgentMessageAnalytics } from "@app/temporal/agent_loop/activities/analytics";
 import {
   finalizeCancellation,
@@ -21,7 +16,6 @@ import {
   launchEmitMetronomeUsageEvents,
   launchTrackProgrammaticUsage,
 } from "@app/temporal/agent_loop/activities/usage_tracking";
-import { signalProjectTodoComplete } from "@app/temporal/project_todo/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
 export async function finalizeSuccessfulAgentLoopActivity(
@@ -33,18 +27,6 @@ export async function finalizeSuccessfulAgentLoopActivity(
     return;
   }
 
-  const auth = authResult.value;
-  const featureFlags = await getFeatureFlags(auth);
-
-  let shouldSignalTodo = false;
-  if (featureFlags.includes("project_todo")) {
-    const conversation = await ConversationResource.fetchById(
-      auth,
-      agentLoopArgs.conversationId
-    );
-    shouldSignalTodo = conversation?.spaceId !== null;
-  }
-
   await Promise.all([
     snapshotAgentMessageSkills(authType, agentLoopArgs),
     launchAgentMessageAnalytics(authType, agentLoopArgs),
@@ -53,13 +35,6 @@ export async function finalizeSuccessfulAgentLoopActivity(
     conversationUnreadNotificationActivity(authType, agentLoopArgs),
     handleMentions(authType, agentLoopArgs),
     sendEmailReplyOnCompletion(authType, agentLoopArgs),
-    shouldSignalTodo
-      ? signalProjectTodoComplete({
-          authType,
-          conversationId: agentLoopArgs.conversationId,
-          messageId: agentLoopArgs.agentMessageId,
-        })
-      : Promise.resolve(),
   ]);
 }
 

--- a/front/temporal/project_todo/activities.ts
+++ b/front/temporal/project_todo/activities.ts
@@ -43,8 +43,8 @@ export async function analyzeProjectTodosActivity({
   await analyzeConversationTodos(auth, { conversation, messageId });
 }
 
-// Called by projectTodoWorkflow after a successful analysis run. Uses signalWithStart
-// so the merge workflow is automatically created if not already running.
+// Starts or signals `projectMergeWorkflow` (signalWithStart). Used when merge is driven
+// via signals; the cron `projectTodoWorkflow` path calls `mergeTodosForProjectActivity` directly.
 export async function signalOrStartMergeWorkflowActivity({
   authType,
   spaceId,

--- a/front/temporal/project_todo/client.ts
+++ b/front/temporal/project_todo/client.ts
@@ -1,23 +1,24 @@
 import type { AuthenticatorType } from "@app/lib/auth";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/project_todo/config";
-import {
-  mergeRequestSignal,
-  todoCompleteSignal,
-  todoRefreshSignal,
-} from "@app/temporal/project_todo/signals";
+import { mergeRequestSignal } from "@app/temporal/project_todo/signals";
 import {
   projectMergeWorkflow,
   projectTodoWorkflow,
 } from "@app/temporal/project_todo/workflows";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import {
+  WorkflowExecutionAlreadyStartedError,
+  WorkflowNotFoundError,
+} from "@temporalio/client";
 
 function makeProjectTodoWorkflowId(
   workspaceId: string,
-  conversationId: string
+  spaceId: string
 ): string {
-  return `conversation-todo-${workspaceId}-${conversationId}`;
+  return `project-todo-${workspaceId}-${spaceId}`;
 }
 
 function makeProjectMergeWorkflowId(
@@ -30,84 +31,81 @@ function makeProjectMergeWorkflowId(
 export async function launchOrSignalProjectTodoWorkflow({
   authType,
   spaceId,
-  conversationId,
-  messageId,
 }: {
   authType: AuthenticatorType;
   spaceId: string;
-  conversationId: string;
-  messageId: string;
 }): Promise<void> {
   const client = await getTemporalClientForFrontNamespace();
-  const workflowId = makeProjectTodoWorkflowId(
-    authType.workspaceId,
-    conversationId
-  );
+  const workflowId = makeProjectTodoWorkflowId(authType.workspaceId, spaceId);
+  const spaceModelId = getResourceIdFromSId(spaceId);
+  if (!spaceModelId) {
+    logger.warn(
+      { workspaceId: authType.workspaceId, spaceId },
+      "Skipping project todo workflow start for invalid space ID"
+    );
+    return;
+  }
+  const scheduleOffsetMinutes = spaceModelId % 60;
+  // Spread merges across the hour: one run per workspace project at this minute every hour (UTC).
+  const cronSchedule = `${scheduleOffsetMinutes} * * * *`;
 
   try {
-    await client.workflow.signalWithStart(projectTodoWorkflow, {
-      args: [{ authType, conversationId, messageId, spaceId }],
+    await client.workflow.start(projectTodoWorkflow, {
+      args: [{ authType, spaceId }],
       taskQueue: QUEUE_NAME,
       workflowId,
-      signal: todoRefreshSignal,
-      signalArgs: [messageId],
-      workflowExecutionTimeout: "1 hour",
+      cronSchedule,
       memo: {
         workspaceId: authType.workspaceId,
-        conversationId,
-        messageId,
         spaceId,
+        scheduleOffsetMinutes,
       },
     });
   } catch (e) {
-    // Swallow errors — todo workflow failures must not block conversation flow.
-    logger.error(
-      {
-        workflowId,
-        workspaceId: authType.workspaceId,
-        conversationId,
-        messageId,
-        spaceId,
-        error: normalizeError(e),
-      },
-      "Failed starting conversation todo workflow"
-    );
+    if (!(e instanceof WorkflowExecutionAlreadyStartedError)) {
+      // Swallow errors — todo workflow failures must not block request flow.
+      logger.error(
+        {
+          workflowId,
+          workspaceId: authType.workspaceId,
+          spaceId,
+          error: normalizeError(e),
+        },
+        "Failed starting project todo workflow"
+      );
+    }
   }
 }
 
-export async function signalProjectTodoComplete({
+export async function stopProjectTodoWorkflow({
   authType,
-  conversationId,
-  messageId,
+  spaceId,
+  stopReason = "project archived",
 }: {
   authType: AuthenticatorType;
-  conversationId: string;
-  messageId: string;
+  spaceId: string;
+  stopReason?: string;
 }): Promise<void> {
   try {
     const client = await getTemporalClientForFrontNamespace();
-    const workflowId = makeProjectTodoWorkflowId(
-      authType.workspaceId,
-      conversationId
-    );
-    await client.workflow
-      .getHandle(workflowId)
-      .signal(todoCompleteSignal, messageId);
+    const workflowId = makeProjectTodoWorkflowId(authType.workspaceId, spaceId);
+    await client.workflow.getHandle(workflowId).terminate(stopReason);
   } catch (e) {
-    // Swallow errors — workflow may have already completed or timed out.
-    logger.warn(
-      {
-        conversationId,
-        error: normalizeError(e),
-      },
-      "Failed signaling conversation todo complete (workflow may have already finished)"
-    );
+    if (!(e instanceof WorkflowNotFoundError)) {
+      // Swallow errors — workflow may have already been terminated.
+      logger.warn(
+        {
+          spaceId,
+          error: normalizeError(e),
+        },
+        "Failed terminating project todo workflow"
+      );
+    }
   }
 }
 
-// Called from signalOrStartMergeWorkflowActivity to fan-in signals from per-conversation
-// workflows into the single per-project merge workflow. Uses signalWithStart so the merge
-// workflow is automatically created if not already running.
+// Called from `signalOrStartMergeWorkflowActivity` to fan-in into the per-project merge
+// workflow. Uses signalWithStart so the merge workflow is created if not already running.
 export async function signalOrStartProjectMergeWorkflow({
   authType,
   spaceId,

--- a/front/temporal/project_todo/config.ts
+++ b/front/temporal/project_todo/config.ts
@@ -3,11 +3,6 @@ const QUEUE_VERSION = 1;
 // TODO: rename this queue
 export const QUEUE_NAME = `conversation-todo-queue-v${QUEUE_VERSION}`;
 
-// Throttle for the per-conversation analysis workflow: at most one analysis run
-// every 5 minutes, starting immediately on the first signal. Signals that arrive
-// during the cool-down are coalesced into the next run.
-export const TODO_THROTTLE_MS = 5 * 60 * 1_000;
-
 // The merge workflow (projectMergeWorkflow) calls an LLM to update project todos.
 // This throttle prevents more than one LLM merge per project per hour.
 export const MERGE_THROTTLE_MS = 60 * 60 * 1_000; // 1 hour

--- a/front/temporal/project_todo/signals.ts
+++ b/front/temporal/project_todo/signals.ts
@@ -7,8 +7,8 @@ export const todoCompleteSignal = defineSignal<[string]>(
   "project_todo_complete_signal"
 );
 
-// Sent by projectTodoWorkflow to projectMergeWorkflow after a successful analysis run.
-// Carries no payload — the merge workflow only needs to know "there is work to do".
+// Sent to projectMergeWorkflow to request a merge. Carries no payload — the merge workflow
+// only needs to know there is work to do.
 export const mergeRequestSignal = defineSignal<[]>(
   "project_todo_merge_request_signal"
 );

--- a/front/temporal/project_todo/workflows.ts
+++ b/front/temporal/project_todo/workflows.ts
@@ -1,14 +1,7 @@
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/project_todo/activities";
-import {
-  MERGE_THROTTLE_MS,
-  TODO_THROTTLE_MS,
-} from "@app/temporal/project_todo/config";
-import {
-  mergeRequestSignal,
-  todoCompleteSignal,
-  todoRefreshSignal,
-} from "@app/temporal/project_todo/signals";
+import { MERGE_THROTTLE_MS } from "@app/temporal/project_todo/config";
+import { mergeRequestSignal } from "@app/temporal/project_todo/signals";
 import {
   condition,
   proxyActivities,
@@ -16,83 +9,26 @@ import {
   sleep,
 } from "@temporalio/workflow";
 
-const {
-  analyzeProjectTodosActivity,
-  signalOrStartMergeWorkflowActivity,
-  mergeTodosForProjectActivity,
-} = proxyActivities<typeof activities>({
+const { mergeTodosForProjectActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
 });
 
-// Per-conversation workflow. Throttles analysis to at most once per TODO_THROTTLE_MS
-// and signals the per-project merge workflow after each successful run. spaceId
-// identifies the project the conversation belongs to and is forwarded to the merge
-// workflow.
+// Cron-driven workflow (see `cronSchedule` in `launchOrSignalProjectTodoWorkflow`): each
+// execution runs once and completes; Temporal starts the next run on schedule until the
+// workflow is terminated (e.g. project archived or deleted).
 export async function projectTodoWorkflow({
   authType,
-  conversationId,
-  messageId,
   spaceId,
 }: {
   authType: AuthenticatorType;
-  conversationId: string;
-  messageId: string;
   spaceId: string;
 }): Promise<void> {
-  let needsAnalysis = true;
-  let complete = false;
-  let latestMessageId: string | null = null;
-  let isCoolingDown = false;
-
-  setHandler(todoRefreshSignal, (msgId: string) => {
-    needsAnalysis = true;
-    latestMessageId = msgId;
-  });
-
-  setHandler(todoCompleteSignal, (msgId: string) => {
-    needsAnalysis = true;
-    complete = true;
-    latestMessageId = msgId;
-  });
-
-  while (!complete) {
-    // Wait until there is work to do AND the throttle cool-down has elapsed.
-    await condition(() => needsAnalysis && !isCoolingDown);
-    needsAnalysis = false;
-    isCoolingDown = true;
-    const msgId = latestMessageId;
-
-    if (msgId) {
-      await analyzeProjectTodosActivity({
-        authType,
-        conversationId,
-        messageId: msgId,
-      });
-      // Signal the per-project merge workflow that fresh analysis data is available.
-      // Uses signalWithStart so the merge workflow is started if not already running.
-      await signalOrStartMergeWorkflowActivity({ authType, spaceId });
-    }
-
-    // Cool-down: don't run again for TODO_THROTTLE_MS. Exit early if the complete
-    // signal arrives so the final analysis is not delayed unnecessarily.
-    await condition(() => complete, TODO_THROTTLE_MS);
-    isCoolingDown = false;
-  }
-
-  // Final analysis + merge signal after completion.
-  if (latestMessageId) {
-    await analyzeProjectTodosActivity({
-      authType,
-      conversationId,
-      messageId: latestMessageId,
-    });
-    await signalOrStartMergeWorkflowActivity({ authType, spaceId });
-  }
+  // Do nothing for now
+  // await mergeTodosForProjectActivity({ authType, spaceId });
 }
 
 // One long-running workflow per (workspace, project/space). Receives merge-request signals
-// from per-conversation projectTodoWorkflows and runs the LLM merge at most once per
-// MERGE_THROTTLE_MS, batching all dirty conversations into a single call.
+// and runs the LLM merge at most once per MERGE_THROTTLE_MS, batching dirty conversations.
 export async function projectMergeWorkflow({
   authType,
   spaceId,


### PR DESCRIPTION
## Description

The `project_todo` workflow was launched and signaled on every message sent, edited, retried, or completed in a project conversation. This meant each conversation had its own workflow instance running in parallel, the lifecycle was coupled to individual message events via `todoRefreshSignal` / `todoCompleteSignal`, and `TODO_THROTTLE_MS` was the only guard against excessive runs.

Replacing this with a per-project cron schedule simplifies the model: one long-running workflow per project, fired at a deterministic offset (`spaceModelId % 60` minutes past the hour) to spread load across the hour.

- Switch `projectTodoWorkflow` to a `cronSchedule` keyed by `spaceId` instead of `conversationId`; remove `conversationId` / `messageId` from workflow args
- Remove all `launchOrSignalProjectTodoWorkflow` / `signalProjectTodoComplete` calls from `conversation.ts`, `editUserMessage`, `retryAgentMessage`, `postNewContentFragment`, and `finalizeSuccessfulAgentLoopActivity`
- Start the cron on project creation (`createSpaceAndGroup`); stop (terminate) on deletion or archiving; restart on unarchive
- Replace `signalProjectTodoComplete` with `stopProjectTodoWorkflow` (terminate + swallow `WorkflowNotFoundError`)
- Remove `todoRefreshSignal`, `todoCompleteSignal`, and `TODO_THROTTLE_MS` — no longer needed
- Add backfill script `start_project_todo_workflows_for_projects_workspaces.ts` to start the cron for all existing non-archived projects

## Tests

Local

## Risk

Medium — changes the todo workflow trigger model; existing per-conversation workflows will keep running until they expire (1h timeout), new ones start on cron. Backfill script needed to start the schedule for existing projects.

## Deploy Plan

Deploy `front`, then run the backfill script
