### PR TITLE
[front] Optimize skills API

### DIFF
--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -68,7 +68,11 @@ export class InternalMCPServerInMemoryResource {
 
   private static async init(
     auth: Authenticator,
-    id: string
+    id: string,
+    prefetchedCredential?: {
+      sharedSecret: string | null;
+      customHeaders: Record<string, string> | null;
+    } | null
   ): Promise<InternalMCPServerInMemoryResource | null> {
     const r = getInternalMCPServerNameAndWorkspaceId(id);
     if (r.isErr()) {
@@ -101,7 +105,9 @@ export class InternalMCPServerInMemoryResource {
       tools: serverMetadata.tools,
     };
     server.internalServerCredential =
-      await server.fetchInternalServerCredential(auth);
+      prefetchedCredential !== undefined
+        ? prefetchedCredential
+        : await server.fetchInternalServerCredential(auth);
 
     return server;
   }
@@ -307,9 +313,56 @@ export class InternalMCPServerInMemoryResource {
     });
     validIds.push(...removeNulls(servers.map((s) => s.internalMCPServerId)));
 
+    // Batch-fetch all credentials in a single query to avoid an N+1 (one findOne per server).
+    const workspace = auth.getNonNullableWorkspace();
+    const idsRequiringCredentials = validIds.filter(
+      doesInternalMCPServerRequireBearerToken
+    );
+    const credentialModels =
+      idsRequiringCredentials.length > 0
+        ? await InternalMCPServerCredentialModel.findAll({
+            where: {
+              workspaceId: workspace.id,
+              internalMCPServerId: { [Op.in]: idsRequiringCredentials },
+            },
+          })
+        : [];
+    const credentialModelById = new Map(
+      credentialModels.map((c) => [c.internalMCPServerId, c])
+    );
+    const credentialByServerId = new Map(
+      validIds.map((id) => {
+        if (!doesInternalMCPServerRequireBearerToken(id)) {
+          return [id, null] as const;
+        }
+        const credModel = credentialModelById.get(id);
+        if (!credModel) {
+          return [id, null] as const;
+        }
+        return [
+          id,
+          {
+            sharedSecret: credModel.encryptedKey
+              ? decrypt({
+                  encrypted: credModel.encryptedKey,
+                  key: workspace.sId,
+                  useCase: "mcp_server_credentials",
+                })
+              : null,
+            customHeaders: credModel.customHeaders,
+          },
+        ] as const;
+      })
+    );
+
     const resources = await concurrentExecutor(
       validIds,
-      (id) => InternalMCPServerInMemoryResource.init(auth, id),
+      (id) =>
+        InternalMCPServerInMemoryResource.init(
+          auth,
+          id,
+          credentialByServerId.get(id)
+        ),
       { concurrency: 10 }
     );
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -543,95 +543,94 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     let allowedCustomSkillsRes: SkillResource[] = [];
     if (allowedCustomSkills.length > 0) {
-      const mcpServerConfigurations =
-        await SkillMCPServerConfigurationModel.findAll({
+      // Round 1: all four queries are independent — run in parallel.
+      const [
+        mcpServerConfigurations,
+        dataSourceConfigurations,
+        fileAttachmentModels,
+        editorGroupSkills,
+      ] = await Promise.all([
+        SkillMCPServerConfigurationModel.findAll({
           where: {
             workspaceId: workspace.id,
             skillConfigurationId: {
               [Op.in]: allowedCustomSkillIds,
             },
           },
-        });
-
-      const skillMCPServerConfigsBySkillId = groupBy(
-        mcpServerConfigurations,
-        "skillConfigurationId"
-      );
-
-      const dataSourceConfigurations =
-        await SkillDataSourceConfigurationModel.findAll({
+        }),
+        SkillDataSourceConfigurationModel.findAll({
           where: {
             workspaceId: workspace.id,
             skillConfigurationId: {
               [Op.in]: customSkills.map((c) => c.id),
             },
           },
-        });
+        }),
+        SkillFileAttachmentModel.findAll({
+          where: {
+            workspaceId: workspace.id,
+            skillConfigurationId: {
+              [Op.in]: allowedCustomSkillIds,
+            },
+          },
+        }),
+        // TODO(SKILLS 2025-12-11): Ensure all skills have ONE group.
+        GroupSkillModel.findAll({
+          where: {
+            skillConfigurationId: {
+              [Op.in]: allowedCustomSkillIds,
+            },
+            workspaceId: workspace.id,
+          },
+          attributes: ["groupId", "skillConfigurationId"],
+        }),
+      ]);
 
+      const skillMCPServerConfigsBySkillId = groupBy(
+        mcpServerConfigurations,
+        "skillConfigurationId"
+      );
       const dataSourceConfigsBySkillId = groupBy(
         dataSourceConfigurations,
         "skillConfigurationId"
       );
-
-      const fileAttachmentModels = await SkillFileAttachmentModel.findAll({
-        where: {
-          workspaceId: workspace.id,
-          skillConfigurationId: {
-            [Op.in]: allowedCustomSkillIds,
-          },
-        },
-      });
-
-      const allFileResources = await FileResource.fetchByModelIdsWithAuth(
-        auth,
-        fileAttachmentModels.map((a) => a.fileId)
-      );
-
-      const fileResourceById = new Map(allFileResources.map((f) => [f.id, f]));
-
       const fileAttachmentsBySkillId = groupBy(
         fileAttachmentModels,
         "skillConfigurationId"
       );
 
-      // Fetch editor groups for all skills.
-      const skillEditorGroupsMap = new Map<number, GroupResource>();
-
-      // Batch fetch all editor groups for all skills.
-      const editorGroupSkills = await GroupSkillModel.findAll({
-        where: {
-          skillConfigurationId: {
-            [Op.in]: allowedCustomSkillIds,
-          },
-          workspaceId: workspace.id,
-        },
-        attributes: ["groupId", "skillConfigurationId"],
-      });
-
-      // TODO(SKILLS 2025-12-11): Ensure all skills have ONE group.
-
-      if (editorGroupSkills.length > 0) {
-        const uniqueGroupIds = Array.from(
-          new Set(editorGroupSkills.map((eg) => eg.groupId))
-        );
-        const editorGroups = await GroupResource.fetchByModelIds(
+      // Round 2: file resources and editor groups depend on Round 1 but are
+      // independent of each other — run in parallel.
+      const uniqueGroupIds = Array.from(
+        new Set(editorGroupSkills.map((eg) => eg.groupId))
+      );
+      const [allFileResources, editorGroups] = await Promise.all([
+        FileResource.fetchByModelIdsWithAuth(
           auth,
-          uniqueGroupIds
-        );
+          fileAttachmentModels.map((a) => a.fileId)
+        ),
+        uniqueGroupIds.length > 0
+          ? GroupResource.fetchByModelIds(auth, uniqueGroupIds)
+          : Promise.resolve([]),
+      ]);
 
-        // Build a map from a skill's ID to its editor group.
-        const editorGroupsById = new Map(editorGroups.map((g) => [g.id, g]));
-        for (const editorGroupSkill of editorGroupSkills) {
-          const group = editorGroupsById.get(editorGroupSkill.groupId);
-          if (group) {
-            skillEditorGroupsMap.set(
-              editorGroupSkill.skillConfigurationId,
-              group
-            );
-          }
+      const fileResourceById = new Map(allFileResources.map((f) => [f.id, f]));
+
+      // Build a map from a skill's ID to its editor group.
+      const skillEditorGroupsMap = new Map<number, GroupResource>();
+      const editorGroupsById = new Map(editorGroups.map((g) => [g.id, g]));
+      for (const editorGroupSkill of editorGroupSkills) {
+        const group = editorGroupsById.get(editorGroupSkill.groupId);
+        if (group) {
+          skillEditorGroupsMap.set(
+            editorGroupSkill.skillConfigurationId,
+            group
+          );
         }
       }
 
+      // Round 3: isolated — MCPServerViewResource triggers a credential-batch
+      // cascade and is kept separate to simplify profiling and future refactoring.
       const allMCPServerViews = await MCPServerViewResource.fetchByModelIds(
         auth,
         removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId)),

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -639,16 +639,21 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         { includeMetadata: false }
       );
 
+      const mcpServerViewById = new Map(
+        allMCPServerViews.map((v) => [v.id, v])
+      );
+
       allowedCustomSkillsRes = allowedCustomSkills.map((customSkill) => {
-        const skillMCPServerViewIds = skillMCPServerConfigsBySkillId[
-          customSkill.id
-        ]?.map((skillConfig) => skillConfig.mcpServerViewId);
+        const skillMCPServerViewIds =
+          skillMCPServerConfigsBySkillId[customSkill.id]?.map(
+            (skillConfig) => skillConfig.mcpServerViewId
+          ) ?? [];
 
         const skillDataSourceConfigs =
           dataSourceConfigsBySkillId[customSkill.id] ?? [];
 
-        const skillMCPServerViews = allMCPServerViews.filter((view) =>
-          skillMCPServerViewIds?.includes(view.id)
+        const skillMCPServerViews = removeNulls(
+          skillMCPServerViewIds.map((id) => mcpServerViewById.get(id) ?? null)
         );
 
         return new this(this.model, customSkill.get(), {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -620,10 +620,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         );
 
         // Build a map from a skill's ID to its editor group.
+        const editorGroupsById = new Map(editorGroups.map((g) => [g.id, g]));
         for (const editorGroupSkill of editorGroupSkills) {
-          const group = editorGroups.find(
-            (g) => g.id === editorGroupSkill.groupId
-          );
+          const group = editorGroupsById.get(editorGroupSkill.groupId);
           if (group) {
             skillEditorGroupsMap.set(
               editorGroupSkill.skillConfigurationId,

--- a/x/thervier/skill-api-optimization/implementation-optimization.md
+++ b/x/thervier/skill-api-optimization/implementation-optimization.md
@@ -206,7 +206,7 @@ calls out of `fromGlobalSkill` and batch them at the `baseFetch` level, similar 
 ## Tasks
 
 - [x] **[Issue 1]** Batch-fetch credentials in `InternalMCPServerInMemoryResource.fetchByIds` — single `WHERE internalMCPServerId IN (...)` instead of K individual `findOne` calls.
-- [ ] **[Issue 2]** Build `mcpServerViewById: Map<id, MCPServerViewResource>` before the `allowedCustomSkills.map` loop and replace `.filter`+`.includes` with direct `Map.get` lookups.
+- [x] **[Issue 2]** Build `mcpServerViewById: Map<id, MCPServerViewResource>` before the `allowedCustomSkills.map` loop and replace `.filter`+`.includes` with direct `Map.get` lookups.
 - [ ] **[Issue 3]** Build `editorGroupsById: Map<id, Group>` before the `editorGroupSkills` loop and replace `.find` with `Map.get`.
 
 **Issue 4 — Global skills `baseFetch` cascade (won't fix for now):** we currently have very few global skills, so the G × M `baseFetch` cascade has negligible real-world impact. Revisit if the number of global skills grows significantly.

--- a/x/thervier/skill-api-optimization/implementation-optimization.md
+++ b/x/thervier/skill-api-optimization/implementation-optimization.md
@@ -207,6 +207,6 @@ calls out of `fromGlobalSkill` and batch them at the `baseFetch` level, similar 
 
 - [x] **[Issue 1]** Batch-fetch credentials in `InternalMCPServerInMemoryResource.fetchByIds` — single `WHERE internalMCPServerId IN (...)` instead of K individual `findOne` calls.
 - [x] **[Issue 2]** Build `mcpServerViewById: Map<id, MCPServerViewResource>` before the `allowedCustomSkills.map` loop and replace `.filter`+`.includes` with direct `Map.get` lookups.
-- [ ] **[Issue 3]** Build `editorGroupsById: Map<id, Group>` before the `editorGroupSkills` loop and replace `.find` with `Map.get`.
+- [x] **[Issue 3]** Build `editorGroupsById: Map<id, Group>` before the `editorGroupSkills` loop and replace `.find` with `Map.get`.
 
 **Issue 4 — Global skills `baseFetch` cascade (won't fix for now):** we currently have very few global skills, so the G × M `baseFetch` cascade has negligible real-world impact. Revisit if the number of global skills grows significantly.

--- a/x/thervier/skill-api-optimization/implementation-optimization.md
+++ b/x/thervier/skill-api-optimization/implementation-optimization.md
@@ -10,7 +10,7 @@ The bottleneck was traced to `SkillResource.baseFetch` in
 const allMCPServerViews = await MCPServerViewResource.fetchByModelIds(
   auth,
   removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId)),
-  { includeMetadata: false }
+  { includeMetadata: false },
 );
 ```
 
@@ -32,8 +32,8 @@ which calls `InternalMCPServerInMemoryResource.fetchByIds`
 ```ts
 const resources = await concurrentExecutor(
   validIds,
-  (id) => InternalMCPServerInMemoryResource.init(auth, id),  // called once per ID
-  { concurrency: 10 }
+  (id) => InternalMCPServerInMemoryResource.init(auth, id), // called once per ID
+  { concurrency: 10 },
 );
 ```
 
@@ -44,7 +44,7 @@ Each `init` call fires `fetchDecryptedCredentials` → `InternalMCPServerCredent
 const credential = await InternalMCPServerCredentialModel.findOne({
   where: {
     workspaceId: auth.getNonNullableWorkspace().id,
-    internalMCPServerId,   // one query per server
+    internalMCPServerId, // one query per server
   },
 });
 ```
@@ -144,8 +144,9 @@ quadratic in the number of editor group associations × number of groups:
 
 ```ts
 for (const editorGroupSkill of editorGroupSkills) {
-  const group = editorGroups.find(   // O(G) per iteration
-    (g) => g.id === editorGroupSkill.groupId
+  const group = editorGroups.find(
+    // O(G) per iteration
+    (g) => g.id === editorGroupSkill.groupId,
   );
   if (group) {
     skillEditorGroupsMap.set(editorGroupSkill.skillConfigurationId, group);
@@ -203,10 +204,88 @@ calls out of `fromGlobalSkill` and batch them at the `baseFetch` level, similar 
 
 ---
 
+## Issue 5 — Sequential DB queries in `baseFetch` custom skills block
+
+**Severity: Medium**
+
+### What happens
+
+Inside `if (allowedCustomSkills.length > 0)` in `skill_resource.ts`, seven DB calls are issued
+sequentially even though most of them are independent:
+
+```ts
+const mcpServerConfigurations   = await SkillMCPServerConfigurationModel.findAll(...)
+const dataSourceConfigurations  = await SkillDataSourceConfigurationModel.findAll(...)
+const fileAttachmentModels      = await SkillFileAttachmentModel.findAll(...)
+const allFileResources          = await FileResource.fetchByModelIdsWithAuth(...)   // needs fileAttachmentModels
+const editorGroupSkills         = await GroupSkillModel.findAll(...)
+const editorGroups              = await GroupResource.fetchByModelIds(...)           // needs editorGroupSkills
+const allMCPServerViews         = await MCPServerViewResource.fetchByModelIds(...)  // needs mcpServerConfigurations
+```
+
+Each awaits the previous call even when there is no data dependency.
+
+### Fix
+
+Reorganise into three rounds using `Promise.all` (each round has ≤ 8 known promises, satisfying BACK7):
+
+**Round 1 — fully independent:**
+
+```ts
+const [
+  mcpServerConfigurations,
+  dataSourceConfigurations,
+  fileAttachmentModels,
+  editorGroupSkills,
+] = await Promise.all([
+  SkillMCPServerConfigurationModel.findAll(...),
+  SkillDataSourceConfigurationModel.findAll(...),
+  SkillFileAttachmentModel.findAll(...),
+  GroupSkillModel.findAll(...),
+]);
+```
+
+**Round 2 — depends on Round 1 results, independent of each other:**
+
+```ts
+const uniqueGroupIds = Array.from(
+  new Set(editorGroupSkills.map((eg) => eg.groupId)),
+);
+
+const [allFileResources, editorGroups] = await Promise.all([
+  FileResource.fetchByModelIdsWithAuth(
+    auth,
+    fileAttachmentModels.map((a) => a.fileId),
+  ),
+  uniqueGroupIds.length > 0
+    ? GroupResource.fetchByModelIds(auth, uniqueGroupIds)
+    : Promise.resolve([]),
+]);
+```
+
+**Round 3 — isolated (depends on `mcpServerConfigurations` from Round 1):**
+
+```ts
+const allMCPServerViews = await MCPServerViewResource.fetchByModelIds(
+  auth,
+  removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId)),
+  { includeMetadata: false },
+);
+```
+
+`MCPServerViewResource.fetchByModelIds` is kept in its own round because it triggers the
+credential-batch cascade (Issue 1) and may be more expensive than the other Round 2 fetches;
+isolating it makes profiling and future refactoring easier.
+
+**Expected impact**: reduces 7 sequential async calls to 3 rounds of parallel calls.
+
+---
+
 ## Tasks
 
 - [x] **[Issue 1]** Batch-fetch credentials in `InternalMCPServerInMemoryResource.fetchByIds` — single `WHERE internalMCPServerId IN (...)` instead of K individual `findOne` calls.
 - [x] **[Issue 2]** Build `mcpServerViewById: Map<id, MCPServerViewResource>` before the `allowedCustomSkills.map` loop and replace `.filter`+`.includes` with direct `Map.get` lookups.
 - [x] **[Issue 3]** Build `editorGroupsById: Map<id, Group>` before the `editorGroupSkills` loop and replace `.find` with `Map.get`.
+- [x] **[Issue 5]** Parallelize the 7 sequential DB calls in the custom skills block into 3 rounds using `Promise.all`.
 
 **Issue 4 — Global skills `baseFetch` cascade (won't fix for now):** we currently have very few global skills, so the G × M `baseFetch` cascade has negligible real-world impact. Revisit if the number of global skills grows significantly.

--- a/x/thervier/skill-api-optimization/implementation-optimization.md
+++ b/x/thervier/skill-api-optimization/implementation-optimization.md
@@ -1,0 +1,212 @@
+# Skills API — Performance Analysis & Optimization Plan
+
+## Context
+
+The skills API endpoint is slow when a workspace has many custom skills with MCP server views.
+The bottleneck was traced to `SkillResource.baseFetch` in
+`front/lib/resources/skill/skill_resource.ts`, specifically the call at line 637:
+
+```ts
+const allMCPServerViews = await MCPServerViewResource.fetchByModelIds(
+  auth,
+  removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId)),
+  { includeMetadata: false }
+);
+```
+
+This call looks like a single batched fetch but triggers a cascade of hidden SQL queries.
+
+---
+
+## Issue 1 — N+1 in `InternalMCPServerInMemoryResource.fetchByIds` (main culprit)
+
+**Severity: High**
+
+### What happens
+
+`MCPServerViewResource.fetchByModelIds` calls `MCPServerViewResource.baseFetch`
+([mcp_server_view_resource.ts:352](../../front/lib/resources/mcp_server_view_resource.ts#L352)),
+which calls `InternalMCPServerInMemoryResource.fetchByIds`
+([internal_mcp_server_in_memory_resource.ts:281](../../front/lib/resources/internal_mcp_server_in_memory_resource.ts#L281)):
+
+```ts
+const resources = await concurrentExecutor(
+  validIds,
+  (id) => InternalMCPServerInMemoryResource.init(auth, id),  // called once per ID
+  { concurrency: 10 }
+);
+```
+
+Each `init` call fires `fetchDecryptedCredentials` → `InternalMCPServerCredentialModel.findOne`
+([internal_mcp_server_in_memory_resource.ts:503](../../front/lib/resources/internal_mcp_server_in_memory_resource.ts#L503)):
+
+```ts
+const credential = await InternalMCPServerCredentialModel.findOne({
+  where: {
+    workspaceId: auth.getNonNullableWorkspace().id,
+    internalMCPServerId,   // one query per server
+  },
+});
+```
+
+With K distinct internal MCP server IDs across all custom skills, this produces **K individual
+SQL queries** — a classic N+1.
+
+### Fix
+
+Introduce a `fetchDecryptedCredentialsBatch` static method that fetches all credentials in
+a single `WHERE internalMCPServerId IN (...)` query. Refactor `fetchByIds` to call this once
+and pass the results into `init` (or a new `initWithCredential` variant).
+
+```ts
+// Proposed batch method on InternalMCPServerInMemoryResource
+static async fetchByIds(auth, ids, systemSpace) {
+  // ... existing filter for validIds / manualIds ...
+
+  // Single batch fetch instead of N findOne calls
+  const credentials = await InternalMCPServerCredentialModel.findAll({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      internalMCPServerId: { [Op.in]: validIds },
+    },
+  });
+  const credentialMap = new Map(credentials.map(c => [c.internalMCPServerId, c]));
+
+  const resources = await concurrentExecutor(
+    validIds,
+    (id) => InternalMCPServerInMemoryResource.initWithCredential(auth, id, credentialMap.get(id)),
+    { concurrency: 10 }
+  );
+
+  return removeNulls(resources);
+}
+```
+
+**Expected impact**: reduces K SQL queries to 1 for the credential fetch step.
+
+---
+
+## Issue 2 — O(n²) in views-to-skills mapping
+
+**Severity: Medium**
+
+### What happens
+
+At lines 643–653 of `skill_resource.ts`, for each custom skill the code scans all fetched views
+using `.filter` + `.includes`:
+
+```ts
+allowedCustomSkillsRes = allowedCustomSkills.map((customSkill) => {
+  const skillMCPServerViewIds = skillMCPServerConfigsBySkillId[customSkill.id]
+    ?.map((skillConfig) => skillConfig.mcpServerViewId);
+
+  const skillMCPServerViews = allMCPServerViews.filter((view) =>
+    skillMCPServerViewIds?.includes(view.id)   // O(M) per view in allMCPServerViews
+  );
+  ...
+});
+```
+
+For S skills, V total views, and M view IDs per skill: **O(S × V × M)**.
+
+### Fix
+
+Build a `Map<viewId, MCPServerViewResource>` from `allMCPServerViews` once, then do direct
+lookups per skill:
+
+```ts
+const mcpServerViewById = new Map(allMCPServerViews.map((v) => [v.id, v]));
+
+allowedCustomSkillsRes = allowedCustomSkills.map((customSkill) => {
+  const skillMCPServerViewIds = skillMCPServerConfigsBySkillId[customSkill.id]
+    ?.map((skillConfig) => skillConfig.mcpServerViewId) ?? [];
+
+  const skillMCPServerViews = removeNulls(
+    skillMCPServerViewIds.map((id) => mcpServerViewById.get(id) ?? null)
+  );
+  ...
+});
+```
+
+**Expected impact**: reduces complexity to O(S × M) total — linear in the number of
+(skill, view) associations.
+
+---
+
+## Issue 3 — O(n²) in editor groups map building
+
+**Severity: Low–Medium**
+
+### What happens
+
+At lines 623–634 of `skill_resource.ts`, a `.find` call inside a loop makes group lookup
+quadratic in the number of editor group associations × number of groups:
+
+```ts
+for (const editorGroupSkill of editorGroupSkills) {
+  const group = editorGroups.find(   // O(G) per iteration
+    (g) => g.id === editorGroupSkill.groupId
+  );
+  if (group) {
+    skillEditorGroupsMap.set(editorGroupSkill.skillConfigurationId, group);
+  }
+}
+```
+
+For E group-skill associations and G groups: **O(E × G)**.
+
+### Fix
+
+Build a `Map` from the groups array before the loop:
+
+```ts
+const editorGroupsById = new Map(editorGroups.map((g) => [g.id, g]));
+
+for (const editorGroupSkill of editorGroupSkills) {
+  const group = editorGroupsById.get(editorGroupSkill.groupId);
+  if (group) {
+    skillEditorGroupsMap.set(editorGroupSkill.skillConfigurationId, group);
+  }
+}
+```
+
+**Expected impact**: reduces to O(E + G) total — effectively linear.
+
+---
+
+## Issue 4 — `SpaceResource.fetchWorkspaceSystemSpace` called inside every `baseFetch`
+
+**Severity: Low (custom skills path) / High (global skills path)**
+
+### What happens
+
+`MCPServerViewResource.baseFetch` always fetches the system space from the database
+([mcp_server_view_resource.ts:379](../../front/lib/resources/mcp_server_view_resource.ts#L379)).
+In the custom skills path this is called once, so it adds 1 SQL query — acceptable.
+
+However, in the **global skills path** (`fromGlobalSkill` at line 1390), for each global skill
+definition × each `def.mcpServers` entry, `listMCPServerViewsAutoInternalForSpaces` →
+`listByMCPServer` → `baseFetch` is called independently. With G global skills × M mcp servers
+each, this produces **G × M full `baseFetch` cascades**, each with their own system-space fetch,
+remote-server fetch, and internal-server N+1.
+
+### Fix (custom path)
+
+No action needed — the system space is fetched once.
+
+### Fix (global path)
+
+Refactor `fromGlobalSkill` to accept pre-fetched data (system space, available views) and avoid
+redundant `baseFetch` calls. Alternatively, hoist the `listMCPServerViewsAutoInternalForSpaces`
+calls out of `fromGlobalSkill` and batch them at the `baseFetch` level, similar to how
+`allMCPServerViews` is already batched for custom skills.
+
+---
+
+## Tasks
+
+- [x] **[Issue 1]** Batch-fetch credentials in `InternalMCPServerInMemoryResource.fetchByIds` — single `WHERE internalMCPServerId IN (...)` instead of K individual `findOne` calls.
+- [ ] **[Issue 2]** Build `mcpServerViewById: Map<id, MCPServerViewResource>` before the `allowedCustomSkills.map` loop and replace `.filter`+`.includes` with direct `Map.get` lookups.
+- [ ] **[Issue 3]** Build `editorGroupsById: Map<id, Group>` before the `editorGroupSkills` loop and replace `.find` with `Map.get`.
+
+**Issue 4 — Global skills `baseFetch` cascade (won't fix for now):** we currently have very few global skills, so the G × M `baseFetch` cascade has negligible real-world impact. Revisit if the number of global skills grows significantly.


### PR DESCRIPTION
## Description

First part of https://github.com/dust-tt/tasks/issues/7443
Optimizes the performance of skills API by fixing the following:
- N+1 in `InternalMCPServerInMemoryResource.fetchByIds`
- O(n²) in views-to-skills mapping
- O(n²) in editor groups map building
- Parallelize DB queries in `SkillResource.baseFetch` custom skills block

See x/thervier/skill-api-optimization/implementation-optimization.md in this PR for more details if needed

## Tests

Tested locally in CapabilitiesPicker and AgentBuilder

## Risk

Medium, as it impacts all the retrievals of skills but also MCP server views

## Deploy Plan

- Deploy front