### PR TITLE
Enable shared workspace credentials for the Outlook tool

### DIFF
--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -304,7 +304,7 @@ export const OUTLOOK_MAIL_SERVER = {
     description: "Read emails, manage drafts and contacts.",
     authorization: {
       provider: "microsoft_tools",
-      supported_use_cases: ["personal_actions"],
+      supported_use_cases: ["personal_actions", "platform_actions"],
       scope:
         "Mail.ReadWrite.Shared Mail.Send Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read offline_access",
       availableScopes: [

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -304,7 +304,7 @@ export const OUTLOOK_MAIL_SERVER = {
     description: "Read emails, manage drafts and contacts.",
     authorization: {
       provider: "microsoft_tools",
-      supported_use_cases: ["personal_actions", "platform_actions"],
+      supported_use_cases: ["personal_actions"],
       scope:
         "Mail.ReadWrite.Shared Mail.Send Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read offline_access",
       availableScopes: [


### PR DESCRIPTION
## Description

Allows the Outlook MCP to be configured as a shared tool.

## Tests

Tested locally manually.

## Risk

N/A. A previous revision (#23330) attempted to re-use existing client configurations, resulting in errors across Microsoft tools. This change is localized to simply enabling "platform_actions" and should not result in similar issues.

## Deploy Plan

Standard deployment.