### PR TITLE
[front] enh: add dialog upon disabling provider workspace-wide

### DIFF
--- a/front/components/pages/workspace/model_providers/DisableProviderDialog.tsx
+++ b/front/components/pages/workspace/model_providers/DisableProviderDialog.tsx
@@ -21,9 +21,7 @@ export function DisableProviderDialog({
   onConfirm,
   onCancel,
 }: DisableProviderDialogProps) {
-  const providerName = providerId
-    ? PRETTIFIED_PROVIDER_NAMES[providerId]
-    : "";
+  const providerName = providerId ? PRETTIFIED_PROVIDER_NAMES[providerId] : "";
 
   return (
     <Dialog open={providerId !== null} onOpenChange={() => onCancel()}>

--- a/front/components/pages/workspace/model_providers/DisableProviderDialog.tsx
+++ b/front/components/pages/workspace/model_providers/DisableProviderDialog.tsx
@@ -1,0 +1,54 @@
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@dust-tt/sparkle";
+
+interface DisableProviderDialogProps {
+  providerId: ModelProviderIdType | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function DisableProviderDialog({
+  providerId,
+  onConfirm,
+  onCancel,
+}: DisableProviderDialogProps) {
+  const providerName = providerId
+    ? PRETTIFIED_PROVIDER_NAMES[providerId]
+    : "";
+
+  return (
+    <Dialog open={providerId !== null} onOpenChange={() => onCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Disable {providerName}?</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <DialogDescription>
+            Agents using {providerName} models will stop responding until they
+            are reconfigured to use another provider.
+          </DialogDescription>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+          }}
+          rightButtonProps={{
+            label: "Disable provider",
+            variant: "warning",
+            onClick: onConfirm,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/pages/workspace/model_providers/ProvidersToggleList.tsx
+++ b/front/components/pages/workspace/model_providers/ProvidersToggleList.tsx
@@ -1,7 +1,9 @@
+import { DisableProviderDialog } from "@app/components/pages/workspace/model_providers/DisableProviderDialog";
 import { ProviderToggleContextItem } from "@app/components/pages/workspace/model_providers/ProviderToggleContextItem";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import type { ProvidersSelection } from "@app/types/provider_selection";
 import { ContextItem } from "@dust-tt/sparkle";
+import { useCallback, useState } from "react";
 
 interface ProvidersToggleListProps {
   providersSelection: ProvidersSelection;
@@ -16,23 +18,51 @@ export function ProvidersToggleList({
   isWorkspaceValidating,
   modelsDescriptionByProvider,
 }: ProvidersToggleListProps) {
+  const [pendingDisableProvider, setPendingDisableProvider] =
+    useState<ModelProviderIdType | null>(null);
+
+  const handleToggle = useCallback(
+    (providerId: ModelProviderIdType) => {
+      if (providersSelection[providerId]) {
+        setPendingDisableProvider(providerId);
+      } else {
+        onToggleProvider(providerId);
+      }
+    },
+    [providersSelection, onToggleProvider]
+  );
+
+  const handleConfirmDisable = useCallback(() => {
+    if (pendingDisableProvider) {
+      onToggleProvider(pendingDisableProvider);
+      setPendingDisableProvider(null);
+    }
+  }, [pendingDisableProvider, onToggleProvider]);
+
   return (
-    <ContextItem.List>
-      {(
-        Object.entries(modelsDescriptionByProvider) as [
-          ModelProviderIdType,
-          string,
-        ][]
-      ).map(([providerId, description]) => (
-        <ProviderToggleContextItem
-          key={providerId}
-          providerId={providerId}
-          description={description}
-          providersSelection={providersSelection}
-          handleToggleChange={() => onToggleProvider(providerId)}
-          disabled={isWorkspaceValidating}
-        />
-      ))}
-    </ContextItem.List>
+    <>
+      <ContextItem.List>
+        {(
+          Object.entries(modelsDescriptionByProvider) as [
+            ModelProviderIdType,
+            string,
+          ][]
+        ).map(([providerId, description]) => (
+          <ProviderToggleContextItem
+            key={providerId}
+            providerId={providerId}
+            description={description}
+            providersSelection={providersSelection}
+            handleToggleChange={() => handleToggle(providerId)}
+            disabled={isWorkspaceValidating}
+          />
+        ))}
+      </ContextItem.List>
+      <DisableProviderDialog
+        providerId={pendingDisableProvider}
+        onConfirm={handleConfirmDisable}
+        onCancel={() => setPendingDisableProvider(null)}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Description

- This PR adds a confirmation dialog upon disabling a provider across the workspace.
- Goal is to add a disclaimer and avoid missclicks.

<img width="1249" height="1072" alt="Screenshot 2026-04-15 at 7 08 15 PM" src="https://github.com/user-attachments/assets/aa49dd6d-7fa5-4109-9a32-8d03060665b1" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
