### PR TITLE
Render compaction messages for model context and interaction grouping

### DIFF
--- a/front/lib/api/assistant/conversation/interactions.test.ts
+++ b/front/lib/api/assistant/conversation/interactions.test.ts
@@ -92,10 +92,13 @@ describe("groupMessagesIntoInteractions", () => {
       msg("user", "u2"),
       msg("assistant", "a2"),
     ]);
-    expect(interactions).toHaveLength(3);
+    expect(interactions).toHaveLength(2);
     expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1", "a1"]);
-    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["c1"]);
-    expect(interactions[2].messages.map((m) => m.tag)).toEqual(["u2", "a2"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual([
+      "c1",
+      "u2",
+      "a2",
+    ]);
   });
 
   it("creates a boundary at each compaction message", () => {
@@ -109,12 +112,18 @@ describe("groupMessagesIntoInteractions", () => {
       msg("user", "u3"),
       msg("assistant", "a3"),
     ]);
-    expect(interactions).toHaveLength(5);
+    expect(interactions).toHaveLength(3);
     expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1", "a1"]);
-    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["c1"]);
-    expect(interactions[2].messages.map((m) => m.tag)).toEqual(["u2", "a2"]);
-    expect(interactions[3].messages.map((m) => m.tag)).toEqual(["c2"]);
-    expect(interactions[4].messages.map((m) => m.tag)).toEqual(["u3", "a3"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual([
+      "c1",
+      "u2",
+      "a2",
+    ]);
+    expect(interactions[2].messages.map((m) => m.tag)).toEqual([
+      "c2",
+      "u3",
+      "a3",
+    ]);
   });
 
   it("handles compaction as the last message", () => {
@@ -134,9 +143,12 @@ describe("groupMessagesIntoInteractions", () => {
       msg("user", "u1"),
       msg("assistant", "a1"),
     ]);
-    expect(interactions).toHaveLength(2);
-    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["c1"]);
-    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["u1", "a1"]);
+    expect(interactions).toHaveLength(1);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
+      "c1",
+      "u1",
+      "a1",
+    ]);
   });
 
   it("handles compaction mid-interaction (closes partial interaction)", () => {
@@ -146,10 +158,13 @@ describe("groupMessagesIntoInteractions", () => {
       msg("user", "u2"),
       msg("assistant", "a2"),
     ]);
-    expect(interactions).toHaveLength(3);
+    expect(interactions).toHaveLength(2);
     expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1"]);
-    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["c1"]);
-    expect(interactions[2].messages.map((m) => m.tag)).toEqual(["u2", "a2"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual([
+      "c1",
+      "u2",
+      "a2",
+    ]);
   });
 
   it("handles compaction followed by multiple interactions", () => {
@@ -162,10 +177,13 @@ describe("groupMessagesIntoInteractions", () => {
       msg("user", "u3"),
       msg("assistant", "a3"),
     ]);
-    expect(interactions).toHaveLength(4);
+    expect(interactions).toHaveLength(3);
     expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1", "a1"]);
-    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["c1"]);
-    expect(interactions[2].messages.map((m) => m.tag)).toEqual(["u2", "a2"]);
-    expect(interactions[3].messages.map((m) => m.tag)).toEqual(["u3", "a3"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual([
+      "c1",
+      "u2",
+      "a2",
+    ]);
+    expect(interactions[2].messages.map((m) => m.tag)).toEqual(["u3", "a3"]);
   });
 });

--- a/front/lib/api/assistant/conversation/interactions.test.ts
+++ b/front/lib/api/assistant/conversation/interactions.test.ts
@@ -84,7 +84,7 @@ describe("groupMessagesIntoInteractions", () => {
     expect(interactions[1].messages.map((m) => m.tag)).toEqual(["u2"]);
   });
 
-  it("discards all interactions before a compaction message", () => {
+  it("creates a new interaction boundary at a compaction message", () => {
     const interactions = groupMessagesIntoInteractions([
       msg("user", "u1"),
       msg("assistant", "a1"),
@@ -92,15 +92,13 @@ describe("groupMessagesIntoInteractions", () => {
       msg("user", "u2"),
       msg("assistant", "a2"),
     ]);
-    expect(interactions).toHaveLength(1);
-    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
-      "c1",
-      "u2",
-      "a2",
-    ]);
+    expect(interactions).toHaveLength(3);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1", "a1"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["c1"]);
+    expect(interactions[2].messages.map((m) => m.tag)).toEqual(["u2", "a2"]);
   });
 
-  it("uses the last compaction message when multiple exist", () => {
+  it("creates a boundary at each compaction message", () => {
     const interactions = groupMessagesIntoInteractions([
       msg("user", "u1"),
       msg("assistant", "a1"),
@@ -111,12 +109,12 @@ describe("groupMessagesIntoInteractions", () => {
       msg("user", "u3"),
       msg("assistant", "a3"),
     ]);
-    expect(interactions).toHaveLength(1);
-    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
-      "c2",
-      "u3",
-      "a3",
-    ]);
+    expect(interactions).toHaveLength(5);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1", "a1"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["c1"]);
+    expect(interactions[2].messages.map((m) => m.tag)).toEqual(["u2", "a2"]);
+    expect(interactions[3].messages.map((m) => m.tag)).toEqual(["c2"]);
+    expect(interactions[4].messages.map((m) => m.tag)).toEqual(["u3", "a3"]);
   });
 
   it("handles compaction as the last message", () => {
@@ -125,8 +123,9 @@ describe("groupMessagesIntoInteractions", () => {
       msg("assistant", "a1"),
       msg("compaction", "c1"),
     ]);
-    expect(interactions).toHaveLength(1);
-    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["c1"]);
+    expect(interactions).toHaveLength(2);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1", "a1"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["c1"]);
   });
 
   it("handles compaction as the first message", () => {
@@ -135,27 +134,22 @@ describe("groupMessagesIntoInteractions", () => {
       msg("user", "u1"),
       msg("assistant", "a1"),
     ]);
-    expect(interactions).toHaveLength(1);
-    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
-      "c1",
-      "u1",
-      "a1",
-    ]);
+    expect(interactions).toHaveLength(2);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["c1"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["u1", "a1"]);
   });
 
-  it("handles compaction mid-interaction (discards partial in-progress interaction)", () => {
+  it("handles compaction mid-interaction (closes partial interaction)", () => {
     const interactions = groupMessagesIntoInteractions([
       msg("user", "u1"),
       msg("compaction", "c1"),
       msg("user", "u2"),
       msg("assistant", "a2"),
     ]);
-    expect(interactions).toHaveLength(1);
-    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
-      "c1",
-      "u2",
-      "a2",
-    ]);
+    expect(interactions).toHaveLength(3);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["c1"]);
+    expect(interactions[2].messages.map((m) => m.tag)).toEqual(["u2", "a2"]);
   });
 
   it("handles compaction followed by multiple interactions", () => {
@@ -168,12 +162,10 @@ describe("groupMessagesIntoInteractions", () => {
       msg("user", "u3"),
       msg("assistant", "a3"),
     ]);
-    expect(interactions).toHaveLength(2);
-    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
-      "c1",
-      "u2",
-      "a2",
-    ]);
-    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["u3", "a3"]);
+    expect(interactions).toHaveLength(4);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1", "a1"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["c1"]);
+    expect(interactions[2].messages.map((m) => m.tag)).toEqual(["u2", "a2"]);
+    expect(interactions[3].messages.map((m) => m.tag)).toEqual(["u3", "a3"]);
   });
 });

--- a/front/lib/api/assistant/conversation/interactions.test.ts
+++ b/front/lib/api/assistant/conversation/interactions.test.ts
@@ -129,6 +129,35 @@ describe("groupMessagesIntoInteractions", () => {
     expect(interactions[0].messages.map((m) => m.tag)).toEqual(["c1"]);
   });
 
+  it("handles compaction as the first message", () => {
+    const interactions = groupMessagesIntoInteractions([
+      msg("compaction", "c1"),
+      msg("user", "u1"),
+      msg("assistant", "a1"),
+    ]);
+    expect(interactions).toHaveLength(1);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
+      "c1",
+      "u1",
+      "a1",
+    ]);
+  });
+
+  it("handles compaction mid-interaction (discards partial in-progress interaction)", () => {
+    const interactions = groupMessagesIntoInteractions([
+      msg("user", "u1"),
+      msg("compaction", "c1"),
+      msg("user", "u2"),
+      msg("assistant", "a2"),
+    ]);
+    expect(interactions).toHaveLength(1);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
+      "c1",
+      "u2",
+      "a2",
+    ]);
+  });
+
   it("handles compaction followed by multiple interactions", () => {
     const interactions = groupMessagesIntoInteractions([
       msg("user", "u1"),

--- a/front/lib/api/assistant/conversation/interactions.test.ts
+++ b/front/lib/api/assistant/conversation/interactions.test.ts
@@ -83,4 +83,68 @@ describe("groupMessagesIntoInteractions", () => {
     ]);
     expect(interactions[1].messages.map((m) => m.tag)).toEqual(["u2"]);
   });
+
+  it("discards all interactions before a compaction message", () => {
+    const interactions = groupMessagesIntoInteractions([
+      msg("user", "u1"),
+      msg("assistant", "a1"),
+      msg("compaction", "c1"),
+      msg("user", "u2"),
+      msg("assistant", "a2"),
+    ]);
+    expect(interactions).toHaveLength(1);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
+      "c1",
+      "u2",
+      "a2",
+    ]);
+  });
+
+  it("uses the last compaction message when multiple exist", () => {
+    const interactions = groupMessagesIntoInteractions([
+      msg("user", "u1"),
+      msg("assistant", "a1"),
+      msg("compaction", "c1"),
+      msg("user", "u2"),
+      msg("assistant", "a2"),
+      msg("compaction", "c2"),
+      msg("user", "u3"),
+      msg("assistant", "a3"),
+    ]);
+    expect(interactions).toHaveLength(1);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
+      "c2",
+      "u3",
+      "a3",
+    ]);
+  });
+
+  it("handles compaction as the last message", () => {
+    const interactions = groupMessagesIntoInteractions([
+      msg("user", "u1"),
+      msg("assistant", "a1"),
+      msg("compaction", "c1"),
+    ]);
+    expect(interactions).toHaveLength(1);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["c1"]);
+  });
+
+  it("handles compaction followed by multiple interactions", () => {
+    const interactions = groupMessagesIntoInteractions([
+      msg("user", "u1"),
+      msg("assistant", "a1"),
+      msg("compaction", "c1"),
+      msg("user", "u2"),
+      msg("assistant", "a2"),
+      msg("user", "u3"),
+      msg("assistant", "a3"),
+    ]);
+    expect(interactions).toHaveLength(2);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
+      "c1",
+      "u2",
+      "a2",
+    ]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["u3", "a3"]);
+  });
 });

--- a/front/lib/api/assistant/conversation/interactions.ts
+++ b/front/lib/api/assistant/conversation/interactions.ts
@@ -7,9 +7,9 @@ import type {
  * Group messages into interactions (user turn + agent responses),
  * using turn type (user/content_fragment vs assistant/function) as the delimiter.
  *
- * A compaction message acts as an era boundary: all interactions before it are discarded and the
- * compaction summary starts a fresh era. This mirrors the fact that all messages before a succeeded
- * compaction are already summarized in its content.
+ * A compaction message acts as an interaction boundary: it closes the current interaction and
+ * starts a new one. Pre-compaction messages should already have been filtered out by
+ * renderAllMessages before reaching this function.
  *
  * Example: [content_fragment, user, content_fragment, user, assistant, function, function]
  * results in a single interaction.
@@ -38,17 +38,14 @@ export function groupMessagesIntoInteractions<T extends MinimalMessageType>(
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
 
-    // A compaction message starts a new era: discard all previous interactions and the current
-    // in-progress interaction. The compaction summary becomes the first message of a new era.
+    // A compaction message closes the current interaction (if any) and forms its own
+    // single-message interaction.
     if (turnTypeForMessage(message) === "compaction") {
-      interactions.length = 0;
-      currentInteraction = [message];
-
-      // If this is the last message, flush the interaction.
-      if (i === messages.length - 1) {
+      if (currentInteraction.length > 0) {
         interactions.push({ messages: currentInteraction });
-        currentInteraction = [];
       }
+      interactions.push({ messages: [message] });
+      currentInteraction = [];
       continue;
     }
 
@@ -59,7 +56,8 @@ export function groupMessagesIntoInteractions<T extends MinimalMessageType>(
     // Decide if we should close the current interaction.
     // We close when:
     // - it's the last message, or
-    // - the next message is a "user" turn while the current message is an "agent" turn.
+    // - the next message is a "user" turn while the current message is an "agent" turn,
+    // - the next message is a compaction boundary.
     // This ensures that all consecutive user/content_fragment messages remain in the same
     // user turn, followed by all agent/tool messages for that interaction.
     const shouldClose = (() => {

--- a/front/lib/api/assistant/conversation/interactions.ts
+++ b/front/lib/api/assistant/conversation/interactions.ts
@@ -38,14 +38,13 @@ export function groupMessagesIntoInteractions<T extends MinimalMessageType>(
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
 
-    // A compaction message closes the current interaction (if any) and forms its own
-    // single-message interaction.
+    // A compaction message closes the current interaction (if any) and starts a new one. The
+    // compaction summary is the first message of the next interaction.
     if (turnTypeForMessage(message) === "compaction") {
       if (currentInteraction.length > 0) {
         interactions.push({ messages: currentInteraction });
       }
-      interactions.push({ messages: [message] });
-      currentInteraction = [];
+      currentInteraction = [message];
       continue;
     }
 
@@ -73,6 +72,11 @@ export function groupMessagesIntoInteractions<T extends MinimalMessageType>(
       interactions.push({ messages: currentInteraction });
       currentInteraction = [];
     }
+  }
+
+  // Flush any remaining messages (e.g. a trailing compaction message).
+  if (currentInteraction.length > 0) {
+    interactions.push({ messages: currentInteraction });
   }
 
   return interactions;

--- a/front/lib/api/assistant/conversation/interactions.ts
+++ b/front/lib/api/assistant/conversation/interactions.ts
@@ -7,6 +7,10 @@ import type {
  * Group messages into interactions (user turn + agent responses),
  * using turn type (user/content_fragment vs assistant/function) as the delimiter.
  *
+ * A compaction message acts as an era boundary: all interactions before it are discarded and the
+ * compaction summary starts a fresh era. This mirrors the fact that all messages before a succeeded
+ * compaction are already summarized in its content.
+ *
  * Example: [content_fragment, user, content_fragment, user, assistant, function, function]
  * results in a single interaction.
  */
@@ -19,16 +23,35 @@ export function groupMessagesIntoInteractions<T extends MinimalMessageType>(
   // Determine the high-level turn type for a message.
   // - "user": user messages and content fragments
   // - "agent": assistant messages and tool/function results
-  const turnTypeForMessage = (message: T): "user" | "agent" => {
+  // - "compaction": compaction summary boundary
+  const turnTypeForMessage = (message: T): "user" | "agent" | "compaction" => {
+    if (message.role === "compaction") {
+      return "compaction";
+    }
     if (message.role === "user" || message.role === "content_fragment") {
       return "user";
     }
-    // Includes "assistant" and "function" roles
+    // Includes "assistant" and "function" roles.
     return "agent";
   };
 
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
+
+    // A compaction message starts a new era: discard all previous interactions and the current
+    // in-progress interaction. The compaction summary becomes the first message of a new era.
+    if (turnTypeForMessage(message) === "compaction") {
+      interactions.length = 0;
+      currentInteraction = [message];
+
+      // If this is the last message, flush the interaction.
+      if (i === messages.length - 1) {
+        interactions.push({ messages: currentInteraction });
+        currentInteraction = [];
+      }
+      continue;
+    }
+
     currentInteraction.push(message);
 
     const isLastMessage = i === messages.length - 1;

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -20,10 +20,12 @@ import type {
 } from "@app/types/assistant/agent_message_content";
 import type {
   AgentMessageType,
+  CompactionMessageType,
   ConversationWithoutContentType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
 import type {
+  CompactionMessageTypeModel,
   FunctionCallType,
   FunctionMessageTypeModel,
   ModelMessageTypeMultiActions,
@@ -368,7 +370,7 @@ export function renderOtherAgentMessageAsUserMessage(
   const agentName = message.configuration.name;
 
   const systemContext = `<dust_system>
-This is the output of another agent "@${agentName}" that was invoked in this conversation.
+This is the output of another invoked agent: "@${agentName}".
 You are seeing the final response only, not the full reasoning or tool execution steps.
 </dust_system>
 
@@ -404,4 +406,24 @@ export async function renderContentFragment(
     }
   );
   return renderedContentFragment;
+}
+
+/**
+ * Renders a succeeded compaction message as a model message. The summary is wrapped in
+ * <compaction_summary> tags so the model can distinguish it from regular user messages.
+ * Returns null for failed or in-progress compactions (they are inert).
+ */
+export function renderCompactionMessage(
+  message: CompactionMessageType
+): CompactionMessageTypeModel | null {
+  if (message.status !== "succeeded" || !message.content) {
+    return null;
+  }
+  return {
+    role: "compaction",
+    content: `<dust_system>Context was compacted</dust_system>
+<compaction_summary>
+${message.content}
+</compaction_summary>`,
+  };
 }

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -348,6 +348,8 @@ async function countTokensForMessages(
         }
       }
       text += textContents.join("\n");
+    } else if (m.role === "compaction") {
+      text += m.content;
     } else {
       assertNever(m);
     }

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -5,6 +5,7 @@
 import type { Step } from "@app/lib/api/assistant/conversation_rendering/helpers";
 import {
   getSteps,
+  renderCompactionMessage,
   renderContentFragment,
   renderOtherAgentMessageAsUserMessage,
   renderUserMessage,
@@ -204,8 +205,10 @@ export async function renderAllMessages(
         }
       }
     } else if (isCompactionMessageType(m)) {
-      // TODO(compaction): rendering
-      continue;
+      const rendered = renderCompactionMessage(m);
+      if (rendered) {
+        messages.push(rendered);
+      }
     } else {
       assertNever(m);
     }

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -211,6 +211,11 @@ export function toMessage(
       return functionMessage(message);
     case "assistant":
       return assistantMessage(message, omittedThinking);
+    case "compaction":
+      return {
+        role: "user",
+        content: message.content,
+      };
     default:
       assertNever(message);
   }

--- a/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
+++ b/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
@@ -198,6 +198,12 @@ export async function toContent(
     case "assistant": {
       return assistantMessageToParts(message);
     }
+    case "compaction": {
+      return {
+        role: "user",
+        parts: [{ text: message.content }],
+      };
+    }
     default:
       assertNever(message);
   }

--- a/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
+++ b/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
@@ -173,6 +173,12 @@ export function toMessage(
     case "assistant": {
       return toAssistantMessage(message);
     }
+    case "compaction": {
+      return {
+        role: "user" as const,
+        content: message.content,
+      };
+    }
     default:
       assertNever(message);
   }

--- a/front/lib/api/llm/utils/openai_like/chat/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/conversation_to_openai.ts
@@ -133,6 +133,12 @@ export function toMessages(
       case "function":
         messages.push(toToolMessage(message));
         break;
+      case "compaction":
+        messages.push({
+          role: "user",
+          content: message.content,
+        });
+        break;
       default:
         assertNever(message);
     }

--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -153,6 +153,12 @@ export function toInput(
       case "function":
         inputs.push(toToolCallOutputItem(message));
         break;
+      case "compaction":
+        inputs.push({
+          role: "user",
+          content: message.content,
+        });
+        break;
       default:
         assertNever(message);
     }

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -8,7 +8,7 @@ import type {
  */
 
 export interface ModelMessageType {
-  role: "action" | "agent" | "user" | "content_fragment";
+  role: "action" | "agent" | "user" | "content_fragment" | "compaction";
   name: string;
   content: string;
 }
@@ -85,11 +85,18 @@ export interface FunctionMessageTypeModel {
   content: string | Content[];
 }
 
+// Compaction summary rendered as a history boundary for the model.
+export interface CompactionMessageTypeModel {
+  role: "compaction";
+  content: string;
+}
+
 export type ModelMessageTypeMultiActionsWithoutContentFragment =
   | UserMessageTypeModel
   | AssistantFunctionCallMessageTypeModel
   | AssistantContentMessageTypeModel
-  | FunctionMessageTypeModel;
+  | FunctionMessageTypeModel
+  | CompactionMessageTypeModel;
 
 export type ModelMessageTypeMultiActions =
   | ModelMessageTypeMultiActionsWithoutContentFragment

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -159,7 +159,7 @@ Make compaction actually affect what the model sees.
 
 ## Phase 5: Client-Side & Triggering (pending design)
 
-### - [ ] PR 5.1 — Context usage indicator in conversation UI
+### - [x] PR 5.1 — Context usage indicator in conversation UI
 
 - Use the context-usage endpoint (from PR 2.2) to get `promptTokens` and `modelContextWindow`,
   compute usage percentage on the client.
@@ -176,7 +176,7 @@ Make compaction actually affect what the model sees.
 
 - Add support for steering (creating pending message) while compaction is running.
 
-### - [ ] PR 5.4 — Manual compaction trigger
+### - [x] PR 5.4 — Manual compaction trigger
 
 - Add a UI affordance (button in the context usage indicator, or a `/compact` command) that calls
   `compaction`.


### PR DESCRIPTION
## Description

Phase 4 of the compaction plan: make compaction actually affect what the model sees.

**Interaction grouping (4.2):** A message with `role: "compaction"` acts as an interaction boundary in `groupMessagesIntoInteractions`.

**Message rendering (4.1):** Succeeded compaction messages are rendered as
`CompactionMessageTypeModel` with `role: "compaction"` and content wrapped in
`<compaction_summary>` tags. All LLM provider converters (Anthropic, OpenAI chat/responses,
Google, Mistral) convert them to user messages. Tokenization handles the new role.

Follow-up PR: start ignoring message before latest compaction in the main rendering loop.

## Tests

- unit tests in `interactions.test.ts` covering compaction boundary behavior (discards prior
interactions, multiple compactions, compaction as first/last message, mid-interaction).
- Covered by existing tests.
- Tested locally => conversation rendering from poke looks good with and without compaction

## Risk

Medium: touches the conversation rendering code but there is no compaction message in production yet.

## Deploy Plan

- deploy `front`