### PR TITLE
Add skill suggestion conflict handling

### DIFF
--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -1,6 +1,9 @@
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import { instructionBlockSetsConflict } from "@app/lib/editor/instructions_block_conflict";
+import {
+  buildDescendantMap,
+  instructionBlockSetsConflict,
+} from "@app/lib/editor/instructions_block_conflict";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
@@ -345,11 +348,20 @@ export async function pruneConflictingInstructionSuggestions(
 
   const newTargetBlockIds = new Set(newSuggestions.map((s) => s.targetBlockId));
 
+  const allBlockIds = new Set([
+    ...newTargetBlockIds,
+    ...existingPending.map((s) => s.suggestion.targetBlockId),
+  ]);
+  const descendantMap = agentConfiguration.instructionsHtml
+    ? buildDescendantMap(agentConfiguration.instructionsHtml, allBlockIds)
+    : new Map<string, Set<string>>();
+
   const toMarkOutdated = existingPending.filter((existingSugg) =>
     instructionBlockSetsConflict(
       newTargetBlockIds,
       new Set([existingSugg.suggestion.targetBlockId]),
-      agentConfiguration.instructionsHtml
+      agentConfiguration.instructionsHtml,
+      descendantMap
     )
   );
 

--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -1,5 +1,6 @@
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { Authenticator } from "@app/lib/auth";
+import { instructionBlockSetsConflict } from "@app/lib/editor/instructions_block_conflict";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
@@ -15,7 +16,6 @@ import {
   INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
   parseAgentSuggestionData,
 } from "@app/types/suggestions/agent_suggestion";
-import { JSDOM } from "jsdom";
 
 type ToolsSuggestionResource = AgentSuggestionResource & {
   kind: "tools";
@@ -310,31 +310,6 @@ function getInstructionSuggestionsWithoutExistingBlockId(
   return outdatedSuggestions;
 }
 
-function getDescendantBlockIds(
-  instructionsHtml: string,
-  targetBlockId: string
-): Set<string> {
-  const descendants = new Set<string>();
-
-  const dom = new JSDOM(instructionsHtml);
-  const doc = dom.window.document;
-
-  const targetElement = doc.querySelector(`[data-block-id="${targetBlockId}"]`);
-  if (!targetElement) {
-    return descendants;
-  }
-
-  const descendantElements = targetElement.querySelectorAll("[data-block-id]");
-  descendantElements.forEach((element) => {
-    const descendantId = element.getAttribute("data-block-id");
-    if (descendantId && descendantId !== targetBlockId) {
-      descendants.add(descendantId);
-    }
-  });
-
-  return descendants;
-}
-
 /**
  * Marks existing instruction suggestions as outdated when new suggestions conflict.
  *
@@ -368,56 +343,15 @@ export async function pruneConflictingInstructionSuggestions(
     return;
   }
 
-  // Build conflict detection sets: which blocks are being changed, and which are their descendants
-  const newTargetBlockIds = new Set<string>();
-  const allDescendantBlockIds = new Set<string>();
+  const newTargetBlockIds = new Set(newSuggestions.map((s) => s.targetBlockId));
 
-  for (const newSugg of newSuggestions) {
-    const { targetBlockId } = newSugg;
-    newTargetBlockIds.add(targetBlockId);
-
-    // instructions-root is a full rewrite: mark everything outdated
-    if (targetBlockId === INSTRUCTIONS_ROOT_TARGET_BLOCK_ID) {
-      if (existingPending.length > 0) {
-        await AgentSuggestionResource.bulkUpdateState(
-          auth,
-          existingPending,
-          "outdated"
-        );
-      }
-      return;
-    }
-
-    if (agentConfiguration.instructionsHtml) {
-      const descendants = getDescendantBlockIds(
-        agentConfiguration.instructionsHtml,
-        targetBlockId
-      );
-      descendants.forEach((id) => allDescendantBlockIds.add(id));
-    }
-  }
-
-  const toMarkOutdated: InstructionsSuggestionResource[] = [];
-  for (const existingSugg of existingPending) {
-    const existingTargetId = existingSugg.suggestion.targetBlockId;
-
-    // Conflict 1: Same block (duplicate suggestion for same target)
-    if (newTargetBlockIds.has(existingTargetId)) {
-      toMarkOutdated.push(existingSugg);
-      continue;
-    }
-
-    // Conflict 2: Child block (existing targets a descendant that will be replaced)
-    if (allDescendantBlockIds.has(existingTargetId)) {
-      toMarkOutdated.push(existingSugg);
-      continue;
-    }
-
-    // Conflict 3: Existing is instructions-root but new suggestions are block-level.
-    if (existingTargetId === INSTRUCTIONS_ROOT_TARGET_BLOCK_ID) {
-      toMarkOutdated.push(existingSugg);
-    }
-  }
+  const toMarkOutdated = existingPending.filter((existingSugg) =>
+    instructionBlockSetsConflict(
+      newTargetBlockIds,
+      new Set([existingSugg.suggestion.targetBlockId]),
+      agentConfiguration.instructionsHtml
+    )
+  );
 
   if (toMarkOutdated.length > 0) {
     await AgentSuggestionResource.bulkUpdateState(

--- a/front/lib/editor/instructions_block_conflict.ts
+++ b/front/lib/editor/instructions_block_conflict.ts
@@ -1,6 +1,24 @@
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import { JSDOM } from "jsdom";
 
+function getDescendantBlockIdsFromDoc(
+  doc: Document,
+  targetBlockId: string
+): Set<string> {
+  const descendants = new Set<string>();
+  const targetElement = doc.querySelector(`[data-block-id="${targetBlockId}"]`);
+  if (!targetElement) {
+    return descendants;
+  }
+  targetElement.querySelectorAll("[data-block-id]").forEach((element) => {
+    const descendantId = element.getAttribute("data-block-id");
+    if (descendantId && descendantId !== targetBlockId) {
+      descendants.add(descendantId);
+    }
+  });
+  return descendants;
+}
+
 /**
  * Returns every `data-block-id` nested under `targetBlockId` in serialized
  * instructions HTML
@@ -9,25 +27,26 @@ export function getDescendantBlockIds(
   instructionsHtml: string,
   targetBlockId: string
 ): Set<string> {
-  const descendants = new Set<string>();
+  const dom = new JSDOM(instructionsHtml);
+  return getDescendantBlockIdsFromDoc(dom.window.document, targetBlockId);
+}
 
+/**
+ * Parses instructions HTML once and returns a map of blockId -> descendant block IDs
+ * for the given block IDs. Use this to avoid repeated HTML parsing when checking
+ * conflicts for multiple block IDs.
+ */
+export function buildDescendantMap(
+  instructionsHtml: string,
+  blockIds: Iterable<string>
+): Map<string, Set<string>> {
   const dom = new JSDOM(instructionsHtml);
   const doc = dom.window.document;
-
-  const targetElement = doc.querySelector(`[data-block-id="${targetBlockId}"]`);
-  if (!targetElement) {
-    return descendants;
+  const map = new Map<string, Set<string>>();
+  for (const blockId of blockIds) {
+    map.set(blockId, getDescendantBlockIdsFromDoc(doc, blockId));
   }
-
-  const descendantElements = targetElement.querySelectorAll("[data-block-id]");
-  descendantElements.forEach((element) => {
-    const descendantId = element.getAttribute("data-block-id");
-    if (descendantId && descendantId !== targetBlockId) {
-      descendants.add(descendantId);
-    }
-  });
-
-  return descendants;
+  return map;
 }
 
 /**
@@ -41,7 +60,8 @@ export function getDescendantBlockIds(
 export function instructionBlockSetsConflict(
   blockIdsA: Set<string>,
   blockIdsB: Set<string>,
-  instructionsHtml: string | null
+  instructionsHtml: string | null,
+  descendantMap: Map<string, Set<string>>
 ): boolean {
   if (blockIdsA.size === 0 || blockIdsB.size === 0) {
     return false;
@@ -65,7 +85,7 @@ export function instructionBlockSetsConflict(
   // Ancestor-descendant relationship (symmetric: check both directions).
   if (instructionsHtml) {
     for (const id of blockIdsA) {
-      const descendants = getDescendantBlockIds(instructionsHtml, id);
+      const descendants = descendantMap.get(id) ?? new Set<string>();
       for (const bId of blockIdsB) {
         if (descendants.has(bId)) {
           return true;
@@ -73,7 +93,7 @@ export function instructionBlockSetsConflict(
       }
     }
     for (const id of blockIdsB) {
-      const descendants = getDescendantBlockIds(instructionsHtml, id);
+      const descendants = descendantMap.get(id) ?? new Set<string>();
       for (const aId of blockIdsA) {
         if (descendants.has(aId)) {
           return true;

--- a/front/lib/editor/instructions_block_conflict.ts
+++ b/front/lib/editor/instructions_block_conflict.ts
@@ -1,0 +1,86 @@
+import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
+import { JSDOM } from "jsdom";
+
+/**
+ * Returns every `data-block-id` nested under `targetBlockId` in serialized
+ * instructions HTML
+ */
+export function getDescendantBlockIds(
+  instructionsHtml: string,
+  targetBlockId: string
+): Set<string> {
+  const descendants = new Set<string>();
+
+  const dom = new JSDOM(instructionsHtml);
+  const doc = dom.window.document;
+
+  const targetElement = doc.querySelector(`[data-block-id="${targetBlockId}"]`);
+  if (!targetElement) {
+    return descendants;
+  }
+
+  const descendantElements = targetElement.querySelectorAll("[data-block-id]");
+  descendantElements.forEach((element) => {
+    const descendantId = element.getAttribute("data-block-id");
+    if (descendantId && descendantId !== targetBlockId) {
+      descendants.add(descendantId);
+    }
+  });
+
+  return descendants;
+}
+
+/**
+ * Returns true if two sets of block IDs target overlapping parts of the HTML tree.
+ *
+ * Conflict cases (symmetric):
+ * - Either set contains the root block ID (mutually exclusive with any other edit)
+ * - Both sets contain the same block ID
+ * - Any block in setA is an ancestor of any block in setB, or vice versa
+ */
+export function instructionBlockSetsConflict(
+  blockIdsA: Set<string>,
+  blockIdsB: Set<string>,
+  instructionsHtml: string | null
+): boolean {
+  if (blockIdsA.size === 0 || blockIdsB.size === 0) {
+    return false;
+  }
+
+  // Root rewrite conflicts with everything.
+  if (
+    blockIdsA.has(INSTRUCTIONS_ROOT_TARGET_BLOCK_ID) ||
+    blockIdsB.has(INSTRUCTIONS_ROOT_TARGET_BLOCK_ID)
+  ) {
+    return true;
+  }
+
+  // Same block targeted in both sets.
+  for (const id of blockIdsA) {
+    if (blockIdsB.has(id)) {
+      return true;
+    }
+  }
+
+  // Ancestor-descendant relationship (symmetric: check both directions).
+  if (instructionsHtml) {
+    for (const id of blockIdsA) {
+      const descendants = getDescendantBlockIds(instructionsHtml, id);
+      for (const bId of blockIdsB) {
+        if (descendants.has(bId)) {
+          return true;
+        }
+      }
+    }
+    for (const id of blockIdsB) {
+      const descendants = getDescendantBlockIds(instructionsHtml, id);
+      for (const aId of blockIdsA) {
+        if (descendants.has(aId)) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -8,6 +8,10 @@ import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import {
+  hasSuggestionSelfConflict,
+  pruneConflictingSkillEditSuggestions,
+} from "@app/lib/reinforcement/skill_suggestion_pruning";
+import {
   ALL_TOOLS,
   DESCRIBE_MCP_TOOL_NAME,
   type ExploratoryToolCallInfo,
@@ -68,7 +72,7 @@ const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
             content: z
               .string()
               .describe(
-                "Full replacement content for the block, including its wrapping tag. Must be a single-line string with no literal newlines."
+                "Full HTML replacement content for the block, including its wrapping tag. Must be a single-line string with no literal newlines."
               ),
             type: z.literal("replace"),
           })
@@ -405,55 +409,37 @@ async function createSkillSuggestionsFromToolCall({
         };
       }
 
-      if (hasInstructionEdits && parsed.data.instructionEdits) {
-        const edits = parsed.data.instructionEdits;
-
-        // Reject if multiple edits target the same block.
-        const blockIds = edits.map(
-          (e: { targetBlockId: string }) => e.targetBlockId
-        );
-        const uniqueBlockIds = new Set(blockIds);
-        if (uniqueBlockIds.size !== blockIds.length) {
-          return {
-            suggestionsCreated: 0,
-            error:
-              "Multiple edits target the same block ID. Use one edit per block.",
-          };
-        }
-      }
-
-      // Mark any existing pending edit suggestions for this skill as outdated.
-      // TODO(reinforced-skills): Allow multiple pending edit suggestions (Issue #7444)
-      const existingPending =
-        await SkillSuggestionResource.listBySkillConfigurationId(
-          auth,
-          skill.sId,
+      if (
+        hasSuggestionSelfConflict(
           {
-            states: ["pending"],
-            kind: "edit",
-            sources: ["reinforcement", "synthetic"],
-          }
-        );
-      if (existingPending.length > 0) {
-        await SkillSuggestionResource.bulkUpdateState(
-          auth,
-          existingPending,
-          "outdated"
-        );
+            instructionEdits: parsed.data.instructionEdits,
+            toolEdits: parsed.data.toolEdits,
+          },
+          skill.instructionsHtml
+        )
+      ) {
+        return {
+          suggestionsCreated: 0,
+          error:
+            "Suggestion has conflicting edits (overlapping block targets or duplicate tool IDs).",
+        };
       }
 
-      await SkillSuggestionResource.createSuggestionForSkill(auth, skill, {
-        kind: "edit",
-        suggestion: {
-          instructionEdits: parsed.data.instructionEdits,
-          toolEdits: parsed.data.toolEdits,
-        },
-        analysis: parsed.data.analysis ?? null,
-        state: "pending",
-        source,
-        sourceConversationId: conversation?.id ?? null,
-        groupId: null,
-      });
+      const newSuggestion =
+        await SkillSuggestionResource.createSuggestionForSkill(auth, skill, {
+          kind: "edit",
+          suggestion: {
+            instructionEdits: parsed.data.instructionEdits,
+            toolEdits: parsed.data.toolEdits,
+          },
+          analysis: parsed.data.analysis ?? null,
+          state: "pending",
+          source,
+          sourceConversationId: conversation?.id ?? null,
+          groupId: null,
+        });
+
+      await pruneConflictingSkillEditSuggestions(auth, skill, newSuggestion);
 
       return { suggestionsCreated: 1 };
     }

--- a/front/lib/reinforcement/skill_suggestion_pruning.test.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.test.ts
@@ -1,0 +1,253 @@
+import {
+  hasSuggestionSelfConflict,
+  instructionEditSetsConflict,
+  toolEditSetsConflict,
+} from "@app/lib/reinforcement/skill_suggestion_pruning";
+import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
+import type { SkillEditSuggestionType } from "@app/types/suggestions/skill_suggestion";
+import { describe, expect, it } from "vitest";
+
+const HIERARCHY_HTML = `
+  <div data-block-id="section-1">
+    <p data-block-id="para-1">First paragraph.</p>
+    <p data-block-id="para-2">Second paragraph.</p>
+  </div>
+  <div data-block-id="section-2">
+    <p data-block-id="para-3">Third paragraph.</p>
+  </div>
+`;
+
+function makeInstructionEdit(targetBlockId: string): {
+  targetBlockId: string;
+  content: string;
+  type: "replace";
+} {
+  return {
+    targetBlockId,
+    content: `<p>Content for ${targetBlockId}</p>`,
+    type: "replace",
+  };
+}
+
+function makeToolEdit(
+  toolId: string,
+  action: "add" | "remove" = "add"
+): { toolId: string; action: "add" | "remove" } {
+  return { toolId, action };
+}
+
+describe("instructionEditSetsConflict", () => {
+  it("returns false when either set is empty", () => {
+    expect(
+      instructionEditSetsConflict([], [makeInstructionEdit("para-1")], null)
+    ).toBe(false);
+    expect(
+      instructionEditSetsConflict([makeInstructionEdit("para-1")], [], null)
+    ).toBe(false);
+    expect(instructionEditSetsConflict([], [], null)).toBe(false);
+  });
+
+  it("conflicts when either set contains root rewrite", () => {
+    const root = makeInstructionEdit(INSTRUCTIONS_ROOT_TARGET_BLOCK_ID);
+    const block = makeInstructionEdit("para-1");
+
+    expect(instructionEditSetsConflict([root], [block], null)).toBe(true);
+    expect(instructionEditSetsConflict([block], [root], null)).toBe(true);
+    expect(instructionEditSetsConflict([root], [root], null)).toBe(true);
+  });
+
+  it("conflicts when both sets target the same block ID", () => {
+    const editA = makeInstructionEdit("para-1");
+    const editB = makeInstructionEdit("para-1");
+
+    expect(instructionEditSetsConflict([editA], [editB], null)).toBe(true);
+  });
+
+  it("does not conflict when sets target different, unrelated blocks", () => {
+    expect(
+      instructionEditSetsConflict(
+        [makeInstructionEdit("para-1")],
+        [makeInstructionEdit("para-3")],
+        HIERARCHY_HTML
+      )
+    ).toBe(false);
+  });
+
+  it("conflicts when A targets an ancestor of a block in B", () => {
+    expect(
+      instructionEditSetsConflict(
+        [makeInstructionEdit("section-1")],
+        [makeInstructionEdit("para-1")],
+        HIERARCHY_HTML
+      )
+    ).toBe(true);
+  });
+
+  it("conflicts when B targets an ancestor of a block in A (symmetric)", () => {
+    expect(
+      instructionEditSetsConflict(
+        [makeInstructionEdit("para-1")],
+        [makeInstructionEdit("section-1")],
+        HIERARCHY_HTML
+      )
+    ).toBe(true);
+  });
+
+  it("does not conflict for siblings even without instructionsHtml", () => {
+    expect(
+      instructionEditSetsConflict(
+        [makeInstructionEdit("para-1")],
+        [makeInstructionEdit("para-2")],
+        null
+      )
+    ).toBe(false);
+  });
+
+  it("does not conflict for siblings with instructionsHtml", () => {
+    expect(
+      instructionEditSetsConflict(
+        [makeInstructionEdit("para-1")],
+        [makeInstructionEdit("para-2")],
+        HIERARCHY_HTML
+      )
+    ).toBe(false);
+  });
+
+  it("conflicts when a block in A targets a deeply nested descendant via B", () => {
+    expect(
+      instructionEditSetsConflict(
+        [makeInstructionEdit("section-1")],
+        [makeInstructionEdit("para-2")],
+        HIERARCHY_HTML
+      )
+    ).toBe(true);
+  });
+});
+
+describe("toolEditSetsConflict", () => {
+  it("returns false when sets target different tool IDs", () => {
+    expect(
+      toolEditSetsConflict(
+        [makeToolEdit("tool-search")],
+        [makeToolEdit("tool-calendar")]
+      )
+    ).toBe(false);
+  });
+
+  it("conflicts when sets share a tool ID", () => {
+    expect(
+      toolEditSetsConflict(
+        [makeToolEdit("tool-search", "add")],
+        [makeToolEdit("tool-search", "remove")]
+      )
+    ).toBe(true);
+  });
+
+  it("conflicts when both sets add the same tool ID", () => {
+    expect(
+      toolEditSetsConflict(
+        [makeToolEdit("tool-search", "add")],
+        [makeToolEdit("tool-search", "add")]
+      )
+    ).toBe(true);
+  });
+
+  it("returns false when either set is empty", () => {
+    expect(toolEditSetsConflict([], [makeToolEdit("tool-search")])).toBe(false);
+    expect(toolEditSetsConflict([makeToolEdit("tool-search")], [])).toBe(false);
+  });
+});
+
+function makeSuggestion(
+  overrides: Partial<SkillEditSuggestionType> = {}
+): SkillEditSuggestionType {
+  return {
+    instructionEdits: [],
+    toolEdits: [],
+    ...overrides,
+  } as SkillEditSuggestionType;
+}
+
+describe("hasSuggestionSelfConflict", () => {
+  it("returns false for non-conflicting instruction edits", () => {
+    expect(
+      hasSuggestionSelfConflict(
+        makeSuggestion({
+          instructionEdits: [
+            makeInstructionEdit("para-1"),
+            makeInstructionEdit("para-3"),
+          ],
+        }),
+        HIERARCHY_HTML
+      )
+    ).toBe(false);
+  });
+
+  it("conflicts when root rewrite is combined with any other instruction edit", () => {
+    expect(
+      hasSuggestionSelfConflict(
+        makeSuggestion({
+          instructionEdits: [
+            makeInstructionEdit(INSTRUCTIONS_ROOT_TARGET_BLOCK_ID),
+            makeInstructionEdit("para-1"),
+          ],
+        }),
+        null
+      )
+    ).toBe(true);
+  });
+
+  it("conflicts when two instruction edits target the same block", () => {
+    expect(
+      hasSuggestionSelfConflict(
+        makeSuggestion({
+          instructionEdits: [
+            makeInstructionEdit("para-1"),
+            makeInstructionEdit("para-1"),
+          ],
+        }),
+        null
+      )
+    ).toBe(true);
+  });
+
+  it("conflicts when one instruction edit targets an ancestor of another", () => {
+    expect(
+      hasSuggestionSelfConflict(
+        makeSuggestion({
+          instructionEdits: [
+            makeInstructionEdit("section-1"),
+            makeInstructionEdit("para-1"),
+          ],
+        }),
+        HIERARCHY_HTML
+      )
+    ).toBe(true);
+  });
+
+  it("conflicts when two tool edits target the same tool ID", () => {
+    expect(
+      hasSuggestionSelfConflict(
+        makeSuggestion({
+          toolEdits: [
+            makeToolEdit("tool-search", "add"),
+            makeToolEdit("tool-search", "remove"),
+          ],
+        }),
+        null
+      )
+    ).toBe(true);
+  });
+
+  it("returns false for mixed non-conflicting instruction and tool edits", () => {
+    expect(
+      hasSuggestionSelfConflict(
+        makeSuggestion({
+          instructionEdits: [makeInstructionEdit("para-1")],
+          toolEdits: [makeToolEdit("tool-search")],
+        }),
+        HIERARCHY_HTML
+      )
+    ).toBe(false);
+  });
+});

--- a/front/lib/reinforcement/skill_suggestion_pruning.test.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.test.ts
@@ -1,3 +1,4 @@
+import { buildDescendantMap } from "@app/lib/editor/instructions_block_conflict";
 import {
   hasSuggestionSelfConflict,
   instructionEditSetsConflict,
@@ -36,59 +37,104 @@ function makeToolEdit(
   return { toolId, action };
 }
 
+const EMPTY_DESCENDANT_MAP = new Map<string, Set<string>>();
+
+function descendantMapForConflict(
+  html: string | null,
+  editsA: Array<{ targetBlockId: string }>,
+  editsB: Array<{ targetBlockId: string }>
+): Map<string, Set<string>> {
+  if (!html) {
+    return EMPTY_DESCENDANT_MAP;
+  }
+  return buildDescendantMap(html, [
+    ...editsA.map((e) => e.targetBlockId),
+    ...editsB.map((e) => e.targetBlockId),
+  ]);
+}
+
 describe("instructionEditSetsConflict", () => {
   it("returns false when either set is empty", () => {
     expect(
-      instructionEditSetsConflict([], [makeInstructionEdit("para-1")], null)
+      instructionEditSetsConflict(
+        [],
+        [makeInstructionEdit("para-1")],
+        null,
+        EMPTY_DESCENDANT_MAP
+      )
     ).toBe(false);
     expect(
-      instructionEditSetsConflict([makeInstructionEdit("para-1")], [], null)
+      instructionEditSetsConflict(
+        [makeInstructionEdit("para-1")],
+        [],
+        null,
+        EMPTY_DESCENDANT_MAP
+      )
     ).toBe(false);
-    expect(instructionEditSetsConflict([], [], null)).toBe(false);
+    expect(
+      instructionEditSetsConflict([], [], null, EMPTY_DESCENDANT_MAP)
+    ).toBe(false);
   });
 
   it("conflicts when either set contains root rewrite", () => {
     const root = makeInstructionEdit(INSTRUCTIONS_ROOT_TARGET_BLOCK_ID);
     const block = makeInstructionEdit("para-1");
 
-    expect(instructionEditSetsConflict([root], [block], null)).toBe(true);
-    expect(instructionEditSetsConflict([block], [root], null)).toBe(true);
-    expect(instructionEditSetsConflict([root], [root], null)).toBe(true);
+    expect(
+      instructionEditSetsConflict([root], [block], null, EMPTY_DESCENDANT_MAP)
+    ).toBe(true);
+    expect(
+      instructionEditSetsConflict([block], [root], null, EMPTY_DESCENDANT_MAP)
+    ).toBe(true);
+    expect(
+      instructionEditSetsConflict([root], [root], null, EMPTY_DESCENDANT_MAP)
+    ).toBe(true);
   });
 
   it("conflicts when both sets target the same block ID", () => {
     const editA = makeInstructionEdit("para-1");
     const editB = makeInstructionEdit("para-1");
 
-    expect(instructionEditSetsConflict([editA], [editB], null)).toBe(true);
+    expect(
+      instructionEditSetsConflict([editA], [editB], null, EMPTY_DESCENDANT_MAP)
+    ).toBe(true);
   });
 
   it("does not conflict when sets target different, unrelated blocks", () => {
+    const editsA = [makeInstructionEdit("para-1")];
+    const editsB = [makeInstructionEdit("para-3")];
     expect(
       instructionEditSetsConflict(
-        [makeInstructionEdit("para-1")],
-        [makeInstructionEdit("para-3")],
-        HIERARCHY_HTML
+        editsA,
+        editsB,
+        HIERARCHY_HTML,
+        descendantMapForConflict(HIERARCHY_HTML, editsA, editsB)
       )
     ).toBe(false);
   });
 
   it("conflicts when A targets an ancestor of a block in B", () => {
+    const editsA = [makeInstructionEdit("section-1")];
+    const editsB = [makeInstructionEdit("para-1")];
     expect(
       instructionEditSetsConflict(
-        [makeInstructionEdit("section-1")],
-        [makeInstructionEdit("para-1")],
-        HIERARCHY_HTML
+        editsA,
+        editsB,
+        HIERARCHY_HTML,
+        descendantMapForConflict(HIERARCHY_HTML, editsA, editsB)
       )
     ).toBe(true);
   });
 
   it("conflicts when B targets an ancestor of a block in A (symmetric)", () => {
+    const editsA = [makeInstructionEdit("para-1")];
+    const editsB = [makeInstructionEdit("section-1")];
     expect(
       instructionEditSetsConflict(
-        [makeInstructionEdit("para-1")],
-        [makeInstructionEdit("section-1")],
-        HIERARCHY_HTML
+        editsA,
+        editsB,
+        HIERARCHY_HTML,
+        descendantMapForConflict(HIERARCHY_HTML, editsA, editsB)
       )
     ).toBe(true);
   });
@@ -98,27 +144,34 @@ describe("instructionEditSetsConflict", () => {
       instructionEditSetsConflict(
         [makeInstructionEdit("para-1")],
         [makeInstructionEdit("para-2")],
-        null
+        null,
+        EMPTY_DESCENDANT_MAP
       )
     ).toBe(false);
   });
 
   it("does not conflict for siblings with instructionsHtml", () => {
+    const editsA = [makeInstructionEdit("para-1")];
+    const editsB = [makeInstructionEdit("para-2")];
     expect(
       instructionEditSetsConflict(
-        [makeInstructionEdit("para-1")],
-        [makeInstructionEdit("para-2")],
-        HIERARCHY_HTML
+        editsA,
+        editsB,
+        HIERARCHY_HTML,
+        descendantMapForConflict(HIERARCHY_HTML, editsA, editsB)
       )
     ).toBe(false);
   });
 
   it("conflicts when a block in A targets a deeply nested descendant via B", () => {
+    const editsA = [makeInstructionEdit("section-1")];
+    const editsB = [makeInstructionEdit("para-2")];
     expect(
       instructionEditSetsConflict(
-        [makeInstructionEdit("section-1")],
-        [makeInstructionEdit("para-2")],
-        HIERARCHY_HTML
+        editsA,
+        editsB,
+        HIERARCHY_HTML,
+        descendantMapForConflict(HIERARCHY_HTML, editsA, editsB)
       )
     ).toBe(true);
   });

--- a/front/lib/reinforcement/skill_suggestion_pruning.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.ts
@@ -1,5 +1,8 @@
 import type { Authenticator } from "@app/lib/auth";
-import { instructionBlockSetsConflict } from "@app/lib/editor/instructions_block_conflict";
+import {
+  buildDescendantMap,
+  instructionBlockSetsConflict,
+} from "@app/lib/editor/instructions_block_conflict";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
@@ -11,11 +14,15 @@ import type {
 
 /**
  * Returns true if two sets of instruction edits target overlapping parts of the HTML tree.
+ *
+ * @param descendantMap Optional pre-built map of blockId -> descendants to avoid
+ *   repeated HTML parsing when called in a loop. Build once with buildDescendantMap.
  */
 export function instructionEditSetsConflict(
   editsA: SkillInstructionEditItemType[],
   editsB: SkillInstructionEditItemType[],
-  instructionsHtml: string | null
+  instructionsHtml: string | null,
+  descendantMap: Map<string, Set<string>>
 ): boolean {
   if (editsA.length === 0 || editsB.length === 0) {
     return false;
@@ -23,7 +30,8 @@ export function instructionEditSetsConflict(
   return instructionBlockSetsConflict(
     new Set(editsA.map((e) => e.targetBlockId)),
     new Set(editsB.map((e) => e.targetBlockId)),
-    instructionsHtml
+    instructionsHtml,
+    descendantMap
   );
 }
 
@@ -48,13 +56,23 @@ export function hasSuggestionSelfConflict(
   const instructionEdits = suggestion.instructionEdits ?? [];
   const toolEdits = suggestion.toolEdits ?? [];
 
+  // O(n²) acceptable: instructionEdits is bounded by LLM output (< 20 elements per suggestion).
+  // Precompute descendant map once to avoid repeated HTML parsing across all pair checks.
+  const descendantMap = instructionsHtml
+    ? buildDescendantMap(
+        instructionsHtml,
+        instructionEdits.map((e) => e.targetBlockId)
+      )
+    : new Map<string, Set<string>>();
+
   for (let i = 0; i < instructionEdits.length; i++) {
     for (let j = i + 1; j < instructionEdits.length; j++) {
       if (
         instructionEditSetsConflict(
           [instructionEdits[i]],
           [instructionEdits[j]],
-          instructionsHtml
+          instructionsHtml,
+          descendantMap
         )
       ) {
         return true;
@@ -110,13 +128,30 @@ export async function pruneConflictingSkillEditSuggestions(
     return;
   }
 
+  // Precompute descendant map for all instruction-edit targets (new + existing) so each pair
+  // check shares one parse.
+  const allInstructionTargetIds = new Set<string>();
+  for (const e of newInstructionEdits) {
+    allInstructionTargetIds.add(e.targetBlockId);
+  }
+  for (const p of existingPending) {
+    for (const e of p.toJSON().suggestion.instructionEdits ?? []) {
+      allInstructionTargetIds.add(e.targetBlockId);
+    }
+  }
+  const descendantMap =
+    skill.instructionsHtml && allInstructionTargetIds.size > 0
+      ? buildDescendantMap(skill.instructionsHtml, allInstructionTargetIds)
+      : new Map<string, Set<string>>();
+
   const toMarkOutdated = existingPending.filter((existing) => {
     const existingData = existing.toJSON();
     return (
       instructionEditSetsConflict(
         newInstructionEdits,
         existingData.suggestion.instructionEdits ?? [],
-        skill.instructionsHtml
+        skill.instructionsHtml,
+        descendantMap
       ) ||
       toolEditSetsConflict(
         newToolEdits,

--- a/front/lib/reinforcement/skill_suggestion_pruning.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.ts
@@ -1,0 +1,133 @@
+import type { Authenticator } from "@app/lib/auth";
+import { instructionBlockSetsConflict } from "@app/lib/editor/instructions_block_conflict";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
+import type {
+  SkillEditSuggestionType,
+  SkillInstructionEditItemType,
+  SkillToolEditItemType,
+} from "@app/types/suggestions/skill_suggestion";
+
+/**
+ * Returns true if two sets of instruction edits target overlapping parts of the HTML tree.
+ */
+export function instructionEditSetsConflict(
+  editsA: SkillInstructionEditItemType[],
+  editsB: SkillInstructionEditItemType[],
+  instructionsHtml: string | null
+): boolean {
+  if (editsA.length === 0 || editsB.length === 0) {
+    return false;
+  }
+  return instructionBlockSetsConflict(
+    new Set(editsA.map((e) => e.targetBlockId)),
+    new Set(editsB.map((e) => e.targetBlockId)),
+    instructionsHtml
+  );
+}
+
+/**
+ * Returns true if two sets of tool edits target the same tool ID.
+ */
+export function toolEditSetsConflict(
+  editsA: SkillToolEditItemType[],
+  editsB: SkillToolEditItemType[]
+): boolean {
+  const toolIdsA = new Set(editsA.map((e) => e.toolId));
+  return editsB.some((e) => toolIdsA.has(e.toolId));
+}
+
+/**
+ * Returns true if a single suggestion's edits are internally inconsistent.
+ */
+export function hasSuggestionSelfConflict(
+  suggestion: SkillEditSuggestionType,
+  instructionsHtml: string | null
+): boolean {
+  const instructionEdits = suggestion.instructionEdits ?? [];
+  const toolEdits = suggestion.toolEdits ?? [];
+
+  for (let i = 0; i < instructionEdits.length; i++) {
+    for (let j = i + 1; j < instructionEdits.length; j++) {
+      if (
+        instructionEditSetsConflict(
+          [instructionEdits[i]],
+          [instructionEdits[j]],
+          instructionsHtml
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+
+  const toolIds = toolEdits.map((e) => e.toolId);
+  if (new Set(toolIds).size < toolIds.length) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Marks existing pending skill edit suggestions as outdated when a new suggestion conflicts.
+ */
+export async function pruneConflictingSkillEditSuggestions(
+  auth: Authenticator,
+  skill: SkillResource,
+  newSuggestion: SkillSuggestionResource
+): Promise<void> {
+  const allPending = await SkillSuggestionResource.listBySkillConfigurationId(
+    auth,
+    skill.sId,
+    {
+      states: ["pending"],
+      kind: "edit",
+    }
+  );
+
+  const existingPending = allPending.filter((s) => s.sId !== newSuggestion.sId);
+  if (existingPending.length === 0) {
+    return;
+  }
+
+  const newData = newSuggestion.toJSON();
+  const newInstructionEdits = newData.suggestion.instructionEdits ?? [];
+  const newToolEdits = newData.suggestion.toolEdits ?? [];
+
+  // Full rewrite — everything is outdated.
+  if (
+    newInstructionEdits.some(
+      (e) => e.targetBlockId === INSTRUCTIONS_ROOT_TARGET_BLOCK_ID
+    )
+  ) {
+    await SkillSuggestionResource.bulkUpdateState(
+      auth,
+      existingPending,
+      "outdated"
+    );
+    return;
+  }
+
+  const toMarkOutdated = existingPending.filter((existing) => {
+    const existingData = existing.toJSON();
+    return (
+      instructionEditSetsConflict(
+        newInstructionEdits,
+        existingData.suggestion.instructionEdits ?? [],
+        skill.instructionsHtml
+      ) ||
+      toolEditSetsConflict(
+        newToolEdits,
+        existingData.suggestion.toolEdits ?? []
+      )
+    );
+  });
+
+  await SkillSuggestionResource.bulkUpdateState(
+    auth,
+    toMarkOutdated,
+    "outdated"
+  );
+}


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/7444
* Marking overlapping suggestions as outdated with new suggestion
* Rejecting a suggestion if a single batch overlaps with itself (like one suggestion has multiple edits for the same block)
* Some consolidation with agent logic

## Tests

* Full unit test coverage (see below)

## Risk

* Low

## Deploy Plan

1. Deploy front