### PR TITLE
[Front] Fix sidekick context formatting on main

### DIFF
--- a/front/lib/api/assistant/global_agents/sidekick_context.ts
+++ b/front/lib/api/assistant/global_agents/sidekick_context.ts
@@ -91,9 +91,7 @@ interface InputParamSchema {
   required?: string[];
 }
 
-function formatInputParams(
-  inputSchema: InputParamSchema | undefined
-): string {
+function formatInputParams(inputSchema: InputParamSchema | undefined): string {
   if (inputSchema?.type !== "object" || !inputSchema.properties) {
     return "  Input parameters: none";
   }
@@ -149,11 +147,7 @@ export function formatMcpDescription(
     for (const tool of server.tools) {
       lines.push(`- ${tool.name}`);
       lines.push(`  Description: ${tool.description}`);
-      lines.push(
-        formatInputParams(
-          tool.inputSchema
-        )
-      );
+      lines.push(formatInputParams(tool.inputSchema));
       lines.push("");
     }
   }


### PR DESCRIPTION
## Description
Fixes broken formatting, likely from https://github.com/dust-tt/dust/pull/24247

Applies the Biome formatting expected by the failing  job on  in .

## Risks
Blast radius: formatting only in sidekick context prompt construction
Risk: none

## Deploy Plan
- pmrr
- no deploy required