### PR TITLE
[Sessions] Render fork notices in parent conversations

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -601,7 +601,7 @@ export function AgentMessage({
     await deleteAgentMessage(agentMessage.sId);
 
     methods.data.map((m) => {
-      if (m.sId === agentMessage.sId) {
+      if (isAgentMessageWithStreaming(m) && m.sId === agentMessage.sId) {
         return {
           ...m,
           visibility: "deleted",

--- a/front/components/assistant/conversation/ConversationForkNotice.tsx
+++ b/front/components/assistant/conversation/ConversationForkNotice.tsx
@@ -1,0 +1,38 @@
+import type { ConversationForkNoticeMessage } from "@app/components/assistant/conversation/types";
+import { LinkWrapper } from "@app/lib/platform";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { WorkspaceType } from "@app/types/user";
+
+const UNTITLED_CONVERSATION_TITLE = "Untitled conversation";
+
+function getForkingUserDisplayName(
+  message: ConversationForkNoticeMessage
+): string {
+  return message.user.fullName || message.user.username;
+}
+
+export function ConversationForkNotice({
+  message,
+  owner,
+}: {
+  message: ConversationForkNoticeMessage;
+  owner: WorkspaceType;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <div className="h-px flex-1 bg-border dark:bg-border-dark-night" />
+      <div className="min-w-0 break-words text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+        <span>
+          {getForkingUserDisplayName(message)} branched this conversation:{" "}
+        </span>
+        <LinkWrapper
+          href={getConversationRoute(owner.sId, message.childConversationId)}
+          className="text-foreground transition duration-200 hover:underline dark:text-foreground-night"
+        >
+          {message.childConversationTitle ?? UNTITLED_CONVERSATION_TITLE}
+        </LinkWrapper>
+      </div>
+      <div className="h-px flex-1 bg-border dark:bg-border-dark-night" />
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/ConversationViewer.test.ts
+++ b/front/components/assistant/conversation/ConversationViewer.test.ts
@@ -280,14 +280,23 @@ describe("addConversationForkNotices", () => {
       addConversationForkNotices(messages, forkedChildren).map((message) => ({
         type: message.type,
         sId: message.sId,
+        created: message.created,
       }))
     ).toEqual([
-      { type: "user_message", sId: "usr_0" },
-      { type: "agent_message", sId: "agt_1" },
-      { type: "user_message", sId: "usr_2" },
-      { type: "agent_message", sId: "agt_3" },
-      { type: "conversation_fork_notice", sId: "conversation-fork-notice-c_1" },
-      { type: "conversation_fork_notice", sId: "conversation-fork-notice-c_2" },
+      { type: "user_message", sId: "usr_0", created: 0 },
+      { type: "agent_message", sId: "agt_1", created: 1 },
+      { type: "user_message", sId: "usr_2", created: 2 },
+      { type: "agent_message", sId: "agt_3", created: 3 },
+      {
+        type: "conversation_fork_notice",
+        sId: "conversation-fork-notice-c_1",
+        created: 3,
+      },
+      {
+        type: "conversation_fork_notice",
+        sId: "conversation-fork-notice-c_2",
+        created: 3,
+      },
     ]);
   });
 });

--- a/front/components/assistant/conversation/ConversationViewer.test.ts
+++ b/front/components/assistant/conversation/ConversationViewer.test.ts
@@ -1,5 +1,13 @@
-import { getBranchedInsertIndex } from "@app/components/assistant/conversation/ConversationViewer";
+import {
+  addConversationForkNotices,
+  getBranchedInsertIndex,
+} from "@app/components/assistant/conversation/ConversationViewer";
 import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
+import type {
+  ConversationForkedChildType,
+  LightMessageType,
+} from "@app/types/assistant/conversation";
+import type { UserType } from "@app/types/user";
 import { describe, expect, it } from "vitest";
 
 describe("getBranchedInsertIndex", () => {
@@ -165,5 +173,121 @@ describe("getBranchedInsertIndex", () => {
     const index = getBranchedInsertIndex(data, newMessage);
     // Pure rank-based behavior: before first rank > 2 (i.e. before rank 3)
     expect(index).toBe(2);
+  });
+});
+
+describe("addConversationForkNotices", () => {
+  const forkUser: UserType = {
+    sId: "usr_1",
+    id: 1,
+    createdAt: 0,
+    provider: null,
+    username: "clement",
+    email: "clement@dust.tt",
+    firstName: "Clement",
+    lastName: null,
+    fullName: "Clément",
+    image: null,
+    lastLoginAt: null,
+  };
+
+  const makeUserMessage = (sId: string, rank: number): LightMessageType =>
+    ({
+      type: "user_message",
+      sId,
+      id: `${rank}`,
+      created: rank,
+      rank,
+      branchId: null,
+      visibility: "visible",
+      version: 0,
+      user: forkUser,
+      mentions: [],
+      richMentions: [],
+      content: "",
+      context: {
+        username: forkUser.username,
+        fullName: forkUser.fullName,
+        email: forkUser.email,
+        profilePictureUrl: forkUser.image,
+        timezone: "UTC",
+        origin: "web",
+      },
+      reactions: [],
+      contentFragments: [],
+    }) as unknown as LightMessageType;
+
+  const makeAgentMessage = (sId: string, rank: number): LightMessageType =>
+    ({
+      type: "agent_message",
+      sId,
+      id: `${rank}`,
+      agentMessageId: `${rank}`,
+      version: 0,
+      rank,
+      branchId: null,
+      created: rank,
+      completedTs: rank,
+      parentMessageId: `usr_${rank}`,
+      parentAgentMessageId: null,
+      status: "succeeded",
+      content: "done",
+      chainOfThought: null,
+      error: null,
+      visibility: "visible",
+      richMentions: [],
+      completionDurationMs: null,
+      reactions: [],
+      configuration: {
+        sId: "agt_1",
+      },
+      skipToolsValidation: false,
+    }) as unknown as LightMessageType;
+
+  it("inserts fork notices after the source agent message in branch time order", () => {
+    const messages: LightMessageType[] = [
+      makeUserMessage("usr_0", 0),
+      makeAgentMessage("agt_1", 1),
+      makeUserMessage("usr_2", 2),
+      makeAgentMessage("agt_3", 3),
+    ];
+
+    const forkedChildren: ConversationForkedChildType[] = [
+      {
+        childConversationId: "c_2",
+        childConversationTitle: "Later fork",
+        sourceMessageId: "agt_3",
+        branchedAt: 20,
+        user: forkUser,
+      },
+      {
+        childConversationId: "c_1",
+        childConversationTitle: "Earlier fork",
+        sourceMessageId: "agt_3",
+        branchedAt: 10,
+        user: forkUser,
+      },
+      {
+        childConversationId: "c_missing",
+        childConversationTitle: "Missing source",
+        sourceMessageId: "agt_missing",
+        branchedAt: 30,
+        user: forkUser,
+      },
+    ];
+
+    expect(
+      addConversationForkNotices(messages, forkedChildren).map((message) => ({
+        type: message.type,
+        sId: message.sId,
+      }))
+    ).toEqual([
+      { type: "user_message", sId: "usr_0" },
+      { type: "agent_message", sId: "agt_1" },
+      { type: "user_message", sId: "usr_2" },
+      { type: "agent_message", sId: "agt_3" },
+      { type: "conversation_fork_notice", sId: "conversation-fork-notice-c_1" },
+      { type: "conversation_fork_notice", sId: "conversation-fork-notice-c_2" },
+    ]);
   });
 });

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -13,6 +13,7 @@ import {
 } from "@app/components/assistant/conversation/lib";
 import { MessageItem } from "@app/components/assistant/conversation/MessageItem";
 import type {
+  ConversationForkNoticeMessage,
   VirtuosoMessage,
   VirtuosoMessageListContext,
 } from "@app/components/assistant/conversation/types";
@@ -22,6 +23,7 @@ import {
   getPredicateForRankAndBranch,
   isAgentMessageWithStreaming,
   isCompactionMessage,
+  isConversationForkNotice,
   isUserMessage,
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
@@ -53,8 +55,10 @@ import {
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import logger from "@app/logger/logger";
 import {
+  type ConversationForkedChildType,
   type ConversationWithoutContentType,
   isUserMessageTypeWithContentFragments,
+  type LightMessageType,
 } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import {
@@ -160,6 +164,74 @@ export function getBranchedInsertIndex(
   // with a strictly greater rank, or append if none.
   const rankOffset = data.findIndex((m) => m.rank > newMessage.rank);
   return rankOffset === -1 ? data.length : rankOffset;
+}
+
+function makeConversationForkNoticeMessage(
+  rank: number,
+  forkedChild: ConversationForkedChildType
+): ConversationForkNoticeMessage {
+  return {
+    type: "conversation_fork_notice",
+    sId: `conversation-fork-notice-${forkedChild.childConversationId}`,
+    created: forkedChild.branchedAt,
+    rank,
+    branchId: null,
+    visibility: "visible",
+    reactions: [],
+    richMentions: [],
+    sourceMessageId: forkedChild.sourceMessageId,
+    childConversationId: forkedChild.childConversationId,
+    childConversationTitle: forkedChild.childConversationTitle,
+    user: forkedChild.user,
+  };
+}
+
+export function addConversationForkNotices(
+  messages: LightMessageType[],
+  forkedChildren: ConversationForkedChildType[] = []
+): VirtuosoMessage[] {
+  const renderedMessages = convertLightMessageTypeToVirtuosoMessages(messages);
+
+  if (forkedChildren.length === 0) {
+    return renderedMessages;
+  }
+
+  const forkedChildrenBySourceMessageId = new Map<
+    string,
+    ConversationForkedChildType[]
+  >();
+
+  for (const forkedChild of forkedChildren) {
+    const currentChildren =
+      forkedChildrenBySourceMessageId.get(forkedChild.sourceMessageId) ?? [];
+    currentChildren.push(forkedChild);
+    forkedChildrenBySourceMessageId.set(
+      forkedChild.sourceMessageId,
+      currentChildren
+    );
+  }
+
+  const mergedMessages: VirtuosoMessage[] = [];
+
+  for (const message of renderedMessages) {
+    mergedMessages.push(message);
+
+    if (!isAgentMessageWithStreaming(message)) {
+      continue;
+    }
+
+    const forkedChildrenForMessage = [
+      ...(forkedChildrenBySourceMessageId.get(message.sId) ?? []),
+    ].sort((a, b) => a.branchedAt - b.branchedAt);
+
+    mergedMessages.push(
+      ...forkedChildrenForMessage.map((forkedChild) =>
+        makeConversationForkNoticeMessage(message.rank, forkedChild)
+      )
+    );
+  }
+
+  return mergedMessages;
 }
 
 export const ConversationViewer = ({
@@ -279,10 +351,17 @@ export const ConversationViewer = ({
     // Load a conversation A, send a message, answer is streaming (streaming events have a short TTL).
     // Switch to conversation B, wait till A is done streaming, then switch back to A.
     // Without waiting for revalidation, we would use whatever data was in the swr cache and see the last message as "streaming" (old data, no more streaming events).
-    if (!initialListData && messages.length > 0 && !isValidating) {
+    if (
+      !initialListData &&
+      conversation &&
+      messages.length > 0 &&
+      !isValidating
+    ) {
       const raw = messages.flatMap((m) => m.messages);
-
-      const messagesToRender = convertLightMessageTypeToVirtuosoMessages(raw);
+      const messagesToRender = addConversationForkNotices(
+        raw,
+        conversation.forkedChildren
+      );
 
       setInitialListData(messagesToRender);
 
@@ -328,6 +407,7 @@ export const ConversationViewer = ({
     }
   }, [
     initialListData,
+    conversation,
     messages,
     setInitialListData,
     isValidating,
@@ -385,7 +465,10 @@ export const ConversationViewer = ({
 
     if (olderMessagesFromBackend.length > 0) {
       ref.current.data.prepend(
-        convertLightMessageTypeToVirtuosoMessages(olderMessagesFromBackend)
+        addConversationForkNotices(
+          olderMessagesFromBackend,
+          conversation?.forkedChildren
+        )
       );
     }
 
@@ -397,10 +480,13 @@ export const ConversationViewer = ({
 
     if (recentMessagesFromBackend.length > 0) {
       ref.current.data.append(
-        convertLightMessageTypeToVirtuosoMessages(recentMessagesFromBackend)
+        addConversationForkNotices(
+          recentMessagesFromBackend,
+          conversation?.forkedChildren
+        )
       );
     }
-  }, [messages]);
+  }, [conversation?.forkedChildren, messages]);
 
   const { feedbacks } = useConversationFeedbacks({
     conversationId: conversationId ?? "",
@@ -875,12 +961,18 @@ export const ConversationViewer = ({
       data: VirtuosoMessage;
       context: VirtuosoMessageListContext;
     }) => {
+      if (isConversationForkNotice(data)) {
+        return `conversation-${context.conversation?.sId}-${data.sId}`;
+      }
       return `conversation-${context.conversation?.sId}-message-rank-${data.rank}-message-branchId-${data.branchId}`;
     },
     []
   );
 
   const itemIdentity = useCallback((item: VirtuosoMessage) => {
+    if (isConversationForkNotice(item)) {
+      return item.sId;
+    }
     return `message-rank-${item.rank}-message-branchId-${item.branchId}`;
   }, []);
 

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -167,14 +167,14 @@ export function getBranchedInsertIndex(
 }
 
 function makeConversationForkNoticeMessage(
-  rank: number,
+  sourceMessage: VirtuosoMessage,
   forkedChild: ConversationForkedChildType
 ): ConversationForkNoticeMessage {
   return {
     type: "conversation_fork_notice",
     sId: `conversation-fork-notice-${forkedChild.childConversationId}`,
-    created: forkedChild.branchedAt,
-    rank,
+    created: sourceMessage.created,
+    rank: sourceMessage.rank,
     branchId: null,
     visibility: "visible",
     reactions: [],
@@ -186,11 +186,13 @@ function makeConversationForkNoticeMessage(
   };
 }
 
-export function addConversationForkNotices(
-  messages: LightMessageType[],
+function mergeConversationForkNotices(
+  messages: VirtuosoMessage[],
   forkedChildren: ConversationForkedChildType[] = []
 ): VirtuosoMessage[] {
-  const renderedMessages = convertLightMessageTypeToVirtuosoMessages(messages);
+  const renderedMessages = messages.filter(
+    (message) => !isConversationForkNotice(message)
+  );
 
   if (forkedChildren.length === 0) {
     return renderedMessages;
@@ -226,12 +228,22 @@ export function addConversationForkNotices(
 
     mergedMessages.push(
       ...forkedChildrenForMessage.map((forkedChild) =>
-        makeConversationForkNoticeMessage(message.rank, forkedChild)
+        makeConversationForkNoticeMessage(message, forkedChild)
       )
     );
   }
 
   return mergedMessages;
+}
+
+export function addConversationForkNotices(
+  messages: LightMessageType[],
+  forkedChildren: ConversationForkedChildType[] = []
+): VirtuosoMessage[] {
+  return mergeConversationForkNotices(
+    convertLightMessageTypeToVirtuosoMessages(messages),
+    forkedChildren
+  );
 }
 
 export const ConversationViewer = ({
@@ -487,6 +499,42 @@ export const ConversationViewer = ({
       );
     }
   }, [conversation?.forkedChildren, messages]);
+
+  useEffect(() => {
+    if (!ref.current || !ref.current.data.get().length) {
+      return;
+    }
+
+    const currentData = ref.current.data.get();
+    const reconciledData = mergeConversationForkNotices(
+      currentData,
+      conversation?.forkedChildren
+    );
+
+    if (
+      currentData.length === reconciledData.length &&
+      currentData.every(
+        (message, index) => message.sId === reconciledData[index]?.sId
+      )
+    ) {
+      return;
+    }
+
+    while (ref.current.data.get().some(isConversationForkNotice)) {
+      ref.current.data.findAndDelete((message) =>
+        isConversationForkNotice(message)
+      );
+    }
+
+    let index = 0;
+
+    for (const message of reconciledData) {
+      if (isConversationForkNotice(message)) {
+        ref.current.data.insert([message], index);
+      }
+      index += 1;
+    }
+  }, [conversation?.forkedChildren]);
 
   const { feedbacks } = useConversationFeedbacks({
     conversationId: conversationId ?? "",

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -2,6 +2,7 @@ import { AgentMessage } from "@app/components/assistant/conversation/AgentMessag
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
 import { contentFragmentToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import { CompactionMessage } from "@app/components/assistant/conversation/CompactionMessage";
+import { ConversationForkNotice } from "@app/components/assistant/conversation/ConversationForkNotice";
 import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { MentionInvalid } from "@app/components/assistant/conversation/MentionInvalid";
 import { MentionValidationRequired } from "@app/components/assistant/conversation/MentionValidationRequired";
@@ -14,6 +15,7 @@ import {
   getMessageDate,
   isAgentMessageWithStreaming,
   isCompactionMessage,
+  isConversationForkNotice,
   isHiddenMessage,
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
@@ -237,7 +239,11 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       return messageUser;
     }, [isAgentMessage, parentMessageId, messageUser, methods.data]);
 
-    if (!allowBranchMessages && data.branchId) {
+    if (
+      !allowBranchMessages &&
+      data.branchId &&
+      !isConversationForkNotice(data)
+    ) {
       return null;
     }
 
@@ -272,6 +278,25 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
         >
           <CompactionMessage message={data} />
         </div>
+      );
+    }
+
+    if (isConversationForkNotice(data)) {
+      return (
+        <>
+          {!areSameDate && <MessageDateIndicator message={data} />}
+          <div
+            key={`message-id-${sId}`}
+            ref={ref}
+            className={cn(
+              "mx-auto max-w-conversation",
+              topMargin,
+              !nextData && "mb-8"
+            )}
+          >
+            <ConversationForkNotice message={data} owner={context.owner} />
+          </div>
+        </>
       );
     }
 

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -80,6 +80,21 @@ export type AgentMessageWithStreaming = LightAgentMessageWithActionsType & {
   };
 };
 
+export type ConversationForkNoticeMessage = {
+  type: "conversation_fork_notice";
+  sId: string;
+  created: number;
+  rank: number;
+  branchId: null;
+  visibility: "visible";
+  reactions: [];
+  richMentions: [];
+  sourceMessageId: string;
+  childConversationId: string;
+  childConversationTitle: string | null;
+  user: UserType;
+};
+
 export type AgentMessageStateEvent = (
   | AgentMessageEvents
   | ToolNotificationEvent
@@ -92,7 +107,8 @@ export type AgentMessageStateWithControlEvent =
 export type VirtuosoMessage =
   | AgentMessageWithStreaming
   | UserMessageTypeWithContentFragments
-  | CompactionMessageType;
+  | CompactionMessageType
+  | ConversationForkNoticeMessage;
 
 export type VirtuosoMessageListContext = {
   owner: LightWorkspaceType;
@@ -163,6 +179,11 @@ export const isHiddenMessage = (message: VirtuosoMessage): boolean => {
 export const isCompactionMessage = (
   msg: VirtuosoMessage
 ): msg is CompactionMessageType => msg.type === "compaction_message";
+
+export const isConversationForkNotice = (
+  msg: VirtuosoMessage
+): msg is ConversationForkNoticeMessage =>
+  msg.type === "conversation_fork_notice";
 
 export const isUserMessage = (
   msg: VirtuosoMessage

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -3688,4 +3688,117 @@ describe("conversation fetch forkedFrom", () => {
       });
     }
   });
+
+  it("includes forkedChildren in the without-content payload", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Fork Fetch Agent",
+      description: "Fork fetch agent",
+    });
+
+    const parentConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date("2026-01-05T00:00:00.000Z")],
+    });
+    const firstChildConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const secondChildConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+
+    await ConversationModel.update(
+      { title: "Later fork" },
+      { where: { id: firstChildConversation.id, workspaceId: workspace.id } }
+    );
+    await ConversationModel.update(
+      { title: "Earlier fork" },
+      { where: { id: secondChildConversation.id, workspaceId: workspace.id } }
+    );
+
+    const parentConversationResource = await ConversationResource.fetchById(
+      auth,
+      parentConversation.sId
+    );
+    const firstChildConversationResource = await ConversationResource.fetchById(
+      auth,
+      firstChildConversation.sId
+    );
+    const secondChildConversationResource =
+      await ConversationResource.fetchById(auth, secondChildConversation.sId);
+
+    expect(parentConversationResource).not.toBeNull();
+    expect(firstChildConversationResource).not.toBeNull();
+    expect(secondChildConversationResource).not.toBeNull();
+
+    if (
+      !parentConversationResource ||
+      !firstChildConversationResource ||
+      !secondChildConversationResource
+    ) {
+      throw new Error("Failed to fetch fork conversations");
+    }
+
+    const sourceMessage = await MessageModel.findOne({
+      where: {
+        conversationId: parentConversation.id,
+        workspaceId: workspace.id,
+        rank: 1,
+      },
+    });
+    expect(sourceMessage).not.toBeNull();
+    if (!sourceMessage) {
+      throw new Error("Failed to fetch source message");
+    }
+
+    const laterBranchedAt = new Date("2026-01-06T11:00:00.000Z");
+    const earlierBranchedAt = new Date("2026-01-06T10:00:00.000Z");
+
+    await ConversationForkResource.makeNew(auth, {
+      parentConversation: parentConversationResource,
+      childConversation: firstChildConversationResource,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt: laterBranchedAt,
+    });
+    await ConversationForkResource.makeNew(auth, {
+      parentConversation: parentConversationResource,
+      childConversation: secondChildConversationResource,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt: earlierBranchedAt,
+    });
+
+    const expectedForkedChildren = [
+      {
+        childConversationId: secondChildConversation.sId,
+        childConversationTitle: "Earlier fork",
+        sourceMessageId: sourceMessage.sId,
+        branchedAt: earlierBranchedAt.getTime(),
+        user: auth.getNonNullableUser().toJSON(),
+      },
+      {
+        childConversationId: firstChildConversation.sId,
+        childConversationTitle: "Later fork",
+        sourceMessageId: sourceMessage.sId,
+        branchedAt: laterBranchedAt.getTime(),
+        user: auth.getNonNullableUser().toJSON(),
+      },
+    ];
+
+    const conversationWithoutContentResult =
+      await ConversationResource.fetchConversationWithoutContent(
+        auth,
+        parentConversation.sId
+      );
+    expect(conversationWithoutContentResult.isOk()).toBe(true);
+
+    if (conversationWithoutContentResult.isOk()) {
+      expect(conversationWithoutContentResult.value.forkedChildren).toEqual(
+        expectedForkedChildren
+      );
+    }
+  });
 });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -10,7 +10,7 @@ import {
   UserConversationReadsModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
-import "@app/lib/models/agent/conversation_fork";
+import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { REINFORCEMENT_METADATA_KEYS } from "@app/lib/reinforced_agent/types";
 import { REINFORCED_SKILLS_METADATA_KEYS } from "@app/lib/reinforcement/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -24,6 +24,7 @@ import { RunResource } from "@app/lib/resources/run_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
@@ -32,6 +33,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
+  ConversationForkedChildType,
   ConversationForkedFromType,
   ConversationMCPServerViewType,
   ConversationVisibility,
@@ -209,6 +211,106 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   get forkedFromInfo(): ConversationForkedFromType | undefined {
     return this.forkedFromData;
+  }
+
+  static async listReadableForkedChildren(
+    auth: Authenticator,
+    conversation: ConversationResource
+  ): Promise<ConversationForkedChildType[]> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const forks = await ConversationForkModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        parentConversationId: conversation.id,
+      },
+      order: [
+        ["branchedAt", "ASC"],
+        ["id", "ASC"],
+      ],
+      include: [
+        {
+          model: ConversationModel,
+          as: "childConversation",
+          required: true,
+          attributes: ["sId", "title"],
+        },
+        {
+          model: MessageModel,
+          as: "sourceMessage",
+          required: true,
+          attributes: ["sId"],
+        },
+        {
+          model: UserModel,
+          as: "createdByUser",
+          required: true,
+          attributes: [
+            "id",
+            "sId",
+            "createdAt",
+            "provider",
+            "username",
+            "email",
+            "firstName",
+            "lastName",
+            "imageUrl",
+            "lastLoginAt",
+          ],
+        },
+      ],
+    });
+
+    if (forks.length === 0) {
+      return [];
+    }
+
+    const childConversationIds = forks.flatMap((fork) => {
+      assert(
+        fork.childConversation,
+        "Forked child conversation must be loaded for parent lineage."
+      );
+
+      return [fork.childConversation.sId];
+    });
+
+    const readableChildConversationIds = new Set(
+      (await this.fetchByIds(auth, childConversationIds)).map(
+        (childConversation) => childConversation.sId
+      )
+    );
+
+    return forks.flatMap((fork) => {
+      assert(
+        fork.childConversation,
+        "Forked child conversation must be loaded for parent lineage."
+      );
+      assert(
+        fork.sourceMessage,
+        "Forked source message must be loaded for parent lineage."
+      );
+      assert(
+        fork.createdByUser,
+        "Forked creator must be loaded for parent lineage."
+      );
+
+      if (!readableChildConversationIds.has(fork.childConversation.sId)) {
+        return [];
+      }
+
+      return [
+        {
+          childConversationId: fork.childConversation.sId,
+          childConversationTitle: fork.childConversation.title,
+          sourceMessageId: fork.sourceMessage.sId,
+          branchedAt: fork.branchedAt.getTime(),
+          user: new UserResource(
+            UserResource.model,
+            fork.createdByUser.get()
+          ).toJSON(),
+        },
+      ];
+    });
   }
 
   get space(): SpaceResource | null {
@@ -1046,6 +1148,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         auth,
         conversation.id
       );
+    const forkedChildren =
+      await ConversationResource.listReadableForkedChildren(auth, conversation);
 
     return new Ok({
       id: conversation.id,
@@ -1067,6 +1171,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       ...(conversation.forkedFromInfo && {
         forkedFrom: conversation.forkedFromInfo,
       }),
+      ...(forkedChildren.length > 0 && { forkedChildren }),
     });
   }
 

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -147,6 +147,50 @@
  *           type: array
  *           items:
  *             type: string
+ *         forkedChildren:
+ *           type: array
+ *           items:
+ *             type: object
+ *             properties:
+ *               childConversationId:
+ *                 type: string
+ *               childConversationTitle:
+ *                 type: string
+ *                 nullable: true
+ *               sourceMessageId:
+ *                 type: string
+ *               branchedAt:
+ *                 type: integer
+ *               user:
+ *                 type: object
+ *                 properties:
+ *                   sId:
+ *                     type: string
+ *                   id:
+ *                     type: integer
+ *                   createdAt:
+ *                     type: integer
+ *                   provider:
+ *                     type: string
+ *                     nullable: true
+ *                     enum: [auth0, github, google, okta, samlp, waad]
+ *                   username:
+ *                     type: string
+ *                   email:
+ *                     type: string
+ *                   firstName:
+ *                     type: string
+ *                   lastName:
+ *                     type: string
+ *                     nullable: true
+ *                   fullName:
+ *                     type: string
+ *                   image:
+ *                     type: string
+ *                     nullable: true
+ *                   lastLoginAt:
+ *                     type: integer
+ *                     nullable: true
  *     PrivateFullConversation:
  *       type: object
  *       description: Full conversation including content, owner, and visibility.

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -382,6 +382,14 @@ export type ConversationForkedFromType = {
   user: UserType;
 };
 
+export type ConversationForkedChildType = {
+  childConversationId: string;
+  childConversationTitle: string | null;
+  sourceMessageId: string;
+  branchedAt: number;
+  user: UserType;
+};
+
 /**
  * A lighter version of Conversation without the content (for menu display).
  *
@@ -403,6 +411,7 @@ export type ConversationWithoutContentType = {
   metadata: ConversationMetadata;
   branchId: string | null;
   forkedFrom?: ConversationForkedFromType;
+  forkedChildren?: ConversationForkedChildType[];
 
   // Ideally, this property should be moved to the ConversationType.
   requestedSpaceIds: string[];


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24233

Adds the parent-conversation lineage row for readable child forks.
The viewer injects a lightweight notice after the source agent message instead of introducing a new persisted message type.

## Risks
Blast radius: parent conversation rendering for fork lineage notices.
Risk: low

## Deploy Plan
- deploy front