### PR TITLE
feat(sbx): exec capture helpers and pending approval sandboxes

### DIFF
--- a/front/components/assistant/conversation/files_panel/SandboxStatusChip.tsx
+++ b/front/components/assistant/conversation/files_panel/SandboxStatusChip.tsx
@@ -12,6 +12,8 @@ export function SandboxStatusChip({ status }: SandboxStatusChipProps) {
       return <Chip size="mini" color="success" label="Sandbox running" />;
     case "sleeping":
       return <Chip size="mini" color="warning" label="Sandbox sleeping" />;
+    case "pending_approval":
+      return <Chip size="mini" color="warning" label="Waiting for approval" />;
     case "deleted":
       return <Chip size="mini" color="primary" label="Sandbox expired" />;
     default:

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -81,6 +81,8 @@ export type StepContext = {
   fileAuthorizationInfo?: FileAuthorizationInfo;
   resumeState: Record<string, unknown> | null;
   retrievalTopK: number;
+  sandboxOrigin?: boolean;
+  sandboxPaused?: boolean;
   websearchResultCount: number;
 };
 

--- a/front/lib/api/sandbox/image/profile.test.ts
+++ b/front/lib/api/sandbox/image/profile.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWaitAndCollectCommand,
+  wrapCommand,
+  wrapCommandWithCapture,
+} from "./profile";
+
+describe("wrapCommandWithCapture", () => {
+  it("includes tee redirect to output file", () => {
+    const result = wrapCommandWithCapture("ls -la", "abc123", "anthropic");
+    expect(result).toContain("tee /tmp/dust_exec_abc123.out");
+  });
+
+  it("includes exit sentinel", () => {
+    const result = wrapCommandWithCapture("ls -la", "abc123", "anthropic");
+    expect(result).toContain("echo $_EXIT > /tmp/dust_exec_abc123.exit");
+  });
+
+  it("sources the profile and wraps the command", () => {
+    const result = wrapCommandWithCapture("echo hello", "abc123", "anthropic");
+    expect(result).toContain(
+      'source /opt/dust/profile/common.sh && shell "echo hello" 60'
+    );
+  });
+
+  it("escapes double quotes and backslashes", () => {
+    const result = wrapCommandWithCapture(
+      'echo "hello \\ world"',
+      "abc123",
+      "anthropic"
+    );
+    expect(result).toContain('shell "echo \\"hello \\\\ world\\"" 60');
+  });
+
+  it("respects custom timeout", () => {
+    const result = wrapCommandWithCapture("ls", "abc123", "anthropic", {
+      timeoutSec: 120,
+    });
+    expect(result).toContain("120");
+  });
+});
+
+describe("buildWaitAndCollectCommand", () => {
+  it("includes PID-based orphan cleanup", () => {
+    const result = buildWaitAndCollectCommand("abc123");
+    expect(result).toContain("kill $(cat /tmp/dust_wac_abc123.pid)");
+  });
+
+  it("writes its own PID", () => {
+    const result = buildWaitAndCollectCommand("abc123");
+    expect(result).toContain("echo $$ > /tmp/dust_wac_abc123.pid");
+  });
+
+  it("waits for exit sentinel", () => {
+    const result = buildWaitAndCollectCommand("abc123");
+    expect(result).toContain(
+      "while [ ! -f /tmp/dust_exec_abc123.exit ]; do sleep 0.5; done"
+    );
+  });
+
+  it("reads the output file", () => {
+    const result = buildWaitAndCollectCommand("abc123");
+    expect(result).toContain("cat /tmp/dust_exec_abc123.out");
+  });
+
+  it("exits with the captured exit code", () => {
+    const result = buildWaitAndCollectCommand("abc123");
+    expect(result).toContain("exit $(cat /tmp/dust_exec_abc123.exit)");
+  });
+});
+
+describe("wrapCommand", () => {
+  it("still works unchanged", () => {
+    const result = wrapCommand("echo hi", "anthropic");
+    expect(result).toBe(
+      'source /opt/dust/profile/common.sh && shell "echo hi" 60'
+    );
+  });
+});

--- a/front/lib/api/sandbox/image/profile.ts
+++ b/front/lib/api/sandbox/image/profile.ts
@@ -23,3 +23,38 @@ export function wrapCommand(
   const escapedCmd = cmd.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   return `source ${PROFILE_DIR}/${profile} && shell "${escapedCmd}" ${timeoutSec}`;
 }
+
+export function wrapCommandWithCapture(
+  cmd: string,
+  execId: string,
+  providerId: ModelProviderIdType,
+  opts?: WrapCommandOptions
+): string {
+  const baseCommand = wrapCommand(cmd, providerId, opts);
+  const outFile = `/tmp/dust_exec_${execId}.out`;
+  const exitFile = `/tmp/dust_exec_${execId}.exit`;
+
+  return [
+    `exec > >(tee ${outFile}) 2>&1`,
+    baseCommand,
+    `_EXIT=$?`,
+    `echo $_EXIT > ${exitFile}`,
+    `exit $_EXIT`,
+  ].join("\n");
+}
+
+export function buildWaitAndCollectCommand(execId: string): string {
+  const pidFile = `/tmp/dust_wac_${execId}.pid`;
+  const outFile = `/tmp/dust_exec_${execId}.out`;
+  const exitFile = `/tmp/dust_exec_${execId}.exit`;
+
+  return [
+    `if [ -f ${pidFile} ]; then`,
+    `  kill $(cat ${pidFile}) 2>/dev/null`,
+    `fi`,
+    `echo $$ > ${pidFile}`,
+    `while [ ! -f ${exitFile} ]; do sleep 0.5; done`,
+    `cat ${outFile}`,
+    `exit $(cat ${exitFile})`,
+  ].join("\n");
+}

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1034,6 +1034,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       step: this.stepContent.step,
       executionDurationMs: this.executionDurationMs,
       displayLabels,
+      sandboxOrigin: this.stepContext.sandboxOrigin,
     };
   }
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -388,6 +388,25 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         case "running":
           break;
 
+        case "pending_approval": {
+          // The sandbox was paused (betaPause) while waiting for tool approval.
+          // Wake it, but do NOT fall through to recreation on failure — the
+          // frozen process state and output files are unrecoverable.
+          const pendingWakeResult = await provider.wake(
+            existing.providerId,
+            tracingOpts
+          );
+          if (pendingWakeResult.isErr()) {
+            return new Err(
+              new Error(
+                `Failed to wake pending_approval sandbox: ${pendingWakeResult.error.message}`
+              )
+            );
+          }
+          wokeFromSleep = true;
+          break;
+        }
+
         case "sleeping": {
           const wakeResult = await provider.wake(
             existing.providerId,
@@ -516,6 +535,68 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       await sandbox.updateStatus("sleeping", { ctx });
       recordLifecycleOperation("sleep", ctx);
       logger.info({ sandbox: sandbox.toLogJSON() }, "Sandbox put to sleep.");
+      return new Ok(undefined);
+    });
+  }
+
+  /**
+   * Pause a running sandbox for tool approval. Calls sleep() on the
+   * provider and sets the status to `pending_approval`. Unlike sleep, this
+   * status prevents recreation on wake failure (frozen state is unrecoverable).
+   */
+  static async pauseForApproval(
+    auth: Authenticator,
+    conversationId: string
+  ): Promise<Result<void, Error>> {
+    return this.withLifecycleLock(conversationId, async (provider) => {
+      const sandbox = await SandboxResource.fetchByConversationId(
+        auth,
+        conversationId
+      );
+      if (!sandbox || sandbox.status !== "running") {
+        return new Ok(undefined);
+      }
+
+      const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
+
+      const result = await provider.sleep(sandbox.providerId, ctx);
+      if (result.isErr()) {
+        return result;
+      }
+
+      await sandbox.updateStatus("pending_approval", { ctx });
+      logger.info(
+        { sandbox: sandbox.toLogJSON() },
+        "Sandbox paused for tool approval."
+      );
+      return new Ok(undefined);
+    });
+  }
+
+  /**
+   * Transition a pending_approval sandbox to sleeping. The sandbox is already
+   * paused via betaPause(), so no provider call is needed — we just update the
+   * DB status so the regular destroy phase can reap it later.
+   *
+   * WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
+   */
+  static async dangerouslySleepIfPendingApproval(
+    auth: Authenticator,
+    conversationId: string
+  ): Promise<Result<void, Error>> {
+    return this.withLifecycleLock(conversationId, async () => {
+      const sandbox =
+        await SandboxResource.dangerouslyFetchByConversationId(conversationId);
+      if (!sandbox || sandbox.status !== "pending_approval") {
+        return new Ok(undefined);
+      }
+
+      const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
+      await sandbox.updateStatus("sleeping", { ctx });
+      logger.info(
+        { sandbox: sandbox.toLogJSON() },
+        "Pending-approval sandbox transitioned to sleeping."
+      );
       return new Ok(undefined);
     });
   }

--- a/front/lib/resources/storage/models/sandbox.ts
+++ b/front/lib/resources/storage/models/sandbox.ts
@@ -4,7 +4,11 @@ import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspa
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-export type SandboxStatus = "running" | "sleeping" | "deleted";
+export type SandboxStatus =
+  | "running"
+  | "sleeping"
+  | "deleted"
+  | "pending_approval";
 
 export class SandboxModel extends WorkspaceAwareModel<SandboxModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -6,7 +6,12 @@ import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types/shared/model_id";
 import { heartbeat } from "@temporalio/activity";
 
-import { BATCH_SIZE, DESTROY_THRESHOLD_MS, SLEEP_THRESHOLD_MS } from "./config";
+import {
+  BATCH_SIZE,
+  DESTROY_THRESHOLD_MS,
+  PENDING_APPROVAL_THRESHOLD_MS,
+  SLEEP_THRESHOLD_MS,
+} from "./config";
 
 const REAPER_CONCURRENCY = 16;
 
@@ -90,7 +95,55 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
     );
   }
 
-  // Phase 2: Destroy sleeping sandboxes that have been idle > DESTROY_THRESHOLD_MS.
+  // Phase 2: Transition abandoned pending_approval sandboxes to sleeping.
+  const pendingConversations =
+    await SandboxResource.dangerouslyGetStaleConversationIds({
+      status: "pending_approval",
+      olderThanMs: PENDING_APPROVAL_THRESHOLD_MS,
+      limit: BATCH_SIZE,
+    });
+
+  if (pendingConversations.length > 0) {
+    logger.info(
+      { count: pendingConversations.length },
+      "Reaper: stale pending_approval sandboxes found."
+    );
+
+    const workspaceMap = await fetchWorkspaceMap(pendingConversations);
+
+    await concurrentExecutor(
+      pendingConversations,
+      async ({ conversationId, workspaceModelId }) => {
+        const workspace = workspaceMap.get(workspaceModelId);
+
+        if (!workspace) {
+          logger.warn(
+            { conversationId, workspaceModelId },
+            "Workspace not found, skipping"
+          );
+          return;
+        }
+
+        const auth = await Authenticator.internalBuilderForWorkspace(
+          workspace.sId
+        );
+        const result = await SandboxResource.dangerouslySleepIfPendingApproval(
+          auth,
+          conversationId
+        );
+        if (result.isErr()) {
+          logger.error(
+            { conversationId, error: result.error.message },
+            "Reaper: failed to transition pending_approval sandbox — continuing."
+          );
+        }
+        heartbeat();
+      },
+      { concurrency: REAPER_CONCURRENCY }
+    );
+  }
+
+  // Phase 3: Destroy sleeping sandboxes that have been idle > DESTROY_THRESHOLD_MS.
   const sleepingConversations =
     await SandboxResource.dangerouslyGetStaleConversationIds({
       status: "sleeping",
@@ -149,6 +202,7 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
 
   return (
     runningConversations.length >= BATCH_SIZE ||
+    pendingConversations.length >= BATCH_SIZE ||
     sleepingConversations.length >= BATCH_SIZE
   );
 }

--- a/front/temporal/sandbox_reaper/config.ts
+++ b/front/temporal/sandbox_reaper/config.ts
@@ -15,6 +15,14 @@ export const SLEEP_THRESHOLD_MS = sleepThresholdEnv
   ? Number(sleepThresholdEnv)
   : 10 * 60 * 1_000;
 
+/** Transition pending_approval sandboxes to sleeping after this long. Default: 30 min. */
+const pendingApprovalThresholdEnv = EnvironmentConfig.getOptionalEnvVariable(
+  "SANDBOX_PENDING_APPROVAL_THRESHOLD_MS"
+);
+export const PENDING_APPROVAL_THRESHOLD_MS = pendingApprovalThresholdEnv
+  ? Number(pendingApprovalThresholdEnv)
+  : 30 * 60 * 1_000;
+
 /** Destroy sandboxes that have been inactive for this long. Default: 24 h. */
 const destroyThresholdEnv = EnvironmentConfig.getOptionalEnvVariable(
   "SANDBOX_DESTROY_THRESHOLD_MS"

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -27,6 +27,7 @@ export type AgentMCPActionType = {
     running: string;
     done: string;
   } | null;
+  sandboxOrigin?: boolean;
 };
 
 export type AgentMCPActionWithOutputType = AgentMCPActionType & {


### PR DESCRIPTION
## Description

Adds the `pending_approval` sandbox status and the infrastructure needed for the pause/resume flow when sandbox tool calls require user approval.

**Sandbox lifecycle:**
- New `pending_approval` status on `SandboxStatus` — represents a sandbox frozen via `betaPause()` while waiting for tool approval. Unlike `sleeping`, wake failure is fatal (frozen process state is unrecoverable).
- `pauseForApproval()` — sleeps the provider and transitions to `pending_approval`.
- `dangerouslySleepIfPendingApproval()` — transitions abandoned `pending_approval` sandboxes to `sleeping` so the destroy phase can reap them.
- `ensureActive()` now handles `pending_approval` — wakes the sandbox but does NOT fall through to recreation on failure.

**Types:**
- `sandboxOrigin` and `sandboxPaused` on `StepContext` — marks actions originating from sandbox tool calls, used by the approval and validation flows.
- `sandboxOrigin` on `AgentMCPActionType` — exposed in `toJSON()` so the frontend can filter sandbox-originated actions.

**Exec capture helpers:**
- `wrapCommandWithCapture(cmd, execId, providerId)` — wraps a command with `tee` to capture output to `/tmp/dust_exec_{id}.out` and write an exit sentinel to `/tmp/dust_exec_{id}.exit`. Decouples SDK connection from process output so pause/resume doesn't lose data.
- `buildWaitAndCollectCommand(execId)` — lightweight script that waits for the exit sentinel and reads the output file. Used on resume to reattach to a still-running process.

**Reaper:**
- New phase 2: transitions stale `pending_approval` sandboxes to `sleeping` after 30 minutes (configurable via `SANDBOX_PENDING_APPROVAL_THRESHOLD_MS`).

## Tests

Unit tests for `wrapCommandWithCapture` and `buildWaitAndCollectCommand`.
Tested with the full scale implementation.

## Risk

Low. The new status is additive, no existing code paths produce `pending_approval` yet (that comes later in the bash handler PR). The reaper phase is a no-op until sandboxes start entering this status.

## Deploy Plan

Single deploy, no migration needed.