### PR TITLE
Compaction boundary enforcement

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -330,11 +330,19 @@ describe("renderAllMessages", () => {
     });
 
     expect(result).toHaveLength(3);
-    expect(result.map((m) => m.role)).toEqual(["compaction", "user", "assistant"]);
+    expect(result.map((m) => m.role)).toEqual([
+      "compaction",
+      "user",
+      "assistant",
+    ]);
     expect(renderUserMessage).toHaveBeenCalledTimes(1);
     expect(getSteps).toHaveBeenCalledTimes(1);
-    expect((result[0] as { content: string }).content).toContain("Latest summary");
-    expect((result[0] as { content: string }).content).not.toContain("Old summary");
+    expect((result[0] as { content: string }).content).toContain(
+      "Latest summary"
+    );
+    expect((result[0] as { content: string }).content).not.toContain(
+      "Old summary"
+    );
   });
 
   describe("excludeActions", () => {

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -2,6 +2,7 @@ import { renderAllMessages } from "@app/lib/api/assistant/conversation_rendering
 import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentMessageType,
+  CompactionMessageType,
   ConversationType,
   ConversationWithoutContentType,
   UserMessageType,
@@ -57,10 +58,22 @@ describe("renderAllMessages", () => {
   });
 
   function createConversation(
-    messages: Array<{
-      type: "user" | "agent";
-      visibility: "visible" | "deleted";
-    }>
+    messages: Array<
+      | {
+          type: "user";
+          visibility: "visible" | "deleted";
+        }
+      | {
+          type: "agent";
+          visibility: "visible" | "deleted";
+        }
+      | {
+          type: "compaction";
+          visibility: "visible" | "deleted";
+          status: CompactionMessageType["status"];
+          content: string | null;
+        }
+    >
   ): ConversationType {
     const content = messages.map((msg, idx) => {
       if (msg.type === "user") {
@@ -89,7 +102,9 @@ describe("renderAllMessages", () => {
             reactions: [],
           } satisfies UserMessageType,
         ];
-      } else {
+      }
+
+      if (msg.type === "agent") {
         return [
           {
             id: idx + 1,
@@ -125,6 +140,22 @@ describe("renderAllMessages", () => {
           } satisfies AgentMessageType,
         ];
       }
+
+      return [
+        {
+          id: idx + 1,
+          compactionMessageId: idx + 1,
+          created: Date.now(),
+          type: "compaction_message" as const,
+          sId: `compaction_msg_${idx}`,
+          visibility: msg.visibility,
+          version: 1,
+          rank: idx * 2 + 1,
+          branchId: null,
+          status: msg.status,
+          content: msg.content,
+        } satisfies CompactionMessageType,
+      ];
     });
 
     return {
@@ -262,6 +293,48 @@ describe("renderAllMessages", () => {
     });
 
     expect(result).toHaveLength(0);
+  });
+
+  it("should skip messages before the last succeeded compaction boundary", async () => {
+    const conversation = createConversation([
+      { type: "user", visibility: "visible" },
+      { type: "agent", visibility: "visible" },
+      {
+        type: "compaction",
+        visibility: "visible",
+        status: "succeeded",
+        content: "Old summary",
+      },
+      { type: "user", visibility: "visible" },
+      { type: "agent", visibility: "visible" },
+      {
+        type: "compaction",
+        visibility: "visible",
+        status: "failed",
+        content: null,
+      },
+      {
+        type: "compaction",
+        visibility: "visible",
+        status: "succeeded",
+        content: "Latest summary",
+      },
+      { type: "user", visibility: "visible" },
+      { type: "agent", visibility: "visible" },
+    ]);
+
+    const result = await renderAllMessages(auth, {
+      conversation,
+      model,
+      onMissingAction: "skip",
+    });
+
+    expect(result).toHaveLength(3);
+    expect(result.map((m) => m.role)).toEqual(["compaction", "user", "assistant"]);
+    expect(renderUserMessage).toHaveBeenCalledTimes(1);
+    expect(getSteps).toHaveBeenCalledTimes(1);
+    expect((result[0] as { content: string }).content).toContain("Latest summary");
+    expect((result[0] as { content: string }).content).not.toContain("Old summary");
   });
 
   describe("excludeActions", () => {

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -152,8 +152,21 @@ export async function renderAllMessages(
 ): Promise<ModelMessageTypeMultiActions[]> {
   const messages: ModelMessageTypeMultiActions[] = [];
 
-  // Render loop: render all messages and all actions.
-  for (const versions of conversation.content) {
+  // Find the last succeeded compaction to use as a history boundary. Messages before it are
+  // already summarized in the compaction content, so we skip them to avoid redundancy and
+  // reduce token usage.
+  let startIndex = 0;
+  for (let i = conversation.content.length - 1; i >= 0; i--) {
+    const m = conversation.content[i][conversation.content[i].length - 1];
+    if (isCompactionMessageType(m) && m.status === "succeeded") {
+      startIndex = i;
+      break;
+    }
+  }
+
+  // Render loop: render messages from the compaction boundary onward.
+  for (let idx = startIndex; idx < conversation.content.length; idx++) {
+    const versions = conversation.content[idx];
     const m = versions[versions.length - 1];
 
     if (isAgentMessageType(m)) {

--- a/x/spolu/compaction/compaction.md
+++ b/x/spolu/compaction/compaction.md
@@ -29,8 +29,8 @@ Four parts:
    conversation when compaction is completed.
 2. **Token consumption evaluation** — using the LLM's reported token usage from the last agent
    message to determine when compaction should trigger, and surfacing it client-side.
-3. **Compaction method** — a new `compaction` method in `conversation.ts` that triggers
-   compaction through Temporal.
+3. **Compaction method** — a new `compactConversation` method in `conversation.ts` that
+   triggers compaction through Temporal.
 4. **Blocking during compaction** — preventing `postUserMessage` while compaction is in progress,
    similar to steering's pending message mechanism.
 
@@ -60,13 +60,15 @@ A `CompactionMessage` is a fourth variant in the `MessageType` union with its ow
 type CompactionMessageStatus = "created" | "succeeded" | "failed";
 
 type CompactionMessageType = {
-  id: ModelId;
-  sId: string;
   type: "compaction_message";
+  id: ModelId;
+  compactionMessageId: ModelId;
+  sId: string;
   created: number;
+  visibility: MessageVisibility;
   version: number;
   rank: number;
-  branchId: number;
+  branchId: string | null;
 
   // Compaction payload.
   status: CompactionMessageStatus;  // Lifecycle: created → succeeded | failed.
@@ -74,8 +76,8 @@ type CompactionMessageType = {
 };
 ```
 
-`visibility`, `version`, `rank`, `branchId` come from `MessageModel` (same as all other message
-types). `CompactionMessageType` doesn't need its own visibility field.
+`visibility`, `version`, `rank`, and `branchId` come from `MessageModel` (same as all other
+message types) and are serialized on `CompactionMessageType` like the other message variants.
 
 ```
 MessageType = AgentMessageType | UserMessageType | ContentFragmentType | CompactionMessageType
@@ -124,8 +126,9 @@ When rendering the conversation for a model call (`renderConversationForModel`),
 `CompactionMessage` acts as a **history boundary**:
 
 - Messages **before** the compaction message are **not rendered** (they've been summarized).
-- The compaction message itself is rendered as a system or user message containing the summary
-  (similar to Claude Code's post-compact summary message).
+- The compaction message itself is rendered as a dedicated model message with `role:
+  "compaction"`, wrapping the summary in `<compaction_summary>` tags. Provider adapters then
+  convert that role to a user message for the upstream LLM API.
 - Messages **after** the compaction message are rendered normally.
 
 If multiple compaction messages exist (compaction happened more than once), only the **last** one
@@ -211,15 +214,15 @@ token count on-the-fly:
 
 ```
 GET /api/w/[wId]/assistant/conversations/[cId]/context-usage
-→ { promptTokens: number | null, modelContextWindow: number }
+→ { model: SupportedModel, contextUsage: number, contextSize: number }
 ```
 
-The endpoint finds the last succeeded/gracefully-stopped `AgentMessage`, resolves its last run's
-`promptTokens` from `RunResource`, and returns it alongside the model's context window. The client
-can then compute:
+The endpoint finds the last succeeded/gracefully-stopped `AgentMessage`, resolves its latest run
+usage from `RunResource`, takes the max `promptTokens` across usages, and returns it alongside the
+resolved model and its context window. The client can then compute:
 
 ```
-contextUsagePercent = promptTokens / modelContextWindow
+contextUsagePercent = contextUsage / contextSize
 ```
 
 This avoids any client-side token estimation — the number comes directly from the provider's
@@ -229,36 +232,40 @@ usage report, resolved on-the-fly from the existing run data.
 
 ## Part 3: Compaction Method
 
-### `compaction` in `conversation.ts`
+### `compactConversation` in `conversation.ts`
 
-A new method in `front/lib/api/assistant/conversation.ts` that orchestrates compaction through
-Temporal, following the same patterns as `postUserMessage` and
-`updateAgentMessageWithFinalStatus`:
+A new method in `front/lib/api/assistant/conversation.ts` orchestrates compaction through Temporal,
+following the same patterns as `postUserMessage` and `updateAgentMessageWithFinalStatus`:
 
 ```typescript
-export async function compaction(
+export async function compactConversation(
   auth: Authenticator,
   {
     conversation,
+    model,
   }: {
     conversation: ConversationType;
+    model: SupportedModel;
   }
-): Promise<Result<CompactionMessageType, ConversationError>>
+): Promise<
+  Result<{ compactionMessage: CompactionMessageType }, APIErrorWithStatusCode>
+>
 ```
 
 **Flow:**
 
-1. Acquire the conversation advisory lock (`getConversationRankVersionLock`).
-2. Create a `CompactionMessage` with `status: "created"` and `content: null`. This immediately
+1. Reject the request if an agent message or another compaction is already running.
+2. Acquire the conversation advisory lock (`getConversationRankVersionLock`).
+3. Create a `CompactionMessage` with `status: "created"` and `content: null`. This immediately
    signals to the rest of the system that compaction is in progress.
-3. Launch a Temporal workflow (`compactionWorkflow`) that:
+4. Publish a `CompactionMessageNewEvent` on the conversation SSE channel.
+5. Launch a Temporal workflow (`compactionWorkflow`) that:
    a. Reads all messages before the compaction message (or since the last succeeded compaction).
    b. Renders them into a compaction prompt.
    c. Calls an LLM to generate the summary.
    d. Updates the `CompactionMessage` with `status: "succeeded"` and the generated `content`.
    e. On failure, updates to `status: "failed"`.
-4. Publish a `CompactionMessageNewEvent` on the conversation SSE channel (mirrors
-   `AgentMessageNewEvent` pattern).
+6. Return the created `compactionMessage` to the caller.
 
 ### Temporal Workflow
 
@@ -273,7 +280,7 @@ Reasons for a separate workflow (vs inline in finalization):
 - It's independently retryable if the LLM call fails.
 - It cleanly separates the agent loop lifecycle from compaction lifecycle.
 
-The workflow is initially triggered from `compaction()` in `conversation.ts` (called by
+The workflow is initially triggered from `compactConversation()` in `conversation.ts` (called by
 the API endpoint). In the future it could also be triggered directly from the agent loop
 finalization path when context usage exceeds the compaction threshold, similar to how the title
 workflow is spawned as a child workflow after the first step.
@@ -375,33 +382,32 @@ arriving _after_ the context window has been exceeded.
 | 3 | Migration: add `compaction_message` table + `compactionMessageId` FK on `message` table | Update CHECK constraint on MessageModel validation hook |
 | 4 | Handle `"compaction_message"` in all exhaustive switches on `MessageType` | Audit all switch/if-else on message type discrimination |
 
-### Phase 2: Compaction Method & Temporal Workflow
+### Phase 2: Token Consumption Evaluation
 
 | # | Work | Notes |
 |---|------|-------|
-| 5 | Add `compaction` in `conversation.ts` | Advisory lock, create `CompactionMessage` with `status: "created"`, launch Temporal workflow |
-| 6 | Block `postUserMessage` when a `CompactionMessage` with `status: "created"` exists | Return 409, following steering pattern |
-| 7 | Add `CompactionMessageNewEvent` / `CompactionMessageDoneEvent` SSE events | Mirrors `AgentMessageNewEvent` / `AgentMessageDoneEvent` pattern |
-| 8 | Implement `compactionWorkflow` Temporal workflow | Read messages, call LLM, update `CompactionMessage` with content + `status: "succeeded"` |
-| 9 | Implement compaction summary generation prompt | LLM call with compaction prompt (adapt from Claude Code's approach) |
+| 5 | Add a context-usage endpoint | Resolve the latest run usage on-the-fly and return `{ model, contextUsage, contextSize }` |
 
-### Phase 3: Rendering, API & Pruning
+### Phase 3: Compaction Method & Temporal Workflow
 
 | # | Work | Notes |
 |---|------|-------|
-| 10 | Update `renderConversationForModel` to use compaction as history boundary | Skip messages before the last compaction, render summary as context |
-| 11 | Update conversation API endpoints to include `CompactionMessageType` | Serialization, fetching |
-| 12 | Update `groupMessagesIntoInteractions` to account for compaction boundaries | Compaction message starts a new "era" for interaction grouping |
-| 13 | Update context pruning to work with compacted conversations | Pruning should only apply to messages after the compaction boundary |
+| 6 | Add `compactConversation` in `conversation.ts` | Advisory lock, create `CompactionMessage` with `status: "created"`, publish SSE event, launch Temporal workflow |
+| 7 | Block `postUserMessage` when a `CompactionMessage` with `status: "created"` exists | Return 409, following steering pattern |
+| 8 | Add `CompactionMessageNewEvent` / `CompactionMessageDoneEvent` SSE events | Mirrors `AgentMessageNewEvent` / `AgentMessageDoneEvent` pattern |
+| 9 | Implement `compactionWorkflow` Temporal workflow | Read messages, call LLM, update `CompactionMessage` with content + `status: "succeeded"` |
+| 10 | Implement compaction summary generation prompt | LLM call with compaction prompt (adapt from Claude Code's approach) |
 
-### Phase 4: Client-Side Context Usage & UI (pending design)
+### Phase 4: Rendering, API, Pruning & UI (pending design)
 
 | # | Work | Notes |
 |---|------|-------|
-| 14 | Resolve last run's `promptTokens` in agent loop finalization | Add to `AgentMessageSuccessEvent` or `AgentMessageType` |
-| 15 | Surface context usage on conversation API responses | Include latest `promptTokens` + model context window so client can compute % |
-| 16 | Context usage indicator in conversation UI | Progress bar / warning when approaching context limits |
-| 17 | Compaction message rendering in conversation UI | Separator/divider with expandable summary |
+| 11 | Update `renderConversationForModel` to use compaction as history boundary | Skip messages before the last compaction, render the summary as a `role: "compaction"` message |
+| 12 | Update conversation API endpoints to include `CompactionMessageType` | Serialization, fetching |
+| 13 | Update `groupMessagesIntoInteractions` to account for compaction boundaries | Compaction message starts a new boundary for interaction grouping |
+| 14 | Update context pruning to work with compacted conversations | Pruning should only apply to messages after the compaction boundary |
+| 15 | Context usage indicator in conversation UI | Use `{ model, contextUsage, contextSize }` to compute the percentage client-side |
+| 16 | Compaction message rendering in conversation UI | Separator/divider with expandable summary |
 
 ### Phase 5: Future UI/UX Integration
 

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -170,7 +170,7 @@ PR #24293 (combined with 4.1).
 
 ### - [x] PR 5.1 — Context usage indicator in conversation UI
 
-- Use the context-usage endpoint (from PR 2.2) to get `promptTokens` and `modelContextWindow`,
+- Use the context-usage endpoint (from PR 2.1) to get `contextUsage` and `contextSize`,
   compute usage percentage on the client.
 - Display a progress bar or indicator showing context fullness.
 - Show a warning when approaching the compaction threshold.
@@ -188,15 +188,15 @@ PR #24293 (combined with 4.1).
 ### - [x] PR 5.4 — Manual compaction trigger
 
 - Add a UI affordance (button in the context usage indicator, or a `/compact` command) that calls
-  `compaction`.
+  the compaction API.
 - Initially, compaction is user-triggered only — block the input bar once context usage reaches a
   high threshold, prompting the user to compact.
-- API endpoint: `POST /api/w/[wId]/assistant/conversations/[cId]/compact`.
+- API endpoint: `POST /api/w/[wId]/assistant/conversations/[cId]/compactions`.
 
 ### Future: Automatic compaction trigger from agent loop finalization
 
 - In `finalizeSuccessfulAgentLoopActivity` / `finalizeGracefullyStoppedAgentLoopActivity`: after
   storing `promptTokens`, check against `compactionThreshold`. If exceeded, call
-  `launchCompactConversationWorkflow`.
+  `launchCompactionWorkflow`.
 - Requires careful handling of the steering interaction (see "Interaction with Steering" in the
   proposal): steering goes first, compaction runs after. Pruning remains as safety net.

--- a/x/spolu/compaction/plan.md
+++ b/x/spolu/compaction/plan.md
@@ -137,23 +137,32 @@ PR #24111. The LLM call that produces the summary.
 
 Make compaction actually affect what the model sees.
 
-### - [ ] PR 4.1 — Use compaction as history boundary in `renderConversationForModel`
+### - [x] PR 4.1 — Use compaction as history boundary in `renderConversationForModel`
+
+PR #24293 (combined with 4.2).
 
 - In `renderAllMessages()` (`front/lib/api/assistant/conversation_rendering/message_rendering.ts`):
   - Find the last `CompactionMessage` with `status: "succeeded"` in the conversation content.
-  - Skip all messages before it.
-  - Render the compaction summary as a system/user message (the history preamble).
+  - Skip all messages before it (history boundary).
+  - Render the compaction summary via `renderCompactionMessage` (in `helpers.ts`) as a
+    `CompactionMessageTypeModel` with `role: "compaction"` and content wrapped in
+    `<compaction_summary>` tags.
   - Render all messages after it normally.
-- Update `renderConversationForModel` (`conversation_rendering/index.ts`) to account for the
-  compaction boundary when computing token budgets.
+- Added `CompactionMessageTypeModel` (with `role: "compaction"`) to `generation.ts` type unions.
+- All LLM provider converters (Anthropic, OpenAI chat/responses, Google, Mistral) handle
+  `role: "compaction"` by converting to a user message.
+- Tokenization in `conversation_rendering/index.ts` handles the new role.
 
-### - [ ] PR 4.2 — Update interactions and pruning for compacted conversations
+### - [x] PR 4.2 — Update interactions and pruning for compacted conversations
+
+PR #24293 (combined with 4.1).
 
 - In `groupMessagesIntoInteractions` (`front/lib/api/assistant/conversation/interactions.ts`):
-  a compaction message starts a new "era" — interactions before it are not grouped.
-- In `prunePreviousInteractions`: only prune interactions after the compaction boundary (everything
-  before is already hidden by the compaction).
-- Add tests in `interactions.test.ts`.
+  a compaction message acts as an interaction boundary — it closes the current interaction and
+  becomes the first message of the next interaction (grouped with the messages that follow it).
+- Pre-compaction messages are already excluded by the history boundary in `renderAllMessages`,
+  so pruning naturally only operates on post-compaction interactions.
+- 12 tests in `interactions.test.ts` covering boundary behavior.
 
 ---
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7451

Enforce compaction boundary in conversation rendering + test.

## Tests

- Covered by `message_rendering.test.ts`.
- Tested locally, checking conversation renders.

## Risk

Medium. Touches main conversation rendering.

## Deploy Plan

- deploy `front`
