### PR TITLE
Close compaction popover when compaction starts

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -48,6 +48,7 @@ import type { DustError } from "@app/lib/error";
 import {
   AgentMessageCompletedEvent,
   CompactionCompletedEvent,
+  CompactionStartedEvent,
 } from "@app/lib/notifications/events";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import logger from "@app/logger/logger";
@@ -596,6 +597,9 @@ export const ConversationViewer = ({
                   ref.current.data.append([compactionMessage]);
                 }
               }
+            }
+            if (conversationId) {
+              window.dispatchEvent(new CompactionStartedEvent(conversationId));
             }
             break;
 

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -26,6 +26,8 @@ interface CircleProgressProps {
   size?: number;
 }
 
+const CONTEXT_USAGE_PERCENT_THRESHOLD = 33;
+
 function CircleProgress({ percentage, size = 16 }: CircleProgressProps) {
   const strokeWidth = size * 0.14;
   const radius = (size - strokeWidth) / 2;
@@ -121,7 +123,7 @@ export function ContextUsageIndicator({
                 The current context usage is at {percentage}%
               </span>
             </div>
-            {percentage > 33 && (
+            {percentage > CONTEXT_USAGE_PERCENT_THRESHOLD && (
               <Button
                 variant="outline"
                 size="xs"

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -2,6 +2,10 @@ import {
   useCompactConversation,
   useConversationContextUsage,
 } from "@app/hooks/conversations";
+import {
+  COMPACTION_STARTED_EVENT,
+  CompactionStartedEvent,
+} from "@app/lib/notifications/events";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -9,6 +13,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
 
 interface ContextUsageIndicatorProps {
   buttonSize: "xs" | "sm";
@@ -61,6 +66,7 @@ export function ContextUsageIndicator({
   owner,
   conversationId,
 }: ContextUsageIndicatorProps) {
+  const [isOpen, setIsOpen] = useState(false);
   const { contextUsage } = useConversationContextUsage({
     conversationId,
     workspaceId: owner.sId,
@@ -76,9 +82,28 @@ export function ContextUsageIndicator({
       ? Math.round((contextUsage.contextUsage / contextUsage.contextSize) * 100)
       : 0;
 
+  useEffect(() => {
+    const handleCompactionStarted = (event: Event) => {
+      if (
+        event instanceof CompactionStartedEvent &&
+        event.detail.conversationId === conversationId
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener(COMPACTION_STARTED_EVENT, handleCompactionStarted);
+    return () => {
+      window.removeEventListener(
+        COMPACTION_STARTED_EVENT,
+        handleCompactionStarted
+      );
+    };
+  }, [conversationId]);
+
   return (
     <div className="hidden md:block">
-      <DropdownMenu>
+      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost-secondary"

--- a/front/lib/notifications/events.ts
+++ b/front/lib/notifications/events.ts
@@ -14,6 +14,18 @@ export class AgentMessageCompletedEvent extends CustomEvent<void> {
   }
 }
 
+export const COMPACTION_STARTED_EVENT = "compaction-started";
+
+export class CompactionStartedEvent extends CustomEvent<{
+  conversationId: string;
+}> {
+  constructor(conversationId: string) {
+    super(COMPACTION_STARTED_EVENT, {
+      detail: { conversationId },
+    });
+  }
+}
+
 export const COMPACTION_COMPLETED_EVENT = "compaction-completed";
 
 export class CompactionCompletedEvent extends CustomEvent<void> {


### PR DESCRIPTION
## Description

- add a client-side `COMPACTION_STARTED_EVENT`
- dispatch it when the compaction message appears in the conversation stream
- close the context usage compaction popover when the start event is received for the current conversation

## Tests

- tested locally

## Risk

Low. 

## Deploy Plan

- deploy `front`