### PR TITLE
Grant monthly free credits on Metronome

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -786,6 +786,58 @@ export async function listMetronomeUsageWithGroups({
 }
 
 /**
+ * Update the amount of a free credit segment created from a recurring credit in a package.
+ * Called when a credit.segment.start webhook fires, to set the correct user-based amount.
+ * The segment_id is the access schedule item ID provided in the webhook event.
+ */
+export async function updateMetronomeFreeCreditSegmentAmount({
+  metronomeCustomerId,
+  contractId,
+  creditId,
+  segmentId,
+  amount,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  creditId: string;
+  segmentId: string;
+  amount: number;
+}): Promise<Result<void, Error>> {
+  try {
+    await getMetronomeClient().v2.contracts.edit({
+      customer_id: metronomeCustomerId,
+      contract_id: contractId,
+      update_credits: [
+        {
+          credit_id: creditId,
+          access_schedule: {
+            update_schedule_items: [
+              {
+                id: segmentId,
+                amount,
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    logger.info(
+      { metronomeCustomerId, contractId, creditId, segmentId, amount },
+      "[Metronome] Free credit segment amount updated"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, contractId, creditId, segmentId, amount },
+      "[Metronome] Failed to update free credit segment amount"
+    );
+    return new Err(error);
+  }
+}
+
+/**
  * Create a credit grant on a Metronome customer.
  * Used for monthly free programmatic credits on legacy plans.
  */

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -786,11 +786,11 @@ export async function listMetronomeUsageWithGroups({
 }
 
 /**
- * Update the amount of a free credit segment created from a recurring credit in a package.
+ * Update the amount of a credit segment created from a recurring credit in a package.
  * Called when a credit.segment.start webhook fires, to set the correct user-based amount.
  * The segment_id is the access schedule item ID provided in the webhook event.
  */
-export async function updateMetronomeFreeCreditSegmentAmount({
+export async function updateMetronomeCreditSegmentAmount({
   metronomeCustomerId,
   contractId,
   creditId,

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -6,9 +6,12 @@ import {
 } from "@app/lib/credits/free";
 import {
   getMetronomeClient,
-  updateMetronomeFreeCreditSegmentAmount,
+  updateMetronomeCreditSegmentAmount,
 } from "@app/lib/metronome/client";
-import { getProductFreeMonthlyCreditId } from "@app/lib/metronome/constants";
+import {
+  getCreditTypeProgrammaticUsdId,
+  getProductFreeMonthlyCreditId,
+} from "@app/lib/metronome/constants";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -149,7 +152,10 @@ async function handler(
             product,
           } = parsed.data;
 
-          if (product.id !== getProductFreeMonthlyCreditId()) {
+          if (
+            product.id !== getProductFreeMonthlyCreditId() ||
+            creditId !== getCreditTypeProgrammaticUsdId()
+          ) {
             logger.info(
               { customerId, creditId, productId: product.id },
               "[Metronome Webhook] credit.segment.start: ignoring non-free-credit segment"
@@ -171,7 +177,7 @@ async function handler(
           const amountMicroUsd = calculateFreeCreditAmountMicroUsd(userCount);
           const amount = amountMicroUsd / 1_000_000;
 
-          const updateResult = await updateMetronomeFreeCreditSegmentAmount({
+          const updateResult = await updateMetronomeCreditSegmentAmount({
             metronomeCustomerId: customerId,
             contractId,
             creditId,

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -1,6 +1,14 @@
 /** @ignoreswagger */
 import apiConfig from "@app/lib/api/config";
-import { getMetronomeClient } from "@app/lib/metronome/client";
+import {
+  calculateFreeCreditAmountMicroUsd,
+  countEligibleUsersForFreeCredits,
+} from "@app/lib/credits/free";
+import {
+  getMetronomeClient,
+  updateMetronomeFreeCreditSegmentAmount,
+} from "@app/lib/metronome/client";
+import { getProductFreeMonthlyCreditId } from "@app/lib/metronome/constants";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -24,6 +32,15 @@ const ContractEndEventSchema = z.object({
   type: z.literal("contract.end"),
   contract_id: z.string(),
   customer_id: z.string(),
+});
+
+const CreditSegmentStartEventSchema = z.object({
+  type: z.literal("credit.segment.start"),
+  customer_id: z.string(),
+  contract_id: z.string(),
+  credit_id: z.string(),
+  segment_id: z.string(),
+  product: z.object({ id: z.string() }),
 });
 
 // Disable Next.js body parsing so we can read the raw body for signature verification.
@@ -113,6 +130,90 @@ async function handler(
             "[Metronome Webhook] New commit segment started (credits available)"
           );
           break;
+
+        case "credit.segment.start": {
+          const parsed = CreditSegmentStartEventSchema.safeParse(event);
+          if (!parsed.success) {
+            logger.error(
+              { event, error: parsed.error.message },
+              "[Metronome Webhook] Invalid credit.segment.start event"
+            );
+            break;
+          }
+
+          const {
+            customer_id: customerId,
+            contract_id: contractId,
+            credit_id: creditId,
+            segment_id: segmentId,
+            product,
+          } = parsed.data;
+
+          if (product.id !== getProductFreeMonthlyCreditId()) {
+            logger.info(
+              { customerId, creditId, productId: product.id },
+              "[Metronome Webhook] credit.segment.start: ignoring non-free-credit segment"
+            );
+            break;
+          }
+
+          const workspace =
+            await WorkspaceResource.fetchByMetronomeCustomerId(customerId);
+          if (!workspace) {
+            logger.warn(
+              { customerId },
+              "[Metronome Webhook] credit.segment.start: workspace not found"
+            );
+            break;
+          }
+
+          const userCount = await countEligibleUsersForFreeCredits(workspace);
+          const amountMicroUsd = calculateFreeCreditAmountMicroUsd(userCount);
+          const amount = amountMicroUsd / 1_000_000;
+
+          const updateResult = await updateMetronomeFreeCreditSegmentAmount({
+            metronomeCustomerId: customerId,
+            contractId,
+            creditId,
+            segmentId,
+            amount,
+          });
+
+          if (updateResult.isErr()) {
+            logger.error(
+              {
+                customerId,
+                contractId,
+                creditId,
+                segmentId,
+                error: updateResult.error,
+                workspaceId: workspace.sId,
+              },
+              "[Metronome Webhook] credit.segment.start: failed to update free credit amount"
+            );
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: `Error updating free credit amount: ${updateResult.error.message}`,
+              },
+            });
+          }
+
+          logger.info(
+            {
+              customerId,
+              contractId,
+              creditId,
+              segmentId,
+              amountMicroUsd,
+              userCount,
+              workspaceId: workspace.sId,
+            },
+            "[Metronome Webhook] credit.segment.start: free credit amount updated"
+          );
+          break;
+        }
 
         case "credit.create":
           logger.info(

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -139,6 +139,24 @@ interface PackageSubscription {
   };
 }
 
+interface RecurringCreditDef {
+  product_name: string; // resolved to product ID at runtime
+  access_amount: {
+    credit_type_id: string; // evaluated after detectEnvironment()
+    unit_price: number;
+    quantity?: number;
+  };
+  commit_duration: { value: number; unit?: "PERIODS" };
+  priority: number;
+  starting_at_offset: {
+    unit: "DAYS" | "WEEKS" | "MONTHS" | "YEARS";
+    value: number;
+  };
+  applicable_product_tags?: string[];
+  recurrence_frequency?: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
+  name?: string;
+}
+
 interface PackageDef {
   // Base name without version suffix. Version is auto-computed at sync time.
   name: string;
@@ -153,6 +171,7 @@ interface PackageDef {
   };
   // Consolidate scheduled/commit charges onto the usage invoice instead of separate invoices.
   scheduled_charges_on_usage_invoices?: "ALL";
+  recurring_credits?: RecurringCreditDef[];
 }
 
 // ---------------------------------------------------------------------------
@@ -677,6 +696,24 @@ function getRateCards(): RateCardDef[] {
   ];
 }
 
+// Recurring free credit definition shared by all packages.
+// Quantity starts at 0 — the credit.segment.start webhook updates it each period
+// to the actual user-based amount.
+const FREE_MONTHLY_RECURRING_CREDITS: RecurringCreditDef = {
+  product_name: "Free Monthly Credits",
+  access_amount: {
+    credit_type_id: getCreditTypeProgrammaticUsdId(),
+    unit_price: 0,
+    quantity: 0,
+  },
+  commit_duration: { value: 1 },
+  priority: 1,
+  starting_at_offset: { unit: "DAYS", value: 0 },
+  applicable_product_tags: [USAGE_TAG],
+  recurrence_frequency: "MONTHLY",
+  name: "Free Monthly Credits",
+};
+
 // Seat subscription definition shared by all legacy packages.
 const LEGACY_SEAT_SUBSCRIPTION: PackageSubscription = {
   temporary_id: "legacy-seat-sub",
@@ -715,6 +752,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-monthly" }],
     rate_card_name: "Legacy Pro USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -722,6 +760,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-business" }],
     rate_card_name: "Legacy Business USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -729,6 +768,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-annual" }],
     rate_card_name: "Legacy Pro Annual USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   // Enterprise: MAU-based billing, no seat subscriptions.
@@ -737,6 +777,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-enterprise" }],
     rate_card_name: "Legacy Enterprise MAU USD",
     scheduled_charges_on_usage_invoices: "ALL",
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   // EUR variants
@@ -745,6 +786,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-monthly-eur" }],
     rate_card_name: "Legacy Pro EUR",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -752,6 +794,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-business-eur" }],
     rate_card_name: "Legacy Business EUR",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -759,6 +802,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-annual-eur" }],
     rate_card_name: "Legacy Pro Annual EUR",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -766,6 +810,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-enterprise-eur" }],
     rate_card_name: "Legacy Enterprise MAU EUR",
     scheduled_charges_on_usage_invoices: "ALL",
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
 ];
@@ -1357,6 +1402,19 @@ interface ExistingPackage {
     quantity_management_mode?: string;
     seat_config?: { seat_group_key: string };
   }>;
+  recurring_credits?: Array<{
+    product: { id: string };
+    access_amount: {
+      credit_type_id: string;
+      unit_price: number;
+      quantity?: number;
+    };
+    commit_duration: { value: number };
+    priority: number;
+    starting_at_offset: { unit: string; value: number };
+    applicable_product_tags?: string[];
+    recurrence_frequency?: string;
+  }>;
 }
 
 function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
@@ -1427,6 +1485,29 @@ function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
     (ex.scheduled_charges_on_usage_invoices ?? undefined)
   ) {
     return false;
+  }
+
+  // Check recurring credits count and product IDs (implicit product recreation cascade).
+  const desiredCredits = desired.recurring_credits ?? [];
+  const existingCredits = ex.recurring_credits ?? [];
+  if (desiredCredits.length !== existingCredits.length) {
+    return false;
+  }
+  for (const desiredCredit of desiredCredits) {
+    const productId = ids.products[desiredCredit.product_name];
+    const match = existingCredits.find((c) => c.product.id === productId);
+    if (!match) {
+      return false;
+    }
+    if (
+      match.access_amount.credit_type_id !==
+      desiredCredit.access_amount.credit_type_id
+    ) {
+      return false;
+    }
+    if (match.priority !== desiredCredit.priority) {
+      return false;
+    }
   }
 
   return true;
@@ -1535,6 +1616,32 @@ async function syncPackages(): Promise<void> {
           };
         });
 
+        // Resolve recurring credit product IDs
+        const recurringCredits = (desired.recurring_credits ?? []).map(
+          (credit) => {
+            const productId = ids.products[credit.product_name];
+            if (!productId) {
+              throw new Error(
+                `Product not found for recurring credit: ${credit.product_name}`
+              );
+            }
+            return {
+              product_id: productId,
+              access_amount: credit.access_amount,
+              commit_duration: credit.commit_duration,
+              priority: credit.priority,
+              starting_at_offset: credit.starting_at_offset,
+              ...(credit.applicable_product_tags
+                ? { applicable_product_tags: credit.applicable_product_tags }
+                : {}),
+              ...(credit.recurrence_frequency
+                ? { recurrence_frequency: credit.recurrence_frequency }
+                : {}),
+              ...(credit.name ? { name: credit.name } : {}),
+            };
+          }
+        );
+
         const created = await client.v1.packages.create({
           name: versionedName,
           contract_name: versionedName,
@@ -1545,6 +1652,9 @@ async function syncPackages(): Promise<void> {
             ? { usage_statement_schedule: desired.usage_statement_schedule }
             : {}),
           ...(subscriptions.length > 0 ? { subscriptions } : {}),
+          ...(recurringCredits.length > 0
+            ? { recurring_credits: recurringCredits }
+            : {}),
           ...(desired.scheduled_charges_on_usage_invoices
             ? {
                 scheduled_charges_on_usage_invoices:

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -139,23 +139,23 @@ interface PackageSubscription {
   };
 }
 
-interface RecurringCreditDef {
-  product_name: string; // resolved to product ID at runtime
-  access_amount: {
-    credit_type_id: string; // evaluated after detectEnvironment()
-    unit_price: number;
-    quantity?: number;
-  };
-  commit_duration: { value: number; unit?: "PERIODS" };
-  priority: number;
-  starting_at_offset: {
-    unit: "DAYS" | "WEEKS" | "MONTHS" | "YEARS";
-    value: number;
-  };
-  applicable_product_tags?: string[];
-  recurrence_frequency?: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
-  name?: string;
-}
+// interface RecurringCreditDef {
+//   product_name: string; // resolved to product ID at runtime
+//   access_amount: {
+//     credit_type_id: string; // evaluated after detectEnvironment()
+//     unit_price: number;
+//     quantity?: number;
+//   };
+//   commit_duration: { value: number; unit?: "PERIODS" };
+//   priority: number;
+//   starting_at_offset: {
+//     unit: "DAYS" | "WEEKS" | "MONTHS" | "YEARS";
+//     value: number;
+//   };
+//   applicable_product_tags?: string[];
+//   recurrence_frequency?: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
+//   name?: string;
+// }
 
 interface PackageDef {
   // Base name without version suffix. Version is auto-computed at sync time.
@@ -171,7 +171,7 @@ interface PackageDef {
   };
   // Consolidate scheduled/commit charges onto the usage invoice instead of separate invoices.
   scheduled_charges_on_usage_invoices?: "ALL";
-  recurring_credits?: RecurringCreditDef[];
+  // recurring_credits?: RecurringCreditDef[];
 }
 
 // ---------------------------------------------------------------------------
@@ -699,20 +699,20 @@ function getRateCards(): RateCardDef[] {
 // Recurring free credit definition shared by all packages.
 // Quantity starts at 0 — the credit.segment.start webhook updates it each period
 // to the actual user-based amount.
-const FREE_MONTHLY_RECURRING_CREDITS: RecurringCreditDef = {
-  product_name: "Free Monthly Credits",
-  access_amount: {
-    credit_type_id: getCreditTypeProgrammaticUsdId(),
-    unit_price: 0,
-    quantity: 0,
-  },
-  commit_duration: { value: 1 },
-  priority: 1,
-  starting_at_offset: { unit: "DAYS", value: 0 },
-  applicable_product_tags: [USAGE_TAG],
-  recurrence_frequency: "MONTHLY",
-  name: "Free Monthly Credits",
-};
+// const FREE_MONTHLY_RECURRING_CREDITS: RecurringCreditDef = {
+//   product_name: "Free Monthly Credits",
+//   access_amount: {
+//     credit_type_id: getCreditTypeProgrammaticUsdId(),
+//     unit_price: 0,
+//     quantity: 0,
+//   },
+//   commit_duration: { value: 1 },
+//   priority: 1,
+//   starting_at_offset: { unit: "DAYS", value: 0 },
+//   applicable_product_tags: [USAGE_TAG],
+//   recurrence_frequency: "MONTHLY",
+//   name: "Free Monthly Credits",
+// };
 
 // Seat subscription definition shared by all legacy packages.
 const LEGACY_SEAT_SUBSCRIPTION: PackageSubscription = {
@@ -752,7 +752,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-monthly" }],
     rate_card_name: "Legacy Pro USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -760,7 +760,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-business" }],
     rate_card_name: "Legacy Business USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -768,7 +768,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-annual" }],
     rate_card_name: "Legacy Pro Annual USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   // Enterprise: MAU-based billing, no seat subscriptions.
@@ -777,7 +777,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-enterprise" }],
     rate_card_name: "Legacy Enterprise MAU USD",
     scheduled_charges_on_usage_invoices: "ALL",
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   // EUR variants
@@ -786,7 +786,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-monthly-eur" }],
     rate_card_name: "Legacy Pro EUR",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -794,7 +794,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-business-eur" }],
     rate_card_name: "Legacy Business EUR",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -802,7 +802,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-annual-eur" }],
     rate_card_name: "Legacy Pro Annual EUR",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -810,7 +810,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-enterprise-eur" }],
     rate_card_name: "Legacy Enterprise MAU EUR",
     scheduled_charges_on_usage_invoices: "ALL",
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
 ];
@@ -1402,19 +1402,19 @@ interface ExistingPackage {
     quantity_management_mode?: string;
     seat_config?: { seat_group_key: string };
   }>;
-  recurring_credits?: Array<{
-    product: { id: string };
-    access_amount: {
-      credit_type_id: string;
-      unit_price: number;
-      quantity?: number;
-    };
-    commit_duration: { value: number };
-    priority: number;
-    starting_at_offset: { unit: string; value: number };
-    applicable_product_tags?: string[];
-    recurrence_frequency?: string;
-  }>;
+  // recurring_credits?: Array<{
+  //   product: { id: string };
+  //   access_amount: {
+  //     credit_type_id: string;
+  //     unit_price: number;
+  //     quantity?: number;
+  //   };
+  //   commit_duration: { value: number };
+  //   priority: number;
+  //   starting_at_offset: { unit: string; value: number };
+  //   applicable_product_tags?: string[];
+  //   recurrence_frequency?: string;
+  // }>;
 }
 
 function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
@@ -1488,27 +1488,27 @@ function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
   }
 
   // Check recurring credits count and product IDs (implicit product recreation cascade).
-  const desiredCredits = desired.recurring_credits ?? [];
-  const existingCredits = ex.recurring_credits ?? [];
-  if (desiredCredits.length !== existingCredits.length) {
-    return false;
-  }
-  for (const desiredCredit of desiredCredits) {
-    const productId = ids.products[desiredCredit.product_name];
-    const match = existingCredits.find((c) => c.product.id === productId);
-    if (!match) {
-      return false;
-    }
-    if (
-      match.access_amount.credit_type_id !==
-      desiredCredit.access_amount.credit_type_id
-    ) {
-      return false;
-    }
-    if (match.priority !== desiredCredit.priority) {
-      return false;
-    }
-  }
+  // const desiredCredits = desired.recurring_credits ?? [];
+  // const existingCredits = ex.recurring_credits ?? [];
+  // if (desiredCredits.length !== existingCredits.length) {
+  //   return false;
+  // }
+  // for (const desiredCredit of desiredCredits) {
+  //   const productId = ids.products[desiredCredit.product_name];
+  //   const match = existingCredits.find((c) => c.product.id === productId);
+  //   if (!match) {
+  //     return false;
+  //   }
+  //   if (
+  //     match.access_amount.credit_type_id !==
+  //     desiredCredit.access_amount.credit_type_id
+  //   ) {
+  //     return false;
+  //   }
+  //   if (match.priority !== desiredCredit.priority) {
+  //     return false;
+  //   }
+  // }
 
   return true;
 }
@@ -1617,30 +1617,30 @@ async function syncPackages(): Promise<void> {
         });
 
         // Resolve recurring credit product IDs
-        const recurringCredits = (desired.recurring_credits ?? []).map(
-          (credit) => {
-            const productId = ids.products[credit.product_name];
-            if (!productId) {
-              throw new Error(
-                `Product not found for recurring credit: ${credit.product_name}`
-              );
-            }
-            return {
-              product_id: productId,
-              access_amount: credit.access_amount,
-              commit_duration: credit.commit_duration,
-              priority: credit.priority,
-              starting_at_offset: credit.starting_at_offset,
-              ...(credit.applicable_product_tags
-                ? { applicable_product_tags: credit.applicable_product_tags }
-                : {}),
-              ...(credit.recurrence_frequency
-                ? { recurrence_frequency: credit.recurrence_frequency }
-                : {}),
-              ...(credit.name ? { name: credit.name } : {}),
-            };
-          }
-        );
+        // const recurringCredits = (desired.recurring_credits ?? []).map(
+        //   (credit) => {
+        //     const productId = ids.products[credit.product_name];
+        //     if (!productId) {
+        //       throw new Error(
+        //         `Product not found for recurring credit: ${credit.product_name}`
+        //       );
+        //     }
+        //     return {
+        //       product_id: productId,
+        //       access_amount: credit.access_amount,
+        //       commit_duration: credit.commit_duration,
+        //       priority: credit.priority,
+        //       starting_at_offset: credit.starting_at_offset,
+        //       ...(credit.applicable_product_tags
+        //         ? { applicable_product_tags: credit.applicable_product_tags }
+        //         : {}),
+        //       ...(credit.recurrence_frequency
+        //         ? { recurrence_frequency: credit.recurrence_frequency }
+        //         : {}),
+        //       ...(credit.name ? { name: credit.name } : {}),
+        //     };
+        //   }
+        // );
 
         const created = await client.v1.packages.create({
           name: versionedName,
@@ -1652,9 +1652,9 @@ async function syncPackages(): Promise<void> {
             ? { usage_statement_schedule: desired.usage_statement_schedule }
             : {}),
           ...(subscriptions.length > 0 ? { subscriptions } : {}),
-          ...(recurringCredits.length > 0
-            ? { recurring_credits: recurringCredits }
-            : {}),
+          // ...(recurringCredits.length > 0
+          //   ? { recurring_credits: recurringCredits }
+          //   : {}),
           ...(desired.scheduled_charges_on_usage_invoices
             ? {
                 scheduled_charges_on_usage_invoices:


### PR DESCRIPTION
## Description

Adds monthly free credit grants using Metronome's native recurring credits feature. 

The recurring credit is configured with `quantity: 0` — when Metronome fires a `credit.segment.start` webhook at the beginning of each billing period, the webhook handler counts eligible users, calculates the bracket-based amount, and updates the segment amount via `v2.contracts.edit`. The bracket formula remains unchanged: 1–10 users → $5/user, 11–50 users → $2/user, 51–100 users → $1/user.

**New function** `updateMetronomeFreeCreditSegmentAmount()`: edits a contract to update a recurring credit segment's amount using `update_credits` and `update_schedule_items`.

**New webhook handler** `credit.segment.start`: validates the product is "Free Monthly Credits", fetches the workspace, counts users, calculates the amount, and updates the segment. Fire-and-forget — errors are logged but don't block the webhook.

## Tests


## Risk

Low

## Deploy Plan

Deploy front.
Another PR will come to add recurring credits to existing contracts (via migration script)