### PR TITLE
feat: use pinact to pin github actions to sha1

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -68,14 +68,14 @@ runs:
   steps:
     - id: "auth"
       name: "Authenticate to Google Cloud"
-      uses: "google-github-actions/auth@v3.0.0"
+      uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # v3.0.0
       with:
         create_credentials_file: true
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: "github-build-invoker@${{ inputs.project_id }}.iam.gserviceaccount.com"
 
     - name: "Configure GCP Artifact Auth"
-      uses: "google-github-actions/setup-gcloud@v3.0.1"
+      uses: "google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db" # v3.0.1
       with:
         install_components: "docker-credential-gcr"
 
@@ -90,7 +90,7 @@ runs:
         gcloud storage cp gs://bkt-dust-infra-model-configs/custom.json front/custom-models.json 2>/dev/null || echo '{"models":[]}' > front/custom-models.json
 
     - name: "Setup Depot"
-      uses: "depot/setup-action@v1.7.1"
+      uses: "depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461" # v1.7.1
 
     - name: "Build and Push"
       shell: bash

--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v6.3.0
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{ inputs.node-version }}
 
@@ -31,7 +31,7 @@ runs:
 
     - name: Cache node_modules
       id: cache-node-modules
-      uses: actions/cache@v5.0.5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           node_modules

--- a/.github/actions/slack-check-deployment-blocked/action.yml
+++ b/.github/actions/slack-check-deployment-blocked/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Get channel info
       id: slack_channel_info
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         method: conversations.info
         token: ${{ inputs.slack_token }}

--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -67,7 +67,7 @@ runs:
     - name: Lookup by email
       if: inputs.step == 'start' || inputs.step == 'spa_start'
       id: email
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         errors: false
         method: users.lookupByEmail
@@ -90,7 +90,7 @@ runs:
     - name: Notify Build And Deploy Start
       if: inputs.step == 'start'
       id: start_notification
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
@@ -169,7 +169,7 @@ runs:
 
     - name: Notify Build Success
       if: inputs.step == 'build_success'
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
@@ -178,7 +178,7 @@ runs:
     - name: Notify SPA Deploy Start
       if: inputs.step == 'spa_start'
       id: spa_start_notification
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
@@ -194,7 +194,7 @@ runs:
 
     - name: Notify SPA Preview Uploaded
       if: inputs.step == 'spa_preview_success'
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
@@ -207,7 +207,7 @@ runs:
 
     - name: Notify SPA Deployed to Production
       if: inputs.step == 'spa_production_success'
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}
@@ -220,7 +220,7 @@ runs:
 
     - name: Notify Deploy Failure
       if: inputs.step == 'failure'
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_token }}

--- a/.github/workflows/assign-issues-to-eng-runner.yml
+++ b/.github/workflows/assign-issues-to-eng-runner.yml
@@ -17,7 +17,7 @@ jobs:
     name: Assign to EngRunner project
     steps:
       - name: Assign new issues to project 2 (eng runner)
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: 'https://github.com/orgs/dust-tt/projects/2'
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/build-and-lint-dust-hive.yml
+++ b/.github/workflows/build-and-lint-dust-hive.yml
@@ -17,8 +17,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: oven-sh/setup-bun@v2.2.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - name: Install dependencies
         working-directory: x/henry/dust-hive
         run: bun install --frozen-lockfile
@@ -29,8 +29,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: oven-sh/setup-bun@v2.2.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - name: Install dependencies
         working-directory: x/henry/dust-hive
         run: bun install --frozen-lockfile
@@ -41,8 +41,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: oven-sh/setup-bun@v2.2.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - name: Install dependencies
         working-directory: x/henry/dust-hive
         run: bun install --frozen-lockfile

--- a/.github/workflows/build-and-test-connectors.yml
+++ b/.github/workflows/build-and-test-connectors.yml
@@ -16,7 +16,7 @@ jobs:
   tsgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -32,7 +32,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -55,7 +55,7 @@ jobs:
         run: npx tsx src/admin/db.ts && npm run test:ci
       - name: Build Tests Report
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.0
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
         with:
           report_paths: "**/connectors/junit*.xml"
           detailed_summary: true

--- a/.github/workflows/build-and-test-core.yml
+++ b/.github/workflows/build-and-test-core.yml
@@ -15,10 +15,10 @@ jobs:
       core-changed: ${{ steps.changes.outputs.core }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check for relevant changes
-        uses: dorny/paths-filter@v4.0.1
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           base: ${{ github.event.repository.default_branch }}
@@ -46,15 +46,15 @@ jobs:
     if: needs.check-changes.outputs.core-changed == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
         with:
           components: rustfmt
 
       - name: Install Redis
-        uses: chenjuneking/redis-setup-action@v1
+        uses: chenjuneking/redis-setup-action@36d2a503dcaa6984bb9331708770438c4d323f88 # v1
         with:
           version: "7.2.5"
           hostPort: 5434
@@ -71,12 +71,12 @@ jobs:
           postgresql port: 5433
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3.0.0
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Rust Cache
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: core
 

--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -33,7 +33,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -61,7 +61,7 @@ jobs:
         run: npx tsx admin/db.ts && npm run test:ci -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --outputFile=junit-shard-${{ matrix.shardIndex }}.xml
       - name: Build Tests Report
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.0
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
         with:
           report_paths: "front/junit-shard-${{ matrix.shardIndex }}.xml"
           detailed_summary: true
@@ -71,7 +71,7 @@ jobs:
   tsgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -88,7 +88,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-canary-image.yml
+++ b/.github/workflows/build-canary-image.yml
@@ -50,7 +50,7 @@ jobs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
       long_sha: ${{ steps.short_sha.outputs.long_sha }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get short sha
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -64,7 +64,7 @@ jobs:
     outputs:
       thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Notify Build And Deploy Start
         id: build_message
@@ -102,7 +102,7 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 50 # Fetch last 50 commits for commit diff functionality
 

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install build dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/build-dust-sandbox.yml
+++ b/.github/workflows/build-dust-sandbox.yml
@@ -15,10 +15,10 @@ jobs:
       dust-sandbox-changed: ${{ steps.changes.outputs.dust-sandbox }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check for relevant changes
-        uses: dorny/paths-filter@v4.0.1
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           base: ${{ github.event.repository.default_branch }}
@@ -46,15 +46,15 @@ jobs:
     if: needs.check-changes.outputs.dust-sandbox-changed == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
         with:
           components: rustfmt
 
       - name: Setup Rust Cache
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: cli/dust-sandbox
 

--- a/.github/workflows/build-egress-proxy.yml
+++ b/.github/workflows/build-egress-proxy.yml
@@ -15,10 +15,10 @@ jobs:
       egress-proxy-changed: ${{ steps.changes.outputs.egress-proxy }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check for relevant changes
-        uses: dorny/paths-filter@v4.0.1
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           base: ${{ github.event.repository.default_branch }}
@@ -46,10 +46,10 @@ jobs:
     if: needs.check-changes.outputs.egress-proxy-changed == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
         with:
           components: clippy, rustfmt
 
@@ -57,7 +57,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y openssl
 
       - name: Setup Rust Cache
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: egress-proxy
 

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -18,7 +18,7 @@ jobs:
   tsgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-spa.yaml
+++ b/.github/workflows/build-spa.yaml
@@ -17,7 +17,7 @@ jobs:
   tsgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-sparkle.yml
+++ b/.github/workflows/build-sparkle.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/build-viz.yml
+++ b/.github/workflows/build-viz.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,7 +17,7 @@ jobs:
       # Determine if we should run the review
       - name: Determine if review should run
         id: should-run
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           result-encoding: string
@@ -33,7 +33,7 @@ jobs:
       # Only proceed if the label is added.
       - name: Checkout code
         if: steps.should-run.outputs.result == 'true'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Fetch full history for accurate diffs
 
@@ -48,7 +48,7 @@ jobs:
       - name: Run Code Review with Claude
         if: steps.should-run.outputs.result == 'true'
         id: code-review
-        uses: anthropics/claude-code-action@v1.0.96
+        uses: anthropics/claude-code-action@5fb899572b81d2bb648d4d187173a2f423a9677c # v1.0.96
         with:
           # Define the review focus areas
           direct_prompt: >-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Full depth for better git operations
 
       # Setup Node.js for JS/TS projects
       - name: Setup Node.js
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22.22.0
 
@@ -45,7 +45,7 @@ jobs:
 
       # Setup Rust for core project
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
         with:
           components: rustfmt
 
@@ -60,7 +60,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.96
+        uses: anthropics/claude-code-action@5fb899572b81d2bb648d4d187173a2f423a9677c # v1.0.96
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/.github/workflows/deploy-docs-openapi.yml
+++ b/.github/workflows/deploy-docs-openapi.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run `openapi` command 🚀
-        uses: readmeio/rdme@v10.6.2
+        uses: readmeio/rdme@3c41af599df44e516c90ba4107a81c05d4945822 # v10.6.2
         with:
           rdme: openapi front/public/swagger.json --version=v1.1 --key=${{ secrets.README_API_KEY }} --id=66cee36af1922700458e4678

--- a/.github/workflows/deploy-spa-preview.yaml
+++ b/.github/workflows/deploy-spa-preview.yaml
@@ -29,7 +29,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment preview URL on PR
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const marker = '<!-- spa-preview-app -->';

--- a/.github/workflows/deploy-spa-production.yaml
+++ b/.github/workflows/deploy-spa-production.yaml
@@ -32,7 +32,7 @@ jobs:
           || format('["{0}"]', github.event.client_payload.app || inputs.app)
           ) }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
@@ -53,7 +53,7 @@ jobs:
           echo "Promoting version: ${VERSION_ID}"
 
       - name: Promote version to production
-        uses: cloudflare/wrangler-action@v3.14.1
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Create deploy tag
         if: ${{ github.event.client_payload.sha && github.event.client_payload.image_tag }}
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const tag = `refs/tags/spa/${{ matrix.app }}/${{ github.event.client_payload.image_tag }}`;

--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -80,7 +80,7 @@ jobs:
     outputs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get short sha
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -92,7 +92,7 @@ jobs:
     outputs:
       thread_ts: ${{ inputs.thread_ts || steps.build_message.outputs.thread_ts }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Notify SPA Deploy Start
         if: ${{ !inputs.thread_ts }}
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
@@ -184,7 +184,7 @@ jobs:
 
       - name: Upload version
         id: upload_version
-        uses: cloudflare/wrangler-action@v3.14.1
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,7 @@ jobs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
       long_sha: ${{ steps.short_sha.outputs.long_sha }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get short sha
         id: short_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -103,7 +103,7 @@ jobs:
     outputs:
       thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Notify Build And Deploy Start
         id: build_message
@@ -150,7 +150,7 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 50 # Fetch last 50 commits for commit diff functionality
 
@@ -218,11 +218,11 @@ jobs:
     if: ${{ !failure() && !cancelled() && inputs.component != 'egress-proxy' && (needs.ensure-sandbox-images.result == 'success' || needs.ensure-sandbox-images.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@v3.1.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.INFRA_DISPATCH_APP_ID }}
           private-key: ${{ secrets.INFRA_DISPATCH_APP_PRIVATE_KEY }}
@@ -230,7 +230,7 @@ jobs:
           repositories: dust-infra
 
       - name: Trigger dust-infra workflow
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           OWNER: ${{ github.repository_owner }}
           COMPONENT: ${{ inputs.component }}

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -28,8 +28,8 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6.3.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22.22.0
           cache: "npm"

--- a/.github/workflows/label-pmrr.yml
+++ b/.github/workflows/label-pmrr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add PMRR label
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.issues.addLabels({

--- a/.github/workflows/list-tags.yaml
+++ b/.github/workflows/list-tags.yaml
@@ -53,14 +53,14 @@ jobs:
 
       - id: "auth"
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v3.0.0"
+        uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # v3.0.0
         with:
           create_credentials_file: true
           workload_identity_provider: "projects/357744735673/locations/global/workloadIdentityPools/github-pool-apps/providers/github-provider-apps"
           service_account: "github-build-invoker@${{ steps.project.outputs.PROJECT_ID }}.iam.gserviceaccount.com"
 
       - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v3.0.1"
+        uses: "google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db" # v3.0.1
 
       - name: List available tags
         run: |

--- a/.github/workflows/node24-compat.yml
+++ b/.github/workflows/node24-compat.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -47,7 +47,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -75,7 +75,7 @@ jobs:
         run: npx tsx admin/db.ts && npm run test:ci -- --outputFile=junit.xml
       - name: Build Tests Report
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.0
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
         with:
           report_paths: "front/junit.xml"
           detailed_summary: true
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
@@ -125,7 +125,7 @@ jobs:
         run: npx tsx src/admin/db.ts && npm run test:ci
       - name: Build Tests Report
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.0
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
         with:
           report_paths: "**/connectors/junit*.xml"
           detailed_summary: true

--- a/.github/workflows/package-extension-preview.yaml
+++ b/.github/workflows/package-extension-preview.yaml
@@ -26,7 +26,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment artifact link on PR
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const marker = '<!-- package-extension-preview-chrome -->';
@@ -71,7 +71,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment artifact link on PR
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const marker = '<!-- package-extension-preview-firefox -->';

--- a/.github/workflows/package-extension.yaml
+++ b/.github/workflows/package-extension.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
@@ -65,7 +65,7 @@ jobs:
         run: echo "name=$(basename *.zip .zip)-${{ steps.short_sha.outputs.short_sha }}" >> $GITHUB_OUTPUT
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.artifact.outputs.name }}
           path: extension/platforms/${{ contains(inputs.target, 'chrome') && 'chrome' || contains(inputs.target, 'firefox') && 'firefox' || 'front' }}/build/

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -18,8 +18,8 @@ jobs:
     # This ensures the workflow only runs on main branch
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6.3.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22.22.0"
           cache: "npm"

--- a/.github/workflows/publish-sdk-client.yml
+++ b/.github/workflows/publish-sdk-client.yml
@@ -18,8 +18,8 @@ jobs:
     # This ensures the workflow only runs on main branch
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-node@v6.3.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22.22.0"
           cache: "npm"

--- a/.github/workflows/release-dsbx-cli.yml
+++ b/.github/workflows/release-dsbx-cli.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
 
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross
@@ -45,7 +45,7 @@ jobs:
           sha256sum dsbx-linux-x86_64 > checksums-sha256.txt
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3.0.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: dsbx-v${{ steps.version.outputs.version }}
           name: dsbx v${{ steps.version.outputs.version }}

--- a/.github/workflows/release-sandbox-tool.yml
+++ b/.github/workflows/release-sandbox-tool.yml
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codex repo at pinned tag
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: openai/codex
           ref: ${{ inputs.codex_tag }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
 
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross
@@ -50,7 +50,7 @@ jobs:
           sha256sum apply_patch-linux-x86_64 > checksums-sha256.txt
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3.0.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: apply-patch-v${{ inputs.apply_patch_version }}
           name: apply_patch v${{ inputs.apply_patch_version }}

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -65,7 +65,7 @@ jobs:
     outputs:
       thread_ts: ${{ steps.build_message.outputs.thread_ts }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Notify Start
         id: build_message
@@ -103,7 +103,7 @@ jobs:
         region: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
       fail-fast: true
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set project ID
         id: project
@@ -116,14 +116,14 @@ jobs:
 
       - id: "auth"
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v3.0.0"
+        uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # v3.0.0
         with:
           create_credentials_file: true
           workload_identity_provider: "projects/357744735673/locations/global/workloadIdentityPools/github-pool-apps/providers/github-provider-apps"
           service_account: "github-build-invoker@${{ steps.project.outputs.PROJECT_ID }}.iam.gserviceaccount.com"
 
       - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v3.0.1"
+        uses: "google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db" # v3.0.1
 
       - name: Validate image tag exists
         run: |
@@ -160,11 +160,11 @@ jobs:
     needs: [notify-start, validate-image]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@v3.1.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.INFRA_DISPATCH_APP_ID }}
           private-key: ${{ secrets.INFRA_DISPATCH_APP_PRIVATE_KEY }}
@@ -172,7 +172,7 @@ jobs:
           repositories: dust-infra
 
       - name: Trigger dust-infra workflow
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |

--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sandbox-bedrock-release.yml
+++ b/.github/workflows/sandbox-bedrock-release.yml
@@ -26,13 +26,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3.1.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.SPARKLE_RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.SPARKLE_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -58,7 +58,7 @@ jobs:
           echo "version=$NEXT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3.0.0
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: "projects/357744735673/locations/global/workloadIdentityPools/github-pool-apps/providers/github-provider-apps"
           service_account: "github-build-invoker@or1g1n-186209.iam.gserviceaccount.com"
@@ -68,7 +68,7 @@ jobs:
           gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
       - name: Setup Depot
-        uses: depot/setup-action@v1.7.1
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 
       - name: Build and push
         env:

--- a/.github/workflows/sandbox-img-registry.yml
+++ b/.github/workflows/sandbox-img-registry.yml
@@ -25,7 +25,7 @@ jobs:
       has-missing: ${{ steps.check.outputs.has-missing }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
@@ -64,7 +64,7 @@ jobs:
       matrix: ${{ fromJson(needs.check.outputs.build-matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps


### PR DESCRIPTION
## Description

It is a good manner to pin GitHub Actions versions by commit hash. GitHub tags are mutable so they have a substantial security and reliability risk.

Used [pinact](https://github.com/suzuki-shunsuke/pinact) to do this by running `pinact run`
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
