### PR TITLE
Include in-progress agent messages in context usage endpoint

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2011,11 +2011,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return pendingMessages;
   }
 
-  async getLatestCompletedAgentMessageRun(
+  async getLatestAgentMessageRun(
     auth: Authenticator
   ): Promise<RunResource | null> {
     const owner = auth.getNonNullableWorkspace();
 
+    // Include in-progress ("created") agent messages so that context usage is available even while
+    // the agent is still running (it accumulates runIds step by step).
     const message = await MessageModel.findOne({
       where: {
         conversationId: this.id,
@@ -2027,7 +2029,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           as: "agentMessage",
           required: true,
           where: {
-            status: ["succeeded", "gracefully_stopped"],
+            status: ["succeeded", "gracefully_stopped", "created"],
           },
         },
       ],

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -46,13 +46,13 @@ async function handler(
         });
       }
 
-      const run = await conversation.getLatestCompletedAgentMessageRun(auth);
+      const run = await conversation.getLatestAgentMessageRun(auth);
       if (!run) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {
             type: "conversation_context_usage_not_found",
-            message: "No completed agent message found in this conversation.",
+            message: "Latest agent message has no run data.",
           },
         });
       }


### PR DESCRIPTION
## Description

The context-usage endpoint was returning a 404 when the latest agent message was still running
(`status: "created"`). This widens the query to also include in-progress agent messages so that
context usage is available mid-run (as long as at least one step has been processed).

- Renamed `getLatestCompletedAgentMessageRun` to `getLatestAgentMessageRun`.
- Added `"created"` to the status filter alongside `"succeeded"` and `"gracefully_stopped"`.

Caveat is that we may get a few error as a new agent message just got created and didn't run any step. But that's rather unlikely and will get updated naturally as the first step complete (follow-up PR to mutateContextUsage more granularly)

## Tests

N/A, tested locally.

## Risk

Low — the method still returns `null` if no `runIds` exist yet.

## Deploy Plan

- deploy `front`