### PR TITLE
Remove "conversation_branches" flag and bundle with "projects"

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -2296,10 +2296,10 @@ describe("postUserMessage", () => {
       projectConversation = fetchedConversationResult.value;
     }
 
-    describe("with conversation_branches feature flag enabled", () => {
+    describe("with projects feature flag enabled regarding branches", () => {
       beforeEach(async () => {
         await setupProjectWithRestrictedAgent();
-        await FeatureFlagFactory.basic(auth, "conversation_branches");
+        await FeatureFlagFactory.basic(auth, "projects");
       });
 
       it("should create a branch and put first message in branch when posting with restricted agent", async () => {
@@ -2446,62 +2446,6 @@ describe("postUserMessage", () => {
         );
         expect(branchRow).not.toBeNull();
         expect(secondUserMessageRow!.branchId).toBe(branchRow!.id);
-
-        rateLimiterSpy.mockRestore();
-      });
-    });
-
-    describe("with conversation_branches feature flag disabled", () => {
-      beforeEach(async () => {
-        await setupProjectWithRestrictedAgent();
-      });
-
-      it("should not create a branch when posting with restricted agent", async () => {
-        const user = auth.getNonNullableUser();
-        const userJson = user.toJSON();
-
-        const rateLimiterSpy = vi
-          .spyOn(rateLimiterModule, "rateLimiter")
-          .mockResolvedValue(100);
-
-        const result = await postUserMessage(auth, {
-          conversation: projectConversation,
-          content: `Hello @${agentWithDifferentSpace.name}`,
-          mentions: [{ configurationId: agentWithDifferentSpace.sId }],
-          context: {
-            username: userJson.username,
-            timezone: "UTC",
-            fullName: userJson.fullName,
-            email: userJson.email,
-            profilePictureUrl: userJson.image,
-            origin: "web",
-          },
-          skipToolsValidation: false,
-        });
-
-        expect(result.isOk()).toBe(true);
-        if (!result.isOk()) {
-          return;
-        }
-
-        const branchesAfter =
-          await ConversationBranchResource.listForConversation(
-            auth,
-            projectConversation.id
-          );
-        expect(branchesAfter.length).toBe(0);
-
-        expect(projectConversation.branchId).toBeNull();
-
-        // When the agent is restricted and we don't create a branch, no agent message is created
-        // but the mention is stored with status agent_restricted_by_space_usage
-        const agentMessages = result.value.agentMessages;
-        expect(agentMessages.length).toBe(0);
-        const richMention = result.value.userMessage.richMentions.find(
-          (m) => m.type === "agent" && m.id === agentWithDifferentSpace.sId
-        );
-        expect(richMention).toBeDefined();
-        expect(richMention!.status).toBe("agent_restricted_by_space_usage");
 
         rateLimiterSpy.mockRestore();
       });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -795,9 +795,8 @@ export async function postUserMessage(
       });
     }
 
-    // If the conversation is part of a project and the conversation branches feature flag is enabled.
     // When the agent is not usable, we will create a branch.
-    if (isPartOfProject && featureFlags.includes("conversation_branches")) {
+    if (isPartOfProject) {
       const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
         configuration: agentConfig,
         conversation,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -209,8 +209,8 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
   },
   projects: {
-    description: "Enable use Spaces as Projects",
-    stage: "dust_only",
+    description: "Enable the Projects feature",
+    stage: "on_demand",
   },
   databricks_tool: {
     description: "Databricks MCP tool",
@@ -238,10 +238,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "After a response from Anthropic, make an additional API call to get the reasoning token count for better usage tracking",
     // Not really on_demand but we want to be able to enable it for customers
     stage: "on_demand",
-  },
-  conversation_branches: {
-    description: "Enable conversation branches",
-    stage: "dust_only",
   },
   sessions_branching: {
     description: "Enable sessions branching",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -685,7 +685,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "claude_4_5_opus_feature"
   | "claude_4_opus_feature"
   | "confluence_tool"
-  | "conversation_branches"
   | "sessions_branching"
   | "project_todo"
   | "projects"


### PR DESCRIPTION
## Description

`conversation_branches` was a separate flag gating branch creation in project conversations, but branches are an intrinsic part of the Projects feature — there's no reason to gate them independently. Bundling them under `projects` removes the extra flag and simplifies the rollout surface.

- Drop the `conversation_branches` feature flag check in `postUserMessage` — branch logic now fires for all project conversations (already gated by `projects`)
- Remove `conversation_branches` from `WHITELISTABLE_FEATURES_CONFIG` and from the SDK's `WhitelistableFeaturesSchema`
- Change `projects` stage from `dust_only` to `on_demand` and update its description

## Tests

Local

## Risk

Low — anyone with `projects` already had `conversation_branches` enabled; the behavior is unchanged for them

## Deploy Plan

Deploy `front` + SDK
