### PR TITLE
fix: correct author in notification for messages from project triggers

### DIFF
--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -261,9 +261,11 @@ const getConversationDetails = async ({
     author = "Someone else";
     authorIsAgent = false;
   } else if (isUserMessageType(message)) {
-    author = message.user?.fullName ?? "Someone else";
+    author =
+      message.user?.fullName ?? message.context.fullName ?? "Someone else";
     authorUserId = message.user?.sId ?? undefined;
-    avatarUrl = message.user?.image ?? undefined;
+    avatarUrl =
+      message.user?.image ?? message.context.profilePictureUrl ?? undefined;
     authorIsAgent = false;
 
     // Extract approved user mentions from the rendered message.

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -118,7 +118,6 @@ const ConversationDetailsSchema = z.object({
   author: z.string(),
   authorIsAgent: z.boolean(),
   authorUserId: z.string().optional(),
-  avatarUrl: z.string().optional(),
   isFromTrigger: z.boolean(),
   isFromEmailAgentConversation: z.boolean(),
   workspaceName: z.string(),
@@ -236,7 +235,6 @@ const getConversationDetails = async ({
   let author: string;
   let authorIsAgent: boolean;
   let authorUserId: string | undefined;
-  let avatarUrl: string | undefined;
   let mentionedUserIds: string[] = [];
   const messageContent =
     message.type === "agent_message" || message.type === "user_message"
@@ -264,8 +262,6 @@ const getConversationDetails = async ({
     author =
       message.user?.fullName ?? message.context.fullName ?? "Someone else";
     authorUserId = message.user?.sId ?? undefined;
-    avatarUrl =
-      message.user?.image ?? message.context.profilePictureUrl ?? undefined;
     authorIsAgent = false;
 
     // Extract approved user mentions from the rendered message.
@@ -276,7 +272,6 @@ const getConversationDetails = async ({
     author = message.configuration.name
       ? `@${message.configuration.name}`
       : "An agent";
-    avatarUrl = message.configuration.pictureUrl ?? undefined;
     authorIsAgent = true;
   } else {
     assertNever(message);
@@ -325,7 +320,6 @@ const getConversationDetails = async ({
     author,
     authorIsAgent,
     authorUserId,
-    avatarUrl,
     isFromTrigger,
     isFromEmailAgentConversation,
     workspaceName,


### PR DESCRIPTION
## Description

This PR fixes the author information in notifications for messages originating from triggers in projects by adding fallback values from the message context.

The unused `avatarUrl` is also removed from the conversation details.

- When a user message doesn't have a direct `user` object (e.g., messages from triggers in projects), the code now falls back to `message.context.fullName`

## Tests

Manually

## Risks

Low.

## Deploy Plan

Standard deployment - no special considerations needed.
