### PR TITLE
[front] Fix logo wall: restore Photoroom, keep Decagon replacing EvenUp

### DIFF
--- a/front/components/home/TrustedBy.tsx
+++ b/front/components/home/TrustedBy.tsx
@@ -42,7 +42,7 @@ const CASE_STUDIES: Record<string, string> = {
 const LOGO_SETS = {
   default: {
     us: [
-      { name: "decagon", src: "/static/landing/logos/gray/decagon.svg" },
+      { name: "photoroom", src: "/static/landing/logos/gray/photoroom.svg" },
       { name: "clay", src: "/static/landing/logos/gray/clay.svg" },
       //  { name: "cursor", src: "/static/landing/logos/gray/cursor.svg" }, -- temporary
       { name: "assembled", src: "/static/landing/logos/gray/assembled.svg" },
@@ -66,14 +66,14 @@ const LOGO_SETS = {
       { name: "malt", src: "/static/landing/logos/gray/malt.svg" },
       { name: "vanta", src: "/static/landing/logos/gray/vanta.svg" },
       { name: "payfit", src: "/static/landing/logos/gray/payfit.svg" },
-      { name: "decagon", src: "/static/landing/logos/gray/decagon.svg" },
+      { name: "photoroom", src: "/static/landing/logos/gray/photoroom.svg" },
       { name: "pennylane", src: "/static/landing/logos/gray/pennylane.svg" },
       { name: "qonto", src: "/static/landing/logos/gray/qonto.svg" },
     ],
   },
   landing: {
     us: [
-      { name: "decagon", src: "/static/landing/logos/gray/decagon.svg" },
+      { name: "photoroom", src: "/static/landing/logos/gray/photoroom.svg" },
       { name: "clay", src: "/static/landing/logos/gray/clay.svg" },
       // { name: "cursor", src: "/static/landing/logos/gray/cursor.svg" }, -- temporary
       { name: "assembled", src: "/static/landing/logos/gray/assembled.svg" },
@@ -97,7 +97,7 @@ const LOGO_SETS = {
       { name: "malt", src: "/static/landing/logos/gray/malt.svg" },
       { name: "vanta", src: "/static/landing/logos/gray/vanta.svg" },
       { name: "payfit", src: "/static/landing/logos/gray/payfit.svg" },
-      { name: "decagon", src: "/static/landing/logos/gray/decagon.svg" },
+      { name: "photoroom", src: "/static/landing/logos/gray/photoroom.svg" },
       { name: "pennylane", src: "/static/landing/logos/gray/pennylane.svg" },
       { name: "qonto", src: "/static/landing/logos/gray/qonto.svg" },
     ],


### PR DESCRIPTION
## Description

Fixes a regression from #24198.

PR #24198 was merged via squash from a branch that contained two commits. GitHub computed the squash diff from the original fork point (not from main at merge time), so the net-zero changes to Photoroom positions were omitted. This left the 4 positions that #24182 changed to Decagon unchanged, resulting in 6 Decagon logos.

This PR restores Photoroom to `default.us`, `default.eu`, `landing.us`, `landing.eu` while keeping Decagon where EvenUp was (`default.us` position 4, `landing.us` position 4).

## Changes

**`TrustedBy.tsx` — 4 lines:**
```diff
// default.us (position 1), default.eu, landing.us (position 1), landing.eu
- { name: "decagon", ... },
+ { name: "photoroom", ... },
```

## Test Plan
- [x] Verified locally — no duplicate logos
- [x] All pre-commit checks passed (biome + typecheck)