### PR TITLE
[BYOK] Fix sub-agents losing providersHealth on auth exchange

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -905,6 +905,7 @@ export class Authenticator {
       user,
       subscription: auth._subscription,
       workspace: auth._workspace,
+      providersHealth: auth._providersHealth,
     });
   }
 
@@ -918,6 +919,7 @@ export class Authenticator {
       subscription: this._subscription,
       workspace: this._workspace,
       clientIp: this._clientIp,
+      providersHealth: this._providersHealth,
     });
   }
 


### PR DESCRIPTION
## Description

`exchangeSystemKeyForUserAuthByEmail` and `exchangeKey` in `Authenticator` were constructing new instances without forwarding `_providersHealth`. In the sub-agent (`run_agent`) flow, the system API key auth goes through both exchanges, causing BYOK workspaces to lose their provider health info — `getWhitelistedProviders` would then return an empty set and block all model providers with a "model disabled" error.

## Tests

Tested manually on a BYOK workspace by running a sub-agent and verifying `providersHealth` is preserved through the auth exchange chain.

## Risk

Low — additive change, only forwards an existing field that was previously dropped. No behavior change for non-BYOK workspaces (their `providersHealth` is already `null`).

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`