### PR TITLE
[Sessions] Fix cancelled workstream state in conversation UI

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1381,7 +1381,7 @@ function AgentMessageContent({
         {agentMessage.status === "cancelled" && (
           <div className="flex flex-col gap-2">
             <div className="text-sm text-faint dark:text-faint-night">
-              Message generation was interrupted
+              Agent workstream was cancelled.
             </div>
             <div>
               <ButtonGroupDropdown

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1381,7 +1381,7 @@ function AgentMessageContent({
         {agentMessage.status === "cancelled" && (
           <div className="flex flex-col gap-2">
             <div className="text-sm text-faint dark:text-faint-night">
-              Agent work was cancelled.
+              Message generation stopped by user
             </div>
             <div>
               <ButtonGroupDropdown

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1381,7 +1381,7 @@ function AgentMessageContent({
         {agentMessage.status === "cancelled" && (
           <div className="flex flex-col gap-2">
             <div className="text-sm text-faint dark:text-faint-night">
-              Agent workstream was cancelled.
+              Agent work was cancelled.
             </div>
             <div>
               <ButtonGroupDropdown

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -87,7 +87,9 @@ export function AgentMessageActions({
     : null;
 
   const showMessageBreakdownButton =
-    lastAgentStateClassification === "done" || agentMessage.status === "failed";
+    lastAgentStateClassification === "done" ||
+    agentMessage.status === "failed" ||
+    agentMessage.status === "cancelled";
   const showPendingToolCalls =
     lastAgentStateClassification !== "acting" && pendingToolCalls.length > 0;
   const latestPendingToolCall = showPendingToolCalls

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -27,6 +27,7 @@ import {
   ChevronRightIcon,
   cn,
   Icon,
+  StopIcon,
   ToolsIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -55,6 +56,15 @@ function getCompletionLabel(
   }
 }
 
+function getTerminalLabel(status: LightAgentMessageType["status"]): string {
+  switch (status) {
+    case "cancelled":
+      return "Cancelled";
+    default:
+      return "Completed";
+  }
+}
+
 function getCollapseAnimationStyle(isCollapsed: boolean): React.CSSProperties {
   return {
     gridTemplateRows: isCollapsed ? "0fr" : "1fr",
@@ -68,7 +78,7 @@ function getCollapseAnimationStyle(isCollapsed: boolean): React.CSSProperties {
 /**
  * Inline activity steps component.
  * Everything is wrapped in a single collapsible "Work" section
- * with a stepper timeline containing CoT, actions, and a "Done" marker.
+ * with a stepper timeline containing CoT, actions, and a terminal marker.
  *
  * Steps are accumulated by useAgentMessageStream — this component is a pure render.
  */
@@ -119,7 +129,7 @@ export function InlineActivitySteps({
           agentMessage.completionDurationMs
         )
       : isDone
-        ? "Completed"
+        ? getTerminalLabel(agentMessage.status)
         : null;
 
   // Writing-only: no prior steps, just streaming text. Show "Writing..."
@@ -353,9 +363,14 @@ export function InlineActivitySteps({
             {isDone &&
               completedSteps.length > 0 &&
               agentMessage.status !== "gracefully_stopped" && (
-                <TimelineRow icon={CheckIcon} isLast>
+                <TimelineRow
+                  icon={
+                    agentMessage.status === "cancelled" ? StopIcon : CheckIcon
+                  }
+                  isLast
+                >
                   <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    Done
+                    {agentMessage.status === "cancelled" ? "Cancelled" : "Done"}
                   </span>
                 </TimelineRow>
               )}

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -27,8 +27,8 @@ import {
   ChevronRightIcon,
   cn,
   Icon,
-  StopIcon,
   ToolsIcon,
+  XCircleIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -365,7 +365,9 @@ export function InlineActivitySteps({
               agentMessage.status !== "gracefully_stopped" && (
                 <TimelineRow
                   icon={
-                    agentMessage.status === "cancelled" ? StopIcon : CheckIcon
+                    agentMessage.status === "cancelled"
+                      ? XCircleIcon
+                      : CheckIcon
                   }
                   isLast
                 >

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -89,7 +89,9 @@ export function InlineActivitySteps({
   const { openPanel } = useConversationSidePanelContext();
 
   const isDone =
-    lastAgentStateClassification === "done" || agentMessage.status === "failed";
+    lastAgentStateClassification === "done" ||
+    agentMessage.status === "failed" ||
+    agentMessage.status === "cancelled";
 
   const [isCollapsed, setIsCollapsed] = useState(isDone && !isLastMessage);
 
@@ -108,7 +110,7 @@ export function InlineActivitySteps({
   const isThinking = lastAgentStateClassification === "thinking";
   const isWriting = lastAgentStateClassification === "writing";
   const isActing = lastAgentStateClassification === "acting";
-  const showPendingToolCalls = pendingToolCalls.length > 0;
+  const showPendingToolCalls = !isDone && pendingToolCalls.length > 0;
 
   const headerLabel =
     agentMessage.completionDurationMs !== null
@@ -138,8 +140,8 @@ export function InlineActivitySteps({
 
   // Show active thinking whenever the agent is thinking.
   // Dedup in appendThinkingStep handles duplicate content at capture time.
-  const showActiveThinking = isThinking;
-  const showActiveWriting = isWriting;
+  const showActiveThinking = !isDone && isThinking;
+  const showActiveWriting = !isDone && isWriting;
   const latestPendingToolCall = showPendingToolCalls
     ? pendingToolCalls[pendingToolCalls.length - 1]
     : null;
@@ -147,7 +149,9 @@ export function InlineActivitySteps({
     (showActiveThinking && !chainOfThought) ||
     (showActiveWriting && !agentMessage.content);
   const activeAction =
-    isActing && isAgentMessageWithActions ? actions[actions.length - 1] : null;
+    !isDone && isActing && isAgentMessageWithActions
+      ? actions[actions.length - 1]
+      : null;
 
   const hasContent =
     completedSteps.length > 0 ||


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7562

Treat cancelled agent messages as terminal when rendering the conversation activity UI so pending steps stop showing. Update the timeline to show 'Cancelled' instead of 'Done' and change cancelled copy to `Agent work was cancelled.`

<img width="919" height="772" alt="image" src="https://github.com/user-attachments/assets/9df4536f-2a60-4c98-bcae-60ed1cd0214d" />


## Risks
Blast radius: conversation rendering for cancelled agent messages in sessions.
Risk: low

## Deploy Plan
- deploy front