### PR TITLE
Drop egress-proxy guard in Deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -212,10 +212,7 @@ jobs:
 
   deploy:
     needs: [prepare, notify-start, build, deploy-app, deploy-poke, ensure-sandbox-images]
-    # egress-proxy has no dust-infra helm release yet; this workflow is used as a
-    # build-and-publish-only path until the chart lands. Drop this guard once the
-    # release exists.
-    if: ${{ !failure() && !cancelled() && inputs.component != 'egress-proxy' && (needs.ensure-sandbox-images.result == 'success' || needs.ensure-sandbox-images.result == 'skipped') }}
+    if: ${{ !failure() && !cancelled() && (needs.ensure-sandbox-images.result == 'success' || needs.ensure-sandbox-images.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Description

The `Deploy` workflow had a one-off guard (`inputs.component != 'egress-proxy'`) on the final `deploy` job, added when the image was wired into the build/publish pipeline ahead of the chart landing in dust-infra. The chart (`egress-proxy` 0.1.1) is now published and deployed to `dust-kube` in both regions, so the guard is obsolete — drop it so egress-proxy rollouts go through the normal end-to-end path (build → publish → dust-infra dispatch) like every other component.

## Tests

N/A — workflow-only change. Manual verification: `gh workflow view deploy.yaml` still lists egress-proxy in the component choice, and a subsequent `workflow_dispatch` with `component=egress-proxy` will now reach the `deploy` job instead of short-circuiting.

## Risk

Low. The deploy job dispatches to dust-infra's `Deploy Kubernetes Component`, which has been successfully exercised twice today for egress-proxy already. Simple revert if anything regresses.

## Deploy Plan

Merge only. Next rollout of egress-proxy can use the standard `Deploy` workflow path.