### PR TITLE
Run hard delete logic concurrently

### DIFF
--- a/front/lib/api/llm/clients/google/imageGeneration.ts
+++ b/front/lib/api/llm/clients/google/imageGeneration.ts
@@ -9,7 +9,7 @@ import {
   type ImageGenerationOutput,
 } from "@app/lib/api/llm/imageGeneration";
 import type { Authenticator } from "@app/lib/auth";
-import { concurrentExecutor } from "@app/temporal/utils";
+import { concurrentExecutor } from "@app/temporal/workflow_utils";
 import type { ImageModelIdType } from "@app/types/assistant/models/models";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { Err, Ok, type Result } from "@app/types/shared/result";

--- a/front/lib/api/llm/clients/openai/imageGeneration.ts
+++ b/front/lib/api/llm/clients/openai/imageGeneration.ts
@@ -11,7 +11,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { trustedFetch } from "@app/lib/egress/server";
 import type { FileResource } from "@app/lib/resources/file_resource";
-import { concurrentExecutor } from "@app/temporal/utils";
+import { concurrentExecutor } from "@app/temporal/workflow_utils";
 import type { ImageModelIdType } from "@app/types/assistant/models/models";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { Err, Ok, type Result } from "@app/types/shared/result";

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -24,6 +24,11 @@ export const ENT_PLAN_FAKE_CODE = "ENT_PLAN_FAKE_CODE";
 // Dust's own workspace plan.
 export const DUST_COMPANY_PLAN_CODE = "DUST_COMPANY";
 
+/** Plan codes excluded from reinforcement-related batch operations. */
+export const REINFORCEMENT_EXCLUDED_PLAN_CODES = new Set([
+  FREE_TRIAL_PHONE_PLAN_CODE,
+]);
+
 // If the plan code starts with ENT_, it's an entreprise plan
 export const isEntreprisePlanPrefix = (planCode: string) =>
   planCode.startsWith("ENT_");

--- a/front/temporal/activity_utils.ts
+++ b/front/temporal/activity_utils.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/temporal/workflow_utils";
 import { Context } from "@temporalio/activity";
 
 const DEFAULT_WORKSPACE_CONCURRENCY = 50;
@@ -44,30 +45,4 @@ export async function runOnAllWorkspacesInActivity<T>(
     },
     { concurrency }
   );
-}
-
-/**
- * Temporal-workflow-safe concurrent executor (inlined to avoid @app/ imports
- * that require bundlerOptions with TsconfigPathsPlugin).
- */
-export async function concurrentExecutor<T, V>(
-  items: T[] | readonly T[],
-  iterator: (item: T, idx: number) => Promise<V>,
-  { concurrency }: { concurrency: number }
-): Promise<V[]> {
-  const results: V[] = new Array(items.length);
-  const queue = items.map((item, index) => ({ item, index }));
-
-  async function worker() {
-    let work;
-    while ((work = queue.shift())) {
-      results[work.index] = await iterator(work.item, work.index);
-    }
-  }
-
-  await Promise.all(
-    Array.from({ length: Math.min(concurrency, items.length) }, () => worker())
-  );
-
-  return results;
 }

--- a/front/temporal/hard_delete/activities.test.ts
+++ b/front/temporal/hard_delete/activities.test.ts
@@ -1,19 +1,20 @@
 import { createPendingAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
-import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import {
   purgeExpiredPendingAgentsActivity,
-  purgeExpiredSyntheticSuggestionsActivity,
+  purgeExpiredSyntheticSkillSuggestionsActivity,
 } from "@app/temporal/hard_delete/activities";
 import {
   PENDING_AGENTS_RETENTION_HOURS,
   SYNTHETIC_SUGGESTIONS_RETENTION_DAYS,
 } from "@app/temporal/hard_delete/utils";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
-import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@temporalio/activity", () => ({
@@ -230,82 +231,70 @@ describe("purgeExpiredPendingAgentsActivity", () => {
 const PAST_SYNTHETIC_THRESHOLD_MS =
   (SYNTHETIC_SUGGESTIONS_RETENTION_DAYS + 1) * 24 * 3600 * 1000;
 
-describe("purgeExpiredSyntheticSuggestionsActivity", () => {
-  it("deletes synthetic suggestions older than threshold", async () => {
+describe("purgeExpiredSyntheticSkillSuggestionsActivity", () => {
+  it("deletes synthetic skill suggestions older than threshold", async () => {
     const { authenticator } = await createResourceTest({
       role: "admin",
     });
 
-    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+    const skill = await SkillFactory.create(authenticator);
+    const suggestion = await SkillSuggestionFactory.create(
       authenticator,
-      { name: "Agent with suggestions" }
-    );
-
-    const suggestion = await AgentSuggestionFactory.createInstructions(
-      authenticator,
-      agentConfig,
+      skill,
       { source: "synthetic" }
     );
 
     // Advance time past the synthetic retention threshold.
     vi.advanceTimersByTime(PAST_SYNTHETIC_THRESHOLD_MS);
 
-    await purgeExpiredSyntheticSuggestionsActivity();
+    await purgeExpiredSyntheticSkillSuggestionsActivity();
 
-    const remaining = await AgentSuggestionResource.fetchById(
+    const remaining = await SkillSuggestionResource.fetchById(
       authenticator,
       suggestion.sId
     );
     expect(remaining).toBeNull();
   });
 
-  it("does not delete synthetic suggestions younger than threshold", async () => {
+  it("does not delete synthetic skill suggestions younger than threshold", async () => {
     const { authenticator } = await createResourceTest({
       role: "admin",
     });
 
-    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+    const skill = await SkillFactory.create(authenticator);
+    const suggestion = await SkillSuggestionFactory.create(
       authenticator,
-      { name: "Agent with fresh suggestions" }
-    );
-
-    const suggestion = await AgentSuggestionFactory.createInstructions(
-      authenticator,
-      agentConfig,
+      skill,
       { source: "synthetic" }
     );
 
-    await purgeExpiredSyntheticSuggestionsActivity();
+    await purgeExpiredSyntheticSkillSuggestionsActivity();
 
-    const remaining = await AgentSuggestionResource.fetchById(
+    const remaining = await SkillSuggestionResource.fetchById(
       authenticator,
       suggestion.sId
     );
     expect(remaining).not.toBeNull();
   });
 
-  it("does not delete non-synthetic suggestions older than threshold", async () => {
+  it("does not delete non-synthetic skill suggestions older than threshold", async () => {
     const { authenticator } = await createResourceTest({
       role: "admin",
     });
 
-    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+    const skill = await SkillFactory.create(authenticator);
+    const suggestion = await SkillSuggestionFactory.create(
       authenticator,
-      { name: "Agent with sidekick suggestions" }
-    );
-
-    const suggestion = await AgentSuggestionFactory.createInstructions(
-      authenticator,
-      agentConfig,
-      { source: "sidekick" }
+      skill,
+      { source: "reinforcement" }
     );
 
     // Advance time past the synthetic retention threshold.
     vi.advanceTimersByTime(PAST_SYNTHETIC_THRESHOLD_MS);
 
-    await purgeExpiredSyntheticSuggestionsActivity();
+    await purgeExpiredSyntheticSkillSuggestionsActivity();
 
-    const remaining = await AgentSuggestionResource.fetchById(
+    const remaining = await SkillSuggestionResource.fetchById(
       authenticator,
       suggestion.sId
     );

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -15,7 +15,7 @@ import {
   getSyntheticSuggestionsDeletionCutoffDate,
   isSequelizeForeignKeyConstraintError,
 } from "@app/temporal/hard_delete/utils";
-import { runOnAllWorkspacesInActivity } from "@app/temporal/utils";
+import { runOnAllWorkspacesInActivity } from "@app/temporal/activity_utils";
 import { Context } from "@temporalio/activity";
 import type { Sequelize } from "sequelize";
 import { Op, QueryTypes } from "sequelize";

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -1,6 +1,7 @@
 // biome-ignore-all lint/plugin/noRawSql: hard delete activities require raw SQL for cascade deletions
 import { batchHardDeletePendingAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { REINFORCEMENT_EXCLUDED_PLAN_CODES } from "@app/lib/plans/plan_codes";
 import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import logger from "@app/logger/logger";
@@ -182,27 +183,31 @@ export async function purgeExpiredSyntheticSkillSuggestionsActivity(
     `About to purge synthetic skill suggestions created before ${cutoffDate.toISOString()}.`
   );
 
-  const results = await runOnAllWorkspacesInActivity(async (auth) => {
-    let deleted = 0;
-    let hasMore = true;
+  const results = await runOnAllWorkspacesInActivity(
+    async (auth) => {
+      let deleted = 0;
+      let hasMore = true;
 
-    do {
-      const deletedCount = await SkillSuggestionResource.deleteExpiredSynthetic(
-        auth,
-        cutoffDate,
-        {
-          limit: batchSize,
-        }
-      );
+      do {
+        const deletedCount =
+          await SkillSuggestionResource.deleteExpiredSynthetic(
+            auth,
+            cutoffDate,
+            {
+              limit: batchSize,
+            }
+          );
 
-      deleted += deletedCount;
-      hasMore = deletedCount === batchSize;
+        deleted += deletedCount;
+        hasMore = deletedCount === batchSize;
 
-      Context.current().heartbeat();
-    } while (hasMore);
+        Context.current().heartbeat();
+      } while (hasMore);
 
-    return deleted;
-  });
+      return deleted;
+    },
+    { excludePlanCodes: REINFORCEMENT_EXCLUDED_PLAN_CODES }
+  );
 
   const totalDeleted = results.reduce((sum, count) => sum + count, 0);
 

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -1,11 +1,8 @@
 // biome-ignore-all lint/plugin/noRawSql: hard delete activities require raw SQL for cascade deletions
 import { batchHardDeletePendingAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
-import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type {
   RunExecutionRow,
@@ -17,6 +14,7 @@ import {
   getSyntheticSuggestionsDeletionCutoffDate,
   isSequelizeForeignKeyConstraintError,
 } from "@app/temporal/hard_delete/utils";
+import { runOnAllWorkspacesInActivity } from "@app/temporal/utils";
 import { Context } from "@temporalio/activity";
 import type { Sequelize } from "sequelize";
 import { Op, QueryTypes } from "sequelize";
@@ -136,77 +134,41 @@ export async function purgeExpiredPendingAgentsActivity(
     `About to purge pending agents created before ${cutoffDate.toISOString()}.`
   );
 
-  const workspaces = await WorkspaceResource.listAll();
+  const results = await runOnAllWorkspacesInActivity(
+    async (_auth, workspace) => {
+      let deleted = 0;
+      let hasMore = true;
 
-  let totalDeleted = 0;
+      do {
+        const batch = await AgentConfigurationModel.findAll({
+          where: {
+            status: "pending",
+            createdAt: { [Op.lt]: cutoffDate },
+            workspaceId: workspace.id,
+          },
+          limit: batchSize,
+          order: [["createdAt", "ASC"]],
+        });
 
-  for (const workspace of workspaces) {
-    let hasMore = true;
-    do {
-      const batch = await AgentConfigurationModel.findAll({
-        where: {
-          status: "pending",
-          createdAt: { [Op.lt]: cutoffDate },
-          workspaceId: workspace.id,
-        },
-        limit: batchSize,
-        order: [["createdAt", "ASC"]],
-      });
+        hasMore = batch.length === batchSize;
 
-      hasMore = batch.length === batchSize;
+        if (batch.length > 0) {
+          await batchHardDeletePendingAgentConfigurations(batch, workspace.id);
+          deleted += batch.length;
+        }
 
-      if (batch.length > 0) {
-        await batchHardDeletePendingAgentConfigurations(batch, workspace.id);
-        totalDeleted += batch.length;
-      }
+        Context.current().heartbeat();
+      } while (hasMore);
 
-      Context.current().heartbeat();
-    } while (hasMore);
-  }
+      return deleted;
+    }
+  );
+
+  const totalDeleted = results.reduce((sum, count) => sum + count, 0);
 
   logger.info(
     { totalDeleted },
     "Done purging expired pending agent configurations."
-  );
-}
-
-export async function purgeExpiredSyntheticSuggestionsActivity(
-  batchSize: number = BATCH_SIZE
-) {
-  const cutoffDate = getSyntheticSuggestionsDeletionCutoffDate();
-
-  logger.info(
-    {},
-    `About to purge synthetic agent suggestions created before ${cutoffDate.toISOString()}.`
-  );
-
-  const workspaces = await WorkspaceResource.listAll();
-
-  let totalDeleted = 0;
-
-  for (const workspace of workspaces) {
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    let hasMore = true;
-
-    do {
-      const deletedCount = await AgentSuggestionResource.deleteExpiredSynthetic(
-        auth,
-        cutoffDate,
-        {
-          limit: batchSize,
-        }
-      );
-
-      totalDeleted += deletedCount;
-      hasMore = deletedCount === batchSize;
-
-      Context.current().heartbeat();
-    } while (hasMore);
-  }
-
-  logger.info(
-    { totalDeleted },
-    "Done purging expired synthetic agent suggestions."
   );
 }
 
@@ -220,12 +182,8 @@ export async function purgeExpiredSyntheticSkillSuggestionsActivity(
     `About to purge synthetic skill suggestions created before ${cutoffDate.toISOString()}.`
   );
 
-  const workspaces = await WorkspaceResource.listAll();
-
-  let totalDeleted = 0;
-
-  for (const workspace of workspaces) {
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const results = await runOnAllWorkspacesInActivity(async (auth) => {
+    let deleted = 0;
     let hasMore = true;
 
     do {
@@ -237,12 +195,16 @@ export async function purgeExpiredSyntheticSkillSuggestionsActivity(
         }
       );
 
-      totalDeleted += deletedCount;
+      deleted += deletedCount;
       hasMore = deletedCount === batchSize;
 
       Context.current().heartbeat();
     } while (hasMore);
-  }
+
+    return deleted;
+  });
+
+  const totalDeleted = results.reduce((sum, count) => sum + count, 0);
 
   logger.info(
     { totalDeleted },

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -5,6 +5,7 @@ import { REINFORCEMENT_EXCLUDED_PLAN_CODES } from "@app/lib/plans/plan_codes";
 import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import logger from "@app/logger/logger";
+import { runOnAllWorkspacesInActivity } from "@app/temporal/activity_utils";
 import type {
   RunExecutionRow,
   RunsJoinsRow,
@@ -15,7 +16,6 @@ import {
   getSyntheticSuggestionsDeletionCutoffDate,
   isSequelizeForeignKeyConstraintError,
 } from "@app/temporal/hard_delete/utils";
-import { runOnAllWorkspacesInActivity } from "@app/temporal/activity_utils";
 import { Context } from "@temporalio/activity";
 import type { Sequelize } from "sequelize";
 import { Op, QueryTypes } from "sequelize";

--- a/front/temporal/hard_delete/workflows.ts
+++ b/front/temporal/hard_delete/workflows.ts
@@ -5,7 +5,6 @@ import { proxyActivities } from "@temporalio/workflow";
 const {
   purgeExpiredRunExecutionsActivity,
   purgeExpiredPendingAgentsActivity,
-  purgeExpiredSyntheticSuggestionsActivity,
   purgeExpiredSyntheticSkillSuggestionsActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "60 minutes",
@@ -14,6 +13,5 @@ const {
 export async function hardDeleteCronWorkflow(): Promise<void> {
   await purgeExpiredRunExecutionsActivity();
   await purgeExpiredPendingAgentsActivity();
-  await purgeExpiredSyntheticSuggestionsActivity();
   await purgeExpiredSyntheticSkillSuggestionsActivity();
 }

--- a/front/temporal/reinforced_agent/workflows.ts
+++ b/front/temporal/reinforced_agent/workflows.ts
@@ -15,7 +15,7 @@ import {
   proxyActivities,
   sleep,
 } from "@temporalio/workflow";
-import { concurrentExecutor } from "../utils";
+import { concurrentExecutor } from "../workflow_utils";
 
 // Export an interceptors variable to add OpenTelemetry interceptors to the workflow.
 export const interceptors: WorkflowInterceptorsFactory = () => ({

--- a/front/temporal/reinforcement/client.ts
+++ b/front/temporal/reinforcement/client.ts
@@ -1,10 +1,10 @@
 import { config, REGION_TIMEZONES } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
+import { REINFORCEMENT_EXCLUDED_PLAN_CODES } from "@app/lib/plans/plan_codes";
 import { hasReinforcementEnabled } from "@app/lib/reinforced_agent/workspace_check";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
-import { EXCLUDED_PLAN_CODES } from "@app/temporal/utils";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type { WorkflowHandle } from "@temporalio/client";
@@ -46,7 +46,7 @@ async function getReinforcementWorkspaceIds(): Promise<string[]> {
       const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
       const planCode = auth.plan()?.code;
-      if (planCode && EXCLUDED_PLAN_CODES.has(planCode)) {
+      if (planCode && REINFORCEMENT_EXCLUDED_PLAN_CODES.has(planCode)) {
         continue;
       }
 

--- a/front/temporal/reinforcement/client.ts
+++ b/front/temporal/reinforcement/client.ts
@@ -1,10 +1,10 @@
 import { config, REGION_TIMEZONES } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
-import { FREE_TRIAL_PHONE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { hasReinforcementEnabled } from "@app/lib/reinforced_agent/workspace_check";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
+import { EXCLUDED_PLAN_CODES } from "@app/temporal/utils";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type { WorkflowHandle } from "@temporalio/client";
@@ -32,8 +32,6 @@ const WORKSPACE_WORKFLOW_ID_PREFIX = "reinforcement-workspace-";
 export function makeWorkspaceCronWorkflowId(workspaceId: string): string {
   return `${WORKSPACE_WORKFLOW_ID_PREFIX}${workspaceId}`;
 }
-
-const EXCLUDED_PLAN_CODES = new Set([FREE_TRIAL_PHONE_PLAN_CODE]);
 
 /**
  * List workspace sIds that have the reinforced_agents feature flag,

--- a/front/temporal/reinforcement/workflows.ts
+++ b/front/temporal/reinforcement/workflows.ts
@@ -13,7 +13,7 @@ import {
   proxyActivities,
   sleep,
 } from "@temporalio/workflow";
-import { concurrentExecutor } from "../utils";
+import { concurrentExecutor } from "../workflow_utils";
 
 // Export an interceptors variable to add OpenTelemetry interceptors to the workflow.
 export const interceptors: WorkflowInterceptorsFactory = () => ({

--- a/front/temporal/utils.ts
+++ b/front/temporal/utils.ts
@@ -1,3 +1,55 @@
+import { Authenticator } from "@app/lib/auth";
+import { FREE_TRIAL_PHONE_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { Context } from "@temporalio/activity";
+
+const DEFAULT_WORKSPACE_CONCURRENCY = 50;
+
+/** Plan codes excluded from batch workspace operations (e.g. free trial). */
+export const EXCLUDED_PLAN_CODES = new Set([FREE_TRIAL_PHONE_PLAN_CODE]);
+
+/**
+ * List all workspaces and run `fn` on each in parallel (activity-safe, heartbeats
+ * after every workspace). When `excludePlanCodes` is provided, workspaces on
+ * those plans are silently skipped.
+ */
+export async function runOnAllWorkspacesInActivity<T>(
+  fn: (auth: Authenticator, workspace: WorkspaceResource) => Promise<T>,
+  options?: { concurrency?: number; excludePlanCodes?: Set<string> }
+): Promise<T[]> {
+  const allWorkspaces = await WorkspaceResource.listAll();
+  const concurrency = options?.concurrency ?? DEFAULT_WORKSPACE_CONCURRENCY;
+
+  // Build authenticators concurrently, then filter by plan if needed.
+  let workspacesWithAuth = await concurrentExecutor(
+    allWorkspaces,
+    async (workspace) => {
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+      Context.current().heartbeat();
+      return { workspace, auth };
+    },
+    { concurrency }
+  );
+
+  if (options?.excludePlanCodes) {
+    const excluded = options.excludePlanCodes;
+    workspacesWithAuth = workspacesWithAuth.filter(({ auth }) => {
+      const planCode = auth.plan()?.code;
+      return !(planCode && excluded.has(planCode));
+    });
+  }
+
+  return concurrentExecutor(
+    workspacesWithAuth,
+    async ({ auth, workspace }) => {
+      const result = await fn(auth, workspace);
+      Context.current().heartbeat();
+      return result;
+    },
+    { concurrency }
+  );
+}
+
 /**
  * Temporal-workflow-safe concurrent executor (inlined to avoid @app/ imports
  * that require bundlerOptions with TsconfigPathsPlugin).

--- a/front/temporal/utils.ts
+++ b/front/temporal/utils.ts
@@ -1,12 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
-import { FREE_TRIAL_PHONE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { Context } from "@temporalio/activity";
 
 const DEFAULT_WORKSPACE_CONCURRENCY = 50;
-
-/** Plan codes excluded from batch workspace operations (e.g. free trial). */
-export const EXCLUDED_PLAN_CODES = new Set([FREE_TRIAL_PHONE_PLAN_CODE]);
 
 /**
  * List all workspaces and run `fn` on each in parallel (activity-safe, heartbeats

--- a/front/temporal/workflow_utils.ts
+++ b/front/temporal/workflow_utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Temporal-workflow-safe concurrent executor (inlined to avoid @app/ imports
+ * that require bundlerOptions with TsconfigPathsPlugin).
+ */
+export async function concurrentExecutor<T, V>(
+  items: T[] | readonly T[],
+  iterator: (item: T, idx: number) => Promise<V>,
+  { concurrency }: { concurrency: number }
+): Promise<V[]> {
+  const results: V[] = new Array(items.length);
+  const queue = items.map((item, index) => ({ item, index }));
+
+  async function worker() {
+    let work;
+    while ((work = queue.shift())) {
+      results[work.index] = await iterator(work.item, work.index);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () => worker())
+  );
+
+  return results;
+}


### PR DESCRIPTION
## Description

- Add reusable runOnAllWorkspacesInActivity helper in temporal/utils.ts that lists all workspaces, processes them in parallel with heartbeats, and supports optional plan exclusion
- Refactor purgeExpiredPendingAgentsActivity and purgeExpiredSyntheticSkillSuggestionsActivity to use it instead of sequential workspace loops
- Remove purgeExpiredSyntheticSuggestionsActivity (superseded by the skill suggestions variant)
- Extract EXCLUDED_PLAN_CODES to temporal/utils.ts so it's shared between hard_delete activities and reinforcement client
- Add test for purgeExpiredSyntheticSkillSuggestionsActivity

## Tests

One added

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front