### PR TITLE
perf: cap command palette results to avoid slow rendering

### DIFF
--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -75,7 +75,13 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
 
   const isDebouncing = searchQuery.trim() !== debouncedQuery;
 
-  const filteredAgents = useMemo(
+  // Cap the number of rendered items to avoid slow DOM rendering on large workspaces.
+  // This is a temporary measure until the command palette moves to Sparkle with
+  // proper list virtualization (@tanstack/react-virtual).
+  const MAX_DISPLAYED_AGENTS = 25;
+  const MAX_DISPLAYED_SKILLS = 15;
+
+  const allFilteredAgents = useMemo(
     () =>
       debouncedQuery
         ? filterAndSortAgents(agentConfigurations, debouncedQuery)
@@ -83,13 +89,18 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
     [agentConfigurations, debouncedQuery]
   );
 
-  const filteredSkills = useMemo(() => {
+  const allFilteredSkills = useMemo(() => {
     if (!debouncedQuery) {
       return skills;
     }
     const lowerQuery = debouncedQuery.toLowerCase();
     return skills.filter((s) => subFilter(lowerQuery, s.name.toLowerCase()));
   }, [skills, debouncedQuery]);
+
+  const filteredAgents = allFilteredAgents.slice(0, MAX_DISPLAYED_AGENTS);
+  const filteredSkills = allFilteredSkills.slice(0, MAX_DISPLAYED_SKILLS);
+  const hasMoreAgents = allFilteredAgents.length > MAX_DISPLAYED_AGENTS;
+  const hasMoreSkills = allFilteredSkills.length > MAX_DISPLAYED_SKILLS;
 
   const isLoading =
     isAgentConfigurationsLoading || isSkillsLoading || isDebouncing;
@@ -182,6 +193,8 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
               onSearchQueryChange={setSearchQuery}
               agents={filteredAgents}
               skills={filteredSkills}
+              hasMoreAgents={hasMoreAgents}
+              hasMoreSkills={hasMoreSkills}
               isLoading={isLoading}
               selectedIndex={selectedIndex}
               onSelectedIndexChange={setSelectedIndex}

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -19,6 +19,8 @@ interface CommandPaletteSearchPhaseProps {
   onSearchQueryChange: (query: string) => void;
   agents: LightAgentConfigurationType[];
   skills: SkillType[];
+  hasMoreAgents: boolean;
+  hasMoreSkills: boolean;
   isLoading: boolean;
   selectedIndex: number;
   onSelectedIndexChange: (index: number) => void;
@@ -41,6 +43,8 @@ export function CommandPaletteSearchPhase({
   onSearchQueryChange,
   agents,
   skills,
+  hasMoreAgents,
+  hasMoreSkills,
   isLoading,
   selectedIndex,
   onSelectedIndexChange,
@@ -162,6 +166,11 @@ export function CommandPaletteSearchPhase({
                 </div>
               </ItemRow>
             ))}
+            {hasMoreAgents && (
+              <div className="px-3 py-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
+                More agents available. Type to filter.
+              </div>
+            )}
           </div>
         )}
 
@@ -194,6 +203,11 @@ export function CommandPaletteSearchPhase({
                 </ItemRow>
               );
             })}
+            {hasMoreSkills && (
+              <div className="px-3 py-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
+                More skills available. Type to filter.
+              </div>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Description

Caps the number of displayed items in the command palette to 25 agents and 15 skills to avoid slow DOM rendering on large workspaces with hundreds of agents. When results are truncated, a hint ("Type to see more agents/skills.") is shown at the bottom of each section. The cap is a temporary measure until the command palette moves to Sparkle with proper list virtualization via @tanstack/react-virtual.

The number of rendered items is capped at 25 agents and 15 skills to avoid slow DOM rendering on large workspaces with hundreds of agents. The full dataset is still fetched and filtered client-side so fuzzy search matches are never missed, and the cap only limits what gets painted in the DOM. 

## Tests

Preview app. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
