### PR TITLE
Re-fetch context usage after each agent action step

### DIFF
--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -6,6 +6,7 @@ import type {
   VirtuosoMessageListContext,
 } from "@app/components/assistant/conversation/types";
 import { isAgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
+import { useConversationContextUsage } from "@app/hooks/conversations";
 import { useEventSource } from "@app/hooks/useEventSource";
 import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
 import {
@@ -293,6 +294,10 @@ export function useAgentMessageStream({
   streamId,
 }: UseAgentMessageStreamParams) {
   const sId = agentMessage.sId;
+  const { mutateContextUsage } = useConversationContextUsage({
+    conversationId,
+    workspaceId: owner.sId,
+  });
   const methods = useVirtuosoMethods<
     VirtuosoMessage,
     VirtuosoMessageListContext
@@ -479,6 +484,7 @@ export function useAgentMessageStream({
             };
           });
 
+          void mutateContextUsage();
           break;
 
         case "tool_params":

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -677,7 +677,13 @@ export function useAgentMessageStream({
         customOnEventCallback(eventPayload);
       }
     },
-    [customOnEventCallback, isInlineActivityEnabled, methods, sId]
+    [
+      customOnEventCallback,
+      isInlineActivityEnabled,
+      methods,
+      sId,
+      mutateContextUsage,
+    ]
   );
 
   const { isError } = useEventSource(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2040,12 +2040,19 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return null;
     }
 
-    // runIds is ordered chronologically (appended step by step in the agent loop), so the last
-    // element is the most recent run.
-    const lastRunId =
-      message.agentMessage.runIds[message.agentMessage.runIds.length - 1];
+    // The runIds array ordering is not guaranteed to be chronological. Fetch all runs and pick
+    // the most recently created one.
+    const runs = await RunResource.listByDustRunIds(auth, {
+      dustRunIds: message.agentMessage.runIds,
+    });
 
-    return RunResource.fetchByDustRunId(auth, { dustRunId: lastRunId });
+    if (runs.length === 0) {
+      return null;
+    }
+
+    return runs.reduce((latest, r) =>
+      r.createdAt > latest.createdAt ? r : latest
+    );
   }
 
   static async resolveForkSourceMessage(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -68,19 +68,19 @@ async function handler(
         });
       }
 
-      // Take the max promptTokens across usages of the last run — in a multi-step agent loop,
-      // each step sees all previous steps' outputs, so the last step's promptTokens is the full
-      // context size as seen by the model.
-      const lastUsage = usages[usages.length - 1];
-      const contextUsage = Math.max(...usages.map((u) => u.promptTokens));
-      const modelConfig = getModelConfigByModelId(lastUsage.modelId);
+      // Take the max promptTokens across usages of the latest run — this represents the peak
+      // context usage as seen by the model.
+      const maxUsage = usages.reduce((max, u) =>
+        u.promptTokens > max.promptTokens ? u : max
+      );
+      const modelConfig = getModelConfigByModelId(maxUsage.modelId);
 
       return res.status(200).json({
         model: {
-          providerId: lastUsage.providerId,
-          modelId: lastUsage.modelId,
+          providerId: maxUsage.providerId,
+          modelId: maxUsage.modelId,
         },
-        contextUsage,
+        contextUsage: maxUsage.promptTokens,
         contextSize: modelConfig?.contextSize ?? 0,
       });
     }


### PR DESCRIPTION
## Description

The context usage indicator now updates progressively during multi-step agent runs instead of
only after the agent message completes. Uses the shared SWR hook (`useConversationContextUsage`)
in `useAgentMessageStream` to call `mutateContextUsage()` on each `agent_action_success` event.

Also discovered that runIds have no order guarantee so we want to grab the latest (in the resource) and the max of usages in the endpoint.

## Tests

N/A, tested locally.

## Risk

None.

## Deploy Plan

- deploy `front`