### PR TITLE
[front] enh(skills): hide discoverability section on new skill

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -256,7 +256,7 @@ export default function SkillBuilder({
           <SkillBuilderInstructionsSection />
           {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
           <SkillBuilderToolsSection extendedSkill={extendedSkill} />
-          <SkillBuilderSettingsOrComparisonFooter />
+          <SkillBuilderSettingsOrComparisonFooter skill={skill} />
         </div>
       </ScrollArea>
       <BarFooter
@@ -326,12 +326,16 @@ export default function SkillBuilder({
   );
 }
 
-function SkillBuilderSettingsOrComparisonFooter() {
+function SkillBuilderSettingsOrComparisonFooter({
+  skill,
+}: {
+  skill?: SkillType;
+}) {
   const { compareVersion } = useSkillVersionComparisonContext();
 
   if (compareVersion) {
     return <SkillBuilderVersionComparisonFooter />;
   }
 
-  return <SkillBuilderSettingsSection />;
+  return <SkillBuilderSettingsSection skill={skill} />;
 }

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -3,13 +3,13 @@ import { SkillBuilderIsDefaultSection } from "@app/components/skill_builder/Skil
 import { SkillBuilderNameSection } from "@app/components/skill_builder/SkillBuilderNameSection";
 import { SkillBuilderUserFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderUserFacingDescriptionSection";
 import { SkillEditorsSheet } from "@app/components/skill_builder/SkillEditorsSheet";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
   Label,
 } from "@dust-tt/sparkle";
-import type {SkillType} from "@app/types/assistant/skill_configuration";
 
 interface SkillBuilderSettingsSectionProps {
   skill?: SkillType;

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -9,8 +9,15 @@ import {
   CollapsibleTrigger,
   Label,
 } from "@dust-tt/sparkle";
+import type {SkillType} from "@app/types/assistant/skill_configuration";
 
-export function SkillBuilderSettingsSection() {
+interface SkillBuilderSettingsSectionProps {
+  skill?: SkillType;
+}
+
+export function SkillBuilderSettingsSection({
+  skill,
+}: SkillBuilderSettingsSectionProps) {
   return (
     <div className="space-y-5">
       <h2 className="heading-lg text-foreground dark:text-foreground-night">
@@ -31,14 +38,16 @@ export function SkillBuilderSettingsSection() {
           <SkillEditorsSheet />
         </div>
       </div>
-      <Collapsible defaultOpen>
-        <CollapsibleTrigger variant="secondary">Advanced</CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="pt-3">
-            <SkillBuilderIsDefaultSection />
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
+      {skill && (
+        <Collapsible defaultOpen>
+          <CollapsibleTrigger variant="secondary">Advanced</CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="pt-3">
+              <SkillBuilderIsDefaultSection />
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

- This PR hides the Advanced settings section (which contains the checkbox to make skills discoverable) on new skills.
- Rationale is that new skills are never good candidates for being discoverable, and that filling in the checkbox can feel like a necessary step to saving the skill (understanding this part enough to not fill it requires more effort arguably). On our workspace, we had 6 skills that were incorrectly made discoverable immediately.
- May cause a discoverability issue where not having seen the section at creation time can reduce the ability of users to discover it.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
