### PR TITLE
Fix steering promotion after cancelled agent message

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -232,13 +232,9 @@ export function UserMessage({
 
   const isDeleted = message.visibility === "deleted";
   const isPending = message.visibility === "pending";
-  const pendingMessageCount = useMemo(
-    () =>
-      methods.data
-        .get()
-        .filter((m) => isUserMessage(m) && m.visibility === "pending").length,
-    [methods.data]
-  );
+  const pendingMessageCount = methods.data
+    .get()
+    .filter((m) => isUserMessage(m) && m.visibility === "pending").length;
   const isEmpty = !message.content && message.contentFragments.length === 0;
   const isCurrentUser = message.user?.sId === currentUserId;
   const canDelete =

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2871,6 +2871,17 @@ export async function updateAgentMessageWithFinalStatus(
       t,
     });
 
+    if (status === "cancelled") {
+      // When the agent message is cancelled it means the user pushed the "stop" button so the
+      // intent is to interrupt all work. We promot user messages but don't trigger a new agent
+      // message.
+      return {
+        promotedUserMessages,
+        promotedAuth,
+        agentMessage: null,
+      };
+    }
+
     const nextMessageRank = await getNextConversationMessageRank(auth, {
       conversation,
       transaction: t,

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -33,10 +33,16 @@ export class WorkspaceFactory {
     planCode: string,
     overrides?: WorkspaceOverrides
   ): Promise<WorkspaceType> {
+    const workspaceDescription =
+      `[DEBUG] ${expect.getState().currentTestName}\n\n${faker.company.catchPhrase()}`.slice(
+        0,
+        255
+      );
+
     const workspace = await WorkspaceModel.create({
       sId: generateRandomModelSId(),
       name: faker.company.name(),
-      description: `[DEBUG] ${expect.getState().currentTestName}\n\n${faker.company.catchPhrase()}`,
+      description: workspaceDescription,
       workOSOrganizationId: faker.string.alpha(10),
       ...(overrides?.whiteListedProviders !== undefined && {
         whiteListedProviders: overrides.whiteListedProviders,


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/7589

- do not trigger a new agent message when pending steering messages are promoted after a cancelled agent message
- fix the client-side queued message indicator so it disappears immediately when a pending message is promoted

## Tests

- N/A, tested locally

## Risk

Low. This only affects the cancelled steering path and the client-side pending message indicator.

## Deploy Plan

- deploy `front`