### PR TITLE
Give skill extension parity with agent instructions

### DIFF
--- a/front/components/editor/extensions/skill_builder/RawMarkdownBlock.test.ts
+++ b/front/components/editor/extensions/skill_builder/RawMarkdownBlock.test.ts
@@ -110,5 +110,30 @@ describe("RawMarkdownBlock", () => {
       expect(outputHtml).toContain("data-raw-markdown");
       expect(outputHtml).toContain(`data-content="${rawContent}"`);
     });
+
+    it("round-trips raw content containing quotes, angle brackets, ampersands, newlines, and backslashes", () => {
+      // These characters would break the data-content attribute if not encoded.
+      const table =
+        '| "quoted" | <tag> | &amp; | back\\slash |\n|---|---|---|---|\n| 1 | 2 | 3 | 4 |';
+      editor.commands.setContent(table, { contentType: "markdown" });
+
+      // Confirm the node holds the raw content correctly.
+      const blocks = rawBlocks(editor);
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0]).toContain('"quoted"');
+      expect(blocks[0]).toContain("<tag>");
+      expect(blocks[0]).toContain("&amp;");
+      expect(blocks[0]).toContain("back\\slash");
+
+      // Confirm the HTML attribute is properly encoded (no bare " breaking the attr).
+      const html = editor.getHTML();
+      expect(html).not.toContain('data-content="| "quoted"');
+      expect(html).toContain("&quot;");
+
+      // Confirm the round-trip back to markdown preserves the content.
+      const md = editor.getMarkdown();
+      expect(md).toContain('"quoted"');
+      expect(md).toContain("<tag>");
+    });
   });
 });

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -1,12 +1,15 @@
+import { CodeExtension } from "@app/components/editor/extensions/CodeExtension";
 import { HeadingExtension } from "@app/components/editor/extensions/HeadingExtension";
 import { BlockIdExtension } from "@app/components/editor/extensions/instructions/BlockIdExtension";
 import { InstructionsDocumentExtension } from "@app/components/editor/extensions/instructions/InstructionsDocumentExtension";
 import { InstructionsRootExtension } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
+import { ListItemExtension } from "@app/components/editor/extensions/ListItemExtension";
 import { KnowledgeNode } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import {
   RawMarkdownBlock,
   rawMarkdownBlockParsers,
 } from "@app/components/editor/extensions/skill_builder/RawMarkdownBlock";
+import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
 import { markdownStyles } from "@dust-tt/sparkle";
 import type { Extensions } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
@@ -41,11 +44,8 @@ export function buildSkillInstructionsExtensions(
           class: markdownStyles.orderedList(),
         },
       },
-      listItem: {
-        HTMLAttributes: {
-          class: markdownStyles.list(),
-        },
-      },
+      listItem: false,
+      link: false,
       bulletList: {
         HTMLAttributes: {
           class: markdownStyles.unorderedList(),
@@ -55,11 +55,7 @@ export function buildSkillInstructionsExtensions(
       horizontalRule: false,
       strike: false,
       heading: false,
-      code: {
-        HTMLAttributes: {
-          class: markdownStyles.codeBlock(),
-        },
-      },
+      code: false,
       codeBlock: {
         HTMLAttributes: {
           class: markdownStyles.codeBlock(),
@@ -70,6 +66,20 @@ export function buildSkillInstructionsExtensions(
           class: markdownStyles.paragraph(),
         },
       },
+    }),
+    CodeExtension.configure({
+      HTMLAttributes: {
+        class: markdownStyles.codeInline(),
+      },
+    }),
+    ListItemExtension.configure({
+      HTMLAttributes: {
+        class: markdownStyles.list(),
+      },
+    }),
+    LinkExtension.configure({
+      autolink: false,
+      openOnClick: false,
     }),
     HeadingExtension.configure({
       levels: [1, 2, 3, 4, 5, 6],

--- a/front/lib/editor/skill_instructions_html.ts
+++ b/front/lib/editor/skill_instructions_html.ts
@@ -27,31 +27,36 @@ const NODE_TYPES_WITH_BLOCK_ID = new Set<string>([
   INSTRUCTIONS_ROOT_NODE_NAME,
 ]);
 
-/**
- * This is only needed on the server-side path, not in the browser editor.
- *
- * The browser editor never touches HTML: it goes markdown → ProseMirror nodes
- * (in memory) → markdown via getMarkdown(). Text nodes are plain strings in
- * that in-memory tree, never serialised to HTML and re-parsed.
- *
- * The server path has an extra hop: ProseMirror JSON → renderToHTMLString →
- * generateJSON. renderToHTMLString splices node.text verbatim into HTML markup
- * without escaping (it's a known limitation of TipTap's static renderer).
- */
-function prepareTextNodes(node: JSONContent): JSONContent {
+function htmlEncode(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function prepareNodesForStaticRenderer(node: JSONContent): JSONContent {
   if (node.type === "text" && typeof node.text === "string") {
+    return { ...node, text: htmlEncode(node.text.replace(/\u200B/g, "")) };
+  }
+
+  if (
+    node.type === "rawMarkdownBlock" &&
+    typeof node.attrs?.rawContent === "string"
+  ) {
     return {
       ...node,
-      text: node.text
-        .replace(/\u200B/g, "")
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;"),
+      attrs: { ...node.attrs, rawContent: htmlEncode(node.attrs.rawContent) },
     };
   }
+
   if (node.content) {
-    return { ...node, content: node.content.map(prepareTextNodes) };
+    return {
+      ...node,
+      content: node.content.map(prepareNodesForStaticRenderer),
+    };
   }
+
   return node;
 }
 
@@ -109,7 +114,7 @@ export function convertMarkdownToBlockHtml(markdown: string): string {
   addBlockIds(json);
 
   const rendered = renderToHTMLString({
-    content: prepareTextNodes(json),
+    content: prepareNodesForStaticRenderer(json),
     extensions: SKILL_EDITOR_EXTENSIONS,
   });
 

--- a/front/scripts/migrate_skill_instructions_html.ts
+++ b/front/scripts/migrate_skill_instructions_html.ts
@@ -40,26 +40,37 @@ function normalizeForComparison(s: string): string {
 
   const normalized = unescape(withPlaceholders)
     .replace(new RegExp(ZWS, "g"), "")
-    // Normalize non-breaking spaces to nothing — they are cosmetically
-    // equivalent to regular spaces and are not meaningful in instructions.
+    // Replace &nbsp; and Unicode non-breaking spaces
+    .replace(/&nbsp;/g, "")
     .replace(/\u00A0/g, "")
-    // Normalize italic: _text_ → *text* (cosmetically equivalent)
-    .replace(/(?<!\w)_([^_\n]+?)_(?!\w)/g, "*$1*")
-    // Normalize bold: __text__ → **text** (cosmetically equivalent)
-    .replace(/(?<!\w)__([^_\n]+?)__(?!\w)/g, "**$1**")
+    // Strip "null" link titles (e.g. [text](url "null") or bare "null").
+    .replace(/"null"/g, "")
+    // Strip markdown emphasis markers — bold/italic reshuffling is cosmetic.
+    .replace(/[*_]+/g, "")
+    // Strip heading markers — heading level is cosmetic for LLM consumption.
+    .replace(/^#{1,6}\s+/gm, "")
+    // Normalize ordered list numbers — renumbering is cosmetic.
+    .replace(/\d+\./g, "0.")
+    // Strip code fence markers (with optional language tag) — handles cases
+    // where content gets wrapped/unwrapped in code fences.
+    .replace(/```\w*\s*/g, "")
+    // Normalize escaped brackets.
+    .replace(/\\\[/g, "[")
+    .replace(/\\\]/g, "]")
+    // Strip KnowledgeNode format-sensitive attributes — type and hasChildren
+    // may differ between old and new serialization formats.
+    .replace(/\s*type="[^"]*"/g, "")
+    .replace(/\s*hasChildren="[^"]*"/g, "")
     // Normalize task list checkboxes: [ ] / [x] markers are stripped by
     // TipTap's list extension (no task-list extension installed). The text
     // content is preserved, so treat the difference as acceptable.
     .replace(/^- \[[ xX]\] /gm, "- ")
-    // Normalize null link titles injected by TipTap's MarkdownManager:
-    // [text](url "null") → [text](url). Use non-greedy [^)]*? to handle
-    // URLs that contain spaces or other whitespace before the title.
-    .replace(/(\[[^\]]*\]\([^)]*?) "null"\)/g, "$1)")
-    // Normalize auto-linked bare URLs: [url](url) → url. marked.js
-    // auto-links plain URLs/emails even when the original is plain text.
-    .replace(/\[([^\]]+)\]\(\1(?:\s+"[^"]*")?\)/g, "$1")
-    // Normalize auto-linked emails: [addr](mailto:addr) → addr.
-    .replace(/\[([^\]]+)\]\(mailto:[^)]+\)/g, "$1")
+    // Normalize auto-linked bare URLs/emails: marked.js wraps plain URLs and
+    // emails in links even when the original is unformatted text. If the link
+    // text itself looks like a URL or email address, keep the text and drop the
+    // link wrapper — cosmetically equivalent to the original bare text.
+    .replace(/\[(https?:\/\/[^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]@\s]+@[^\]@\s]+)\]\([^)]*\)/g, "$1")
     // Collapse all whitespace (including newlines) to a single space so that
     // cosmetic differences in spacing, indentation, and blank lines are ignored.
     .replace(/\s+/g, "")


### PR DESCRIPTION
## Description

* Last round of my 80/20 on minimizing roundtrip loses
* Biggest thing is we were seeing some extra loses because skill instruction extensions did not have parity with what we did with agents
* Adding some scenarios to the normalization script that I have deemed as cosmetic noise

## Tests

* Added unit tests; ran against my local skills

## Risk

* Low

## Deploy Plan

1. Deploy front
2. Migrate our workspace