### PR TITLE
Fix serialized knowledge nodes in migration script

### DIFF
--- a/front/lib/editor/skill_instructions_html.test.ts
+++ b/front/lib/editor/skill_instructions_html.test.ts
@@ -113,4 +113,20 @@ describe("convertMarkdownToBlockHtml", () => {
     expect($("strong").length).toBe(1);
     expect($("em[class], strong[class]").length).toBe(0);
   });
+
+  it("recovers standalone <knowledge /> lines as knowledge nodes (not HTML-escaped text)", () => {
+    const md = [
+      "Intro",
+      "",
+      '<knowledge id="n1" title="My Doc" space="sp1" dsv="dsv1" hasChildren="false" />',
+      "",
+      "Outro",
+    ].join("\n");
+
+    const html = convertMarkdownToBlockHtml(md);
+
+    expect(html).not.toContain("&lt;knowledge");
+    expect(html).toContain('data-type="knowledge-node"');
+    expect(html).toContain("My Doc");
+  });
 });

--- a/front/lib/editor/skill_instructions_html.ts
+++ b/front/lib/editor/skill_instructions_html.ts
@@ -92,6 +92,55 @@ function stripPresentationAttributes(html: string): string {
 }
 
 /**
+ * TipTap's server-side parseHTMLToken has no DOM, so it converts block-level
+ * HTML tokens (e.g. a standalone <knowledge .../> on its own line) to plain-
+ * text paragraphs instead of calling generateJSON + parseHTML rules. Walk the
+ * parsed JSON tree and restore any such nodes back to proper knowledgeNode
+ * JSONContent before rendering to HTML.
+ */
+const KNOWLEDGE_TAG_REGEX = /^<knowledge\s+([^>]+)\s*\/>$/;
+
+function recoverKnowledgeNodes(node: JSONContent): JSONContent {
+  if (node.type === "paragraph" && node.content?.length === 1) {
+    const child = node.content[0];
+    if (child.type === "text") {
+      const text = (child.text ?? "").trim();
+      const match = KNOWLEDGE_TAG_REGEX.exec(text);
+      if (match) {
+        const attrs = match[1];
+        const id = /id="([^"]+)"/.exec(attrs)?.[1];
+        const title = /title="([^"]+)"/.exec(attrs)?.[1];
+        if (id && title) {
+          return {
+            ...node,
+            content: [
+              {
+                type: "knowledgeNode",
+                attrs: {
+                  selectedItems: [
+                    {
+                      nodeId: id,
+                      label: title,
+                      spaceId: /space="([^"]*)"/.exec(attrs)?.[1] ?? "",
+                      dataSourceViewId: /dsv="([^"]*)"/.exec(attrs)?.[1] ?? "",
+                      hasChildren: /hasChildren="true"/.test(attrs),
+                    },
+                  ],
+                },
+              },
+            ],
+          };
+        }
+      }
+    }
+  }
+  if (node.content) {
+    return { ...node, content: node.content.map(recoverKnowledgeNodes) };
+  }
+  return node;
+}
+
+/**
  * Convert Markdown to stored skill instructionsHtml.
  * Uses the same extension schema as the browser editor, then strips CSS class attrs.
  */
@@ -101,12 +150,14 @@ export function convertMarkdownToBlockHtml(markdown: string): string {
     ? MARKDOWN_MANAGER.parse(preprocessed)
     : null;
 
+  const rawContent = parsedDoc?.content ?? [{ type: "paragraph" }];
+
   const json: JSONContent = {
     type: "doc",
     content: [
       {
         type: INSTRUCTIONS_ROOT_NODE_NAME,
-        content: parsedDoc?.content ?? [{ type: "paragraph" }],
+        content: rawContent.map(recoverKnowledgeNodes),
       },
     ],
   };


### PR DESCRIPTION
## Description
* See inline comment for technical explanation
* There was a bug in our skill markdown to html migration script where inline knowledge nodes were serialized into a string instead of a proper knowledge type. This change is only used in migration script, will never be used in production
## Tests

<img width="1338" height="414" alt="Screenshot 2026-04-15 at 8 52 52 PM" src="https://github.com/user-attachments/assets/37a79573-7039-4f3e-942a-b5b31b2d06dc" />

## Risk

* Fix of existing issue

## Deploy Plan

1. Rerun migration for our workspce