### PR TITLE
[front] fix tags on post/patch endpoint

### DIFF
--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -8,9 +8,9 @@ import {
 import { getAgentConfigurationAsYAMLConfig } from "@app/lib/api/assistant/configuration/yaml_export";
 import type { Authenticator } from "@app/lib/auth";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import { TagResource } from "@app/lib/resources/tags_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
-import { TagResource } from "@app/lib/resources/tags_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -10,11 +10,12 @@ import type { Authenticator } from "@app/lib/auth";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
+import { TagResource } from "@app/lib/resources/tags_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import uniqueId from "lodash/uniqueId";
+import type { TagType } from "@app/types/tag";
 
 interface SkippedAction {
   name: string;
@@ -91,6 +92,14 @@ async function importAgentConfiguration(
   const { configurations: mcpConfigurations, skipped: skippedActions } =
     mcpConfigurationsResult.value;
 
+  const resolvedTags: TagType[] = [];
+  for (const tag of yamlConfig.tags) {
+    const tagResource = await TagResource.findByName(auth, tag.name);
+    if (tagResource) {
+      resolvedTags.push(tagResource.toJSON());
+    }
+  }
+
   const assistant = {
     name: yamlConfig.agent.handle,
     description: yamlConfig.agent.description,
@@ -108,11 +117,7 @@ async function importAgentConfiguration(
     maxStepsPerRun: yamlConfig.agent.max_steps_per_run,
     actions: mcpConfigurations,
     templateId: null,
-    tags: yamlConfig.tags.map((tag) => ({
-      sId: uniqueId(),
-      name: tag.name,
-      kind: tag.kind,
-    })),
+    tags: resolvedTags,
     editors: editorUsers.map((user) => ({
       sId: user.sId,
     })),

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -15,7 +15,6 @@ import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { TagType } from "@app/types/tag";
 
 interface SkippedAction {
   name: string;
@@ -92,12 +91,19 @@ async function importAgentConfiguration(
   const { configurations: mcpConfigurations, skipped: skippedActions } =
     mcpConfigurationsResult.value;
 
-  const resolvedTags: TagType[] = [];
+  const resolvedTags: TagResource[] = [];
   for (const tag of yamlConfig.tags) {
     const tagResource = await TagResource.findByName(auth, tag.name);
-    if (tagResource) {
-      resolvedTags.push(tagResource.toJSON());
+    if (!tagResource) {
+      return new Err({
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Tag not found: "${tag.name}".`,
+        },
+      });
     }
+    resolvedTags.push(tagResource);
   }
 
   const assistant = {
@@ -117,7 +123,7 @@ async function importAgentConfiguration(
     maxStepsPerRun: yamlConfig.agent.max_steps_per_run,
     actions: mcpConfigurations,
     templateId: null,
-    tags: resolvedTags,
+    tags: resolvedTags.map((t) => t.toJSON()),
     editors: editorUsers.map((user) => ({
       sId: user.sId,
     })),

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -96,6 +96,7 @@ async function importAgentConfiguration(
   const missingTags = tagNames.filter(
     (name) => !resolvedTags.some((t) => t.name === name)
   );
+
   if (missingTags.length > 0) {
     return new Err({
       status_code: 400,

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -91,19 +91,19 @@ async function importAgentConfiguration(
   const { configurations: mcpConfigurations, skipped: skippedActions } =
     mcpConfigurationsResult.value;
 
-  const resolvedTags: TagResource[] = [];
-  for (const tag of yamlConfig.tags) {
-    const tagResource = await TagResource.findByName(auth, tag.name);
-    if (!tagResource) {
-      return new Err({
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: `Tag not found: "${tag.name}".`,
-        },
-      });
-    }
-    resolvedTags.push(tagResource);
+  const tagNames = yamlConfig.tags.map((t) => t.name);
+  const resolvedTags = await TagResource.findByNames(auth, tagNames);
+  const missingTags = tagNames.filter(
+    (name) => !resolvedTags.some((t) => t.name === name)
+  );
+  if (missingTags.length > 0) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Tags not found: ${missingTags.map((t) => `"${t}"`).join(", ")}.`,
+      },
+    });
   }
 
   const assistant = {

--- a/front/lib/resources/tags_resource.ts
+++ b/front/lib/resources/tags_resource.ts
@@ -111,6 +111,17 @@ export class TagResource extends BaseResource<TagModel> {
     return tags.length > 0 ? tags[0] : null;
   }
 
+  static async findByNames(
+    auth: Authenticator,
+    names: string[]
+  ): Promise<TagResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        name: names,
+      },
+    });
+  }
+
   static async findAll(auth: Authenticator, { kind }: { kind?: TagKind } = {}) {
     return this.baseFetch(auth, {
       where: {


### PR DESCRIPTION
## Description
This PR fixes https://github.com/dust-tt/tasks/issues/7552. When you create/update agent via api, we always generate new id with `uniqueId()`. Later inside createAgentConfiguration, we fetch tags but we won't be able to find them so we wipe out all the tags: https://github.com/dust-tt/dust/blob/d4d57175bc44d4ebfb4f032937d9909ca87c99b2/front/lib/api/assistant/configuration/agent.ts#L686

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested locally 
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
