### PR TITLE
Disable conversation input while compaction is running

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -7,6 +7,7 @@ import type {
 } from "@app/components/assistant/conversation/types";
 import {
   isAgentMessageWithStreaming,
+  isCompactionMessage,
   isHandoverUserMessage,
   isHiddenMessage,
   isUserMessage,
@@ -100,6 +101,11 @@ export const AgentInputBar = ({
     : null;
 
   const draftAgent = agentBuilderContext?.draftAgent;
+  const compactionBlockMessage = allMessages.some(
+    (message) => isCompactionMessage(message) && message.status === "created"
+  )
+    ? "Wait for compaction to finish"
+    : null;
 
   const autoMentions = useMemo(() => {
     // If we are in the agent builder, we show the draft agent as the sticky mention, all the time.
@@ -447,6 +453,7 @@ export const AgentInputBar = ({
         actions={agentBuilderContext?.actionsToShow}
         isSubmitting={agentBuilderContext?.isSubmitting === true}
         isAgentBuilder={!!agentBuilderContext}
+        compactionBlockMessage={compactionBlockMessage}
       />
     </div>
   );

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -453,7 +453,7 @@ export const AgentInputBar = ({
         actions={agentBuilderContext?.actionsToShow}
         isSubmitting={agentBuilderContext?.isSubmitting === true}
         isAgentBuilder={!!agentBuilderContext}
-        compactionBlockMessage={compactionBlockMessage}
+        submitBlockMessage={compactionBlockMessage}
       />
     </div>
   );

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -67,6 +67,7 @@ interface InputBarProps {
   isSubmitting?: boolean;
   disable?: boolean;
   isAgentBuilder?: boolean;
+  compactionBlockMessage?: string | null;
 }
 
 export const InputBar = React.memo(function InputBar({
@@ -84,6 +85,7 @@ export const InputBar = React.memo(function InputBar({
   isFloating = true,
   isSubmitting = false,
   disable = false,
+  compactionBlockMessage = null,
 }: InputBarProps) {
   const [isLocalSubmitting, setIsLocalSubmitting] = useState(isSubmitting);
   const { hasFeature } = useFeatureFlags();
@@ -185,6 +187,7 @@ export const InputBar = React.memo(function InputBar({
   ]);
 
   const isBlockedByAgentSwitch = agentSwitchBlockMessage !== null;
+  const submitBlockMessage = compactionBlockMessage ?? agentSwitchBlockMessage;
 
   // Tools selection
 
@@ -265,7 +268,7 @@ export const InputBar = React.memo(function InputBar({
       isLocalSubmitting ||
       isEmpty ||
       fileUploaderService.isProcessingFiles ||
-      isBlockedByAgentSwitch
+      submitBlockMessage !== null
     ) {
       return;
     }
@@ -479,7 +482,8 @@ export const InputBar = React.memo(function InputBar({
             saveDraft={saveDraft}
             getDraft={getDraft}
             user={user}
-            agentSwitchBlockMessage={agentSwitchBlockMessage}
+            disableAgentSelector={isBlockedByAgentSwitch}
+            submitBlockMessage={submitBlockMessage}
             onShake={handleShake}
           />
         </div>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -67,7 +67,7 @@ interface InputBarProps {
   isSubmitting?: boolean;
   disable?: boolean;
   isAgentBuilder?: boolean;
-  compactionBlockMessage?: string | null;
+  submitBlockMessage?: string | null;
 }
 
 export const InputBar = React.memo(function InputBar({
@@ -85,7 +85,7 @@ export const InputBar = React.memo(function InputBar({
   isFloating = true,
   isSubmitting = false,
   disable = false,
-  compactionBlockMessage = null,
+  submitBlockMessage: externalSubmitBlockMessage = null,
 }: InputBarProps) {
   const [isLocalSubmitting, setIsLocalSubmitting] = useState(isSubmitting);
   const { hasFeature } = useFeatureFlags();
@@ -187,7 +187,8 @@ export const InputBar = React.memo(function InputBar({
   ]);
 
   const isBlockedByAgentSwitch = agentSwitchBlockMessage !== null;
-  const submitBlockMessage = compactionBlockMessage ?? agentSwitchBlockMessage;
+  const submitBlockMessage =
+    externalSubmitBlockMessage ?? agentSwitchBlockMessage;
 
   // Tools selection
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -187,8 +187,8 @@ export const InputBar = React.memo(function InputBar({
   ]);
 
   const isBlockedByAgentSwitch = agentSwitchBlockMessage !== null;
-  const effectiveSubmitBlockMessage =
-    submitBlockMessage ?? agentSwitchBlockMessage;
+  const isBlockedForSubmission =
+    isBlockedByAgentSwitch || submitBlockMessage !== null;
 
   // Tools selection
 
@@ -269,7 +269,7 @@ export const InputBar = React.memo(function InputBar({
       isLocalSubmitting ||
       isEmpty ||
       fileUploaderService.isProcessingFiles ||
-      effectiveSubmitBlockMessage !== null
+      isBlockedForSubmission
     ) {
       return;
     }
@@ -484,7 +484,7 @@ export const InputBar = React.memo(function InputBar({
             getDraft={getDraft}
             user={user}
             disableAgentSelector={isBlockedByAgentSwitch}
-            submitBlockMessage={effectiveSubmitBlockMessage}
+            submitBlockMessage={submitBlockMessage ?? agentSwitchBlockMessage}
             onShake={handleShake}
           />
         </div>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -85,7 +85,7 @@ export const InputBar = React.memo(function InputBar({
   isFloating = true,
   isSubmitting = false,
   disable = false,
-  submitBlockMessage: externalSubmitBlockMessage = null,
+  submitBlockMessage = null,
 }: InputBarProps) {
   const [isLocalSubmitting, setIsLocalSubmitting] = useState(isSubmitting);
   const { hasFeature } = useFeatureFlags();
@@ -187,8 +187,8 @@ export const InputBar = React.memo(function InputBar({
   ]);
 
   const isBlockedByAgentSwitch = agentSwitchBlockMessage !== null;
-  const submitBlockMessage =
-    externalSubmitBlockMessage ?? agentSwitchBlockMessage;
+  const effectiveSubmitBlockMessage =
+    submitBlockMessage ?? agentSwitchBlockMessage;
 
   // Tools selection
 
@@ -269,7 +269,7 @@ export const InputBar = React.memo(function InputBar({
       isLocalSubmitting ||
       isEmpty ||
       fileUploaderService.isProcessingFiles ||
-      submitBlockMessage !== null
+      effectiveSubmitBlockMessage !== null
     ) {
       return;
     }
@@ -484,7 +484,7 @@ export const InputBar = React.memo(function InputBar({
             getDraft={getDraft}
             user={user}
             disableAgentSelector={isBlockedByAgentSwitch}
-            submitBlockMessage={submitBlockMessage}
+            submitBlockMessage={effectiveSubmitBlockMessage}
             onShake={handleShake}
           />
         </div>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -132,7 +132,8 @@ export interface InputBarContainerProps {
   actions: InputBarAction[];
   allAgents: LightAgentConfigurationType[];
   attachedNodes: DataSourceViewContentNode[];
-  agentSwitchBlockMessage: string | null;
+  disableAgentSelector: boolean;
+  submitBlockMessage: string | null;
   onShake: () => void;
   conversation?: ConversationWithoutContentType;
   space?: SpaceType;
@@ -193,10 +194,11 @@ const InputBarContainer = ({
   selectedSkills,
   saveDraft,
   user,
-  agentSwitchBlockMessage,
+  disableAgentSelector,
+  submitBlockMessage,
   onShake,
 }: InputBarContainerProps) => {
-  const isBlockedByAgentSwitch = agentSwitchBlockMessage !== null;
+  const isSubmitBlocked = submitBlockMessage !== null;
   const { subscription } = useAuth();
   const isMobile = useIsMobile();
   const { hasFeature } = useFeatureFlags();
@@ -403,7 +405,7 @@ const InputBarContainer = ({
   // Wrap onEnterKeyDown so that a blocked Enter attempt triggers the shake animation.
   const onEnterKeyDownWithShake: typeof onEnterKeyDown = useCallback(
     (isEmpty, markdownAndMentions, resetEditorText, setLoading) => {
-      if (isBlockedByAgentSwitch) {
+      if (isSubmitBlocked) {
         onShake();
         return;
       }
@@ -414,7 +416,7 @@ const InputBarContainer = ({
         setLoading
       );
     },
-    [isBlockedByAgentSwitch, canSubmitEmpty, onEnterKeyDown, onShake]
+    [isSubmitBlocked, canSubmitEmpty, onEnterKeyDown, onShake]
   );
 
   onFirstAgentMentionPasteRef.current = singleAgentInput
@@ -918,7 +920,7 @@ const InputBarContainer = ({
     (isEmpty && !canSubmitEmpty) ||
     isSubmitting ||
     disableInput ||
-    isBlockedByAgentSwitch ||
+    isSubmitBlocked ||
     voiceTranscriberService.status !== "idle";
 
   const [isToolbarOpen, setIsToolbarOpen] = useState(false);
@@ -1116,7 +1118,7 @@ const InputBarContainer = ({
                     buttonSize={buttonSize}
                     clientType={clientType}
                     conversation={conversation}
-                    disableAgentSelector={isBlockedByAgentSwitch}
+                    disableAgentSelector={disableAgentSelector}
                     disableInput={disableInput}
                     editorService={editorService}
                     fileInputRef={fileInputRef}
@@ -1265,11 +1267,11 @@ const InputBarContainer = ({
               isSubmitting && voiceTranscriberService.status !== "transcribing"
             }
             icon={ArrowUpIcon}
-            variant={isBlockedByAgentSwitch ? "ghost-secondary" : "highlight"}
+            variant={isSubmitBlocked ? "ghost-secondary" : "highlight"}
             disabled={isSubmitDisabled}
-            tooltip={agentSwitchBlockMessage ?? undefined}
+            tooltip={submitBlockMessage ?? undefined}
             className={cn(
-              isBlockedByAgentSwitch &&
+              isSubmitBlocked &&
                 "hover:s-bg-transparent dark:hover:s-bg-transparent hover:s-text-muted-foreground dark:hover:s-text-muted-foreground-night"
             )}
             onClick={async (e: React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION

## Description

Fixes: https://github.com/dust-tt/tasks/issues/7610

- disable the conversation input while a compaction message is running
- reuse the same submit-button disabled state, visual treatment, and tooltip pattern already used when agent switching is blocked during generation
- show the tooltip `Wait for compaction to finish` while compaction is in progress

<img width="755" height="165" alt="Screenshot 2026-04-16 at 15 18 35" src="https://github.com/user-attachments/assets/359be4c5-eea0-491c-8127-2de79003a0ae" />

## Tests

- tested locally

## Risk

Low. This only changes the client-side input bar behavior while a compaction is in progress.

## Deploy Plan

- deploy `front`