### PR TITLE
Persist compaction run IDs when compaction starts

### DIFF
--- a/front/lib/api/assistant/call_llm.ts
+++ b/front/lib/api/assistant/call_llm.ts
@@ -21,6 +21,7 @@ export interface LLMConfig {
 export interface LLMOptions {
   tracingRecords?: Record<string, string>;
   context?: LLMTraceContext;
+  onRunId?: (runId: string) => Promise<void> | void;
 }
 
 // Zod schema to validate runActionStreamed output.
@@ -65,6 +66,8 @@ export async function runMultiActionsAgent(
     // Should not happen
     return new Err(new Error(`Model ${config.modelId} not supported`));
   }
+
+  await options.onRunId?.(llm.getTraceId());
 
   const actions: NonNullable<LLMOutput["actions"]> = [];
   let generation = "";

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2022,13 +2022,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     }
   ): Promise<void> {
     const workspaceId = auth.getNonNullableWorkspace().id;
+    const sanitizedRunIds = runIds.map((runId) => runId.replaceAll("'", "''"));
 
     await CompactionMessageModel.update(
       {
         runIds: fn(
           "ARRAY",
           literal(
-            `SELECT DISTINCT unnest(COALESCE("runIds", '{}') || ARRAY['${runIds.join("','")}']::text[])`
+            `SELECT DISTINCT unnest(COALESCE("runIds", '{}') || ARRAY['${sanitizedRunIds.join("','")}']::text[])`
           )
         ),
       },

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2011,6 +2011,36 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return pendingMessages;
   }
 
+  static async updateCompactionMessageRunIds(
+    auth: Authenticator,
+    {
+      compactionMessageModelId,
+      runIds,
+    }: {
+      compactionMessageModelId: ModelId;
+      runIds: string[];
+    }
+  ): Promise<void> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    await CompactionMessageModel.update(
+      {
+        runIds: fn(
+          "ARRAY",
+          literal(
+            `SELECT DISTINCT unnest(COALESCE("runIds", '{}') || ARRAY['${runIds.join("','")}']::text[])`
+          )
+        ),
+      },
+      {
+        where: {
+          id: compactionMessageModelId,
+          workspaceId,
+        },
+      }
+    );
+  }
+
   async getLatestAgentMessageRun(
     auth: Authenticator
   ): Promise<RunResource | null> {

--- a/front/temporal/agent_loop/lib/compaction.test.ts
+++ b/front/temporal/agent_loop/lib/compaction.test.ts
@@ -1,0 +1,153 @@
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { compactConversation } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import type { Authenticator } from "@app/lib/auth";
+import { CompactionMessageModel } from "@app/lib/models/agent/conversation";
+import { runCompaction } from "@app/temporal/agent_loop/lib/compaction";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  CompactionMessageType,
+  ConversationType,
+} from "@app/types/assistant/conversation";
+import type { SupportedModel } from "@app/types/assistant/models/types";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/assistant/call_llm", () => ({
+  runMultiActionsAgent: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/assistant/streaming/events", () => ({
+  publishAgentMessagesEvents: vi.fn(),
+  publishConversationEvent: vi.fn(),
+  publishMessageEventsOnMessagePostOrEdit: vi.fn(),
+}));
+
+vi.mock("@app/temporal/agent_loop/client", () => ({
+  launchAgentLoopWorkflow: vi.fn(),
+  launchCompactionWorkflow: vi.fn(),
+}));
+
+const MODEL: SupportedModel = {
+  providerId: "anthropic",
+  modelId: "claude-haiku-4-5-20251001",
+};
+
+describe("runCompaction", () => {
+  let auth: Authenticator;
+  let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+  let conversation: ConversationType;
+  let agentConfig: LightAgentConfigurationType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+
+    agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent Description",
+    });
+
+    const conversationWithoutContent = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const fetchedConversationResult = await getConversation(
+      auth,
+      conversationWithoutContent.sId
+    );
+    if (fetchedConversationResult.isErr()) {
+      throw new Error("Failed to fetch conversation");
+    }
+    conversation = fetchedConversationResult.value;
+
+    vi.clearAllMocks();
+  });
+
+  async function createCompactionMessage(): Promise<CompactionMessageType> {
+    const result = await compactConversation(auth, {
+      conversation,
+      model: MODEL,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    return result.value.compactionMessage;
+  }
+
+  it("stores the run id before marking compaction as succeeded", async () => {
+    const compactionMessage = await createCompactionMessage();
+
+    vi.mocked(runMultiActionsAgent).mockImplementationOnce(
+      async (_auth, _config, _input, options) => {
+        await options?.onRunId?.("llm_trace_run_1");
+
+        return new Ok({
+          actions: [],
+          generation:
+            "<analysis>Scratchpad.</analysis><summary>Summary.</summary>",
+        });
+      }
+    );
+
+    const result = await runCompaction(auth, {
+      conversationId: conversation.sId,
+      compactionMessageId: compactionMessage.sId,
+      compactionMessageVersion: compactionMessage.version,
+      model: MODEL,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const compactionMessageRow = await CompactionMessageModel.findOne({
+      where: {
+        id: compactionMessage.compactionMessageId,
+        workspaceId: workspace.id,
+      },
+    });
+
+    expect(compactionMessageRow?.runIds).toEqual(["llm_trace_run_1"]);
+    expect(compactionMessageRow?.status).toBe("succeeded");
+    expect(compactionMessageRow?.content).toBe("Summary.");
+  });
+
+  it("keeps the run id when compaction fails", async () => {
+    const compactionMessage = await createCompactionMessage();
+
+    vi.mocked(runMultiActionsAgent).mockImplementationOnce(
+      async (_auth, _config, _input, options) => {
+        await options?.onRunId?.("llm_trace_run_2");
+
+        return new Err(new Error("LLM failed"));
+      }
+    );
+
+    const result = await runCompaction(auth, {
+      conversationId: conversation.sId,
+      compactionMessageId: compactionMessage.sId,
+      compactionMessageVersion: compactionMessage.version,
+      model: MODEL,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const compactionMessageRow = await CompactionMessageModel.findOne({
+      where: {
+        id: compactionMessage.compactionMessageId,
+        workspaceId: workspace.id,
+      },
+    });
+
+    expect(compactionMessageRow?.runIds).toEqual(["llm_trace_run_2"]);
+    expect(compactionMessageRow?.status).toBe("failed");
+    expect(compactionMessageRow?.content).toBeNull();
+  });
+});

--- a/front/temporal/agent_loop/lib/compaction.test.ts
+++ b/front/temporal/agent_loop/lib/compaction.test.ts
@@ -150,4 +150,38 @@ describe("runCompaction", () => {
     expect(compactionMessageRow?.status).toBe("failed");
     expect(compactionMessageRow?.content).toBeNull();
   });
+
+  it("sanitizes run ids before interpolating them into SQL", async () => {
+    const compactionMessage = await createCompactionMessage();
+
+    vi.mocked(runMultiActionsAgent).mockImplementationOnce(
+      async (_auth, _config, _input, options) => {
+        await options?.onRunId?.("llm_trace_run_'quoted'");
+
+        return new Ok({
+          actions: [],
+          generation:
+            "<analysis>Scratchpad.</analysis><summary>Summary.</summary>",
+        });
+      }
+    );
+
+    const result = await runCompaction(auth, {
+      conversationId: conversation.sId,
+      compactionMessageId: compactionMessage.sId,
+      compactionMessageVersion: compactionMessage.version,
+      model: MODEL,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const compactionMessageRow = await CompactionMessageModel.findOne({
+      where: {
+        id: compactionMessage.compactionMessageId,
+        workspaceId: workspace.id,
+      },
+    });
+
+    expect(compactionMessageRow?.runIds).toEqual(["llm_trace_run_'quoted'"]);
+  });
 });

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -7,6 +7,7 @@ import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conver
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import { isProviderWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type {
   CompactionMessageType,
@@ -129,6 +130,7 @@ export async function runCompaction(
 
   const summaryRes = await generateCompactionSummary(auth, {
     conversation,
+    compactionMessage,
     model,
   });
 
@@ -185,8 +187,13 @@ async function generateCompactionSummary(
   auth: Authenticator,
   {
     conversation,
+    compactionMessage,
     model,
-  }: { conversation: ConversationType; model: SupportedModel }
+  }: {
+    conversation: ConversationType;
+    compactionMessage: CompactionMessageType;
+    model: SupportedModel;
+  }
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
@@ -240,6 +247,12 @@ async function generateCompactionSummary(
         conversationId: conversation.sId,
         userId: auth.user()?.sId,
         workspaceId: owner.sId,
+      },
+      onRunId: async (runId) => {
+        await ConversationResource.updateCompactionMessageRunIds(auth, {
+          compactionMessageModelId: compactionMessage.compactionMessageId,
+          runIds: [runId],
+        });
       },
     }
   );

--- a/x/spolu/compaction/runids_plan.md
+++ b/x/spolu/compaction/runids_plan.md
@@ -131,55 +131,35 @@ In `createCompactionMessage(...)`, create the subtype row with:
 
 This mirrors agent message initialization.
 
-### - [ ] 3. Add a compaction metadata updater for `runIds`
+### - [x] 3. Add a `ConversationResource` static updater for compaction `runIds`
 
-Introduce a focused helper for non-terminal compaction metadata updates, similar in spirit to the
-non-terminal branch of `updateAgentMessageDBAndMemory(...)`.
+Move the non-terminal `runIds` persistence into a dedicated static function on
+`front/lib/resources/conversation_resource.ts`.
+
+Behavior:
+- Update `CompactionMessageModel` from `ConversationResource.updateCompactionMessageRunIds(...)`.
+- Use an atomic merge + dedupe SQL expression.
+- No advisory lock is required for this non-terminal metadata update.
 
 Suggested shape:
 
 ```ts
-async function updateCompactionMessageRunIds(
+static async updateCompactionMessageRunIds(
   auth: Authenticator,
   {
-    compactionMessage,
+    compactionMessageModelId,
     runIds,
   }: {
-    compactionMessage: CompactionMessageType;
+    compactionMessageModelId: ModelId;
     runIds: string[];
   }
 ): Promise<void>
 ```
 
-Behavior:
-- Update `CompactionMessageModel` directly.
-- Use an atomic merge + dedupe SQL expression.
-- No advisory lock required for this non-terminal metadata update.
+This preserves the same semantics as agent messages while keeping the raw model update logic in the
+Resource layer.
 
-Suggested merge logic:
-
-```ts
-await CompactionMessageModel.update(
-  {
-    runIds: fn(
-      "ARRAY",
-      literal(
-        `SELECT DISTINCT unnest(COALESCE("runIds", '{}') || ARRAY['${runIds.join("','")}']::text[])`
-      )
-    ),
-  },
-  {
-    where: {
-      id: compactionMessage.compactionMessageId,
-      workspaceId: auth.getNonNullableWorkspace().id,
-    },
-  }
-);
-```
-
-This preserves the same semantics as agent messages.
-
-### - [ ] 4. Expose the LLM trace id from `runMultiActionsAgent`
+### - [x] 4. Expose the LLM trace id from `runMultiActionsAgent`
 
 File:
 - `front/lib/api/assistant/call_llm.ts`
@@ -206,21 +186,18 @@ await options.onRunId?.(llm.getTraceId());
 Why this shape:
 - It exposes the run id early.
 - It allows persistence even if the LLM call later fails.
-- It matches the agent-message behavior where run ids are persisted while the message is still in a
-  running state.
+- It keeps the compaction-specific trigger in `compaction.ts` while moving the raw model update to
+  the Resource layer.
 
-An alternative would be to change the return type to include `runId`, but that only exposes the id
-at the end of the call and is therefore less aligned with the current agent pattern.
-
-### - [ ] 5. Persist compaction run ids as soon as compaction starts the LLM call
+### - [x] 5. Persist compaction run ids as soon as compaction starts the LLM call
 
 File:
 - `front/temporal/agent_loop/lib/compaction.ts`
 
 Thread the current `compactionMessage` through to the code that performs the LLM call.
 
-In `generateCompactionSummary(...)`, call `runMultiActionsAgent(...)` with `onRunId`, and in that
-callback invoke `updateCompactionMessageRunIds(...)`.
+In `generateCompactionSummary(...)`, call `runMultiActionsAgent(...)` with `onRunId`, and call
+`ConversationResource.updateCompactionMessageRunIds(...)` from that callback.
 
 Desired lifecycle:
 


### PR DESCRIPTION
## Description

- persist compaction `runIds` as soon as the compaction LLM instance is created via `onRunId`
- move the atomic compaction `runIds` update into `ConversationResource.updateCompactionMessageRunIds(...)`
- add compaction tests covering both successful and failed runs preserving the `runId`
- update the runIds work plan to match the implementation

## Tests

- `NODE_ENV=test npm test temporal/agent_loop/lib/compaction.test.ts`
- Tested locally

## Risk

Low. This only affects compaction run tracking metadata and adds focused coverage for the success and failure paths.

## Deploy Plan

- deploy `front`