### PR TITLE
Context-usage indicator and Compaction button

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -25,6 +25,7 @@ import {
 } from "@app/components/assistant/conversation/types";
 import {
   useConversation,
+  useConversationContextUsage,
   useConversationFeedbacks,
   useConversationMarkAsRead,
   useConversationMessages,
@@ -239,6 +240,11 @@ export const ConversationViewer = ({
     conversationId,
     workspaceId: owner.sId,
     options: { disabled: true }, // We don't need the participants, only the mutator.
+  });
+
+  const { mutateContextUsage } = useConversationContextUsage({
+    conversationId,
+    workspaceId: owner.sId,
   });
 
   const submitMessage = useSubmitMessage({
@@ -547,6 +553,9 @@ export const ConversationViewer = ({
             // Debounce the call as we might receive multiple events for the same conversation (as we replay the events).
             void debouncedMarkAsRead(event.conversationId);
 
+            // Re-fetch context usage after the agent finishes so the indicator is up-to-date.
+            void mutateContextUsage();
+
             // Update the conversation hasError state in the local cache without making a network request.
             void mutateConversations(
               (currentData: ConversationWithoutContentType[] | undefined) =>
@@ -575,6 +584,7 @@ export const ConversationViewer = ({
     [
       conversationId,
       debouncedMarkAsRead,
+      mutateContextUsage,
       mutateConversation,
       mutateConversationAttachments,
       mutateConversationParticipants,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -38,6 +38,7 @@ import { useEnableBrowserNotification } from "@app/hooks/useEnableBrowserNotific
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitMessage } from "@app/hooks/useSubmitMessage";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types";
 import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/event_handlers";
@@ -170,6 +171,8 @@ export const ConversationViewer = ({
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
   const sendNotification = useSendNotification();
+  const { hasFeature } = useFeatureFlags();
+  const isCompactionEnabled = hasFeature("enable_compaction");
 
   const { mutateConversationAttachments } = useConversationAttachments({
     conversationId,
@@ -243,7 +246,7 @@ export const ConversationViewer = ({
   });
 
   const { mutateContextUsage } = useConversationContextUsage({
-    conversationId,
+    conversationId: isCompactionEnabled ? conversationId : null,
     workspaceId: owner.sId,
   });
 

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -38,9 +38,9 @@ import { useEnableBrowserNotification } from "@app/hooks/useEnableBrowserNotific
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitMessage } from "@app/hooks/useSubmitMessage";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/event_handlers";
 import type { DustError } from "@app/lib/error";
 import { AgentMessageCompletedEvent } from "@app/lib/notifications/events";

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -11,13 +11,15 @@ interface ContextUsageIndicatorProps {
   buttonSize: "xs" | "sm";
 }
 
+interface CircleProgressProps {
+  percentage: number;
+  size?: number;
+}
+
 function CircleProgress({
   percentage,
   size = 16,
-}: {
-  percentage: number;
-  size?: number;
-}) {
+}: CircleProgressProps) {
   const strokeWidth = size * 0.12;
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -1,0 +1,94 @@
+import {
+  Button,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+} from "@dust-tt/sparkle";
+
+interface ContextUsageIndicatorProps {
+  contextUsage: number;
+  contextSize: number;
+  buttonSize: "xs" | "sm";
+}
+
+function CircleProgress({
+  percentage,
+  size = 16,
+}: {
+  percentage: number;
+  size?: number;
+}) {
+  const strokeWidth = size * 0.12;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const clampedPct = Math.min(100, Math.max(0, percentage));
+  const offset = circumference - (clampedPct / 100) * circumference;
+
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        opacity={0.2}
+        strokeWidth={strokeWidth}
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="butt"
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        style={{ transition: "stroke-dashoffset 0.3s ease" }}
+      />
+    </svg>
+  );
+}
+
+export function ContextUsageIndicator({
+  contextUsage,
+  contextSize,
+  buttonSize,
+}: ContextUsageIndicatorProps) {
+  const percentage =
+    contextSize > 0 ? Math.round((contextUsage / contextSize) * 100) : 0;
+
+  return (
+    <PopoverRoot>
+      <PopoverTrigger asChild>
+        <div className="hidden md:block">
+          <Button
+            variant="ghost-secondary"
+            size={buttonSize}
+            icon={() => <CircleProgress percentage={percentage} size={16} />}
+          />
+        </div>
+      </PopoverTrigger>
+      <PopoverContent side="top" align="end">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <span className="text-sm font-semibold text-foreground">
+              Context
+            </span>
+            <span className="text-sm text-muted-foreground">
+              The current context of this conversation is {percentage}%
+            </span>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            label="Compact now"
+            disabled={true}
+          />
+        </div>
+      </PopoverContent>
+    </PopoverRoot>
+  );
+}

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -16,10 +16,7 @@ interface CircleProgressProps {
   size?: number;
 }
 
-function CircleProgress({
-  percentage,
-  size = 16,
-}: CircleProgressProps) {
+function CircleProgress({ percentage, size = 16 }: CircleProgressProps) {
   const strokeWidth = size * 0.12;
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -1,8 +1,8 @@
 import {
   Button,
-  PopoverContent,
-  PopoverRoot,
-  PopoverTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
 
 interface ContextUsageIndicatorProps {
@@ -61,34 +61,34 @@ export function ContextUsageIndicator({
     contextSize > 0 ? Math.round((contextUsage / contextSize) * 100) : 0;
 
   return (
-    <PopoverRoot>
-      <PopoverTrigger asChild>
-        <div className="hidden md:block">
+    <div className="hidden md:block">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
           <Button
             variant="ghost-secondary"
             size={buttonSize}
             icon={() => <CircleProgress percentage={percentage} size={16} />}
           />
-        </div>
-      </PopoverTrigger>
-      <PopoverContent side="top" align="end">
-        <div className="flex flex-col gap-3">
-          <div className="flex flex-col gap-1">
-            <span className="text-sm font-semibold text-foreground">
-              Context
-            </span>
-            <span className="text-sm text-muted-foreground">
-              The current context of this conversation is {percentage}%
-            </span>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="top" align="end" className="w-64">
+          <div className="flex flex-col items-start gap-3 p-3">
+            <div className="flex flex-col gap-1">
+              <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                Context
+              </span>
+              <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                The current context usage is at {percentage}%
+              </span>
+            </div>
+            <Button
+              variant="outline"
+              size="xs"
+              label="Compact now"
+              disabled={true}
+            />
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            label="Compact now"
-            disabled={true}
-          />
-        </div>
-      </PopoverContent>
-    </PopoverRoot>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1245,7 +1245,7 @@ const InputBarContainer = ({
           className={cn("absolute bottom-2 right-2 flex items-center gap-2")}
         >
           <div className="flex items-center">
-            {isCompactionEnabled && (
+            {isCompactionEnabled && conversation && (
               <ContextUsageIndicator
                 contextUsage={contextUsage?.contextUsage ?? 0}
                 contextSize={contextUsage?.contextSize ?? 0}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,3 +1,4 @@
+import { ContextUsageIndicator } from "@app/components/assistant/conversation/input_bar/ContextUsageIndicator";
 import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
 import { InputBarButtons } from "@app/components/assistant/conversation/input_bar/InputBarButtons";
 import {
@@ -11,6 +12,7 @@ import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import useHandleMentions from "@app/components/editor/input_bar/useHandleMentions";
 import useUrlHandler from "@app/components/editor/input_bar/useUrlHandler";
 import { getIcon } from "@app/components/resources/resources_icons";
+import { useConversationContextUsage } from "@app/hooks/conversations";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceTranscriberService } from "@app/hooks/useVoiceTranscriberService";
@@ -202,6 +204,11 @@ const InputBarContainer = ({
   const singleAgentInput = hasFeature("enable_steering");
   const { selectedSingleAgent, setSelectedSingleAgent } =
     useContext(InputBarContext);
+
+  const { contextUsage } = useConversationContextUsage({
+    conversationId: conversation?.sId,
+    workspaceId: owner.sId,
+  });
   const [hasUserMention, setHasUserMention] = useState(false);
   const canSubmitEmpty = singleAgentInput && !!selectedSingleAgent;
 
@@ -1238,20 +1245,29 @@ const InputBarContainer = ({
             "absolute bottom-2 right-2 flex items-center gap-2 md:gap-1"
           )}
         >
-          {!subscription.plan.isByok &&
-            owner.metadata?.allowVoiceTranscription !== false &&
-            actions.includes("voice") && (
-              <VoicePicker
-                status={voiceTranscriberService.status}
-                level={voiceTranscriberService.level}
-                elapsedSeconds={voiceTranscriberService.elapsedSeconds}
-                onRecordStart={voiceTranscriberService.startRecording}
-                onRecordStop={voiceTranscriberService.stopRecording}
-                disabled={disableInput}
-                size={buttonSize}
-                showStopLabel={!isMobile}
+          <div className="flex items-center">
+            {contextUsage && (
+              <ContextUsageIndicator
+                contextUsage={contextUsage.contextUsage}
+                contextSize={contextUsage.contextSize}
+                buttonSize={buttonSize}
               />
             )}
+            {!subscription.plan.isByok &&
+              owner.metadata?.allowVoiceTranscription !== false &&
+              actions.includes("voice") && (
+                <VoicePicker
+                  status={voiceTranscriberService.status}
+                  level={voiceTranscriberService.level}
+                  elapsedSeconds={voiceTranscriberService.elapsedSeconds}
+                  onRecordStart={voiceTranscriberService.startRecording}
+                  onRecordStop={voiceTranscriberService.stopRecording}
+                  disabled={disableInput}
+                  size={buttonSize}
+                  showStopLabel={!isMobile}
+                />
+              )}
+          </div>
           <Button
             size={buttonSize}
             isLoading={

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -202,11 +202,12 @@ const InputBarContainer = ({
   const isMobile = useIsMobile();
   const { hasFeature } = useFeatureFlags();
   const singleAgentInput = hasFeature("enable_steering");
+  const isCompactionEnabled = hasFeature("enable_compaction");
   const { selectedSingleAgent, setSelectedSingleAgent } =
     useContext(InputBarContext);
 
   const { contextUsage } = useConversationContextUsage({
-    conversationId: conversation?.sId,
+    conversationId: isCompactionEnabled ? conversation?.sId : null,
     workspaceId: owner.sId,
   });
   const [hasUserMention, setHasUserMention] = useState(false);
@@ -1241,15 +1242,13 @@ const InputBarContainer = ({
           </div>
         </div>
         <div
-          className={cn(
-            "absolute bottom-2 right-2 flex items-center gap-2"
-          )}
+          className={cn("absolute bottom-2 right-2 flex items-center gap-2")}
         >
           <div className="flex items-center">
-            {contextUsage && (
+            {isCompactionEnabled && (
               <ContextUsageIndicator
-                contextUsage={contextUsage.contextUsage}
-                contextSize={contextUsage.contextSize}
+                contextUsage={contextUsage?.contextUsage ?? 0}
+                contextSize={contextUsage?.contextSize ?? 0}
                 buttonSize={buttonSize}
               />
             )}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1242,7 +1242,7 @@ const InputBarContainer = ({
         </div>
         <div
           className={cn(
-            "absolute bottom-2 right-2 flex items-center gap-2 md:gap-1"
+            "absolute bottom-2 right-2 flex items-center gap-2"
           )}
         >
           <div className="flex items-center">

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -3,8 +3,8 @@ export { useAgentMessageTools } from "./useAgentMessageTools";
 export { useBranchConversation } from "./useBranchConversation";
 export { useCancelMessage } from "./useCancelMessage";
 export { useConversation } from "./useConversation";
-export { useConversationContextUsage } from "./useConversationContextUsage";
 export { useConversationBranchActions } from "./useConversationBranchActions";
+export { useConversationContextUsage } from "./useConversationContextUsage";
 export { useConversationFeedbacks } from "./useConversationFeedbacks";
 export { useConversationMarkAsRead } from "./useConversationMarkAsRead";
 export {

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -3,6 +3,7 @@ export { useAgentMessageTools } from "./useAgentMessageTools";
 export { useBranchConversation } from "./useBranchConversation";
 export { useCancelMessage } from "./useCancelMessage";
 export { useConversation } from "./useConversation";
+export { useConversationContextUsage } from "./useConversationContextUsage";
 export { useConversationBranchActions } from "./useConversationBranchActions";
 export { useConversationFeedbacks } from "./useConversationFeedbacks";
 export { useConversationMarkAsRead } from "./useConversationMarkAsRead";

--- a/front/hooks/conversations/useConversationContextUsage.ts
+++ b/front/hooks/conversations/useConversationContextUsage.ts
@@ -1,0 +1,29 @@
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetConversationContextUsageResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage";
+import type { Fetcher } from "swr";
+
+export function useConversationContextUsage({
+  conversationId,
+  workspaceId,
+}: {
+  conversationId?: string | null;
+  workspaceId: string;
+}) {
+  const { fetcher } = useFetcher();
+  const contextUsageFetcher: Fetcher<GetConversationContextUsageResponse> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    conversationId
+      ? `/api/w/${workspaceId}/assistant/conversations/${conversationId}/context-usage`
+      : null,
+    contextUsageFetcher
+  );
+
+  return {
+    contextUsage: data ?? null,
+    isContextUsageLoading: !error && !data,
+    isContextUsageError: error,
+    mutateContextUsage: mutate,
+  };
+}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -279,6 +279,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Dummy feature flag used for testing feature flag behavior",
     stage: "dust_only",
   },
+  enable_compaction: {
+    description:
+      "Enable context compaction: summarize older messages to free up context window",
+    stage: "dust_only",
+  },
   enable_steering: {
     description:
       "Enable steering: pending user messages + graceful stop of running agent loops",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -743,6 +743,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "anthropic_reasoning_token_count"
   | "collapsible_messages"
   | "use_dust_keys"
+  | "enable_compaction"
   | "enable_steering"
 >();
 


### PR DESCRIPTION
## Description

- Add `enable-compaction` feature flag
- Add context-usage jauge with button to compact (disabled for now) (behind flag)

<img width="671" height="196" alt="Screenshot 2026-04-14 at 22 20 26" src="https://github.com/user-attachments/assets/039a4bae-b805-470b-8c0e-9e0d773d6844" />
<img width="667" height="206" alt="Screenshot 2026-04-14 at 22 20 59" src="https://github.com/user-attachments/assets/077ed172-e25d-42f2-9d29-c718b1090a95" />

## Tests

Tesed locally

## Risk

Low

## Deploy Plan

- deploy `front`