### PR TITLE
Use compaction runs in conversation context usage

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -608,6 +608,7 @@ export const ConversationViewer = ({
                   : m
               );
             }
+            void mutateContextUsage();
             window.dispatchEvent(new CompactionCompletedEvent());
             break;
           default:

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2042,9 +2042,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
   }
 
+  // Return the latest run from a successful compaction message.
   async getLatestCompactionMessageRun(
     auth: Authenticator
-  ): Promise<RunResource | null> {
+  ): Promise<{ rank: number; run: RunResource } | null> {
     const owner = auth.getNonNullableWorkspace();
 
     const message = await MessageModel.findOne({
@@ -2057,6 +2058,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           model: CompactionMessageModel,
           as: "compactionMessage",
           required: true,
+          where: {
+            status: "succeeded",
+          },
         },
       ],
       order: [["rank", "DESC"]],
@@ -2076,14 +2080,19 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return null;
     }
 
-    return runs.reduce((latest, r) =>
-      r.createdAt > latest.createdAt ? r : latest
-    );
+    return {
+      rank: message.rank,
+      run: runs.reduce((latest, r) =>
+        r.createdAt > latest.createdAt ? r : latest
+      ),
+    };
   }
 
+  // Return the latest run from an agent message. We accept all statuses as they all have valid
+  // runIds that represent the actual latest run.
   async getLatestAgentMessageRun(
     auth: Authenticator
-  ): Promise<RunResource | null> {
+  ): Promise<{ rank: number; run: RunResource } | null> {
     const owner = auth.getNonNullableWorkspace();
 
     const message = await MessageModel.findOne({
@@ -2115,9 +2124,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return null;
     }
 
-    return runs.reduce((latest, r) =>
-      r.createdAt > latest.createdAt ? r : latest
-    );
+    return {
+      rank: message.rank,
+      run: runs.reduce((latest, r) =>
+        r.createdAt > latest.createdAt ? r : latest
+      ),
+    };
   }
 
   static async resolveForkSourceMessage(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2042,13 +2042,50 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
   }
 
+  async getLatestCompactionMessageRun(
+    auth: Authenticator
+  ): Promise<RunResource | null> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const message = await MessageModel.findOne({
+      where: {
+        conversationId: this.id,
+        workspaceId: owner.id,
+      },
+      include: [
+        {
+          model: CompactionMessageModel,
+          as: "compactionMessage",
+          required: true,
+        },
+      ],
+      order: [["rank", "DESC"]],
+    });
+
+    if (!message?.compactionMessage?.runIds?.length) {
+      return null;
+    }
+
+    // The runIds array ordering is not guaranteed to be chronological. Fetch all runs and pick
+    // the most recently created one.
+    const runs = await RunResource.listByDustRunIds(auth, {
+      dustRunIds: message.compactionMessage.runIds,
+    });
+
+    if (runs.length === 0) {
+      return null;
+    }
+
+    return runs.reduce((latest, r) =>
+      r.createdAt > latest.createdAt ? r : latest
+    );
+  }
+
   async getLatestAgentMessageRun(
     auth: Authenticator
   ): Promise<RunResource | null> {
     const owner = auth.getNonNullableWorkspace();
 
-    // Include in-progress ("created") agent messages so that context usage is available even while
-    // the agent is still running (it accumulates runIds step by step).
     const message = await MessageModel.findOne({
       where: {
         conversationId: this.id,
@@ -2059,9 +2096,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           model: AgentMessageModel,
           as: "agentMessage",
           required: true,
-          where: {
-            status: ["succeeded", "gracefully_stopped", "created"],
-          },
         },
       ],
       order: [["rank", "DESC"]],

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts
@@ -1,0 +1,247 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  CompactionMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import {
+  RunModel,
+  RunUsageModel,
+} from "@app/lib/resources/storage/models/runs";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { describe, expect, it } from "vitest";
+
+import handler from "./context-usage";
+
+async function setupTest() {
+  const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+    role: "admin",
+    method: "GET",
+  });
+
+  const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+    name: "Test Agent",
+    description: "Test agent for context usage.",
+  });
+
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agent.sId,
+    messagesCreatedAt: [],
+  });
+
+  req.query.wId = workspace.sId;
+  req.query.cId = conversation.sId;
+  req.url = `/api/w/${workspace.sId}/assistant/conversations/${conversation.sId}/context-usage`;
+
+  return {
+    req,
+    res,
+    auth,
+    workspace,
+    agent,
+    conversation,
+  };
+}
+
+async function createRunWithUsage(
+  auth: Authenticator,
+  {
+    dustRunId,
+    createdAt,
+    promptTokens,
+    completionTokens = 10,
+  }: {
+    dustRunId: string;
+    createdAt: Date;
+    promptTokens: number;
+    completionTokens?: number;
+  }
+) {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const run = await RunModel.create({
+    dustRunId,
+    runType: "deploy",
+    useWorkspaceCredentials: false,
+    workspaceId: workspace.id,
+    createdAt,
+    updatedAt: createdAt,
+  });
+
+  await RunUsageModel.create({
+    runId: run.id,
+    providerId: "anthropic",
+    modelId: "claude-haiku-4-5-20251001",
+    promptTokens,
+    completionTokens,
+    cachedTokens: null,
+    cacheCreationTokens: null,
+    costMicroUsd: 1,
+    isBatch: false,
+    workspaceId: workspace.id,
+  });
+}
+
+async function createAgentMessage(
+  auth: Authenticator,
+  {
+    agent,
+    conversation,
+    rank,
+    runIds,
+  }: {
+    agent: LightAgentConfigurationType;
+    conversation: ConversationWithoutContentType;
+    rank: number;
+    runIds: string[] | null;
+  }
+) {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const agentMessage = await AgentMessageModel.create({
+    status: "succeeded",
+    agentConfigurationId: agent.sId,
+    agentConfigurationVersion: 0,
+    runIds,
+    workspaceId: workspace.id,
+    skipToolsValidation: false,
+  });
+
+  await MessageModel.create({
+    sId: generateRandomModelSId(),
+    rank,
+    conversationId: conversation.id,
+    agentMessageId: agentMessage.id,
+    workspaceId: workspace.id,
+  });
+}
+
+async function createCompactionMessage(
+  auth: Authenticator,
+  {
+    conversation,
+    rank,
+    status,
+    runIds,
+  }: {
+    conversation: ConversationWithoutContentType;
+    rank: number;
+    status: "created" | "succeeded" | "failed";
+    runIds: string[] | null;
+  }
+) {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const compactionMessage = await CompactionMessageModel.create({
+    status,
+    content: status === "succeeded" ? "Summary." : null,
+    runIds,
+    workspaceId: workspace.id,
+  });
+
+  await MessageModel.create({
+    sId: generateRandomModelSId(),
+    rank,
+    conversationId: conversation.id,
+    compactionMessageId: compactionMessage.id,
+    workspaceId: workspace.id,
+  });
+}
+
+describe("GET /api/w/[wId]/assistant/conversations/[cId]/context-usage", () => {
+  it("uses the latest succeeded compaction run when it is newer than the latest agent run", async () => {
+    const { req, res, auth, agent, conversation } = await setupTest();
+
+    await createAgentMessage(auth, {
+      agent,
+      conversation,
+      rank: 10,
+      runIds: ["agent_run"],
+    });
+    await createCompactionMessage(auth, {
+      conversation,
+      rank: 20,
+      status: "succeeded",
+      runIds: ["compaction_run"],
+    });
+    await createCompactionMessage(auth, {
+      conversation,
+      rank: 30,
+      status: "failed",
+      runIds: ["failed_compaction_run"],
+    });
+
+    await createRunWithUsage(auth, {
+      dustRunId: "agent_run",
+      createdAt: new Date("2024-01-01T00:00:01.000Z"),
+      promptTokens: 111,
+    });
+    await createRunWithUsage(auth, {
+      dustRunId: "compaction_run",
+      createdAt: new Date("2024-01-01T00:00:02.000Z"),
+      promptTokens: 222,
+      completionTokens: 123,
+    });
+    await createRunWithUsage(auth, {
+      dustRunId: "failed_compaction_run",
+      createdAt: new Date("2024-01-01T00:00:03.000Z"),
+      promptTokens: 333,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toMatchObject({
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-haiku-4-5-20251001",
+      },
+      contextUsage: 123,
+    });
+  });
+
+  it("uses the latest agent run when it is newer than the latest succeeded compaction run", async () => {
+    const { req, res, auth, agent, conversation } = await setupTest();
+
+    await createCompactionMessage(auth, {
+      conversation,
+      rank: 10,
+      status: "succeeded",
+      runIds: ["compaction_run"],
+    });
+    await createAgentMessage(auth, {
+      agent,
+      conversation,
+      rank: 20,
+      runIds: ["agent_run"],
+    });
+
+    await createRunWithUsage(auth, {
+      dustRunId: "compaction_run",
+      createdAt: new Date("2024-01-01T00:00:01.000Z"),
+      promptTokens: 111,
+      completionTokens: 77,
+    });
+    await createRunWithUsage(auth, {
+      dustRunId: "agent_run",
+      createdAt: new Date("2024-01-01T00:00:02.000Z"),
+      promptTokens: 222,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toMatchObject({
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-haiku-4-5-20251001",
+      },
+      contextUsage: 222,
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts
@@ -1,247 +1,150 @@
-import type { Authenticator } from "@app/lib/auth";
-import {
-  AgentMessageModel,
-  CompactionMessageModel,
-  MessageModel,
-} from "@app/lib/models/agent/conversation";
-import {
-  RunModel,
-  RunUsageModel,
-} from "@app/lib/resources/storage/models/runs";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
-import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
-import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import { describe, expect, it } from "vitest";
+import type { SupportedModel } from "@app/types/assistant/models/types";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./context-usage";
 
-async function setupTest() {
-  const { req, res, workspace, auth } = await createPrivateApiMockRequest({
-    role: "admin",
-    method: "GET",
-  });
+const MODEL: SupportedModel = {
+  providerId: "anthropic",
+  modelId: "claude-haiku-4-5-20251001",
+};
 
-  const agent = await AgentConfigurationFactory.createTestAgent(auth, {
-    name: "Test Agent",
-    description: "Test agent for context usage.",
-  });
-
-  const conversation = await ConversationFactory.create(auth, {
-    agentConfigurationId: agent.sId,
-    messagesCreatedAt: [],
-  });
-
-  req.query.wId = workspace.sId;
-  req.query.cId = conversation.sId;
-  req.url = `/api/w/${workspace.sId}/assistant/conversations/${conversation.sId}/context-usage`;
-
+function makeRunUsage({
+  promptTokens,
+  completionTokens,
+}: {
+  promptTokens: number;
+  completionTokens: number;
+}): RunUsageType {
   return {
-    req,
-    res,
-    auth,
-    workspace,
-    agent,
-    conversation,
-  };
-}
-
-async function createRunWithUsage(
-  auth: Authenticator,
-  {
-    dustRunId,
-    createdAt,
-    promptTokens,
-    completionTokens = 10,
-  }: {
-    dustRunId: string;
-    createdAt: Date;
-    promptTokens: number;
-    completionTokens?: number;
-  }
-) {
-  const workspace = auth.getNonNullableWorkspace();
-
-  const run = await RunModel.create({
-    dustRunId,
-    runType: "deploy",
-    useWorkspaceCredentials: false,
-    workspaceId: workspace.id,
-    createdAt,
-    updatedAt: createdAt,
-  });
-
-  await RunUsageModel.create({
-    runId: run.id,
-    providerId: "anthropic",
-    modelId: "claude-haiku-4-5-20251001",
+    providerId: MODEL.providerId,
+    modelId: MODEL.modelId,
     promptTokens,
     completionTokens,
     cachedTokens: null,
     cacheCreationTokens: null,
     costMicroUsd: 1,
     isBatch: false,
-    workspaceId: workspace.id,
-  });
+  };
 }
 
-async function createAgentMessage(
-  auth: Authenticator,
-  {
-    agent,
-    conversation,
-    rank,
-    runIds,
-  }: {
-    agent: LightAgentConfigurationType;
-    conversation: ConversationWithoutContentType;
+function makeRunWithUsages(usages: RunUsageType[]) {
+  return {
+    listRunUsages: vi.fn().mockResolvedValue(usages),
+  };
+}
+
+function makeConversationResource({
+  latestAgentMessageRun,
+  latestCompactionMessageRun,
+}: {
+  latestAgentMessageRun: {
     rank: number;
-    runIds: string[] | null;
-  }
-) {
-  const workspace = auth.getNonNullableWorkspace();
-
-  const agentMessage = await AgentMessageModel.create({
-    status: "succeeded",
-    agentConfigurationId: agent.sId,
-    agentConfigurationVersion: 0,
-    runIds,
-    workspaceId: workspace.id,
-    skipToolsValidation: false,
-  });
-
-  await MessageModel.create({
-    sId: generateRandomModelSId(),
-    rank,
-    conversationId: conversation.id,
-    agentMessageId: agentMessage.id,
-    workspaceId: workspace.id,
-  });
-}
-
-async function createCompactionMessage(
-  auth: Authenticator,
-  {
-    conversation,
-    rank,
-    status,
-    runIds,
-  }: {
-    conversation: ConversationWithoutContentType;
+    run: ReturnType<typeof makeRunWithUsages>;
+  } | null;
+  latestCompactionMessageRun: {
     rank: number;
-    status: "created" | "succeeded" | "failed";
-    runIds: string[] | null;
-  }
-) {
-  const workspace = auth.getNonNullableWorkspace();
-
-  const compactionMessage = await CompactionMessageModel.create({
-    status,
-    content: status === "succeeded" ? "Summary." : null,
-    runIds,
-    workspaceId: workspace.id,
-  });
-
-  await MessageModel.create({
-    sId: generateRandomModelSId(),
-    rank,
-    conversationId: conversation.id,
-    compactionMessageId: compactionMessage.id,
-    workspaceId: workspace.id,
-  });
+    run: ReturnType<typeof makeRunWithUsages>;
+  } | null;
+}) {
+  return {
+    getLatestAgentMessageRun: vi.fn().mockResolvedValue(latestAgentMessageRun),
+    getLatestCompactionMessageRun: vi
+      .fn()
+      .mockResolvedValue(latestCompactionMessageRun),
+  } satisfies Pick<
+    ConversationResource,
+    "getLatestAgentMessageRun" | "getLatestCompactionMessageRun"
+  >;
 }
+
+async function setupTest() {
+  const { req, res, workspace } = await createPrivateApiMockRequest({
+    role: "admin",
+    method: "GET",
+  });
+
+  req.query.wId = workspace.sId;
+  req.query.cId = "conversation_sid";
+  req.url = `/api/w/${workspace.sId}/assistant/conversations/conversation_sid/context-usage`;
+
+  return { req, res };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("GET /api/w/[wId]/assistant/conversations/[cId]/context-usage", () => {
   it("uses the latest succeeded compaction run when it is newer than the latest agent run", async () => {
-    const { req, res, auth, agent, conversation } = await setupTest();
+    const { req, res } = await setupTest();
 
-    await createAgentMessage(auth, {
-      agent,
-      conversation,
-      rank: 10,
-      runIds: ["agent_run"],
-    });
-    await createCompactionMessage(auth, {
-      conversation,
-      rank: 20,
-      status: "succeeded",
-      runIds: ["compaction_run"],
-    });
-    await createCompactionMessage(auth, {
-      conversation,
-      rank: 30,
-      status: "failed",
-      runIds: ["failed_compaction_run"],
+    const agentRun = makeRunWithUsages([
+      makeRunUsage({ promptTokens: 111, completionTokens: 11 }),
+    ]);
+    const compactionRun = makeRunWithUsages([
+      makeRunUsage({ promptTokens: 222, completionTokens: 123 }),
+    ]);
+    const conversation = makeConversationResource({
+      latestAgentMessageRun: {
+        rank: 10,
+        run: agentRun,
+      },
+      latestCompactionMessageRun: {
+        rank: 20,
+        run: compactionRun,
+      },
     });
 
-    await createRunWithUsage(auth, {
-      dustRunId: "agent_run",
-      createdAt: new Date("2024-01-01T00:00:01.000Z"),
-      promptTokens: 111,
-    });
-    await createRunWithUsage(auth, {
-      dustRunId: "compaction_run",
-      createdAt: new Date("2024-01-01T00:00:02.000Z"),
-      promptTokens: 222,
-      completionTokens: 123,
-    });
-    await createRunWithUsage(auth, {
-      dustRunId: "failed_compaction_run",
-      createdAt: new Date("2024-01-01T00:00:03.000Z"),
-      promptTokens: 333,
-    });
+    vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+      conversation as unknown as ConversationResource
+    );
 
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData()).toMatchObject({
-      model: {
-        providerId: "anthropic",
-        modelId: "claude-haiku-4-5-20251001",
-      },
+      model: MODEL,
       contextUsage: 123,
     });
+    expect(agentRun.listRunUsages).not.toHaveBeenCalled();
+    expect(compactionRun.listRunUsages).toHaveBeenCalledOnce();
   });
 
   it("uses the latest agent run when it is newer than the latest succeeded compaction run", async () => {
-    const { req, res, auth, agent, conversation } = await setupTest();
+    const { req, res } = await setupTest();
 
-    await createCompactionMessage(auth, {
-      conversation,
-      rank: 10,
-      status: "succeeded",
-      runIds: ["compaction_run"],
-    });
-    await createAgentMessage(auth, {
-      agent,
-      conversation,
-      rank: 20,
-      runIds: ["agent_run"],
+    const agentRun = makeRunWithUsages([
+      makeRunUsage({ promptTokens: 222, completionTokens: 22 }),
+    ]);
+    const compactionRun = makeRunWithUsages([
+      makeRunUsage({ promptTokens: 111, completionTokens: 77 }),
+    ]);
+    const conversation = makeConversationResource({
+      latestAgentMessageRun: {
+        rank: 20,
+        run: agentRun,
+      },
+      latestCompactionMessageRun: {
+        rank: 10,
+        run: compactionRun,
+      },
     });
 
-    await createRunWithUsage(auth, {
-      dustRunId: "compaction_run",
-      createdAt: new Date("2024-01-01T00:00:01.000Z"),
-      promptTokens: 111,
-      completionTokens: 77,
-    });
-    await createRunWithUsage(auth, {
-      dustRunId: "agent_run",
-      createdAt: new Date("2024-01-01T00:00:02.000Z"),
-      promptTokens: 222,
-    });
+    vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+      conversation as unknown as ConversationResource
+    );
 
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData()).toMatchObject({
-      model: {
-        providerId: "anthropic",
-        modelId: "claude-haiku-4-5-20251001",
-      },
+      model: MODEL,
       contextUsage: 222,
     });
+    expect(compactionRun.listRunUsages).not.toHaveBeenCalled();
+    expect(agentRun.listRunUsages).toHaveBeenCalledOnce();
   });
 });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -46,43 +46,82 @@ async function handler(
         });
       }
 
-      const run = await conversation.getLatestAgentMessageRun(auth);
-      if (!run) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "conversation_context_usage_not_found",
-            message: "Latest agent message has no run data.",
+      const [lastAgentRun, lastCompactionRun] = await Promise.all([
+        conversation.getLatestAgentMessageRun(auth),
+        conversation.getLatestCompactionMessageRun(auth),
+      ]);
+
+      if (
+        lastCompactionRun &&
+        lastCompactionRun.rank >= (lastAgentRun?.rank || 0)
+      ) {
+        // If the lastest run is a compaction run we provide a best guess estimate of the context
+        // usage with the compaction generated tokens. This misses the system prompt context usage
+        // but this will recover at the next agent message and allow us in a somewhat hacky but
+        // minimal way to show reduciton of context usage as soon as possible.
+        const usages = await lastCompactionRun.run.listRunUsages(auth);
+        if (usages.length === 0) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "conversation_context_usage_not_found",
+              message: "No run usage found for the latest conversation run.",
+            },
+          });
+        }
+
+        const maxUsage = usages.reduce((max, u) =>
+          u.completionTokens > max.completionTokens ? u : max
+        );
+
+        const modelConfig = getModelConfigByModelId(maxUsage.modelId);
+
+        return res.status(200).json({
+          model: {
+            providerId: maxUsage.providerId,
+            modelId: maxUsage.modelId,
           },
+          contextUsage: maxUsage.completionTokens,
+          contextSize: modelConfig?.contextSize ?? 0,
+        });
+      } else {
+        if (!lastAgentRun) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "conversation_context_usage_not_found",
+              message: "Conversation has no run data.",
+            },
+          });
+        }
+
+        const usages = await lastAgentRun.run.listRunUsages(auth);
+        if (usages.length === 0) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "conversation_context_usage_not_found",
+              message: "No run usage found for the latest conversation run.",
+            },
+          });
+        }
+
+        // Take the max promptTokens across usages of the latest run — this represents the peak
+        // context usage as seen by the model.
+        const maxUsage = usages.reduce((max, u) =>
+          u.promptTokens > max.promptTokens ? u : max
+        );
+        const modelConfig = getModelConfigByModelId(maxUsage.modelId);
+
+        return res.status(200).json({
+          model: {
+            providerId: maxUsage.providerId,
+            modelId: maxUsage.modelId,
+          },
+          contextUsage: maxUsage.promptTokens,
+          contextSize: modelConfig?.contextSize ?? 0,
         });
       }
-
-      const usages = await run.listRunUsages(auth);
-      if (usages.length === 0) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "conversation_context_usage_not_found",
-            message: "No run usage found for the last agent message.",
-          },
-        });
-      }
-
-      // Take the max promptTokens across usages of the latest run — this represents the peak
-      // context usage as seen by the model.
-      const maxUsage = usages.reduce((max, u) =>
-        u.promptTokens > max.promptTokens ? u : max
-      );
-      const modelConfig = getModelConfigByModelId(maxUsage.modelId);
-
-      return res.status(200).json({
-        model: {
-          providerId: maxUsage.providerId,
-          modelId: maxUsage.modelId,
-        },
-        contextUsage: maxUsage.promptTokens,
-        contextSize: modelConfig?.contextSize ?? 0,
-      });
     }
 
     default:


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/7585

- add `ConversationResource.getLatestCompactionMessageRun()` and make the latest run helpers return both the run and the message rank
- update the conversation context-usage endpoint to compare the latest agent run with the latest succeeded compaction run and use the newer one
- refresh the client-side context usage indicator when compaction completes
- add endpoint tests covering agent-vs-compaction selection logic

## Tests

- `cd front && npx tsgo --noEmit`
- `cd front && NODE_ENV=test npm test pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts`
- `cd front && NODE_ENV=test npm test temporal/agent_loop/lib/compaction.test.ts`
- tested locally

## Risk

Low.

## Deploy Plan

- deploy `front`