### PR TITLE
Only restore draft agent mention when draft has text content

### DIFF
--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -81,7 +81,7 @@ const useHandleMentions = ({
 
     // 1. Draft has a saved agent → use it.
     const draft = getDraft();
-    if (draft?.agentMention) {
+    if (draft?.agentMention && draft.text?.trim()) {
       setSelectedSingleAgent(draft.agentMention);
       return;
     }


### PR DESCRIPTION
## Description
Context: https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1776193635510009
We stopped saving a draft without text in https://github.com/dust-tt/dust/pull/24124 but since these drafts persist in local storage, my hunch is that there are some lingering around causing a blank draft with an agent being restored on first page load. This PR ensures we don't set an agent from draft if there isn't a drafted message associated. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Not a super easy way to test this but I think it's a good layer of protection
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
