### PR TITLE
Prevent creating a compaction after a compaction message

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -2555,6 +2555,37 @@ describe("compactConversation", () => {
     expect(compactionMessage.content).toBeNull();
   });
 
+  it("should reject compaction when the last message is already a compaction message", async () => {
+    const compactionMessageRow = await CompactionMessageModel.create({
+      status: "succeeded",
+      content: "compacted summary",
+      workspaceId: workspace.id,
+    });
+    await MessageModel.create({
+      sId: generateRandomModelSId(),
+      rank: 0,
+      conversationId: conversation.id,
+      compactionMessageId: compactionMessageRow.id,
+      workspaceId: workspace.id,
+    });
+
+    const fetched = await getConversation(auth, conversation.sId);
+    expect(fetched.isOk()).toBe(true);
+    if (fetched.isErr()) {
+      return;
+    }
+
+    const result = await compactConversation(auth, {
+      conversation: fetched.value,
+      model: { providerId: "anthropic", modelId: "claude-haiku-4-5-20251001" },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(409);
+    }
+  });
+
   it("should reject compaction when an agent message is running", async () => {
     // Insert a user message then an agent message with status "created" (running).
     const { messageRow: userMessageRow } =

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2577,12 +2577,12 @@ export async function compactConversation(
       (m): m is CompactionMessageType =>
         isCompactionMessageType(m) && m.status === "created"
     );
-  const lastConversationMessage = conversation.content.at(-1)?.at(-1);
+  const lastMessage = conversation.content.at(-1)?.at(-1);
 
   if (
     runningAgentMessage ||
     runningCompaction ||
-    (lastConversationMessage && isCompactionMessageType(lastConversationMessage))
+    (lastMessage && isCompactionMessageType(lastMessage))
   ) {
     return new Err({
       status_code: 409,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2577,13 +2577,19 @@ export async function compactConversation(
       (m): m is CompactionMessageType =>
         isCompactionMessageType(m) && m.status === "created"
     );
-  if (runningAgentMessage || runningCompaction) {
+  const lastConversationMessage = conversation.content.at(-1)?.at(-1);
+
+  if (
+    runningAgentMessage ||
+    runningCompaction ||
+    (lastConversationMessage && isCompactionMessageType(lastConversationMessage))
+  ) {
     return new Err({
       status_code: 409,
       api_error: {
         type: "invalid_request_error",
         message:
-          "Cannot compact while another compaction or an agent message is running.",
+          "Cannot compact while another compaction or an agent message is running, or when the last message is already a compaction message.",
       },
     });
   }


### PR DESCRIPTION
## Description

- prevent `compactConversation` from creating a new compaction when the last conversation message is already a compaction message
- add a regression test covering the case where the last message is a completed compaction message

## Tests

- `cd front && NODE_ENV=test npm run test -- lib/api/assistant/conversation.test.ts`

## Risk

- Low. The change only adds a guard before creating a compaction and extends the existing test coverage.

## Deploy Plan

- deploy `front`
