### PR TITLE
fix: cancel Stripe subscription on Metronome migration

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.test.ts
@@ -2,7 +2,7 @@ import { switchToMetronomeBillingPlugin } from "@app/lib/api/poke/plugins/worksp
 import { Authenticator } from "@app/lib/auth";
 import { addStripeMetronomeBillingConfig } from "@app/lib/metronome/client";
 import {
-  cancelSubscriptionAtPeriodEnd,
+  cancelSubscriptionImmediatelyNoInvoice,
   getStripeSubscription,
 } from "@app/lib/plans/stripe";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -18,7 +18,7 @@ vi.mock("@app/lib/plans/stripe", async () => {
   return {
     ...actual,
     getStripeSubscription: vi.fn(),
-    cancelSubscriptionAtPeriodEnd: vi.fn(),
+    cancelSubscriptionImmediatelyNoInvoice: vi.fn(),
   };
 });
 
@@ -188,7 +188,7 @@ describe("switchToMetronomeBillingPlugin", () => {
       vi.mocked(addStripeMetronomeBillingConfig).mockResolvedValue(
         new Ok(undefined)
       );
-      vi.mocked(cancelSubscriptionAtPeriodEnd).mockRejectedValue(
+      vi.mocked(cancelSubscriptionImmediatelyNoInvoice).mockRejectedValue(
         new Error("Stripe API error")
       );
 
@@ -223,7 +223,7 @@ describe("switchToMetronomeBillingPlugin", () => {
       vi.mocked(addStripeMetronomeBillingConfig).mockResolvedValue(
         new Ok(undefined)
       );
-      vi.mocked(cancelSubscriptionAtPeriodEnd).mockResolvedValue(true);
+      vi.mocked(cancelSubscriptionImmediatelyNoInvoice).mockResolvedValue(true);
 
       const result = await switchToMetronomeBillingPlugin.execute(
         auth,
@@ -239,14 +239,14 @@ describe("switchToMetronomeBillingPlugin", () => {
       }
 
       // New active subscription has no stripeSubscriptionId, keeps metronomeContractId,
-      // and starts at the Stripe period end date.
+      // and starts now (Stripe is cancelled immediately, not at period end).
       const newSub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
         workspace.id
       );
       expect(newSub).not.toBeNull();
       expect(newSub!.stripeSubscriptionId).toBeNull();
       expect(newSub!.metronomeContractId).toBe(METRONOME_CONTRACT_ID);
-      expect(newSub!.startDate.getTime()).toBe(PERIOD_END_SECONDS * 1000);
+      expect(newSub!.startDate.getTime()).toBeCloseTo(Date.now(), -3);
     });
   });
 });

--- a/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.ts
+++ b/front/lib/api/poke/plugins/workspaces/switch_to_metronome_billing.ts
@@ -2,7 +2,7 @@ import { createPlugin } from "@app/lib/api/poke/types";
 import type { Authenticator } from "@app/lib/auth";
 import { addStripeMetronomeBillingConfig } from "@app/lib/metronome/client";
 import {
-  cancelSubscriptionAtPeriodEnd,
+  cancelSubscriptionImmediatelyNoInvoice,
   getStripeSubscription,
 } from "@app/lib/plans/stripe";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -46,8 +46,6 @@ async function switchWorkspaceToMetronomeBilling(
     return new Err(billingConfigResult.error);
   }
 
-  const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
-
   await withTransaction(async (t) => {
     const subscriptionResource =
       await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id, t);
@@ -62,7 +60,7 @@ async function switchWorkspaceToMetronomeBilling(
         planId: subscriptionResource.planId,
         status: "active",
         trialing: false,
-        startDate: periodEnd,
+        startDate: new Date(),
         endDate: null,
         stripeSubscriptionId: null,
         metronomeContractId: subscription.metronomeContractId,
@@ -73,7 +71,7 @@ async function switchWorkspaceToMetronomeBilling(
   });
 
   try {
-    await cancelSubscriptionAtPeriodEnd({
+    await cancelSubscriptionImmediatelyNoInvoice({
       stripeSubscriptionId: subscription.stripeSubscriptionId,
     });
   } catch (err) {
@@ -86,22 +84,22 @@ async function switchWorkspaceToMetronomeBilling(
       },
       "[SwitchToMetronomeBilling] MANUAL ACTION REQUIRED: DB and Metronome are already migrated " +
         "to Metronome billing but Stripe subscription cancellation failed. " +
-        "Cancel the Stripe subscription manually to avoid double-charging the customer at period end."
+        "Cancel the Stripe subscription manually (with invoice_now=false, prorate=false) to avoid extra invoicing."
     );
     return new Ok({
       display: "text",
       value:
         `WARNING: DB migrated and Metronome billing enabled, but failed to cancel Stripe ` +
         `subscription ${subscription.stripeSubscriptionId}: ${error.message}. ` +
-        `Cancel it manually in Stripe to avoid double-charging at period end.`,
+        `Cancel the Stripe subscription manually (with invoice_now=false, prorate=false) to avoid extra invoicing.`,
     });
   }
 
   return new Ok({
     display: "text",
     value:
-      `Stripe subscription ${subscription.stripeSubscriptionId} will be cancelled on ${periodEnd.toISOString()}. ` +
-      `New Metronome contract ${subscription.metronomeContractId} continues from that date with Stripe as billing provider.`,
+      `Stripe subscription ${subscription.stripeSubscriptionId} cancelled immediately (no proration invoice). ` +
+      `New Metronome contract ${subscription.metronomeContractId} is now the active billing provider.`,
   });
 }
 
@@ -110,7 +108,7 @@ export const switchToMetronomeBillingPlugin = createPlugin({
     id: "switch-to-metronome-billing",
     name: "Switch to Metronome Billing",
     description:
-      "Cancels the Stripe subscription at period end and enables Metronome as the billing provider. The Metronome contract transitions at the same date to avoid double-billing.",
+      "Cancels the Stripe subscription immediately (no proration invoice) and enables Metronome as the billing provider.",
     resourceTypes: ["workspaces"],
     args: {},
   },

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -544,6 +544,25 @@ export async function cancelSubscriptionAtPeriodEnd({
 }
 
 /**
+ * Cancel a subscription immediately without generating any additional invoice.
+ * Pending proration items (e.g. from mid-period seat changes) are discarded.
+ * Used to handle takeover to Metronome, Metronome will handle the proration items.
+ */
+export async function cancelSubscriptionImmediatelyNoInvoice({
+  stripeSubscriptionId,
+}: {
+  stripeSubscriptionId: string;
+}) {
+  const stripe = getStripeClient();
+  await stripe.subscriptions.cancel(stripeSubscriptionId, {
+    invoice_now: false,
+    prorate: false,
+  });
+
+  return true;
+}
+
+/**
  * Creates a new Stripe Business subscription for upgrading Pro → Business.
  * The old subscription is cancelled separately after the DB flip.
  */


### PR DESCRIPTION
Replacing `cancel_at_period_end` with an immediate cancel `(invoice_now=false, prorate=false)` avoids a second billing cycle invoice that would charge customers for mid-period seat changes that Metronome now owns.

part of https://github.com/dust-tt/tasks/issues/7509

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
