### PR TITLE
Clear dangling setTimeout on each SSE generator iteration

### DIFF
--- a/front/lib/api/assistant/mcp_events.ts
+++ b/front/lib/api/assistant/mcp_events.ts
@@ -8,7 +8,6 @@ import type { EventPayload } from "@app/lib/api/redis-hybrid-manager";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
 import { createCallbackReader } from "@app/lib/utils";
-import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 
 interface GetMCPEventsForServerOptions {
@@ -33,7 +32,7 @@ export async function* getMCPEventsForServer(
     { lastEventId }
   );
 
-  // Unsubscribe if the signal is aborted.
+  // Unsubscribe if the signal is aborted, to unblock the callbackReader.next() await below.
   signal.addEventListener("abort", unsubscribe, { once: true });
 
   try {
@@ -54,10 +53,15 @@ export async function* getMCPEventsForServer(
       if (signal.aborted) {
         break;
       }
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<"timeout">((resolve) => {
+        timeoutId = setTimeout(() => resolve("timeout"), MCP_EVENTS_TIMEOUT_MS);
+      });
       const rawEvent = await Promise.race([
         callbackReader.next(),
-        setTimeoutAsync(MCP_EVENTS_TIMEOUT_MS),
+        timeoutPromise,
       ]);
+      clearTimeout(timeoutId);
 
       // Determine if we timeouted.
       if (rawEvent === "timeout") {

--- a/front/lib/api/assistant/mcp_events.ts
+++ b/front/lib/api/assistant/mcp_events.ts
@@ -61,12 +61,12 @@ export async function* getMCPEventsForServer(
         callbackReader.next(),
         timeoutPromise,
       ]);
-      clearTimeout(timeoutId);
 
       // Determine if we timeouted.
       if (rawEvent === "timeout") {
         break;
       }
+      clearTimeout(timeoutId);
 
       if (rawEvent === "close") {
         break;

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -47,7 +47,7 @@ export async function* getConversationEvents({
     { lastEventId }
   );
 
-  // Unsubscribe if the signal is aborted
+  // Unsubscribe if the signal is aborted, to unblock the callbackReader.next() await below.
   signal.addEventListener("abort", unsubscribe, { once: true });
 
   try {
@@ -70,15 +70,15 @@ export async function* getConversationEvents({
       if (signal.aborted) {
         break;
       }
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
       const timeoutPromise = new Promise<"timeout">((resolve) => {
-        setTimeout(() => {
-          resolve("timeout");
-        }, TIMEOUT);
+        timeoutId = setTimeout(() => resolve("timeout"), TIMEOUT);
       });
       const rawEvent = await Promise.race([
         callbackReader.next(),
         timeoutPromise,
       ]);
+      clearTimeout(timeoutId);
 
       // Determine if we timeouted
       if (rawEvent === "timeout") {

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -78,12 +78,12 @@ export async function* getConversationEvents({
         callbackReader.next(),
         timeoutPromise,
       ]);
-      clearTimeout(timeoutId);
 
-      // Determine if we timeouted
+      // Determine if we timeouted.
       if (rawEvent === "timeout") {
         break;
       }
+      clearTimeout(timeoutId);
 
       if (rawEvent === "close") {
         break;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/24357.

Each iteration of the while (true) loop in `getConversationEvents` and `getMCPEventsForServer` races `callbackReader.next()` against a `setTimeout`. When `callbackReader.next()` wins, which is the common case for every real event, the timer is never cancelled.

The Promise object, its resolve closure, and the timer handle all stayed alive until the timer eventually fired, at which point
it resolved a Promise that nobody was awaiting anymore.

On a busy connection with frequent events, this stacks one leaked timer per event for the entire connection lifetime.

This PR fixes it by capturing the timer id and call `clearTimeout` immediately after `Promise.race` settles.

<img width="785" height="1226" alt="image" src="https://github.com/user-attachments/assets/d811a3ed-7875-4d91-a1b6-8aac6612390d" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
