### PR TITLE
Wire compact button to compaction endpoint

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -44,7 +44,10 @@ import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types"
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/event_handlers";
 import type { DustError } from "@app/lib/error";
-import { AgentMessageCompletedEvent } from "@app/lib/notifications/events";
+import {
+  AgentMessageCompletedEvent,
+  CompactionCompletedEvent,
+} from "@app/lib/notifications/events";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import logger from "@app/logger/logger";
 import {
@@ -604,6 +607,7 @@ export const ConversationViewer = ({
                   : m
               );
             }
+            window.dispatchEvent(new CompactionCompletedEvent());
             break;
           default:
             ((t: never) => {

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -73,9 +73,7 @@ export function ContextUsageIndicator({
 
   const percentage =
     contextUsage && contextUsage.contextSize > 0
-      ? Math.round(
-          (contextUsage.contextUsage / contextUsage.contextSize) * 100
-        )
+      ? Math.round((contextUsage.contextUsage / contextUsage.contextSize) * 100)
       : 0;
 
   return (

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -1,3 +1,6 @@
+import { useCompactConversation } from "@app/hooks/conversations";
+import type { SupportedModel } from "@app/types/assistant/models/types";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   DropdownMenu,
@@ -8,7 +11,10 @@ import {
 interface ContextUsageIndicatorProps {
   contextUsage: number;
   contextSize: number;
+  model: SupportedModel | null;
   buttonSize: "xs" | "sm";
+  owner: LightWorkspaceType;
+  conversationId?: string | null;
 }
 
 interface CircleProgressProps {
@@ -54,10 +60,18 @@ function CircleProgress({ percentage, size = 16 }: CircleProgressProps) {
 export function ContextUsageIndicator({
   contextUsage,
   contextSize,
+  model,
   buttonSize,
+  owner,
+  conversationId,
 }: ContextUsageIndicatorProps) {
   const percentage =
     contextSize > 0 ? Math.round((contextUsage / contextSize) * 100) : 0;
+
+  const { compact, isCompacting } = useCompactConversation({
+    owner,
+    conversationId,
+  });
 
   return (
     <div className="hidden md:block">
@@ -83,7 +97,13 @@ export function ContextUsageIndicator({
               variant="outline"
               size="xs"
               label="Compact now"
-              disabled={true}
+              onClick={() => {
+                if (model) {
+                  void compact(model);
+                }
+              }}
+              disabled={isCompacting || !model}
+              isLoading={isCompacting}
             />
           </div>
         </DropdownMenuContent>

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -1,5 +1,7 @@
-import { useCompactConversation } from "@app/hooks/conversations";
-import type { SupportedModel } from "@app/types/assistant/models/types";
+import {
+  useCompactConversation,
+  useConversationContextUsage,
+} from "@app/hooks/conversations";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -9,9 +11,6 @@ import {
 } from "@dust-tt/sparkle";
 
 interface ContextUsageIndicatorProps {
-  contextUsage: number;
-  contextSize: number;
-  model: SupportedModel | null;
   buttonSize: "xs" | "sm";
   owner: LightWorkspaceType;
   conversationId?: string | null;
@@ -23,7 +22,7 @@ interface CircleProgressProps {
 }
 
 function CircleProgress({ percentage, size = 16 }: CircleProgressProps) {
-  const strokeWidth = size * 0.12;
+  const strokeWidth = size * 0.14;
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
   const clampedPct = Math.min(100, Math.max(0, percentage));
@@ -58,20 +57,26 @@ function CircleProgress({ percentage, size = 16 }: CircleProgressProps) {
 }
 
 export function ContextUsageIndicator({
-  contextUsage,
-  contextSize,
-  model,
   buttonSize,
   owner,
   conversationId,
 }: ContextUsageIndicatorProps) {
-  const percentage =
-    contextSize > 0 ? Math.round((contextUsage / contextSize) * 100) : 0;
+  const { contextUsage } = useConversationContextUsage({
+    conversationId,
+    workspaceId: owner.sId,
+  });
 
   const { compact, isCompacting } = useCompactConversation({
     owner,
     conversationId,
   });
+
+  const percentage =
+    contextUsage && contextUsage.contextSize > 0
+      ? Math.round(
+          (contextUsage.contextUsage / contextUsage.contextSize) * 100
+        )
+      : 0;
 
   return (
     <div className="hidden md:block">
@@ -98,11 +103,11 @@ export function ContextUsageIndicator({
               size="xs"
               label="Compact now"
               onClick={() => {
-                if (model) {
-                  void compact(model);
+                if (contextUsage?.model) {
+                  void compact(contextUsage.model);
                 }
               }}
-              disabled={isCompacting || !model}
+              disabled={isCompacting || !contextUsage?.model}
               isLoading={isCompacting}
             />
           </div>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -12,7 +12,6 @@ import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import useHandleMentions from "@app/components/editor/input_bar/useHandleMentions";
 import useUrlHandler from "@app/components/editor/input_bar/useUrlHandler";
 import { getIcon } from "@app/components/resources/resources_icons";
-import { useConversationContextUsage } from "@app/hooks/conversations";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceTranscriberService } from "@app/hooks/useVoiceTranscriberService";
@@ -206,10 +205,6 @@ const InputBarContainer = ({
   const { selectedSingleAgent, setSelectedSingleAgent } =
     useContext(InputBarContext);
 
-  const { contextUsage } = useConversationContextUsage({
-    conversationId: isCompactionEnabled ? conversation?.sId : null,
-    workspaceId: owner.sId,
-  });
   const [hasUserMention, setHasUserMention] = useState(false);
   const canSubmitEmpty = singleAgentInput && !!selectedSingleAgent;
 
@@ -1247,9 +1242,6 @@ const InputBarContainer = ({
           <div className="flex items-center">
             {isCompactionEnabled && conversation && (
               <ContextUsageIndicator
-                contextUsage={contextUsage?.contextUsage ?? 0}
-                contextSize={contextUsage?.contextSize ?? 0}
-                model={contextUsage?.model ?? null}
                 buttonSize={buttonSize}
                 owner={owner}
                 conversationId={conversation?.sId}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1249,7 +1249,10 @@ const InputBarContainer = ({
               <ContextUsageIndicator
                 contextUsage={contextUsage?.contextUsage ?? 0}
                 contextSize={contextUsage?.contextSize ?? 0}
+                model={contextUsage?.model ?? null}
                 buttonSize={buttonSize}
+                owner={owner}
+                conversationId={conversation?.sId}
               />
             )}
             {!subscription.plan.isByok &&

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -2,6 +2,7 @@ export { useAgentMessageSkills } from "./useAgentMessageSkills";
 export { useAgentMessageTools } from "./useAgentMessageTools";
 export { useBranchConversation } from "./useBranchConversation";
 export { useCancelMessage } from "./useCancelMessage";
+export { useCompactConversation } from "./useCompactConversation";
 export { useConversation } from "./useConversation";
 export { useConversationBranchActions } from "./useConversationBranchActions";
 export { useConversationContextUsage } from "./useConversationContextUsage";

--- a/front/hooks/conversations/useCompactConversation.ts
+++ b/front/hooks/conversations/useCompactConversation.ts
@@ -1,0 +1,66 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { COMPACTION_COMPLETED_EVENT } from "@app/lib/notifications/events";
+import type { SupportedModel } from "@app/types/assistant/models/types";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useEffect, useState } from "react";
+
+export function useCompactConversation({
+  owner,
+  conversationId,
+}: {
+  owner: LightWorkspaceType;
+  conversationId?: string | null;
+}) {
+  const sendNotification = useSendNotification();
+  const [isCompacting, setIsCompacting] = useState(false);
+
+  // Listen for the compaction_message_done SSE event (dispatched as a DOM custom event).
+  useEffect(() => {
+    const handler = () => {
+      setIsCompacting(false);
+    };
+    window.addEventListener(COMPACTION_COMPLETED_EVENT, handler);
+    return () => {
+      window.removeEventListener(COMPACTION_COMPLETED_EVENT, handler);
+    };
+  }, []);
+
+  const compact = useCallback(
+    async (model: SupportedModel) => {
+      if (!conversationId) {
+        return;
+      }
+      setIsCompacting(true);
+      try {
+        const res = await clientFetch(
+          `/api/w/${owner.sId}/assistant/conversations/${conversationId}/compactions`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ model }),
+          }
+        );
+        if (!res.ok) {
+          const body = await res.json();
+          sendNotification({
+            type: "error",
+            title: "Failed to compact conversation",
+            description: body?.api_error?.message ?? "Unknown error.",
+          });
+          setIsCompacting(false);
+        }
+        // isCompacting stays true until the compaction_message_done event is received.
+      } catch {
+        sendNotification({
+          type: "error",
+          title: "Failed to compact conversation",
+        });
+        setIsCompacting(false);
+      }
+    },
+    [owner.sId, conversationId, sendNotification]
+  );
+
+  return { compact, isCompacting };
+}

--- a/front/lib/notifications/events.ts
+++ b/front/lib/notifications/events.ts
@@ -13,3 +13,11 @@ export class AgentMessageCompletedEvent extends CustomEvent<void> {
     super(AGENT_MESSAGE_COMPLETED_EVENT);
   }
 }
+
+export const COMPACTION_COMPLETED_EVENT = "compaction-completed";
+
+export class CompactionCompletedEvent extends CustomEvent<void> {
+  constructor() {
+    super(COMPACTION_COMPLETED_EVENT);
+  }
+}


### PR DESCRIPTION
## Description

Connects the "Compact now" button in the context usage indicator to the compaction API endpoint.

- `useCompactConversation` hook: POSTs to `/compactions` with the model from the last agent run, stays in loading state until `CompactionCompletedEvent` (dispatched on `compaction_message_done` SSE) is received.
- `CompactionCompletedEvent`: new custom DOM event dispatched by `ConversationViewer` when compaction completes.
- The hook lives inside `ContextUsageIndicator` where it's used.

## Tests

N/A, tested locally.

## Risk

Low — additive, behind `enable_compaction` feature flag.

## Deploy Plan

- deploy `front`