### PR TITLE
[front] fix broken auto scroll

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -726,17 +726,15 @@ export const ConversationViewer = ({
         // user keep their current scroll position.
         const isMentioningAgent = mentions.some(isRichAgentMention);
 
+        // When steering (hasRunningAgent), the message is pending and no new
+        // agent message is created — stay at the current scroll position.
+        const shouldScrollToUserMessage = isMentioningAgent && !hasRunningAgent;
+
         const nbMessages = ref.current.data.get().length;
         ref.current.data.append(
           [placeholderUserMsg, ...placeholderAgentMessages],
-          isMentioningAgent && !hasRunningAgent
-            ? () => {
-                return {
-                  index: nbMessages, // Avoid jumping around when the agent message is generated.
-                  align: "start",
-                  behavior: customSmoothScroll,
-                };
-              }
+          shouldScrollToUserMessage
+            ? false // Skip append-time scroll; handled by scrollToItem below.
             : (params) => {
                 if (params.scrollLocation.bottomOffset >= 0) {
                   return {
@@ -749,6 +747,18 @@ export const ConversationViewer = ({
                 }
               }
         );
+
+        // We use scrollToItem instead of the append callback because
+        // Virtuoso's append callback clamps the scroll target before applying
+        // the bottom padding needed for align:"start" near the end of the
+        // list, causing the scroll to undershoot.
+        if (shouldScrollToUserMessage && ref.current) {
+          ref.current.scrollToItem({
+            index: nbMessages,
+            align: "start",
+            behavior: customSmoothScroll,
+          });
+        }
 
         const result = await submitMessage(messageData);
 


### PR DESCRIPTION
## Description
This PR is to fix auto scroll behavior. Auto scroll doesn't work reliably (with / without steering ff). Seems like there is a bug in virtuso auto scroll behavior? (not sure when it's introduced though)

```
 Root cause: A bug in @virtuoso.dev/message-list's scroll handler (index.js:1651-1672). When align: "start" is used,
   Virtuoso calculates forceBottomSpace (extra bottom padding so the target item can be scrolled to the viewport
  top). But the handler:

  1. Clamps the scroll target to scrollHeight - clientHeight before applying the padding
  2. If the user is already at the bottom (the normal case when sending), the clamped target equals currentScrollTop
  3. This triggers an "already at target" early return — padding is never applied, scroll never happens
```

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
