### PR TITLE
Add recurring credits to existing contracts

### DIFF
--- a/front/scripts/backfill_metronome_recurring_credits.ts
+++ b/front/scripts/backfill_metronome_recurring_credits.ts
@@ -1,0 +1,149 @@
+/**
+ * Backfill a recurring $0 credit to existing Metronome contracts.
+ *
+ * For each workspace with a Metronome customer ID, lists all active contracts
+ * directly from Metronome and adds a monthly recurring commit with $0 amount
+ * using the Free Monthly Credits product. The credit amount is expected to be
+ * updated each billing period via the credit.segment.start webhook
+ * (see updateMetronomeCreditSegmentAmount).
+ *
+ * Idempotent: checks whether a recurring commit with the Free Monthly Credits
+ * product already exists on each contract before adding one.
+ * Re-running the script will not create duplicate entries.
+ *
+ * Run with: npx tsx scripts/backfill_metronome_recurring_credits.ts [--execute] [--workspaceId <sId>]
+ */
+
+import { floorToHourISO, getMetronomeClient } from "@app/lib/metronome/client";
+import {
+  CURRENCY_TO_CREDIT_TYPE_ID,
+  getProductFreeMonthlyCreditId,
+} from "@app/lib/metronome/constants";
+import type { Logger } from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
+
+async function backfillRecurringCreditForWorkspace(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return; // Workspace not provisioned in Metronome — skip.
+  }
+
+  const client = getMetronomeClient();
+
+  // List all contracts for this customer directly from Metronome.
+  let contracts;
+  try {
+    const contractsResponse = await client.v2.contracts.list({
+      customer_id: metronomeCustomerId,
+    });
+    contracts = contractsResponse.data;
+  } catch (err) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId,
+        error: normalizeError(err).message,
+      },
+      "[Backfill] Failed to list contracts from Metronome"
+    );
+    return;
+  }
+
+  const freeCreditProductId = getProductFreeMonthlyCreditId();
+  const creditTypeId = CURRENCY_TO_CREDIT_TYPE_ID["usd"];
+
+  for (const contract of contracts) {
+    const contractId = contract.id;
+
+    const existingCommitProductIds = new Set(
+      (contract.recurring_commits ?? []).map((c) => c.product.id)
+    );
+
+    if (existingCommitProductIds.has(freeCreditProductId)) {
+      logger.info(
+        { workspaceId: workspace.sId, contractId },
+        "[Backfill] Recurring credit already exists on contract, skipping"
+      );
+      continue;
+    }
+
+    const startingAt = floorToHourISO(new Date(contract.starting_at));
+
+    const recurringCommit = {
+      product_id: freeCreditProductId,
+      name: "Monthly Free Credit",
+      starting_at: startingAt,
+      priority: 1, // Apply before prepaid commits.
+      access_amount: {
+        credit_type_id: creditTypeId,
+        unit_price: 0,
+        quantity: 1,
+      },
+      invoice_amount: {
+        credit_type_id: creditTypeId,
+        unit_price: 0,
+        quantity: 1,
+      },
+      commit_duration: { value: 1, unit: "PERIODS" as const },
+      recurrence_frequency: "MONTHLY" as const,
+      applicable_product_tags: ["usage"],
+    };
+
+    if (!execute) {
+      logger.info(
+        { workspaceId: workspace.sId, contractId, recurringCommit },
+        "[Backfill] [DRY RUN] Would add recurring credit to contract"
+      );
+      continue;
+    }
+
+    try {
+      await client.v2.contracts.edit({
+        customer_id: metronomeCustomerId,
+        contract_id: contractId,
+        add_recurring_commits: [recurringCommit],
+      });
+
+      logger.info(
+        { workspaceId: workspace.sId, contractId },
+        "[Backfill] Successfully added recurring credit to contract"
+      );
+    } catch (err) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          contractId,
+          error: normalizeError(err).message,
+        },
+        "[Backfill] Failed to add recurring credit to contract"
+      );
+    }
+  }
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string" as const,
+      description:
+        "Optional workspace sId to process (processes all if omitted)",
+      required: false,
+    },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await backfillRecurringCreditForWorkspace(workspace, execute, logger);
+      },
+      { concurrency: 4, wId: workspaceId }
+    );
+  }
+);


### PR DESCRIPTION
## Description

Adds a backfill script to provision recurring monthly free credits on existing Metronome contracts. The script lists all active contracts for workspaces with a Metronome customer ID and adds a monthly recurring commit using the "Free Monthly Credits" product with $0 initial amount. The actual credit amount will be calculated and updated each billing period via the `credit.segment.start` webhook handler (implemented in #24354). The script is idempotent—it checks whether a recurring commit with the Free Monthly Credits product already exists before adding one.

## Tests

Tested manually in dry-run mode and execute mode.

## Risk

Low. The script is idempotent and safe to re-run. No database schema changes or library upgrades.

## Deploy Plan

Deploy front, then run: `npx tsx scripts/backfill_metronome_recurring_credits.ts --execute`