### PR TITLE
Add daily 'ensure' workflow to start/stop reinforced workflows

### DIFF
--- a/front/lib/production_checks/checks/check_active_workflows_for_front.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_front.ts
@@ -1,8 +1,9 @@
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import { ENSURE_CRONS_WORKFLOW_ID } from "@app/temporal/reinforcement/client";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
 import type { Client, WorkflowHandle } from "@temporalio/client";
 
-const WORKFLOW_IDS = ["data-retention-workflow"];
+const WORKFLOW_IDS = ["data-retention-workflow", ENSURE_CRONS_WORKFLOW_ID];
 
 async function isWorkflowRunning(client: Client, workflowId: string) {
   try {

--- a/front/lib/production_checks/checks/check_reinforcement_workspace_workflows.ts
+++ b/front/lib/production_checks/checks/check_reinforcement_workspace_workflows.ts
@@ -6,11 +6,19 @@ import { makeWorkspaceCronWorkflowId } from "@app/temporal/reinforcement/client"
 import type { CheckFunction } from "@app/types/production_checks";
 import type { Client, WorkflowHandle } from "@temporalio/client";
 
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
 async function getFlaggedWorkspaceIds(): Promise<string[]> {
   const allWorkspaces = await WorkspaceResource.listAll();
   const flaggedIds: string[] = [];
+  const now = Date.now();
 
   for (const workspace of allWorkspaces) {
+    // Ignore workspaces created in the last 24h — the daily ensure-crons
+    // workflow hasn't had a chance to start their cron yet.
+    if (now - workspace.createdAt.getTime() < TWENTY_FOUR_HOURS_MS) {
+      continue;
+    }
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     if (await hasReinforcementEnabled(auth)) {
       flaggedIds.push(workspace.sId);

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -53,6 +53,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import logger from "@app/logger/logger";
+import { ensureReinforcementWorkspaceCrons } from "@app/temporal/reinforcement/client";
 import { ApplicationFailure } from "@temporalio/common";
 
 // Re-export runToolActivity so the reinforced skills worker registers it,
@@ -1021,4 +1022,15 @@ export async function processSkillAggregationBatchResultActivity({
     reinforcementConversationId: firstConvId,
     toolActionInfo,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Ensure crons activity
+// ---------------------------------------------------------------------------
+
+export async function ensureReinforcementWorkspaceCronsActivity(): Promise<{
+  started: string[];
+  stopped: string[];
+}> {
+  return ensureReinforcementWorkspaceCrons();
 }

--- a/front/temporal/reinforcement/admin/cli.ts
+++ b/front/temporal/reinforcement/admin/cli.ts
@@ -1,16 +1,20 @@
 import {
-  launchAllReinforcedSkillsWorkspaceCrons,
+  ensureReinforcementWorkspaceCrons,
+  launchEnsureReinforcementCronsWorkflow,
   launchReinforcementWorkspaceCron,
   startReinforcementWorkspaceWorkflow,
-  stopAllReinforcedSkillsWorkspaceCrons,
+  stopAllReinforcementWorkspaceCrons,
+  stopEnsureReinforcementCronsWorkflow,
   stopReinforcementWorkspaceCron,
 } from "@app/temporal/reinforcement/client";
 import parseArgs from "minimist";
 
 function usage() {
   console.error(`Usage:
-  start                                                                          Start cron workflows for all flagged workspaces
-  stop                                                                           Stop cron workflows for all flagged workspaces
+  start                                                                          Ensure all workspace crons match feature flags (start missing, stop extra)
+  stop                                                                           Stop all running workspace cron workflows
+  start-ensure                                                                   Start the daily ensure-crons workflow (11pm local)
+  stop-ensure                                                                    Stop the daily ensure-crons workflow
   start-workspace --workspace-id <sId>                                          Start the cron workflow for a specific workspace
   stop-workspace --workspace-id <sId>                                           Stop the cron workflow for a specific workspace
   run-workspace --workspace-id <sId> [--batch] [--skill-id <sId>] [--days <n>] Run once for a specific workspace
@@ -28,10 +32,16 @@ const main = async () => {
 
   switch (command) {
     case "start":
-      await launchAllReinforcedSkillsWorkspaceCrons();
+      await ensureReinforcementWorkspaceCrons();
       return;
     case "stop":
-      await stopAllReinforcedSkillsWorkspaceCrons();
+      await stopAllReinforcementWorkspaceCrons();
+      return;
+    case "start-ensure":
+      await launchEnsureReinforcementCronsWorkflow();
+      return;
+    case "stop-ensure":
+      await stopEnsureReinforcementCronsWorkflow();
       return;
     case "start-workspace": {
       const workspaceId = argv["workspace-id"];

--- a/front/temporal/reinforcement/client.ts
+++ b/front/temporal/reinforcement/client.ts
@@ -3,7 +3,6 @@ import { Authenticator } from "@app/lib/auth";
 import { hasReinforcementEnabled } from "@app/lib/reinforced_agent/workspace_check";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -14,7 +13,10 @@ import {
 } from "@temporalio/client";
 import moment from "moment-timezone";
 import { QUEUE_NAME } from "./config";
-import { reinforcementWorkspaceWorkflow } from "./workflows";
+import {
+  ensureReinforcementWorkspaceCronsWorkflow,
+  reinforcementWorkspaceWorkflow,
+} from "./workflows";
 
 /**
  * Returns the UTC hour corresponding to midnight in the given timezone.
@@ -24,8 +26,10 @@ function getMidnightUtcHour(timezone: string): number {
   return midnightInTz.utc().hour();
 }
 
+const WORKSPACE_WORKFLOW_ID_PREFIX = "reinforcement-workspace-";
+
 export function makeWorkspaceCronWorkflowId(workspaceId: string): string {
-  return `reinforcement-workspace-${workspaceId}`;
+  return `${WORKSPACE_WORKFLOW_ID_PREFIX}${workspaceId}`;
 }
 
 /**
@@ -131,45 +135,145 @@ export async function stopReinforcementWorkspaceCron({
 }
 
 // ---------------------------------------------------------------------------
-// Bulk operations (all flagged workspaces)
+// Ensure crons (start missing, stop extra)
 // ---------------------------------------------------------------------------
 
-export async function launchAllReinforcedSkillsWorkspaceCrons(): Promise<
-  Result<undefined, Error>
-> {
-  const workspaceIds = await getFlaggedWorkspaceIds();
+export const ENSURE_CRONS_WORKFLOW_ID = `ensure-${WORKSPACE_WORKFLOW_ID_PREFIX}crons`;
 
-  await concurrentExecutor(
-    workspaceIds,
-    (workspaceId) => launchReinforcementWorkspaceCron({ workspaceId }),
-    { concurrency: 8 }
-  );
+/**
+ * Ensure all flagged workspaces have a running cron and stop crons for
+ * workspaces that are no longer flagged.
+ */
+export async function ensureReinforcementWorkspaceCrons(): Promise<{
+  started: string[];
+  stopped: string[];
+}> {
+  const client = await getTemporalClientForFrontNamespace();
+  const flaggedWorkspaceIds = new Set(await getFlaggedWorkspaceIds());
+
+  // Find currently running cron workflows by workflow type.
+  const runningWorkspaceIds = new Set<string>();
+  for await (const workflow of client.workflow.list({
+    query: `WorkflowType = "reinforcementWorkspaceWorkflow" AND ExecutionStatus = 'Running'`,
+  })) {
+    runningWorkspaceIds.add(
+      workflow.workflowId.slice(WORKSPACE_WORKFLOW_ID_PREFIX.length)
+    );
+  }
+
+  // Start crons for flagged workspaces that aren't running.
+  const started: string[] = [];
+  for (const workspaceId of flaggedWorkspaceIds) {
+    if (!runningWorkspaceIds.has(workspaceId)) {
+      await launchReinforcementWorkspaceCron({ workspaceId });
+      started.push(workspaceId);
+    }
+  }
+
+  // Stop crons for workspaces that are running but no longer flagged.
+  const stopped: string[] = [];
+  for (const workspaceId of runningWorkspaceIds) {
+    if (!flaggedWorkspaceIds.has(workspaceId)) {
+      await stopReinforcementWorkspaceCron({
+        workspaceId,
+        stopReason: "Workspace no longer flagged for reinforcement",
+      });
+      stopped.push(workspaceId);
+    }
+  }
 
   logger.info(
-    { workspaceCount: workspaceIds.length },
-    "[ReinforcedSkills] Launched cron workflows for all flagged workspaces."
+    { startedCount: started.length, stoppedCount: stopped.length },
+    "[ReinforcedSkills] Ensured reinforcement workspace crons."
   );
 
-  return new Ok(undefined);
+  return { started, stopped };
 }
 
-export async function stopAllReinforcedSkillsWorkspaceCrons(): Promise<void> {
-  const workspaceIds = await getFlaggedWorkspaceIds();
+// ---------------------------------------------------------------------------
+// Bulk stop (all flagged workspaces)
+// ---------------------------------------------------------------------------
 
-  await concurrentExecutor(
-    workspaceIds,
-    (workspaceId) =>
-      stopReinforcementWorkspaceCron({
-        workspaceId,
-        stopReason: "Stopped all via CLI",
-      }),
-    { concurrency: 8 }
-  );
+export async function stopAllReinforcementWorkspaceCrons(): Promise<void> {
+  const client = await getTemporalClientForFrontNamespace();
+
+  // Stop all running reinforcement workspace cron workflows.
+  const runningWorkspaceIds: string[] = [];
+  for await (const workflow of client.workflow.list({
+    query: `WorkflowType = "reinforcementWorkspaceWorkflow" AND ExecutionStatus = 'Running'`,
+  })) {
+    runningWorkspaceIds.push(
+      workflow.workflowId.slice(WORKSPACE_WORKFLOW_ID_PREFIX.length)
+    );
+  }
+
+  for (const workspaceId of runningWorkspaceIds) {
+    await stopReinforcementWorkspaceCron({
+      workspaceId,
+      stopReason: "Stopped all via CLI",
+    });
+  }
 
   logger.info(
-    { workspaceCount: workspaceIds.length },
-    "[ReinforcedSkills] Stopped cron workflows for all flagged workspaces."
+    { workspaceCount: runningWorkspaceIds.length },
+    "[ReinforcedSkills] Stopped cron workflows for all workspaces."
   );
+}
+
+export async function launchEnsureReinforcementCronsWorkflow(): Promise<
+  Result<string, Error>
+> {
+  const client = await getTemporalClientForFrontNamespace();
+  const region = config.getCurrentRegion();
+  const timezone = REGION_TIMEZONES[region];
+  const elevenPmInTz = moment.tz("23:00", "HH:mm", timezone);
+  const utcHour = elevenPmInTz.utc().hour();
+
+  try {
+    await client.workflow.start(ensureReinforcementWorkspaceCronsWorkflow, {
+      args: [],
+      taskQueue: QUEUE_NAME,
+      workflowId: ENSURE_CRONS_WORKFLOW_ID,
+      cronSchedule: `0 ${utcHour} * * *`,
+    });
+
+    logger.info(
+      { region, timezone, utcHour, workflowId: ENSURE_CRONS_WORKFLOW_ID },
+      "[ReinforcedSkills] Launched ensure-crons workflow."
+    );
+  } catch (e) {
+    if (e instanceof WorkflowExecutionAlreadyStartedError) {
+      logger.info(
+        { workflowId: ENSURE_CRONS_WORKFLOW_ID },
+        "[ReinforcedSkills] Ensure-crons workflow already running, skipping."
+      );
+    } else {
+      throw e;
+    }
+  }
+
+  return new Ok(ENSURE_CRONS_WORKFLOW_ID);
+}
+
+export async function stopEnsureReinforcementCronsWorkflow(): Promise<void> {
+  const client = await getTemporalClientForFrontNamespace();
+
+  try {
+    const handle = client.workflow.getHandle(ENSURE_CRONS_WORKFLOW_ID);
+    await handle.terminate("Stopped via CLI");
+  } catch (e) {
+    if (e instanceof WorkflowNotFoundError) {
+      logger.info(
+        { workflowId: ENSURE_CRONS_WORKFLOW_ID },
+        "[ReinforcedSkills] Ensure-crons workflow not running, skipping."
+      );
+    } else {
+      logger.error(
+        { error: e, workflowId: ENSURE_CRONS_WORKFLOW_ID },
+        "[ReinforcedSkills] Failed stopping ensure-crons workflow."
+      );
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -190,7 +294,7 @@ export async function startReinforcementWorkspaceWorkflow({
   disableNotifications?: boolean;
 }): Promise<Result<string, Error>> {
   const client = await getTemporalClientForFrontNamespace();
-  const workflowId = `reinforcement-workspace-${workspaceId}-manual-${Date.now()}`;
+  const workflowId = `${WORKSPACE_WORKFLOW_ID_PREFIX}${workspaceId}-manual-${Date.now()}`;
 
   await client.workflow.start(reinforcementWorkspaceWorkflow, {
     args: [

--- a/front/temporal/reinforcement/workflows.ts
+++ b/front/temporal/reinforcement/workflows.ts
@@ -22,6 +22,12 @@ export const interceptors: WorkflowInterceptorsFactory = () => ({
   internals: [new OpenTelemetryInternalsInterceptor()],
 });
 
+const { ensureReinforcementWorkspaceCronsActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "10 minutes",
+});
+
 const { getReinforcementSettingsActivity } = proxyActivities<typeof activities>(
   {
     startToCloseTimeout: "5 minutes",
@@ -267,6 +273,14 @@ async function aggregateSkillWithMultiStepBatch({
     suggestionsCreated: totalSuggestionsCreated,
     disableNotifications,
   });
+}
+
+/**
+ * Cron workflow that ensures all flagged workspaces have a running
+ * reinforcement cron and stops crons for workspaces that lost the flag.
+ */
+export async function ensureReinforcementWorkspaceCronsWorkflow(): Promise<void> {
+  await ensureReinforcementWorkspaceCronsActivity();
 }
 
 /**


### PR DESCRIPTION
## Description

- Add a daily ensureReinforcementWorkspaceCronsWorkflow (cron at 11pm local time) that starts missing reinforcement workspace crons and stops crons for workspaces that lost the feature flag
- Replace launchAllReinforcedSkillsWorkspaceCrons with ensureReinforcementWorkspaceCrons which both starts and stops as needed; the CLI start command now runs ensure, stop stops all running crons
- Add start-ensure / stop-ensure CLI commands to manage the daily ensure workflow itself
- In checkReinforcementWorkspaceWorkflows, ignore workspaces created in the last 24h since the daily ensure workflow hasn't had a chance to start their cron yet
- Add the ensure workflow to check_active_workflows_for_front so it's monitored

## Tests

Tested all new commands locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front