### PR TITLE
Wire dsbx forward subcommand

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -74,6 +74,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +126,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -160,10 +184,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "deranged"
@@ -186,17 +235,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dust-sandbox"
 version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
+ "libc",
  "reqwest",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "tempfile",
  "time",
  "tokio",
+ "tokio-rustls",
  "tracing",
  "tracing-subscriber",
 ]
@@ -231,6 +290,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -529,6 +594,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +710,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking_lot"
@@ -912,12 +993,26 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -936,6 +1031,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -954,10 +1050,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"

--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -242,7 +242,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-rustls = "0.23"
+rustls = { version = "0.23", features = ["ring"] }
 rustls-native-certs = "0.8"
 time = { version = "=0.3.36", features = ["formatting"] }
 tokio-rustls = "0.26"

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -11,10 +11,14 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
+libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rustls = "0.23"
+rustls-native-certs = "0.8"
 time = { version = "=0.3.36", features = ["formatting"] }
+tokio-rustls = "0.26"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -125,6 +125,11 @@ async fn load_token(token_file: &PathBuf) -> Result<String> {
 }
 
 fn build_tls_connector() -> Result<TlsConnector> {
+    // rustls 0.23 requires an explicit process-level CryptoProvider.
+    // install_default returns Err if one is already installed — we just want to
+    // guarantee some provider is present before ClientConfig::builder().
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let mut roots = RootCertStore::empty();
     let certs = rustls_native_certs::load_native_certs();
 

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -172,7 +172,8 @@ async fn handle_connection(
         .await
         .context("failed to establish TLS connection to proxy")?;
 
-    let frame = build_handshake_frame(&runtime.token, &domain_extraction.domain, original_port);
+    let frame = build_handshake_frame(&runtime.token, &domain_extraction.domain, original_port)
+        .context("failed to build proxy handshake frame")?;
     proxy_stream
         .write_all(&frame)
         .await

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -1,13 +1,333 @@
-#![allow(dead_code)] // PR 3 wires these primitives into the forward runtime.
-
 mod deny_log;
 mod handshake;
 mod http_host;
+mod original_dst;
 mod sni;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{ensure, Context, Result};
+use clap::Args;
+use rustls::pki_types::ServerName;
+use rustls::ClientConfig;
+use rustls::RootCertStore;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::{sleep, timeout, timeout_at, Instant};
+use tokio_rustls::TlsConnector;
+use tracing::{debug, info, warn};
+
+use self::deny_log::{append_deny_log, DenyReason};
+use self::handshake::{build_handshake_frame, ALLOW_RESPONSE, DENY_RESPONSE};
+use self::http_host::parse_http_host;
+use self::original_dst::resolve_original_dst;
+use self::sni::parse_client_hello_sni;
+
+const DOMAIN_PEEK_TIMEOUT: Duration = Duration::from_secs(2);
+const DOMAIN_PEEK_RETRY_DELAY: Duration = Duration::from_millis(25);
+const PROXY_RESPONSE_TIMEOUT: Duration = Duration::from_secs(2);
+const DOMAIN_PEEK_BUFFER_SIZE: usize = 16 * 1024;
+
+#[derive(Args, Debug, Clone)]
+pub struct ForwardArgs {
+    /// Path to the JWT token file
+    #[arg(long)]
+    token_file: PathBuf,
+    /// Proxy TCP address in host:port form
+    #[arg(long)]
+    proxy_addr: std::net::SocketAddr,
+    /// TLS server name used for certificate verification
+    #[arg(long)]
+    proxy_tls_name: String,
+    /// Local listen address in host:port form
+    #[arg(long)]
+    listen: std::net::SocketAddr,
+    /// Path to the deny log file
+    #[arg(long, default_value = "/tmp/dust-egress-denied.log")]
+    deny_log: PathBuf,
+}
+
+#[derive(Clone)]
+struct ForwardRuntime {
+    token: Arc<str>,
+    proxy_addr: std::net::SocketAddr,
+    proxy_tls_name: Arc<str>,
+    deny_log: Arc<PathBuf>,
+    tls_connector: TlsConnector,
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum DomainParseResult {
     Found(String),
     NotFound,
     Incomplete,
+}
+
+#[derive(Debug)]
+struct DomainExtraction {
+    domain: String,
+    failed: bool,
+}
+
+pub async fn cmd_forward(args: ForwardArgs) -> Result<()> {
+    let token = load_token(&args.token_file).await?;
+    let tls_connector = build_tls_connector()?;
+    let listener = TcpListener::bind(args.listen)
+        .await
+        .with_context(|| format!("failed to bind forward listener on {}", args.listen))?;
+
+    info!(
+        listen_addr = %args.listen,
+        proxy_addr = %args.proxy_addr,
+        proxy_tls_name = %args.proxy_tls_name,
+        deny_log = %args.deny_log.display(),
+        "starting dsbx forwarder"
+    );
+
+    let runtime = ForwardRuntime {
+        token: Arc::<str>::from(token),
+        proxy_addr: args.proxy_addr,
+        proxy_tls_name: Arc::<str>::from(args.proxy_tls_name),
+        deny_log: Arc::new(args.deny_log),
+        tls_connector,
+    };
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, peer_addr)) => {
+                let runtime = runtime.clone();
+                tokio::spawn(async move {
+                    if let Err(error) = handle_connection(runtime, stream, peer_addr).await {
+                        warn!(peer_addr = %peer_addr, error = %error, "forwarded connection failed");
+                    }
+                });
+            }
+            Err(error) => {
+                warn!(error = %error, "failed to accept forwarded connection");
+            }
+        }
+    }
+}
+
+async fn load_token(token_file: &PathBuf) -> Result<String> {
+    let token = tokio::fs::read_to_string(token_file)
+        .await
+        .with_context(|| format!("failed to read token file {}", token_file.display()))?;
+    let trimmed = token.trim().to_string();
+    ensure!(
+        !trimmed.is_empty(),
+        "token file {} did not contain a JWT",
+        token_file.display()
+    );
+    Ok(trimmed)
+}
+
+fn build_tls_connector() -> Result<TlsConnector> {
+    let mut roots = RootCertStore::empty();
+    let certs = rustls_native_certs::load_native_certs();
+
+    for error in certs.errors {
+        warn!(error = %error, "failed to load a native root certificate");
+    }
+
+    let (loaded, ignored) = roots.add_parsable_certificates(certs.certs);
+    if ignored != 0 {
+        warn!(
+            ignored_cert_count = ignored,
+            "ignored native root certificates"
+        );
+    }
+    ensure!(
+        loaded != 0,
+        "failed to load any native root certificates for proxy TLS validation"
+    );
+
+    let config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+    Ok(TlsConnector::from(Arc::new(config)))
+}
+
+async fn handle_connection(
+    runtime: ForwardRuntime,
+    mut client_stream: TcpStream,
+    peer_addr: std::net::SocketAddr,
+) -> Result<()> {
+    let original_dst =
+        resolve_original_dst(&client_stream).context("failed to resolve original destination")?;
+    let original_port = original_dst.port();
+    let domain_extraction = extract_domain(&client_stream, original_port).await;
+
+    let server_name = ServerName::try_from(runtime.proxy_tls_name.to_string())
+        .context("invalid proxy TLS server name")?;
+    let proxy_stream = TcpStream::connect(runtime.proxy_addr)
+        .await
+        .with_context(|| format!("failed to connect to proxy {}", runtime.proxy_addr))?;
+    let mut proxy_stream = runtime
+        .tls_connector
+        .connect(server_name, proxy_stream)
+        .await
+        .context("failed to establish TLS connection to proxy")?;
+
+    let frame = build_handshake_frame(&runtime.token, &domain_extraction.domain, original_port);
+    proxy_stream
+        .write_all(&frame)
+        .await
+        .context("failed to write proxy handshake frame")?;
+
+    let proxy_response = read_proxy_response(&mut proxy_stream).await;
+    match proxy_response {
+        ProxyDecision::Allow => {
+            info!(
+                peer_addr = %peer_addr,
+                original_port,
+                domain = display_domain(&domain_extraction.domain),
+                "proxy allowed forwarded connection"
+            );
+            tokio::io::copy_bidirectional(&mut client_stream, &mut proxy_stream)
+                .await
+                .context("bidirectional copy failed")?;
+        }
+        ProxyDecision::Deny => {
+            let reason = if domain_extraction.failed {
+                DenyReason::DomainExtractionFailed
+            } else {
+                DenyReason::ProxyDenied
+            };
+            append_deny_log(
+                &runtime.deny_log,
+                &domain_extraction.domain,
+                original_port,
+                reason,
+            )
+            .await
+            .context("failed to append deny log entry")?;
+            info!(
+                peer_addr = %peer_addr,
+                original_port,
+                domain = display_domain(&domain_extraction.domain),
+                reason = reason.as_str(),
+                "proxy denied forwarded connection"
+            );
+        }
+        ProxyDecision::ProtocolError => {
+            append_deny_log(
+                &runtime.deny_log,
+                &domain_extraction.domain,
+                original_port,
+                DenyReason::ProxyProtocolError,
+            )
+            .await
+            .context("failed to append protocol-error deny log entry")?;
+            warn!(
+                peer_addr = %peer_addr,
+                original_port,
+                domain = display_domain(&domain_extraction.domain),
+                "proxy returned an invalid response"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn display_domain(domain: &str) -> &str {
+    if domain.is_empty() {
+        "<unknown>"
+    } else {
+        domain
+    }
+}
+
+async fn extract_domain(stream: &TcpStream, original_port: u16) -> DomainExtraction {
+    match original_port {
+        80 => extract_domain_with_parser(stream, parse_http_host).await,
+        443 => extract_domain_with_parser(stream, parse_client_hello_sni).await,
+        _ => DomainExtraction {
+            domain: String::new(),
+            failed: false,
+        },
+    }
+}
+
+async fn extract_domain_with_parser<F>(stream: &TcpStream, parser: F) -> DomainExtraction
+where
+    F: Fn(&[u8]) -> DomainParseResult,
+{
+    let mut buffer = vec![0_u8; DOMAIN_PEEK_BUFFER_SIZE];
+    let deadline = Instant::now() + DOMAIN_PEEK_TIMEOUT;
+
+    loop {
+        let bytes_read = match timeout_at(deadline, stream.peek(&mut buffer)).await {
+            Ok(Ok(bytes_read)) => bytes_read,
+            Ok(Err(error)) => {
+                debug!(error = %error, "failed to peek client bytes for domain extraction");
+                return DomainExtraction {
+                    domain: String::new(),
+                    failed: true,
+                };
+            }
+            Err(_) => {
+                return DomainExtraction {
+                    domain: String::new(),
+                    failed: true,
+                };
+            }
+        };
+
+        if bytes_read == 0 {
+            return DomainExtraction {
+                domain: String::new(),
+                failed: true,
+            };
+        }
+
+        match parser(&buffer[..bytes_read]) {
+            DomainParseResult::Found(domain) => {
+                return DomainExtraction {
+                    domain,
+                    failed: false,
+                };
+            }
+            DomainParseResult::NotFound => {
+                return DomainExtraction {
+                    domain: String::new(),
+                    failed: false,
+                };
+            }
+            DomainParseResult::Incomplete => {
+                if bytes_read == buffer.len() || Instant::now() >= deadline {
+                    return DomainExtraction {
+                        domain: String::new(),
+                        failed: true,
+                    };
+                }
+                sleep(DOMAIN_PEEK_RETRY_DELAY).await;
+            }
+        }
+    }
+}
+
+enum ProxyDecision {
+    Allow,
+    Deny,
+    ProtocolError,
+}
+
+async fn read_proxy_response<IO>(io: &mut IO) -> ProxyDecision
+where
+    IO: AsyncReadExt + Unpin,
+{
+    let mut response = [0_u8; 1];
+    match timeout(PROXY_RESPONSE_TIMEOUT, io.read_exact(&mut response)).await {
+        Ok(Ok(_)) => match response[0] {
+            ALLOW_RESPONSE => ProxyDecision::Allow,
+            DENY_RESPONSE => ProxyDecision::Deny,
+            _ => ProxyDecision::ProtocolError,
+        },
+        Ok(Err(_)) | Err(_) => ProxyDecision::ProtocolError,
+    }
 }

--- a/cli/dust-sandbox/src/commands/forward/original_dst.rs
+++ b/cli/dust-sandbox/src/commands/forward/original_dst.rs
@@ -1,0 +1,48 @@
+use std::io;
+#[cfg(target_os = "linux")]
+use std::mem;
+use std::net::SocketAddr;
+#[cfg(target_os = "linux")]
+use std::net::{Ipv4Addr, SocketAddrV4};
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
+
+use tokio::net::TcpStream;
+
+#[cfg(target_os = "linux")]
+const SO_ORIGINAL_DST: libc::c_int = 80;
+
+#[cfg(target_os = "linux")]
+pub fn resolve_original_dst(stream: &TcpStream) -> io::Result<SocketAddr> {
+    resolve_original_dst_linux(stream)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn resolve_original_dst(stream: &TcpStream) -> io::Result<SocketAddr> {
+    stream.peer_addr()
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_original_dst_linux(stream: &TcpStream) -> io::Result<SocketAddr> {
+    let fd = stream.as_raw_fd();
+    let mut sockaddr: libc::sockaddr_in = unsafe { mem::zeroed() };
+    let mut len = mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
+
+    let result = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_IP,
+            SO_ORIGINAL_DST,
+            (&mut sockaddr as *mut libc::sockaddr_in).cast(),
+            &mut len,
+        )
+    };
+
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let ip = Ipv4Addr::from(u32::from_be(sockaddr.sin_addr.s_addr));
+    let port = u16::from_be(sockaddr.sin_port);
+    Ok(SocketAddr::V4(SocketAddrV4::new(ip, port)))
+}

--- a/cli/dust-sandbox/src/commands/mod.rs
+++ b/cli/dust-sandbox/src/commands/mod.rs
@@ -2,5 +2,6 @@ pub mod forward;
 pub mod tools;
 mod version;
 
+pub use forward::cmd_forward;
 pub use tools::{cmd_exec, cmd_list_servers, cmd_list_tools};
 pub use version::cmd_version;

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -15,6 +15,8 @@ struct Cli {
 enum Commands {
     /// Print version information
     Version,
+    /// Forward sandbox egress traffic to the Dust egress proxy
+    Forward(commands::forward::ForwardArgs),
     /// Interact with MCP servers and tools
     Tools {
         /// Server name (omit to list all servers)
@@ -42,6 +44,7 @@ async fn run() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Version => commands::cmd_version(),
+        Commands::Forward(args) => commands::cmd_forward(args).await?,
         Commands::Tools {
             server_name,
             tool_name,


### PR DESCRIPTION
## Description

Third and final PR in the stack splitting #24344. Wires the primitives from PR 2 into a working `dsbx forward` subcommand that relays sandbox TCP traffic through the Dust egress proxy over TLS.

Stacked on top of PR 2 (forward primitives). Retarget to `main` after PR 2 lands.

New file:

- `forward/original_dst.rs` — recovers the original destination of an iptables-`REDIRECT`ed socket via `SO_ORIGINAL_DST` on Linux; non-Linux builds fall back to `peer_addr()` so `cargo test` passes on macOS dev machines.

Modified:

- `forward/mod.rs` — adds `ForwardArgs` (clap), `ForwardRuntime`, the accept loop, native-root TLS connector via `rustls-native-certs`, per-connection `handle_connection` (peek → TLS-connect proxy → write handshake frame → read 1-byte response → allow/deny), `extract_domain` dispatch (SNI for 443, Host header for 80, empty otherwise), deny-log integration for all three deny reasons.
- `commands/mod.rs`, `main.rs` — register the `Forward` clap variant + dispatch it.
- `Cargo.toml` — forward-specific runtime deps: `rustls`, `tokio-rustls`, `rustls-native-certs`, `libc`.

CLI surface:

```
dsbx forward \
  --token-file /etc/dust/egress-token \
  --proxy-addr <ip>:<port> \
  --proxy-tls-name egress-proxy.dust.tt \
  --listen 127.0.0.1:9990 \
  [--deny-log /tmp/dust-egress-denied.log]
```

Not in this PR (will ship via separate sandbox-image work): iptables `REDIRECT` rules, `dust-fwd` system user, front-side JWT minting, GCS policy writes. Those land as a separate sandbox-image PR per `notion-s7-network.md`.

## Tests

- `cargo test --manifest-path cli/dust-sandbox/Cargo.toml` green on macOS.
- Manual: `dsbx forward --help` shows all five flags (four required + optional `--deny-log`).
- End-to-end smoke against the live EU proxy (`eu.sandbox-egress.dust.tt:4443`) is still pending — requires the iptables `REDIRECT` setup from the upcoming sandbox-image PR. The wire protocol is already covered by `egress-proxy/scripts/smoke.ts`.

## Risk

Low. The subcommand is only reachable when invoked explicitly; nothing wires it into the sandbox image yet. Existing subcommands (`version`, `tools`) are untouched. New runtime deps are all widely-used (`rustls`, `tokio-rustls`, `rustls-native-certs`, `libc`).

Rollback: revert. No data / infra / state change.

## Deploy Plan

Ships with the next `dust-sandbox` binary build. Sandbox-image PR lands separately and is what actually activates `dsbx forward` for real traffic.