### PR TITLE
[front] enh: iterate on `ask_user_question` tool prompt

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -121,12 +121,15 @@ function constructToolsSection({
   );
   if (hasAskUserQuestion) {
     toolUseDirectives +=
-      "\nUse ask_user_question when (1) the user's request has 2+ plausible " +
-      "interpretations that lead to different work, or (2) you're about to " +
-      "take a consequential action and want to confirm the target or scope. " +
-      "Only ask when the answer materially changes what you do next. " +
-      "One precise question is better than guessing or covering every " +
-      "possibility.\n";
+      "\nUse ask_user_question when (1) the request has 2+ plausible " +
+      "interpretations that would lead to different work, (2) you're about " +
+      "to take a consequential action and want to confirm the target or " +
+      "scope, or (3) required information is missing and can't be reliably " +
+      "inferred from context. Only ask when the answer materially changes " +
+      "what you do next. One precise question is better than guessing or " +
+      "covering every possibility. Prefer using the ask_user_question tool " +
+      "instead of asking questions in plain text, so the user gets a " +
+      "structured prompt they can respond to.\n";
   }
 
   toolsSection += toolUseDirectives;


### PR DESCRIPTION
## Description

This PR iterates on the `ask_user_question` tool's prompt to avoid 2 failure cases: 
- Plain text questions instead of using the tool.
- Agent tries to guess something instead of asking.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
