### PR TITLE
[skills] Add withTools query param to Skills API

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -27,7 +27,7 @@ import {
   trackEvent,
 } from "@app/lib/tracking";
 import type {
-  SkillType,
+  SkillWithoutToolsType,
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
@@ -50,7 +50,7 @@ import {
 import { useEffect, useMemo, useState } from "react";
 
 type MergedCapabilityItem =
-  | { kind: "skill"; skill: SkillType; sortName: string }
+  | { kind: "skill"; skill: SkillWithoutToolsType; sortName: string }
   | { kind: "tool"; serverView: MCPServerViewType; sortName: string };
 
 function CapabilitiesPickerLoading({ count = 5 }: { count?: number }) {
@@ -72,8 +72,8 @@ function CapabilitiesPickerLoading({ count = 5 }: { count?: number }) {
 }
 
 interface SkillMenuItemProps {
-  skill: SkillType;
-  onSelect: (skill: SkillType) => void;
+  skill: SkillWithoutToolsType;
+  onSelect: (skill: SkillWithoutToolsType) => void;
   onDetails: (skillSId: string) => void;
   closeDropdown: () => void;
 }
@@ -246,8 +246,8 @@ interface CapabilitiesPickerProps {
   user: UserType | null;
   selectedMCPServerViews: MCPServerViewType[];
   onSelect: (serverView: MCPServerViewType) => void;
-  selectedSkills: SkillType[];
-  onSkillSelect: (skill: SkillType) => void;
+  selectedSkills: SkillWithoutToolsType[];
+  onSkillSelect: (skill: SkillWithoutToolsType) => void;
   isLoading?: boolean;
   disabled?: boolean;
   buttonSize?: "xs" | "sm" | "md";
@@ -366,6 +366,7 @@ export function CapabilitiesPicker({
     status: "active",
     globalSpaceOnly: true,
     disabled: !shouldFetchToolsData,
+    withTools: false,
   });
 
   const isSkillsDataReady = !isSkillsLoading;

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -25,7 +25,7 @@ import {
 } from "@app/types/assistant/assistant";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { SkillWithoutToolsType } from "@app/types/assistant/skill_configuration";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { isEqualNode } from "@app/types/data_source_view";
@@ -190,7 +190,9 @@ export const InputBar = React.memo(function InputBar({
     MCPServerViewType[]
   >([]);
 
-  const [selectedSkills, setSelectedSkills] = useState<SkillType[]>([]);
+  const [selectedSkills, setSelectedSkills] = useState<SkillWithoutToolsType[]>(
+    []
+  );
 
   const { conversationTools } = useConversationTools({
     conversationId: conversation?.sId,
@@ -237,12 +239,12 @@ export const InputBar = React.memo(function InputBar({
     void deleteTool(serverView.sId);
   };
 
-  const handleSkillSelect = (skill: SkillType) => {
+  const handleSkillSelect = (skill: SkillWithoutToolsType) => {
     setSelectedSkills((prev) => [...prev, skill]);
     void addSkill(skill.sId);
   };
 
-  const handleSkillDeselect = (skill: SkillType) => {
+  const handleSkillDeselect = (skill: SkillWithoutToolsType) => {
     setSelectedSkills((prev) => prev.filter((s) => s.sId !== skill.sId));
     void deleteSkill(skill.sId);
   };

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -14,7 +14,7 @@ import type {
   RichMention,
 } from "@app/types/assistant/mentions";
 import { toRichAgentMentionType } from "@app/types/assistant/mentions";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { SkillWithoutToolsType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { getSupportedFileExtensions } from "@app/types/files";
 import type { SpaceType } from "@app/types/space";
@@ -37,11 +37,11 @@ interface InputBarButtonsProps {
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
-  onSkillSelect: (skill: SkillType) => void;
+  onSkillSelect: (skill: SkillWithoutToolsType) => void;
   owner: WorkspaceType;
   selectedAgent: RichAgentMention | null;
   selectedMCPServerViews: MCPServerViewType[];
-  selectedSkills: SkillType[];
+  selectedSkills: SkillWithoutToolsType[];
   space: SpaceType | undefined;
   user: UserType | null;
 }

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -36,7 +36,7 @@ import {
   isRichAgentMention,
   toRichAgentMentionType,
 } from "@app/types/assistant/mentions";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { SkillWithoutToolsType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -142,14 +142,14 @@ export interface InputBarContainerProps {
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
   onResetSelections: () => void;
-  onSkillDeselect: (skill: SkillType) => void;
-  onSkillSelect: (skill: SkillType) => void;
+  onSkillDeselect: (skill: SkillWithoutToolsType) => void;
+  onSkillSelect: (skill: SkillWithoutToolsType) => void;
   owner: WorkspaceType;
   saveDraft: (markdown: string, agentMention?: RichAgentMention | null) => void;
   pendingInputText: string | null;
   selectedAgent: RichAgentMention | null;
   selectedMCPServerViews: MCPServerViewType[];
-  selectedSkills: SkillType[];
+  selectedSkills: SkillWithoutToolsType[];
   stickyMentions?: RichMention[];
   user: UserType | null;
 }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -505,7 +505,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const workspace = auth.getNonNullableWorkspace();
     const { agentLoopData, transaction } = context;
 
-    const { where, includes, onlyCustom, ...otherOptions } = options;
+    const {
+      where,
+      includes,
+      onlyCustom,
+      withTools = true,
+      ...otherOptions
+    } = options;
 
     const customSkills = await this.model.findAll({
       ...otherOptions,
@@ -548,16 +554,27 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     let allowedCustomSkillsRes: SkillResource[] = [];
     if (allowedCustomSkills.length > 0) {
-      const mcpServerConfigurations =
-        await SkillMCPServerConfigurationModel.findAll({
-          where: {
-            workspaceId: workspace.id,
-            skillConfigurationId: {
-              [Op.in]: allowedCustomSkillIds,
+      let mcpServerConfigurations: SkillMCPServerConfigurationModel[] = [];
+      let allMCPServerViews: MCPServerViewResource[] = [];
+
+      if (withTools) {
+        mcpServerConfigurations =
+          await SkillMCPServerConfigurationModel.findAll({
+            where: {
+              workspaceId: workspace.id,
+              skillConfigurationId: {
+                [Op.in]: allowedCustomSkillIds,
+              },
             },
-          },
-          transaction,
-        });
+            transaction,
+          });
+
+        allMCPServerViews = await MCPServerViewResource.fetchByModelIds(
+          auth,
+          removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId)),
+          { includeMetadata: false }
+        );
+      }
 
       const skillMCPServerConfigsBySkillId = groupBy(
         mcpServerConfigurations,
@@ -644,12 +661,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }
       }
 
-      const allMCPServerViews = await MCPServerViewResource.fetchByModelIds(
-        auth,
-        removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId)),
-        { includeMetadata: false, transaction }
-      );
-
       allowedCustomSkillsRes = allowedCustomSkills.map((customSkill) => {
         const skillMCPServerViewIds = skillMCPServerConfigsBySkillId[
           customSkill.id
@@ -695,7 +706,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           if (agentLoopData && def.isDisabledForAgentLoop?.(agentLoopData)) {
             return null;
           }
-          return this.fromGlobalSkill(auth, def, context);
+          return this.fromGlobalSkill(auth, def, context, { withTools });
         },
         { concurrency: 5 }
       )
@@ -1020,6 +1031,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       isDefault,
       updatedAfter,
       reinforcementNotOff,
+      withTools = true,
     }: {
       status?: SkillStatus | SkillStatus[];
       limit?: number;
@@ -1028,6 +1040,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       isDefault?: boolean;
       updatedAfter?: Date;
       reinforcementNotOff?: boolean;
+      withTools?: boolean;
     } = {}
   ): Promise<SkillResource[]> {
     const skills = await this.baseFetch(auth, {
@@ -1039,6 +1052,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       },
       ...(limit ? { limit } : {}),
       onlyCustom,
+      withTools,
     });
 
     if (globalSpaceOnly) {
@@ -1394,6 +1408,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }: {
       agentLoopData?: AgentLoopExecutionData;
       transaction?: Transaction;
+    } = {},
+    {
+      withTools = true,
+    }: {
+      withTools?: boolean;
     } = {}
   ): Promise<SkillResource> {
     const { agentConfiguration } = agentLoopData ?? {};
@@ -1404,7 +1423,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     let mcpServerConfigurations: SkillMCPServerConfiguration[] = [];
 
-    if (def.mcpServers) {
+    if (withTools && def.mcpServers) {
       const mcpServerConfigurationsByName = await concurrentExecutor(
         def.mcpServers,
         async ({ name, childAgentId, serverNameOverride }) => {

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -15,12 +15,14 @@ export type AllSkillConfigurationFindOptions = Omit<
     isDefault?: boolean;
   };
   onlyCustom?: false; // Default: include global skills.
+  withTools?: boolean;
 };
 
 // Full find options only custom skills from database.
 type CustomSkillConfigurationFindOptions =
   ResourceFindOptions<SkillConfigurationModel> & {
     onlyCustom: true; // Explicit: only custom skills.
+    withTools?: boolean;
   };
 
 export type SkillConfigurationFindOptions =

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -5,6 +5,7 @@ import type { DetectedSkillSummary } from "@app/lib/skill_detection";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   GetSkillsResponseBody,
+  GetSkillsWithoutToolsResponseBody,
   GetSkillsWithRelationsResponseBody,
 } from "@app/pages/api/w/[wId]/skills";
 import type {
@@ -18,6 +19,7 @@ import type { GetSimilarSkillsResponseBody } from "@app/pages/api/w/[wId]/skills
 import type {
   SkillStatus,
   SkillType,
+  SkillWithoutToolsType,
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import { isAPIErrorResponse } from "@app/types/error";
@@ -92,21 +94,56 @@ export function useSkill({
   };
 }
 
+export function useSkills(options: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+  status?: SkillStatus;
+  globalSpaceOnly?: boolean;
+  isDefault?: boolean;
+  withTools: false;
+}): {
+  skills: SkillWithoutToolsType[];
+  isSkillsError: boolean;
+  isSkillsLoading: boolean;
+  mutateSkills: () => void;
+};
+export function useSkills(options: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+  status?: SkillStatus;
+  globalSpaceOnly?: boolean;
+  isDefault?: boolean;
+  withTools?: true;
+}): {
+  skills: SkillType[];
+  isSkillsError: boolean;
+  isSkillsLoading: boolean;
+  mutateSkills: () => void;
+};
 export function useSkills({
   owner,
   disabled,
   status,
   globalSpaceOnly,
   isDefault,
+  withTools = true,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
   status?: SkillStatus;
   globalSpaceOnly?: boolean;
   isDefault?: boolean;
-}) {
+  withTools?: boolean;
+}): {
+  skills: SkillWithoutToolsType[] | SkillType[];
+  isSkillsError: boolean;
+  isSkillsLoading: boolean;
+  mutateSkills: () => void;
+} {
   const { fetcher } = useFetcher();
-  const skillsFetcher: Fetcher<GetSkillsResponseBody> = fetcher;
+  const skillsFetcher: Fetcher<
+    GetSkillsWithoutToolsResponseBody | GetSkillsResponseBody
+  > = fetcher;
 
   const queryParams = new URLSearchParams();
   if (status) {
@@ -117,6 +154,9 @@ export function useSkills({
   }
   if (isDefault) {
     queryParams.set("isDefault", "true");
+  }
+  if (!withTools) {
+    queryParams.set("withTools", "false");
   }
   const queryString = queryParams.toString();
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -11,6 +11,7 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type {
   SkillType,
+  SkillWithoutToolsType,
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -21,6 +22,10 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import uniq from "lodash/uniq";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetSkillsWithoutToolsResponseBody = {
+  skills: SkillWithoutToolsType[];
+};
 
 export type GetSkillsResponseBody = {
   skills: SkillType[];
@@ -93,6 +98,7 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<
+      | GetSkillsWithoutToolsResponseBody
       | GetSkillsResponseBody
       | GetSkillsWithRelationsResponseBody
       | PostSkillResponseBody
@@ -104,7 +110,18 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const { withRelations, status, globalSpaceOnly, isDefault } = req.query;
+      const { withRelations, withTools, status, globalSpaceOnly, isDefault } =
+        req.query;
+
+      if (withRelations === "true" && withTools === "false") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "withTools=false is incompatible with withRelations=true.",
+          },
+        });
+      }
 
       const statusValidation = SkillStatusSchema.decode(status);
       if (isLeft(statusValidation)) {
@@ -118,10 +135,14 @@ async function handler(
       }
       const skillStatus = statusValidation.right;
 
+      // withTools defaults to true
+      const shouldIncludeTools = withTools !== "false";
+
       const skills = await SkillResource.listByWorkspace(auth, {
         status: skillStatus,
         globalSpaceOnly: globalSpaceOnly === "true",
         isDefault: isDefault === "true" ? true : undefined,
+        withTools: shouldIncludeTools,
       });
 
       if (withRelations === "true") {
@@ -157,6 +178,15 @@ async function handler(
         );
 
         return res.status(200).json({ skills: skillsWithRelations });
+      }
+
+      if (!shouldIncludeTools) {
+        return res.status(200).json({
+          skills: skills.map((sc) => {
+            const { tools: _tools, ...withoutTools } = sc.toJSON(auth);
+            return withoutTools;
+          }),
+        });
       }
 
       return res.status(200).json({

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -25,7 +25,7 @@ export const SkillSourceMetadataSchema = z.object({
 
 export type SkillSourceMetadata = z.infer<typeof SkillSourceMetadataSchema>;
 
-export const SkillSchema = z.object({
+export const SkillWithoutToolsSchema = z.object({
   id: z.number(),
   sId: z.string(),
   createdAt: z.number().nullable(),
@@ -43,7 +43,6 @@ export const SkillSchema = z.object({
   reinforcement: z.enum(SKILL_REINFORCEMENT_MODES).optional(),
   lastReinforcementAnalysisAt: z.string().nullable().optional(),
   requestedSpaceIds: z.array(z.string()),
-  tools: z.array(MCPServerViewSchema),
   fileAttachments: z.array(
     z.object({
       fileId: z.string(),
@@ -54,6 +53,12 @@ export const SkillSchema = z.object({
   isExtendable: z.boolean(),
   isDefault: z.boolean(),
   extendedSkillId: z.string().nullable(),
+});
+
+export type SkillWithoutToolsType = z.infer<typeof SkillWithoutToolsSchema>;
+
+export const SkillSchema = SkillWithoutToolsSchema.extend({
+  tools: z.array(MCPServerViewSchema),
 });
 
 export type SkillType = z.infer<typeof SkillSchema>;


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/7443

- Separates SkillWithoutToolsType from SkillType (full, includes MCP server views).
- Add withTools parameter to skills APIs
- The withTools param defaults to true for backward compatibility
- Passing withTools=false skips MCP server DB fetches entirely rather than just omitting the field from the response.
- Used only in CapabilitiesPicker for the moment
- All the other calls default to SkillType

## Tests

- Tested locally in CapabilitiesPicker

## Risk

Medium, impacts everywhere Skills are used

## Deploy Plan

Deploy front