### PR TITLE
Add dsbx forward subcommand for sandbox egress

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +74,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +126,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -151,10 +184,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "displaydoc"
@@ -168,15 +235,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dust-sandbox"
 version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
+ "libc",
  "reqwest",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
+ "tempfile",
+ "time",
  "tokio",
+ "tokio-rustls",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -188,6 +269,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -203,6 +290,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -501,6 +594,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,10 +614,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -544,6 +659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +685,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +710,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking_lot"
@@ -621,6 +766,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -749,6 +900,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,17 +975,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -836,6 +1031,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -854,10 +1050,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -912,6 +1140,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1002,6 +1239,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1269,46 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1136,7 +1426,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1146,6 +1448,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1189,6 +1534,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "want"

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -11,6 +11,16 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
+libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rustls = "0.23"
+rustls-native-certs = "0.8"
+time = { version = "=0.3.36", features = ["formatting"] }
+tokio-rustls = "0.26"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+
+[dev-dependencies]
+tempfile = "=3.20.0"

--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -1,0 +1,86 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+use tokio::io::AsyncWriteExt;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DenyReason {
+    ProxyDenied,
+    ProxyProtocolError,
+    DomainExtractionFailed,
+}
+
+impl DenyReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ProxyDenied => "proxy_denied",
+            Self::ProxyProtocolError => "proxy_protocol_error",
+            Self::DomainExtractionFailed => "domain_extraction_failed",
+        }
+    }
+}
+
+pub async fn append_deny_log(
+    path: &Path,
+    domain: &str,
+    port: u16,
+    reason: DenyReason,
+) -> Result<()> {
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await
+        .with_context(|| format!("failed to open deny log {}", path.display()))?;
+    let line = format_deny_log_line(domain, port, reason)?;
+    file.write_all(line.as_bytes())
+        .await
+        .with_context(|| format!("failed to write deny log {}", path.display()))?;
+    Ok(())
+}
+
+fn format_deny_log_line(domain: &str, port: u16, reason: DenyReason) -> Result<String> {
+    let timestamp = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .context("failed to format deny log timestamp")?;
+    let domain = if domain.is_empty() {
+        "<unknown>"
+    } else {
+        domain
+    };
+    Ok(format!(
+        "{timestamp} DENIED {domain}:{port} (reason: {})\n",
+        reason.as_str()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::{append_deny_log, DenyReason};
+
+    #[tokio::test]
+    async fn appends_deny_log_entries() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let path = tempdir.path().join("deny.log");
+
+        append_deny_log(&path, "api.openai.com", 443, DenyReason::ProxyDenied)
+            .await
+            .expect("first append should succeed");
+        append_deny_log(&path, "", 80, DenyReason::DomainExtractionFailed)
+            .await
+            .expect("second append should succeed");
+
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .expect("deny log should be readable");
+        let lines: Vec<&str> = content.lines().collect();
+
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("DENIED api.openai.com:443 (reason: proxy_denied)"));
+        assert!(lines[1].contains("DENIED <unknown>:80 (reason: domain_extraction_failed)"));
+    }
+}

--- a/cli/dust-sandbox/src/commands/forward/handshake.rs
+++ b/cli/dust-sandbox/src/commands/forward/handshake.rs
@@ -1,0 +1,63 @@
+// Keep these constants and frame layout in sync with egress-proxy/src/handshake.rs.
+pub const PROTOCOL_VERSION: u8 = 0x01;
+pub const ALLOW_RESPONSE: u8 = 0x00;
+pub const DENY_RESPONSE: u8 = 0x01;
+
+pub fn build_handshake_frame(token: &str, domain: &str, original_dest_port: u16) -> Vec<u8> {
+    let token_bytes = token.as_bytes();
+    let domain_bytes = domain.as_bytes();
+    let token_len =
+        u16::try_from(token_bytes.len()).expect("token length should fit in the wire format");
+    let domain_len =
+        u16::try_from(domain_bytes.len()).expect("domain length should fit in the wire format");
+
+    let mut frame = Vec::with_capacity(1 + 2 + token_bytes.len() + 2 + domain_bytes.len() + 2);
+    frame.push(PROTOCOL_VERSION);
+    frame.extend_from_slice(&token_len.to_be_bytes());
+    frame.extend_from_slice(token_bytes);
+    frame.extend_from_slice(&domain_len.to_be_bytes());
+    frame.extend_from_slice(domain_bytes);
+    frame.extend_from_slice(&original_dest_port.to_be_bytes());
+    frame
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_handshake_frame, ALLOW_RESPONSE, DENY_RESPONSE, PROTOCOL_VERSION};
+
+    #[test]
+    fn encodes_handshake_frame_in_proxy_wire_format() {
+        let frame = build_handshake_frame("token", "example.com", 443);
+
+        assert_eq!(
+            frame,
+            vec![
+                PROTOCOL_VERSION,
+                0x00,
+                0x05,
+                b't',
+                b'o',
+                b'k',
+                b'e',
+                b'n',
+                0x00,
+                0x0b,
+                b'e',
+                b'x',
+                b'a',
+                b'm',
+                b'p',
+                b'l',
+                b'e',
+                b'.',
+                b'c',
+                b'o',
+                b'm',
+                0x01,
+                0xbb
+            ]
+        );
+        assert_eq!(ALLOW_RESPONSE, 0x00);
+        assert_eq!(DENY_RESPONSE, 0x01);
+    }
+}

--- a/cli/dust-sandbox/src/commands/forward/http_host.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_host.rs
@@ -15,6 +15,9 @@ pub fn parse_http_host(bytes: &[u8]) -> DomainParseResult {
         }
         if let Some((name, value)) = line.split_once(':') {
             if name.eq_ignore_ascii_case("host") {
+                if header_end.is_none() {
+                    return DomainParseResult::Incomplete;
+                }
                 let host = strip_port(value.trim());
                 return if host.is_empty() {
                     DomainParseResult::NotFound
@@ -99,6 +102,12 @@ mod tests {
     #[test]
     fn returns_incomplete_for_partial_headers() {
         let request = b"GET / HTTP/1.1\r\nUser-Agent: curl\r\n";
+        assert_eq!(parse_http_host(request), DomainParseResult::Incomplete);
+    }
+
+    #[test]
+    fn returns_incomplete_for_partial_host_header_line() {
+        let request = b"GET / HTTP/1.1\r\nHost: api.op";
         assert_eq!(parse_http_host(request), DomainParseResult::Incomplete);
     }
 }

--- a/cli/dust-sandbox/src/commands/forward/http_host.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_host.rs
@@ -1,0 +1,104 @@
+use super::DomainParseResult;
+
+pub fn parse_http_host(bytes: &[u8]) -> DomainParseResult {
+    let header_end = find_subslice(bytes, b"\r\n\r\n");
+    let parse_end = header_end.map_or(bytes.len(), |index| index + 4);
+    let header_bytes = &bytes[..parse_end];
+    let header_text = match std::str::from_utf8(header_bytes) {
+        Ok(text) => text,
+        Err(_) => return DomainParseResult::NotFound,
+    };
+
+    for line in header_text.split("\r\n").skip(1) {
+        if line.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            if name.eq_ignore_ascii_case("host") {
+                let host = strip_port(value.trim());
+                return if host.is_empty() {
+                    DomainParseResult::NotFound
+                } else {
+                    DomainParseResult::Found(host.to_string())
+                };
+            }
+        }
+    }
+
+    if header_end.is_some() {
+        DomainParseResult::NotFound
+    } else {
+        DomainParseResult::Incomplete
+    }
+}
+
+fn strip_port(host: &str) -> &str {
+    if let Some(end_bracket) = host.find(']') {
+        if host.starts_with('[') {
+            return &host[1..end_bracket];
+        }
+    }
+
+    if host.matches(':').count() == 1 {
+        return host.split(':').next().unwrap_or(host);
+    }
+
+    host
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::DomainParseResult;
+    use super::parse_http_host;
+
+    #[test]
+    fn parses_standard_host_header() {
+        let request = b"GET / HTTP/1.1\r\nHost: example.com\r\nUser-Agent: curl\r\n\r\n";
+        assert_eq!(
+            parse_http_host(request),
+            DomainParseResult::Found("example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_host_header_case_insensitively() {
+        let lowercase = b"GET / HTTP/1.1\r\nhost: lowercase.example\r\n\r\n";
+        let uppercase = b"GET / HTTP/1.1\r\nHOST: uppercase.example\r\n\r\n";
+
+        assert_eq!(
+            parse_http_host(lowercase),
+            DomainParseResult::Found("lowercase.example".to_string())
+        );
+        assert_eq!(
+            parse_http_host(uppercase),
+            DomainParseResult::Found("uppercase.example".to_string())
+        );
+    }
+
+    #[test]
+    fn strips_port_from_host_header() {
+        let request = b"GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n";
+        assert_eq!(
+            parse_http_host(request),
+            DomainParseResult::Found("example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_not_found_when_host_header_is_missing() {
+        let request = b"GET / HTTP/1.1\r\nUser-Agent: curl\r\n\r\n";
+        assert_eq!(parse_http_host(request), DomainParseResult::NotFound);
+    }
+
+    #[test]
+    fn returns_incomplete_for_partial_headers() {
+        let request = b"GET / HTTP/1.1\r\nUser-Agent: curl\r\n";
+        assert_eq!(parse_http_host(request), DomainParseResult::Incomplete);
+    }
+}

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -1,0 +1,333 @@
+mod deny_log;
+mod handshake;
+mod http_host;
+mod original_dst;
+mod sni;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{ensure, Context, Result};
+use clap::Args;
+use rustls::pki_types::ServerName;
+use rustls::ClientConfig;
+use rustls::RootCertStore;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::{sleep, timeout, timeout_at, Instant};
+use tokio_rustls::TlsConnector;
+use tracing::{debug, info, warn};
+
+use self::deny_log::{append_deny_log, DenyReason};
+use self::handshake::{build_handshake_frame, ALLOW_RESPONSE, DENY_RESPONSE};
+use self::http_host::parse_http_host;
+use self::original_dst::resolve_original_dst;
+use self::sni::parse_client_hello_sni;
+
+const DOMAIN_PEEK_TIMEOUT: Duration = Duration::from_secs(2);
+const DOMAIN_PEEK_RETRY_DELAY: Duration = Duration::from_millis(25);
+const PROXY_RESPONSE_TIMEOUT: Duration = Duration::from_secs(2);
+const DOMAIN_PEEK_BUFFER_SIZE: usize = 16 * 1024;
+
+#[derive(Args, Debug, Clone)]
+pub struct ForwardArgs {
+    /// Path to the JWT token file
+    #[arg(long)]
+    token_file: PathBuf,
+    /// Proxy TCP address in host:port form
+    #[arg(long)]
+    proxy_addr: std::net::SocketAddr,
+    /// TLS server name used for certificate verification
+    #[arg(long)]
+    proxy_tls_name: String,
+    /// Local listen address in host:port form
+    #[arg(long)]
+    listen: std::net::SocketAddr,
+    /// Path to the deny log file
+    #[arg(long, default_value = "/tmp/dust-egress-denied.log")]
+    deny_log: PathBuf,
+}
+
+#[derive(Clone)]
+struct ForwardRuntime {
+    token: Arc<str>,
+    proxy_addr: std::net::SocketAddr,
+    proxy_tls_name: Arc<str>,
+    deny_log: Arc<PathBuf>,
+    tls_connector: TlsConnector,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum DomainParseResult {
+    Found(String),
+    NotFound,
+    Incomplete,
+}
+
+#[derive(Debug)]
+struct DomainExtraction {
+    domain: String,
+    failed: bool,
+}
+
+pub async fn cmd_forward(args: ForwardArgs) -> Result<()> {
+    let token = load_token(&args.token_file).await?;
+    let tls_connector = build_tls_connector()?;
+    let listener = TcpListener::bind(args.listen)
+        .await
+        .with_context(|| format!("failed to bind forward listener on {}", args.listen))?;
+
+    info!(
+        listen_addr = %args.listen,
+        proxy_addr = %args.proxy_addr,
+        proxy_tls_name = %args.proxy_tls_name,
+        deny_log = %args.deny_log.display(),
+        "starting dsbx forwarder"
+    );
+
+    let runtime = ForwardRuntime {
+        token: Arc::<str>::from(token),
+        proxy_addr: args.proxy_addr,
+        proxy_tls_name: Arc::<str>::from(args.proxy_tls_name),
+        deny_log: Arc::new(args.deny_log),
+        tls_connector,
+    };
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, peer_addr)) => {
+                let runtime = runtime.clone();
+                tokio::spawn(async move {
+                    if let Err(error) = handle_connection(runtime, stream, peer_addr).await {
+                        warn!(peer_addr = %peer_addr, error = %error, "forwarded connection failed");
+                    }
+                });
+            }
+            Err(error) => {
+                warn!(error = %error, "failed to accept forwarded connection");
+            }
+        }
+    }
+}
+
+async fn load_token(token_file: &PathBuf) -> Result<String> {
+    let token = tokio::fs::read_to_string(token_file)
+        .await
+        .with_context(|| format!("failed to read token file {}", token_file.display()))?;
+    let trimmed = token.trim().to_string();
+    ensure!(
+        !trimmed.is_empty(),
+        "token file {} did not contain a JWT",
+        token_file.display()
+    );
+    Ok(trimmed)
+}
+
+fn build_tls_connector() -> Result<TlsConnector> {
+    let mut roots = RootCertStore::empty();
+    let certs = rustls_native_certs::load_native_certs();
+
+    for error in certs.errors {
+        warn!(error = %error, "failed to load a native root certificate");
+    }
+
+    let (loaded, ignored) = roots.add_parsable_certificates(certs.certs);
+    if ignored != 0 {
+        warn!(
+            ignored_cert_count = ignored,
+            "ignored native root certificates"
+        );
+    }
+    ensure!(
+        loaded != 0,
+        "failed to load any native root certificates for proxy TLS validation"
+    );
+
+    let config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+    Ok(TlsConnector::from(Arc::new(config)))
+}
+
+async fn handle_connection(
+    runtime: ForwardRuntime,
+    mut client_stream: TcpStream,
+    peer_addr: std::net::SocketAddr,
+) -> Result<()> {
+    let original_dst =
+        resolve_original_dst(&client_stream).context("failed to resolve original destination")?;
+    let original_port = original_dst.port();
+    let domain_extraction = extract_domain(&client_stream, original_port).await;
+
+    let server_name = ServerName::try_from(runtime.proxy_tls_name.to_string())
+        .context("invalid proxy TLS server name")?;
+    let proxy_stream = TcpStream::connect(runtime.proxy_addr)
+        .await
+        .with_context(|| format!("failed to connect to proxy {}", runtime.proxy_addr))?;
+    let mut proxy_stream = runtime
+        .tls_connector
+        .connect(server_name, proxy_stream)
+        .await
+        .context("failed to establish TLS connection to proxy")?;
+
+    let frame = build_handshake_frame(&runtime.token, &domain_extraction.domain, original_port);
+    proxy_stream
+        .write_all(&frame)
+        .await
+        .context("failed to write proxy handshake frame")?;
+
+    let proxy_response = read_proxy_response(&mut proxy_stream).await;
+    match proxy_response {
+        ProxyDecision::Allow => {
+            info!(
+                peer_addr = %peer_addr,
+                original_port,
+                domain = display_domain(&domain_extraction.domain),
+                "proxy allowed forwarded connection"
+            );
+            tokio::io::copy_bidirectional(&mut client_stream, &mut proxy_stream)
+                .await
+                .context("bidirectional copy failed")?;
+        }
+        ProxyDecision::Deny => {
+            let reason = if domain_extraction.failed {
+                DenyReason::DomainExtractionFailed
+            } else {
+                DenyReason::ProxyDenied
+            };
+            append_deny_log(
+                &runtime.deny_log,
+                &domain_extraction.domain,
+                original_port,
+                reason,
+            )
+            .await
+            .context("failed to append deny log entry")?;
+            info!(
+                peer_addr = %peer_addr,
+                original_port,
+                domain = display_domain(&domain_extraction.domain),
+                reason = reason.as_str(),
+                "proxy denied forwarded connection"
+            );
+        }
+        ProxyDecision::ProtocolError => {
+            append_deny_log(
+                &runtime.deny_log,
+                &domain_extraction.domain,
+                original_port,
+                DenyReason::ProxyProtocolError,
+            )
+            .await
+            .context("failed to append protocol-error deny log entry")?;
+            warn!(
+                peer_addr = %peer_addr,
+                original_port,
+                domain = display_domain(&domain_extraction.domain),
+                "proxy returned an invalid response"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn display_domain(domain: &str) -> &str {
+    if domain.is_empty() {
+        "<unknown>"
+    } else {
+        domain
+    }
+}
+
+async fn extract_domain(stream: &TcpStream, original_port: u16) -> DomainExtraction {
+    match original_port {
+        80 => extract_domain_with_parser(stream, parse_http_host).await,
+        443 => extract_domain_with_parser(stream, parse_client_hello_sni).await,
+        _ => DomainExtraction {
+            domain: String::new(),
+            failed: false,
+        },
+    }
+}
+
+async fn extract_domain_with_parser<F>(stream: &TcpStream, parser: F) -> DomainExtraction
+where
+    F: Fn(&[u8]) -> DomainParseResult,
+{
+    let mut buffer = vec![0_u8; DOMAIN_PEEK_BUFFER_SIZE];
+    let deadline = Instant::now() + DOMAIN_PEEK_TIMEOUT;
+
+    loop {
+        let bytes_read = match timeout_at(deadline, stream.peek(&mut buffer)).await {
+            Ok(Ok(bytes_read)) => bytes_read,
+            Ok(Err(error)) => {
+                debug!(error = %error, "failed to peek client bytes for domain extraction");
+                return DomainExtraction {
+                    domain: String::new(),
+                    failed: true,
+                };
+            }
+            Err(_) => {
+                return DomainExtraction {
+                    domain: String::new(),
+                    failed: true,
+                };
+            }
+        };
+
+        if bytes_read == 0 {
+            return DomainExtraction {
+                domain: String::new(),
+                failed: true,
+            };
+        }
+
+        match parser(&buffer[..bytes_read]) {
+            DomainParseResult::Found(domain) => {
+                return DomainExtraction {
+                    domain,
+                    failed: false,
+                };
+            }
+            DomainParseResult::NotFound => {
+                return DomainExtraction {
+                    domain: String::new(),
+                    failed: false,
+                };
+            }
+            DomainParseResult::Incomplete => {
+                if bytes_read == buffer.len() || Instant::now() >= deadline {
+                    return DomainExtraction {
+                        domain: String::new(),
+                        failed: true,
+                    };
+                }
+                sleep(DOMAIN_PEEK_RETRY_DELAY).await;
+            }
+        }
+    }
+}
+
+enum ProxyDecision {
+    Allow,
+    Deny,
+    ProtocolError,
+}
+
+async fn read_proxy_response<IO>(io: &mut IO) -> ProxyDecision
+where
+    IO: AsyncReadExt + Unpin,
+{
+    let mut response = [0_u8; 1];
+    match timeout(PROXY_RESPONSE_TIMEOUT, io.read_exact(&mut response)).await {
+        Ok(Ok(_)) => match response[0] {
+            ALLOW_RESPONSE => ProxyDecision::Allow,
+            DENY_RESPONSE => ProxyDecision::Deny,
+            _ => ProxyDecision::ProtocolError,
+        },
+        Ok(Err(_)) | Err(_) => ProxyDecision::ProtocolError,
+    }
+}

--- a/cli/dust-sandbox/src/commands/forward/original_dst.rs
+++ b/cli/dust-sandbox/src/commands/forward/original_dst.rs
@@ -14,10 +14,7 @@ const SO_ORIGINAL_DST: libc::c_int = 80;
 
 #[cfg(target_os = "linux")]
 pub fn resolve_original_dst(stream: &TcpStream) -> io::Result<SocketAddr> {
-    match resolve_original_dst_linux(stream) {
-        Ok(addr) => Ok(addr),
-        Err(_) => stream.local_addr(),
-    }
+    resolve_original_dst_linux(stream)
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/cli/dust-sandbox/src/commands/forward/original_dst.rs
+++ b/cli/dust-sandbox/src/commands/forward/original_dst.rs
@@ -1,0 +1,51 @@
+use std::io;
+#[cfg(target_os = "linux")]
+use std::mem;
+use std::net::SocketAddr;
+#[cfg(target_os = "linux")]
+use std::net::{Ipv4Addr, SocketAddrV4};
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
+
+use tokio::net::TcpStream;
+
+#[cfg(target_os = "linux")]
+const SO_ORIGINAL_DST: libc::c_int = 80;
+
+#[cfg(target_os = "linux")]
+pub fn resolve_original_dst(stream: &TcpStream) -> io::Result<SocketAddr> {
+    match resolve_original_dst_linux(stream) {
+        Ok(addr) => Ok(addr),
+        Err(_) => stream.local_addr(),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn resolve_original_dst(stream: &TcpStream) -> io::Result<SocketAddr> {
+    stream.peer_addr()
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_original_dst_linux(stream: &TcpStream) -> io::Result<SocketAddr> {
+    let fd = stream.as_raw_fd();
+    let mut sockaddr: libc::sockaddr_in = unsafe { mem::zeroed() };
+    let mut len = mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
+
+    let result = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_IP,
+            SO_ORIGINAL_DST,
+            (&mut sockaddr as *mut libc::sockaddr_in).cast(),
+            &mut len,
+        )
+    };
+
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let ip = Ipv4Addr::from(u32::from_be(sockaddr.sin_addr.s_addr));
+    let port = u16::from_be(sockaddr.sin_port);
+    Ok(SocketAddr::V4(SocketAddrV4::new(ip, port)))
+}

--- a/cli/dust-sandbox/src/commands/forward/sni.rs
+++ b/cli/dust-sandbox/src/commands/forward/sni.rs
@@ -1,0 +1,209 @@
+use super::DomainParseResult;
+
+pub fn parse_client_hello_sni(bytes: &[u8]) -> DomainParseResult {
+    let record = match bytes.get(..5) {
+        Some(record) => record,
+        None => return DomainParseResult::Incomplete,
+    };
+
+    if record[0] != 0x16 {
+        return DomainParseResult::NotFound;
+    }
+
+    let record_len = read_u16(&record[3..5]) as usize;
+    let record_payload = match bytes.get(5..5 + record_len) {
+        Some(payload) => payload,
+        None => return DomainParseResult::Incomplete,
+    };
+
+    if record_payload.is_empty() || record_payload[0] != 0x01 {
+        return DomainParseResult::NotFound;
+    }
+
+    let hello_len = read_u24(&record_payload[1..4]) as usize;
+    let client_hello = match record_payload.get(4..4 + hello_len) {
+        Some(hello) => hello,
+        None => return DomainParseResult::Incomplete,
+    };
+
+    match parse_server_name_extension(client_hello) {
+        Some(hostname) => DomainParseResult::Found(hostname),
+        None => DomainParseResult::NotFound,
+    }
+}
+
+fn parse_server_name_extension(client_hello: &[u8]) -> Option<String> {
+    let mut cursor = Cursor::new(client_hello);
+
+    cursor.take(2)?;
+    cursor.take(32)?;
+    let session_id_len = cursor.take_u8()? as usize;
+    cursor.take(session_id_len)?;
+
+    let cipher_suites_len = cursor.take_u16()? as usize;
+    cursor.take(cipher_suites_len)?;
+
+    let compression_methods_len = cursor.take_u8()? as usize;
+    cursor.take(compression_methods_len)?;
+
+    let extensions_len = cursor.take_u16()? as usize;
+    let mut extensions = Cursor::new(cursor.take(extensions_len)?);
+
+    while !extensions.is_empty() {
+        let extension_type = extensions.take_u16()?;
+        let extension_len = extensions.take_u16()? as usize;
+        let extension = extensions.take(extension_len)?;
+
+        if extension_type == 0x0000 {
+            return parse_sni_extension(extension);
+        }
+    }
+
+    None
+}
+
+fn parse_sni_extension(extension: &[u8]) -> Option<String> {
+    let mut cursor = Cursor::new(extension);
+    let server_name_list_len = cursor.take_u16()? as usize;
+    let mut server_names = Cursor::new(cursor.take(server_name_list_len)?);
+
+    while !server_names.is_empty() {
+        let name_type = server_names.take_u8()?;
+        let name_len = server_names.take_u16()? as usize;
+        let name = server_names.take(name_len)?;
+
+        if name_type == 0x00 {
+            let hostname = std::str::from_utf8(name).ok()?.to_string();
+            return Some(hostname);
+        }
+    }
+
+    None
+}
+
+struct Cursor<'a> {
+    remaining: &'a [u8],
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { remaining: bytes }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.remaining.is_empty()
+    }
+
+    fn take(&mut self, len: usize) -> Option<&'a [u8]> {
+        let bytes = self.remaining.get(..len)?;
+        self.remaining = &self.remaining[len..];
+        Some(bytes)
+    }
+
+    fn take_u8(&mut self) -> Option<u8> {
+        Some(*self.take(1)?.first()?)
+    }
+
+    fn take_u16(&mut self) -> Option<u16> {
+        Some(read_u16(self.take(2)?))
+    }
+}
+
+fn read_u16(bytes: &[u8]) -> u16 {
+    u16::from_be_bytes([bytes[0], bytes[1]])
+}
+
+fn read_u24(bytes: &[u8]) -> u32 {
+    ((bytes[0] as u32) << 16) | ((bytes[1] as u32) << 8) | bytes[2] as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::DomainParseResult;
+    use super::parse_client_hello_sni;
+
+    #[test]
+    fn parses_sni_from_client_hello() {
+        let hello = build_client_hello(Some("api.openai.com"));
+        assert_eq!(
+            parse_client_hello_sni(&hello),
+            DomainParseResult::Found("api.openai.com".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_not_found_when_sni_extension_is_missing() {
+        let hello = build_client_hello(None);
+        assert_eq!(parse_client_hello_sni(&hello), DomainParseResult::NotFound);
+    }
+
+    #[test]
+    fn returns_incomplete_for_truncated_record() {
+        let hello = build_client_hello(Some("api.openai.com"));
+        let truncated = &hello[..10];
+        assert_eq!(
+            parse_client_hello_sni(truncated),
+            DomainParseResult::Incomplete
+        );
+    }
+
+    #[test]
+    fn returns_not_found_for_non_tls_bytes() {
+        assert_eq!(
+            parse_client_hello_sni(b"GET / HTTP/1.1\r\n\r\n"),
+            DomainParseResult::NotFound
+        );
+    }
+
+    fn build_client_hello(server_name: Option<&str>) -> Vec<u8> {
+        let mut client_hello = Vec::new();
+        client_hello.extend_from_slice(&[0x03, 0x03]);
+        client_hello.extend_from_slice(&[0_u8; 32]);
+        client_hello.push(0x00);
+        client_hello.extend_from_slice(&2_u16.to_be_bytes());
+        client_hello.extend_from_slice(&[0x13, 0x01]);
+        client_hello.push(0x01);
+        client_hello.push(0x00);
+
+        let extensions = if let Some(server_name) = server_name {
+            build_sni_extension(server_name)
+        } else {
+            Vec::new()
+        };
+        client_hello.extend_from_slice(&(extensions.len() as u16).to_be_bytes());
+        client_hello.extend_from_slice(&extensions);
+
+        let mut handshake = Vec::new();
+        handshake.push(0x01);
+        let hello_len = client_hello.len() as u32;
+        handshake.extend_from_slice(&[
+            ((hello_len >> 16) & 0xff) as u8,
+            ((hello_len >> 8) & 0xff) as u8,
+            (hello_len & 0xff) as u8,
+        ]);
+        handshake.extend_from_slice(&client_hello);
+
+        let mut record = Vec::new();
+        record.push(0x16);
+        record.extend_from_slice(&[0x03, 0x01]);
+        record.extend_from_slice(&(handshake.len() as u16).to_be_bytes());
+        record.extend_from_slice(&handshake);
+        record
+    }
+
+    fn build_sni_extension(server_name: &str) -> Vec<u8> {
+        let server_name_bytes = server_name.as_bytes();
+        let server_name_entry_len = 1 + 2 + server_name_bytes.len();
+        let server_name_list_len = server_name_entry_len as u16;
+        let extension_payload_len = 2 + server_name_entry_len;
+
+        let mut extension = Vec::new();
+        extension.extend_from_slice(&0x0000_u16.to_be_bytes());
+        extension.extend_from_slice(&(extension_payload_len as u16).to_be_bytes());
+        extension.extend_from_slice(&server_name_list_len.to_be_bytes());
+        extension.push(0x00);
+        extension.extend_from_slice(&(server_name_bytes.len() as u16).to_be_bytes());
+        extension.extend_from_slice(server_name_bytes);
+        extension
+    }
+}

--- a/cli/dust-sandbox/src/commands/forward/sni.rs
+++ b/cli/dust-sandbox/src/commands/forward/sni.rs
@@ -20,7 +20,10 @@ pub fn parse_client_hello_sni(bytes: &[u8]) -> DomainParseResult {
         return DomainParseResult::NotFound;
     }
 
-    let hello_len = read_u24(&record_payload[1..4]) as usize;
+    let hello_len = match record_payload.get(1..4) {
+        Some(hello_len_bytes) => read_u24(hello_len_bytes) as usize,
+        None => return DomainParseResult::Incomplete,
+    };
     let client_hello = match record_payload.get(4..4 + hello_len) {
         Some(hello) => hello,
         None => return DomainParseResult::Incomplete,
@@ -143,6 +146,14 @@ mod tests {
         let truncated = &hello[..10];
         assert_eq!(
             parse_client_hello_sni(truncated),
+            DomainParseResult::Incomplete
+        );
+    }
+
+    #[test]
+    fn returns_incomplete_for_truncated_tls_record_with_missing_hello_length() {
+        assert_eq!(
+            parse_client_hello_sni(&[0x16, 0x03, 0x01, 0x00, 0x01, 0x01]),
             DomainParseResult::Incomplete
         );
     }

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -1,5 +1,7 @@
+pub mod forward;
 pub mod tools;
 mod version;
 
+pub use forward::cmd_forward;
 pub use tools::{cmd_exec, cmd_list_servers, cmd_list_tools};
 pub use version::cmd_version;

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -2,6 +2,7 @@ mod api;
 mod commands;
 
 use clap::{Parser, Subcommand};
+use tracing::error;
 
 #[derive(Parser)]
 #[command(name = "dsbx", version, about = "Dust sandbox CLI")]
@@ -14,6 +15,8 @@ struct Cli {
 enum Commands {
     /// Print version information
     Version,
+    /// Forward sandbox egress traffic to the Dust egress proxy
+    Forward(commands::forward::ForwardArgs),
     /// Interact with MCP servers and tools
     Tools {
         /// Server name (omit to list all servers)
@@ -27,11 +30,21 @@ enum Commands {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() {
+    init_tracing();
+
+    if let Err(error) = run().await {
+        error!(error = %error, "dsbx command failed");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
         Commands::Version => commands::cmd_version(),
+        Commands::Forward(args) => commands::cmd_forward(args).await?,
         Commands::Tools {
             server_name,
             tool_name,
@@ -49,6 +62,18 @@ async fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn init_tracing() {
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .json()
+        .finish();
+
+    let _ = tracing::subscriber::set_global_default(subscriber);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

Adds a new `forward` subcommand to the `dsbx` CLI that tunnels redirected TCP connections through the Dust egress proxy. This is the in-sandbox counterpart to the egress-proxy service that is already live in EU.

For every connection accepted on `--listen` (intended target: `127.0.0.1:9990`, fed by iptables `REDIRECT`), the forwarder:

1. Resolves the original destination port via `SO_ORIGINAL_DST` (Linux only; falls back to `peer_addr` on other OSes so tests still run on macOS).
2. Peeks at the unencrypted handshake to extract the target domain — TLS ClientHello SNI on :443, HTTP `Host:` header on :80. Other ports send an empty domain. Peek has a 2s timeout; failures fall through with empty domain.
3. Opens a TLS connection to `--proxy-addr` (rustls + native roots), with the TLS server name set to `--proxy-tls-name`.
4. Sends the v1 handshake frame: `u8 version | u16 token_len | token | u16 domain_len | domain | u16 port`. Wire layout matches `egress-proxy/src/handshake.rs`.
5. Reads the 1-byte response: `0x00` ALLOW → `tokio::io::copy_bidirectional` between client and proxy; `0x01` DENY → append to deny log; anything else → protocol-error deny log.

Denies are written to a configurable deny log (default `/tmp/dust-egress-denied.log`) as `<rfc3339> DENIED <domain>:<port> (reason: <reason>)`, where reasons are `proxy_denied`, `proxy_protocol_error`, or `domain_extraction_failed`.

Also adds a `tracing` + `tracing-subscriber` (JSON, `RUST_LOG`-driven) logger to the `dsbx` binary, which previously had no logger.

### Out of scope

- iptables rules and the `dust-fwd` system user — sandbox-image change.
- Front-side JWT minting + GCS policy writes.
- Token file hot-reload, graceful shutdown, per-connection metrics.

## Tests

- 11 new unit tests covering: TLS ClientHello SNI parsing (valid / missing SNI / truncated / non-TLS bytes), HTTP Host parsing (standard / case-insensitive / port stripping / missing / incomplete), handshake frame encoding (byte-for-byte against the proxy wire format with `example.com:443`), and deny-log append behaviour.
- Full `cargo test -p dust-sandbox` green on macOS (21/21).
- `dsbx forward --help` manually verified: documents all five flags with `--deny-log` defaulted.
- End-to-end against the live EU proxy will be exercised once the sandbox-image PR lands the iptables redirect; the proxy itself is already covered by `egress-proxy/scripts/smoke.ts`.

## Risk

Low. The `forward` subcommand is net-new and unused until the sandbox image starts routing through `127.0.0.1:9990`. Nothing calls it today. The only behaviour change to existing `dsbx` usage is that `main` now initialises a `tracing` subscriber; existing commands (`version`, `tools`) still write their user-facing output to stdout unchanged. The `SO_ORIGINAL_DST` path is `#[cfg(target_os = "linux")]` and falls back on other platforms, keeping `cargo test` green on developer Macs.

## Deploy Plan

No deploy action for this PR on its own — the new code only runs when explicitly invoked. Follow-ups that unlock end-to-end use:

1. Sandbox image: add `dust-fwd` user and the iptables rules documented in `notion-s7-network.md`.
2. Front: mint short-lived egress JWTs and write per-sandbox policies to GCS.
3. Egress proxy: swap env-based allowlist for the GCS-backed policy store (separate PR).