### PR TITLE
Add DELETE method and body_base64 for binary content

### DIFF
--- a/core/src/http/request.rs
+++ b/core/src/http/request.rs
@@ -162,8 +162,7 @@ impl HttpRequest {
                 let is_text = headers
                     .get(reqwest::header::CONTENT_TYPE)
                     .and_then(|v| v.to_str().ok())
-                    .map(|ct| ct.starts_with("text/"))
-                    .unwrap_or(false);
+                    .is_some_and(|ct| ct.starts_with("text/"));
                 (!is_text).then(|| general_purpose::STANDARD.encode(&b))
             },
         })

--- a/core/src/http/request.rs
+++ b/core/src/http/request.rs
@@ -164,11 +164,7 @@ impl HttpRequest {
                     .and_then(|v| v.to_str().ok())
                     .map(|ct| ct.starts_with("text/"))
                     .unwrap_or(false);
-                if is_text {
-                    None
-                } else {
-                    Some(general_purpose::STANDARD.encode(&b))
-                }
+                (!is_text).then(|| general_purpose::STANDARD.encode(&b))
             },
         })
     }

--- a/core/src/http/request.rs
+++ b/core/src/http/request.rs
@@ -2,6 +2,7 @@ use crate::stores::store::Store;
 use crate::utils;
 use crate::{cached_request::CachedRequest, project::Project};
 use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose, Engine as _};
 use hyper::body::Buf;
 use reqwest::redirect::Policy;
 use reqwest::{header, Method};
@@ -28,6 +29,7 @@ pub struct HttpResponse {
     pub status: u16,
     pub headers: Value,
     pub body: Value,
+    pub body_base64: Option<String>,
 }
 
 impl CachedRequest for HttpRequest {
@@ -68,8 +70,9 @@ impl HttpRequest {
             "POST" => Method::POST,
             "PUT" => Method::PUT,
             "PATCH" => Method::PATCH,
+            "DELETE" => Method::DELETE,
             _ => Err(anyhow!(
-                "Invalid method {}, supported methods are GET, POST, PUT.",
+                "Invalid method {}, supported methods are GET, POST, PUT, PATCH, DELETE.",
                 self.method
             ))?,
         };
@@ -155,6 +158,7 @@ impl HttpRequest {
                 Ok(body) => body,
                 Err(_) => Value::String(response_body),
             },
+            body_base64: Some(general_purpose::STANDARD.encode(&b)),
         })
     }
 

--- a/core/src/http/request.rs
+++ b/core/src/http/request.rs
@@ -158,7 +158,18 @@ impl HttpRequest {
                 Ok(body) => body,
                 Err(_) => Value::String(response_body),
             },
-            body_base64: Some(general_purpose::STANDARD.encode(&b)),
+            body_base64: {
+                let is_text = headers
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .map(|ct| ct.starts_with("text/"))
+                    .unwrap_or(false);
+                if is_text {
+                    None
+                } else {
+                    Some(general_purpose::STANDARD.encode(&b))
+                }
+            },
         })
     }
 

--- a/front/components/app/blocks/Curl.tsx
+++ b/front/components/app/blocks/Curl.tsx
@@ -54,7 +54,7 @@ export default function Curl({
   onBlockDown: () => void;
   onBlockNew: (blockType: BlockType | "map_reduce" | "while_end") => void;
 }>) {
-  const availableMethods = ["GET", "POST", "PUT", "PATCH"];
+  const availableMethods = ["GET", "POST", "PUT", "PATCH", "DELETE"];
 
   const handleSchemeChange = (scheme: string) => {
     const b = shallowBlockClone(block);


### PR DESCRIPTION
## Description

- Support `DELETE` HTTP method in the curl block (core + UI dropdown)
- Add `body_base64` field to `HttpResponse` with the base64-encoded raw response bytes, allowing callers to recover binary content without relying on the lossy UTF-8 body field

## Tests

None

## Risk

Changes are safe to rollback.

Impact: HTTP method dropdown menu + HTTP requests