### PR TITLE
Handle token expiration error

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -359,7 +359,6 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       return new Ok(nRes.value);
     }
 
-    const client = await getMicrosoftClient(connector.connectionId);
     const nodes = [];
 
     const selectedResources = (
@@ -376,6 +375,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     const { nodeType } = typeAndPathFromInternalId(parentInternalId);
 
     try {
+      const client = await getMicrosoftClient(connector.connectionId);
       switch (nodeType) {
         case "sites-root": {
           const config =


### PR DESCRIPTION
## Description

Moves the `getMicrosoftClient(connector.connectionId)` call inside the try block in `retrievePermissions`. Previously, if the OAuth token was expired or invalid when fetching the client, the error was thrown before the try-catch and not properly handled. This could cause the permission retrieval to fail with an unhandled `ExternalOAuthTokenError` instead of being gracefully caught and converted to a proper error response.

## Tests


## Risk

Low

## Deploy Plan

Deploy connectors.