### PR TITLE
[front] enh: revamp poke killswitch page

### DIFF
--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -1,150 +1,213 @@
+import { cn } from "@app/components/poke/shadcn/lib/utils";
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import type { KillSwitchType } from "@app/lib/poke/types";
+import { KILL_SWITCH_TYPES, type KillSwitchType } from "@app/lib/poke/types";
 import { usePokeKillSwitches } from "@app/poke/swr/kill";
-import { SliderToggle, Spinner } from "@dust-tt/sparkle";
-// biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { useState } from "react";
-import { useSWRConfig } from "swr/_internal";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import {
+  ActionFireIcon,
+  AnthropicLogo,
+  ArrowPathIcon,
+  BoltIcon,
+  CloudArrowLeftRightIcon,
+  Cog6ToothIcon,
+  OpenaiLogo,
+  SliderToggle,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+import { useState } from "react";
 
-const killSwitchMap: Record<
-  KillSwitchType,
-  {
-    title: string;
-    description: string;
-  }
-> = {
+interface KillSwitchDefinition {
+  title: string;
+  description: string;
+  note?: string;
+  icon: ComponentType<{ className?: string }>;
+}
+
+const KILL_SWITCH_DEFINITIONS: Record<KillSwitchType, KillSwitchDefinition> = {
   save_agent_configurations: {
     title: "Agent Configurations",
-    description: "Disable saving of agent configurations",
+    description: "Disable saving of agent configurations.",
+    icon: Cog6ToothIcon,
   },
   save_data_source_views: {
     title: "Data Source Views",
-    description: "Disable saving of data source views",
+    description: "Disable saving of data source views.",
+    icon: CloudArrowLeftRightIcon,
   },
   global_blacklist_anthropic: {
-    title: "Global Blacklist Anthropic",
-    description: "Disable Anthropic models in all agents",
+    title: "Anthropic Models",
+    description: "Disable Anthropic models in all agents.",
+    icon: AnthropicLogo,
   },
   global_blacklist_openai: {
-    title: "Global Blacklist OpenAI",
-    description: "Disable OpenAI models in all agents",
+    title: "OpenAI Models",
+    description: "Disable OpenAI models in all agents.",
+    icon: OpenaiLogo,
   },
   global_disable_firecrawl: {
-    title: "Global Disable Firecrawl",
+    title: "Firecrawl",
     description:
-      "Disable Firecrawl for webbrowse tool, use Spider.cloud instead",
+      "Disable Firecrawl for web browsing and use Spider.cloud instead.",
+    icon: ActionFireIcon,
   },
   global_dust_agents_fallback: {
     title: "Dust Agents Fallback Provider",
     description:
-      "Force dust and deep-dive agents to use non-Anthropic models (OpenAI > Gemini > others). ONLY USE when either latest Sonnet or Opus models are down.",
+      "Force Dust and Deep Dive agents to use non-Anthropic providers.",
+    note: "Use only when the latest Sonnet or Opus models are down.",
+    icon: ArrowPathIcon,
   },
 };
 
 export function KillPage() {
   useDocumentTitle("Poke - Kill Switches");
 
-  const { killSwitches, isKillSwitchesLoading } = usePokeKillSwitches();
-  const [loading, setLoading] = useState(false);
-  const { mutate } = useSWRConfig();
+  const { killSwitches, isKillSwitchesLoading, mutateKillSwitches } =
+    usePokeKillSwitches();
+  const [updatingKillSwitch, setUpdatingKillSwitch] =
+    useState<KillSwitchType | null>(null);
   const sendNotification = useSendNotification();
+  const enabledKillSwitches = new Set(killSwitches);
 
-  async function toggleKillSwitch(killSwitch: KillSwitchType) {
-    if (loading) {
+  async function updateKillSwitch(
+    killSwitch: KillSwitchType,
+    enabled: boolean
+  ): Promise<void> {
+    if (updatingKillSwitch) {
       return;
     }
 
-    setLoading(true);
+    if (
+      enabled &&
+      !window.confirm(
+        `Enable "${KILL_SWITCH_DEFINITIONS[killSwitch].title}" kill switch?`
+      )
+    ) {
+      return;
+    }
 
-    const isEnabled = killSwitches.includes(killSwitch);
+    setUpdatingKillSwitch(killSwitch);
 
-    if (!isEnabled) {
-      if (
-        !window.confirm(
-          `Are you sure you want to enable the ${killSwitchMap[killSwitch].title} kill switch?`
-        )
-      ) {
-        setLoading(false);
+    try {
+      const res = await clientFetch("/api/poke/kill", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          enabled,
+          type: killSwitch,
+        }),
+      });
+
+      if (!res.ok) {
+        const errorData = await res.json();
+        sendNotification({
+          title: "Error updating kill switch",
+          description: errorData.error?.message ?? "Unknown error",
+          type: "error",
+        });
         return;
       }
-    }
 
-    const res = await clientFetch(`/api/poke/kill`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        enabled: !isEnabled,
-        type: killSwitch,
-      }),
-    });
-
-    if (res.ok) {
-      await mutate("/api/poke/kill");
+      await mutateKillSwitches();
       sendNotification({
         title: "Kill switch updated",
-        description: `Kill switch ${killSwitch} updated`,
+        description: `${KILL_SWITCH_DEFINITIONS[killSwitch].title} ${
+          enabled ? "enabled" : "disabled"
+        }.`,
         type: "success",
       });
-    } else {
-      const errorData = await res.json();
-      console.error(errorData);
+    } catch (error) {
       sendNotification({
         title: "Error updating kill switch",
-        description: `Error: ${errorData.error.message}`,
+        description: normalizeError(error).message,
         type: "error",
       });
+    } finally {
+      setUpdatingKillSwitch(null);
     }
-
-    setLoading(false);
   }
 
   return (
-    <main className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-      <div className="py-12">
-        <div className="text-center">
-          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-            System Kill Switches
-          </h1>
-          <p className="mt-2 text-sm text-gray-600">
-            Control critical system functionalities
-          </p>
-        </div>
+    <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+      <header className="space-y-2">
+        <h1 className="flex items-center gap-2.5 text-2xl font-semibold tracking-tight text-foreground dark:text-foreground-night">
+          <BoltIcon className="h-4 w-4 text-muted-foreground dark:text-muted-foreground-night" />
+          <span>Kill switches</span>
+        </h1>
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          Control critical system functionality.
+        </p>
+      </header>
 
-        {isKillSwitchesLoading ? (
+      {isKillSwitchesLoading ? (
+        <div className="flex justify-center py-12">
           <Spinner />
-        ) : (
-          <div className="mx-auto mt-12 max-w-xl">
-            <div className="space-y-6 rounded-lg bg-white p-6 shadow-sm">
-              {Object.entries(killSwitchMap).map(([key, value]) => {
-                return (
-                  <div
-                    className="flex items-center justify-between border-b border-gray-100 py-4"
-                    key={key}
-                  >
-                    <div>
-                      <h3 className="text-sm font-medium text-gray-900">
-                        {value.title}
-                      </h3>
-                      <p className="text-sm text-gray-500">
-                        {value.description}
-                      </p>
-                    </div>
+        </div>
+      ) : (
+        <section
+          className={cn(
+            "mt-6 rounded-2xl border border-border",
+            "bg-background shadow-sm dark:border-border-night dark:bg-background-night"
+          )}
+        >
+          {KILL_SWITCH_TYPES.map((type, index) => {
+            const {
+              title,
+              description,
+              note,
+              icon: Icon,
+            } = KILL_SWITCH_DEFINITIONS[type];
+
+            const isEnabled = enabledKillSwitches.has(type);
+            const isUpdating = updatingKillSwitch === type;
+
+            return (
+              <div
+                key={type}
+                className={cn(
+                  "grid gap-4 p-5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center",
+                  index > 0 && "border-t border-border dark:border-border-night"
+                )}
+              >
+                <div className="space-y-1">
+                  <h2 className="flex items-center gap-3 text-sm font-medium text-foreground dark:text-foreground-night">
+                    <Icon className="h-4 w-4 text-foreground dark:text-foreground-night" />
+                    <span>{title}</span>
+                  </h2>
+
+                  <p className="text-sm leading-6 text-muted-foreground dark:text-muted-foreground-night">
+                    {description}
+                  </p>
+
+                  {note && (
+                    <p className="text-xs leading-5 text-muted-foreground dark:text-muted-foreground-night">
+                      {note}
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex h-7 w-10 items-center justify-center">
+                  {isUpdating ? (
+                    <Spinner size="xs" />
+                  ) : (
                     <SliderToggle
-                      onClick={() => toggleKillSwitch(key as KillSwitchType)}
-                      selected={killSwitches.includes(key as KillSwitchType)}
-                      disabled={loading}
+                      disabled={updatingKillSwitch !== null}
+                      onClick={() => void updateKillSwitch(type, !isEnabled)}
+                      selected={isEnabled}
+                      size="xs"
                     />
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
-      </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </section>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Description

- This PR revamps the UI of the poke page that hosts the kill switches.
- Main goals are to avoid the buggy small toggle and to add dark mode support.

Before

<img width="544" height="654" alt="Screenshot 2026-04-15 at 3 40 04 PM" src="https://github.com/user-attachments/assets/e66c5666-b748-49ac-9024-6ca382b7cd85" />

After

<img width="544" height="654" alt="Screenshot 2026-04-15 at 3 39 49 PM" src="https://github.com/user-attachments/assets/782aca0c-471b-4425-addc-9f55f95ed454" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
