### PR TITLE
feat: add poke plugin to switch workspace to Metronome billing

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -29,6 +29,7 @@ export * from "./run_reinforced_agent_workflow";
 export * from "./run_reinforcement_workflow";
 export * from "./send_onboarding_conversation";
 export * from "./soft_delete_conversation";
+export * from "./switch_to_metronome_billing";
 export * from "./sync_missing_transcripts_date_range";
 export * from "./toggle_auto_create_space";
 export * from "./toggle_disable_manual_invitations";

--- a/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.test.ts
@@ -1,0 +1,213 @@
+import { switchToMetronomeBillingPlugin } from "@app/lib/api/poke/plugins/workspaces/switch_to_metronome_billing";
+import { Authenticator } from "@app/lib/auth";
+import { addStripeMetronomeBillingConfig } from "@app/lib/metronome/client";
+import { getStripeSubscription } from "@app/lib/plans/stripe";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import type Stripe from "stripe";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/plans/stripe", async () => {
+  const actual = await vi.importActual("@app/lib/plans/stripe");
+  return {
+    ...actual,
+    getStripeSubscription: vi.fn(),
+    cancelSubscriptionAtPeriodEnd: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual("@app/lib/metronome/client");
+  return {
+    ...actual,
+    addStripeMetronomeBillingConfig: vi.fn(),
+  };
+});
+
+const METRONOME_CUSTOMER_ID = "metronome-customer-id";
+const STRIPE_SUBSCRIPTION_ID = "sub_test_xxx";
+const METRONOME_CONTRACT_ID = "contract_test_xxx";
+const PERIOD_END_SECONDS = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+
+function makeMockStripeSubscription(
+  overrides: Partial<Stripe.Subscription> = {}
+): Stripe.Subscription {
+  return {
+    id: STRIPE_SUBSCRIPTION_ID,
+    customer: "cus_test",
+    current_period_end: PERIOD_END_SECONDS,
+    status: "active",
+    cancel_at_period_end: false,
+    items: { data: [], has_more: false, object: "list", url: "" },
+    ...overrides,
+  } as Stripe.Subscription;
+}
+
+/**
+ * Sets up a workspace with metronomeCustomerId and a subscription with both
+ * stripeSubscriptionId and metronomeContractId, simulating a shadow-billed workspace.
+ */
+async function setupWorkspaceWithMetronomeAndStripe() {
+  const workspace = await WorkspaceFactory.basic();
+  await WorkspaceResource.updateMetronomeCustomerId(
+    workspace.id,
+    METRONOME_CUSTOMER_ID
+  );
+
+  const sub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  await sub!.markAsEnded("ended");
+  await SubscriptionResource.makeNew(
+    {
+      sId: generateRandomModelSId(),
+      workspaceId: workspace.id,
+      planId: sub!.planId,
+      status: "active",
+      startDate: new Date(),
+      endDate: null,
+      stripeSubscriptionId: STRIPE_SUBSCRIPTION_ID,
+      metronomeContractId: METRONOME_CONTRACT_ID,
+    },
+    sub!.getPlan()
+  );
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  return { workspace, auth };
+}
+
+describe("switchToMetronomeBillingPlugin", () => {
+  describe("execute", () => {
+    it("returns Err when workspace has no Metronome contract", async () => {
+      // WorkspaceFactory creates a workspace with no metronomeCustomerId and
+      // no metronomeContractId on the subscription.
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const result = await switchToMetronomeBillingPlugin.execute(
+        auth,
+        null,
+        {}
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("No Metronome contract");
+      }
+    });
+
+    it("returns Err when subscription has no Stripe subscription ID", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      await WorkspaceResource.updateMetronomeCustomerId(
+        workspace.id,
+        METRONOME_CUSTOMER_ID
+      );
+
+      // Subscription has metronomeContractId but no stripeSubscriptionId.
+      const sub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+        workspace.id
+      );
+      await sub!.markAsEnded("ended");
+      await SubscriptionResource.makeNew(
+        {
+          sId: generateRandomModelSId(),
+          workspaceId: workspace.id,
+          planId: sub!.planId,
+          status: "active",
+          startDate: new Date(),
+          endDate: null,
+          stripeSubscriptionId: null,
+          metronomeContractId: METRONOME_CONTRACT_ID,
+        },
+        sub!.getPlan()
+      );
+
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+      const result = await switchToMetronomeBillingPlugin.execute(
+        auth,
+        null,
+        {}
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("No Stripe subscription found");
+      }
+    });
+
+    it("returns Err when Stripe subscription is not found", async () => {
+      const { auth } = await setupWorkspaceWithMetronomeAndStripe();
+      vi.mocked(getStripeSubscription).mockResolvedValue(null);
+
+      const result = await switchToMetronomeBillingPlugin.execute(
+        auth,
+        null,
+        {}
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain(
+          "Could not retrieve Stripe subscription"
+        );
+      }
+    });
+
+    it("returns Err when addStripeMetronomeBillingConfig fails", async () => {
+      const { auth } = await setupWorkspaceWithMetronomeAndStripe();
+      vi.mocked(getStripeSubscription).mockResolvedValue(
+        makeMockStripeSubscription()
+      );
+      vi.mocked(addStripeMetronomeBillingConfig).mockResolvedValue(
+        new Err(new Error("Metronome API error"))
+      );
+
+      const result = await switchToMetronomeBillingPlugin.execute(
+        auth,
+        null,
+        {}
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toBe("Metronome API error");
+      }
+    });
+
+    it("marks old subscription as ended_backend_only, creates new one without Stripe, and returns success message", async () => {
+      const { workspace, auth } = await setupWorkspaceWithMetronomeAndStripe();
+      vi.mocked(getStripeSubscription).mockResolvedValue(
+        makeMockStripeSubscription()
+      );
+      vi.mocked(addStripeMetronomeBillingConfig).mockResolvedValue(
+        new Ok(undefined)
+      );
+
+      const result = await switchToMetronomeBillingPlugin.execute(
+        auth,
+        null,
+        {}
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.display).toBe("text");
+        expect(result.value.value).toContain(STRIPE_SUBSCRIPTION_ID);
+        expect(result.value.value).toContain(METRONOME_CONTRACT_ID);
+      }
+
+      // New active subscription has no stripeSubscriptionId, keeps metronomeContractId,
+      // and starts at the Stripe period end date.
+      const newSub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+        workspace.id
+      );
+      expect(newSub).not.toBeNull();
+      expect(newSub!.stripeSubscriptionId).toBeNull();
+      expect(newSub!.metronomeContractId).toBe(METRONOME_CONTRACT_ID);
+      expect(newSub!.startDate.getTime()).toBe(PERIOD_END_SECONDS * 1000);
+    });
+  });
+});

--- a/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.test.ts
@@ -1,7 +1,10 @@
 import { switchToMetronomeBillingPlugin } from "@app/lib/api/poke/plugins/workspaces/switch_to_metronome_billing";
 import { Authenticator } from "@app/lib/auth";
 import { addStripeMetronomeBillingConfig } from "@app/lib/metronome/client";
-import { getStripeSubscription } from "@app/lib/plans/stripe";
+import {
+  cancelSubscriptionAtPeriodEnd,
+  getStripeSubscription,
+} from "@app/lib/plans/stripe";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -177,6 +180,41 @@ describe("switchToMetronomeBillingPlugin", () => {
       }
     });
 
+    it("returns Ok with a warning and keeps DB changes when Stripe cancellation fails", async () => {
+      const { workspace, auth } = await setupWorkspaceWithMetronomeAndStripe();
+      vi.mocked(getStripeSubscription).mockResolvedValue(
+        makeMockStripeSubscription()
+      );
+      vi.mocked(addStripeMetronomeBillingConfig).mockResolvedValue(
+        new Ok(undefined)
+      );
+      vi.mocked(cancelSubscriptionAtPeriodEnd).mockRejectedValue(
+        new Error("Stripe API error")
+      );
+
+      const result = await switchToMetronomeBillingPlugin.execute(
+        auth,
+        null,
+        {}
+      );
+
+      // Returns Ok (not Err) so the operator knows the DB is already migrated.
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.value).toContain("WARNING");
+        expect(result.value.value).toContain(STRIPE_SUBSCRIPTION_ID);
+        expect(result.value.value).toContain("Stripe API error");
+      }
+
+      // DB changes are committed despite the Stripe failure.
+      const newSub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+        workspace.id
+      );
+      expect(newSub).not.toBeNull();
+      expect(newSub!.stripeSubscriptionId).toBeNull();
+      expect(newSub!.metronomeContractId).toBe(METRONOME_CONTRACT_ID);
+    });
+
     it("marks old subscription as ended_backend_only, creates new one without Stripe, and returns success message", async () => {
       const { workspace, auth } = await setupWorkspaceWithMetronomeAndStripe();
       vi.mocked(getStripeSubscription).mockResolvedValue(
@@ -185,6 +223,7 @@ describe("switchToMetronomeBillingPlugin", () => {
       vi.mocked(addStripeMetronomeBillingConfig).mockResolvedValue(
         new Ok(undefined)
       );
+      vi.mocked(cancelSubscriptionAtPeriodEnd).mockResolvedValue(true);
 
       const result = await switchToMetronomeBillingPlugin.execute(
         auth,

--- a/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.ts
+++ b/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.ts
@@ -51,10 +51,6 @@ export const switchToMetronomeBillingPlugin = createPlugin({
       return new Err(billingConfigResult.error);
     }
 
-    await cancelSubscriptionAtPeriodEnd({
-      stripeSubscriptionId: subscription.stripeSubscriptionId,
-    });
-
     const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
 
     await withTransaction(async (t) => {
@@ -82,6 +78,10 @@ export const switchToMetronomeBillingPlugin = createPlugin({
         subscriptionResource.getPlan(),
         t
       );
+    });
+
+    await cancelSubscriptionAtPeriodEnd({
+      stripeSubscriptionId: subscription.stripeSubscriptionId,
     });
 
     return new Ok({

--- a/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.ts
+++ b/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.ts
@@ -1,0 +1,94 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { addStripeMetronomeBillingConfig } from "@app/lib/metronome/client";
+import {
+  cancelSubscriptionAtPeriodEnd,
+  getStripeSubscription,
+} from "@app/lib/plans/stripe";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const switchToMetronomeBillingPlugin = createPlugin({
+  manifest: {
+    id: "switch-to-metronome-billing",
+    name: "Switch to Metronome Billing",
+    description:
+      "Cancels the Stripe subscription at period end and enables Metronome as the billing provider. The Metronome contract transitions at the same date to avoid double-billing.",
+    resourceTypes: ["workspaces"],
+    args: {},
+  },
+  execute: async (auth) => {
+    const workspace = auth.getNonNullableWorkspace();
+    const subscription = auth.subscription();
+
+    if (!subscription?.metronomeContractId || !workspace.metronomeCustomerId) {
+      return new Err(
+        new Error("No Metronome contract found on this workspace")
+      );
+    }
+
+    if (!subscription.stripeSubscriptionId) {
+      return new Err(
+        new Error(
+          "No Stripe subscription found, workspace may already be on Metronome billing."
+        )
+      );
+    }
+
+    const stripeSubscription = await getStripeSubscription(
+      subscription.stripeSubscriptionId
+    );
+    if (!stripeSubscription) {
+      return new Err(new Error("Could not retrieve Stripe subscription."));
+    }
+
+    const billingConfigResult = await addStripeMetronomeBillingConfig({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      metronomeContractId: subscription.metronomeContractId,
+    });
+    if (billingConfigResult.isErr()) {
+      return new Err(billingConfigResult.error);
+    }
+
+    await cancelSubscriptionAtPeriodEnd({
+      stripeSubscriptionId: subscription.stripeSubscriptionId,
+    });
+
+    const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
+
+    await withTransaction(async (t) => {
+      const subscriptionResource =
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(
+          workspace.id,
+          t
+        );
+      if (!subscriptionResource) {
+        throw new Error("Could not fetch active subscription resource.");
+      }
+      await subscriptionResource.markAsEnded("ended_backend_only", t);
+      await SubscriptionResource.makeNew(
+        {
+          sId: generateRandomModelSId(),
+          workspaceId: workspace.id,
+          planId: subscriptionResource.planId,
+          status: "active",
+          trialing: false,
+          startDate: periodEnd,
+          endDate: null,
+          stripeSubscriptionId: null,
+          metronomeContractId: subscription.metronomeContractId,
+        },
+        subscriptionResource.getPlan(),
+        t
+      );
+    });
+
+    return new Ok({
+      display: "text",
+      value:
+        `Stripe subscription ${subscription.stripeSubscriptionId} will be cancelled on ${periodEnd.toISOString()}. ` +
+        `New Metronome contract ${subscription.metronomeContractId} continues from that date with Stripe as billing provider.`,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.ts
+++ b/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.ts
@@ -13,7 +13,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-export async function switchWorkspaceToMetronomeBilling(
+async function switchWorkspaceToMetronomeBilling(
   auth: Authenticator
 ): Promise<Result<{ display: "text"; value: string }, Error>> {
   const workspace = auth.getNonNullableWorkspace();

--- a/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.ts
+++ b/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.ts
@@ -1,4 +1,5 @@
 import { createPlugin } from "@app/lib/api/poke/types";
+import type { Authenticator } from "@app/lib/auth";
 import { addStripeMetronomeBillingConfig } from "@app/lib/metronome/client";
 import {
   cancelSubscriptionAtPeriodEnd,
@@ -7,7 +8,102 @@ import {
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export async function switchWorkspaceToMetronomeBilling(
+  auth: Authenticator
+): Promise<Result<{ display: "text"; value: string }, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription();
+
+  if (!subscription?.metronomeContractId || !workspace.metronomeCustomerId) {
+    return new Err(new Error("No Metronome contract found on this workspace"));
+  }
+
+  if (!subscription.stripeSubscriptionId) {
+    return new Err(
+      new Error(
+        "No Stripe subscription found, workspace may already be on Metronome billing."
+      )
+    );
+  }
+
+  const stripeSubscription = await getStripeSubscription(
+    subscription.stripeSubscriptionId
+  );
+  if (!stripeSubscription) {
+    return new Err(new Error("Could not retrieve Stripe subscription."));
+  }
+
+  const billingConfigResult = await addStripeMetronomeBillingConfig({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    metronomeContractId: subscription.metronomeContractId,
+  });
+  if (billingConfigResult.isErr()) {
+    return new Err(billingConfigResult.error);
+  }
+
+  const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
+
+  await withTransaction(async (t) => {
+    const subscriptionResource =
+      await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id, t);
+    if (!subscriptionResource) {
+      throw new Error("Could not fetch active subscription resource.");
+    }
+    await subscriptionResource.markAsEnded("ended_backend_only", t);
+    await SubscriptionResource.makeNew(
+      {
+        sId: generateRandomModelSId(),
+        workspaceId: workspace.id,
+        planId: subscriptionResource.planId,
+        status: "active",
+        trialing: false,
+        startDate: periodEnd,
+        endDate: null,
+        stripeSubscriptionId: null,
+        metronomeContractId: subscription.metronomeContractId,
+      },
+      subscriptionResource.getPlan(),
+      t
+    );
+  });
+
+  try {
+    await cancelSubscriptionAtPeriodEnd({
+      stripeSubscriptionId: subscription.stripeSubscriptionId,
+    });
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      {
+        error,
+        workspaceSId: workspace.sId,
+        stripeSubscriptionId: subscription.stripeSubscriptionId,
+      },
+      "[SwitchToMetronomeBilling] MANUAL ACTION REQUIRED: DB and Metronome are already migrated " +
+        "to Metronome billing but Stripe subscription cancellation failed. " +
+        "Cancel the Stripe subscription manually to avoid double-charging the customer at period end."
+    );
+    return new Ok({
+      display: "text",
+      value:
+        `WARNING: DB migrated and Metronome billing enabled, but failed to cancel Stripe ` +
+        `subscription ${subscription.stripeSubscriptionId}: ${error.message}. ` +
+        `Cancel it manually in Stripe to avoid double-charging at period end.`,
+    });
+  }
+
+  return new Ok({
+    display: "text",
+    value:
+      `Stripe subscription ${subscription.stripeSubscriptionId} will be cancelled on ${periodEnd.toISOString()}. ` +
+      `New Metronome contract ${subscription.metronomeContractId} continues from that date with Stripe as billing provider.`,
+  });
+}
 
 export const switchToMetronomeBillingPlugin = createPlugin({
   manifest: {
@@ -19,76 +115,6 @@ export const switchToMetronomeBillingPlugin = createPlugin({
     args: {},
   },
   execute: async (auth) => {
-    const workspace = auth.getNonNullableWorkspace();
-    const subscription = auth.subscription();
-
-    if (!subscription?.metronomeContractId || !workspace.metronomeCustomerId) {
-      return new Err(
-        new Error("No Metronome contract found on this workspace")
-      );
-    }
-
-    if (!subscription.stripeSubscriptionId) {
-      return new Err(
-        new Error(
-          "No Stripe subscription found, workspace may already be on Metronome billing."
-        )
-      );
-    }
-
-    const stripeSubscription = await getStripeSubscription(
-      subscription.stripeSubscriptionId
-    );
-    if (!stripeSubscription) {
-      return new Err(new Error("Could not retrieve Stripe subscription."));
-    }
-
-    const billingConfigResult = await addStripeMetronomeBillingConfig({
-      metronomeCustomerId: workspace.metronomeCustomerId,
-      metronomeContractId: subscription.metronomeContractId,
-    });
-    if (billingConfigResult.isErr()) {
-      return new Err(billingConfigResult.error);
-    }
-
-    const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
-
-    await withTransaction(async (t) => {
-      const subscriptionResource =
-        await SubscriptionResource.fetchActiveByWorkspaceModelId(
-          workspace.id,
-          t
-        );
-      if (!subscriptionResource) {
-        throw new Error("Could not fetch active subscription resource.");
-      }
-      await subscriptionResource.markAsEnded("ended_backend_only", t);
-      await SubscriptionResource.makeNew(
-        {
-          sId: generateRandomModelSId(),
-          workspaceId: workspace.id,
-          planId: subscriptionResource.planId,
-          status: "active",
-          trialing: false,
-          startDate: periodEnd,
-          endDate: null,
-          stripeSubscriptionId: null,
-          metronomeContractId: subscription.metronomeContractId,
-        },
-        subscriptionResource.getPlan(),
-        t
-      );
-    });
-
-    await cancelSubscriptionAtPeriodEnd({
-      stripeSubscriptionId: subscription.stripeSubscriptionId,
-    });
-
-    return new Ok({
-      display: "text",
-      value:
-        `Stripe subscription ${subscription.stripeSubscriptionId} will be cancelled on ${periodEnd.toISOString()}. ` +
-        `New Metronome contract ${subscription.metronomeContractId} continues from that date with Stripe as billing provider.`,
-    });
+    return switchWorkspaceToMetronomeBilling(auth);
   },
 });

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -181,6 +181,88 @@ export async function findMetronomeCustomerByAlias(
   }
 }
 
+/**
+ * Add Stripe billing configuration from the Metronome customer to the contract
+ * Idempotent: if Stripe billing is already configured, logs and returns Ok.
+ */
+export async function addStripeMetronomeBillingConfig({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<Result<void, Error>> {
+  let configs;
+
+  try {
+    configs =
+      await getMetronomeClient().v1.customers.retrieveBillingConfigurations({
+        customer_id: metronomeCustomerId,
+      });
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId },
+      "[Metronome] Failed to retrieve billing configurations"
+    );
+    return new Err(error);
+  }
+
+  const stripeConfig = configs.data.find(
+    (c) => c.billing_provider === "stripe" && !c.archived_at
+  );
+  if (!stripeConfig) {
+    return new Err(
+      new Error(
+        `No active Stripe billing configuration found for Metronome customer ${metronomeCustomerId}`
+      )
+    );
+  }
+
+  try {
+    await getMetronomeClient().v2.contracts.edit({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+      add_billing_provider_configuration_update: {
+        billing_provider_configuration: {
+          billing_provider_configuration_id: stripeConfig.id,
+        },
+        schedule: {
+          effective_at: "START_OF_CURRENT_PERIOD",
+        },
+      },
+    });
+
+    logger.info(
+      {
+        metronomeCustomerId,
+        metronomeContractId,
+        billingProviderConfigurationId: stripeConfig.id,
+      },
+      "[Metronome] Stripe billing provider linked to contract"
+    );
+
+    return new Ok(undefined);
+  } catch (err) {
+    if (err instanceof ConflictError) {
+      logger.info(
+        { metronomeCustomerId, metronomeContractId },
+        "[Metronome] Contract billing provider already configured, skipping"
+      );
+
+      return new Ok(undefined);
+    }
+
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, metronomeContractId },
+      "[Metronome] Failed to link Stripe billing provider to contract"
+    );
+
+    return new Err(error);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Contract management
 // ---------------------------------------------------------------------------

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -1309,7 +1309,8 @@ async function handler(
             if (
               endDate &&
               subscription.metronomeContractId &&
-              workspace.metronomeCustomerId
+              workspace.metronomeCustomerId &&
+              subscription.status !== "ended_backend_only" // Don't sunset Metronome contract when gracefully ending Stripe subscription
             ) {
               void scheduleMetronomeContractEnd({
                 metronomeCustomerId: workspace.metronomeCustomerId,


### PR DESCRIPTION
## Description

Adds the `switch-to-metronome-billing` poke plugin that transitions a shadow-billed workspace to full Metronome billing. The plugin links Stripe as billing provider on the existing Metronome contract, cancels the Stripe subscription at period end, and creates a new internal subscription starting at that date so Metronome takes over billing without any overlap.

Also guards the webhook's Metronome contract sunset logic so it does not fire when a Stripe subscription is gracefully wound down via this plugin (`ended_backend_only` status).

Implements dust-tt/tasks#7509

## Tests

Unit testing + local

## Risk

Only works when manually triggering the poke plugin, no effect otherwise. Then if bugged, the risk is a customer can get into a wrong billing situation (either no billing provider, or double billing). Tests should cover for these risks.

If Stripe cancellation fails, returns an alert and logs an error to indicate manual action is required to avoid double-billing at the start of the next billing cycle.

## Deploy Plan

Front