### PR TITLE
Update batch polling to exponential backoff and extend timeout duration

### DIFF
--- a/front/temporal/reinforcement/workflows.ts
+++ b/front/temporal/reinforcement/workflows.ts
@@ -89,10 +89,9 @@ const MAX_REINFORCED_ANALYSIS_STEPS = 4;
 const CONVERSATION_ANALYSIS_CONCURRENCY = 4;
 const SKILL_AGGREGATION_CONCURRENCY = 8;
 
-const BATCH_POLL_INTERVAL_MIN_MS = 30_000; // 30 seconds (linear backoff start).
-const BATCH_POLL_INTERVAL_MAX_MS = 5 * 60_000; // 5 minutes (linear backoff cap).
-const BATCH_POLL_INTERVAL_STEP_MS = 10_000; // 10 seconds (linear backoff step).
-const BATCH_TIMEOUT_MS = 6 * 60 * 60_000; // 6 hours.
+const BATCH_POLL_INTERVAL_MIN_MS = 30_000; // 30 seconds (exponential backoff start).
+const BATCH_POLL_INTERVAL_MAX_MS = 30 * 60_000; // 30 minutes (exponential backoff cap).
+const BATCH_TIMEOUT_MS = 24 * 60 * 60_000 + 5 * 60_000; // 24 hours + 5 minutes (to guarantee we wait longer than Anthropic's batch limit).
 
 const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
 
@@ -111,8 +110,8 @@ function computeWorkspaceDelayMs(workspaceId: string): number {
 
 /**
  * Wait for a batch to complete.
- * Polls with linear backoff starting at 30 seconds, adding 10 seconds each time, capped at 5 minutes.
- * Throws a non-retryable error after 6 hours.
+ * Polls with exponential backoff starting at 30 seconds, doubling each time, capped at 30 minutes.
+ * Throws a non-retryable error after 24 hours.
  */
 async function waitForBatch({
   workspaceId,
@@ -127,10 +126,7 @@ async function waitForBatch({
   while (elapsedMs < BATCH_TIMEOUT_MS) {
     await sleep(intervalMs);
     elapsedMs += intervalMs;
-    intervalMs = Math.min(
-      intervalMs + BATCH_POLL_INTERVAL_STEP_MS,
-      BATCH_POLL_INTERVAL_MAX_MS
-    );
+    intervalMs = Math.min(intervalMs * 2, BATCH_POLL_INTERVAL_MAX_MS);
 
     const status = await checkBatchStatusActivity({ workspaceId, batchId });
     if (status === "ready") {
@@ -139,7 +135,7 @@ async function waitForBatch({
   }
 
   throw new ApplicationFailure(
-    `Batch ${batchId} in workspace ${workspaceId} timed out after 6 hours.`,
+    `Batch ${batchId} in workspace ${workspaceId} timed out after 24 hours.`,
     "BATCH_TIMEOUT",
     true // non-retryable
   );


### PR DESCRIPTION
## Description

 - Switch waitForBatch polling from linear backoff (+10s per poll, capped at 5min) to exponential backoff (×2 per poll, capped at 30min)
 - Increase batch timeout from 6 hours to 24h+5min to guarantee we wait longer than Anthropic's batch limit
 - Polling sequence: 30s, 1m, 2m, 4m, 8m, 16m, 30m, 30m, ...

Fixes https://github.com/dust-tt/tasks/issues/7557
 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Under flag

## Deploy Plan

Front