### PR TITLE
Update cancelled message UI to say "Stopped by user"

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1381,7 +1381,7 @@ function AgentMessageContent({
         {agentMessage.status === "cancelled" && (
           <div className="flex flex-col gap-2">
             <div className="text-sm text-faint dark:text-faint-night">
-              Message generation was interrupted
+              Message generation stopped by user
             </div>
             <div>
               <ButtonGroupDropdown

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -28,6 +28,7 @@ import {
   cn,
   Icon,
   ToolsIcon,
+  XCircleIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -117,7 +118,9 @@ export function InlineActivitySteps({
           agentMessage.completionDurationMs
         )
       : isDone
-        ? "Completed"
+        ? agentMessage.status === "cancelled"
+          ? "Cancelled"
+          : "Completed"
         : null;
 
   // Writing-only: no prior steps, just streaming text. Show "Writing..."
@@ -349,9 +352,16 @@ export function InlineActivitySteps({
             {isDone &&
               completedSteps.length > 0 &&
               agentMessage.status !== "gracefully_stopped" && (
-                <TimelineRow icon={CheckIcon} isLast>
+                <TimelineRow
+                  icon={
+                    agentMessage.status === "cancelled"
+                      ? XCircleIcon
+                      : CheckIcon
+                  }
+                  isLast
+                >
                   <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    Done
+                    {agentMessage.status === "cancelled" ? "Cancelled" : "Done"}
                   </span>
                 </TimelineRow>
               )}


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/7417#issuecomment-4244782010
## Description
- Update "Message generation was interrupted" text to be "Message generation stopped by user"
- Show XCircleIcon with "Cancelled" instead of CheckIcon "Done" in inline activity timeline for cancelled messages

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Test via link

Before:
<img width="790" height="335" alt="Screenshot 2026-04-15 at 7 00 30 PM" src="https://github.com/user-attachments/assets/e82c4f3a-df12-40e5-ac32-3298686430bc" />

After:
<img width="802" height="320" alt="Screenshot 2026-04-15 at 6 58 36 PM" src="https://github.com/user-attachments/assets/7c842df8-0d45-4348-8a4c-9033a32cec9c" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
