### PR TITLE
Fixed tier pricing

### DIFF
--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -292,7 +292,11 @@ describe("buildEnterpriseOverrides", () => {
       floorCents: 500000,
     };
 
-    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+    const result = buildEnterpriseOverrides({
+      pricing,
+      startDate: START_DATE,
+      initialMauCount: 0,
+    });
 
     // 1 MAU + 6 tier products = 7 disabled.
     expect(result.overrides).toHaveLength(7);
@@ -315,7 +319,11 @@ describe("buildEnterpriseOverrides", () => {
       floorCents: 450000,
     };
 
-    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+    const result = buildEnterpriseOverrides({
+      pricing,
+      startDate: START_DATE,
+      initialMauCount: 0,
+    });
 
     // Simple mode: MAU product enabled.
     const mauOverride = findOverride(result.overrides, "mau-product");
@@ -354,7 +362,11 @@ describe("buildEnterpriseOverrides", () => {
       floorCents: 0,
     };
 
-    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+    const result = buildEnterpriseOverrides({
+      pricing,
+      startDate: START_DATE,
+      initialMauCount: 0,
+    });
 
     const tier1 = findOverride(result.overrides, "tier1-product");
     expect(tier1?.overwrite_rate.price).toBe(0);
@@ -377,7 +389,11 @@ describe("buildEnterpriseOverrides", () => {
       floorCents: 0,
     };
 
-    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+    const result = buildEnterpriseOverrides({
+      pricing,
+      startDate: START_DATE,
+      initialMauCount: 0,
+    });
 
     const tier1 = findOverride(result.overrides, "tier1-product");
     expect(tier1?.overwrite_rate.price).toBe(4000);
@@ -403,7 +419,11 @@ describe("buildEnterpriseOverrides", () => {
       floorCents: 315000,
     };
 
-    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+    const result = buildEnterpriseOverrides({
+      pricing,
+      startDate: START_DATE,
+      initialMauCount: 0,
+    });
 
     // 5 tier products enabled with correct prices.
     const enabledTiers = result.overrides.filter((o) => o.entitled);
@@ -433,7 +453,11 @@ describe("buildEnterpriseOverrides", () => {
       floorCents: 0,
     };
 
-    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+    const result = buildEnterpriseOverrides({
+      pricing,
+      startDate: START_DATE,
+      initialMauCount: 0,
+    });
 
     // Single tier → simple mode: MAU product enabled.
     const mauOverride = findOverride(result.overrides, "mau-product");
@@ -461,7 +485,11 @@ describe("buildEnterpriseOverrides", () => {
       floorCents: 225000,
     };
 
-    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+    const result = buildEnterpriseOverrides({
+      pricing,
+      startDate: START_DATE,
+      initialMauCount: 0,
+    });
 
     // Simple mode: MAU product enabled (same price across tiers).
     expect(findOverride(result.overrides, "mau-product")?.entitled).toBe(true);
@@ -486,7 +514,11 @@ describe("buildEnterpriseOverrides", () => {
       floorCents: 120000,
     };
 
-    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+    const result = buildEnterpriseOverrides({
+      pricing,
+      startDate: START_DATE,
+      initialMauCount: 0,
+    });
 
     // Simple mode: MAU product with EUR credit type and price in euros.
     const mauOverride = findOverride(result.overrides, "mau-product");
@@ -512,7 +544,11 @@ describe("buildEnterpriseOverrides", () => {
       floorCents: 325000,
     };
 
-    const result = buildEnterpriseOverrides({ pricing, startDate: START_DATE });
+    const result = buildEnterpriseOverrides({
+      pricing,
+      startDate: START_DATE,
+      initialMauCount: 0,
+    });
 
     const tier1 = findOverride(result.overrides, "tier1-product");
     expect(tier1?.overwrite_rate.price).toBe(3250); // 325000 / 100

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -14,11 +14,16 @@ import {
   getProductMauTierIds,
   MAX_MAU_TIERS,
 } from "@app/lib/metronome/constants";
-import { syncMauCount } from "@app/lib/metronome/mau_sync";
+import {
+  computeTierQuantity,
+  parseMauTiers,
+  syncMauCount,
+} from "@app/lib/metronome/mau_sync";
 import { syncSeatCount } from "@app/lib/metronome/seats";
 import { LEGACY_ENTERPRISE_PACKAGE_ALIAS } from "@app/lib/metronome/types";
 import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
 import { getStripeClient } from "@app/lib/plans/stripe";
+import { countActiveUsersForPeriodInWorkspace } from "@app/lib/plans/usage/mau";
 import {
   isEnterpriseReportUsage,
   type SupportedEnterpriseReportUsage,
@@ -196,6 +201,34 @@ export interface EnterprisePricingCents {
   tiers: StripeTierCents[];
   /** Monthly floor amount in cents (flat_amount on first tier, or unit_amount for FIXED). */
   floorCents: number;
+}
+
+/** Extract the MAU threshold number from a billing mode (MAU_1→1, MAU_5→5, MAU_10→10). */
+function billingModeToMauThreshold(
+  billingMode: SupportedEnterpriseReportUsage
+): number {
+  switch (billingMode) {
+    case "MAU_5":
+      return 5;
+    case "MAU_10":
+      return 10;
+    default:
+      return 1;
+  }
+}
+
+/** Count MAUs for a workspace using the given billing mode's threshold. */
+export async function countMauForWorkspace(
+  workspace: LightWorkspaceType,
+  billingMode: SupportedEnterpriseReportUsage
+): Promise<number> {
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const count = await countActiveUsersForPeriodInWorkspace({
+    messagesPerMonthForMau: billingModeToMauThreshold(billingMode),
+    since: thirtyDaysAgo,
+    workspace,
+  });
+  return Math.max(count, 1);
 }
 
 /**
@@ -432,9 +465,11 @@ function deriveTierPrices(
 export function buildEnterpriseOverrides({
   pricing,
   startDate,
+  initialMauCount,
 }: {
   pricing: EnterprisePricingCents;
   startDate: string;
+  initialMauCount: number;
 }): EnterpriseOverridesPayload {
   const creditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[pricing.currency];
   if (!creditTypeId) {
@@ -475,12 +510,7 @@ export function buildEnterpriseOverrides({
 
   const tierPrices = deriveTierPrices(pricing.tiers, pricing.currency);
   const tierProductIds = getProductMauTierIds();
-  const mauThreshold =
-    pricing.billingMode === "MAU_5"
-      ? "5"
-      : pricing.billingMode === "MAU_10"
-        ? "10"
-        : "1";
+  const mauThreshold = String(billingModeToMauThreshold(pricing.billingMode));
 
   // If all tiers have the same effective price, use the simple MAU product
   // instead of tier products. The floor (if any) is still handled by a commit.
@@ -550,9 +580,9 @@ export function buildEnterpriseOverrides({
             product_id: getProductMauId(),
           },
           quantity_management_mode: "QUANTITY_ONLY" as const,
-          initial_quantity: 0,
+          initial_quantity: initialMauCount,
           proration: {
-            is_prorated: true,
+            is_prorated: false,
             invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE" as const,
           },
         },
@@ -628,8 +658,15 @@ export function buildEnterpriseOverrides({
       : undefined;
 
   // Add subscriptions for each enabled tier (so syncMauCount can set quantities).
+  // Distribute initialMauCount across tiers for the first invoice.
+  const mauTiersField = buildMauTiersField(pricing.tiers);
+  const tierBoundaries = parseMauTiers(mauTiersField) ?? [];
   const addSubscriptions: SubscriptionEntry[] = [];
   for (let i = 0; i < pricing.tiers.length; i++) {
+    const tierQuantity = tierBoundaries[i]
+      ? computeTierQuantity(initialMauCount, tierBoundaries[i])
+      : 0;
+
     addSubscriptions.push({
       collection_schedule: "ADVANCE" as const,
       subscription_rate: {
@@ -637,16 +674,13 @@ export function buildEnterpriseOverrides({
         product_id: tierProductIds[i],
       },
       quantity_management_mode: "QUANTITY_ONLY" as const,
-      initial_quantity: 0,
+      initial_quantity: tierQuantity,
       proration: {
-        is_prorated: true,
+        is_prorated: false,
         invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE" as const,
       },
     });
   }
-
-  // Build custom fields for syncMauCount.
-  const mauTiersField = buildMauTiersField(pricing.tiers);
 
   return {
     overrides,
@@ -670,6 +704,7 @@ export async function applyEnterpriseOverrides({
   startDate,
   overrideLogger,
   workspaceId,
+  initialMauCount,
 }: {
   metronomeCustomerId: string;
   contractId: string;
@@ -677,8 +712,13 @@ export async function applyEnterpriseOverrides({
   startDate: string;
   overrideLogger: Logger;
   workspaceId: string;
+  initialMauCount: number;
 }): Promise<void> {
-  const payload = buildEnterpriseOverrides({ pricing, startDate });
+  const payload = buildEnterpriseOverrides({
+    pricing,
+    startDate,
+    initialMauCount,
+  });
 
   overrideLogger.info(
     { workspaceId, contractId, ...payload },
@@ -687,15 +727,52 @@ export async function applyEnterpriseOverrides({
 
   const client = getMetronomeClient();
 
+  // Check existing contract state to avoid adding duplicate subscriptions/commits on re-runs.
+  let subscriptionsToAdd = payload.add_subscriptions;
+  let commitsToAdd = payload.recurring_commits;
+
+  if (
+    (subscriptionsToAdd && subscriptionsToAdd.length > 0) ||
+    (commitsToAdd && commitsToAdd.length > 0)
+  ) {
+    const contractResponse = await client.v2.contracts.retrieve({
+      customer_id: metronomeCustomerId,
+      contract_id: contractId,
+    });
+    const contractData = contractResponse.data;
+
+    // Filter out subscriptions that already exist.
+    if (subscriptionsToAdd && subscriptionsToAdd.length > 0) {
+      const existingSubProductIds = new Set(
+        (contractData.subscriptions ?? []).map(
+          (s) => s.subscription_rate.product.id
+        )
+      );
+      subscriptionsToAdd = subscriptionsToAdd.filter(
+        (s) => !existingSubProductIds.has(s.subscription_rate.product_id)
+      );
+    }
+
+    // Filter out recurring commits whose product already has one.
+    if (commitsToAdd && commitsToAdd.length > 0) {
+      const existingCommitProductIds = new Set(
+        (contractData.recurring_commits ?? []).map((c) => c.product.id)
+      );
+      commitsToAdd = commitsToAdd.filter(
+        (c) => !existingCommitProductIds.has(c.product_id)
+      );
+    }
+  }
+
   await client.v2.contracts.edit({
     customer_id: metronomeCustomerId,
     contract_id: contractId,
     add_overrides: payload.overrides,
-    ...(payload.add_subscriptions
-      ? { add_subscriptions: payload.add_subscriptions }
+    ...(subscriptionsToAdd && subscriptionsToAdd.length > 0
+      ? { add_subscriptions: subscriptionsToAdd }
       : {}),
-    ...(payload.recurring_commits
-      ? { add_recurring_commits: payload.recurring_commits }
+    ...(commitsToAdd && commitsToAdd.length > 0
+      ? { add_recurring_commits: commitsToAdd }
       : {}),
   });
 
@@ -777,6 +854,12 @@ export async function provisionEnterpriseMetronomeContract({
     stripeSubscription.current_period_start
   );
 
+  // Count MAUs for initial subscription quantities on the first invoice.
+  const initialMauCount = await countMauForWorkspace(
+    workspace,
+    enterprisePricing.billingMode
+  );
+
   // Apply MAU rate overrides + floor commit.
   await applyEnterpriseOverrides({
     metronomeCustomerId,
@@ -785,6 +868,7 @@ export async function provisionEnterpriseMetronomeContract({
     startDate,
     overrideLogger: logger,
     workspaceId: workspace.sId,
+    initialMauCount,
   });
 
   return new Ok({ metronomeCustomerId, metronomeContractId });

--- a/front/lib/metronome/mau_sync.test.ts
+++ b/front/lib/metronome/mau_sync.test.ts
@@ -62,90 +62,157 @@ describe("parseMauTiers", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build SubscriptionInfo[] from tiers with all quantities at 0. */
+function makeSubscriptions(tiersField: string) {
+  const tiers = parseMauTiers(tiersField)!;
+  return tiers.map((tier, i) => ({
+    id: `sub-${i}`,
+    currentQuantity: 0,
+    nextPeriodStart: undefined,
+    tier,
+  }));
+}
+
+/** Extract just the new quantities from the result. */
+function quantities(
+  result: ReturnType<typeof distributeMauAcrossTiers>
+): number[] {
+  return result.map((s) => s.currentQuantity);
+}
+
+// ---------------------------------------------------------------------------
 // distributeMauAcrossTiers
 // ---------------------------------------------------------------------------
 
 describe("distributeMauAcrossTiers", () => {
-  it("FLOOR-4-6-8 with 15 MAUs → 3-2-2-8", () => {
-    const tiers = parseMauTiers("FLOOR-4-6-8")!;
-    expect(distributeMauAcrossTiers(15, tiers)).toEqual([3, 2, 2, 8]);
+  // Note: distributeMauAcrossTiers only returns entries whose quantity changed.
+  // Since makeSubscriptions starts at 0, tiers that compute to 0 are filtered out.
+
+  it("FLOOR-4-6-8 with 15 MAUs → all tiers change", () => {
+    const subs = makeSubscriptions("FLOOR-4-6-8");
+    expect(quantities(distributeMauAcrossTiers(15, subs))).toEqual([
+      3, 2, 2, 8,
+    ]);
   });
 
-  it("FLOOR-4-6-8 with 1 MAU → 1-0-0-0", () => {
-    const tiers = parseMauTiers("FLOOR-4-6-8")!;
-    expect(distributeMauAcrossTiers(1, tiers)).toEqual([1, 0, 0, 0]);
+  it("FLOOR-4-6-8 with 1 MAU → only tier 1 changes", () => {
+    const subs = makeSubscriptions("FLOOR-4-6-8");
+    const result = distributeMauAcrossTiers(1, subs);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("sub-0");
+    expect(result[0].currentQuantity).toBe(1);
   });
 
-  it("FLOOR-4-6-8 with 5 MAUs → 3-2-0-0", () => {
-    const tiers = parseMauTiers("FLOOR-4-6-8")!;
-    expect(distributeMauAcrossTiers(5, tiers)).toEqual([3, 2, 0, 0]);
+  it("FLOOR-4-6-8 with 5 MAUs → tiers 1-2 change", () => {
+    const subs = makeSubscriptions("FLOOR-4-6-8");
+    const result = distributeMauAcrossTiers(5, subs);
+    expect(result).toHaveLength(2);
+    expect(quantities(result)).toEqual([3, 2]);
   });
 
-  it("FLOOR-4-6-8 with 3 MAUs → 3-0-0-0", () => {
-    const tiers = parseMauTiers("FLOOR-4-6-8")!;
-    expect(distributeMauAcrossTiers(3, tiers)).toEqual([3, 0, 0, 0]);
+  it("FLOOR-4-6-8 with 3 MAUs → only tier 1 changes", () => {
+    const subs = makeSubscriptions("FLOOR-4-6-8");
+    const result = distributeMauAcrossTiers(3, subs);
+    expect(result).toHaveLength(1);
+    expect(result[0].currentQuantity).toBe(3);
   });
 
-  it("FLOOR-4-6-8 with 8 MAUs → 3-2-2-1", () => {
-    const tiers = parseMauTiers("FLOOR-4-6-8")!;
-    expect(distributeMauAcrossTiers(8, tiers)).toEqual([3, 2, 2, 1]);
+  it("FLOOR-4-6-8 with 8 MAUs → all tiers change", () => {
+    const subs = makeSubscriptions("FLOOR-4-6-8");
+    expect(quantities(distributeMauAcrossTiers(8, subs))).toEqual([3, 2, 2, 1]);
   });
 
-  it("FLOOR-101-201 with 150 MAUs → 100-50-0", () => {
-    const tiers = parseMauTiers("FLOOR-101-201")!;
-    expect(distributeMauAcrossTiers(150, tiers)).toEqual([100, 50, 0]);
+  it("FLOOR-101-201 with 150 MAUs → tiers 1-2 change", () => {
+    const subs = makeSubscriptions("FLOOR-101-201");
+    expect(quantities(distributeMauAcrossTiers(150, subs))).toEqual([100, 50]);
   });
 
-  it("FLOOR-101-201 with 250 MAUs → 100-100-50", () => {
-    const tiers = parseMauTiers("FLOOR-101-201")!;
-    expect(distributeMauAcrossTiers(250, tiers)).toEqual([100, 100, 50]);
+  it("FLOOR-101-201 with 250 MAUs → all tiers change", () => {
+    const subs = makeSubscriptions("FLOOR-101-201");
+    expect(quantities(distributeMauAcrossTiers(250, subs))).toEqual([
+      100, 100, 50,
+    ]);
   });
 
-  it("FLOOR-101-201 with 50 MAUs → 50-0-0", () => {
-    const tiers = parseMauTiers("FLOOR-101-201")!;
-    expect(distributeMauAcrossTiers(50, tiers)).toEqual([50, 0, 0]);
+  it("FLOOR-101-201 with 50 MAUs → only tier 1 changes", () => {
+    const subs = makeSubscriptions("FLOOR-101-201");
+    const result = distributeMauAcrossTiers(50, subs);
+    expect(result).toHaveLength(1);
+    expect(result[0].currentQuantity).toBe(50);
   });
 
-  it("1-101 with 150 MAUs (no floor) → 100-50", () => {
-    const tiers = parseMauTiers("1-101")!;
-    expect(distributeMauAcrossTiers(150, tiers)).toEqual([100, 50]);
+  it("1-101 with 150 MAUs (no floor) → both tiers change", () => {
+    const subs = makeSubscriptions("1-101");
+    expect(quantities(distributeMauAcrossTiers(150, subs))).toEqual([100, 50]);
   });
 
-  it("1-101 with 50 MAUs (no floor) → 50-0", () => {
-    const tiers = parseMauTiers("1-101")!;
-    expect(distributeMauAcrossTiers(50, tiers)).toEqual([50, 0]);
+  it("1-101 with 50 MAUs (no floor) → only tier 1 changes", () => {
+    const subs = makeSubscriptions("1-101");
+    const result = distributeMauAcrossTiers(50, subs);
+    expect(result).toHaveLength(1);
+    expect(result[0].currentQuantity).toBe(50);
   });
 
-  it("1 with 25 MAUs (single tier) → 25", () => {
-    const tiers = parseMauTiers("1")!;
-    expect(distributeMauAcrossTiers(25, tiers)).toEqual([25]);
+  it("1 with 25 MAUs (single tier) → changes", () => {
+    const subs = makeSubscriptions("1");
+    expect(quantities(distributeMauAcrossTiers(25, subs))).toEqual([25]);
   });
 
-  it("FLOOR-71-101-201-501 with 300 MAUs → 70-30-100-100-0", () => {
-    const tiers = parseMauTiers("FLOOR-71-101-201-501")!;
-    expect(distributeMauAcrossTiers(300, tiers)).toEqual([70, 30, 100, 100, 0]);
+  it("FLOOR-71-101-201-501 with 300 MAUs → tiers 1-4 change", () => {
+    const subs = makeSubscriptions("FLOOR-71-101-201-501");
+    expect(quantities(distributeMauAcrossTiers(300, subs))).toEqual([
+      70, 30, 100, 100,
+    ]);
   });
 
-  it("FLOOR-71-101-201-501 with 600 MAUs → 70-30-100-300-100", () => {
-    const tiers = parseMauTiers("FLOOR-71-101-201-501")!;
-    expect(distributeMauAcrossTiers(600, tiers)).toEqual([
+  it("FLOOR-71-101-201-501 with 600 MAUs → all tiers change", () => {
+    const subs = makeSubscriptions("FLOOR-71-101-201-501");
+    expect(quantities(distributeMauAcrossTiers(600, subs))).toEqual([
       70, 30, 100, 300, 100,
     ]);
   });
 
-  it("totals always sum to totalMau", () => {
+  it("returns empty when no quantities changed", () => {
     const tiers = parseMauTiers("FLOOR-4-6-8")!;
-    for (const total of [1, 3, 5, 8, 15, 100]) {
-      const distributed = distributeMauAcrossTiers(total, tiers);
-      expect(distributed.reduce((a, b) => a + b, 0)).toBe(total);
-    }
+    const subs = tiers.map((tier, i) => ({
+      id: `sub-${i}`,
+      currentQuantity: [3, 2, 2, 8][i],
+      nextPeriodStart: undefined,
+      tier,
+    }));
+    // Same total (15) → no changes needed.
+    expect(distributeMauAcrossTiers(15, subs)).toEqual([]);
   });
 
-  it("totals sum correctly for no-floor tiers", () => {
-    const tiers = parseMauTiers("1-101-201")!;
-    for (const total of [1, 50, 101, 150, 201, 300]) {
-      const distributed = distributeMauAcrossTiers(total, tiers);
-      expect(distributed.reduce((a, b) => a + b, 0)).toBe(total);
-    }
+  it("returns only changed tiers on partial update", () => {
+    const tiers = parseMauTiers("FLOOR-4-6-8")!;
+    // Current: 3-2-2-8 (15 MAUs). Update to 20 → 3-2-2-13. Only tier 4 changes.
+    const subs = tiers.map((tier, i) => ({
+      id: `sub-${i}`,
+      currentQuantity: [3, 2, 2, 8][i],
+      nextPeriodStart: undefined,
+      tier,
+    }));
+    const result = distributeMauAcrossTiers(20, subs);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("sub-3");
+    expect(result[0].currentQuantity).toBe(13);
+  });
+
+  it("total of changed entries matches expected non-zero tiers", () => {
+    // With 15 MAUs across FLOOR-4-6-8: all tiers get non-zero → sum = 15
+    const subs = makeSubscriptions("FLOOR-4-6-8");
+    const result = distributeMauAcrossTiers(15, subs);
+    expect(result.reduce((a, b) => a + b.currentQuantity, 0)).toBe(15);
+  });
+
+  it("total of changed entries for no-floor tiers", () => {
+    // With 150 MAUs across 1-101: both tiers non-zero → sum = 150
+    const subs = makeSubscriptions("1-101");
+    const result = distributeMauAcrossTiers(150, subs);
+    expect(result.reduce((a, b) => a + b.currentQuantity, 0)).toBe(150);
   });
 });

--- a/front/lib/metronome/mau_sync.ts
+++ b/front/lib/metronome/mau_sync.ts
@@ -16,24 +16,15 @@ import type { LightWorkspaceType } from "@app/types/user";
 // MAU_TIERS parsing
 // ---------------------------------------------------------------------------
 
-interface TierBoundary {
-  /** Start of this tier (inclusive). */
+export interface TierBoundary {
+  /** Start of this tier (inclusive, 1-indexed). */
   start: number;
   /** End of this tier (exclusive). undefined = unlimited. */
   end: number | undefined;
-  /** If true, this tier's quantity is always 1 (floor tier). */
+  /** If true, this tier has a floor (minimum charge via recurring commit). */
   isFloor: boolean;
 }
 
-/**
- * Parse the MAU_TIERS custom field value into tier boundaries.
- *
- * Format: "FLOOR-101-201" or "0-101-201"
- * - "FLOOR" as first element means tier 1 quantity is always 1.
- * - Numbers are the start of each tier.
- *
- * Returns undefined if the field is missing or empty.
- */
 /**
  * Parse the MAU_TIERS custom field value into tier boundaries.
  *
@@ -82,47 +73,65 @@ export function parseMauTiers(
 }
 
 /**
- * Distribute a total MAU count across tier boundaries.
- * Returns the quantity for each tier.
+ * Compute the quantity for a single tier boundary given a total MAU count.
+ * Tiers are 1-indexed (start/end represent MAU numbers).
  */
+export function computeTierQuantity(
+  totalMau: number,
+  tier: TierBoundary
+): number {
+  if (totalMau < tier.start) {
+    return 0;
+  }
+  const lastInTier = tier.end !== undefined ? tier.end - 1 : totalMau;
+  const count = Math.min(totalMau, lastInTier) - tier.start + 1;
+  return Math.max(count, 0);
+}
+
 /**
- * Distribute a total MAU count across tier boundaries.
+ * Distribute a total MAU count across tiered subscriptions.
+ * Returns only subscriptions whose quantity needs updating (changed from current).
+ * Each returned entry has `currentQuantity` set to the new target quantity.
  *
- * Tiers are 1-indexed (start/end represent MAU numbers, not zero-based indices).
- * Example: tiers [{start:1,end:4}, {start:4,end:6}, {start:6}], totalMau=15
- *   → [3, 2, 10] (MAUs 1-3, 4-5, 6-15)
+ * Example: subscriptions with tiers [{start:1,end:4}, {start:4,end:6}, {start:6}], totalMau=15
+ *   → returns entries with quantities: 3, 2, 10
  */
 export function distributeMauAcrossTiers(
   totalMau: number,
-  tiers: TierBoundary[]
-): number[] {
-  return tiers.map((tier) => {
-    if (totalMau < tier.start) {
-      return 0;
-    }
-    // For 1-indexed tiers: count = min(totalMau, lastInTier) - firstInTier + 1
-    // lastInTier = (end - 1) if end is defined, else totalMau
-    const lastInTier = tier.end !== undefined ? tier.end - 1 : totalMau;
-    const count = Math.min(totalMau, lastInTier) - tier.start + 1;
-    return Math.max(count, 0);
-  });
+  subscriptions: SubscriptionInfo[]
+): SubscriptionInfo[] {
+  return subscriptions
+    .map((sub) => {
+      const newQuantity = computeTierQuantity(totalMau, sub.tier);
+      return sub.currentQuantity !== newQuantity
+        ? { ...sub, currentQuantity: newQuantity }
+        : undefined;
+    })
+    .filter((sub) => sub !== undefined);
 }
 
 // ---------------------------------------------------------------------------
 // Contract MAU info extraction
 // ---------------------------------------------------------------------------
 
+interface SubscriptionInfo {
+  id: string;
+  currentQuantity: number;
+  /** Start of the next billing period — quantity updates target the next period only. */
+  nextPeriodStart: string | undefined;
+  tier: TierBoundary;
+}
+
 interface SimpleMauInfo {
   type: "simple";
-  subscriptionId: string;
+  subscription: SubscriptionInfo;
   threshold: number;
 }
 
 interface TieredMauInfo {
   type: "tiered";
-  tierSubscriptionIds: string[];
+  subscriptions: SubscriptionInfo[];
   threshold: number;
-  tiers: TierBoundary[];
 }
 
 type MauInfo = SimpleMauInfo | TieredMauInfo;
@@ -149,22 +158,28 @@ async function getContractMauInfo(
     return undefined;
   }
 
-  const customFields = (
-    contract as typeof contract & {
-      custom_fields?: Record<string, string>;
-    }
-  ).custom_fields;
+  const customFields = contract.custom_fields;
   const threshold = parseInt(customFields?.MAU_THRESHOLD ?? "1", 10);
   const safeThreshold = isNaN(threshold) ? 1 : threshold;
 
-  // Build product → subscription mapping.
-  const subscriptionByProductId = new Map<string, string>();
+  // Build product → subscription info mapping.
+  const subscriptionByProductId = new Map<
+    string,
+    { id: string; currentQuantity: number; nextPeriodStart: string | undefined }
+  >();
   for (const sub of contract.subscriptions) {
-    const productId = (
-      sub as { subscription_rate: { product: { id: string } }; id: string }
-    ).subscription_rate.product.id;
-    const subId = (sub as { id: string }).id;
-    subscriptionByProductId.set(productId, subId);
+    const productId = sub.subscription_rate.product.id;
+    const qSchedule = sub.quantity_schedule ?? [];
+    const currentQuantity =
+      qSchedule.length > 0 ? qSchedule[qSchedule.length - 1].quantity : 0;
+    const nextPeriodStart = sub.billing_periods?.next?.starting_at;
+    if (sub.id) {
+      subscriptionByProductId.set(productId, {
+        id: sub.id,
+        currentQuantity,
+        nextPeriodStart,
+      });
+    }
   }
 
   // Check for MAU_TIERS custom field → tiered mode.
@@ -173,34 +188,40 @@ async function getContractMauInfo(
 
   if (tiers) {
     const tierProductIds = getProductMauTierIds();
-    const tierSubscriptionIds: string[] = [];
+    const subscriptions: SubscriptionInfo[] = [];
     for (let i = 0; i < tiers.length; i++) {
-      const subId = subscriptionByProductId.get(tierProductIds[i]);
-      if (!subId) {
+      const subInfo = subscriptionByProductId.get(tierProductIds[i]);
+      if (!subInfo) {
         logger.warn(
           { contractId, tierIndex: i, productId: tierProductIds[i] },
           "[Metronome] MAU tier subscription not found"
         );
         return undefined;
       }
-      tierSubscriptionIds.push(subId);
+      subscriptions.push({ ...subInfo, tier: tiers[i] });
     }
 
     return {
       type: "tiered",
-      tierSubscriptionIds,
+      subscriptions,
       threshold: safeThreshold,
-      tiers,
     };
   }
 
-  // Simple mode: single MAU product.
-  const mauSubId = subscriptionByProductId.get(getProductMauId());
-  if (!mauSubId) {
+  // Simple mode: single MAU product (default tier covers all MAUs).
+  const mauSubInfo = subscriptionByProductId.get(getProductMauId());
+  if (!mauSubInfo) {
     return undefined;
   }
 
-  return { type: "simple", subscriptionId: mauSubId, threshold: safeThreshold };
+  return {
+    type: "simple",
+    subscription: {
+      ...mauSubInfo,
+      tier: { start: 1, end: undefined, isFloor: false },
+    },
+    threshold: safeThreshold,
+  };
 }
 
 /**
@@ -210,6 +231,7 @@ async function getContractMauInfo(
  * - Simple (no MAU_TIERS): single MAU product, set quantity to total MAU count.
  * - Tiered (MAU_TIERS set): multiple MAU Tier products, distribute count across tiers.
  *
+ * Skips updates when the quantity hasn't changed.
  * MAU_THRESHOLD custom field controls the MAU counting threshold (default 1).
  */
 export async function syncMauCount({
@@ -241,31 +263,25 @@ export async function syncMauCount({
 
   const totalMau = Math.max(mauCount, 1);
 
-  // Uniqueness key prevents duplicate updates within the same hour.
-  const hourKey = startingAt ?? new Date().toISOString().slice(0, 13); // "YYYY-MM-DDTHH"
+  // Get subscriptions that need updating (works for both simple and tiered).
+  const subscriptions =
+    mauInfo.type === "simple" ? [mauInfo.subscription] : mauInfo.subscriptions;
+  const toUpdate = distributeMauAcrossTiers(totalMau, subscriptions);
 
-  if (mauInfo.type === "simple") {
-    return updateSubscriptionQuantity({
-      metronomeCustomerId,
-      contractId,
-      subscriptionId: mauInfo.subscriptionId,
-      quantity: totalMau,
-      uniquenessKey: `mau-sync-${contractId}-${hourKey}`,
-      startingAt,
-    });
-  }
+  logger.info(
+    { workspaceId: workspace.sId, contractId, toUpdate, totalMau },
+    "[Metronome] Updating MAU quantities"
+  );
 
-  // Tiered mode: distribute MAU across tier subscriptions.
-  const tierQuantities = distributeMauAcrossTiers(totalMau, mauInfo.tiers);
-
-  for (let i = 0; i < mauInfo.tierSubscriptionIds.length; i++) {
+  for (const sub of toUpdate) {
+    // Target the next billing period — current period stays as-is.
+    const effectiveStartingAt = sub.nextPeriodStart ?? startingAt;
     const result = await updateSubscriptionQuantity({
       metronomeCustomerId,
       contractId,
-      subscriptionId: mauInfo.tierSubscriptionIds[i],
-      quantity: Math.max(tierQuantities[i], 0),
-      startingAt,
-      uniquenessKey: `mau-sync-${contractId}-tier${i}-${hourKey}`,
+      subscriptionId: sub.id,
+      quantity: sub.currentQuantity,
+      startingAt: effectiveStartingAt,
     });
     if (result.isErr()) {
       return result;

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -72,6 +72,11 @@ export async function syncSeatCount({
   });
   const memberCount = memberships.length;
 
+  logger.info(
+    { workspaceId: workspace.sId, contractId, memberCount },
+    "[Metronome] Updating seat quantities"
+  );
+
   return await updateSubscriptionQuantity({
     metronomeCustomerId,
     contractId,

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -24,6 +24,7 @@ import {
 import {
   applyEnterpriseOverrides,
   buildEnterpriseOverrides,
+  countMauForWorkspace,
   type EnterprisePricingCents,
   extractEnterprisePricing,
 } from "@app/lib/metronome/contracts";
@@ -305,12 +306,21 @@ async function migrateWorkspace(
     break;
   }
 
+  // Count MAUs for initial subscription quantities.
+  const initialMauCount = isEnterprise
+    ? await countMauForWorkspace(
+        workspace,
+        subInfo.enterprisePricing!.billingMode
+      )
+    : 0;
+
   // Build enterprise overrides for both logging and contract creation.
   const enterpriseOverrides =
     isEnterprise && subInfo.enterprisePricing
       ? buildEnterpriseOverrides({
           pricing: subInfo.enterprisePricing,
           startDate: subInfo.startDate,
+          initialMauCount,
         })
       : undefined;
 
@@ -376,6 +386,7 @@ async function migrateWorkspace(
       startDate: subInfo.startDate,
       overrideLogger: logger,
       workspaceId: workspace.sId,
+      initialMauCount,
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes and improvements to the tiered MAU billing implementation.

### Skip-if-unchanged & no duplicate updates
- `SubscriptionInfo` now includes `currentQuantity` and `nextPeriodStart` — `distributeMauAcrossTiers` returns only subscriptions whose quantity actually changed
- Quantity updates target the **next billing period** (`nextPeriodStart`) to avoid creating multiple windows in the current period
- `applyEnterpriseOverrides` checks existing subscriptions and recurring commits before adding — prevents duplicates on re-runs

### Initial MAU count on first invoice
- `buildEnterpriseOverrides` accepts `initialMauCount` to set subscription quantities at creation time (instead of 0)
- `provisionEnterpriseMetronomeContract` computes MAU count using `countMauForWorkspace` before applying overrides
- Migration script also computes initial MAU count before creating contracts
- Uses `computeTierQuantity` from `mau_sync.ts` to distribute across tiers — no duplicated tier math

### No proration
- Subscription creation uses `is_prorated: false` — quantity changes apply to the full billing period

### Helpers
- `billingModeToMauThreshold(billingMode)` — converts `MAU_1→1`, `MAU_5→5`, `MAU_10→10`
- `countMauForWorkspace(workspace, billingMode)` — counts MAUs with the correct threshold, returns at least 1
- `computeTierQuantity` and `TierBoundary` exported from `mau_sync.ts` for reuse in `contracts.ts`

### Refactored `mau_sync.ts`
- `SubscriptionInfo` type: `{ id, currentQuantity, nextPeriodStart, tier }` — tier boundary embedded in each subscription
- `distributeMauAcrossTiers` takes `SubscriptionInfo[]`, returns only changed entries
- `syncMauCount` unified for simple/tiered — iterates only the changed subscriptions
- Removed `SimpleMauInfo`/`TieredMauInfo` parallel arrays in favor of `SubscriptionInfo[]`

### Migration script
- Uncommented contract creation + override application
- Uses `countMauForWorkspace` with correct billing mode threshold

### Tests
- Updated `mau_sync.test.ts` for new `SubscriptionInfo`-based API
- Added "returns empty when no quantities changed" and "returns only changed tiers on partial update" tests
- Updated `contracts.test.ts` for simple mode routing (same-price tiers → simple mode)

## Test plan

- [x] Create enterprise contract with initial MAU count — verify first invoice shows correct quantities
- [x] Update MAU count — verify only next period is affected, single line per subscription
- [x] Re-run migration on existing contract — verify no duplicate subscriptions or commits
- [x] Test tiered contract (different prices) — verify tier quantities distributed correctly
- [x] Test simple contract (same prices) — verify single MAU product used
- [x] Run unit tests for `parseMauTiers`, `distributeMauAcrossTiers`, `buildEnterpriseOverrides`

🤖 Generated with [Claude Code](https://claude.com/claude-code)