### PR TITLE
Use res.on("close") to detect client disconnect in SSE handlers

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -108,8 +108,10 @@ async function handler(
       const controller = new AbortController();
       const { signal } = controller;
 
-      // Handle client disconnection
-      req.on("close", () => {
+      // Use res.on("close") rather than req.on("close"): Next.js fully reads and
+      // closes the request body before the handler runs, so req never emits "close"
+      // on client disconnect. The response stream is still live and fires reliably.
+      res.on("close", () => {
         controller.abort();
       });
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -97,8 +97,10 @@ async function handler(
       const controller = new AbortController();
       const { signal } = controller;
 
-      // Handle client disconnection
-      req.on("close", () => {
+      // Use res.on("close") rather than req.on("close"): Next.js fully reads and
+      // closes the request body before the handler runs, so req never emits "close"
+      // on client disconnect. The response stream is still live and fires reliably.
+      res.on("close", () => {
         controller.abort();
       });
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -139,8 +139,10 @@ async function handler(
       const controller = new AbortController();
       const { signal } = controller;
 
-      // Handle client disconnection
-      req.on("close", () => {
+      // Use res.on("close") rather than req.on("close"): Next.js fully reads and
+      // closes the request body before the handler runs, so req never emits "close"
+      // on client disconnect. The response stream is still live and fires reliably.
+      res.on("close", () => {
         controller.abort();
       });
 

--- a/front/pages/api/w/[wId]/mcp/requests.ts
+++ b/front/pages/api/w/[wId]/mcp/requests.ts
@@ -78,8 +78,10 @@ async function handler(
   const controller = new AbortController();
   const { signal } = controller;
 
-  // Handle client disconnection.
-  req.on("close", () => {
+  // Use res.on("close") rather than req.on("close"): Next.js fully reads and
+  // closes the request body before the handler runs, so req never emits "close"
+  // on client disconnect. The response stream is still live and fires reliably.
+  res.on("close", () => {
     controller.abort();
   });
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The `front-sse` pods were accumulating up to 24,000 simultaneous SSE connections, causing OOM kills. Memory profiling showed ~3,400 live `getConversationEvents` generators per pod, each holding HTTP request/response objects and ~188k Datadog spans in memory.

All three SSE endpoints (`conversations/events`, `messages/events`, `mcp/requests`) used `req.on("close")` to detect client disconnects and abort the generator. In practice, this event never fired.

**Root cause:** Next.js fully reads and parses the request body before invoking the API route handler. By the time the handler runs, the underlying `IncomingMessage` stream is already consumed and closed. Node.js will not emit "close" again. Client disconnects were silently swallowed.

Without the abort firing, the only cleanup mechanism was the 3-minute timeout in `getConversationEvents`. At steady-state, this means connections accumulate as 3 min × (new connections/min). At peak load, this reached 3.5k connections on a single pod.

**Memory profiling**
<img width="732" height="1115" alt="image" src="https://github.com/user-attachments/assets/52cd96f0-e86c-4305-a19d-f42ed38d1950" />

## Fix

Replace `req.on("close")` with `res.on("close")` on all three SSE handlers. The response stream is opened by the handler and remains live for the duration of the SSE connection. It reliably emits "close" when the client disconnects, before `res.end()` is called.

This is the pattern Next.js itself uses internally:

https://github.com/vercel/next.js/blob/f49722285b748c26ce5454ea4b9a1772d120cada/packages/next/src/server/lib/router-utils/proxy-request.ts#L40-L49

## Expected impact

Connections now abort within milliseconds of client disconnect instead of waiting up to 3 minutes. The steady-state active subscription count should drop proportionally to the ratio of connection lifetime (milliseconds) vs the previous timeout (3 minutes).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
