### PR TITLE
Refine compaction button behavior

### DIFF
--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -96,18 +96,20 @@ export function ContextUsageIndicator({
                 The current context usage is at {percentage}%
               </span>
             </div>
-            <Button
-              variant="outline"
-              size="xs"
-              label="Compact now"
-              onClick={() => {
-                if (contextUsage?.model) {
-                  void compact(contextUsage.model);
-                }
-              }}
-              disabled={isCompacting || !contextUsage?.model}
-              isLoading={isCompacting}
-            />
+            {percentage > 33 && (
+              <Button
+                variant="outline"
+                size="xs"
+                label={isCompacting ? "Compacting" : "Compact now"}
+                onClick={() => {
+                  if (contextUsage?.model) {
+                    void compact(contextUsage.model);
+                  }
+                }}
+                disabled={isCompacting || !contextUsage?.model}
+                isLoading={isCompacting}
+              />
+            )}
           </div>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/7586

- change the compaction button label to `Compacting` while a compaction is in progress
- only show the compaction button once context usage is above 33%

## Tests

- `cd front && npx tsgo --noEmit`

## Risk

Low. This only changes the visibility and label of the client-side compaction button.

## Deploy Plan

- deploy `front`