### PR TITLE
[front] fix: Split swr hook from display component

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -28,6 +28,7 @@ import {
   isRemoteDatabase,
   isWebsite,
 } from "@app/lib/data_sources";
+import type { UseInfiniteContentNodes } from "@app/lib/swr/data_source_views";
 import { useInfiniteDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { useSpacesSearch } from "@app/lib/swr/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
@@ -70,7 +71,8 @@ const getUseResourceHook =
   (
     owner: LightWorkspaceType,
     dataSourceView: DataSourceViewType,
-    viewType: ContentNodesViewType
+    viewType: ContentNodesViewType,
+    useContentNodes: UseInfiniteContentNodes
   ) =>
   (parentId: string | null) => {
     const {
@@ -83,7 +85,7 @@ const getUseResourceHook =
       totalNodesCountIsAccurate,
       isLoadingMore,
       nextPageCursor,
-    } = useInfiniteDataSourceViewContentNodes({
+    } = useContentNodes({
       owner,
       dataSourceView,
       parentId: parentId ?? undefined,
@@ -112,26 +114,25 @@ interface UseLazyLoadAllNodesOptions {
   owner: LightWorkspaceType;
   dataSourceView: DataSourceViewType;
   viewType: ContentNodesViewType;
-  onComplete: (
-    nodes: ReturnType<typeof useInfiniteDataSourceViewContentNodes>["nodes"]
-  ) => void;
+  useContentNodes: UseInfiniteContentNodes;
+  onComplete: (nodes: ReturnType<UseInfiniteContentNodes>["nodes"]) => void;
 }
 
 function useLazyLoadAllNodes({
   owner,
   dataSourceView,
   viewType,
+  useContentNodes,
   onComplete,
 }: UseLazyLoadAllNodesOptions) {
   const [triggered, setTriggered] = useState(false);
 
-  const { nodes, hasNextPage, isLoadingMore, loadMore } =
-    useInfiniteDataSourceViewContentNodes({
-      owner,
-      dataSourceView: triggered ? dataSourceView : undefined,
-      viewType,
-      pagination: { cursor: null, limit: ITEMS_PER_PAGE },
-    });
+  const { nodes, hasNextPage, isLoadingMore, loadMore } = useContentNodes({
+    owner,
+    dataSourceView: triggered ? dataSourceView : undefined,
+    viewType,
+    pagination: { cursor: null, limit: ITEMS_PER_PAGE },
+  });
 
   useEffect(() => {
     if (!triggered) {
@@ -296,6 +297,7 @@ interface DataSourceViewsSelectorProps {
   space: SpaceType;
   selectionMode?: "checkbox" | "radio";
   allowAdminSearch?: boolean;
+  useContentNodes?: UseInfiniteContentNodes;
 }
 
 export function DataSourceViewsSelector({
@@ -309,6 +311,7 @@ export function DataSourceViewsSelector({
   space,
   selectionMode = "checkbox",
   allowAdminSearch = false,
+  useContentNodes,
 }: DataSourceViewsSelectorProps) {
   const [searchResult, setSearchResult] = useState<
     DataSourceViewContentNode | undefined
@@ -619,6 +622,7 @@ export function DataSourceViewsSelector({
                 useCase={useCase}
                 searchResult={searchResult}
                 selectionMode={selectionMode}
+                useContentNodes={useContentNodes}
               />
             ))}
           </Tree.Item>
@@ -640,6 +644,7 @@ export function DataSourceViewsSelector({
               useCase={useCase}
               searchResult={searchResult}
               selectionMode={selectionMode}
+              useContentNodes={useContentNodes}
             />
           ))}
         {filteredGroups.folders.length > 0 && (
@@ -667,6 +672,7 @@ export function DataSourceViewsSelector({
                 useCase={useCase}
                 searchResult={searchResult}
                 selectionMode={selectionMode}
+                useContentNodes={useContentNodes}
               />
             ))}
           </Tree.Item>
@@ -698,6 +704,7 @@ export function DataSourceViewsSelector({
                   useCase={useCase}
                   searchResult={searchResult}
                   selectionMode={selectionMode}
+                  useContentNodes={useContentNodes}
                 />
               ))}
             </Tree.Item>
@@ -740,6 +747,7 @@ interface DataSourceViewSelectorProps {
   useCase?: DataSourceViewsSelectorProps["useCase"];
   searchResult?: DataSourceViewContentNode;
   selectionMode?: "checkbox" | "radio";
+  useContentNodes?: UseInfiniteContentNodes;
 }
 
 // When `isRootSelectable` is false, you cannot select the entire data source and automatically sync new nodes
@@ -758,6 +766,7 @@ export function DataSourceViewSelector({
   useCase,
   searchResult,
   selectionMode = "checkbox",
+  useContentNodes = useInfiniteDataSourceViewContentNodes,
 }: DataSourceViewSelectorProps) {
   const { isDark } = useTheme();
   const dataSourceView = selectionConfiguration.dataSourceView;
@@ -796,6 +805,7 @@ export function DataSourceViewSelector({
     owner,
     dataSourceView,
     viewType,
+    useContentNodes,
     onComplete: useCallback(
       (nodes: DataSourceViewContentNode[]) => {
         setSelectionConfigurations((prevState) =>
@@ -926,8 +936,13 @@ export function DataSourceViewSelector({
 
   const useResourcesHook = useCallback(
     (parentId: string | null) =>
-      getUseResourceHook(owner, dataSourceView, viewType)(parentId),
-    [owner, dataSourceView, viewType]
+      getUseResourceHook(
+        owner,
+        dataSourceView,
+        viewType,
+        useContentNodes
+      )(parentId),
+    [owner, dataSourceView, viewType, useContentNodes]
   );
 
   const isExpanded = searchResult

--- a/front/components/poke/pages/SpaceDataSourceViewPage.tsx
+++ b/front/components/poke/pages/SpaceDataSourceViewPage.tsx
@@ -5,6 +5,7 @@ import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeDataSourceViewDetails } from "@app/poke/swr/data_source_view_details";
+import { usePokeInfiniteDataSourceViewContentNodes } from "@app/poke/swr/data_source_views";
 import { defaultSelectionConfiguration } from "@app/types/data_source_view";
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
 
@@ -83,6 +84,7 @@ export function SpaceDataSourceViewPage() {
               setSelectionConfigurations={() => {}}
               viewType="all"
               isRootSelectable={true}
+              useContentNodes={usePokeInfiniteDataSourceViewContentNodes}
             />
           </div>
         </div>

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -267,15 +267,17 @@ export function processInfiniteContentNodesData({
   };
 }
 
-const makeURLDataSourceViewContentNodes = (
-  {
-    owner,
-    dataSourceView,
-  }: Required<
+export type ContentNodesURLBuilder = (
+  opts: Required<
     Pick<FetchDataSourceViewContentNodesOptions, "owner" | "dataSourceView">
   >,
   searchParams: URLSearchParams
-): string => {
+) => string;
+
+const makeURLDataSourceViewContentNodes: ContentNodesURLBuilder = (
+  { owner, dataSourceView },
+  searchParams
+) => {
   return `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}/content-nodes?${searchParams}`;
 };
 
@@ -356,72 +358,76 @@ export function useDataSourceViewContentNodes({
   };
 }
 
-export function useInfiniteDataSourceViewContentNodes({
-  owner,
-  dataSourceView,
-  pagination,
-  internalIds,
-  parentId,
-  viewType,
-  sorting,
-  swrOptions,
-}: FetchDataSourceViewContentNodesOptions): InfiniteContentNodesResult {
-  const { fetcherWithBody } = useFetcher();
-  const { data, error, isLoading, size, setSize, mutate, isValidating } =
-    useSWRInfiniteWithDefaults<
-      [string, GetContentNodesOrChildrenRequestBodyType] | null,
-      GetDataSourceViewContentNodes
-    >(
-      (_pageIndex, previousPageData) => {
-        if (
-          (previousPageData && !previousPageData.nextPageCursor) ||
-          !dataSourceView
-        ) {
-          return null;
+export function createUseInfiniteContentNodes(
+  makeURL: ContentNodesURLBuilder
+): UseInfiniteContentNodes {
+  return function useInfiniteContentNodes({
+    owner,
+    dataSourceView,
+    pagination,
+    internalIds,
+    parentId,
+    viewType,
+    sorting,
+    swrOptions,
+  }: FetchDataSourceViewContentNodesOptions): InfiniteContentNodesResult {
+    const { fetcherWithBody } = useFetcher();
+    const { data, error, isLoading, size, setSize, mutate, isValidating } =
+      useSWRInfiniteWithDefaults<
+        [string, GetContentNodesOrChildrenRequestBodyType] | null,
+        GetDataSourceViewContentNodes
+      >(
+        (_pageIndex, previousPageData) => {
+          if (
+            (previousPageData && !previousPageData.nextPageCursor) ||
+            !dataSourceView
+          ) {
+            return null;
+          }
+
+          const params = new URLSearchParams();
+          if (previousPageData?.nextPageCursor) {
+            params.append("cursor", previousPageData.nextPageCursor);
+          }
+
+          if (pagination?.limit) {
+            params.append("limit", pagination.limit.toString());
+          }
+
+          const body: GetContentNodesOrChildrenRequestBodyType = {
+            internalIds,
+            parentId,
+            viewType: viewType ?? "all",
+            sorting,
+          };
+
+          return [makeURL({ owner, dataSourceView }, params), body];
+        },
+        async ([url, body]) => {
+          return fetcherWithBody([url, body, "POST"]);
+        },
+        {
+          revalidateAll: false,
+          revalidateFirstPage: false,
+          ...swrOptions,
         }
+      );
 
-        const params = new URLSearchParams();
-        if (previousPageData?.nextPageCursor) {
-          params.append("cursor", previousPageData.nextPageCursor);
-        }
+    const loadMore = useCallback(() => setSize((s) => s + 1), [setSize]);
+    const processed = processInfiniteContentNodesData({
+      data,
+      error,
+      isLoading,
+      size,
+      isValidating,
+    });
 
-        if (pagination?.limit) {
-          params.append("limit", pagination.limit.toString());
-        }
-
-        const body: GetContentNodesOrChildrenRequestBodyType = {
-          internalIds,
-          parentId,
-          viewType: viewType ?? "all",
-          sorting,
-        };
-
-        return [
-          makeURLDataSourceViewContentNodes({ owner, dataSourceView }, params),
-          body,
-        ];
-      },
-      async ([url, body]) => {
-        return fetcherWithBody([url, body, "POST"]);
-      },
-      {
-        revalidateAll: false,
-        revalidateFirstPage: false,
-        ...swrOptions,
-      }
-    );
-
-  const loadMore = useCallback(() => setSize((s) => s + 1), [setSize]);
-  const processed = processInfiniteContentNodesData({
-    data,
-    error,
-    isLoading,
-    size,
-    isValidating,
-  });
-
-  return { ...processed, loadMore, mutate };
+    return { ...processed, loadMore, mutate };
+  };
 }
+
+export const useInfiniteDataSourceViewContentNodes =
+  createUseInfiniteContentNodes(makeURLDataSourceViewContentNodes);
 
 export function useDataSourceViewConnectorConfiguration({
   dataSourceView,

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -22,6 +22,7 @@ import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Fetcher, KeyedMutator, SWRConfiguration } from "swr";
+import type { SWRInfiniteKeyedMutator } from "swr/infinite";
 
 type DataSourceViewsAndInternalIds = {
   dataSourceView: DataSourceViewType;
@@ -201,7 +202,7 @@ export function useMultipleDataSourceViewsContentNodes({
   );
 }
 
-type FetchDataSourceViewContentNodesOptions = {
+export type FetchDataSourceViewContentNodesOptions = {
   owner: LightWorkspaceType;
   dataSourceView?: DataSourceViewType;
   internalIds?: string[];
@@ -212,6 +213,59 @@ type FetchDataSourceViewContentNodesOptions = {
   disabled?: boolean;
   swrOptions?: SWRConfiguration;
 };
+
+export interface InfiniteContentNodesResult {
+  isNodesLoading: boolean;
+  isNodesValidating: boolean;
+  nodesError: unknown;
+  nodes: GetDataSourceViewContentNodes["nodes"];
+  nextPageCursor: string | null;
+  hasNextPage: boolean;
+  loadMore: () => void;
+  mutate: SWRInfiniteKeyedMutator<GetDataSourceViewContentNodes[]>;
+  totalNodesCount: number;
+  totalNodesCountIsAccurate: boolean;
+  isLoadingMore: boolean | undefined;
+}
+
+export type UseInfiniteContentNodes = (
+  opts: FetchDataSourceViewContentNodesOptions
+) => InfiniteContentNodesResult;
+
+export function processInfiniteContentNodesData({
+  data,
+  error,
+  isLoading,
+  size,
+  isValidating,
+}: {
+  data: GetDataSourceViewContentNodes[] | undefined;
+  error: unknown;
+  isLoading: boolean;
+  size: number;
+  isValidating: boolean;
+}): Omit<InfiniteContentNodesResult, "loadMore" | "mutate"> {
+  const nodes = data?.flatMap((page) => page.nodes) ?? emptyArray();
+  const lastPage = data?.[data.length - 1];
+  const hasNextPage =
+    lastPage?.nextPageCursor !== null && lastPage?.nextPageCursor !== undefined;
+
+  return {
+    isNodesLoading: isLoading && !data,
+    isNodesValidating: isValidating,
+    nodesError: error,
+    nodes,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    nextPageCursor: lastPage?.nextPageCursor || null,
+    hasNextPage,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    totalNodesCount: lastPage?.total || 0,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    totalNodesCountIsAccurate: lastPage?.totalIsAccurate || true,
+    isLoadingMore:
+      isLoading || (size > 0 && data && typeof data[size - 1] === "undefined"),
+  };
+}
 
 const makeURLDataSourceViewContentNodes = (
   {
@@ -311,7 +365,7 @@ export function useInfiniteDataSourceViewContentNodes({
   viewType,
   sorting,
   swrOptions,
-}: FetchDataSourceViewContentNodesOptions) {
+}: FetchDataSourceViewContentNodesOptions): InfiniteContentNodesResult {
   const { fetcherWithBody } = useFetcher();
   const { data, error, isLoading, size, setSize, mutate, isValidating } =
     useSWRInfiniteWithDefaults<
@@ -319,7 +373,6 @@ export function useInfiniteDataSourceViewContentNodes({
       GetDataSourceViewContentNodes
     >(
       (_pageIndex, previousPageData) => {
-        // If we reached the end, stop fetching
         if (
           (previousPageData && !previousPageData.nextPageCursor) ||
           !dataSourceView
@@ -358,30 +411,16 @@ export function useInfiniteDataSourceViewContentNodes({
       }
     );
 
-  const nodes = data?.flatMap((page) => page.nodes) ?? emptyArray();
-  const lastPage = data?.[data.length - 1];
-  const hasNextPage =
-    lastPage?.nextPageCursor !== null && lastPage?.nextPageCursor !== undefined;
-
   const loadMore = useCallback(() => setSize((s) => s + 1), [setSize]);
+  const processed = processInfiniteContentNodesData({
+    data,
+    error,
+    isLoading,
+    size,
+    isValidating,
+  });
 
-  return {
-    isNodesLoading: isLoading && !data,
-    isNodesValidating: isValidating,
-    nodesError: error,
-    nodes,
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    nextPageCursor: lastPage?.nextPageCursor || null,
-    hasNextPage,
-    loadMore,
-    mutate,
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    totalNodesCount: lastPage?.total || 0,
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    totalNodesCountIsAccurate: lastPage?.totalIsAccurate || true,
-    isLoadingMore:
-      isLoading || (size > 0 && data && typeof data[size - 1] === "undefined"),
-  };
+  return { ...processed, loadMore, mutate };
 }
 
 export function useDataSourceViewConnectorConfiguration({

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -1,7 +1,10 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
-import { getCursorPaginationParams } from "@app/lib/api/pagination";
+import {
+  getCursorPaginationParams,
+  SortingParamsCodec,
+} from "@app/lib/api/pagination";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -19,6 +22,7 @@ const GetContentNodesOrChildrenRequestBody = t.type({
   internalIds: t.union([t.array(t.union([t.string, t.null])), t.undefined]),
   parentId: t.union([t.string, t.undefined]),
   viewType: ContentNodesViewTypeCodec,
+  sorting: t.union([SortingParamsCodec, t.undefined]),
 });
 
 export type PokeGetDataSourceViewContentNodes = {
@@ -111,7 +115,7 @@ async function handler(
     });
   }
 
-  const { internalIds, parentId, viewType } = bodyValidation.right;
+  const { internalIds, parentId, viewType, sorting } = bodyValidation.right;
 
   if (parentId && internalIds) {
     return apiError(req, res, {
@@ -141,6 +145,7 @@ async function handler(
       parentId,
       pagination: paginationRes.value,
       viewType,
+      sorting,
     }
   );
 

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -1,15 +1,26 @@
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
-import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type {
+  FetchDataSourceViewContentNodesOptions,
+  InfiniteContentNodesResult,
+} from "@app/lib/swr/data_source_views";
+import { processInfiniteContentNodesData } from "@app/lib/swr/data_source_views";
+import {
+  emptyArray,
+  useFetcher,
+  useSWRInfiniteWithDefaults,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
 import type {
   DataSourceViewWithUsage,
   PokeListDataSourceViews,
 } from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
 import type { PokeGetDataSourceViewContentNodes } from "@app/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes";
+import type { GetContentNodesOrChildrenRequestBodyType } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import type { Fetcher, KeyedMutator } from "swr";
 
 export function usePokeDataSourceViews({
@@ -119,4 +130,86 @@ export function usePokeDataSourceViewContentNodes({
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     nextPageCursor: data?.nextPageCursor || null,
   };
+}
+
+const makePokeURLDataSourceViewContentNodes = (
+  {
+    owner,
+    dataSourceView,
+  }: Required<
+    Pick<FetchDataSourceViewContentNodesOptions, "owner" | "dataSourceView">
+  >,
+  searchParams: URLSearchParams
+): string => {
+  return `/api/poke/workspaces/${owner.sId}/spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}/content-nodes?${searchParams}`;
+};
+
+export function usePokeInfiniteDataSourceViewContentNodes({
+  owner,
+  dataSourceView,
+  pagination,
+  internalIds,
+  parentId,
+  viewType,
+  sorting,
+  swrOptions,
+}: FetchDataSourceViewContentNodesOptions): InfiniteContentNodesResult {
+  const { fetcherWithBody } = useFetcher();
+  const { data, error, isLoading, size, setSize, mutate, isValidating } =
+    useSWRInfiniteWithDefaults<
+      [string, GetContentNodesOrChildrenRequestBodyType] | null,
+      PokeGetDataSourceViewContentNodes
+    >(
+      (_pageIndex, previousPageData) => {
+        if (
+          (previousPageData && !previousPageData.nextPageCursor) ||
+          !dataSourceView
+        ) {
+          return null;
+        }
+
+        const params = new URLSearchParams();
+        if (previousPageData?.nextPageCursor) {
+          params.append("cursor", previousPageData.nextPageCursor);
+        }
+
+        if (pagination?.limit) {
+          params.append("limit", pagination.limit.toString());
+        }
+
+        const body: GetContentNodesOrChildrenRequestBodyType = {
+          internalIds,
+          parentId,
+          viewType: viewType ?? "all",
+          sorting,
+        };
+
+        return [
+          makePokeURLDataSourceViewContentNodes(
+            { owner, dataSourceView },
+            params
+          ),
+          body,
+        ];
+      },
+      async ([url, body]) => {
+        return fetcherWithBody([url, body, "POST"]);
+      },
+      {
+        revalidateAll: false,
+        revalidateFirstPage: false,
+        ...swrOptions,
+      }
+    );
+
+  const loadMore = useCallback(() => setSize((s) => s + 1), [setSize]);
+  const processed = processInfiniteContentNodesData({
+    data,
+    error,
+    isLoading,
+    size,
+    isValidating,
+  });
+
+  return { ...processed, loadMore, mutate };
 }

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -1,26 +1,16 @@
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
-import type {
-  FetchDataSourceViewContentNodesOptions,
-  InfiniteContentNodesResult,
-} from "@app/lib/swr/data_source_views";
-import { processInfiniteContentNodesData } from "@app/lib/swr/data_source_views";
-import {
-  emptyArray,
-  useFetcher,
-  useSWRInfiniteWithDefaults,
-  useSWRWithDefaults,
-} from "@app/lib/swr/swr";
+import { createUseInfiniteContentNodes } from "@app/lib/swr/data_source_views";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   DataSourceViewWithUsage,
   PokeListDataSourceViews,
 } from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
 import type { PokeGetDataSourceViewContentNodes } from "@app/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes";
-import type { GetContentNodesOrChildrenRequestBodyType } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import type { Fetcher, KeyedMutator } from "swr";
 
 export function usePokeDataSourceViews({
@@ -132,84 +122,8 @@ export function usePokeDataSourceViewContentNodes({
   };
 }
 
-const makePokeURLDataSourceViewContentNodes = (
-  {
-    owner,
-    dataSourceView,
-  }: Required<
-    Pick<FetchDataSourceViewContentNodesOptions, "owner" | "dataSourceView">
-  >,
-  searchParams: URLSearchParams
-): string => {
-  return `/api/poke/workspaces/${owner.sId}/spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}/content-nodes?${searchParams}`;
-};
-
-export function usePokeInfiniteDataSourceViewContentNodes({
-  owner,
-  dataSourceView,
-  pagination,
-  internalIds,
-  parentId,
-  viewType,
-  sorting,
-  swrOptions,
-}: FetchDataSourceViewContentNodesOptions): InfiniteContentNodesResult {
-  const { fetcherWithBody } = useFetcher();
-  const { data, error, isLoading, size, setSize, mutate, isValidating } =
-    useSWRInfiniteWithDefaults<
-      [string, GetContentNodesOrChildrenRequestBodyType] | null,
-      PokeGetDataSourceViewContentNodes
-    >(
-      (_pageIndex, previousPageData) => {
-        if (
-          (previousPageData && !previousPageData.nextPageCursor) ||
-          !dataSourceView
-        ) {
-          return null;
-        }
-
-        const params = new URLSearchParams();
-        if (previousPageData?.nextPageCursor) {
-          params.append("cursor", previousPageData.nextPageCursor);
-        }
-
-        if (pagination?.limit) {
-          params.append("limit", pagination.limit.toString());
-        }
-
-        const body: GetContentNodesOrChildrenRequestBodyType = {
-          internalIds,
-          parentId,
-          viewType: viewType ?? "all",
-          sorting,
-        };
-
-        return [
-          makePokeURLDataSourceViewContentNodes(
-            { owner, dataSourceView },
-            params
-          ),
-          body,
-        ];
-      },
-      async ([url, body]) => {
-        return fetcherWithBody([url, body, "POST"]);
-      },
-      {
-        revalidateAll: false,
-        revalidateFirstPage: false,
-        ...swrOptions,
-      }
-    );
-
-  const loadMore = useCallback(() => setSize((s) => s + 1), [setSize]);
-  const processed = processInfiniteContentNodesData({
-    data,
-    error,
-    isLoading,
-    size,
-    isValidating,
-  });
-
-  return { ...processed, loadMore, mutate };
-}
+export const usePokeInfiniteDataSourceViewContentNodes =
+  createUseInfiniteContentNodes(
+    ({ owner, dataSourceView }, searchParams) =>
+      `/api/poke/workspaces/${owner.sId}/spaces/${dataSourceView.spaceId}/data_source_views/${dataSourceView.sId}/content-nodes?${searchParams}`
+  );


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7547

This [PR](https://github.com/dust-tt/dust/pull/23905) introduced a regression in poke, by squeezing useContentNodes (optional param only used in poke).

This PR re-introduces it, with better typing, and proper separation of concerns
- DataSourceViewSelector no longer uses `useInfiniteDataSourceViewContentNodes` but instead expect a `useContentNodes` with `UseInfiniteContentNodes` typing.
- Each parent now defines its own hook implementing this new contract, for space data source it's trivial, for poke we need to define a new one, with a small backend change to support sorting.

## Tests

- Tested on front-edge that we're not breaking user space.
- Can't test poke on front-edge, locally it worked

## Risk

Low
Blast radius: Poke data source view + Space's data source connect data pannel.


## Deploy Plan

- [ ] Deploy front