### PR TITLE
Add production check for Reinforcement

### DIFF
--- a/front/lib/production_checks/checks/check_reinforcement_workspace_workflows.ts
+++ b/front/lib/production_checks/checks/check_reinforcement_workspace_workflows.ts
@@ -2,12 +2,9 @@ import { Authenticator } from "@app/lib/auth";
 import { hasReinforcementEnabled } from "@app/lib/reinforced_agent/workspace_check";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import { makeWorkspaceCronWorkflowId } from "@app/temporal/reinforcement/client";
 import type { CheckFunction } from "@app/types/production_checks";
 import type { Client, WorkflowHandle } from "@temporalio/client";
-
-function makeWorkspaceCronWorkflowId(workspaceId: string): string {
-  return `reinforcement-workspace-${workspaceId}`;
-}
 
 async function getFlaggedWorkspaceIds(): Promise<string[]> {
   const allWorkspaces = await WorkspaceResource.listAll();

--- a/front/lib/production_checks/checks/check_reinforcement_workspace_workflows.ts
+++ b/front/lib/production_checks/checks/check_reinforcement_workspace_workflows.ts
@@ -1,0 +1,78 @@
+import { Authenticator } from "@app/lib/auth";
+import { hasReinforcementEnabled } from "@app/lib/reinforced_agent/workspace_check";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import type { CheckFunction } from "@app/types/production_checks";
+import type { Client, WorkflowHandle } from "@temporalio/client";
+
+function makeWorkspaceCronWorkflowId(workspaceId: string): string {
+  return `reinforcement-workspace-${workspaceId}`;
+}
+
+async function getFlaggedWorkspaceIds(): Promise<string[]> {
+  const allWorkspaces = await WorkspaceResource.listAll();
+  const flaggedIds: string[] = [];
+
+  for (const workspace of allWorkspaces) {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    if (await hasReinforcementEnabled(auth)) {
+      flaggedIds.push(workspace.sId);
+    }
+  }
+
+  return flaggedIds;
+}
+
+async function isWorkflowRunning(
+  client: Client,
+  workflowId: string
+): Promise<boolean> {
+  try {
+    const handle: WorkflowHandle = client.workflow.getHandle(workflowId);
+    const description = await handle.describe();
+    return description.status.name === "RUNNING";
+  } catch {
+    return false;
+  }
+}
+
+export const checkReinforcementWorkspaceWorkflows: CheckFunction = async (
+  _checkName,
+  logger,
+  reportSuccess,
+  reportFailure,
+  heartbeat
+) => {
+  const workspaceIds = await getFlaggedWorkspaceIds();
+
+  logger.info(
+    { workspaceCount: workspaceIds.length },
+    "Checking reinforcement workspace workflows."
+  );
+
+  const client = await getTemporalClientForFrontNamespace();
+
+  const missingWorkflows: string[] = [];
+  for (const workspaceId of workspaceIds) {
+    heartbeat();
+    const workflowId = makeWorkspaceCronWorkflowId(workspaceId);
+    if (!(await isWorkflowRunning(client, workflowId))) {
+      missingWorkflows.push(workspaceId);
+    }
+  }
+
+  if (missingWorkflows.length > 0) {
+    reportFailure(
+      {
+        missingWorkflows,
+        actionLinks: missingWorkflows.map((wId) => ({
+          label: `Missing reinforcement workflow for workspace ${wId}`,
+          url: `/poke/${wId}`,
+        })),
+      },
+      `Missing reinforcement workspace workflows for: ${missingWorkflows.join(", ")}.`
+    );
+  } else {
+    reportSuccess();
+  }
+};

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -8,6 +8,7 @@ import { checkExtraneousWorkflows } from "@app/lib/production_checks/checks/chec
 
 import { checkNotionActiveWorkflows } from "@app/lib/production_checks/checks/check_notion_active_workflows";
 import { checkPausedConnectors } from "@app/lib/production_checks/checks/check_paused_connectors";
+import { checkReinforcementWorkspaceWorkflows } from "@app/lib/production_checks/checks/check_reinforcement_workspace_workflows";
 import { checkWebcrawlerSchedulerActiveWorkflow } from "@app/lib/production_checks/checks/check_webcrawler_scheduler_active_workflow";
 import { managedDataSourceGCGdriveCheck } from "@app/lib/production_checks/checks/managed_data_source_gdrive_gc";
 import mainLogger from "@app/logger/logger";
@@ -75,6 +76,11 @@ export const REGISTERED_CHECKS: Check[] = [
   {
     name: "check_ended_backend_only_subscriptions",
     check: checkEndedBackendOnlySubscriptions,
+    everyHour: 24,
+  },
+  {
+    name: "check_reinforcement_workspace_workflows",
+    check: checkReinforcementWorkspaceWorkflows,
     everyHour: 24,
   },
 ];

--- a/front/temporal/reinforcement/client.ts
+++ b/front/temporal/reinforcement/client.ts
@@ -14,7 +14,7 @@ import {
 } from "@temporalio/client";
 import moment from "moment-timezone";
 import { QUEUE_NAME } from "./config";
-import { reinforcedSkillsWorkspaceWorkflow } from "./workflows";
+import { reinforcementWorkspaceWorkflow } from "./workflows";
 
 /**
  * Returns the UTC hour corresponding to midnight in the given timezone.
@@ -73,7 +73,7 @@ export async function launchReinforcementWorkspaceCron({
   const workflowId = makeWorkspaceCronWorkflowId(workspaceId);
 
   try {
-    await client.workflow.start(reinforcedSkillsWorkspaceWorkflow, {
+    await client.workflow.start(reinforcementWorkspaceWorkflow, {
       args: [{ workspaceId, useBatchMode: true, skipDelay: false }],
       taskQueue: QUEUE_NAME,
       workflowId,
@@ -112,7 +112,7 @@ export async function stopReinforcementWorkspaceCron({
   const workflowId = makeWorkspaceCronWorkflowId(workspaceId);
 
   try {
-    const handle: WorkflowHandle<typeof reinforcedSkillsWorkspaceWorkflow> =
+    const handle: WorkflowHandle<typeof reinforcementWorkspaceWorkflow> =
       client.workflow.getHandle(workflowId);
     await handle.terminate(stopReason);
   } catch (e) {
@@ -192,7 +192,7 @@ export async function startReinforcementWorkspaceWorkflow({
   const client = await getTemporalClientForFrontNamespace();
   const workflowId = `reinforcement-workspace-${workspaceId}-manual-${Date.now()}`;
 
-  await client.workflow.start(reinforcedSkillsWorkspaceWorkflow, {
+  await client.workflow.start(reinforcementWorkspaceWorkflow, {
     args: [
       {
         workspaceId,

--- a/front/temporal/reinforcement/client.ts
+++ b/front/temporal/reinforcement/client.ts
@@ -24,7 +24,7 @@ function getMidnightUtcHour(timezone: string): number {
   return midnightInTz.utc().hour();
 }
 
-function makeWorkspaceCronWorkflowId(workspaceId: string): string {
+export function makeWorkspaceCronWorkflowId(workspaceId: string): string {
   return `reinforcement-workspace-${workspaceId}`;
 }
 

--- a/front/temporal/reinforcement/workflows.ts
+++ b/front/temporal/reinforcement/workflows.ts
@@ -284,7 +284,7 @@ async function aggregateSkillWithMultiStepBatch({
  * 6. Aggregate per-skill concurrently via multi-step loop
  * 7. Finalize per skill
  */
-export async function reinforcedSkillsWorkspaceWorkflow({
+export async function reinforcementWorkspaceWorkflow({
   workspaceId,
   useBatchMode,
   skipDelay = false,


### PR DESCRIPTION
## Description

  - Add a new production check check_reinforcement_workspace_workflows that verifies the reinforcementWorkspaceWorkflow Temporal cron is running for every workspace with reinforcement enabled (feature flag reinforced_agents + not opted out)
  - Rename reinforcedSkillsWorkspaceWorkflow to reinforcementWorkspaceWorkflow for consistency with the rest of the naming in the reinforcement module

## Tests

Ran locally:

```
npx tsx admin/cli.ts production-check run --check check_reinforcement_workspace_workflows
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front