### PR TITLE
[front] enh: refactor shared slash command dropdown

### DIFF
--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -39,8 +39,7 @@ export interface SlashCommandDropdownProps
   emptyMessage?: string;
   header?: React.ReactNode;
   itemsClassName?: string;
-  onEscapeKeyDown?: () => void;
-  onInteractOutside?: () => void;
+  onClose?: () => void;
 }
 
 export interface SlashCommandDropdownRef {
@@ -60,8 +59,7 @@ export const SlashCommandDropdown = forwardRef<
       emptyMessage = "No commands found",
       header,
       itemsClassName,
-      onEscapeKeyDown,
-      onInteractOutside,
+      onClose,
     },
     ref
   ) => {
@@ -169,8 +167,8 @@ export const SlashCommandDropdown = forwardRef<
           collisionPadding={12}
           side="bottom"
           sideOffset={4}
-          onEscapeKeyDown={onEscapeKeyDown}
-          onInteractOutside={onInteractOutside}
+          onEscapeKeyDown={onClose}
+          onInteractOutside={onClose}
           onCloseAutoFocus={(e) => e.preventDefault()}
           onOpenAutoFocus={(e) => e.preventDefault()}
         >

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -23,6 +23,7 @@ interface SlashCommandTooltip {
 
 export interface SlashCommand {
   action: string;
+  description?: string;
   icon: React.ComponentType<any>;
   id: string;
   label: string;
@@ -30,7 +31,17 @@ export interface SlashCommand {
 }
 
 export interface SlashCommandDropdownProps
-  extends SuggestionProps<SlashCommand> {}
+  extends Pick<
+    SuggestionProps<SlashCommand>,
+    "clientRect" | "command" | "items"
+  > {
+  className?: string;
+  emptyMessage?: string;
+  header?: React.ReactNode;
+  itemsClassName?: string;
+  onEscapeKeyDown?: () => void;
+  onInteractOutside?: () => void;
+}
 
 export interface SlashCommandDropdownRef {
   onKeyDown: (props: { event: KeyboardEvent }) => boolean;
@@ -39,141 +50,179 @@ export interface SlashCommandDropdownRef {
 export const SlashCommandDropdown = forwardRef<
   SlashCommandDropdownRef,
   SlashCommandDropdownProps
->(({ items, command, clientRect }, ref) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLDivElement>(null);
-  const [virtualTriggerStyle, setVirtualTriggerStyle] =
-    useState<React.CSSProperties>({});
-
-  const selectItem = useCallback(
-    (index: number) => {
-      const item = items[index];
-      if (item) {
-        command(item);
-      }
+>(
+  (
+    {
+      items,
+      command,
+      clientRect,
+      className = "w-64",
+      emptyMessage = "No commands found",
+      header,
+      itemsClassName,
+      onEscapeKeyDown,
+      onInteractOutside,
     },
-    [command, items]
-  );
+    ref
+  ) => {
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const selectedItemRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLDivElement>(null);
+    const [virtualTriggerStyle, setVirtualTriggerStyle] =
+      useState<React.CSSProperties>({});
 
-  useImperativeHandle(
-    ref,
-    () => ({
-      onKeyDown: ({ event }) => {
-        if (event.key === "ArrowDown") {
-          event.preventDefault();
-          setSelectedIndex((selectedIndex + 1) % items.length);
-          return true;
+    const selectItem = useCallback(
+      (index: number) => {
+        const item = items[index];
+        if (item) {
+          command(item);
         }
-
-        if (event.key === "ArrowUp") {
-          event.preventDefault();
-          setSelectedIndex((selectedIndex + items.length - 1) % items.length);
-          return true;
-        }
-
-        if (event.key === "Enter" || event.key === "Tab") {
-          event.preventDefault();
-          selectItem(selectedIndex);
-          return true;
-        }
-
-        return false;
       },
-    }),
-    [selectItem, selectedIndex, items.length]
-  );
+      [command, items]
+    );
 
-  // Reset selected index when items change.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
-  useEffect(() => {
-    setSelectedIndex(0);
-  }, [items.length]);
+    useImperativeHandle(
+      ref,
+      () => ({
+        onKeyDown: ({ event }) => {
+          if (items.length === 0) {
+            return false;
+          }
 
-  // Update virtual trigger position.
-  const updateTriggerPosition = useCallback(() => {
-    const triggerRect = clientRect?.();
-    if (triggerRect && triggerRef.current) {
-      setVirtualTriggerStyle({
-        position: "fixed",
-        left: triggerRect.left,
-        top: triggerRect.top + (window.visualViewport?.offsetTop ?? 0),
-        width: 1,
-        height: triggerRect.height || 1,
-        pointerEvents: "none",
-        zIndex: -1,
+          if (event.key === "ArrowDown") {
+            event.preventDefault();
+            setSelectedIndex((selectedIndex + 1) % items.length);
+            return true;
+          }
+
+          if (event.key === "ArrowUp") {
+            event.preventDefault();
+            setSelectedIndex((selectedIndex + items.length - 1) % items.length);
+            return true;
+          }
+
+          if (event.key === "Enter" || event.key === "Tab") {
+            event.preventDefault();
+            selectItem(selectedIndex);
+            return true;
+          }
+
+          return false;
+        },
+      }),
+      [selectItem, selectedIndex, items.length]
+    );
+
+    // Reset selected index when items change.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
+    useEffect(() => {
+      setSelectedIndex(0);
+    }, [items.length]);
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: selectedIndex drives which item owns the ref.
+    useEffect(() => {
+      selectedItemRef.current?.scrollIntoView({
+        block: "nearest",
       });
-    }
-  }, [clientRect]);
+    }, [selectedIndex]);
 
-  useEffect(() => {
-    updateTriggerPosition();
+    // Update virtual trigger position.
+    const updateTriggerPosition = useCallback(() => {
+      const triggerRect = clientRect?.();
+      if (triggerRect && triggerRef.current) {
+        setVirtualTriggerStyle({
+          position: "fixed",
+          left: triggerRect.left,
+          top: triggerRect.top + (window.visualViewport?.offsetTop ?? 0),
+          width: 1,
+          height: triggerRect.height || 1,
+          pointerEvents: "none",
+          zIndex: -1,
+        });
+      }
+    }, [clientRect]);
 
-    const viewport = window.visualViewport;
-    if (viewport) {
-      // Event triggered when hitting CMD +/-.
-      viewport.addEventListener("resize", updateTriggerPosition);
-      return () => {
-        viewport.removeEventListener("resize", updateTriggerPosition);
-      };
-    }
-  }, [updateTriggerPosition]);
+    useEffect(() => {
+      updateTriggerPosition();
 
-  return (
-    <DropdownMenu open={true}>
-      <DropdownMenuTrigger asChild>
-        <div ref={triggerRef} style={virtualTriggerStyle} />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        ref={containerRef}
-        className="w-64"
-        align="start"
-        side="bottom"
-        sideOffset={4}
-        onCloseAutoFocus={(e) => e.preventDefault()}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-      >
-        {items.length === 0 ? (
-          <div className="px-2 py-4 text-center text-sm text-muted-foreground">
-            No commands found
-          </div>
-        ) : (
-          items.map((item, index) => {
-            const menuItem = (
-              <DropdownMenuItem
-                key={item.id}
-                icon={item.icon}
-                label={item.label}
-                truncateText
-                onClick={() => selectItem(index)}
-                onMouseEnter={() => setSelectedIndex(index)}
-                className={
-                  index === selectedIndex ? "bg-gray-100 dark:bg-gray-800" : ""
+      const viewport = window.visualViewport;
+      if (viewport) {
+        // Event triggered when hitting CMD +/-.
+        viewport.addEventListener("resize", updateTriggerPosition);
+        return () => {
+          viewport.removeEventListener("resize", updateTriggerPosition);
+        };
+      }
+    }, [updateTriggerPosition]);
+
+    return (
+      <DropdownMenu open={true}>
+        <DropdownMenuTrigger asChild>
+          <div ref={triggerRef} style={virtualTriggerStyle} />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          ref={containerRef}
+          className={className}
+          align="start"
+          avoidCollisions
+          collisionPadding={12}
+          side="bottom"
+          sideOffset={4}
+          onEscapeKeyDown={onEscapeKeyDown}
+          onInteractOutside={onInteractOutside}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          {header}
+          {items.length === 0 ? (
+            <div className="px-2 py-4 text-center text-sm text-muted-foreground">
+              {emptyMessage}
+            </div>
+          ) : (
+            <div className={itemsClassName}>
+              {items.map((item, index) => {
+                const menuItem = (
+                  <DropdownMenuItem
+                    key={item.id}
+                    ref={index === selectedIndex ? selectedItemRef : null}
+                    icon={item.icon}
+                    label={item.label}
+                    description={item.description}
+                    truncateText
+                    onClick={() => selectItem(index)}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    className={
+                      index === selectedIndex
+                        ? "bg-gray-100 dark:bg-gray-800"
+                        : ""
+                    }
+                  />
+                );
+
+                // Wrap with DropdownTooltipTrigger if command has tooltip property.
+                if (item.tooltip) {
+                  return (
+                    <DropdownTooltipTrigger
+                      key={item.id}
+                      description={item.tooltip.description}
+                      media={item.tooltip.media}
+                      side="right"
+                      sideOffset={8}
+                    >
+                      {menuItem}
+                    </DropdownTooltipTrigger>
+                  );
                 }
-              />
-            );
 
-            // Wrap with DropdownTooltipTrigger if command has tooltip property.
-            if (item.tooltip) {
-              return (
-                <DropdownTooltipTrigger
-                  key={item.id}
-                  description={item.tooltip.description}
-                  media={item.tooltip.media}
-                  side="right"
-                  sideOffset={8}
-                >
-                  {menuItem}
-                </DropdownTooltipTrigger>
-              );
-            }
-
-            return menuItem;
-          })
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-});
+                return menuItem;
+              })}
+            </div>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  }
+);
 
 SlashCommandDropdown.displayName = "SlashCommandDropdown";

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -6,9 +6,10 @@ import { SlashCommandDropdown } from "@app/components/editor/extensions/skill_bu
 import { AttachmentIcon } from "@dust-tt/sparkle";
 import { Extension } from "@tiptap/core";
 import { PluginKey } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
 import { ReactRenderer } from "@tiptap/react";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
-import { Suggestion } from "@tiptap/suggestion";
+import { exitSuggestion, Suggestion } from "@tiptap/suggestion";
 
 const slashCommandPluginKey = new PluginKey("slashCommand");
 
@@ -99,11 +100,25 @@ export const SlashCommandExtension =
           },
           render: () => {
             let component: ReactRenderer<SlashCommandDropdownRef> | null = null;
+            let activeEditorView: EditorView | null = null;
+
+            const closeSuggestionDropdown = () => {
+              if (!activeEditorView) {
+                return;
+              }
+
+              exitSuggestion(activeEditorView, slashCommandPluginKey);
+            };
 
             return {
               onStart: (props: SuggestionProps) => {
+                activeEditorView = props.editor.view;
                 component = new ReactRenderer(SlashCommandDropdown, {
-                  props,
+                  props: {
+                    ...props,
+                    onEscapeKeyDown: closeSuggestionDropdown,
+                    onInteractOutside: closeSuggestionDropdown,
+                  },
                   editor: props.editor,
                 });
 
@@ -115,7 +130,12 @@ export const SlashCommandExtension =
               },
 
               onUpdate(props: SuggestionProps) {
-                component?.updateProps(props);
+                activeEditorView = props.editor.view;
+                component?.updateProps({
+                  ...props,
+                  onEscapeKeyDown: closeSuggestionDropdown,
+                  onInteractOutside: closeSuggestionDropdown,
+                });
 
                 if (!props.clientRect) {
                   return;
@@ -124,9 +144,7 @@ export const SlashCommandExtension =
 
               onKeyDown(props: { event: KeyboardEvent }) {
                 if (props.event.key === "Escape") {
-                  component?.element?.remove();
-                  component?.destroy();
-                  component = null;
+                  closeSuggestionDropdown();
                   return true;
                 }
 
@@ -134,6 +152,7 @@ export const SlashCommandExtension =
               },
 
               onExit() {
+                activeEditorView = null;
                 component?.element?.remove();
                 component?.destroy();
                 component = null;

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -116,8 +116,7 @@ export const SlashCommandExtension =
                 component = new ReactRenderer(SlashCommandDropdown, {
                   props: {
                     ...props,
-                    onEscapeKeyDown: closeSuggestionDropdown,
-                    onInteractOutside: closeSuggestionDropdown,
+                    onClose: closeSuggestionDropdown,
                   },
                   editor: props.editor,
                 });
@@ -133,8 +132,7 @@ export const SlashCommandExtension =
                 activeEditorView = props.editor.view;
                 component?.updateProps({
                   ...props,
-                  onEscapeKeyDown: closeSuggestionDropdown,
-                  onInteractOutside: closeSuggestionDropdown,
+                  onClose: closeSuggestionDropdown,
                 });
 
                 if (!props.clientRect) {


### PR DESCRIPTION
## Description

This PR extends what the Slash command extension can do in preparation of using it for the `/skills` command in the input bar.
- Now accepts an optional description
- Accepts optional className, header, emptyMessage, itemsClassName for the dropdown.
- Accepts optional `onEscapeKeyDown` and `onInteractOutside`
- it scrolls the highlighted item into view during keyboard navigation
- enables collision handling (the input bar is usually at the bottom of the screen so the menu needs to flip instead of running off-screen)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy front.
