### PR TITLE
Extract conversation next message rank helper

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -469,6 +469,32 @@ async function getConversationRankVersionLock(
   );
 }
 
+async function getNextConversationMessageRank(
+  auth: Authenticator,
+  {
+    conversation,
+    transaction,
+  }: {
+    conversation: ConversationWithoutContentType;
+    transaction: Transaction;
+  }
+): Promise<number> {
+  const owner = auth.getNonNullableWorkspace();
+
+  return (
+    ((await MessageModel.max<number | null, MessageModel>("rank", {
+      where: {
+        workspaceId: owner.id,
+        conversationId: conversation.id,
+        branchId: conversation.branchId
+          ? getResourceIdFromSId(conversation.branchId)
+          : null,
+      },
+      transaction,
+    })) ?? -1) + 1
+  );
+}
+
 export function isUserMessageContextValid(
   auth: Authenticator,
   req: NextApiRequest,
@@ -846,17 +872,10 @@ export async function postUserMessage(
       );
     }
 
-    nextMessageRank ??=
-      ((await MessageModel.max<number | null, MessageModel>("rank", {
-        where: {
-          workspaceId: owner.id,
-          conversationId: conversation.id,
-          branchId: conversation.branchId
-            ? getResourceIdFromSId(conversation.branchId)
-            : null,
-        },
-        transaction: t,
-      })) ?? -1) + 1;
+    nextMessageRank ??= await getNextConversationMessageRank(auth, {
+      conversation,
+      transaction: t,
+    });
 
     // Enrich context with auth data for analytics tracking.
     const enrichedContext: UserMessageContext = {
@@ -1266,17 +1285,10 @@ export async function editUserMessage(
 
         // Only create agent messages if there are no agent messages after the edited user message
         if (!hasAgentMessagesAfter) {
-          const nextMessageRank =
-            ((await MessageModel.max<number | null, MessageModel>("rank", {
-              where: {
-                workspaceId: owner.id,
-                conversationId: conversation.id,
-                branchId: conversation.branchId
-                  ? getResourceIdFromSId(conversation.branchId)
-                  : null,
-              },
-              transaction: t,
-            })) ?? -1) + 1;
+          const nextMessageRank = await getNextConversationMessageRank(auth, {
+            conversation,
+            transaction: t,
+          });
 
           const {
             agentMessages: newAgentMessages,
@@ -1919,17 +1931,10 @@ export async function postNewContentFragment(
           await withTransaction(async (t) => {
             await getConversationRankVersionLock(auth, conversation, t);
 
-            const nextMessageRank =
-              ((await MessageModel.max<number | null, MessageModel>("rank", {
-                where: {
-                  workspaceId: owner.id,
-                  conversationId: conversation.id,
-                  branchId: conversation.branchId
-                    ? getResourceIdFromSId(conversation.branchId)
-                    : null,
-                },
-                transaction: t,
-              })) ?? -1) + 1;
+            const nextMessageRank = await getNextConversationMessageRank(auth, {
+              conversation,
+              transaction: t,
+            });
 
             await MessageModel.create(
               {
@@ -2018,17 +2023,10 @@ export async function postNewContentFragment(
       }
     })();
 
-    const nextMessageRank =
-      ((await MessageModel.max<number | null, MessageModel>("rank", {
-        where: {
-          workspaceId: owner.id,
-          conversationId: conversation.id,
-          branchId: conversation.branchId
-            ? getResourceIdFromSId(conversation.branchId)
-            : null,
-        },
-        transaction: t,
-      })) ?? -1) + 1;
+    const nextMessageRank = await getNextConversationMessageRank(auth, {
+      conversation,
+      transaction: t,
+    });
     const messageRow = await MessageModel.create(
       {
         sId: messageId,
@@ -2631,17 +2629,10 @@ export async function compactConversation(
       return { compactionMessage: null };
     }
 
-    const nextMessageRank =
-      ((await MessageModel.max<number | null, MessageModel>("rank", {
-        where: {
-          workspaceId: owner.id,
-          conversationId: conversation.id,
-          branchId: conversation.branchId
-            ? getResourceIdFromSId(conversation.branchId)
-            : null,
-        },
-        transaction: t,
-      })) ?? -1) + 1;
+    const nextMessageRank = await getNextConversationMessageRank(auth, {
+      conversation,
+      transaction: t,
+    });
 
     const compactionMessage = await createCompactionMessage(auth, {
       conversation,
@@ -2818,19 +2809,6 @@ export async function updateAgentMessageWithFinalStatus(
       }
     );
 
-    const nextMessageRank =
-      ((await MessageModel.max<number | null, MessageModel>("rank", {
-        where: {
-          workspaceId: owner.id,
-          conversationId: conversation.id,
-          branchId: conversation.branchId
-            ? getResourceIdFromSId(conversation.branchId)
-            : null,
-        },
-        transaction: t,
-      })) ?? -1) + 1;
-
-    // Render all promoted user messages.
     const promotedUserMessages = await batchRenderUserMessagesWithoutMentions(
       auth,
       {
@@ -2857,6 +2835,11 @@ export async function updateAgentMessageWithFinalStatus(
     await ConversationResource.markAsUpdated(promotedAuth, {
       conversation,
       t,
+    });
+
+    const nextMessageRank = await getNextConversationMessageRank(auth, {
+      conversation,
+      transaction: t,
     });
 
     // Create a new agent message using the last promoted user message.


### PR DESCRIPTION
## Description

Extract the repeated next-message-rank lookup in `front/lib/api/assistant/conversation.ts` into a shared helper ahead of the steering-during-compaction work.

## Tests

Covered by `conversation.test.ts` + local tests.

## Risk

High. Small refactor with no intended behavior change, but critical code path.

## Deploy Plan

- deploy `front`
