### PR TITLE
[front] chore: temporarily remove sandbox from deep-dive

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -409,7 +409,6 @@ export function _getDeepDiveGlobalAgent(
     settings,
     preFetchedDataSources,
     mcpServerViews,
-    hasSandbox,
     excludeProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
@@ -419,6 +418,9 @@ export function _getDeepDiveGlobalAgent(
     excludeProviders: ReadonlySet<ModelProviderIdType>;
   }
 ): AgentConfigurationType | null {
+  // TODO(2026-04-15 sandbox): re-enable sandbox for deep-dive once fully ready.
+  const hasSandbox = false;
+
   const {
     run_agent: runAgentMCPServerView,
     ask_user_question: askUserQuestionMCPServerView,


### PR DESCRIPTION
## Description

- This PR removes the sandbox skills from the deep-dive global agent to avoid disruption temporarily.
- Only affects workspaces that have the feature flag.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.