### PR TITLE
fix: delete tool approvals

### DIFF
--- a/front/components/me/UserToolsTable.tsx
+++ b/front/components/me/UserToolsTable.tsx
@@ -12,7 +12,7 @@ import {
   useMCPServerConnections,
 } from "@app/lib/swr/mcp_servers";
 import { useSpaces } from "@app/lib/swr/spaces";
-import { useDeleteMetadata, useUserApprovals } from "@app/lib/swr/user";
+import { useDeleteToolApproval, useUserApprovals } from "@app/lib/swr/user";
 import { classNames } from "@app/lib/utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Chip, DataTable, SearchInput, Spinner } from "@dust-tt/sparkle";
@@ -50,11 +50,11 @@ export function UserToolsTable({ owner }: UserToolsTableProps) {
   });
   const { approvals, isApprovalsLoading, mutateApprovals } =
     useUserApprovals(owner);
-  const { deleteMetadata } = useDeleteMetadata();
+  const { deleteToolApproval } = useDeleteToolApproval();
 
   const handleDeleteToolMetadata = useCallback(
     async (mcpServerId: string) => {
-      const response = await deleteMetadata(`toolsValidations:${mcpServerId}`);
+      const response = await deleteToolApproval(owner, mcpServerId);
       if (response && !response.ok) {
         sendNotification({
           title: "Error",
@@ -71,7 +71,7 @@ export function UserToolsTable({ owner }: UserToolsTableProps) {
         type: "success",
       });
     },
-    [sendNotification, deleteMetadata, mutateApprovals]
+    [sendNotification, deleteToolApproval, mutateApprovals, owner]
   );
 
   const { deleteMCPServerConnection } = useDeleteMCPServerConnection({

--- a/front/lib/resources/user_resource.test.ts
+++ b/front/lib/resources/user_resource.test.ts
@@ -613,5 +613,65 @@ describe("UserResource", () => {
         expect(hasApproval).toBe(true);
       });
     });
+
+    describe("getUserToolApprovals", () => {
+      it("should return empty array when no approvals exist", async () => {
+        const approvals = await user.getUserToolApprovals(auth);
+        expect(approvals).toEqual([]);
+      });
+
+      it("should group tool names by mcpServerId", async () => {
+        await user.createToolApproval(auth, {
+          mcpServerId: "server-a",
+          toolName: "tool-1",
+        });
+        await user.createToolApproval(auth, {
+          mcpServerId: "server-a",
+          toolName: "tool-2",
+        });
+        await user.createToolApproval(auth, {
+          mcpServerId: "server-b",
+          toolName: "tool-3",
+        });
+
+        const approvals = await user.getUserToolApprovals(auth);
+
+        expect(approvals).toHaveLength(2);
+
+        const serverA = approvals.find((a) => a.mcpServerId === "server-a");
+        const serverB = approvals.find((a) => a.mcpServerId === "server-b");
+
+        expect(serverA).toBeDefined();
+        expect(serverA!.toolNames).toHaveLength(2);
+        expect(serverA!.toolNames).toContain("tool-1");
+        expect(serverA!.toolNames).toContain("tool-2");
+
+        expect(serverB).toBeDefined();
+        expect(serverB!.toolNames).toEqual(["tool-3"]);
+      });
+    });
+
+    describe("deleteToolApprovals", () => {
+      it("should delete approvals for the given mcpServerId only", async () => {
+        await user.createToolApproval(auth, {
+          mcpServerId: "server-x",
+          toolName: "tool-1",
+        });
+        await user.createToolApproval(auth, {
+          mcpServerId: "server-x",
+          toolName: "tool-2",
+        });
+        await user.createToolApproval(auth, {
+          mcpServerId: "server-y",
+          toolName: "tool-3",
+        });
+
+        await user.deleteToolApprovals(auth, { mcpServerId: "server-x" });
+
+        const approvals = await user.getUserToolApprovals(auth);
+        expect(approvals).toHaveLength(1);
+        expect(approvals[0].mcpServerId).toBe("server-y");
+      });
+    });
   });
 });

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -660,26 +660,41 @@ export class UserResource extends BaseResource<UserModel> {
     return;
   }
 
-  async getToolValidations(): Promise<
-    { mcpServerId: string; toolNames: string[] }[]
-  > {
-    const metadata = await UserMetadataModel.findAll({
+  async getUserToolApprovals(
+    auth: Authenticator
+  ): Promise<{ mcpServerId: string; toolNames: string[] }[]> {
+    const rows = await UserToolApprovalModel.findAll({
       where: {
         userId: this.id,
-        key: {
-          [Op.like]: "toolsValidations:%",
-        },
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
+      attributes: ["mcpServerId", "toolName"],
     });
 
-    return metadata.map((m) => {
-      const mcpServerId = m.key.replace("toolsValidations:", "");
-      const toolNames = m.value
-        .split(USER_METADATA_COMMA_SEPARATOR)
-        .map((v) => v.replaceAll(USER_METADATA_COMMA_REPLACEMENT, ","))
-        .filter((name) => name.length > 0);
+    const map = new Map<string, Set<string>>();
+    for (const row of rows) {
+      if (!map.has(row.mcpServerId)) {
+        map.set(row.mcpServerId, new Set());
+      }
+      map.get(row.mcpServerId)!.add(row.toolName);
+    }
 
-      return { mcpServerId, toolNames };
+    return Array.from(map.entries()).map(([mcpServerId, toolNames]) => ({
+      mcpServerId,
+      toolNames: Array.from(toolNames),
+    }));
+  }
+
+  async deleteToolApprovals(
+    auth: Authenticator,
+    { mcpServerId }: { mcpServerId: string }
+  ): Promise<void> {
+    await UserToolApprovalModel.destroy({
+      where: {
+        userId: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        mcpServerId,
+      },
     });
   }
 

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -97,6 +97,20 @@ export function useDeleteMetadata() {
   return { deleteMetadata };
 }
 
+export function useDeleteToolApproval() {
+  const deleteToolApproval = async (
+    owner: LightWorkspaceType,
+    mcpServerId: string
+  ) => {
+    return clientFetch(
+      `/api/w/${owner.sId}/me/approvals?mcpServerId=${encodeURIComponent(mcpServerId)}`,
+      { method: "DELETE" }
+    );
+  };
+
+  return { deleteToolApproval };
+}
+
 export function useIsOnboardingConversation(
   conversationId: string | null,
   workspaceId: string

--- a/front/pages/api/w/[wId]/me/approvals.ts
+++ b/front/pages/api/w/[wId]/me/approvals.ts
@@ -18,24 +18,49 @@ export interface GetUserApprovalsResponseBody {
   }[];
 }
 
+export interface DeleteUserApprovalsResponseBody {
+  success: boolean;
+}
+
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetUserApprovalsResponseBody>>,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      GetUserApprovalsResponseBody | DeleteUserApprovalsResponseBody
+    >
+  >,
   auth: Authenticator
 ): Promise<void> {
+  const user = auth.getNonNullableUser();
+  const userResource = new UserResource(UserResource.model, user);
+
+  if (req.method === "DELETE") {
+    const mcpServerId = req.query.mcpServerId;
+    if (typeof mcpServerId !== "string") {
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "mcpServerId query parameter is required.",
+        },
+      });
+    }
+    await userResource.deleteToolApprovals(auth, { mcpServerId });
+    return res.status(200).json({ success: true });
+  }
+
   if (req.method !== "GET") {
     return apiError(req, res, {
       status_code: 405,
       api_error: {
         type: "method_not_supported_error",
-        message: "The method passed is not supported, GET is expected.",
+        message:
+          "The method passed is not supported, GET or DELETE is expected.",
       },
     });
   }
 
-  const user = auth.getNonNullableUser();
-  const userResource = new UserResource(UserResource.model, user);
-  const toolValidations = await userResource.getToolValidations();
+  const toolValidations = await userResource.getUserToolApprovals(auth);
 
   const approvals: {
     mcpServerId: string;

--- a/front/pages/api/w/[wId]/me/approvals.ts
+++ b/front/pages/api/w/[wId]/me/approvals.ts
@@ -8,6 +8,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export interface GetUserApprovalsResponseBody {
@@ -34,84 +35,85 @@ async function handler(
   const user = auth.getNonNullableUser();
   const userResource = new UserResource(UserResource.model, user);
 
-  if (req.method === "DELETE") {
-    const mcpServerId = req.query.mcpServerId;
-    if (typeof mcpServerId !== "string") {
-      return apiError(req, res, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "mcpServerId query parameter is required.",
-        },
-      });
-    }
-    await userResource.deleteToolApprovals(auth, { mcpServerId });
-    return res.status(200).json({ success: true });
-  }
+  switch (req.method) {
+    case "GET": {
+      const toolValidations = await userResource.getUserToolApprovals(auth);
 
-  if (req.method !== "GET") {
-    return apiError(req, res, {
-      status_code: 405,
-      api_error: {
-        type: "method_not_supported_error",
-        message:
-          "The method passed is not supported, GET or DELETE is expected.",
-      },
-    });
-  }
+      const approvals: {
+        mcpServerId: string;
+        toolNames: string[];
+        serverName: string;
+      }[] = [];
 
-  const toolValidations = await userResource.getUserToolApprovals(auth);
+      for (const validation of toolValidations) {
+        if (validation.toolNames.length > 0) {
+          let serverName = "Unknown Server";
 
-  const approvals: {
-    mcpServerId: string;
-    toolNames: string[];
-    serverName: string;
-  }[] = [];
+          try {
+            const { serverType } = getServerTypeAndIdFromSId(
+              validation.mcpServerId
+            );
 
-  for (const validation of toolValidations) {
-    if (validation.toolNames.length > 0) {
-      let serverName = "Unknown Server";
+            if (serverType === "internal") {
+              const systemSpace =
+                await SpaceResource.fetchWorkspaceSystemSpace(auth);
+              const server = await InternalMCPServerInMemoryResource.fetchById(
+                auth,
+                validation.mcpServerId,
+                systemSpace
+              );
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+              serverName = server?.toJSON().name || "Unknown Internal Server";
+            } else if (serverType === "remote") {
+              const server = await RemoteMCPServerResource.fetchById(
+                auth,
+                validation.mcpServerId
+              );
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+              serverName = server?.toJSON().name || "Unknown Remote Server";
+            }
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
+          } catch (error) {
+            // If we can't parse the server ID or fetch the server, use default name
+          }
 
-      try {
-        const { serverType } = getServerTypeAndIdFromSId(
-          validation.mcpServerId
-        );
-
-        if (serverType === "internal") {
-          const systemSpace =
-            await SpaceResource.fetchWorkspaceSystemSpace(auth);
-          const server = await InternalMCPServerInMemoryResource.fetchById(
-            auth,
-            validation.mcpServerId,
-            systemSpace
-          );
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          serverName = server?.toJSON().name || "Unknown Internal Server";
-        } else if (serverType === "remote") {
-          const server = await RemoteMCPServerResource.fetchById(
-            auth,
-            validation.mcpServerId
-          );
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          serverName = server?.toJSON().name || "Unknown Remote Server";
+          approvals.push({
+            mcpServerId: validation.mcpServerId,
+            toolNames: validation.toolNames,
+            serverName,
+          });
         }
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
-      } catch (error) {
-        // If we can't parse the server ID or fetch the server, use default name
       }
 
-      approvals.push({
-        mcpServerId: validation.mcpServerId,
-        toolNames: validation.toolNames,
-        serverName,
-      });
+      return res.status(200).json({ approvals });
     }
-  }
 
-  return res.status(200).json({
-    approvals,
-  });
+    case "DELETE": {
+      const { mcpServerId } = req.query;
+      if (!isString(mcpServerId)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "mcpServerId query parameter is required.",
+          },
+        });
+      }
+      await userResource.deleteToolApprovals(auth, { mcpServerId });
+      return res.status(200).json({ success: true });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or DELETE is expected.",
+        },
+      });
+  }
 }
 
 export default withLogging(withSessionAuthenticationForWorkspace(handler));


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7572

This PR fixes the remaining code paths that were still using the old `UserMetadataModel` for reading and deleting tool approvals, following the migration to `UserToolApprovalModel` done in #20058.
This fixes the "Clear confirmation preferences" action (in the profile page)

- Replaced `getToolValidations()` with `getUserToolApprovals()` querying `UserToolApprovalModel`, instead of the metadata table
- Added `deleteToolApprovals()` to delete approvals by `mcpServerId` and `workspaceId`
- Updated frontend to use new `useDeleteToolApproval` hook instead of `deleteMetadata`

## Tests

- Added unit tests for `getUserToolApprovals`
- Added unit tests for `deleteToolApprovals`

## Risk

Low.

## Deploy Plan

Standard deployment. No migration needed.