### PR TITLE
[front] fix: do not flatten `$ref` in mcp schemas

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -22,6 +22,7 @@ import type {
   UserQuestion,
 } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { isInternalServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type {
   MCPToolRetryPolicyType,
   ToolDisplayLabels,
@@ -255,16 +256,19 @@ const MAX_DESCRIPTION_LENGTH = 1024;
 export function buildToolSpecification(
   actionConfiguration: MCPToolConfigurationType
 ): AgentActionSpecification {
-  // Hide required tool-input configuration from the model; optional internal props stay visible.
-  const filteredInputSchema = hideInternalConfiguration(
-    actionConfiguration.inputSchema
-  );
+  // Internal tools: hide required tool-input configuration from the model.
+  // External/client tools: black-box — pass the schema through as-is.
+  const inputSchema = isInternalServerSideMCPToolConfiguration(
+    actionConfiguration
+  )
+    ? hideInternalConfiguration(actionConfiguration.inputSchema)
+    : actionConfiguration.inputSchema;
 
   return {
     name: actionConfiguration.name,
     description:
       actionConfiguration.description?.slice(0, MAX_DESCRIPTION_LENGTH) ?? "",
-    inputSchema: filteredInputSchema,
+    inputSchema,
   };
 }
 

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -337,10 +337,11 @@ function getDefaultValueAtPath(inputSchema: JSONSchema, keyPath: string) {
 }
 
 /**
- * Recursively filters out **required** properties whose schema matches a configurable
+ * Filters out **required** properties whose schema matches a configurable
  * `INTERNAL_MIME_TYPES.TOOL_INPUT` (those are injected server-side).
  * Optional internal-configuration properties are kept so the model can see them and infer values when useful.
- * Handles nested objects and arrays.
+ *
+ * Only applicable to internal MCP tools — external tool schemas are treated as black-box.
  */
 export function hideInternalConfiguration(inputSchema: JSONSchema): JSONSchema {
   const resultingSchema = { ...inputSchema };
@@ -915,9 +916,9 @@ export function findMatchingSubSchemas(
           // For tuple items, we use the index as part of the key
           for (const match of Object.keys(itemMatches)) {
             if (match !== "") {
-              matches[`items[${i}].${match}`] = itemMatches[match];
+              matches[`items.${i}.${match}`] = itemMatches[match];
             } else {
-              matches[`items[${i}]`] = itemMatches[match];
+              matches[`items.${i}`] = itemMatches[match];
             }
           }
         }

--- a/front/lib/actions/mcp_metadata.test.ts
+++ b/front/lib/actions/mcp_metadata.test.ts
@@ -1,0 +1,34 @@
+import { extractMetadataFromTools } from "@app/lib/actions/mcp_metadata";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+
+describe("extractMetadataFromTools", () => {
+  it("passes through schemas with $ref unchanged", () => {
+    const tools: Tool[] = [
+      {
+        name: "createNote",
+        description: "Create a note",
+        inputSchema: {
+          type: "object",
+          properties: {
+            input: { $ref: "#/definitions/CreateNoteInput" },
+          },
+          required: ["input"],
+          definitions: {
+            CreateNoteInput: {
+              type: "object",
+              properties: {
+                customerId: { type: "string" },
+                text: { type: "string" },
+              },
+              required: ["customerId", "text"],
+            },
+          },
+        },
+      },
+    ];
+
+    const result = extractMetadataFromTools(tools);
+    expect(result[0].inputSchema).toEqual(tools[0].inputSchema);
+  });
+});

--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -1,8 +1,10 @@
 import config from "@app/lib/api/config";
 import { finalizeUriForProvider } from "@app/lib/api/oauth/utils";
+import { isDevelopment } from "@app/types/shared/env";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import type {
   OAuthClientInformationFull,
+  OAuthClientInformationMixed,
   OAuthClientMetadata,
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
@@ -25,14 +27,31 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   }
 
   get clientMetadata(): OAuthClientMetadata {
+    const baseUrl = config.getStaticWebsiteUrl();
+
+    // In production `baseUrl` is always https so these URIs are always set.
+    // In dev `baseUrl` is http://localhost and OAuth servers reject non-https
+    // URIs here — we drop these informational fields entirely; they don't
+    // matter for local testing.
+    if (!isDevelopment() && !baseUrl.startsWith("https://")) {
+      throw new Error(
+        `OAuth client metadata requires an HTTPS base URL, got: ${baseUrl}`
+      );
+    }
+    const informationalUris = isDevelopment()
+      ? {}
+      : {
+          client_uri: baseUrl,
+          logo_uri: baseUrl + "/static/AppIcon.png",
+          tos_uri: baseUrl + "/terms",
+          policy_uri: baseUrl + "/privacy",
+        };
+
     return {
       redirect_uris: [finalizeUriForProvider("mcp")],
       client_name: "Dust",
-      client_uri: config.getStaticWebsiteUrl(),
-      logo_uri: config.getStaticWebsiteUrl() + "/static/AppIcon.png",
+      ...informationalUris,
       contacts: ["support@dust.com"],
-      tos_uri: config.getStaticWebsiteUrl() + "/terms",
-      policy_uri: config.getStaticWebsiteUrl() + "/privacy",
       software_id: "dust",
       token_endpoint_auth_method: "none",
       grant_types: ["authorization_code", "refresh_token"],
@@ -42,6 +61,12 @@ export class MCPOAuthProvider implements OAuthClientProvider {
 
   clientInformation(): OAuthClientInformationFull | undefined {
     return undefined;
+  }
+
+  saveClientInformation(_clientInformation: OAuthClientInformationMixed): void {
+    // No-op: the SDK checks for this method's existence before attempting
+    // dynamic client registration. We provide it so the probe/discovery
+    // flow doesn't throw prematurely.
   }
 
   async tokens(): Promise<OAuthTokens | undefined> {

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -1,5 +1,6 @@
 import type {
   ClientSideMCPToolConfigurationType,
+  InternalServerSideMCPToolConfigurationType,
   LightClientSideMCPToolConfigurationType,
   LightMCPToolConfigurationType,
   LightServerSideMCPToolConfigurationType,
@@ -56,6 +57,14 @@ export function isServerSideMCPToolConfiguration(
   arg: MCPToolConfigurationType
 ): arg is ServerSideMCPToolConfigurationType {
   return isMCPToolConfiguration(arg) && "mcpServerViewId" in arg;
+}
+
+export function isInternalServerSideMCPToolConfiguration(
+  arg: MCPToolConfigurationType
+): arg is InternalServerSideMCPToolConfigurationType {
+  return (
+    isServerSideMCPToolConfiguration(arg) && arg.internalMCPServerId !== null
+  );
 }
 
 // Light tool configuration.

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -290,9 +290,9 @@ const config = {
   getOAuthFathomClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_FATHOM_CLIENT_ID");
   },
-  getDevOAuthFathomRedirectBaseUrl: (): string => {
-    return EnvironmentConfig.getEnvVariable(
-      "DEV_OAUTH_FATHOM_REDIRECT_BASE_URL"
+  getDevOAuthRedirectBaseUrl: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "DEV_OAUTH_REDIRECT_BASE_URL"
     );
   },
   getOAuthLinearClientId: (): string => {

--- a/front/lib/api/oauth/utils.ts
+++ b/front/lib/api/oauth/utils.ts
@@ -4,12 +4,12 @@ import { isDevelopment } from "@app/types/shared/env";
 import type { ParsedUrlQuery } from "querystring";
 
 export function finalizeUriForProvider(provider: OAuthProvider): string {
-  // Fathom does not accept http nor localhost in the redirect URL, even in dev.
-  // Currently relying on an ngrok.
-  if (isDevelopment() && provider === "fathom") {
-    return config.getDevOAuthFathomRedirectBaseUrl() + "/oauth/fathom/finalize";
+  if (isDevelopment()) {
+    const devBaseUrl = config.getDevOAuthRedirectBaseUrl();
+    if (devBaseUrl) {
+      return devBaseUrl + `/oauth/${provider}/finalize`;
+    }
   }
-  // Use auth redirect base URL for OAuth callbacks
   return config.getAuthRedirectBaseUrl() + `/oauth/${provider}/finalize`;
 }
 

--- a/front/lib/egress/server.ts
+++ b/front/lib/egress/server.ts
@@ -62,11 +62,30 @@ export function createProxyFetch(
   init?: globalThis.RequestInit
 ) => Promise<globalThis.Response> {
   const proxyInit = { dispatcher: agent };
-  // @ts-expect-error The return type uses DOM types (globalThis.Response/RequestInit) because
-  // Next.js exports DOM typings and the MCP SDK's FetchLike expects them. undici's fetch is
-  // structurally compatible at runtime; the mismatch is only that DOM RequestInit lacks
-  // `dispatcher` and undici.Response is a distinct (but equivalent) class.
-  return (input, init) => undiciFetch(input, { ...init, ...proxyInit });
+  return async (input, init) => {
+    // @ts-expect-error - globalThis.RequestInit and undici.RequestInit are structurally
+    // compatible at runtime; the mismatch is only that DOM RequestInit lacks `dispatcher`.
+    const response = await undiciFetch(input, { ...init, ...proxyInit });
+    return toGlobalResponse(response);
+  };
+}
+
+/**
+ * Wraps an undici Response in a globalThis.Response.
+ *
+ * undici's fetch returns its own Response class that is structurally compatible
+ * with the Web API Response but fails `instanceof globalThis.Response` checks.
+ * The MCP SDK relies on `instanceof Response` in parseErrorResponse(), so any
+ * fetch function passed to the SDK must return the global variant.
+ */
+export function toGlobalResponse(r: Response): globalThis.Response {
+  // @ts-expect-error - undici's ReadableStream and globalThis.ReadableStream are
+  // structurally identical at runtime but TypeScript treats them as distinct types.
+  return new globalThis.Response(r.body, {
+    status: r.status,
+    statusText: r.statusText,
+    headers: Object.fromEntries(r.headers.entries()),
+  });
 }
 
 // Fetch helper for trusted, first‑party egress or intra‑VPC calls.

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -11,7 +11,7 @@ import {
 import type { MCPToolType, RemoteMCPServerType } from "@app/lib/api/mcp";
 import type { MCPOAuthConnectionMetadataType } from "@app/lib/api/oauth/providers/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import { untrustedFetch } from "@app/lib/egress/server";
+import { toGlobalResponse, untrustedFetch } from "@app/lib/egress/server";
 import { DustError } from "@app/lib/error";
 import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
@@ -449,16 +449,17 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     // Basically, we do the 2 first steps of the Guided Tour.
     // See: https://github.com/modelcontextprotocol/inspector/blob/c2dbff738e582941d6b1af04c4b9f41c28305487/client/src/lib/oauth-state-machine.ts#L31
 
-    // @ts-expect-error - Typescript confusion over the Fetch types from node and elsewhere.
     const fetchFn: FetchLike = async (input, init?) => {
-      // @ts-expect-error - Typescript confusion over the Fetch types from node and elsewhere.
-      return untrustedFetch(input, {
+      // @ts-expect-error - globalThis.RequestInit and undici.RequestInit are structurally
+      // compatible at runtime.
+      const response = await untrustedFetch(String(input), {
         ...init,
         headers: {
           ...init?.headers,
           ...customHeaders,
         },
       });
+      return toGlobalResponse(response);
     };
 
     // Default to discovering from the server's URL

--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -5,6 +5,7 @@ import { ConfigurableToolInputJSONSchemas } from "@app/lib/actions/mcp_internal_
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   ensurePathExists,
+  followInternalRef,
   hasNoRequiredProperties,
   jsonSchemaHasRequiredDustToolInput,
   setValueAtPath,
@@ -126,6 +127,54 @@ describe("JSON Schema Utilities", () => {
           newKey: "new-value",
         },
       });
+    });
+  });
+
+  describe("followInternalRef", () => {
+    it("follows #/definitions/ refs", () => {
+      const schema: JSONSchema = {
+        type: "object",
+        definitions: {
+          Note: {
+            type: "object",
+            properties: { text: { type: "string" } },
+          },
+        },
+      };
+
+      expect(followInternalRef(schema, "#/definitions/Note")).toEqual({
+        type: "object",
+        properties: { text: { type: "string" } },
+      });
+    });
+
+    it("follows #/$defs/ refs", () => {
+      const schema: JSONSchema = {
+        type: "object",
+        $defs: {
+          Note: {
+            type: "object",
+            properties: { text: { type: "string" } },
+          },
+        },
+      };
+
+      expect(followInternalRef(schema, "#/$defs/Note")).toEqual({
+        type: "object",
+        properties: { text: { type: "string" } },
+      });
+    });
+
+    it("returns null for external refs", () => {
+      const schema: JSONSchema = { type: "object" };
+      expect(
+        followInternalRef(schema, "https://example.com/schema")
+      ).toBeNull();
+    });
+
+    it("returns null when path does not exist", () => {
+      const schema: JSONSchema = { type: "object" };
+      expect(followInternalRef(schema, "#/definitions/Missing")).toBeNull();
     });
   });
 

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -11,17 +11,10 @@ import type {
 import isEqual from "lodash/isEqual";
 
 /**
- * Type guard to check if a value is a JSONSchema object
+ * Type guard to check if a value is a JSONSchema object (excludes arrays).
  */
-export function isJSONSchemaObject(
-  value:
-    | JSONSchema
-    | JSONSchemaDefinition
-    | JSONSchemaDefinition[]
-    | boolean
-    | undefined
-): value is JSONSchema {
-  return !!value && typeof value === "object";
+export function isJSONSchemaObject(value: unknown): value is JSONSchema {
+  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 /**
@@ -61,19 +54,30 @@ export function areSchemasEqual(
 }
 
 /**
- * Finds the schema for a property given a $ref to it.
+ * Follows an internal JSON Schema $ref (e.g. "#/definitions/Foo") and returns
+ * the referenced sub-schema, or null if the ref is external or the path is invalid.
  */
 export function followInternalRef(
   schema: JSONSchema,
   ref: string
 ): JSONSchema | null {
-  return findSchemaAtPath(
-    schema,
-    ref
-      .replace("#/", "")
-      .split("/")
-      .filter((key) => key !== "properties")
-  );
+  if (!ref.startsWith("#/")) {
+    return null;
+  }
+
+  let current: object = schema;
+  for (const segment of ref.slice(2).split("/")) {
+    if (!isRecord(current) || !(segment in current)) {
+      return null;
+    }
+    const next = current[segment];
+    if (typeof next !== "object" || next === null) {
+      return null;
+    }
+    current = next;
+  }
+
+  return isJSONSchemaObject(current) ? current : null;
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7361

Currently, when a MCP specifies a `$ref` inside a param, we resolve it successfully but flatten it in place of its reference, eg:
```
{
   "input": { "$ref": "#/path/to/schema" } 
}.

in defs
{
   "a": 1,
   "b": 2,
}
```

becomes 
```
{
   "a": 1,
   "b": 2,
}
```

when it should be
```
{
   "input": {"a": 1, "b": 2}
}
```


## Tests

- [x] Tested locally
- [x] Unit tests
- [ ]  front-edge test

## Risk

Standard
Blast radius: all mcp tool calls


## Deploy Plan

- [ ] Deploy front (after building some confidence)
