### PR TITLE
Stripped useless data from HTML knowledge node + poke plugin to see HTML for skill

### DIFF
--- a/front/components/editor/extensions/skill_builder/KnowledgeNode.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNode.tsx
@@ -112,11 +112,24 @@ export const KnowledgeNode = Node.create<{}>({
 
           return [];
         },
-        renderHTML: (attributes) => ({
-          "data-selected-items": encodeURIComponent(
-            JSON.stringify(attributes.selectedItems)
-          ),
-        }),
+        renderHTML: (attributes) => {
+          // Strip down to BaseKnowledgeItem fields only to avoid persisting
+          // the full DataSourceViewContentNode which bloats the HTML.
+          const items = (attributes.selectedItems as KnowledgeItem[]).map(
+            (item): BaseKnowledgeItem => ({
+              dataSourceViewId: item.dataSourceViewId,
+              hasChildren: isFullKnowledgeItem(item)
+                ? computeHasChildren(item.node)
+                : item.hasChildren,
+              label: item.label,
+              nodeId: item.nodeId,
+              spaceId: item.spaceId,
+            })
+          );
+          return {
+            "data-selected-items": encodeURIComponent(JSON.stringify(items)),
+          };
+        },
       },
     };
   },

--- a/front/components/poke/pages/SkillDetailsPage.tsx
+++ b/front/components/poke/pages/SkillDetailsPage.tsx
@@ -125,6 +125,18 @@ export function SkillDetailsPage() {
 
       <div className="mt-4">
         <div className="border-material-200 rounded-lg border p-4">
+          <h2 className="text-md pb-4 font-bold">Instructions HTML</h2>
+          <TextArea
+            value={skill.instructionsHtml ?? ""}
+            readOnly
+            resize="none"
+            isDisplay
+          />
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="border-material-200 rounded-lg border p-4">
           <h2 className="text-md pb-4 font-bold">
             Tools ({skill.tools.length})
           </h2>


### PR DESCRIPTION
## Description

Here is the poke plugin, see what the knowledge looks like inside:

<img width="3374" height="1234" alt="image" src="https://github.com/user-attachments/assets/fca4a182-3482-4d44-ae7e-a7ed85bb51aa" />

## Tests
tested locally

## Risk

Maaaay break the knowledge, but I tested and it is fine locally, I can still use the knowledge mentionned in the skill

## Deploy Plan

deploy front