### PR TITLE
[Sessions] Thread transactions through group and space resources

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -623,7 +623,8 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   private static async baseFetch(
     auth: Authenticator,
-    { includes, limit, order, where }: ResourceFindOptions<GroupModel> = {}
+    { includes, limit, order, where }: ResourceFindOptions<GroupModel> = {},
+    transaction?: Transaction
   ) {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const includeClauses: Includeable[] = includes || [];
@@ -636,18 +637,27 @@ export class GroupResource extends BaseResource<GroupModel> {
       include: includeClauses,
       limit,
       order,
+      transaction,
     });
     return groupModels.map((b) => new this(this.model, b.get()));
   }
 
-  static async fetchByModelIds(auth: Authenticator, ids: ModelId[]) {
-    return this.baseFetch(auth, {
-      where: {
-        id: {
-          [Op.in]: ids,
+  static async fetchByModelIds(
+    auth: Authenticator,
+    ids: ModelId[],
+    { transaction }: { transaction?: Transaction } = {}
+  ) {
+    return this.baseFetch(
+      auth,
+      {
+        where: {
+          id: {
+            [Op.in]: ids,
+          },
         },
       },
-    });
+      transaction
+    );
   }
 
   static async fetchById(

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -394,9 +394,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static async fetchWorkspaceSystemSpace(
-    auth: Authenticator
+    auth: Authenticator,
+    transaction?: Transaction
   ): Promise<SpaceResource> {
-    const [space] = await this.baseFetch(auth, { where: { kind: "system" } });
+    const [space] = await this.baseFetch(
+      auth,
+      { where: { kind: "system" } },
+      transaction
+    );
 
     if (!space) {
       throw new Error("System space not found.");
@@ -406,9 +411,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static async fetchWorkspaceGlobalSpace(
-    auth: Authenticator
+    auth: Authenticator,
+    transaction?: Transaction
   ): Promise<SpaceResource> {
-    const [space] = await this.baseFetch(auth, { where: { kind: "global" } });
+    const [space] = await this.baseFetch(
+      auth,
+      { where: { kind: "global" } },
+      transaction
+    );
 
     if (!space) {
       throw new Error("Global space not found.");
@@ -460,20 +470,27 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
-    { includeDeleted }: { includeDeleted?: boolean } = {}
+    {
+      includeDeleted,
+      transaction,
+    }: { includeDeleted?: boolean; transaction?: Transaction } = {}
   ) {
     if (ids.length === 0) {
       return [];
     }
 
-    const spaces = await this.baseFetch(auth, {
-      where: {
-        id: {
-          [Op.in]: ids,
+    const spaces = await this.baseFetch(
+      auth,
+      {
+        where: {
+          id: {
+            [Op.in]: ids,
+          },
         },
+        includeDeleted,
       },
-      includeDeleted,
-    });
+      transaction
+    );
 
     return spaces ?? [];
   }


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24213
Part 1 of 3 PRs to add transactionality to various resources, and ultimately skills resource
Context: [review comment](https://github.com/dust-tt/dust/pull/24213#discussion_r3085343750)

Adds optional `transaction` threading to `GroupResource` and `SpaceResource` fetch helpers so higher-level resource stacks can stay on a single conversation-fork transaction.

## Risks
Blast radius: group and space reads that opt into the new transaction argument
Risk: low

## Deploy Plan
- pmrr
- deploy front
