### PR TITLE
Reduce compaction message font size to text-sm

### DIFF
--- a/front/components/assistant/conversation/CompactionMessage.tsx
+++ b/front/components/assistant/conversation/CompactionMessage.tsx
@@ -30,7 +30,7 @@ export function CompactionMessage({ message }: CompactionMessageProps) {
     case "succeeded":
       return (
         <div className="flex items-center justify-center gap-1.5">
-          <span className="text-base text-muted-foreground">
+          <span className="text-sm text-muted-foreground">
             Context compacted · {formatTimestring(message.created)}
           </span>
         </div>
@@ -39,7 +39,7 @@ export function CompactionMessage({ message }: CompactionMessageProps) {
       return (
         <div className="flex items-center justify-center gap-1.5">
           <Spinner size="xs" />
-          <AnimatedText variant="muted" className="text-base">
+          <AnimatedText variant="muted" className="text-sm">
             Compacting context…
           </AnimatedText>
         </div>


### PR DESCRIPTION
## Description

Reduce the "Context compacted" and "Compacting context…" indicator font size from `text-base` (16px) to `text-sm` (14px) so it reads as an activity indicator rather than message text.

## Tests

Didn't test at all. YOLO.

## Risk

None. CSS-only change.

## Deploy Plan

- deploy `front`