### PR TITLE
[Sessions] Copy forked conversation skills inside the transaction

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -404,6 +404,60 @@ describe("createConversationFork", () => {
     expect(childSkills[0].sId).toBe(enabledSkill.sId);
   });
 
+  it("does not copy archived conversation skills into the child conversation", async () => {
+    const { auth, globalSpace } = await createPrivateApiMockRequest();
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: globalSpace.id,
+    });
+
+    const enabledSkill = await SkillFactory.create(auth, {
+      name: "Enabled skill",
+    });
+    const archivedSkill = await SkillFactory.create(auth, {
+      name: "Archived skill",
+      status: "archived",
+    });
+
+    const upsertResult = await SkillResource.upsertConversationSkills(auth, {
+      conversationId: parentConversation.id,
+      skills: [enabledSkill, archivedSkill],
+      enabled: true,
+    });
+    expect(upsertResult.isOk()).toBe(true);
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "Continue with readable skills only.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childSkills = await SkillResource.listEnabledByConversation(auth, {
+      conversation: result.value,
+    });
+
+    expect(childSkills).toHaveLength(1);
+    expect(childSkills[0].sId).toBe(enabledSkill.sId);
+  });
+
   it("inherits the parent's requested spaces so the fork does not broaden visibility", async () => {
     const {
       auth: initialAuth,

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -122,23 +122,11 @@ async function copyConversationSkills(
     transaction: Transaction;
   }
 ): Promise<Result<undefined, DustError<CreateConversationForkErrorCode>>> {
-  const parentSkills = await SkillResource.listEnabledByConversation(auth, {
-    conversation: parentConversation,
+  const upsertResult = await SkillResource.copyEnabledConversationSkills(auth, {
+    parentConversation,
+    childConversationId: childConversation.id,
+    transaction,
   });
-
-  if (parentSkills.length === 0) {
-    return new Ok(undefined);
-  }
-
-  const upsertResult = await SkillResource.upsertConversationSkills(
-    auth,
-    {
-      conversationId: childConversation.id,
-      skills: parentSkills,
-      enabled: true,
-    },
-    { transaction }
-  );
 
   if (upsertResult.isErr()) {
     return new Err(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1176,6 +1176,193 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
+  private static async listEnabledConversationSkillReferences(
+    auth: Authenticator,
+    {
+      conversation,
+      transaction,
+    }: {
+      conversation: ConversationWithoutContentType;
+      transaction: Transaction;
+    }
+  ): Promise<
+    {
+      customSkillId: ModelId | null;
+      globalSkillId: GlobalSkillId | null;
+    }[]
+  > {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const conversationSkills = await ConversationSkillModel.findAll({
+      attributes: ["customSkillId", "globalSkillId"],
+      where: {
+        workspaceId: workspace.id,
+        conversationId: conversation.id,
+        agentConfigurationId: null,
+      },
+      transaction,
+    });
+
+    if (conversationSkills.length === 0) {
+      return [];
+    }
+
+    const customSkillIds = uniq(
+      removeNulls(conversationSkills.map((skill) => skill.customSkillId))
+    );
+    const allowedCustomSkillIds = new Set<ModelId>();
+
+    if (customSkillIds.length > 0) {
+      const customSkills = await this.model.findAll({
+        attributes: ["id", "requestedSpaceIds"],
+        where: {
+          id: {
+            [Op.in]: customSkillIds,
+          },
+          status: "active",
+          workspaceId: workspace.id,
+        },
+        transaction,
+      });
+
+      const uniqueRequestedSpaceIds = uniq(
+        customSkills.flatMap((skill) => skill.requestedSpaceIds)
+      );
+      const spaces =
+        uniqueRequestedSpaceIds.length > 0
+          ? await SpaceResource.fetchByModelIds(auth, uniqueRequestedSpaceIds, {
+              transaction,
+            })
+          : [];
+      const foundSpaceIds = new Set(spaces.map((space) => space.id));
+      const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
+
+      for (const skill of customSkills) {
+        if (!skill.requestedSpaceIds.every((id) => foundSpaceIds.has(id))) {
+          continue;
+        }
+
+        if (
+          !auth.canRead(
+            createResourcePermissionsFromSpacesWithMap(
+              spaceIdToGroupsMap,
+              skill.requestedSpaceIds
+            )
+          )
+        ) {
+          continue;
+        }
+
+        allowedCustomSkillIds.add(skill.id);
+      }
+    }
+
+    const globalSkillIds = uniq(
+      removeNulls(conversationSkills.map((skill) => skill.globalSkillId))
+    );
+    const allowedGlobalSkillIds = new Set<GlobalSkillId>();
+
+    if (globalSkillIds.length > 0) {
+      const globalSkills = await GlobalSkillsRegistry.findAll(auth, {
+        sId: globalSkillIds,
+      });
+
+      for (const skill of globalSkills) {
+        allowedGlobalSkillIds.add(skill.sId as GlobalSkillId);
+      }
+    }
+
+    const seenReferences = new Set<string>();
+    const validatedReferences: {
+      customSkillId: ModelId | null;
+      globalSkillId: GlobalSkillId | null;
+    }[] = [];
+
+    for (const skill of conversationSkills) {
+      if (skill.customSkillId !== null) {
+        if (!allowedCustomSkillIds.has(skill.customSkillId)) {
+          continue;
+        }
+
+        const key = `custom:${skill.customSkillId}`;
+        if (seenReferences.has(key)) {
+          continue;
+        }
+
+        seenReferences.add(key);
+        validatedReferences.push({
+          customSkillId: skill.customSkillId,
+          globalSkillId: null,
+        });
+        continue;
+      }
+
+      if (skill.globalSkillId !== null) {
+        if (!allowedGlobalSkillIds.has(skill.globalSkillId)) {
+          continue;
+        }
+
+        const key = `global:${skill.globalSkillId}`;
+        if (seenReferences.has(key)) {
+          continue;
+        }
+
+        seenReferences.add(key);
+        validatedReferences.push({
+          customSkillId: null,
+          globalSkillId: skill.globalSkillId,
+        });
+      }
+    }
+
+    return validatedReferences;
+  }
+
+  static async copyEnabledConversationSkills(
+    auth: Authenticator,
+    {
+      parentConversation,
+      childConversationId,
+      transaction,
+    }: {
+      parentConversation: ConversationWithoutContentType;
+      childConversationId: ModelId;
+      transaction: Transaction;
+    }
+  ): Promise<Result<undefined, Error>> {
+    const workspace = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
+
+    const parentSkillReferences =
+      await this.listEnabledConversationSkillReferences(auth, {
+        conversation: parentConversation,
+        transaction,
+      });
+
+    if (parentSkillReferences.length === 0) {
+      return new Ok(undefined);
+    }
+
+    // Copy only validated skill references so the fork stays on the current
+    // transaction without hydrating every linked skill and its related records.
+    await ConversationSkillModel.bulkCreate(
+      parentSkillReferences.map(
+        (reference) =>
+          ({
+            ...reference,
+            workspaceId: workspace.id,
+            conversationId: childConversationId,
+            addedByUserId: user.id,
+            source: "conversation",
+            agentConfigurationId: null,
+          }) satisfies ConversationSkillCreationAttributes
+      ),
+      { transaction }
+    );
+
+    return new Ok(undefined);
+  }
+
   /**
    * List skills for the agent loop, returning both (extended) enabled skills and equipped skills.
    */

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -460,7 +460,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
-    { includeDeleted }: { includeDeleted?: boolean } = {}
+    {
+      includeDeleted,
+      transaction,
+    }: { includeDeleted?: boolean; transaction?: Transaction } = {}
   ) {
     if (ids.length === 0) {
       return [];
@@ -473,7 +476,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         },
       },
       includeDeleted,
-    });
+    }, transaction);
 
     return spaces ?? [];
   }


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24213
Context: https://github.com/dust-tt/dust/pull/24213#discussion_r3081008908

Copy forked conversation skills from validated conversation-skill references instead of hydrating full SkillResources. This keeps the fork copy path on the existing transaction while preserving the active/readable filtering for archived or inaccessible skills.

## Risks
Blast radius: conversation fork creation when the parent conversation has conversation-level skills enabled
Risk: low

## Deploy Plan
- deploy front

## Test
- [x] NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run ./lib/api/assistant/conversation/forks.test.ts