### PR TITLE
Hidding Bearer token and showing custom headers already filled

### DIFF
--- a/front/components/actions/mcp/MCPServerHeaders.tsx
+++ b/front/components/actions/mcp/MCPServerHeaders.tsx
@@ -2,11 +2,17 @@ import { WebCrawlerHeaderRedactedValue } from "@app/types/connectors/webcrawler"
 import { Button, Input, XMarkIcon } from "@dust-tt/sparkle";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
+interface MCPServerHeadersProps {
+  predefinedHeaderKeys?: string[];
+}
+
 type FormWithCustomHeaders = {
   customHeaders: Array<{ key: string; value: string }>;
 };
 
-export function MCPServerHeaders() {
+export function MCPServerHeaders({
+  predefinedHeaderKeys,
+}: MCPServerHeadersProps) {
   // `register` binds inputs via DOM refs so RHF tracks values natively without triggering React re-renders on each
   // keystroke. Using `update` instead would replace the field object (regenerating field.id), causing React to remount
   // the input on every keystroke and lose focus.
@@ -24,6 +30,7 @@ export function MCPServerHeaders() {
     <div className="flex w-full flex-col">
       <div className="flex flex-col gap-4">
         {fields.map((field, index) => {
+          const isPredefined = predefinedHeaderKeys?.includes(field.key);
           const isRedacted =
             field.value === WebCrawlerHeaderRedactedValue ||
             getValues(`customHeaders.${index}.value`) ===
@@ -35,7 +42,7 @@ export function MCPServerHeaders() {
                   <Input
                     {...register(`customHeaders.${index}.key`)}
                     placeholder="Header Name"
-                    disabled={isRedacted}
+                    disabled={isRedacted || isPredefined}
                     className="w-full"
                   />
                 </div>
@@ -48,11 +55,13 @@ export function MCPServerHeaders() {
                   />
                 </div>
               </div>
-              <Button
-                variant="outline"
-                icon={XMarkIcon}
-                onClick={() => remove(index)}
-              />
+              {!isPredefined && (
+                <Button
+                  variant="outline"
+                  icon={XMarkIcon}
+                  onClick={() => remove(index)}
+                />
+              )}
             </div>
           );
         })}

--- a/front/components/actions/mcp/MCPServerHeaders.tsx
+++ b/front/components/actions/mcp/MCPServerHeaders.tsx
@@ -2,22 +2,18 @@ import { WebCrawlerHeaderRedactedValue } from "@app/types/connectors/webcrawler"
 import { Button, Input, XMarkIcon } from "@dust-tt/sparkle";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
-interface MCPServerHeadersProps {
-  predefinedHeaderKeys?: string[];
-}
-
 type FormWithCustomHeaders = {
   customHeaders: Array<{ key: string; value: string }>;
+  predefinedHeaderKeys?: string[];
 };
 
-export function MCPServerHeaders({
-  predefinedHeaderKeys,
-}: MCPServerHeadersProps) {
+export function MCPServerHeaders() {
   // `register` binds inputs via DOM refs so RHF tracks values natively without triggering React re-renders on each
   // keystroke. Using `update` instead would replace the field object (regenerating field.id), causing React to remount
   // the input on every keystroke and lose focus.
-  const { control, register, getValues } =
+  const { control, register, getValues, watch } =
     useFormContext<FormWithCustomHeaders>();
+  const predefinedHeaderKeys = watch("predefinedHeaderKeys");
   const { fields, append, remove } = useFieldArray<
     FormWithCustomHeaders,
     "customHeaders"

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -129,9 +129,11 @@ export function CreateMCPServerDialog({
     [needsCustomName, internalMCPServer, existingViewNames]
   );
 
-  const predefinedHeaders = internalMCPServer
-    ? getTokenFieldLabel(internalMCPServer.name).predefinedHeaders
+  const tokenLabel = internalMCPServer
+    ? getTokenFieldLabel(internalMCPServer.name)
     : undefined;
+  const predefinedHeaders = tokenLabel?.predefinedHeaders;
+  const showBearerTokenSection = tokenLabel?.showBearerTokenSection ?? true;
 
   const defaultValues = useMemo<CreateMCPServerDialogFormValues>(() => {
     return {
@@ -533,7 +535,7 @@ export function CreateMCPServerDialog({
 
               {internalMCPServer &&
                 requiresBearerTokenConfiguration(internalMCPServer) &&
-                !predefinedHeaders && (
+                showBearerTokenSection && (
                   <InternalBearerTokenSection
                     serverName={internalMCPServer.name}
                   />

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -26,6 +26,7 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
+import { getTokenFieldLabel } from "@app/lib/actions/mcp_internal_actions/server_token_labels";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
@@ -128,12 +129,20 @@ export function CreateMCPServerDialog({
     [needsCustomName, internalMCPServer, existingViewNames]
   );
 
+  const predefinedHeaders = internalMCPServer
+    ? getTokenFieldLabel(internalMCPServer.name).predefinedHeaders
+    : undefined;
+
   const defaultValues = useMemo<CreateMCPServerDialogFormValues>(() => {
     return {
       ...getCreateMCPServerDialogDefaultValues(defaultServerConfig),
       viewName: suggestedViewName,
+      ...(predefinedHeaders && {
+        useCustomHeaders: true,
+        customHeaders: predefinedHeaders.map((key) => ({ key, value: "" })),
+      }),
     };
-  }, [defaultServerConfig, suggestedViewName]);
+  }, [defaultServerConfig, suggestedViewName, predefinedHeaders]);
 
   const form = useForm<CreateMCPServerDialogFormValues>({
     resolver: zodResolver(createMCPServerDialogFormSchema),
@@ -523,7 +532,8 @@ export function CreateMCPServerDialog({
               )}
 
               {internalMCPServer &&
-                requiresBearerTokenConfiguration(internalMCPServer) && (
+                requiresBearerTokenConfiguration(internalMCPServer) &&
+                !predefinedHeaders && (
                   <InternalBearerTokenSection
                     serverName={internalMCPServer.name}
                   />
@@ -532,6 +542,7 @@ export function CreateMCPServerDialog({
               <CustomHeadersConfigurationSection
                 defaultServerConfig={defaultServerConfig}
                 internalMCPServer={internalMCPServer}
+                predefinedHeaders={predefinedHeaders}
               />
             </div>
           </DialogContainer>

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -139,9 +139,11 @@ export function CreateMCPServerDialog({
     return {
       ...getCreateMCPServerDialogDefaultValues(defaultServerConfig),
       viewName: suggestedViewName,
+      // Pre-fill headers and store their keys so the form can lock them as non-removable.
       ...(predefinedHeaders && {
         useCustomHeaders: true,
         customHeaders: predefinedHeaders.map((key) => ({ key, value: "" })),
+        predefinedHeaderKeys: predefinedHeaders,
       }),
     };
   }, [defaultServerConfig, suggestedViewName, predefinedHeaders]);
@@ -544,7 +546,6 @@ export function CreateMCPServerDialog({
               <CustomHeadersConfigurationSection
                 defaultServerConfig={defaultServerConfig}
                 internalMCPServer={internalMCPServer}
-                predefinedHeaders={predefinedHeaders}
               />
             </div>
           </DialogContainer>

--- a/front/components/actions/mcp/create/CustomHeadersConfigurationSection.tsx
+++ b/front/components/actions/mcp/create/CustomHeadersConfigurationSection.tsx
@@ -31,12 +31,9 @@ export function CustomHeadersConfigurationSection({
 
   const useCustomHeaders = useCustomHeadersField.value;
 
-  if (predefinedHeaders) {
-    return <MCPServerHeaders />;
-  }
-
   const showToggle =
     !defaultServerConfig &&
+    !predefinedHeaders &&
     (!internalMCPServer || requiresBearerTokenConfiguration(internalMCPServer));
 
   return (
@@ -66,7 +63,9 @@ export function CustomHeadersConfigurationSection({
         </div>
       )}
 
-      {useCustomHeaders && <MCPServerHeaders />}
+      {useCustomHeaders && (
+        <MCPServerHeaders predefinedHeaderKeys={predefinedHeaders} />
+      )}
     </>
   );
 }

--- a/front/components/actions/mcp/create/CustomHeadersConfigurationSection.tsx
+++ b/front/components/actions/mcp/create/CustomHeadersConfigurationSection.tsx
@@ -15,11 +15,13 @@ import { useController, useFormContext } from "react-hook-form";
 interface CustomHeadersConfigurationSectionProps {
   defaultServerConfig?: DefaultRemoteMCPServerConfig;
   internalMCPServer?: MCPServerType;
+  predefinedHeaders?: string[];
 }
 
 export function CustomHeadersConfigurationSection({
   defaultServerConfig,
   internalMCPServer,
+  predefinedHeaders,
 }: CustomHeadersConfigurationSectionProps) {
   const form = useFormContext<CreateMCPServerDialogFormValues>();
   const { field: useCustomHeadersField } = useController({
@@ -28,6 +30,10 @@ export function CustomHeadersConfigurationSection({
   });
 
   const useCustomHeaders = useCustomHeadersField.value;
+
+  if (predefinedHeaders) {
+    return <MCPServerHeaders />;
+  }
 
   const showToggle =
     !defaultServerConfig &&

--- a/front/components/actions/mcp/create/CustomHeadersConfigurationSection.tsx
+++ b/front/components/actions/mcp/create/CustomHeadersConfigurationSection.tsx
@@ -15,13 +15,11 @@ import { useController, useFormContext } from "react-hook-form";
 interface CustomHeadersConfigurationSectionProps {
   defaultServerConfig?: DefaultRemoteMCPServerConfig;
   internalMCPServer?: MCPServerType;
-  predefinedHeaders?: string[];
 }
 
 export function CustomHeadersConfigurationSection({
   defaultServerConfig,
   internalMCPServer,
-  predefinedHeaders,
 }: CustomHeadersConfigurationSectionProps) {
   const form = useFormContext<CreateMCPServerDialogFormValues>();
   const { field: useCustomHeadersField } = useController({
@@ -30,10 +28,11 @@ export function CustomHeadersConfigurationSection({
   });
 
   const useCustomHeaders = useCustomHeadersField.value;
+  const predefinedHeaderKeys = form.watch("predefinedHeaderKeys");
 
   const showToggle =
     !defaultServerConfig &&
-    !predefinedHeaders &&
+    !predefinedHeaderKeys?.length &&
     (!internalMCPServer || requiresBearerTokenConfiguration(internalMCPServer));
 
   return (
@@ -63,9 +62,7 @@ export function CustomHeadersConfigurationSection({
         </div>
       )}
 
-      {useCustomHeaders && (
-        <MCPServerHeaders predefinedHeaderKeys={predefinedHeaders} />
-      )}
+      {useCustomHeaders && <MCPServerHeaders />}
     </>
   );
 }

--- a/front/components/actions/mcp/forms/types.ts
+++ b/front/components/actions/mcp/forms/types.ts
@@ -77,6 +77,7 @@ export const createMCPServerDialogFormSchema = mcpServerOAuthFormSchema.extend({
   customHeaders: z
     .array(z.object({ key: z.string(), value: z.string() }))
     .default([]),
+  predefinedHeaderKeys: z.array(z.string()).optional(),
   viewName: z.string().optional(),
   // Admin-selected OAuth scopes. When set, only the selected scopes will be
   // requested during OAuth setup and stored on the server for personal connections.

--- a/front/lib/actions/mcp_internal_actions/server_token_labels.ts
+++ b/front/lib/actions/mcp_internal_actions/server_token_labels.ts
@@ -2,6 +2,7 @@ interface TokenFieldLabel {
   label: string;
   placeholder: string;
   tooltip: string;
+  predefinedHeaders?: string[];
 }
 
 const SERVER_TOKEN_LABELS: Record<string, TokenFieldLabel> = {
@@ -21,8 +22,8 @@ const SERVER_TOKEN_LABELS: Record<string, TokenFieldLabel> = {
     label: "Clari Copilot API Credentials",
     placeholder: "",
     tooltip:
-      "Add two custom headers: X-Api-Key and X-Api-Password. " +
       "You can find your credentials in Clari Copilot under Workspace Settings > Integrations > Clari Copilot API.",
+    predefinedHeaders: ["X-Api-Key", "X-Api-Password"],
   },
   front: {
     label: "Front API Token",

--- a/front/lib/actions/mcp_internal_actions/server_token_labels.ts
+++ b/front/lib/actions/mcp_internal_actions/server_token_labels.ts
@@ -1,8 +1,9 @@
 interface TokenFieldLabel {
   label: string;
-  placeholder: string;
+  placeholder?: string;
   tooltip: string;
   predefinedHeaders?: string[];
+  // Set to false when the API uses custom headers instead of a bearer token.
   showBearerTokenSection?: boolean;
 }
 
@@ -21,7 +22,6 @@ const SERVER_TOKEN_LABELS: Record<string, TokenFieldLabel> = {
   },
   clari_copilot: {
     label: "Clari Copilot API Credentials",
-    placeholder: "",
     tooltip:
       "You can find your credentials in Clari Copilot under Workspace Settings > Integrations > Clari Copilot API.",
     predefinedHeaders: ["X-Api-Key", "X-Api-Password"],

--- a/front/lib/actions/mcp_internal_actions/server_token_labels.ts
+++ b/front/lib/actions/mcp_internal_actions/server_token_labels.ts
@@ -1,11 +1,11 @@
-interface TokenFieldLabel {
+type TokenFieldLabel = {
   label: string;
-  placeholder?: string;
   tooltip: string;
   predefinedHeaders?: string[];
-  // Set to false when the API uses custom headers instead of a bearer token.
-  showBearerTokenSection?: boolean;
-}
+} & (
+  | { showBearerTokenSection?: true; placeholder: string }
+  | { showBearerTokenSection: false; placeholder?: string }
+);
 
 const SERVER_TOKEN_LABELS: Record<string, TokenFieldLabel> = {
   slab: {

--- a/front/lib/actions/mcp_internal_actions/server_token_labels.ts
+++ b/front/lib/actions/mcp_internal_actions/server_token_labels.ts
@@ -3,6 +3,7 @@ interface TokenFieldLabel {
   placeholder: string;
   tooltip: string;
   predefinedHeaders?: string[];
+  showBearerTokenSection?: boolean;
 }
 
 const SERVER_TOKEN_LABELS: Record<string, TokenFieldLabel> = {
@@ -24,6 +25,7 @@ const SERVER_TOKEN_LABELS: Record<string, TokenFieldLabel> = {
     tooltip:
       "You can find your credentials in Clari Copilot under Workspace Settings > Integrations > Clari Copilot API.",
     predefinedHeaders: ["X-Api-Key", "X-Api-Password"],
+    showBearerTokenSection: false,
   },
   front: {
     label: "Front API Token",


### PR DESCRIPTION
## Description

For internal MCP servers with predefined custom headers (currently only Clari Copilot with `X-Api-Key` and `X-Api-Password`), this PR hides the bearer token field and pre-fills the custom header keys in the configuration form. Users no longer need to manually toggle custom headers and type the exact header names—the form now automatically shows the expected header structure.

## Tests

Manually tested with Clari Copilot MCP server configuration.

## Risk

## Deploy Plan

Deploy front.