### PR TITLE
[front] fix: add back dynamic tags filtering toggle in Agent Builder

### DIFF
--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -190,14 +190,10 @@ export function DataSourceViewTagsFilterDropdown() {
         <SliderToggle
           selected={mode === "auto"}
           onClick={() =>
-            toggleInConversationFiltering(
-              mode === "custom" ? "auto" : "custom"
-            )
+            toggleInConversationFiltering(mode === "custom" ? "auto" : "custom")
           }
         />
-        <span className="text-sm font-medium">
-          In-conversation filtering
-        </span>
+        <span className="text-sm font-medium">In-conversation filtering</span>
       </div>
     );
   }

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -184,20 +184,28 @@ export function DataSourceViewTagsFilterDropdown() {
     );
   }, [sources.in]);
 
+  if (isExploratorySearchEnabled) {
+    return (
+      <div className="flex flex-row items-center space-x-2">
+        <SliderToggle
+          selected={mode === "auto"}
+          onClick={() =>
+            toggleInConversationFiltering(
+              mode === "custom" ? "auto" : "custom"
+            )
+          }
+        />
+        <span className="text-sm font-medium">
+          In-conversation filtering
+        </span>
+      </div>
+    );
+  }
+
   return (
     <PopoverRoot>
       <PopoverTrigger asChild>
-        <Button
-          label="Filters"
-          variant="outline"
-          isSelect
-          disabled={isExploratorySearchEnabled}
-          tooltip={
-            isExploratorySearchEnabled
-              ? "Exploratory search mode doesn't support filtering data sources yet"
-              : undefined
-          }
-        />
+        <Button label="Filters" variant="outline" isSelect />
       </PopoverTrigger>
 
       <PopoverContent

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -184,20 +184,6 @@ export function DataSourceViewTagsFilterDropdown() {
     );
   }, [sources.in]);
 
-  if (isExploratorySearchEnabled) {
-    return (
-      <div className="flex flex-row items-center space-x-2">
-        <SliderToggle
-          selected={mode === "auto"}
-          onClick={() =>
-            toggleInConversationFiltering(mode === "custom" ? "auto" : "custom")
-          }
-        />
-        <span className="text-sm font-medium">In-conversation filtering</span>
-      </div>
-    );
-  }
-
   return (
     <PopoverRoot>
       <PopoverTrigger asChild>
@@ -206,40 +192,44 @@ export function DataSourceViewTagsFilterDropdown() {
 
       <PopoverContent
         align="end"
-        className="max-h-[var(--radix-popper-available-height)] w-150 max-w-150 overflow-scroll"
+        className="max-h-[var(--radix-popper-available-height)] w-100 max-w-150 overflow-scroll"
         collisionPadding={20}
       >
         <div className="flex flex-col gap-8 p-2">
-          <div className="flex flex-col gap-2">
-            <Page.SectionHeader
-              title="Filtering"
-              description="Filter to only include content bearing must-have labels, and exclude content with must-not-have labels."
-            />
-          </div>
+          {!isExploratorySearchEnabled && (
+            <>
+              <div className="flex flex-col gap-2">
+                <Page.SectionHeader
+                  title="Filtering"
+                  description="Filter to only include content bearing must-have labels, and exclude content with must-not-have labels."
+                />
+              </div>
 
-          <TagSearchSection
-            label="Must-have labels"
-            dataSourceViews={dataSourceViews}
-            owner={owner}
-            selectedTagsIn={tagsIn}
-            selectedTagsNot={tagsNotIn}
-            onTagAdd={handleTagsOperation("in", "add")}
-            onTagRemove={handleTagsOperation("in", "remove")}
-            operation="in"
-            showChipIcons
-          />
+              <TagSearchSection
+                label="Must-have labels"
+                dataSourceViews={dataSourceViews}
+                owner={owner}
+                selectedTagsIn={tagsIn}
+                selectedTagsNot={tagsNotIn}
+                onTagAdd={handleTagsOperation("in", "add")}
+                onTagRemove={handleTagsOperation("in", "remove")}
+                operation="in"
+                showChipIcons
+              />
 
-          <TagSearchSection
-            label="Must-not-have labels"
-            dataSourceViews={dataSourceViews}
-            owner={owner}
-            selectedTagsIn={tagsIn}
-            selectedTagsNot={tagsNotIn}
-            onTagAdd={handleTagsOperation("not", "add")}
-            onTagRemove={handleTagsOperation("not", "remove")}
-            operation="not"
-            showChipIcons
-          />
+              <TagSearchSection
+                label="Must-not-have labels"
+                dataSourceViews={dataSourceViews}
+                owner={owner}
+                selectedTagsIn={tagsIn}
+                selectedTagsNot={tagsNotIn}
+                onTagAdd={handleTagsOperation("not", "add")}
+                onTagRemove={handleTagsOperation("not", "remove")}
+                operation="not"
+                showChipIcons
+              />
+            </>
+          )}
 
           <div className="text-sm">
             <div className="mb-1 font-semibold">In-conversation filtering</div>


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/7561
- This PR removes the greyed dropdown for configuring tags filtering in the Agent builder knowledge configuration sheet (dsfs only).
- It instead replaces it with a toggle to enable dynamic tags filtering.

<img width="688" height="722" alt="Screenshot 2026-04-15 at 4 46 11 PM" src="https://github.com/user-attachments/assets/8b647ecb-8c24-4579-8c8d-147f80cb4a5d" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
