### PR TITLE
Enable workspace-level OAuth for Google Drive tool

### DIFF
--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -616,7 +616,7 @@ export function getGoogleDriveServerMetadata() {
         "Search, read, create, clone, edit, comment on, and manage permissions for files in Google Drive (Docs, Sheets, Presentations).",
       authorization: {
         provider: "google_drive",
-        supported_use_cases: ["personal_actions"],
+        supported_use_cases: ["personal_actions", "platform_actions"],
         scope:
           "https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.readonly",
       },

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -80,6 +80,14 @@ export async function handleFileAccessError(
 
     // Handle general 403 errors with OAuth re-auth
     if (status === "403") {
+      if (authInfo?.extra?.connectionType === "workspace") {
+        return new Err(
+          new MCPError(
+            "The workspace Google Drive credentials are invalid or expired. A workspace admin needs to re-authenticate the Google Drive connection.",
+            { tracked: false }
+          )
+        );
+      }
       return new Ok(
         makePersonalAuthenticationError(
           "google_drive",
@@ -137,12 +145,23 @@ export async function handleFileAccessError(
  * Uses GAxios error typing for cleaner error handling.
  * Returns OAuth re-auth prompt for 403 errors, or generic error for others.
  */
-function handleDriveAccessError(err: unknown): ToolHandlerResult {
+function handleDriveAccessError(
+  err: unknown,
+  authInfo?: Pick<ToolHandlerExtra, "authInfo">["authInfo"]
+): ToolHandlerResult {
   if (err instanceof Common.GaxiosError) {
     const status = normalizeCode(err.code);
 
     // Handle 403 errors with OAuth re-auth
     if (status === "403") {
+      if (authInfo?.extra?.connectionType === "workspace") {
+        return new Err(
+          new MCPError(
+            "The workspace Google Drive credentials are invalid or expired. A workspace admin needs to re-authenticate the Google Drive connection.",
+            { tracked: false }
+          )
+        );
+      }
       return new Ok(
         makePersonalAuthenticationError(
           "google_drive",
@@ -435,7 +454,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleDriveAccessError(err);
+      return handleDriveAccessError(err, authInfo);
     }
   },
 
@@ -454,7 +473,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
       ]);
     } catch (err) {
-      return handleDriveAccessError(err);
+      return handleDriveAccessError(err, authInfo);
     }
   },
 
@@ -484,7 +503,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
       ]);
     } catch (err) {
-      return handleDriveAccessError(err);
+      return handleDriveAccessError(err, authInfo);
     }
   },
   list_comments: async (
@@ -513,7 +532,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleDriveAccessError(err);
+      return handleDriveAccessError(err, authInfo);
     }
   },
   get_document_structure: async (
@@ -535,7 +554,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
 
       return new Ok([{ type: "text" as const, text: markdown }]);
     } catch (err) {
-      return handleDriveAccessError(err);
+      return handleDriveAccessError(err, authInfo);
     }
   },
   get_presentation_structure: async (
@@ -557,7 +576,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
 
       return new Ok([{ type: "text" as const, text: markdown }]);
     } catch (err) {
-      return handleDriveAccessError(err);
+      return handleDriveAccessError(err, authInfo);
     }
   },
 
@@ -600,7 +619,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleDriveAccessError(err);
+      return handleDriveAccessError(err, authInfo);
     }
   },
 };
@@ -638,7 +657,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleDriveAccessError(err);
+      return handleDriveAccessError(err, authInfo);
     }
   },
 
@@ -672,7 +691,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleDriveAccessError(err);
+      return handleDriveAccessError(err, authInfo);
     }
   },
 
@@ -706,7 +725,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleDriveAccessError(err);
+      return handleDriveAccessError(err, authInfo);
     }
   },
 
@@ -742,7 +761,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         fields: "id,name,mimeType,webViewLink",
       });
     } catch (err) {
-      return handleDriveAccessError(err);
+      return handleDriveAccessError(err, authInfo);
     }
 
     // Construct appropriate URL based on file type


### PR DESCRIPTION
## Description
Add platform_actions to supported_use_cases so admins can configure a shared Google account for all workspace members. Update error handlers to surface an admin re-auth message instead of triggering the personal OAuth flow when workspace credentials fail.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
<img width="634" height="443" alt="Screenshot 2026-04-15 at 4 20 51 PM" src="https://github.com/user-attachments/assets/cb2c980b-31bd-4716-9d2e-7a37cb8f80c2" />

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
