### PR TITLE
Bump CI rust toolchain to 1.94.1

### DIFF
--- a/.github/workflows/build-and-test-core.yml
+++ b/.github/workflows/build-and-test-core.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
+        uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
           components: rustfmt
 

--- a/.github/workflows/build-dust-sandbox.yml
+++ b/.github/workflows/build-dust-sandbox.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
+        uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
           components: rustfmt
 

--- a/.github/workflows/build-egress-proxy.yml
+++ b/.github/workflows/build-egress-proxy.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
+        uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
           components: clippy, rustfmt
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Setup Rust for core project
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
+        uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
           components: rustfmt
 

--- a/.github/workflows/release-dsbx-cli.yml
+++ b/.github/workflows/release-dsbx-cli.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
+        uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
 
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross

--- a/.github/workflows/release-sandbox-tool.yml
+++ b/.github/workflows/release-sandbox-tool.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ inputs.codex_tag }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d # 1.85.0
+        uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
 
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross


### PR DESCRIPTION
## Description

The `release-dsbx-cli` workflow failed on the `dsbx 0.1.4` dispatch ([run 24516421910](https://github.com/dust-tt/dust/actions/runs/24516421910/job/71661603402)) because `cross`'s latest master pulls `home@0.5.12`, which now requires rustc 1.88, while every workflow in this repo pins rustc 1.85:

```
rustc 1.85.0 is not supported by the following package:
  home@0.5.12 requires rustc 1.88
```

Rather than paper over this one workflow with `cargo install --locked`, bump the whole repo's CI toolchain to the current stable (`1.94.1`, released 2026-03-26) so we don't hit the next dep that needs a newer rustc. All six workflows using `dtolnay/rust-toolchain` are updated; SHA-pinning convention preserved.

Files touched:

- `.github/workflows/release-dsbx-cli.yml`
- `.github/workflows/release-sandbox-tool.yml`
- `.github/workflows/build-dust-sandbox.yml`
- `.github/workflows/build-egress-proxy.yml`
- `.github/workflows/build-and-test-core.yml`
- `.github/workflows/claude.yml`

No source changes: `dust-sandbox` and `egress-proxy` are `edition = "2021"` with no MSRV declared, and pass on current stable.

## Tests

Verified on the existing workflows once CI runs on this PR (`build-and-test-core` and `build-dust-sandbox` will exercise 1.94.1). The `release-dsbx-cli` fix can only be confirmed by a post-merge workflow_dispatch.

## Risk

Low. Rust has strong backwards compatibility for stable releases. If a specific workflow is unhappy with 1.94, happy to pin that one down to an older stable.

## Deploy Plan

None.