### PR TITLE
[Front] Align AGENTS and checks script with Biome commands

### DIFF
--- a/front/AGENTS.md
+++ b/front/AGENTS.md
@@ -33,12 +33,17 @@ front/
 
 # Development setup
 
-- You can use `./admin/check.ts` to run all checks (lint, type-check, format) concurrently.
-    - Use `npx tsgo --noEmit` to type-check the front project.
-    - Use `npm run lint` to run ESLint
+- From `front/`, use `npx tsgo --noEmit` to type-check the front project.
+- From the repo root, use `npx biome lint --error-on-warnings front` to lint front files.
+- From the repo root, use `npx biome format --write front` to format front files.
+  - add the `--changed` flag to only format changed front files, e.g.
+    `npx biome format --write front --changed`.
+  - similarly, add the `--staged` flag to only format staged front files.
+- Use `./admin/checks.sh` to run the full front type-check and Biome check concurrently.
 - Read `runbooks/TEST.md` for all things related to testing.
 
 # Running tests
+
 - Use `npm run test -- filetotest
 
 # Runbooks

--- a/front/admin/checks.sh
+++ b/front/admin/checks.sh
@@ -1,24 +1,26 @@
 #!/usr/bin/env bash
 
-# Run type checking, linting, and formatting in parallel with logs under out/.
+# Run front type checking and Biome checks in parallel with logs under out/.
 
 set -u
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-OUT_DIR="$ROOT_DIR/out"
+FRONT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$FRONT_DIR/.." && pwd)"
+OUT_DIR="$FRONT_DIR/out"
 
 mkdir -p "$OUT_DIR"
 
-COMMANDS=("npx tsgo --noEmit" "npm run lint" "npm run format")
-NAMES=("TypeScript (tsgo --noEmit)" "Lint" "Format")
-LOGS=("$OUT_DIR/tsgo.log" "$OUT_DIR/lint.log" "$OUT_DIR/format.log")
+COMMANDS=("npx tsgo --noEmit" "npx biome check --error-on-warnings front")
+DIRS=("$FRONT_DIR" "$REPO_ROOT")
+NAMES=("TypeScript (tsgo --noEmit)" "Biome check")
+LOGS=("$OUT_DIR/tsgo.log" "$OUT_DIR/biome.log")
 PIDS=()
 
 for i in "${!COMMANDS[@]}"; do
   log_path="${LOGS[$i]}"
   : >"$log_path"
   (
-    cd "$ROOT_DIR" || exit 1
+    cd "${DIRS[$i]}" || exit 1
     ${COMMANDS[$i]}
   ) >"$log_path" 2>&1 &
   PIDS[$i]=$!


### PR DESCRIPTION
## Description

- Align `front/AGENTS.md` with the actual front type-check and repo-root Biome commands.
- Update `front/admin/checks.sh` to run a front-scoped Biome check from the monorepo root.

## Risks

Blast radius: front developer documentation and the local `front/admin/checks.sh` helper.
Risk: low

## Deploy Plan

- no deploy required
