### PR TITLE
Lower front connection pool from 80 to 40.

### DIFF
--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -88,7 +88,7 @@ function getPoolMaxForService(): number {
   const service = config.getServiceName();
 
   // DO NOT BLINDLY INCREASE THIS NUMBER (see comment below).
-  return service && WEB_SERVING_SERVICES.has(service) ? 80 : 25;
+  return service && WEB_SERVING_SERVICES.has(service) ? 40 : 25;
 }
 
 export const frontSequelize = new SequelizeWithComments(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Step 1 of the journey towards, improving our SQL usage. We had to bump to 80 to help ease the pressure on our SQL connection pool. With all the recent work around caching and improving critical paths, time to start lowering back this value to a more decent, easily to scale value. 

This PR lowers to a first threshold of 40 for all front connection pools to ensure we don't introduce code that widely used connections. Will monitor and lower to 20 by end of my shift.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
