### PR TITLE
[Sessions] Add conversation file copy primitive

### DIFF
--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -321,6 +321,165 @@ describe("FileResource", () => {
       expect(copiedFile.useCaseMetadata?.spaceId).toBe("space-1");
       expect(copiedFile.useCaseMetadata?.conversationId).toBeUndefined();
     });
+
+    it("should copy a conversation file to a different conversation", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const sourceFile = await FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName: "source.txt",
+        fileSize: testFileContent.length,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: {
+          conversationId: "parent-conv-id",
+          generatedTables: ["TABLE:parent"],
+          lastEditedByAgentConfigurationId: "agent-config",
+          sourceConversationId: "origin-conv-id",
+          sourceProvider: "github",
+          sourceIcon: "github",
+          hideFromUser: true,
+        },
+        snippet: "preserved snippet",
+      });
+
+      const result = await FileResource.copyToConversation(auth, {
+        sourceId: sourceFile.sId,
+        conversationId: "child-conv-id",
+      });
+
+      assert(result.isOk(), "copyToConversation should succeed");
+      const copiedFile = result.value;
+
+      expect(copiedFile.sId).not.toBe(sourceFile.sId);
+      expect(copiedFile.useCase).toBe("conversation");
+      expect(copiedFile.snippet).toBe("preserved snippet");
+      expect(copiedFile.useCaseMetadata).toEqual({
+        conversationId: "child-conv-id",
+        sourceConversationId: "origin-conv-id",
+        sourceProvider: "github",
+        sourceIcon: "github",
+        hideFromUser: true,
+      });
+
+      const row = await FileModel.findOne({
+        where: { id: copiedFile.id, workspaceId: workspace.id },
+      });
+      expect(row?.mountFilePath).toBe(
+        `w/${workspace.sId}/conversations/child-conv-id/files/source.txt`
+      );
+    });
+
+    it("should preserve tool_output use case when copying to a conversation", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const sourceFile = await FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName: "output.txt",
+        fileSize: testFileContent.length,
+        status: "ready",
+        useCase: "tool_output",
+        useCaseMetadata: {
+          conversationId: "parent-conv-id",
+          hideFromUser: true,
+        },
+        snippet: "tool output snippet",
+      });
+
+      const result = await FileResource.copyToConversation(auth, {
+        sourceId: sourceFile.sId,
+        conversationId: "child-conv-id",
+      });
+
+      assert(result.isOk(), "copyToConversation should succeed");
+      const copiedFile = result.value;
+
+      expect(copiedFile.useCase).toBe("tool_output");
+      expect(copiedFile.snippet).toBe("tool output snippet");
+      expect(copiedFile.useCaseMetadata).toEqual({
+        conversationId: "child-conv-id",
+        hideFromUser: true,
+      });
+
+      const row = await FileModel.findOne({
+        where: { id: copiedFile.id, workspaceId: workspace.id },
+      });
+      expect(row?.mountFilePath).toBe(
+        `w/${workspace.sId}/conversations/child-conv-id/files/output.txt`
+      );
+    });
+
+    it("should reject non-conversation source use cases", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const sourceFile = await FileFactory.create(auth, null, {
+        contentType: "application/pdf",
+        fileName: "project.pdf",
+        fileSize: 100,
+        status: "ready",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: "space-1" },
+      });
+
+      const result = await FileResource.copyToConversation(auth, {
+        sourceId: sourceFile.sId,
+        conversationId: "child-conv-id",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain(
+          "Only conversation files can be copied to a conversation"
+        );
+      }
+    });
+
+    it("should return error when source file is missing for copyToConversation", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const result = await FileResource.copyToConversation(auth, {
+        sourceId: "non-existent-file-id",
+        conversationId: "child-conv-id",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("Source file not found");
+      }
+    });
+
+    it("should return error when source file is not ready for copyToConversation", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const sourceFile = await FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName: "not-ready.txt",
+        fileSize: 100,
+        status: "created",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "parent-conv-id" },
+      });
+
+      const result = await FileResource.copyToConversation(auth, {
+        sourceId: sourceFile.sId,
+        conversationId: "child-conv-id",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("not ready for copying");
+      }
+    });
   });
 
   describe("mount path resolution", () => {

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -204,6 +204,7 @@ describe("FileResource", () => {
         status: "ready",
         useCase: "conversation",
         useCaseMetadata: { conversationId: "original-conv-id" },
+        snippet: "copied snippet",
       });
 
       // Copy the file.
@@ -222,6 +223,7 @@ describe("FileResource", () => {
       expect(copiedFile.fileName).toBe(sourceFile.fileName);
       expect(copiedFile.fileSize).toBe(sourceFile.fileSize);
       expect(copiedFile.useCase).toBe("project_context");
+      expect(copiedFile.snippet).toBe("copied snippet");
       expect(copiedFile.useCaseMetadata?.conversationId).toBe("new-conv-id");
       expect(copiedFile.isReady).toBe(true);
     });

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -323,7 +323,7 @@ describe("FileResource", () => {
     });
 
     it("should copy a conversation file to a different conversation", async () => {
-      const { authenticator: auth, workspace } = await createResourceTest({
+      const { authenticator: auth } = await createResourceTest({
         role: "admin",
       });
 
@@ -363,17 +363,10 @@ describe("FileResource", () => {
         sourceIcon: "github",
         hideFromUser: true,
       });
-
-      const row = await FileModel.findOne({
-        where: { id: copiedFile.id, workspaceId: workspace.id },
-      });
-      expect(row?.mountFilePath).toBe(
-        `w/${workspace.sId}/conversations/child-conv-id/files/source.txt`
-      );
     });
 
     it("should preserve tool_output use case when copying to a conversation", async () => {
-      const { authenticator: auth, workspace } = await createResourceTest({
+      const { authenticator: auth } = await createResourceTest({
         role: "admin",
       });
 
@@ -404,13 +397,6 @@ describe("FileResource", () => {
         conversationId: "child-conv-id",
         hideFromUser: true,
       });
-
-      const row = await FileModel.findOne({
-        where: { id: copiedFile.id, workspaceId: workspace.id },
-      });
-      expect(row?.mountFilePath).toBe(
-        `w/${workspace.sId}/conversations/child-conv-id/files/output.txt`
-      );
     });
 
     it("should reject non-conversation source use cases", async () => {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1441,6 +1441,66 @@ export class FileResource extends BaseResource<FileModel> {
     return ALL_FILE_FORMATS[this.contentType].isSafeToDisplay;
   }
 
+  private static async fetchReadyFileForCopy(
+    auth: Authenticator,
+    sourceId: string
+  ): Promise<Result<FileResource, Error>> {
+    const sourceFile = await FileResource.fetchById(auth, sourceId);
+    if (!sourceFile) {
+      return new Err(new Error(`Source file not found: ${sourceId}`));
+    }
+
+    if (!sourceFile.isReady) {
+      return new Err(
+        new Error(
+          `Source file is not ready for copying: ${sourceId} (status: ${sourceFile.status})`
+        )
+      );
+    }
+
+    return new Ok(sourceFile);
+  }
+
+  private static async createCopyFromReadyFile(
+    auth: Authenticator,
+    {
+      sourceFile,
+      useCase,
+      useCaseMetadata,
+      snippet,
+    }: {
+      sourceFile: FileResource;
+      useCase: FileUseCase;
+      useCaseMetadata?: FileUseCaseMetadata;
+      snippet?: string | null;
+    }
+  ): Promise<
+    Result<
+      FileResource,
+      Error | { name: "dust_error"; code: string; message: string }
+    >
+  > {
+    try {
+      const newFile = await FileResource.makeNew({
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: auth.user()?.id ?? null,
+        contentType: sourceFile.contentType,
+        fileName: sourceFile.fileName,
+        fileSize: sourceFile.fileSize,
+        useCase,
+        useCaseMetadata,
+        ...(snippet !== undefined ? { snippet } : {}),
+      });
+
+      await copyContent(auth, sourceFile, newFile);
+      await newFile.markAsReady(auth);
+
+      return new Ok(newFile);
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
+  }
+
   /**
    * Copy a file to a new file with the specified use case and metadata.
    * This method copies both the file metadata and the content stored in GCS.
@@ -1469,41 +1529,63 @@ export class FileResource extends BaseResource<FileModel> {
       Error | { name: "dust_error"; code: string; message: string }
     >
   > {
-    // Fetch the source file.
-    const sourceFile = await FileResource.fetchById(auth, sourceId);
-    if (!sourceFile) {
-      return new Err(new Error(`Source file not found: ${sourceId}`));
+    const sourceFileRes = await this.fetchReadyFileForCopy(auth, sourceId);
+    if (sourceFileRes.isErr()) {
+      return sourceFileRes;
     }
 
-    if (!sourceFile.isReady) {
+    return this.createCopyFromReadyFile(auth, {
+      sourceFile: sourceFileRes.value,
+      useCase,
+      useCaseMetadata,
+    });
+  }
+
+  static async copyToConversation(
+    auth: Authenticator,
+    {
+      sourceId,
+      conversationId,
+    }: {
+      sourceId: string;
+      conversationId: string;
+    }
+  ): Promise<
+    Result<
+      FileResource,
+      Error | { name: "dust_error"; code: string; message: string }
+    >
+  > {
+    const sourceFileRes = await this.fetchReadyFileForCopy(auth, sourceId);
+    if (sourceFileRes.isErr()) {
+      return sourceFileRes;
+    }
+
+    const sourceFile = sourceFileRes.value;
+    if (!isConversationFileUseCase(sourceFile.useCase)) {
       return new Err(
         new Error(
-          `Source file is not ready for copying: ${sourceId} (status: ${sourceFile.status})`
+          `Only conversation files can be copied to a conversation: ${sourceId} (useCase: ${sourceFile.useCase})`
         )
       );
     }
 
-    try {
-      // Create a new file with the same properties.
-      const newFile = await FileResource.makeNew({
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: auth.user()?.id ?? null,
-        contentType: sourceFile.contentType,
-        fileName: sourceFile.fileName,
-        fileSize: sourceFile.fileSize,
-        useCase,
-        useCaseMetadata,
-      });
+    const {
+      conversationId: _sourceConversationId,
+      generatedTables: _generatedTables,
+      lastEditedByAgentConfigurationId: _lastEditedByAgentConfigurationId,
+      ...restMetadata
+    } = sourceFile.useCaseMetadata ?? {};
 
-      await copyContent(auth, sourceFile, newFile);
-
-      // Mark the new file as ready.
-      await newFile.markAsReady(auth);
-
-      return new Ok(newFile);
-    } catch (error) {
-      return new Err(normalizeError(error));
-    }
+    return this.createCopyFromReadyFile(auth, {
+      sourceFile,
+      useCase: sourceFile.useCase,
+      useCaseMetadata: {
+        ...restMetadata,
+        conversationId,
+      },
+      snippet: sourceFile.snippet,
+    });
   }
 }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1461,46 +1461,6 @@ export class FileResource extends BaseResource<FileModel> {
     return new Ok(sourceFile);
   }
 
-  private static async createCopyFromReadyFile(
-    auth: Authenticator,
-    {
-      sourceFile,
-      useCase,
-      useCaseMetadata,
-      snippet,
-    }: {
-      sourceFile: FileResource;
-      useCase: FileUseCase;
-      useCaseMetadata?: FileUseCaseMetadata;
-      snippet?: string | null;
-    }
-  ): Promise<
-    Result<
-      FileResource,
-      Error | { name: "dust_error"; code: string; message: string }
-    >
-  > {
-    try {
-      const newFile = await FileResource.makeNew({
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: auth.user()?.id ?? null,
-        contentType: sourceFile.contentType,
-        fileName: sourceFile.fileName,
-        fileSize: sourceFile.fileSize,
-        useCase,
-        useCaseMetadata,
-        ...(snippet !== undefined ? { snippet } : {}),
-      });
-
-      await copyContent(auth, sourceFile, newFile);
-      await newFile.markAsReady(auth);
-
-      return new Ok(newFile);
-    } catch (error) {
-      return new Err(normalizeError(error));
-    }
-  }
-
   /**
    * Copy a file to a new file with the specified use case and metadata.
    * This method copies both the file metadata and the content stored in GCS.
@@ -1534,11 +1494,26 @@ export class FileResource extends BaseResource<FileModel> {
       return sourceFileRes;
     }
 
-    return this.createCopyFromReadyFile(auth, {
-      sourceFile: sourceFileRes.value,
-      useCase,
-      useCaseMetadata,
-    });
+    try {
+      const sourceFile = sourceFileRes.value;
+      const newFile = await FileResource.makeNew({
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: auth.user()?.id ?? null,
+        contentType: sourceFile.contentType,
+        fileName: sourceFile.fileName,
+        fileSize: sourceFile.fileSize,
+        useCase,
+        useCaseMetadata,
+        snippet: sourceFile.snippet,
+      });
+
+      await copyContent(auth, sourceFile, newFile);
+      await newFile.markAsReady(auth);
+
+      return new Ok(newFile);
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
   }
 
   static async copyToConversation(
@@ -1577,14 +1552,13 @@ export class FileResource extends BaseResource<FileModel> {
       ...restMetadata
     } = sourceFile.useCaseMetadata ?? {};
 
-    return this.createCopyFromReadyFile(auth, {
-      sourceFile,
+    return this.copy(auth, {
+      sourceId,
       useCase: sourceFile.useCase,
       useCaseMetadata: {
         ...restMetadata,
         conversationId,
       },
-      snippet: sourceFile.snippet,
     });
   }
 }

--- a/x/pr/branching.md
+++ b/x/pr/branching.md
@@ -113,6 +113,8 @@ filesystem / MCP version without rewriting the fork flow.
 
 #### 4. UI Surfaces
 
+This stream adds:
+
 - the `Branch conversation` action in the conversation menu
 - the `Branch conversation` action in the per-message menu
 - the lightweight lineage surface in the child conversation
@@ -275,6 +277,7 @@ Scope:
 - add `Branch conversation` to the per-message menu
 - add the lightweight "Branched from ..." UI in the child conversation
 - add the lightweight "XXX branched this conversation: " UI in the parent conversation
+- wire the UI to the backend endpoint
 
 #### 5: Switch Fork Initialization to Shipped Compaction
 

--- a/x/pr/branching.md
+++ b/x/pr/branching.md
@@ -39,7 +39,7 @@ At fork time:
 - we persist an explicit lineage row between parent and child
 - we seed the child with the parent's conversation-level setup that the forking user can read
 - we deep-copy the parent conversation files / filesystem into the child
-- we initialize the child with a compaction message at the top of the child
+- we initialize the child with a placeholder message today, then switch to a compaction message
 - we leave the parent unchanged
 
 For the first version, lineage is surfaced as a parent link in the forked
@@ -59,7 +59,7 @@ fragments would start the child from an incomplete state.
 
 ### Multiple Streams
 
-Changes naturally split into 4 streams.
+Changes naturally split into 5 streams.
 
 #### 1. Fork Lineage and Creation
 
@@ -73,7 +73,8 @@ existing intra-conversation branch feature.
 #### 2. Fork Checkpoint / Compaction Integration
 
 This stream is responsible for the message injected at the top of the child
-conversation.
+conversation. Compaction messages now render in the main conversation UI, but
+fork creation still uses a temporary placeholder user message today.
 
 The target design uses the compaction flow from the parallel compaction proposal:
 
@@ -85,18 +86,16 @@ The target design uses the compaction flow from the parallel compaction proposal
 - the child remains blocked for posting while the initial compaction is in the
   `created` state
 
-Until compaction ships, the fork flow can use an artificial compaction
-placeholder internally. That placeholder reuses the rendered
-conversation-for-model view at the resolved source message of the parent
-conversation and stores it as the initial message in the child, explicitly
-stating that it is a forked starting point.
+The current placeholder path simply posts a visible user message in the child
+linking back to the parent conversation. This keeps the flow user-visible while
+the fork-specific compaction entry point is still pending.
 
 Compaction happens after the fork is created. We never compact the
 parent conversation as part of the fork action.
 
 This placeholder path exists only to unblock internal development and
-integration work while compaction is still in flight. Before release, fork
-initialization switches to the shipped compaction flow.
+integration work. Before release, fork initialization should switch to the
+shipped compaction flow.
 
 #### 3. Filesystem and File Seeding
 
@@ -113,10 +112,15 @@ filesystem / MCP version without rewriting the fork flow.
 
 #### 4. UI Surfaces
 
-This stream adds:
+This stream now mostly covers the remaining lineage surfaces.
+
+Already shipped:
 
 - the `Branch conversation` action in the conversation menu
 - the `Branch conversation` action in the per-message menu
+
+Remaining:
+
 - the lightweight lineage surface in the child conversation
 - the lightweight lineage surface in the parent conversation
 
@@ -158,7 +162,7 @@ The fork flow is:
 2. resolve the source message if the UI did not specify one, and validate that
    it is an agent message
 3. create the child conversation in the same space/project
-4. copy readable conversation-level setup from the parent and recompute child access requirements from what was actually copied
+4. copy readable conversation-level setup from the parent
 5. persist the lineage row with `branchedAt`
 6. seed the child files / filesystem
 7. create the initial compaction message in the child
@@ -171,9 +175,9 @@ In the target design, step 7 uses the real compaction shape:
 - the child remains blocked for posting until the compaction status leaves
   `created`
 
-Until compaction ships, step 7 uses an artificial placeholder with the same
-product role: the placeholder reuses the conversation rendering for model at
-the resolved source message and explicitly states that it is a forked message.
+Current behavior uses a temporary user message that links back to the parent
+conversation. The target design still switches this to a real compaction
+message.
 
 The child carries forward:
 
@@ -183,14 +187,18 @@ The child carries forward:
 - the parent's conversation skills that the forking user can read
 - the copied files / filesystem state that the forking user can read
 
-The child access model is derived from the setup, tools, skills, and data that
-were actually copied into the child.
+The target child access model is derived from the setup, tools, skills, and
+data that were actually copied into the child.
 
-That means:
+Current implementation is simpler:
 
-- we do not blindly copy the parent's `requestedSpaceIds`
-- we recompute child access requirements from the copied setup and files
-- the child inherits access rights from the resources it is actually given
+- we currently preserve the parent's `requestedSpaceIds`
+- we do not yet recompute child access requirements from copied setup or files
+
+Target behavior remains:
+
+- recompute child access requirements from the copied setup and files
+- have the child inherit access rights from the resources it is actually given
 
 The child does not inherit:
 
@@ -252,8 +260,18 @@ Scope:
 - respect compaction blocking semantics in the child when real compaction is
   available
 
-Until compaction is shipped, this uses the artificial
-placeholder behind the same fork initialization seam.
+Current implementation has shipped in a flagged internal form with:
+
+- the private fork endpoint
+- parent source-message resolution
+- child conversation creation
+- MCP server view copy
+- skill copy
+- title suffixing
+- the temporary initialization message
+
+Until the compaction switch lands, this keeps using the placeholder behind the
+same fork initialization seam.
 
 This lands before filesystem seeding is complete as long as the feature
 remains internal / flagged. That gives us a usable backend slice for text-only
@@ -263,8 +281,10 @@ conversations and lets compaction work proceed in parallel.
 
 Scope:
 
+- add a `FileResource.copyToConversation(...)` hard-copy primitive
 - implement hard-copy seeding of conversation files into the child
 - remap child file metadata
+- seed the child conversation datasource from the copied child files
 - ensure child mount paths / filesystem state are isolated
 
 This is the part most exposed to the ongoing filesystem rework.
@@ -273,11 +293,10 @@ This is the part most exposed to the ongoing filesystem rework.
 
 Scope:
 
-- add `Branch conversation` to the conversation menu
-- add `Branch conversation` to the per-message menu
 - add the lightweight "Branched from ..." UI in the child conversation
 - add the lightweight "XXX branched this conversation: " UI in the parent conversation
-- wire the UI to the backend endpoint
+
+The menu and per-message actions are already shipped.
 
 #### 5: Switch Fork Initialization to Shipped Compaction
 
@@ -290,8 +309,8 @@ Scope:
 Why separate:
 
 - compaction is already being developed independently
-- this keeps the forking work moving internally without blocking on compaction
-  shipping
+- compaction rendering is now shipped, but the fork flow still needs to switch
+  off the placeholder path
 - this is the release gate for broad exposure of the feature
 
 ### Non-Goals for the First Version

--- a/x/pr/branching.md
+++ b/x/pr/branching.md
@@ -39,7 +39,7 @@ At fork time:
 - we persist an explicit lineage row between parent and child
 - we seed the child with the parent's conversation-level setup that the forking user can read
 - we deep-copy the parent conversation files / filesystem into the child
-- we initialize the child with a placeholder message today, then switch to a compaction message
+- we initialize the child with a compaction message at the top of the child
 - we leave the parent unchanged
 
 For the first version, lineage is surfaced as a parent link in the forked
@@ -59,7 +59,7 @@ fragments would start the child from an incomplete state.
 
 ### Multiple Streams
 
-Changes naturally split into 5 streams.
+Changes naturally split into 4 streams.
 
 #### 1. Fork Lineage and Creation
 
@@ -73,8 +73,7 @@ existing intra-conversation branch feature.
 #### 2. Fork Checkpoint / Compaction Integration
 
 This stream is responsible for the message injected at the top of the child
-conversation. Compaction messages now render in the main conversation UI, but
-fork creation still uses a temporary placeholder user message today.
+conversation.
 
 The target design uses the compaction flow from the parallel compaction proposal:
 
@@ -86,16 +85,18 @@ The target design uses the compaction flow from the parallel compaction proposal
 - the child remains blocked for posting while the initial compaction is in the
   `created` state
 
-The current placeholder path simply posts a visible user message in the child
-linking back to the parent conversation. This keeps the flow user-visible while
-the fork-specific compaction entry point is still pending.
+Until compaction ships, the fork flow can use an artificial compaction
+placeholder internally. That placeholder reuses the rendered
+conversation-for-model view at the resolved source message of the parent
+conversation and stores it as the initial message in the child, explicitly
+stating that it is a forked starting point.
 
 Compaction happens after the fork is created. We never compact the
 parent conversation as part of the fork action.
 
 This placeholder path exists only to unblock internal development and
-integration work. Before release, fork initialization should switch to the
-shipped compaction flow.
+integration work while compaction is still in flight. Before release, fork
+initialization switches to the shipped compaction flow.
 
 #### 3. Filesystem and File Seeding
 
@@ -112,15 +113,8 @@ filesystem / MCP version without rewriting the fork flow.
 
 #### 4. UI Surfaces
 
-This stream now mostly covers the remaining lineage surfaces.
-
-Already shipped:
-
 - the `Branch conversation` action in the conversation menu
 - the `Branch conversation` action in the per-message menu
-
-Remaining:
-
 - the lightweight lineage surface in the child conversation
 - the lightweight lineage surface in the parent conversation
 
@@ -162,7 +156,7 @@ The fork flow is:
 2. resolve the source message if the UI did not specify one, and validate that
    it is an agent message
 3. create the child conversation in the same space/project
-4. copy readable conversation-level setup from the parent
+4. copy readable conversation-level setup from the parent and recompute child access requirements from what was actually copied
 5. persist the lineage row with `branchedAt`
 6. seed the child files / filesystem
 7. create the initial compaction message in the child
@@ -175,9 +169,9 @@ In the target design, step 7 uses the real compaction shape:
 - the child remains blocked for posting until the compaction status leaves
   `created`
 
-Current behavior uses a temporary user message that links back to the parent
-conversation. The target design still switches this to a real compaction
-message.
+Until compaction ships, step 7 uses an artificial placeholder with the same
+product role: the placeholder reuses the conversation rendering for model at
+the resolved source message and explicitly states that it is a forked message.
 
 The child carries forward:
 
@@ -187,18 +181,14 @@ The child carries forward:
 - the parent's conversation skills that the forking user can read
 - the copied files / filesystem state that the forking user can read
 
-The target child access model is derived from the setup, tools, skills, and
-data that were actually copied into the child.
+The child access model is derived from the setup, tools, skills, and data that
+were actually copied into the child.
 
-Current implementation is simpler:
+That means:
 
-- we currently preserve the parent's `requestedSpaceIds`
-- we do not yet recompute child access requirements from copied setup or files
-
-Target behavior remains:
-
-- recompute child access requirements from the copied setup and files
-- have the child inherit access rights from the resources it is actually given
+- we do not blindly copy the parent's `requestedSpaceIds`
+- we recompute child access requirements from the copied setup and files
+- the child inherits access rights from the resources it is actually given
 
 The child does not inherit:
 
@@ -260,18 +250,8 @@ Scope:
 - respect compaction blocking semantics in the child when real compaction is
   available
 
-Current implementation has shipped in a flagged internal form with:
-
-- the private fork endpoint
-- parent source-message resolution
-- child conversation creation
-- MCP server view copy
-- skill copy
-- title suffixing
-- the temporary initialization message
-
-Until the compaction switch lands, this keeps using the placeholder behind the
-same fork initialization seam.
+Until compaction is shipped, this uses the artificial
+placeholder behind the same fork initialization seam.
 
 This lands before filesystem seeding is complete as long as the feature
 remains internal / flagged. That gives us a usable backend slice for text-only
@@ -281,10 +261,8 @@ conversations and lets compaction work proceed in parallel.
 
 Scope:
 
-- add a `FileResource.copyToConversation(...)` hard-copy primitive
 - implement hard-copy seeding of conversation files into the child
 - remap child file metadata
-- seed the child conversation datasource from the copied child files
 - ensure child mount paths / filesystem state are isolated
 
 This is the part most exposed to the ongoing filesystem rework.
@@ -293,10 +271,10 @@ This is the part most exposed to the ongoing filesystem rework.
 
 Scope:
 
+- add `Branch conversation` to the conversation menu
+- add `Branch conversation` to the per-message menu
 - add the lightweight "Branched from ..." UI in the child conversation
 - add the lightweight "XXX branched this conversation: " UI in the parent conversation
-
-The menu and per-message actions are already shipped.
 
 #### 5: Switch Fork Initialization to Shipped Compaction
 
@@ -309,8 +287,8 @@ Scope:
 Why separate:
 
 - compaction is already being developed independently
-- compaction rendering is now shipped, but the fork flow still needs to switch
-  off the placeholder path
+- this keeps the forking work moving internally without blocking on compaction
+  shipping
 - this is the release gate for broad exposure of the feature
 
 ### Non-Goals for the First Version


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24156 and https://github.com/dust-tt/dust/pull/24213.
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

Adds `FileResource.copyToConversation(...)` as the hard-copy primitive for the upcoming fork file seeding work.

## Risks
Blast radius: conversation file copy primitive
Risk: low

## Deploy Plan
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/resources/file_resource.test.ts`
