### PR TITLE
[sessions]: Fix input bar animations and button layout on chrome extension

### DIFF
--- a/extension/config/tailwind.config.js
+++ b/extension/config/tailwind.config.js
@@ -490,13 +490,24 @@ module.exports = {
             opacity: "0.4",
           },
         },
+        shake: {
+          "0%, 100%": {
+            transform: "translate3d(0, 0, 0)",
+          },
+          "20%, 60%": {
+            transform: "translate3d(-1.5px, 0, 0)",
+          },
+          "40%, 80%": {
+            transform: "translate3d(1.5px, 0, 0)",
+          },
+        },
       },
       animation: {
         "move-square": "move-square 4s ease-out infinite",
         breathing: "breathing 4s infinite ease-in-out",
         "breathing-scale": "breathing-scale 3s infinite ease-in-out",
         "cursor-blink": "cursor-blink 0.9s infinite;",
-        shake: "shake 0.82s cubic-bezier(.36,.07,.19,.97) both",
+        shake: "shake 0.5s ease-in-out both",
         reload: "reload 1000ms ease-out",
         fadeout: "fadeout 500ms ease-out",
       },

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -353,7 +353,7 @@ export const AgentInputBar = ({
             className="flex items-center gap-1 rounded-xl border border-border bg-white p-1 dark:border-border-night dark:bg-muted-night"
             style={{
               position: "absolute",
-              top: "-2em",
+              top: "-2rem",
             }}
           >
             {showStopButton && (

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -267,7 +267,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
           className={cn(
             "mx-auto max-w-conversation",
             topMargin,
-            !nextData && "mb-8"
+            !nextData && "mb-10"
           )}
         >
           <CompactionMessage message={data} />
@@ -284,7 +284,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
           className={cn(
             "mx-auto max-w-conversation",
             topMargin,
-            !nextData && "mb-8"
+            !nextData && "mb-10"
           )}
         >
           {isUserMessage(data) && (

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1140,105 +1140,102 @@ const InputBarContainer = ({
               <div
                 className="flex items-center gap-2 md:gap-1"
                 style={buttonsTransitionStyle}
-              >
-                {clientType === "extension" && (
-                  <>
-                    <div ref={plusButtonRef}>
-                      <DropdownMenu
-                        open={isCaptureDropdownOpen}
-                        onOpenChange={setIsCaptureDropdownOpen}
-                      >
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost-secondary"
-                            icon={PlusIcon}
-                            size={buttonSize}
-                            disabled={disableInput}
-                          />
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          {actions.includes("attachment") && (
-                            <DropdownMenuItem
-                              icon={AttachmentIcon}
-                              label="Attach knowledge"
-                              onClick={() => {
-                                setIsCaptureDropdownOpen(false);
-                                setShowKnowledgePicker(true);
-                              }}
-                            />
-                          )}
-                          {captureActions && (
-                            <>
-                              <DropdownMenuItem
-                                icon={GlobeAltIcon}
-                                label="Attach page content"
-                                disabled={
-                                  captureActions.isCapturing ||
-                                  fileUploaderService.isProcessingFiles
-                                }
-                                onClick={() => captureActions.onCapture("text")}
-                                endComponent={
-                                  <DropdownMenuShortcut
-                                    shortcut={pageShortcut}
-                                    className="text-xs text-faint dark:text-faint-night"
-                                  />
-                                }
-                              />
-                              <DropdownMenuItem
-                                icon={CameraIcon}
-                                label="Take screenshot"
-                                disabled={
-                                  captureActions.isCapturing ||
-                                  fileUploaderService.isProcessingFiles
-                                }
-                                onClick={() =>
-                                  captureActions.onCapture("screenshot")
-                                }
-                                endComponent={
-                                  <DropdownMenuShortcut
-                                    shortcut={screenshotShortcut}
-                                    className="text-xs text-faint dark:text-faint-night"
-                                  />
-                                }
-                              />
-                            </>
-                          )}
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
-                    {actions.includes("attachment") && (
-                      <InputBarAttachmentsPicker
-                        fileUploaderService={fileUploaderService}
-                        owner={owner}
-                        isLoading={false}
-                        onNodeSelect={onNodeSelect}
-                        onNodeUnselect={onNodeUnselect}
-                        attachedNodes={attachedNodes}
-                        disabled={disableInput}
-                        buttonSize={buttonSize}
-                        toolFileUpload={{
-                          useCase: "conversation",
-                          useCaseMetadata: {
-                            conversationId: conversation?.sId,
-                          },
-                        }}
-                        spaceId={space?.sId}
-                        type="dropdown"
-                        onFileChange={() => setShowKnowledgePicker(false)}
-                        externalOpen={showKnowledgePicker}
-                        onExternalOpenChange={setShowKnowledgePicker}
-                        anchorRef={plusButtonRef}
-                      />
-                    )}
-                  </>
-                )}
-              </div>
+              />
             </div>
           </div>
         </div>
         <div
           className={cn("absolute bottom-2 right-2 flex items-center gap-2")}
         >
+          {clientType === "extension" && (
+            <>
+              <div ref={plusButtonRef}>
+                <DropdownMenu
+                  open={isCaptureDropdownOpen}
+                  onOpenChange={setIsCaptureDropdownOpen}
+                >
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost-secondary"
+                      icon={PlusIcon}
+                      size={buttonSize}
+                      disabled={disableInput}
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {actions.includes("attachment") && (
+                      <DropdownMenuItem
+                        icon={AttachmentIcon}
+                        label="Attach knowledge"
+                        onClick={() => {
+                          setIsCaptureDropdownOpen(false);
+                          setShowKnowledgePicker(true);
+                        }}
+                      />
+                    )}
+                    {captureActions && (
+                      <>
+                        <DropdownMenuItem
+                          icon={GlobeAltIcon}
+                          label="Attach page content"
+                          disabled={
+                            captureActions.isCapturing ||
+                            fileUploaderService.isProcessingFiles
+                          }
+                          onClick={() => captureActions.onCapture("text")}
+                          endComponent={
+                            <DropdownMenuShortcut
+                              shortcut={pageShortcut}
+                              className="text-xs text-faint dark:text-faint-night"
+                            />
+                          }
+                        />
+                        <DropdownMenuItem
+                          icon={CameraIcon}
+                          label="Take screenshot"
+                          disabled={
+                            captureActions.isCapturing ||
+                            fileUploaderService.isProcessingFiles
+                          }
+                          onClick={() => captureActions.onCapture("screenshot")}
+                          endComponent={
+                            <DropdownMenuShortcut
+                              shortcut={screenshotShortcut}
+                              className="text-xs text-faint dark:text-faint-night"
+                            />
+                          }
+                        />
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+              {actions.includes("attachment") && (
+                <InputBarAttachmentsPicker
+                  fileUploaderService={fileUploaderService}
+                  owner={owner}
+                  isLoading={false}
+                  onNodeSelect={onNodeSelect}
+                  onNodeUnselect={onNodeUnselect}
+                  attachedNodes={attachedNodes}
+                  disabled={disableInput}
+                  buttonSize={buttonSize}
+                  toolFileUpload={{
+                    useCase: "conversation",
+                    useCaseMetadata: {
+                      conversationId: conversation?.sId,
+                    },
+                  }}
+                  spaceId={space?.sId}
+                  type="dropdown"
+                  onFileChange={() => setShowKnowledgePicker(false)}
+                  externalOpen={showKnowledgePicker}
+                  onExternalOpenChange={setShowKnowledgePicker}
+                  anchorRef={plusButtonRef}
+                />
+              )}
+            </>
+          )}
           <div className="flex items-center">
             {isCompactionEnabled && conversation && (
               <ContextUsageIndicator


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/7421#issuecomment-4254607084
## Description
Fixes a few minor ui issues with the chrome extension:
- Add missing shake keyframe to extension tailwind config and match front's animation timing (0.5s ease-in-out)
- Move extension-only PlusIcon from toolbar row to the absolute bottom-right button cluster to prevent submit button overlap (this was completely hiding behind the submit button before)
- Use rem instead of em for navigation pill positioning for consistent spacing across web and extension
- Increase last message bottom margin (mb-8 → mb-10) to prevent message action buttons from overlapping the navigation pill

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Before changes:
<img width="228" height="109" alt="Screenshot 2026-04-15 at 5 46 50 PM" src="https://github.com/user-attachments/assets/1e0af793-32bd-4fe8-abf2-e50d8b2434c8" />
<img width="422" height="140" alt="Screenshot 2026-04-15 at 5 10 54 PM" src="https://github.com/user-attachments/assets/0a7fd773-441e-48b6-8e1b-e7ed916284e5" />
After:
<img width="490" height="361" alt="Screenshot 2026-04-15 at 6 28 35 PM" src="https://github.com/user-attachments/assets/92d39d86-ad68-4ba6-8151-1efd7c84c230" />
<img width="474" height="183" alt="Screenshot 2026-04-15 at 6 17 46 PM" src="https://github.com/user-attachments/assets/8205e7c7-2d3e-4549-8812-acf53e0e37c0" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

Extension changes will go out with sessions extension deploy

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
