### PR TITLE
Add dsbx forward protocol and parsing primitives

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -166,6 +166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +194,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
+ "time",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -199,6 +210,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -534,6 +551,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +685,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -857,6 +892,19 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"
@@ -1063,6 +1111,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1150,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -14,5 +14,9 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+time = { version = "=0.3.36", features = ["formatting"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+
+[dev-dependencies]
+tempfile = "=3.20.0"

--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -1,0 +1,86 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+use tokio::io::AsyncWriteExt;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DenyReason {
+    ProxyDenied,
+    ProxyProtocolError,
+    DomainExtractionFailed,
+}
+
+impl DenyReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ProxyDenied => "proxy_denied",
+            Self::ProxyProtocolError => "proxy_protocol_error",
+            Self::DomainExtractionFailed => "domain_extraction_failed",
+        }
+    }
+}
+
+pub async fn append_deny_log(
+    path: &Path,
+    domain: &str,
+    port: u16,
+    reason: DenyReason,
+) -> Result<()> {
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await
+        .with_context(|| format!("failed to open deny log {}", path.display()))?;
+    let line = format_deny_log_line(domain, port, reason)?;
+    file.write_all(line.as_bytes())
+        .await
+        .with_context(|| format!("failed to write deny log {}", path.display()))?;
+    Ok(())
+}
+
+fn format_deny_log_line(domain: &str, port: u16, reason: DenyReason) -> Result<String> {
+    let timestamp = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .context("failed to format deny log timestamp")?;
+    let domain = if domain.is_empty() {
+        "<unknown>"
+    } else {
+        domain
+    };
+    Ok(format!(
+        "{timestamp} DENIED {domain}:{port} (reason: {})\n",
+        reason.as_str()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::{append_deny_log, DenyReason};
+
+    #[tokio::test]
+    async fn appends_deny_log_entries() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let path = tempdir.path().join("deny.log");
+
+        append_deny_log(&path, "api.openai.com", 443, DenyReason::ProxyDenied)
+            .await
+            .expect("first append should succeed");
+        append_deny_log(&path, "", 80, DenyReason::DomainExtractionFailed)
+            .await
+            .expect("second append should succeed");
+
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .expect("deny log should be readable");
+        let lines: Vec<&str> = content.lines().collect();
+
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("DENIED api.openai.com:443 (reason: proxy_denied)"));
+        assert!(lines[1].contains("DENIED <unknown>:80 (reason: domain_extraction_failed)"));
+    }
+}

--- a/cli/dust-sandbox/src/commands/forward/handshake.rs
+++ b/cli/dust-sandbox/src/commands/forward/handshake.rs
@@ -1,15 +1,21 @@
+use anyhow::{Context, Result};
+
 // Keep these constants and frame layout in sync with egress-proxy/src/handshake.rs.
 pub const PROTOCOL_VERSION: u8 = 0x01;
 pub const ALLOW_RESPONSE: u8 = 0x00;
 pub const DENY_RESPONSE: u8 = 0x01;
 
-pub fn build_handshake_frame(token: &str, domain: &str, original_dest_port: u16) -> Vec<u8> {
+pub fn build_handshake_frame(
+    token: &str,
+    domain: &str,
+    original_dest_port: u16,
+) -> Result<Vec<u8>> {
     let token_bytes = token.as_bytes();
     let domain_bytes = domain.as_bytes();
-    let token_len =
-        u16::try_from(token_bytes.len()).expect("token length should fit in the wire format");
-    let domain_len =
-        u16::try_from(domain_bytes.len()).expect("domain length should fit in the wire format");
+    let token_len = u16::try_from(token_bytes.len())
+        .context("token length does not fit in the handshake wire format")?;
+    let domain_len = u16::try_from(domain_bytes.len())
+        .context("domain length does not fit in the handshake wire format")?;
 
     let mut frame = Vec::with_capacity(1 + 2 + token_bytes.len() + 2 + domain_bytes.len() + 2);
     frame.push(PROTOCOL_VERSION);
@@ -18,7 +24,7 @@ pub fn build_handshake_frame(token: &str, domain: &str, original_dest_port: u16)
     frame.extend_from_slice(&domain_len.to_be_bytes());
     frame.extend_from_slice(domain_bytes);
     frame.extend_from_slice(&original_dest_port.to_be_bytes());
-    frame
+    Ok(frame)
 }
 
 #[cfg(test)]
@@ -27,7 +33,8 @@ mod tests {
 
     #[test]
     fn encodes_handshake_frame_in_proxy_wire_format() {
-        let frame = build_handshake_frame("token", "example.com", 443);
+        let frame = build_handshake_frame("token", "example.com", 443)
+            .expect("build_handshake_frame should succeed for short inputs");
 
         assert_eq!(
             frame,

--- a/cli/dust-sandbox/src/commands/forward/handshake.rs
+++ b/cli/dust-sandbox/src/commands/forward/handshake.rs
@@ -1,0 +1,63 @@
+// Keep these constants and frame layout in sync with egress-proxy/src/handshake.rs.
+pub const PROTOCOL_VERSION: u8 = 0x01;
+pub const ALLOW_RESPONSE: u8 = 0x00;
+pub const DENY_RESPONSE: u8 = 0x01;
+
+pub fn build_handshake_frame(token: &str, domain: &str, original_dest_port: u16) -> Vec<u8> {
+    let token_bytes = token.as_bytes();
+    let domain_bytes = domain.as_bytes();
+    let token_len =
+        u16::try_from(token_bytes.len()).expect("token length should fit in the wire format");
+    let domain_len =
+        u16::try_from(domain_bytes.len()).expect("domain length should fit in the wire format");
+
+    let mut frame = Vec::with_capacity(1 + 2 + token_bytes.len() + 2 + domain_bytes.len() + 2);
+    frame.push(PROTOCOL_VERSION);
+    frame.extend_from_slice(&token_len.to_be_bytes());
+    frame.extend_from_slice(token_bytes);
+    frame.extend_from_slice(&domain_len.to_be_bytes());
+    frame.extend_from_slice(domain_bytes);
+    frame.extend_from_slice(&original_dest_port.to_be_bytes());
+    frame
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_handshake_frame, ALLOW_RESPONSE, DENY_RESPONSE, PROTOCOL_VERSION};
+
+    #[test]
+    fn encodes_handshake_frame_in_proxy_wire_format() {
+        let frame = build_handshake_frame("token", "example.com", 443);
+
+        assert_eq!(
+            frame,
+            vec![
+                PROTOCOL_VERSION,
+                0x00,
+                0x05,
+                b't',
+                b'o',
+                b'k',
+                b'e',
+                b'n',
+                0x00,
+                0x0b,
+                b'e',
+                b'x',
+                b'a',
+                b'm',
+                b'p',
+                b'l',
+                b'e',
+                b'.',
+                b'c',
+                b'o',
+                b'm',
+                0x01,
+                0xbb
+            ]
+        );
+        assert_eq!(ALLOW_RESPONSE, 0x00);
+        assert_eq!(DENY_RESPONSE, 0x01);
+    }
+}

--- a/cli/dust-sandbox/src/commands/forward/http_host.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_host.rs
@@ -1,0 +1,113 @@
+use super::DomainParseResult;
+
+pub fn parse_http_host(bytes: &[u8]) -> DomainParseResult {
+    let header_end = find_subslice(bytes, b"\r\n\r\n");
+    let parse_end = header_end.map_or(bytes.len(), |index| index + 4);
+    let header_bytes = &bytes[..parse_end];
+    let header_text = match std::str::from_utf8(header_bytes) {
+        Ok(text) => text,
+        Err(_) => return DomainParseResult::NotFound,
+    };
+
+    for line in header_text.split("\r\n").skip(1) {
+        if line.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            if name.eq_ignore_ascii_case("host") {
+                if header_end.is_none() {
+                    return DomainParseResult::Incomplete;
+                }
+                let host = strip_port(value.trim());
+                return if host.is_empty() {
+                    DomainParseResult::NotFound
+                } else {
+                    DomainParseResult::Found(host.to_string())
+                };
+            }
+        }
+    }
+
+    if header_end.is_some() {
+        DomainParseResult::NotFound
+    } else {
+        DomainParseResult::Incomplete
+    }
+}
+
+fn strip_port(host: &str) -> &str {
+    if let Some(end_bracket) = host.find(']') {
+        if host.starts_with('[') {
+            return &host[1..end_bracket];
+        }
+    }
+
+    if host.matches(':').count() == 1 {
+        return host.split(':').next().unwrap_or(host);
+    }
+
+    host
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::DomainParseResult;
+    use super::parse_http_host;
+
+    #[test]
+    fn parses_standard_host_header() {
+        let request = b"GET / HTTP/1.1\r\nHost: example.com\r\nUser-Agent: curl\r\n\r\n";
+        assert_eq!(
+            parse_http_host(request),
+            DomainParseResult::Found("example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_host_header_case_insensitively() {
+        let lowercase = b"GET / HTTP/1.1\r\nhost: lowercase.example\r\n\r\n";
+        let uppercase = b"GET / HTTP/1.1\r\nHOST: uppercase.example\r\n\r\n";
+
+        assert_eq!(
+            parse_http_host(lowercase),
+            DomainParseResult::Found("lowercase.example".to_string())
+        );
+        assert_eq!(
+            parse_http_host(uppercase),
+            DomainParseResult::Found("uppercase.example".to_string())
+        );
+    }
+
+    #[test]
+    fn strips_port_from_host_header() {
+        let request = b"GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n";
+        assert_eq!(
+            parse_http_host(request),
+            DomainParseResult::Found("example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_not_found_when_host_header_is_missing() {
+        let request = b"GET / HTTP/1.1\r\nUser-Agent: curl\r\n\r\n";
+        assert_eq!(parse_http_host(request), DomainParseResult::NotFound);
+    }
+
+    #[test]
+    fn returns_incomplete_for_partial_headers() {
+        let request = b"GET / HTTP/1.1\r\nUser-Agent: curl\r\n";
+        assert_eq!(parse_http_host(request), DomainParseResult::Incomplete);
+    }
+
+    #[test]
+    fn returns_incomplete_for_partial_host_header_line() {
+        let request = b"GET / HTTP/1.1\r\nHost: api.op";
+        assert_eq!(parse_http_host(request), DomainParseResult::Incomplete);
+    }
+}

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code)] // PR 3 wires these primitives into the forward runtime.
+
+mod deny_log;
+mod handshake;
+mod http_host;
+mod sni;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum DomainParseResult {
+    Found(String),
+    NotFound,
+    Incomplete,
+}

--- a/cli/dust-sandbox/src/commands/forward/sni.rs
+++ b/cli/dust-sandbox/src/commands/forward/sni.rs
@@ -1,0 +1,220 @@
+use super::DomainParseResult;
+
+pub fn parse_client_hello_sni(bytes: &[u8]) -> DomainParseResult {
+    let record = match bytes.get(..5) {
+        Some(record) => record,
+        None => return DomainParseResult::Incomplete,
+    };
+
+    if record[0] != 0x16 {
+        return DomainParseResult::NotFound;
+    }
+
+    let record_len = read_u16(&record[3..5]) as usize;
+    let record_payload = match bytes.get(5..5 + record_len) {
+        Some(payload) => payload,
+        None => return DomainParseResult::Incomplete,
+    };
+
+    if record_payload.is_empty() || record_payload[0] != 0x01 {
+        return DomainParseResult::NotFound;
+    }
+
+    let hello_len = match record_payload.get(1..4) {
+        Some(hello_len_bytes) => read_u24(hello_len_bytes) as usize,
+        None => return DomainParseResult::Incomplete,
+    };
+    let client_hello = match record_payload.get(4..4 + hello_len) {
+        Some(hello) => hello,
+        None => return DomainParseResult::Incomplete,
+    };
+
+    match parse_server_name_extension(client_hello) {
+        Some(hostname) => DomainParseResult::Found(hostname),
+        None => DomainParseResult::NotFound,
+    }
+}
+
+fn parse_server_name_extension(client_hello: &[u8]) -> Option<String> {
+    let mut cursor = Cursor::new(client_hello);
+
+    cursor.take(2)?;
+    cursor.take(32)?;
+    let session_id_len = cursor.take_u8()? as usize;
+    cursor.take(session_id_len)?;
+
+    let cipher_suites_len = cursor.take_u16()? as usize;
+    cursor.take(cipher_suites_len)?;
+
+    let compression_methods_len = cursor.take_u8()? as usize;
+    cursor.take(compression_methods_len)?;
+
+    let extensions_len = cursor.take_u16()? as usize;
+    let mut extensions = Cursor::new(cursor.take(extensions_len)?);
+
+    while !extensions.is_empty() {
+        let extension_type = extensions.take_u16()?;
+        let extension_len = extensions.take_u16()? as usize;
+        let extension = extensions.take(extension_len)?;
+
+        if extension_type == 0x0000 {
+            return parse_sni_extension(extension);
+        }
+    }
+
+    None
+}
+
+fn parse_sni_extension(extension: &[u8]) -> Option<String> {
+    let mut cursor = Cursor::new(extension);
+    let server_name_list_len = cursor.take_u16()? as usize;
+    let mut server_names = Cursor::new(cursor.take(server_name_list_len)?);
+
+    while !server_names.is_empty() {
+        let name_type = server_names.take_u8()?;
+        let name_len = server_names.take_u16()? as usize;
+        let name = server_names.take(name_len)?;
+
+        if name_type == 0x00 {
+            let hostname = std::str::from_utf8(name).ok()?.to_string();
+            return Some(hostname);
+        }
+    }
+
+    None
+}
+
+struct Cursor<'a> {
+    remaining: &'a [u8],
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { remaining: bytes }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.remaining.is_empty()
+    }
+
+    fn take(&mut self, len: usize) -> Option<&'a [u8]> {
+        let bytes = self.remaining.get(..len)?;
+        self.remaining = &self.remaining[len..];
+        Some(bytes)
+    }
+
+    fn take_u8(&mut self) -> Option<u8> {
+        Some(*self.take(1)?.first()?)
+    }
+
+    fn take_u16(&mut self) -> Option<u16> {
+        Some(read_u16(self.take(2)?))
+    }
+}
+
+fn read_u16(bytes: &[u8]) -> u16 {
+    u16::from_be_bytes([bytes[0], bytes[1]])
+}
+
+fn read_u24(bytes: &[u8]) -> u32 {
+    ((bytes[0] as u32) << 16) | ((bytes[1] as u32) << 8) | bytes[2] as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::DomainParseResult;
+    use super::parse_client_hello_sni;
+
+    #[test]
+    fn parses_sni_from_client_hello() {
+        let hello = build_client_hello(Some("api.openai.com"));
+        assert_eq!(
+            parse_client_hello_sni(&hello),
+            DomainParseResult::Found("api.openai.com".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_not_found_when_sni_extension_is_missing() {
+        let hello = build_client_hello(None);
+        assert_eq!(parse_client_hello_sni(&hello), DomainParseResult::NotFound);
+    }
+
+    #[test]
+    fn returns_incomplete_for_truncated_record() {
+        let hello = build_client_hello(Some("api.openai.com"));
+        let truncated = &hello[..10];
+        assert_eq!(
+            parse_client_hello_sni(truncated),
+            DomainParseResult::Incomplete
+        );
+    }
+
+    #[test]
+    fn returns_incomplete_for_truncated_tls_record_with_missing_hello_length() {
+        assert_eq!(
+            parse_client_hello_sni(&[0x16, 0x03, 0x01, 0x00, 0x01, 0x01]),
+            DomainParseResult::Incomplete
+        );
+    }
+
+    #[test]
+    fn returns_not_found_for_non_tls_bytes() {
+        assert_eq!(
+            parse_client_hello_sni(b"GET / HTTP/1.1\r\n\r\n"),
+            DomainParseResult::NotFound
+        );
+    }
+
+    fn build_client_hello(server_name: Option<&str>) -> Vec<u8> {
+        let mut client_hello = Vec::new();
+        client_hello.extend_from_slice(&[0x03, 0x03]);
+        client_hello.extend_from_slice(&[0_u8; 32]);
+        client_hello.push(0x00);
+        client_hello.extend_from_slice(&2_u16.to_be_bytes());
+        client_hello.extend_from_slice(&[0x13, 0x01]);
+        client_hello.push(0x01);
+        client_hello.push(0x00);
+
+        let extensions = if let Some(server_name) = server_name {
+            build_sni_extension(server_name)
+        } else {
+            Vec::new()
+        };
+        client_hello.extend_from_slice(&(extensions.len() as u16).to_be_bytes());
+        client_hello.extend_from_slice(&extensions);
+
+        let mut handshake = Vec::new();
+        handshake.push(0x01);
+        let hello_len = client_hello.len() as u32;
+        handshake.extend_from_slice(&[
+            ((hello_len >> 16) & 0xff) as u8,
+            ((hello_len >> 8) & 0xff) as u8,
+            (hello_len & 0xff) as u8,
+        ]);
+        handshake.extend_from_slice(&client_hello);
+
+        let mut record = Vec::new();
+        record.push(0x16);
+        record.extend_from_slice(&[0x03, 0x01]);
+        record.extend_from_slice(&(handshake.len() as u16).to_be_bytes());
+        record.extend_from_slice(&handshake);
+        record
+    }
+
+    fn build_sni_extension(server_name: &str) -> Vec<u8> {
+        let server_name_bytes = server_name.as_bytes();
+        let server_name_entry_len = 1 + 2 + server_name_bytes.len();
+        let server_name_list_len = server_name_entry_len as u16;
+        let extension_payload_len = 2 + server_name_entry_len;
+
+        let mut extension = Vec::new();
+        extension.extend_from_slice(&0x0000_u16.to_be_bytes());
+        extension.extend_from_slice(&(extension_payload_len as u16).to_be_bytes());
+        extension.extend_from_slice(&server_name_list_len.to_be_bytes());
+        extension.push(0x00);
+        extension.extend_from_slice(&(server_name_bytes.len() as u16).to_be_bytes());
+        extension.extend_from_slice(server_name_bytes);
+        extension
+    }
+}

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod forward;
 pub mod tools;
 mod version;
 


### PR DESCRIPTION
## Description

Second of three stacked PRs splitting #24344. Adds the pure, unit-testable building blocks of the sandbox-side egress forwarder under `commands::forward`. This module compiles and tests but is **not yet wired into clap** — `dsbx forward` still returns "unrecognized subcommand" after this PR lands. PR 3 will wire the accept loop, TLS client, and CLI flag on top of these primitives.

Stacked on top of #24373 (tracing bootstrap) — rebase target is `dsbx-forward-pr1-logger`, retarget to `main` after #24373 lands.

New files:

- `forward/handshake.rs` — `build_handshake_frame(token, domain, port)` + `PROTOCOL_VERSION` / `ALLOW_RESPONSE` / `DENY_RESPONSE` constants. Kept in sync with `egress-proxy/src/handshake.rs` (top-of-file comment calls this out). Byte-for-byte fixture test.
- `forward/sni.rs` — TLS ClientHello SNI parser. Tests: valid SNI, missing SNI extension, truncated record, non-TLS bytes.
- `forward/http_host.rs` — HTTP/1.1 Host header parser. Tests: standard, `host:` / `HOST:` case variants, port stripping (incl. IPv6 brackets), missing Host, incomplete headers / partial header line.
- `forward/deny_log.rs` — `DenyReason` enum + `append_deny_log()` with RFC3339 timestamps and the format documented in `notion-s7-network.md` §"Deny Visibility". Test: append twice, assert both lines present.
- `forward/mod.rs` — module declarations + the shared `DomainParseResult` enum.

Deps added (only what the primitives use): `time` (RFC3339 timestamps), `tempfile` (dev-dep for deny log test).

No network code, no `SO_ORIGINAL_DST`, no TLS client, no clap variant, no forward-specific runtime deps (rustls / tokio-rustls / libc land with PR 3).

## Tests

- `cargo test --manifest-path cli/dust-sandbox/Cargo.toml` green on macOS.
- Manual: `dsbx forward` still reports "unrecognized subcommand" (expected — not wired yet).

## Risk

Very low. No new subcommand, no behavior change for existing subcommands, no networking. The module is dead code from the binary's perspective until PR 3 lands; only the unit tests exercise it.

Rollback: revert. No data / infra / state change.

## Deploy Plan

Ships with the next `dust-sandbox` binary build alongside #24373 and PR 3 — no user-visible change on its own.