### PR TITLE
[Sessions] Thread transactions through conversation skill fetches

### DIFF
--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -124,6 +124,7 @@ async function copyConversationSkills(
 ): Promise<Result<undefined, DustError<CreateConversationForkErrorCode>>> {
   const parentSkills = await SkillResource.listEnabledByConversation(auth, {
     conversation: parentConversation,
+    transaction,
   });
 
   if (parentSkills.length === 0) {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -623,7 +623,8 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   private static async baseFetch(
     auth: Authenticator,
-    { includes, limit, order, where }: ResourceFindOptions<GroupModel> = {}
+    { includes, limit, order, where }: ResourceFindOptions<GroupModel> = {},
+    transaction?: Transaction
   ) {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const includeClauses: Includeable[] = includes || [];
@@ -636,18 +637,27 @@ export class GroupResource extends BaseResource<GroupModel> {
       include: includeClauses,
       limit,
       order,
+      transaction,
     });
     return groupModels.map((b) => new this(this.model, b.get()));
   }
 
-  static async fetchByModelIds(auth: Authenticator, ids: ModelId[]) {
-    return this.baseFetch(auth, {
-      where: {
-        id: {
-          [Op.in]: ids,
+  static async fetchByModelIds(
+    auth: Authenticator,
+    ids: ModelId[],
+    { transaction }: { transaction?: Transaction } = {}
+  ) {
+    return this.baseFetch(
+      auth,
+      {
+        where: {
+          id: {
+            [Op.in]: ids,
+          },
         },
       },
-    });
+      transaction
+    );
   }
 
   static async fetchById(

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -630,42 +630,48 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
   static async listByMCPServers(
     auth: Authenticator,
-    mcpServerIds: string[]
+    mcpServerIds: string[],
+    transaction?: Transaction
   ): Promise<MCPServerViewResource[]> {
     const serverTypesAndIds = mcpServerIds.map((mcpServerId) => ({
       ...getServerTypeAndIdFromSId(mcpServerId),
       mcpServerId,
     }));
 
-    return this.baseFetch(auth, {
-      where: {
-        [Op.or]: [
-          {
-            serverType: "internal" as const,
-            internalMCPServerId: {
-              [Op.in]: serverTypesAndIds
-                .filter(({ serverType }) => serverType === "internal")
-                .map(({ mcpServerId }) => mcpServerId),
+    return this.baseFetch(
+      auth,
+      {
+        where: {
+          [Op.or]: [
+            {
+              serverType: "internal" as const,
+              internalMCPServerId: {
+                [Op.in]: serverTypesAndIds
+                  .filter(({ serverType }) => serverType === "internal")
+                  .map(({ mcpServerId }) => mcpServerId),
+              },
             },
-          },
-          {
-            serverType: "remote",
-            remoteMCPServerId: {
-              [Op.in]: serverTypesAndIds
-                .filter(({ serverType }) => serverType === "remote")
-                .map(({ id }) => id),
+            {
+              serverType: "remote",
+              remoteMCPServerId: {
+                [Op.in]: serverTypesAndIds
+                  .filter(({ serverType }) => serverType === "remote")
+                  .map(({ id }) => id),
+              },
             },
-          },
-        ],
+          ],
+        },
       },
-    });
+      { transaction }
+    );
   }
 
   static async listByMCPServer(
     auth: Authenticator,
-    mcpServerId: string
+    mcpServerId: string,
+    transaction?: Transaction
   ): Promise<MCPServerViewResource[]> {
-    return this.listByMCPServers(auth, [mcpServerId]);
+    return this.listByMCPServers(auth, [mcpServerId], transaction);
   }
 
   static async getByMCPServerAndSpace(
@@ -723,14 +729,16 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   static async listMCPServerViewsAutoInternalForSpaces(
     auth: Authenticator,
     name: AutoInternalMCPServerNameType,
-    spaceModelIds: ModelId[]
+    spaceModelIds: ModelId[],
+    transaction?: Transaction
   ) {
     const views = await this.listByMCPServer(
       auth,
       autoInternalMCPServerNameToSId({
         name,
         workspaceId: auth.getNonNullableWorkspace().id,
-      })
+      }),
+      transaction
     );
 
     // We include the global space, which is omitted from the requested space IDs of an agent.

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -353,22 +353,29 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   private static async baseFetch(
     auth: Authenticator,
     options: ResourceFindOptions<MCPServerViewModel> = {},
-    { includeMetadata = true }: { includeMetadata?: boolean } = {}
+    {
+      includeMetadata = true,
+      transaction,
+    }: { includeMetadata?: boolean; transaction?: Transaction } = {}
   ) {
-    const views = await this.baseFetchWithAuthorization(auth, {
-      ...options,
-      where: {
-        ...options.where,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-      includes: [
-        ...(options.includes ?? []),
-        {
-          model: UserModel,
-          as: "editedByUser",
+    const views = await this.baseFetchWithAuthorization(
+      auth,
+      {
+        ...options,
+        where: {
+          ...options.where,
+          workspaceId: auth.getNonNullableWorkspace().id,
         },
-      ],
-    });
+        includes: [
+          ...(options.includes ?? []),
+          {
+            model: UserModel,
+            as: "editedByUser",
+          },
+        ],
+      },
+      transaction
+    );
 
     const filteredViews: MCPServerViewResource[] = [];
 
@@ -377,11 +384,15 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     if (options.includeDeleted) {
       filteredViews.push(...views);
     } else {
-      const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
+      const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(
+        auth,
+        transaction
+      );
 
       const remoteServers = await RemoteMCPServerResource.fetchByModelIds(
         auth,
-        removeNulls(views.map((v) => v.remoteMCPServerId))
+        removeNulls(views.map((v) => v.remoteMCPServerId)),
+        transaction
       );
       const remoteServerMap = new Map(remoteServers.map((s) => [s.id, s]));
 
@@ -414,7 +425,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     }
 
     if (includeMetadata && filteredViews.length > 0) {
-      await this.populateToolsMetadata(auth, filteredViews);
+      await this.populateToolsMetadata(auth, filteredViews, transaction);
     }
 
     return filteredViews;
@@ -425,7 +436,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
    */
   private static async populateToolsMetadata(
     auth: Authenticator,
-    views: MCPServerViewResource[]
+    views: MCPServerViewResource[],
+    transaction?: Transaction
   ): Promise<void> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
@@ -441,6 +453,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
               workspaceId,
               internalMCPServerId: { [Op.in]: internalServerIds },
             },
+            transaction,
           })
         : [],
       remoteServerIds.length > 0
@@ -449,6 +462,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
               workspaceId,
               remoteMCPServerId: { [Op.in]: remoteServerIds },
             },
+            transaction,
           })
         : [],
     ]);
@@ -532,7 +546,10 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
-    { includeMetadata = true }: { includeMetadata?: boolean } = {}
+    {
+      includeMetadata = true,
+      transaction,
+    }: { includeMetadata?: boolean; transaction?: Transaction } = {}
   ) {
     const views = await this.baseFetch(
       auth,
@@ -543,7 +560,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           },
         },
       },
-      { includeMetadata }
+      { includeMetadata, transaction }
     );
 
     return views ?? [];

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -126,7 +126,8 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
 
   private static async baseFetch(
     auth: Authenticator,
-    options?: ResourceFindOptions<RemoteMCPServerModel>
+    options?: ResourceFindOptions<RemoteMCPServerModel>,
+    transaction?: Transaction
   ) {
     const { where, ...otherOptions } = options ?? {};
 
@@ -136,6 +137,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
         workspaceId: auth.getNonNullableWorkspace().id,
       },
       ...otherOptions,
+      transaction,
     });
 
     return servers.map(
@@ -178,14 +180,19 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
 
   static async fetchByModelIds(
     auth: Authenticator,
-    ids: ModelId[]
+    ids: ModelId[],
+    transaction?: Transaction
   ): Promise<RemoteMCPServerResource[]> {
     if (ids.length === 0) {
       return [];
     }
-    return this.baseFetch(auth, {
-      where: { id: { [Op.in]: ids } },
-    });
+    return this.baseFetch(
+      auth,
+      {
+        where: { id: { [Op.in]: ids } },
+      },
+      transaction
+    );
   }
 
   static async resolveNamesBySIds(

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -100,6 +100,7 @@ export abstract class ResourceWithSpace<
         },
       ],
       includeDeleted,
+      transaction,
       // WORKSPACE_ISOLATION_BYPASS: Spaces can be public, preventing to enforce a
       // workspaceId clause in the SQL query. Permissions are enforced at a higher level.
       // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1390,8 +1390,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     def: GlobalSkillDefinition,
     {
       agentLoopData,
+      transaction,
     }: {
       agentLoopData?: AgentLoopExecutionData;
+      transaction?: Transaction;
     } = {}
   ): Promise<SkillResource> {
     const { agentConfiguration } = agentLoopData ?? {};
@@ -1410,7 +1412,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
             await MCPServerViewResource.listMCPServerViewsAutoInternalForSpaces(
               auth,
               name,
-              requestedSpaceModelIds
+              requestedSpaceModelIds,
+              transaction
             );
           return views.map((view) => ({
             view,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -499,9 +499,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     options: SkillConfigurationFindOptions = {},
     context: {
       agentLoopData?: AgentLoopExecutionData;
+      transaction?: Transaction;
     } = {}
   ): Promise<SkillResource[]> {
     const workspace = auth.getNonNullableWorkspace();
+    const { agentLoopData, transaction } = context;
 
     const { where, includes, onlyCustom, ...otherOptions } = options;
 
@@ -514,6 +516,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         workspaceId: workspace.id,
       },
       include: includes,
+      transaction,
     });
 
     // Check if the user has access to skill requested spaces.
@@ -522,7 +525,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
     const spaces =
       uniqueRequestedSpaceIds.length > 0
-        ? await SpaceResource.fetchByModelIds(auth, uniqueRequestedSpaceIds)
+        ? await SpaceResource.fetchByModelIds(auth, uniqueRequestedSpaceIds, {
+            transaction,
+          })
         : [];
     const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
     const foundSpaceIds = new Set(spaces.map((s) => s.id));
@@ -551,6 +556,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
               [Op.in]: allowedCustomSkillIds,
             },
           },
+          transaction,
         });
 
       const skillMCPServerConfigsBySkillId = groupBy(
@@ -566,6 +572,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
               [Op.in]: customSkills.map((c) => c.id),
             },
           },
+          transaction,
         });
 
       const dataSourceConfigsBySkillId = groupBy(
@@ -580,11 +587,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
             [Op.in]: allowedCustomSkillIds,
           },
         },
+        transaction,
       });
 
       const allFileResources = await FileResource.fetchByModelIdsWithAuth(
         auth,
-        fileAttachmentModels.map((a) => a.fileId)
+        fileAttachmentModels.map((a) => a.fileId),
+        transaction
       );
 
       const fileResourceById = new Map(allFileResources.map((f) => [f.id, f]));
@@ -606,6 +615,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           workspaceId: workspace.id,
         },
         attributes: ["groupId", "skillConfigurationId"],
+        transaction,
       });
 
       // TODO(SKILLS 2025-12-11): Ensure all skills have ONE group.
@@ -616,7 +626,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         );
         const editorGroups = await GroupResource.fetchByModelIds(
           auth,
-          uniqueGroupIds
+          uniqueGroupIds,
+          { transaction }
         );
 
         // Build a map from a skill's ID to its editor group.
@@ -636,7 +647,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const allMCPServerViews = await MCPServerViewResource.fetchByModelIds(
         auth,
         removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId)),
-        { includeMetadata: false }
+        { includeMetadata: false, transaction }
       );
 
       allowedCustomSkillsRes = allowedCustomSkills.map((customSkill) => {
@@ -681,10 +692,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       await concurrentExecutor(
         globalSkillDefinitions,
         async (def) => {
-          if (
-            context.agentLoopData &&
-            def.isDisabledForAgentLoop?.(context.agentLoopData)
-          ) {
+          if (agentLoopData && def.isDisabledForAgentLoop?.(agentLoopData)) {
             return null;
           }
           return this.fromGlobalSkill(auth, def, context);
@@ -821,9 +829,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       agentLoopData,
       status,
+      transaction,
     }: {
       agentLoopData?: AgentLoopExecutionData;
       status?: SkillStatus | SkillStatus[];
+      transaction?: Transaction;
     } = {}
   ): Promise<SkillResource[]> {
     const customSkillModelIds = removeNulls(refs.map((r) => r.customSkillId));
@@ -838,7 +848,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(status ? { status } : {}),
         },
       },
-      { agentLoopData }
+      { agentLoopData, transaction }
     );
   }
 
@@ -1148,9 +1158,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       conversation,
       agentLoopData,
+      transaction,
     }: {
       conversation: ConversationWithoutContentType;
       agentLoopData?: AgentLoopExecutionData;
+      transaction?: Transaction;
     }
   ): Promise<SkillResource[]> {
     const { agentConfiguration } = agentLoopData ?? {};
@@ -1169,10 +1181,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
             }
           : { agentConfigurationId: null }),
       },
+      transaction,
     });
 
     return this.fetchBySkillReferences(auth, conversationSkills, {
       agentLoopData,
+      transaction,
     });
   }
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -394,9 +394,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static async fetchWorkspaceSystemSpace(
-    auth: Authenticator
+    auth: Authenticator,
+    transaction?: Transaction
   ): Promise<SpaceResource> {
-    const [space] = await this.baseFetch(auth, { where: { kind: "system" } });
+    const [space] = await this.baseFetch(
+      auth,
+      { where: { kind: "system" } },
+      transaction
+    );
 
     if (!space) {
       throw new Error("System space not found.");
@@ -406,9 +411,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static async fetchWorkspaceGlobalSpace(
-    auth: Authenticator
+    auth: Authenticator,
+    transaction?: Transaction
   ): Promise<SpaceResource> {
-    const [space] = await this.baseFetch(auth, { where: { kind: "global" } });
+    const [space] = await this.baseFetch(
+      auth,
+      { where: { kind: "global" } },
+      transaction
+    );
 
     if (!space) {
       throw new Error("Global space not found.");
@@ -460,20 +470,27 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
-    { includeDeleted }: { includeDeleted?: boolean } = {}
+    {
+      includeDeleted,
+      transaction,
+    }: { includeDeleted?: boolean; transaction?: Transaction } = {}
   ) {
     if (ids.length === 0) {
       return [];
     }
 
-    const spaces = await this.baseFetch(auth, {
-      where: {
-        id: {
-          [Op.in]: ids,
+    const spaces = await this.baseFetch(
+      auth,
+      {
+        where: {
+          id: {
+            [Op.in]: ids,
+          },
         },
+        includeDeleted,
       },
-      includeDeleted,
-    });
+      transaction
+    );
 
     return spaces ?? [];
   }


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24213
Context: [review comment](https://github.com/dust-tt/dust/pull/24213#discussion_r3085343750)

Threads the conversation fork transaction through `SkillResource.listEnabledByConversation` and the DB-backed fetch helpers it relies on so copying enabled conversation skills does not allocate separate read connections mid-fork.

## Risks
Blast radius: conversation skill reads during forking and any call sites that opt into the new transaction argument
Risk: low

## Deploy Plan
- deploy front
