### PR TITLE
Stop indexing size-offloaded tool output files in Qdrant

### DIFF
--- a/front/lib/actions/action_file_helpers.ts
+++ b/front/lib/actions/action_file_helpers.ts
@@ -20,12 +20,14 @@ export async function generatePlainTextFile(
     content,
     snippet,
     hideFromUser,
+    skipDataSourceIndexing,
   }: {
     title: string;
     conversationId: string;
     content: string;
     snippet?: string;
     hideFromUser?: boolean;
+    skipDataSourceIndexing?: boolean;
   }
 ): Promise<FileResource> {
   const workspace = auth.getNonNullableWorkspace();
@@ -41,6 +43,7 @@ export async function generatePlainTextFile(
     useCaseMetadata: {
       conversationId,
       ...(hideFromUser ? { hideFromUser: true } : {}),
+      ...(skipDataSourceIndexing ? { skipDataSourceIndexing: true } : {}),
     },
     snippet,
   });

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -93,7 +93,7 @@ describe("processToolResults", () => {
     // Generate text that exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES (20KB).
     const largeText = "x".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
 
-    const { outputItems } = await processToolResults(auth, {
+    const { outputItems, generatedFiles } = await processToolResults(auth, {
       action,
       conversation,
       localLogger: logger.child({ test: true }),
@@ -112,6 +112,10 @@ describe("processToolResults", () => {
       );
       expect(stored.resource.text).toContain("... (truncated)");
     }
+
+    // Offloaded files must not be indexed in Qdrant. Models read them directly.
+    expect(generatedFiles).toHaveLength(1);
+    expect(generatedFiles[0].skipDataSourceIndexing).toBe(true);
   });
 
   it("should store snippet for large resource text", async () => {
@@ -120,7 +124,7 @@ describe("processToolResults", () => {
     // Generate resource text that exceeds FILE_OFFLOAD_RESOURCE_SIZE_BYTES (20MB).
     const largeResourceText = "y".repeat(FILE_OFFLOAD_RESOURCE_SIZE_BYTES + 1);
 
-    const { outputItems } = await processToolResults(auth, {
+    const { outputItems, generatedFiles } = await processToolResults(auth, {
       action,
       conversation,
       localLogger: logger.child({ test: true }),
@@ -143,6 +147,10 @@ describe("processToolResults", () => {
       );
       expect(stored.resource.text).toContain("... (truncated)");
     }
+
+    // Offloaded files must not be indexed in Qdrant. Models read them directly.
+    expect(generatedFiles).toHaveLength(1);
+    expect(generatedFiles[0].skipDataSourceIndexing).toBe(true);
   });
 
   it("should keep small text content as-is", async () => {

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -180,6 +180,9 @@ export async function processToolResults(
       switch (block.type) {
         case "text": {
           // If the text is too large we create a file and return a resource block that references the file.
+          // These files are offloaded purely for size reasons. the model reads them directly via the
+          // "cat" approach and never uses semantic search on them. `skipDataSourceIndexing` prevents
+          // them from being indexed in Qdrant, which would bloat the vector store for no benefit.
           if (
             computeTextByteSize(block.text) > FILE_OFFLOAD_TEXT_SIZE_BYTES &&
             toolConfiguration.mcpServerName !== "conversation_files"
@@ -195,6 +198,7 @@ export async function processToolResults(
               content: block.text,
               snippet,
               hideFromUser: true,
+              skipDataSourceIndexing: true,
             });
             return {
               content: {
@@ -337,6 +341,7 @@ export async function processToolResults(
             const sanitizedResource = sanitizeStringsDeep(block.resource);
 
             // If the resource text is too large, we create a file and return a resource block that references the file.
+            // Same as the text block case above: offloaded for size, not for search. Skip Qdrant indexing.
             if (
               text &&
               computeTextByteSize(text) > FILE_OFFLOAD_RESOURCE_SIZE_BYTES
@@ -354,6 +359,7 @@ export async function processToolResults(
                 content: text,
                 snippet,
                 hideFromUser: true,
+                skipDataSourceIndexing: true,
               });
               return {
                 content: {
@@ -416,6 +422,8 @@ export async function processToolResults(
         updatedAt: c.file.updatedAt.getTime(),
         isInProjectContext: c.file.useCase === "project_context",
         hidden: c.file.useCaseMetadata?.hideFromUser ?? false,
+        skipDataSourceIndexing:
+          c.file.useCaseMetadata?.skipDataSourceIndexing ?? false,
       } satisfies ActionGeneratedFileType;
     })
   );

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -78,6 +78,7 @@ export async function getFileFromConversationAttachment(
             snippet: f.snippet,
             isInProjectContext: f.isInProjectContext ?? false,
             hideFromUser: f.hidden ?? false,
+            skipDataSourceIndexing: f.skipDataSourceIndexing ?? false,
           });
           break;
         }

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -93,6 +93,9 @@ export type ActionGeneratedFileType = {
   updatedAt?: number;
   isInProjectContext?: boolean;
   hidden?: boolean;
+  // True for files created by offloading oversized tool output to disk. These are never indexed in
+  // Qdrant and should not be flagged as searchable in the conversation render.
+  skipDataSourceIndexing?: boolean;
 };
 
 export type AgentLoopRunContextType = {

--- a/front/lib/api/assistant/conversation/attachments.test.ts
+++ b/front/lib/api/assistant/conversation/attachments.test.ts
@@ -1,0 +1,53 @@
+import { makeFileAttachment } from "@app/lib/api/assistant/conversation/attachments";
+import { describe, expect, it } from "vitest";
+
+describe("makeFileAttachment", () => {
+  const baseArgs = {
+    fileId: "file_123",
+    source: "agent" as const,
+    contentType: "text/plain" as const,
+    title: "output.txt",
+    snippet: "some content snippet",
+    isInProjectContext: false,
+    hideFromUser: true,
+  };
+
+  it("should mark offloaded tool output files as not searchable", () => {
+    const attachment = makeFileAttachment({
+      ...baseArgs,
+      skipDataSourceIndexing: true,
+    });
+
+    expect(attachment.isSearchable).toBe(false);
+  });
+
+  it("should keep web browser files searchable (hideFromUser but no skipDataSourceIndexing)", () => {
+    // Web browser tool also sets hideFromUser: true but should remain searchable.
+    const attachment = makeFileAttachment({
+      ...baseArgs,
+      skipDataSourceIndexing: false,
+    });
+
+    expect(attachment.isSearchable).toBe(true);
+  });
+
+  it("should keep user-uploaded files searchable", () => {
+    const attachment = makeFileAttachment({
+      ...baseArgs,
+      source: "user",
+      hideFromUser: false,
+    });
+
+    expect(attachment.isSearchable).toBe(true);
+  });
+
+  it("should not be searchable when snippet is null regardless of skipDataSourceIndexing", () => {
+    const attachment = makeFileAttachment({
+      ...baseArgs,
+      snippet: null,
+      skipDataSourceIndexing: false,
+    });
+
+    expect(attachment.isSearchable).toBe(false);
+  });
+});

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -243,6 +243,7 @@ export function makeFileAttachment({
   snippet,
   isInProjectContext,
   hideFromUser,
+  skipDataSourceIndexing = false,
   creator = null,
 }: {
   fileId: string;
@@ -254,12 +255,16 @@ export function makeFileAttachment({
   snippet: string | null;
   isInProjectContext: boolean;
   hideFromUser: boolean;
+  skipDataSourceIndexing?: boolean;
   creator?: AttachmentCreator | null;
 }): FileAttachmentType {
   const canDoJIT = snippet !== null;
   const isIncludable = isConversationIncludableFileContentType(contentType);
   const isQueryable = canDoJIT && isQueryableContentType(contentType);
-  const isSearchable = canDoJIT && isSearchableContentType(contentType);
+  // Files offloaded to disk because their tool output was too large are never indexed in Qdrant,
+  // so they must not be advertised as searchable to the model.
+  const isSearchable =
+    canDoJIT && isSearchableContentType(contentType) && !skipDataSourceIndexing;
 
   return {
     fileId,

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -58,6 +58,7 @@ export async function listAttachments(
             snippet: f.snippet,
             isInProjectContext: f.isInProjectContext ?? false,
             hideFromUser: f.hidden ?? false,
+            skipDataSourceIndexing: f.skipDataSourceIndexing ?? false,
             creator: agentCreator,
           })
         );

--- a/front/lib/api/files/upsert.test.ts
+++ b/front/lib/api/files/upsert.test.ts
@@ -85,6 +85,35 @@ describe("processAndUpsertToDataSource", () => {
     vi.clearAllMocks();
   });
 
+  it("should skip all processing for tool_output files with skipDataSourceIndexing", async () => {
+    const file = await FileFactory.create(auth, null, {
+      contentType: "text/plain",
+      fileName: "offloaded_tool_output.txt",
+      fileSize: 1000,
+      status: "ready",
+      useCase: "tool_output",
+      useCaseMetadata: {
+        conversationId: "test-conversation-id",
+        hideFromUser: true,
+        skipDataSourceIndexing: true,
+      },
+    });
+
+    const space = await SpaceFactory.global(workspace);
+    const datasourceView = await DataSourceViewFactory.folder(workspace, space);
+
+    const result = await processAndUpsertToDataSource(
+      auth,
+      datasourceView.dataSource,
+      { file }
+    );
+
+    expect(result.isOk()).toBe(true);
+    // No Qdrant indexing should have happened.
+    expect(upsertTable).not.toHaveBeenCalled();
+    expect(createDataSourceFolder).not.toHaveBeenCalled();
+  });
+
   it("should call upsertTable with the right parameters for a CSV file", async () => {
     // Create a file
     const file = await FileFactory.csv(auth, null, {

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -526,6 +526,12 @@ const maybeApplyProcessing: ProcessingFunction = async (
   auth,
   { file, dataSource, upsertArgs }
 ) => {
+  // Files offloaded to disk because their tool output was too large must not be indexed in Qdrant.
+  // Models access them directly via file reads.
+  if (file.useCaseMetadata?.skipDataSourceIndexing) {
+    return new Ok(undefined);
+  }
+
   const processing = getProcessingFunction(file);
 
   if (processing) {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -989,6 +989,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
                   updatedAt: file.updatedAt.getTime(),
                   isInProjectContext: file.useCase === "project_context",
                   hidden: file.useCaseMetadata?.hideFromUser ?? false,
+                  skipDataSourceIndexing:
+                    file.useCaseMetadata?.skipDataSourceIndexing ?? false,
                 };
               })
             ),

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -41,6 +41,7 @@ export type FileUseCaseMetadata = {
   sourceProvider?: string;
   sourceIcon?: string;
   hideFromUser?: boolean;
+  skipDataSourceIndexing?: boolean;
 };
 
 export function isConversationFileUseCase(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread for full context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1776168536889749).

When a tool returns output larger than the 20 KB threshold, we offload it to a file in the conversation data source
to avoid bloating the model context. A recent change lowered that threshold from 400 KB -> 20 KB, which caused an increased of 20% in the number of files created. All of them being indexed in Qdrant.

This is wasteful: the model _(almost) never_  uses semantic search on these files, it reads them directly (the "cat" approach). It forced us to scale our Qdrant clusters (yes, both regions) horizontally pretty often those past few weeks.

## What this PR does

Introduces a `skipDataSourceIndexing` flag on file `useCaseMetadata`, set only on size-offloaded files resulting from tools execution. When set:
- Qdrant indexing is skipped in `maybeApplyProcessing`
- `isSearchable` is set to false in the conversation render, so the model is never told these files are searchable

Web browser tool files, user uploads, and other intentional tool outputs are unaffected. They don't set the flag.

> [!TIP]
> This is a temporary fix!

The end goal is to stop creating these files entirely and save oversized tool output directly to GCS (the same path
already used behind a feature flag). Once that migration lands, this code path and the flag can be removed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
