### PR TITLE
[front] allow `ask_user_question` tool for user messages originating from extension

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -84,6 +84,13 @@ import { startActiveObservation } from "@langfuse/tracing";
 import { Context, heartbeat } from "@temporalio/activity";
 import assert from "assert";
 
+const ASK_USER_QUESTION_ALLOWED_ORIGINS: UserMessageOrigin[] = [
+  "web",
+  "slack",
+  "extension",
+  "agent_sidekick",
+];
+
 // Concatenate two content strings, ensuring at least one whitespace character
 // between them when both are non-empty. This prevents words from being glued
 // together across successive LLM calls.
@@ -288,11 +295,6 @@ export async function runModel(
   }
 
   // Filter out ask_user_question for origins that don't support interactive questions.
-  const ASK_USER_QUESTION_ALLOWED_ORIGINS: UserMessageOrigin[] = [
-    "web",
-    "slack",
-    "agent_sidekick",
-  ];
   const filteredMcpActions = !ASK_USER_QUESTION_ALLOWED_ORIGINS.includes(
     userMessage.context.origin
   )


### PR DESCRIPTION
## Description

- This PR adds the extension as an allowed origin for adding the `ask_user_question` tool.
- Requires publishing an extension that contains the front-end code to handle those.
- Also moves the constant at the top of the file.

<img width="510" height="848" alt="Screenshot 2026-04-20 at 5 59 55 PM" src="https://github.com/user-attachments/assets/7831e5a9-74ca-4166-aed0-f90e83b6ffd8" />

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
