### PR TITLE
[front] chore: replace checkbox for making skill discoverable with toggle

### DIFF
--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -1,6 +1,5 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import {
-  Checkbox,
   ContentMessage,
   Dialog,
   DialogContent,
@@ -9,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
   InformationCircleIcon,
+  SliderToggle,
   Tooltip,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -24,8 +24,8 @@ export function SkillBuilderIsDefaultSection() {
   const isDescriptionTooShort =
     agentFacingDescription.trim().length < MIN_DISCOVERABLE_DESCRIPTION_LENGTH;
 
-  const handleCheckboxChange = (checked: boolean) => {
-    if (checked) {
+  const handleToggle = () => {
+    if (!isDefault) {
       setShowConfirmDialog(true);
     } else {
       setValue("isDefault", false, { shouldDirty: true });
@@ -40,11 +40,7 @@ export function SkillBuilderIsDefaultSection() {
   return (
     <>
       <div className="flex items-center gap-2">
-        <Checkbox
-          checked={isDefault}
-          onCheckedChange={handleCheckboxChange}
-          size="sm"
-        />
+        <SliderToggle selected={isDefault} onClick={handleToggle} size="xs" />
         <span className="text-sm text-foreground dark:text-foreground-night">
           Allow agents to discover this skill
         </span>


### PR DESCRIPTION
## Description

- This PR replaces the checkbox for making a skill discoverable in Skill Builder with a toggle.

<img width="708" height="354" alt="Screenshot 2026-04-16 at 3 20 43 PM" src="https://github.com/user-attachments/assets/11797146-e1ee-460c-b413-52d22b1f735c" />

## Tests

- Tested locally.

## Risk

- Low. UI-only change, very local.

## Deploy Plan

- Deploy front.
