### PR TITLE
[Sessions] Thread transactions through MCP server resources

### DIFF
--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -353,22 +353,29 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   private static async baseFetch(
     auth: Authenticator,
     options: ResourceFindOptions<MCPServerViewModel> = {},
-    { includeMetadata = true }: { includeMetadata?: boolean } = {}
+    {
+      includeMetadata = true,
+      transaction,
+    }: { includeMetadata?: boolean; transaction?: Transaction } = {}
   ) {
-    const views = await this.baseFetchWithAuthorization(auth, {
-      ...options,
-      where: {
-        ...options.where,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-      includes: [
-        ...(options.includes ?? []),
-        {
-          model: UserModel,
-          as: "editedByUser",
+    const views = await this.baseFetchWithAuthorization(
+      auth,
+      {
+        ...options,
+        where: {
+          ...options.where,
+          workspaceId: auth.getNonNullableWorkspace().id,
         },
-      ],
-    });
+        includes: [
+          ...(options.includes ?? []),
+          {
+            model: UserModel,
+            as: "editedByUser",
+          },
+        ],
+      },
+      transaction
+    );
 
     const filteredViews: MCPServerViewResource[] = [];
 
@@ -377,11 +384,15 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     if (options.includeDeleted) {
       filteredViews.push(...views);
     } else {
-      const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
+      const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(
+        auth,
+        transaction
+      );
 
       const remoteServers = await RemoteMCPServerResource.fetchByModelIds(
         auth,
-        removeNulls(views.map((v) => v.remoteMCPServerId))
+        removeNulls(views.map((v) => v.remoteMCPServerId)),
+        transaction
       );
       const remoteServerMap = new Map(remoteServers.map((s) => [s.id, s]));
 
@@ -414,7 +425,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     }
 
     if (includeMetadata && filteredViews.length > 0) {
-      await this.populateToolsMetadata(auth, filteredViews);
+      await this.populateToolsMetadata(auth, filteredViews, transaction);
     }
 
     return filteredViews;
@@ -425,7 +436,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
    */
   private static async populateToolsMetadata(
     auth: Authenticator,
-    views: MCPServerViewResource[]
+    views: MCPServerViewResource[],
+    transaction?: Transaction
   ): Promise<void> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
@@ -441,6 +453,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
               workspaceId,
               internalMCPServerId: { [Op.in]: internalServerIds },
             },
+            transaction,
           })
         : [],
       remoteServerIds.length > 0
@@ -449,6 +462,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
               workspaceId,
               remoteMCPServerId: { [Op.in]: remoteServerIds },
             },
+            transaction,
           })
         : [],
     ]);
@@ -532,7 +546,10 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
-    { includeMetadata = true }: { includeMetadata?: boolean } = {}
+    {
+      includeMetadata = true,
+      transaction,
+    }: { includeMetadata?: boolean; transaction?: Transaction } = {}
   ) {
     const views = await this.baseFetch(
       auth,
@@ -543,7 +560,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           },
         },
       },
-      { includeMetadata }
+      { includeMetadata, transaction }
     );
 
     return views ?? [];
@@ -613,42 +630,48 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
   static async listByMCPServers(
     auth: Authenticator,
-    mcpServerIds: string[]
+    mcpServerIds: string[],
+    transaction?: Transaction
   ): Promise<MCPServerViewResource[]> {
     const serverTypesAndIds = mcpServerIds.map((mcpServerId) => ({
       ...getServerTypeAndIdFromSId(mcpServerId),
       mcpServerId,
     }));
 
-    return this.baseFetch(auth, {
-      where: {
-        [Op.or]: [
-          {
-            serverType: "internal" as const,
-            internalMCPServerId: {
-              [Op.in]: serverTypesAndIds
-                .filter(({ serverType }) => serverType === "internal")
-                .map(({ mcpServerId }) => mcpServerId),
+    return this.baseFetch(
+      auth,
+      {
+        where: {
+          [Op.or]: [
+            {
+              serverType: "internal" as const,
+              internalMCPServerId: {
+                [Op.in]: serverTypesAndIds
+                  .filter(({ serverType }) => serverType === "internal")
+                  .map(({ mcpServerId }) => mcpServerId),
+              },
             },
-          },
-          {
-            serverType: "remote",
-            remoteMCPServerId: {
-              [Op.in]: serverTypesAndIds
-                .filter(({ serverType }) => serverType === "remote")
-                .map(({ id }) => id),
+            {
+              serverType: "remote",
+              remoteMCPServerId: {
+                [Op.in]: serverTypesAndIds
+                  .filter(({ serverType }) => serverType === "remote")
+                  .map(({ id }) => id),
+              },
             },
-          },
-        ],
+          ],
+        },
       },
-    });
+      { transaction }
+    );
   }
 
   static async listByMCPServer(
     auth: Authenticator,
-    mcpServerId: string
+    mcpServerId: string,
+    transaction?: Transaction
   ): Promise<MCPServerViewResource[]> {
-    return this.listByMCPServers(auth, [mcpServerId]);
+    return this.listByMCPServers(auth, [mcpServerId], transaction);
   }
 
   static async getByMCPServerAndSpace(
@@ -706,14 +729,16 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   static async listMCPServerViewsAutoInternalForSpaces(
     auth: Authenticator,
     name: AutoInternalMCPServerNameType,
-    spaceModelIds: ModelId[]
+    spaceModelIds: ModelId[],
+    transaction?: Transaction
   ) {
     const views = await this.listByMCPServer(
       auth,
       autoInternalMCPServerNameToSId({
         name,
         workspaceId: auth.getNonNullableWorkspace().id,
-      })
+      }),
+      transaction
     );
 
     // We include the global space, which is omitted from the requested space IDs of an agent.

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -126,7 +126,8 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
 
   private static async baseFetch(
     auth: Authenticator,
-    options?: ResourceFindOptions<RemoteMCPServerModel>
+    options?: ResourceFindOptions<RemoteMCPServerModel>,
+    transaction?: Transaction
   ) {
     const { where, ...otherOptions } = options ?? {};
 
@@ -136,6 +137,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
         workspaceId: auth.getNonNullableWorkspace().id,
       },
       ...otherOptions,
+      transaction,
     });
 
     return servers.map(
@@ -178,14 +180,19 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
 
   static async fetchByModelIds(
     auth: Authenticator,
-    ids: ModelId[]
+    ids: ModelId[],
+    transaction?: Transaction
   ): Promise<RemoteMCPServerResource[]> {
     if (ids.length === 0) {
       return [];
     }
-    return this.baseFetch(auth, {
-      where: { id: { [Op.in]: ids } },
-    });
+    return this.baseFetch(
+      auth,
+      {
+        where: { id: { [Op.in]: ids } },
+      },
+      transaction
+    );
   }
 
   static async resolveNamesBySIds(

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -100,6 +100,7 @@ export abstract class ResourceWithSpace<
         },
       ],
       includeDeleted,
+      transaction,
       // WORKSPACE_ISOLATION_BYPASS: Spaces can be public, preventing to enforce a
       // workspaceId clause in the SQL query. Permissions are enforced at a higher level.
       // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24390
Follows https://github.com/dust-tt/dust/pull/24213
Part 2 of 3 PRs to add transactionality to various resources, and ultimately skills resource
Context: [review comment](https://github.com/dust-tt/dust/pull/24213#discussion_r3085343750)

Threads the optional `transaction` through `ResourceWithSpace`, `RemoteMCPServerResource`, and `MCPServerViewResource`, including the auto-internal MCP view lookup path.

## Risks
Blast radius: MCP server view and remote MCP server reads that opt into the new transaction argument
Risk: low

## Deploy Plan
- pmrr
- deploy front
