### PR TITLE
Add: new columns to store title and url for takeaway sources.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -89,7 +89,7 @@ function TodoSources({
               );
             }}
           >
-            {source.title ?? source.sourceId}
+            {source.sourceTitle ?? source.sourceId}
           </button>
         </span>
       ))}

--- a/front/lib/project_todo/analyze_conversation/index.ts
+++ b/front/lib/project_todo/analyze_conversation/index.ts
@@ -120,7 +120,7 @@ async function callExtractActionItemsLLM(
             messages: [
               {
                 role: "user",
-                name: "todo_extractor",
+                name: "takeaway_extractor",
                 content: [{ type: "text", text: document.text }],
               },
             ],
@@ -147,7 +147,7 @@ async function callExtractActionItemsLLM(
         workspaceId: owner.sId,
         error: res.error,
       },
-      "Document todo: LLM call failed"
+      "Document takeaway: LLM call failed"
     );
     return null;
   }
@@ -160,7 +160,7 @@ async function callExtractActionItemsLLM(
         sourceType: document.type,
         workspaceId: owner.sId,
       },
-      "Document todo: no tool call in LLM response"
+      "Document takeaway: no tool call in LLM response"
     );
     return null;
   }
@@ -175,7 +175,7 @@ async function callExtractActionItemsLLM(
         error: parsed.error,
         arguments: action.arguments,
       },
-      "Document todo: failed to parse LLM response"
+      "Document takeaway: failed to parse LLM response"
     );
     return null;
   }
@@ -212,7 +212,7 @@ export async function extractDocumentTakeaways(
         sourceType: document.type,
         workspaceId: owner.sId,
       },
-      "Document todo: no whitelisted model available"
+      "Document takeaway: no whitelisted model available"
     );
     return;
   }
@@ -245,7 +245,7 @@ export async function extractDocumentTakeaways(
         sourceType: document.type,
         workspaceId: owner.sId,
       },
-      "Document todo: no extraction result"
+      "Document takeaway: no extraction result"
     );
     return;
   }
@@ -263,22 +263,22 @@ export async function extractDocumentTakeaways(
     ])
   );
 
-  const exitingAssignees = new Set(assignees.map((u) => u.sId));
+  const existingAssignees = new Set(assignees.map((u) => u.sId));
 
   const actionItems = buildActionItems(
     extraction.action_items,
     new Set(previousActionItems.map((item) => item.sId)),
-    exitingAssignees
+    existingAssignees
   );
   const notableFacts = buildNotableFacts(
     extraction.notable_facts,
     new Set(previousNotableFacts.map((fact) => fact.sId)),
-    exitingAssignees
+    existingAssignees
   );
   const keyDecisions = buildKeyDecisions(
     extraction.key_decisions,
     new Set(previousKeyDecisions.map((d) => d.sId)),
-    exitingAssignees
+    existingAssignees
   );
 
   if (

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -12,6 +12,7 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
+  ProjectTodoSourceInfo,
   ProjectTodoSourceType,
   ProjectTodoType,
 } from "@app/types/project_todo";
@@ -281,9 +282,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
   static async fetchSourcesForTodoSIds(
     auth: Authenticator,
     { sIds }: { sIds: string[] }
-  ): Promise<
-    Map<string, Array<{ sourceType: ProjectTodoSourceType; sourceId: string }>>
-  > {
+  ): Promise<Map<string, Array<ProjectTodoSourceInfo>>> {
     if (sIds.length === 0) {
       return new Map();
     }
@@ -312,10 +311,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
 
     // Group by logical todo sId.
-    const result = new Map<
-      string,
-      Array<{ sourceType: ProjectTodoSourceType; sourceId: string }>
-    >();
+    const result = new Map<string, Array<ProjectTodoSourceInfo>>();
 
     for (const source of sources) {
       const todoSId = idToSId.get(source.projectTodoId);
@@ -327,6 +323,8 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       existing.push({
         sourceType: source.sourceType,
         sourceId: source.sourceId,
+        sourceTitle: source.sourceTitle,
+        sourceUrl: source.sourceUrl,
       });
       result.set(todoSId, existing);
     }

--- a/front/lib/resources/storage/models/project_todo.ts
+++ b/front/lib/resources/storage/models/project_todo.ts
@@ -359,6 +359,8 @@ export class ProjectTodoSourceModel extends WorkspaceAwareModel<ProjectTodoSourc
   declare projectTodoId: ForeignKey<ProjectTodoModel["id"]>;
   declare sourceType: ProjectTodoSourceType;
   declare sourceId: string;
+  declare sourceTitle: string | null;
+  declare sourceUrl: string | null;
 
   declare projectTodo: NonAttribute<ProjectTodoModel>;
 }
@@ -384,6 +386,14 @@ ProjectTodoSourceModel.init(
       allowNull: false,
       comment:
         "String identifier of the source (conversation sId, external URL/ID, etc.) that led to creating this todo.",
+    },
+    sourceTitle: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    sourceUrl: {
+      type: DataTypes.TEXT,
+      allowNull: true,
     },
   },
   {

--- a/front/lib/resources/storage/models/takeaways.ts
+++ b/front/lib/resources/storage/models/takeaways.ts
@@ -155,6 +155,9 @@ export class TakeawaySourcesModel extends WorkspaceAwareModel<TakeawaySourcesMod
   declare takeawaysId: ForeignKey<TakeawaysModel["id"]>;
   declare sourceType: ProjectTodoSourceType;
   declare sourceId: string;
+
+  declare sourceTitle: string | null;
+  declare sourceUrl: string | null;
 }
 
 TakeawaySourcesModel.init(
@@ -184,6 +187,14 @@ TakeawaySourcesModel.init(
       allowNull: false,
       comment:
         "String identifier of the source (internal SID or external URL/ID) that produced this takeaway.",
+    },
+    sourceTitle: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    sourceUrl: {
+      type: DataTypes.TEXT,
+      allowNull: true,
     },
   },
   {

--- a/front/lib/resources/takeaways_resource.ts
+++ b/front/lib/resources/takeaways_resource.ts
@@ -320,7 +320,8 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
         {
           sourceType: s.sourceType,
           sourceId: s.sourceId,
-          title: "MUST ADD TITLE",
+          sourceTitle: s.sourceTitle,
+          sourceUrl: s.sourceUrl,
         },
       ])
     );
@@ -397,6 +398,8 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
       document: {
         id: string;
         type: ProjectTodoSourceType;
+        title: string | null;
+        uri: string | null;
       };
       actionItems: TodoVersionedActionItem[];
       notableFacts: TodoVersionedNotableFact[];
@@ -450,6 +453,8 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
           takeawaysId: takeaway.id,
           sourceType: document.type,
           sourceId: document.id,
+          sourceTitle: document.title,
+          sourceUrl: document.uri,
         },
         { transaction: t }
       );
@@ -486,6 +491,8 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
         document: {
           id: conversationId,
           type: "project_conversation",
+          title: null,
+          uri: null,
         },
         actionItems,
         notableFacts,

--- a/front/migrations/db/migration_586.sql
+++ b/front/migrations/db/migration_586.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "public"."project_todo_sources"
+ADD COLUMN "sourceTitle" TEXT;
+
+ALTER TABLE "public"."project_todo_sources"
+ADD COLUMN "sourceUrl" TEXT;
+
+ALTER TABLE "public"."takeaway_sources"
+ADD COLUMN "sourceTitle" TEXT;
+
+ALTER TABLE "public"."takeaway_sources"
+ADD COLUMN "sourceUrl" TEXT;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
@@ -2,7 +2,6 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -61,26 +60,6 @@ async function handler(
           sIds: todoSIds,
         });
 
-      // Resolve conversation titles for conversation-type sources.
-      const allConversationSIds = new Set<string>();
-      for (const sources of sourcesByTodoSId.values()) {
-        for (const source of sources) {
-          if (source.sourceType === "project_conversation") {
-            allConversationSIds.add(source.sourceId);
-          }
-        }
-      }
-
-      const titleByConversationSId = new Map<string, string | null>();
-      if (allConversationSIds.size > 0) {
-        const conversations = await ConversationResource.fetchByIds(auth, [
-          ...allConversationSIds,
-        ]);
-        for (const conversation of conversations) {
-          titleByConversationSId.set(conversation.sId, conversation.title);
-        }
-      }
-
       // Combine todo data with enriched sources.
       const todosWithSources: ProjectTodoType[] = todos.map((t) => {
         const sources = sourcesByTodoSId.get(t.sId) ?? [];
@@ -89,10 +68,8 @@ async function handler(
           sources: sources.map((s) => ({
             sourceType: s.sourceType,
             sourceId: s.sourceId,
-            title:
-              s.sourceType === "project_conversation"
-                ? (titleByConversationSId.get(s.sourceId) ?? null)
-                : null,
+            sourceTitle: s.sourceTitle,
+            sourceUrl: s.sourceUrl,
           })),
         };
       });

--- a/front/types/project_todo.ts
+++ b/front/types/project_todo.ts
@@ -25,7 +25,8 @@ export type ProjectTodoSourceType = (typeof PROJECT_TODO_SOURCE_TYPES)[number];
 export type ProjectTodoSourceInfo = {
   sourceType: ProjectTodoSourceType;
   sourceId: string;
-  title: string | null;
+  sourceTitle: string | null;
+  sourceUrl: string | null;
 };
 
 // Safe public representation of a ProjectTodo — no internal ModelIds exposed.


### PR DESCRIPTION
## Description

The todos panel was resolving source titles at read time by fetching conversations on-the-fly for every API call. Now that takeaways can come from arbitrary documents (not just conversations), this approach doesn't scale — there's no single resource to resolve titles from. Storing `sourceTitle` and `sourceUrl` at write time alongside `sourceId` is simpler and works for any source type.

- Add `sourceTitle` and `sourceUrl` columns to `project_todo_sources` and `takeaway_sources` (nullable)
- Populate them when upserting takeaway sources (`TakeawaysResource.upsertTakeaways` now takes `document.title` and `document.uri`)
- Remove the on-the-fly `ConversationResource.fetchByIds` + title resolution in the `project_todos` API handler — replaced by reading stored `sourceTitle` directly
- Rename `title` → `sourceTitle` in `ProjectTodoSourceInfo` for consistency with the new columns
- Replace the placeholder `"MUST ADD TITLE"` in `TakeawaysResource` with the real stored values
- Fix `exitingAssignees` → `existingAssignees` typo
- Rename log messages from "Document todo" → "Document takeaway"
- DB migration: `migration_586.sql`

## Tests

Local

## Risk

Low — additive columns, nullable; existing rows get `null` for both fields and degrade gracefully in the UI

## Deploy Plan

Run migration, deploy `front`
