### PR TITLE
[front] Show error ContentMessage when compaction fails

### DIFF
--- a/front/components/assistant/conversation/CompactionMessage.tsx
+++ b/front/components/assistant/conversation/CompactionMessage.tsx
@@ -1,27 +1,51 @@
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import type { CompactionMessageType } from "@app/types/assistant/conversation";
-import { AnimatedText, Spinner } from "@dust-tt/sparkle";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import {
+  AnimatedText,
+  ContentMessage,
+  ExclamationCircleIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
 
 interface CompactionMessageProps {
   message: CompactionMessageType;
 }
 
 export function CompactionMessage({ message }: CompactionMessageProps) {
-  return (
-    <div className="flex items-center justify-center gap-1.5">
-      {message.status === "succeeded" && (
-        <span className="text-base text-muted-foreground">
-          Context compacted · {formatTimestring(message.created)}
-        </span>
-      )}
-      {message.status === "created" && (
-        <>
+  switch (message.status) {
+    case "failed":
+      return (
+        <ContentMessage
+          title="Context compaction failed"
+          variant="warning"
+          className="flex flex-col gap-3"
+          icon={ExclamationCircleIcon}
+        >
+          <div className="whitespace-normal break-words">
+            You may experience reduced performance on very long conversations.
+          </div>
+        </ContentMessage>
+      );
+    case "succeeded":
+      return (
+        <div className="flex items-center justify-center gap-1.5">
+          <span className="text-base text-muted-foreground">
+            Context compacted · {formatTimestring(message.created)}
+          </span>
+        </div>
+      );
+    case "created":
+      return (
+        <div className="flex items-center justify-center gap-1.5">
           <Spinner size="xs" />
           <AnimatedText variant="muted" className="text-base">
             Compacting context…
           </AnimatedText>
-        </>
-      )}
-    </div>
-  );
+        </div>
+      );
+    default:
+      assertNeverAndIgnore(message.status);
+      return null;
+  }
 }

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -255,11 +255,12 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       isPreviousAgentMessageSteered,
     });
 
+    // No message without a conversation
+    if (!context.conversation) {
+      return null;
+    }
+
     if (isCompactionMessage(data)) {
-      // TODO(compaction): handle failed compaction display
-      if (data.status === "failed") {
-        return null;
-      }
       return (
         <div
           ref={ref}
@@ -272,11 +273,6 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
           <CompactionMessage message={data} />
         </div>
       );
-    }
-
-    // No message without a conversation
-    if (!context.conversation) {
-      return null;
     }
 
     return (


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7549

- Use ContentMessage in CompactionMessage for error cases (message.status "failed")
- No retry button for the moment as we are not yet triggering compaction
<img width="837" height="437" alt="Screenshot 2026-04-14 at 23 00 21" src="https://github.com/user-attachments/assets/1bbfe404-ab6e-4a8a-82a1-901182daa25d" />



## Tests

Tested locally by forcing a fake compaction that fails after 3 seconds

## Risk

N/A compaction messages are not yet created

## Deploy Plan

Deploy front