### PR TITLE
test(project-todo): add dedup-evals framework for TODO deduplication regression tests

### DIFF
--- a/front/lib/project_todo/deduplicate_candidates.ts
+++ b/front/lib/project_todo/deduplicate_candidates.ts
@@ -138,7 +138,7 @@ function buildDeduplicationPrompt(
 // existing TODO, or an empty map on failure (treat all candidates as new).
 // Precondition: all candidates must share the same category — batchDeduplicateCandidates
 // enforces this by grouping on makeDedupGroupKey before calling here.
-async function runDeduplicationLLMCall(
+export async function runDeduplicationLLMCall(
   auth: Authenticator,
   {
     model,

--- a/front/tests/dedup-evals/README.md
+++ b/front/tests/dedup-evals/README.md
@@ -1,0 +1,120 @@
+# TODO Deduplication Evaluation Tests
+
+End-to-end eval suite for the project TODO semantic deduplication pipeline. Tests whether
+`runDeduplicationLLMCall` correctly identifies when new candidate TODOs are semantic duplicates
+of existing ones.
+
+Each test case checks two things:
+
+- **Deterministic assertions** — per-candidate match checks (e.g., "candidate 0 should match
+  existing TODO X", "candidate 1 should be new").
+- **LLM-as-judge** — a separate LLM scores the quality of the dedup decisions against
+  scenario-specific criteria.
+
+## Architecture
+
+```
+tests/dedup-evals/
+├── README.md                          # This file
+├── vite.config.mjs                    # Test runner configuration
+├── dedup-eval.test.ts                 # Main Vitest entry point
+├── lib/
+│   ├── types.ts                       # Test case schema + assertion helpers
+│   ├── config.ts                      # Env vars, auth, model setup
+│   ├── assertions.ts                  # Deterministic per-candidate match validators
+│   ├── judge.ts                       # LLM-as-judge evaluation
+│   └── dedup-executor.ts             # Calls real runDeduplicationLLMCall
+└── test-suites/
+    ├── index.ts                       # Exports allTestSuites array
+    └── todo-deduplication.ts          # Deduplication scenario definitions
+```
+
+### Layers
+
+**Layer 1 — Scenario definition** (`lib/types.ts`, `test-suites/`)
+
+Test scenarios are plain TypeScript objects defining existing TODOs (sId + text), new candidates
+(itemId + text + category), and expected match outcomes. No database is involved.
+
+**Layer 2 — Execution** (`lib/dedup-executor.ts`)
+
+Calls the real `runDeduplicationLLMCall` from `@app/lib/project_todo/deduplicate_candidates`,
+passing lightweight mock objects for `ProjectTodoResource`. This tests the full pipeline: prompt
+building, LLM call, and response parsing.
+
+**Layer 3 — Scoring** (`lib/assertions.ts` + `lib/judge.ts`)
+
+Two independent scoring mechanisms:
+- Deterministic assertions: `shouldMatchExisting(candidateIndex, existingSId)` and
+  `shouldBeNew(candidateIndex)` — structural checks on the returned `Map<number, string>`.
+- LLM-as-judge: a separate model (gpt-5-mini) scores the dedup decisions 0–3 against
+  scenario-specific criteria, with majority voting over N runs.
+
+**Layer 4 — Test runner** (`dedup-eval.test.ts`)
+
+Vitest-based, gated by `RUN_DEDUP_EVAL` env var. Each scenario runs concurrently via streaming.
+Fails if either scoring mechanism doesn't meet the threshold.
+
+### Mock strategy
+
+`runDeduplicationLLMCall` only accesses `.sId` and `.text` on existing TODO objects (for prompt
+building). The executor casts minimal `{ sId, text }` objects as `ProjectTodoResource` to avoid
+any database dependency — matching the reinforcement-evals pattern of keeping evals DB-free.
+
+### Scenario types
+
+| Scenario | Description |
+|---|---|
+| `exact-duplicate` | Candidate text nearly identical to existing TODO |
+| `semantic-duplicate` | Same task, different wording |
+| `genuinely-new` | Unrelated candidate alongside existing TODOs |
+| `partial-overlap-distinct` | Related but distinct tasks (should NOT match) |
+| `mixed-batch` | Multiple candidates: some duplicates, some new |
+| `many-existing-one-match` | Many existing TODOs, candidate matches exactly one |
+| `key-decision-dedup` | `to_know` category: equivalent decisions with different wording |
+
+## Quick start
+
+```bash
+# Run all dedup eval tests
+NODE_ENV=test \
+  TEST_FRONT_DATABASE_URI="$FRONT_DATABASE_URI"_test \
+  RUN_DEDUP_EVAL=true \
+  npm run test -- tests/dedup-evals/dedup-eval.test.ts --config tests/dedup-evals/vite.config.mjs
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `RUN_DEDUP_EVAL` | `false` | Set to `true` to enable the tests (skipped otherwise). |
+| `DEDUP_MODEL_ID` | `claude-sonnet-4-6` | Model used for the deduplication LLM calls. |
+| `JUDGE_RUNS` | `3` | Number of judge evaluations per test (majority vote). |
+| `PASS_THRESHOLD` | `2` | Minimum judge score (0–3) required to pass. |
+| `FILTER_CATEGORY` | _(all)_ | Run only tests in the given category (suite name). |
+| `FILTER_SCENARIO` | _(all)_ | Run only the test with the given scenario ID. |
+| `VERBOSE` | `false` | Set to `true` to log match maps and response text. |
+| `DUST_MANAGED_ANTHROPIC_API_KEY` | — | Anthropic API key (required for Claude models). |
+| `DUST_MANAGED_OPENAI_API_KEY` | — | OpenAI API key (required for GPT judge model). |
+
+## Adding a new scenario
+
+1. Open `test-suites/todo-deduplication.ts`
+2. Add a new entry to the `testCases` array:
+   ```ts
+   {
+     scenarioId: "my-new-scenario",
+     category: "to_do",
+     existingTodos: [
+       { sId: "existing-1", text: "Set up CI/CD pipeline" },
+     ],
+     candidates: [
+       { itemId: "candidate-0", text: "Configure automated deployments" },
+     ],
+     expectedMatches: [
+       shouldMatchExisting(0, "existing-1"),
+     ],
+     judgeCriteria: `The candidate describes the same task as the existing TODO...`,
+   }
+   ```
+3. Run the tests to verify.

--- a/front/tests/dedup-evals/dedup-eval.test.ts
+++ b/front/tests/dedup-evals/dedup-eval.test.ts
@@ -1,0 +1,116 @@
+import type { Authenticator } from "@app/lib/auth";
+import { validateDedupAssertion } from "@app/tests/dedup-evals/lib/assertions";
+import {
+  FILTER_SCENARIO,
+  getDedupEvalAuth,
+  JUDGE_RUNS,
+  PASS_THRESHOLD,
+  RUN_DEDUP_EVAL,
+  TIMEOUT_MS,
+  VERBOSE,
+} from "@app/tests/dedup-evals/lib/config";
+import { executeDedup } from "@app/tests/dedup-evals/lib/dedup-executor";
+import { evaluateWithJudge } from "@app/tests/dedup-evals/lib/judge";
+import { filterTestCases } from "@app/tests/dedup-evals/lib/suite-loader";
+import {
+  type CategorizedDedupTestCase,
+  formatMatchMap,
+} from "@app/tests/dedup-evals/lib/types";
+import { allTestSuites } from "@app/tests/dedup-evals/test-suites";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("openai", async (importOriginal) => {
+  const actual = await importOriginal();
+  // @ts-expect-error actual is unknown
+  const OriginalOpenAI = actual.OpenAI;
+  class OpenAIWithBrowserSupport extends OriginalOpenAI {
+    constructor(config: ConstructorParameters<typeof OriginalOpenAI>[0]) {
+      super({ ...config, dangerouslyAllowBrowser: true });
+    }
+  }
+  return { ...(actual as object), OpenAI: OpenAIWithBrowserSupport };
+});
+
+vi.mock("@anthropic-ai/sdk", async (importOriginal) => {
+  const actual = await importOriginal();
+  // @ts-expect-error actual is unknown
+  const OriginalAnthropic = actual.default;
+  class AnthropicWithBrowserSupport extends OriginalAnthropic {
+    constructor(config: ConstructorParameters<typeof OriginalAnthropic>[0]) {
+      super({ ...config, dangerouslyAllowBrowser: true });
+    }
+  }
+  return { ...(actual as object), default: AnthropicWithBrowserSupport };
+});
+
+const testCases = RUN_DEDUP_EVAL
+  ? filterTestCases(allTestSuites, {
+      scenarioId: FILTER_SCENARIO,
+    })
+  : [];
+
+const testGroups = new Map<string, Map<string, CategorizedDedupTestCase>>();
+for (const testCase of testCases) {
+  if (!testGroups.has(testCase.suiteName)) {
+    testGroups.set(testCase.suiteName, new Map());
+  }
+  testGroups.get(testCase.suiteName)!.set(testCase.scenarioId, testCase);
+}
+
+describe.skipIf(!RUN_DEDUP_EVAL)("TODO Deduplication Evaluation Tests", () => {
+  let auth: Authenticator;
+
+  beforeAll(async () => {
+    auth = await getDedupEvalAuth();
+  }, TIMEOUT_MS);
+
+  for (const [suiteName, scenarios] of testGroups) {
+    describe(suiteName, () => {
+      for (const [scenarioId, testCase] of scenarios) {
+        it.concurrent(
+          scenarioId,
+          async () => {
+            const { matchMap } = await executeDedup(auth, testCase);
+
+            if (VERBOSE) {
+              console.log(
+                `[${scenarioId}] Match map: ${formatMatchMap(matchMap)}`
+              );
+            }
+
+            const judgeResult = await evaluateWithJudge(
+              auth,
+              testCase,
+              matchMap,
+              JUDGE_RUNS
+            );
+
+            if (VERBOSE) {
+              console.log(
+                `[${scenarioId}] Judge Result:`,
+                JSON.stringify(judgeResult, null, 2)
+              );
+            }
+
+            const passedJudge = judgeResult.finalScore >= PASS_THRESHOLD;
+            const matchSummary = formatMatchMap(matchMap);
+
+            for (const assertion of testCase.expectedMatches) {
+              const result = validateDedupAssertion(assertion, matchMap);
+              expect(
+                result.success,
+                `${!result.success ? result.error : ""}\n\nMatch map: [${matchSummary}]`
+              ).toBe(true);
+            }
+
+            expect(
+              passedJudge,
+              `Judge score ${judgeResult.finalScore} < threshold ${PASS_THRESHOLD}\nReasoning: ${judgeResult.reasoning}\n\nMatch map: [${matchSummary}]`
+            ).toBe(true);
+          },
+          TIMEOUT_MS
+        );
+      }
+    });
+  }
+});

--- a/front/tests/dedup-evals/lib/assertions.ts
+++ b/front/tests/dedup-evals/lib/assertions.ts
@@ -1,0 +1,40 @@
+import type { DedupAssertion } from "@app/tests/dedup-evals/lib/types";
+
+type AssertionResult = { success: true } | { success: false; error: string };
+
+/**
+ * Validate a single dedup assertion against the actual match map.
+ */
+export function validateDedupAssertion(
+  assertion: DedupAssertion,
+  matchMap: Map<number, string>
+): AssertionResult {
+  switch (assertion.type) {
+    case "shouldMatchExisting": {
+      const actualSId = matchMap.get(assertion.candidateIndex);
+      if (!actualSId) {
+        return {
+          success: false,
+          error: `Expected candidate[${assertion.candidateIndex}] to match existing "${assertion.existingSId}", but no match was found (treated as new)`,
+        };
+      }
+      if (actualSId !== assertion.existingSId) {
+        return {
+          success: false,
+          error: `Expected candidate[${assertion.candidateIndex}] to match "${assertion.existingSId}", but it matched "${actualSId}" instead`,
+        };
+      }
+      return { success: true };
+    }
+    case "shouldBeNew": {
+      const actualSId = matchMap.get(assertion.candidateIndex);
+      if (actualSId) {
+        return {
+          success: false,
+          error: `Expected candidate[${assertion.candidateIndex}] to be new, but it was matched to "${actualSId}"`,
+        };
+      }
+      return { success: true };
+    }
+  }
+}

--- a/front/tests/dedup-evals/lib/config.ts
+++ b/front/tests/dedup-evals/lib/config.ts
@@ -1,0 +1,32 @@
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { isModelId } from "@app/types/assistant/models/models";
+import type { ModelIdType } from "@app/types/assistant/models/types";
+
+export const RUN_DEDUP_EVAL = process.env.RUN_DEDUP_EVAL === "true";
+export const JUDGE_RUNS = parseInt(process.env.JUDGE_RUNS ?? "3", 10);
+export const PASS_THRESHOLD = parseInt(process.env.PASS_THRESHOLD ?? "2", 10);
+export const FILTER_SCENARIO = process.env.FILTER_SCENARIO;
+export const VERBOSE = process.env.VERBOSE === "true";
+
+/** Model used for the deduplication LLM calls. */
+function resolveModelId(): ModelIdType {
+  const id =
+    process.env.DEDUP_MODEL_ID || CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG.modelId;
+  if (!isModelId(id)) {
+    throw new Error(
+      `Invalid DEDUP_MODEL_ID: "${id}". Must be a known model ID.`
+    );
+  }
+  return id;
+}
+
+export const MODEL_ID = resolveModelId();
+
+export const TIMEOUT_MS = 300_000;
+
+export async function getDedupEvalAuth(): Promise<Authenticator> {
+  const workspace = await WorkspaceFactory.basic();
+  return Authenticator.internalAdminForWorkspace(workspace.sId);
+}

--- a/front/tests/dedup-evals/lib/dedup-executor.ts
+++ b/front/tests/dedup-evals/lib/dedup-executor.ts
@@ -1,0 +1,62 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  type DeduplicateCandidate,
+  runDeduplicationLLMCall,
+} from "@app/lib/project_todo/deduplicate_candidates";
+import type { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { MODEL_ID } from "@app/tests/dedup-evals/lib/config";
+import type {
+  DedupExecutionResult,
+  DedupTestCase,
+} from "@app/tests/dedup-evals/lib/types";
+import SUPPORTED_MODEL_CONFIGS from "@app/types/assistant/models/models";
+
+/**
+ * Build a lightweight mock that satisfies the fields runDeduplicationLLMCall
+ * accesses on ProjectTodoResource: `.sId` and `.text`.
+ */
+function buildMockExistingTodos(
+  testCase: DedupTestCase
+): ProjectTodoResource[] {
+  return testCase.existingTodos.map(
+    (t) =>
+      ({
+        sId: t.sId,
+        text: t.text,
+      }) as unknown as ProjectTodoResource
+  );
+}
+
+function buildCandidates(testCase: DedupTestCase): DeduplicateCandidate[] {
+  return testCase.candidates.map((c) => ({
+    itemId: c.itemId,
+    // userId is not used in the prompt — just needs to be a valid ModelId.
+    userId: 1 as unknown as number,
+    text: c.text,
+    category: "to_do",
+  }));
+}
+
+/**
+ * Execute a single dedup eval scenario by calling the real
+ * `runDeduplicationLLMCall` with mock data.
+ */
+export async function executeDedup(
+  auth: Authenticator,
+  testCase: DedupTestCase
+): Promise<DedupExecutionResult> {
+  const model = SUPPORTED_MODEL_CONFIGS.find((m) => m.modelId === MODEL_ID);
+  if (!model) {
+    throw new Error(`Model "${MODEL_ID}" not found in SUPPORTED_MODEL_CONFIGS`);
+  }
+  const existingTodos = buildMockExistingTodos(testCase);
+  const candidates = buildCandidates(testCase);
+
+  const matchMap = await runDeduplicationLLMCall(auth, {
+    model,
+    candidates,
+    existingTodos,
+  });
+
+  return { matchMap };
+}

--- a/front/tests/dedup-evals/lib/judge.ts
+++ b/front/tests/dedup-evals/lib/judge.ts
@@ -1,0 +1,140 @@
+import { getLLM } from "@app/lib/api/llm";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  type DedupTestCase,
+  formatMatchMap,
+  getTestCaseInputForDisplay,
+  type JudgeResult,
+} from "@app/tests/dedup-evals/lib/types";
+
+const JUDGE_PROMPT = `You are evaluating the quality of a TODO deduplication system's decisions.
+
+The system receives a list of existing TODOs and new candidate TODOs, and decides which candidates
+are semantic duplicates of existing ones. Two items are duplicates when they describe the same task
+or decision, regardless of wording differences.
+
+## Scoring Rubric
+
+- 0: Major errors — matched unrelated items, or missed obvious duplicates
+- 1: Partially correct — some matches right but missed important duplicates or made false matches
+- 2: Good with minor issues — mostly correct, perhaps debatable on one borderline case
+- 3: Excellent — all match/no-match decisions are correct and well-reasoned
+
+You MUST provide your response in this exact format:
+
+REASONING: <your detailed analysis>
+SCORE: <number>
+
+Where <number> is between 0 and 3.
+
+IMPORTANT: You must include both REASONING: and SCORE: labels. The score MUST appear at the end of your response.
+
+---
+
+## Test Input
+
+{{TEST_INPUT}}
+
+## Deduplication Decisions
+
+{{MATCH_MAP}}
+
+## Scenario-Specific Criteria
+
+{{JUDGE_CRITERIA}}
+
+---
+
+## General Evaluation Checklist
+
+1. **Correct matches**: Were genuine semantic duplicates correctly identified?
+   - Same task/decision described with different words → should match
+   - Identical or near-identical text → should match
+2. **Correct non-matches**: Were genuinely distinct items left unmatched?
+   - Related but different tasks → should NOT match (e.g., "Set up CI" vs "Set up CD")
+   - Different scope or intent → should NOT match
+3. **Correct sId mapping**: When a match is reported, does it point to the right existing TODO?
+4. **No false positives**: Were unrelated items incorrectly matched?
+5. **No false negatives**: Were obvious duplicates missed?
+
+Provide your evaluation using the REASONING: and SCORE: format described above.`;
+
+export async function evaluateWithJudge(
+  auth: Authenticator,
+  testCase: DedupTestCase,
+  matchMap: Map<number, string>,
+  numRuns: number = 1
+): Promise<JudgeResult> {
+  const prompt = JUDGE_PROMPT.replace(
+    "{{TEST_INPUT}}",
+    getTestCaseInputForDisplay(testCase)
+  )
+    .replace("{{MATCH_MAP}}", formatMatchMap(matchMap))
+    .replace("{{JUDGE_CRITERIA}}", testCase.judgeCriteria);
+
+  const scores: number[] = [];
+  let lastReasoning = "";
+
+  const credentials = await getLlmCredentials(auth, {
+    skipEmbeddingApiKeyRequirement: true,
+  });
+  const llm = await getLLM(auth, {
+    credentials,
+    modelId: "gpt-5-mini",
+    temperature: 0.2,
+    bypassFeatureFlag: true,
+  });
+  if (!llm) {
+    throw new Error("Failed to initialize LLM for judge evaluation");
+  }
+
+  for (let i = 0; i < numRuns; i++) {
+    const events = llm.stream({
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            name: "User",
+            content: [{ type: "text", text: prompt }],
+          },
+        ],
+      },
+      prompt:
+        "You are a careful evaluator. Analyze the deduplication decisions and provide a fair assessment.",
+      specifications: [],
+    });
+
+    let response = "";
+    for await (const event of events) {
+      if (event.type === "text_delta") {
+        response += event.content.delta;
+      }
+      if (event.type === "error") {
+        throw new Error(`Judge evaluation error: ${event.content.message}`);
+      }
+    }
+
+    const scoreMatch = response.match(/SCORE:\s*(\d)/i);
+    if (scoreMatch) {
+      const score = parseInt(scoreMatch[1], 10);
+      if (score >= 0 && score <= 3) {
+        scores.push(score);
+      }
+    }
+
+    const reasoningMatch = response.match(
+      /REASONING:\s*([\s\S]+?)(?=SCORE:|$)/i
+    );
+    if (reasoningMatch) {
+      lastReasoning = reasoningMatch[1].trim();
+    }
+  }
+
+  const finalScore =
+    scores.length > 0
+      ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length)
+      : 0;
+
+  return { finalScore, scores, reasoning: lastReasoning };
+}

--- a/front/tests/dedup-evals/lib/suite-loader.ts
+++ b/front/tests/dedup-evals/lib/suite-loader.ts
@@ -1,0 +1,31 @@
+import type {
+  CategorizedDedupTestCase,
+  DedupTestSuite,
+} from "@app/tests/dedup-evals/lib/types";
+
+/**
+ * Filter test cases from suites based on criteria.
+ * Automatically assigns suiteName to each test case based on suite name.
+ */
+export function filterTestCases(
+  suites: DedupTestSuite[],
+  options?: {
+    scenarioId?: string;
+  }
+): CategorizedDedupTestCase[] {
+  let allTests: CategorizedDedupTestCase[] = [];
+
+  for (const suite of suites) {
+    const categorizedCases = suite.testCases.map((tc) => ({
+      ...tc,
+      suiteName: suite.name,
+    }));
+    allTests = allTests.concat(categorizedCases);
+  }
+
+  if (options?.scenarioId) {
+    allTests = allTests.filter((tc) => tc.scenarioId === options.scenarioId);
+  }
+
+  return allTests;
+}

--- a/front/tests/dedup-evals/lib/types.ts
+++ b/front/tests/dedup-evals/lib/types.ts
@@ -1,0 +1,92 @@
+// ── Mock data types ─────────────────────────────────────────────────────────
+
+export interface MockExistingTodo {
+  sId: string;
+  text: string;
+}
+
+export interface MockCandidate {
+  itemId: string;
+  text: string;
+}
+
+// ── Assertions ──────────────────────────────────────────────────────────────
+
+export type DedupAssertion =
+  | { type: "shouldMatchExisting"; candidateIndex: number; existingSId: string }
+  | { type: "shouldBeNew"; candidateIndex: number };
+
+/** Expects candidate at `candidateIndex` to be matched to `existingSId`. */
+export function shouldMatchExisting(
+  candidateIndex: number,
+  existingSId: string
+): DedupAssertion {
+  return { type: "shouldMatchExisting", candidateIndex, existingSId };
+}
+
+/** Expects candidate at `candidateIndex` to have no match (genuinely new). */
+export function shouldBeNew(candidateIndex: number): DedupAssertion {
+  return { type: "shouldBeNew", candidateIndex };
+}
+
+// ── Test case ───────────────────────────────────────────────────────────────
+
+export interface DedupTestCase {
+  scenarioId: string;
+  existingTodos: MockExistingTodo[];
+  candidates: MockCandidate[];
+  expectedMatches: DedupAssertion[];
+  judgeCriteria: string;
+}
+
+/** TestCase with category name assigned by suite loader. */
+export type CategorizedDedupTestCase = DedupTestCase & { suiteName: string };
+
+export interface DedupTestSuite {
+  name: string;
+  description: string;
+  testCases: DedupTestCase[];
+}
+
+// ── Execution result ────────────────────────────────────────────────────────
+
+/** Result of one runDeduplicationLLMCall invocation. */
+export interface DedupExecutionResult {
+  /** Map from candidate index → matched existing sId (absent = new). */
+  matchMap: Map<number, string>;
+}
+
+// ── Judge ───────────────────────────────────────────────────────────────────
+
+export interface JudgeResult {
+  finalScore: number;
+  scores: number[];
+  reasoning: string;
+}
+
+// ── Display helpers ─────────────────────────────────────────────────────────
+
+/** Returns a short description of the test case input for display/logging. */
+export function getTestCaseInputForDisplay(testCase: DedupTestCase): string {
+  const existingLines = testCase.existingTodos
+    .map((t) => `  [${t.sId}] ${t.text}`)
+    .join("\n");
+
+  const candidateLines = testCase.candidates
+    .map((c, i) => `  [${i}] ${c.text}`)
+    .join("\n");
+
+  return [
+    `Existing TODOs:\n${existingLines || "  (none)"}`,
+    `New candidates:\n${candidateLines}`,
+  ].join("\n");
+}
+
+export function formatMatchMap(matchMap: Map<number, string>): string {
+  if (matchMap.size === 0) {
+    return "(no matches — all candidates are new)";
+  }
+  return [...matchMap.entries()]
+    .map(([idx, sId]) => `candidate[${idx}] → ${sId}`)
+    .join(", ");
+}

--- a/front/tests/dedup-evals/test-suites/index.ts
+++ b/front/tests/dedup-evals/test-suites/index.ts
@@ -1,0 +1,4 @@
+import type { DedupTestSuite } from "@app/tests/dedup-evals/lib/types";
+import { todoDeduplicationSuite } from "@app/tests/dedup-evals/test-suites/todo-deduplication";
+
+export const allTestSuites: DedupTestSuite[] = [todoDeduplicationSuite];

--- a/front/tests/dedup-evals/test-suites/todo-deduplication.ts
+++ b/front/tests/dedup-evals/test-suites/todo-deduplication.ts
@@ -1,0 +1,214 @@
+import {
+  type DedupTestSuite,
+  shouldBeNew,
+  shouldMatchExisting,
+} from "@app/tests/dedup-evals/lib/types";
+
+export const todoDeduplicationSuite: DedupTestSuite = {
+  name: "todo-deduplication",
+  description:
+    "Semantic deduplication of project TODO candidates against existing TODOs",
+  testCases: [
+    // ── Exact and near-exact duplicates ─────────────────────────────────────
+    {
+      scenarioId: "exact-duplicate",
+      existingTodos: [
+        { sId: "existing-1", text: "Set up CI/CD pipeline for staging" },
+      ],
+      candidates: [
+        { itemId: "c-0", text: "Set up CI/CD pipeline for staging" },
+      ],
+      expectedMatches: [shouldMatchExisting(0, "existing-1")],
+      judgeCriteria: `The candidate text is identical to the existing TODO.
+This is the simplest case — the system must recognize it as a duplicate.
+
+Score 0 if candidate is not matched to existing-1.
+Score 3 if correctly matched.`,
+    },
+
+    {
+      scenarioId: "semantic-duplicate",
+      existingTodos: [
+        { sId: "existing-1", text: "Set up CI/CD pipeline for staging" },
+      ],
+      candidates: [
+        {
+          itemId: "c-0",
+          text: "Configure automated build and deployment for the staging environment",
+        },
+      ],
+      expectedMatches: [shouldMatchExisting(0, "existing-1")],
+      judgeCriteria: `The candidate describes the same task as the existing TODO — setting up
+automated builds/deployments for staging — using completely different words.
+The system must recognize semantic equivalence despite different wording.
+
+Score 0 if candidate is not matched.
+Score 2 if matched but to the wrong existing TODO (if multiple existed).
+Score 3 if correctly matched to existing-1.`,
+    },
+
+    // ── Genuinely new items ─────────────────────────────────────────────────
+
+    {
+      scenarioId: "genuinely-new",
+      existingTodos: [
+        { sId: "existing-1", text: "Set up CI/CD pipeline for staging" },
+        {
+          sId: "existing-2",
+          text: "Add unit tests for the authentication module",
+        },
+      ],
+      candidates: [
+        {
+          itemId: "c-0",
+          text: "Implement dark mode toggle in user settings",
+        },
+      ],
+      expectedMatches: [shouldBeNew(0)],
+      judgeCriteria: `The candidate (dark mode toggle) is completely unrelated to either
+existing TODO (CI/CD and auth tests). It must NOT be matched.
+
+Score 0 if candidate is matched to any existing TODO.
+Score 3 if correctly identified as new.`,
+    },
+
+    // ── Partial overlap but distinct tasks ──────────────────────────────────
+
+    {
+      scenarioId: "partial-overlap-distinct",
+      existingTodos: [
+        {
+          sId: "existing-1",
+          text: "Set up continuous integration pipeline with GitHub Actions",
+        },
+      ],
+      candidates: [
+        {
+          itemId: "c-0",
+          text: "Configure continuous deployment to production with rollback support",
+        },
+      ],
+      expectedMatches: [shouldBeNew(0)],
+      judgeCriteria: `The existing TODO is about CI (continuous integration — building and testing),
+while the candidate is about CD to production with rollback. These are related but
+distinct tasks — CI and CD are different pipeline stages with different concerns.
+
+Score 0 if the candidate is incorrectly matched to the CI TODO.
+Score 2 if correctly identified as new but reasoning is unclear.
+Score 3 if correctly identified as new with clear reasoning about CI vs CD distinction.`,
+    },
+
+    // ── Mixed batch: some duplicates, some new ─────────────────────────────
+
+    {
+      scenarioId: "mixed-batch",
+      existingTodos: [
+        {
+          sId: "existing-1",
+          text: "Migrate database from MySQL to PostgreSQL",
+        },
+        { sId: "existing-2", text: "Write API documentation for v2 endpoints" },
+      ],
+      candidates: [
+        {
+          itemId: "c-0",
+          text: "Move the database to PostgreSQL from the current MySQL setup",
+        },
+        {
+          itemId: "c-1",
+          text: "Add rate limiting to the public API",
+        },
+        {
+          itemId: "c-2",
+          text: "Document all v2 API endpoints with request/response examples",
+        },
+      ],
+      expectedMatches: [
+        shouldMatchExisting(0, "existing-1"),
+        shouldBeNew(1),
+        shouldMatchExisting(2, "existing-2"),
+      ],
+      judgeCriteria: `Three candidates against two existing TODOs:
+- c-0 (MySQL→PostgreSQL migration) is a semantic duplicate of existing-1 → must match.
+- c-1 (rate limiting) is entirely unrelated → must be new.
+- c-2 (API docs for v2) is a semantic duplicate of existing-2 → must match.
+
+Score 0 if any match decision is wrong.
+Score 1 if one match is wrong.
+Score 2 if all matches are correct but the mapping points to wrong sIds.
+Score 3 if all three decisions are correct with proper sId mappings.`,
+    },
+
+    // ── Many existing TODOs, one specific match ─────────────────────────────
+
+    {
+      scenarioId: "many-existing-one-match",
+      existingTodos: [
+        { sId: "existing-1", text: "Upgrade Node.js to version 22" },
+        {
+          sId: "existing-2",
+          text: "Add Sentry error monitoring to production",
+        },
+        {
+          sId: "existing-3",
+          text: "Refactor the payment processing module to use Stripe API v3",
+        },
+        { sId: "existing-4", text: "Set up end-to-end tests with Playwright" },
+        {
+          sId: "existing-5",
+          text: "Create a shared component library for the design system",
+        },
+      ],
+      candidates: [
+        {
+          itemId: "c-0",
+          text: "Update the payment module to integrate with Stripe's latest API version",
+        },
+      ],
+      expectedMatches: [shouldMatchExisting(0, "existing-3")],
+      judgeCriteria: `The candidate is about updating the payment module to use Stripe's latest API.
+Among 5 existing TODOs, only existing-3 is about refactoring the payment module for Stripe
+API v3 — the same task described differently. The system must:
+1. Not be distracted by the other 4 unrelated TODOs.
+2. Match specifically to existing-3 (not any other sId).
+
+Score 0 if no match or matched to wrong existing TODO.
+Score 2 if matched to existing-3 but reasoning is unclear.
+Score 3 if correctly matched to existing-3.`,
+    },
+
+    // ── to_know category: key decision deduplication ────────────────────────
+
+    {
+      scenarioId: "key-decision-dedup",
+      existingTodos: [
+        {
+          sId: "existing-1",
+          text: "We decided to use PostgreSQL as our primary database for the new service",
+        },
+        {
+          sId: "existing-2",
+          text: "The team agreed to adopt TypeScript strict mode across all projects",
+        },
+      ],
+      candidates: [
+        {
+          itemId: "c-0",
+          text: "Database choice: PostgreSQL was selected as the main database for the new service",
+        },
+        {
+          itemId: "c-1",
+          text: "We are going to use Redis for caching in the new service",
+        },
+      ],
+      expectedMatches: [shouldMatchExisting(0, "existing-1"), shouldBeNew(1)],
+      judgeCriteria: `Two candidates in the "to_know" category:
+- c-0 restates the PostgreSQL decision from existing-1 with different phrasing → duplicate.
+- c-1 is about Redis caching, which is a separate decision not covered by any existing TODO → new.
+
+Score 0 if c-0 is not matched or c-1 is incorrectly matched.
+Score 2 if both decisions are correct but c-0 maps to wrong sId.
+Score 3 if c-0 correctly maps to existing-1 and c-1 is new.`,
+    },
+  ],
+};

--- a/front/tests/dedup-evals/vite.config.mjs
+++ b/front/tests/dedup-evals/vite.config.mjs
@@ -1,0 +1,44 @@
+import { defineConfig } from "vite";
+import { mergeConfig } from "vite";
+
+import baseConfig from "../../vite.config.mjs";
+
+export default defineConfig(() => {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error(
+      `NODE_ENV must be set to "test" (value: ${process.env.NODE_ENV}). Action: make sure your have the correct environment variable set.`
+    );
+  }
+
+  const testConfig = defineConfig({
+    test: {
+      env: {
+        // Silence the app logger (the base globalSetup sets this, but we
+        // override globalSetup to [] so we must set it ourselves).
+        LOG_LEVEL: "silent",
+        // Skip tests by default, unless explicitly enabled.
+        RUN_DEDUP_EVAL: process.env.RUN_DEDUP_EVAL ?? "false",
+        // Filtering.
+        FILTER_SCENARIO: process.env.FILTER_SCENARIO ?? "",
+        // Judge configuration.
+        JUDGE_RUNS: process.env.JUDGE_RUNS ?? "3",
+        PASS_THRESHOLD: process.env.PASS_THRESHOLD ?? "2",
+        // Model override for the deduplication LLM.
+        VERBOSE: process.env.VERBOSE ?? "false",
+        DEDUP_MODEL_ID: process.env.DEDUP_MODEL_ID ?? "",
+        // API keys forwarded from the shell environment.
+        DUST_MANAGED_ANTHROPIC_API_KEY:
+          process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
+        DUST_MANAGED_OPENAI_API_KEY:
+          process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+      },
+      testTimeout: 300000,
+    },
+  });
+
+  // Merge with base config and override globalSetup.
+  const merged = mergeConfig(baseConfig, testConfig);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  merged.test.globalSetup = [];
+  return merged;
+});

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -39,6 +39,9 @@ class FileStorageMock {
       getPrivateUploadBucket: vi.fn(createStorage),
       getPublicUploadBucket: vi.fn(createStorage),
       getUpsertQueueBucket: vi.fn(createStorage),
+      getDustDataSourcesBucket: vi.fn(createStorage),
+      getWebhookRequestsBucket: vi.fn(createStorage),
+      getLLMTracesBucket: vi.fn(createStorage),
     };
   }
 


### PR DESCRIPTION
## Description

Add an end-to-end eval suite (`front/tests/dedup-evals/`) for the project TODO semantic deduplication pipeline, mirroring the `reinforcement-evals` architecture.

- **7 scenarios** covering exact duplicates, semantic duplicates, genuinely new items, partial overlap, mixed batches, many-existing-one-match, and `to_know` category dedup
- **Dual scoring**: deterministic per-candidate match assertions + LLM-as-judge (gpt-5-mini, 0–3 rubric with majority voting)
- **Gated by `RUN_DEDUP_EVAL=true`** — skipped in normal CI, run on demand
- Exports `runDeduplicationLLMCall` from `deduplicate_candidates.ts` so the eval can call the real prompt-building + LLM + parsing pipeline with lightweight mocks (no DB dependency)

## Tests

This PR *is* the test framework. Run with:
```bash
NODE_ENV=test RUN_DEDUP_EVAL=true npm run test -- tests/dedup-evals/dedup-eval.test.ts --config tests/dedup-evals/vite.config.mjs
```

Locally 

```
➜ NODE_ENV=test RUN_DEDUP_EVAL=true npm run test -- tests/dedup-evals/dedup-eval.test.ts --config tests/dedup-evals/vite.config.mjs

> @dust-tt/front@0.1.0 test
> FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI vitest --run tests/dedup-evals/dedup-eval.test.ts --config tests/dedup-evals/vite.config.mjs


 RUN  v4.0.18 /Users/rcs/Projects/dust/front

 ✓ tests/dedup-evals/dedup-eval.test.ts (7 tests) 17330ms
   ✓ TODO Deduplication Evaluation Tests (7)
     ✓ todo-deduplication (7)
       ✓ exact-duplicate  7548ms
       ✓ semantic-duplicate  10694ms
       ✓ genuinely-new  10715ms
       ✓ partial-overlap-distinct  17225ms
       ✓ mixed-batch  13458ms
       ✓ many-existing-one-match  12443ms
       ✓ key-decision-dedup  11753ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  10:18:33
   Duration  20.72s (transform 845ms, setup 410ms, import 2.55s, tests 17.33s, environment 335ms)
```