### PR TITLE
feat: reduce page size for google drive incremental sync

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -38,6 +38,8 @@ import type { GaxiosResponse } from "googleapis-common";
 import { GaxiosError } from "googleapis-common";
 import type { RedisClientType } from "redis";
 
+const PAGE_SIZE = 500;
+
 export async function incrementalSync(
   connectorId: ModelId,
   driveId: string,
@@ -95,7 +97,7 @@ export async function incrementalSync(
 
     let opts: drive_v3.Params$Resource$Changes$List = {
       pageToken: nextPageToken,
-      pageSize: 1000,
+      pageSize: PAGE_SIZE,
       fields: `nextPageToken, newStartPageToken, changes(changeType, fileId, time, removed, file(${FILE_ATTRIBUTES_TO_FETCH.join(",")}))`,
       includeItemsFromAllDrives: true,
       supportsAllDrives: true,


### PR DESCRIPTION
## Description

We have workflows failing with `startToCloseTimeout` (180 min) at the `incrementalSync` activity step:
- [Example 1](https://cloud.temporal.io/namespaces/eu-dust-prod.gmnlm/workflows/googleDrive-incrementalSync-274877910703-drive-0ADZt8PA142FLUk9PVA/019d906e-9ede-710a-b245-fc3a93f7a61c/history)
- [Example 2](https://cloud.temporal.io/namespaces/eu-dust-prod.gmnlm/workflows/googleDrive-incrementalSync-274877910703-drive-userspace/019d906e-9ed0-7ec8-b649-83ee87b8cecd/history)

Each page of 1000 changes is fully processed within a single activity execution. For large drives with heavy files, this can exceed the 180-minute timeout. Reducing to 500 halves the work per activity invocation, making timeouts less likely.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Reducing the page size will result in more API calls to Google Drive during incremental syncs, which could increase sync duration
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
Standard deployment
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
