### PR TITLE
Remove scheduled_charges_on_usage_invoices on contract.create

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -298,7 +298,6 @@ export async function createMetronomeContract({
       customer_id: metronomeCustomerId,
       package_alias: packageAlias,
       starting_at: startingAt,
-      scheduled_charges_on_usage_invoices: "ALL",
       ...(uniquenessKey ? { uniqueness_key: uniquenessKey } : {}),
     });
 


### PR DESCRIPTION
## Description

We can't pass scheduled_charges_on_usage_invoices when using a package. Removing from contract create (pro plans won't have it, it's only set on enterprise package for now)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
