### PR TITLE
[front] enh: improve slash command dropdown dismissal and navigation

### DIFF
--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -47,7 +47,6 @@ export const SlashCommandDropdown = forwardRef<
 >(({ items, command, clientRect, onClose }, ref) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
-  const selectedItemRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
   const [virtualTriggerStyle, setVirtualTriggerStyle] =
     useState<React.CSSProperties>({});
@@ -99,13 +98,6 @@ export const SlashCommandDropdown = forwardRef<
   useEffect(() => {
     setSelectedIndex(0);
   }, [items.length]);
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedIndex drives which item owns the ref.
-  useEffect(() => {
-    selectedItemRef.current?.scrollIntoView({
-      block: "nearest",
-    });
-  }, [selectedIndex]);
 
   // Update virtual trigger position.
   const updateTriggerPosition = useCallback(() => {
@@ -163,7 +155,6 @@ export const SlashCommandDropdown = forwardRef<
             const menuItem = (
               <DropdownMenuItem
                 key={item.id}
-                ref={index === selectedIndex ? selectedItemRef : null}
                 icon={item.icon}
                 label={item.label}
                 truncateText

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -30,7 +30,12 @@ export interface SlashCommand {
 }
 
 export interface SlashCommandDropdownProps
-  extends SuggestionProps<SlashCommand> {}
+  extends Pick<
+    SuggestionProps<SlashCommand>,
+    "clientRect" | "command" | "items"
+  > {
+  onClose?: () => void;
+}
 
 export interface SlashCommandDropdownRef {
   onKeyDown: (props: { event: KeyboardEvent }) => boolean;
@@ -39,9 +44,10 @@ export interface SlashCommandDropdownRef {
 export const SlashCommandDropdown = forwardRef<
   SlashCommandDropdownRef,
   SlashCommandDropdownProps
->(({ items, command, clientRect }, ref) => {
+>(({ items, command, clientRect, onClose }, ref) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
+  const selectedItemRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
   const [virtualTriggerStyle, setVirtualTriggerStyle] =
     useState<React.CSSProperties>({});
@@ -60,6 +66,10 @@ export const SlashCommandDropdown = forwardRef<
     ref,
     () => ({
       onKeyDown: ({ event }) => {
+        if (items.length === 0) {
+          return false;
+        }
+
         if (event.key === "ArrowDown") {
           event.preventDefault();
           setSelectedIndex((selectedIndex + 1) % items.length);
@@ -89,6 +99,13 @@ export const SlashCommandDropdown = forwardRef<
   useEffect(() => {
     setSelectedIndex(0);
   }, [items.length]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedIndex drives which item owns the ref.
+  useEffect(() => {
+    selectedItemRef.current?.scrollIntoView({
+      block: "nearest",
+    });
+  }, [selectedIndex]);
 
   // Update virtual trigger position.
   const updateTriggerPosition = useCallback(() => {
@@ -128,8 +145,12 @@ export const SlashCommandDropdown = forwardRef<
         ref={containerRef}
         className="w-64"
         align="start"
+        avoidCollisions
+        collisionPadding={12}
         side="bottom"
         sideOffset={4}
+        onEscapeKeyDown={onClose}
+        onInteractOutside={onClose}
         onCloseAutoFocus={(e) => e.preventDefault()}
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
@@ -142,6 +163,7 @@ export const SlashCommandDropdown = forwardRef<
             const menuItem = (
               <DropdownMenuItem
                 key={item.id}
+                ref={index === selectedIndex ? selectedItemRef : null}
                 icon={item.icon}
                 label={item.label}
                 truncateText

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -6,9 +6,10 @@ import { SlashCommandDropdown } from "@app/components/editor/extensions/skill_bu
 import { AttachmentIcon } from "@dust-tt/sparkle";
 import { Extension } from "@tiptap/core";
 import { PluginKey } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
 import { ReactRenderer } from "@tiptap/react";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
-import { Suggestion } from "@tiptap/suggestion";
+import { exitSuggestion, Suggestion } from "@tiptap/suggestion";
 
 const slashCommandPluginKey = new PluginKey("slashCommand");
 
@@ -99,11 +100,24 @@ export const SlashCommandExtension =
           },
           render: () => {
             let component: ReactRenderer<SlashCommandDropdownRef> | null = null;
+            let activeEditorView: EditorView | null = null;
+
+            const closeSuggestionDropdown = () => {
+              if (!activeEditorView) {
+                return;
+              }
+
+              exitSuggestion(activeEditorView, slashCommandPluginKey);
+            };
 
             return {
               onStart: (props: SuggestionProps) => {
+                activeEditorView = props.editor.view;
                 component = new ReactRenderer(SlashCommandDropdown, {
-                  props,
+                  props: {
+                    ...props,
+                    onClose: closeSuggestionDropdown,
+                  },
                   editor: props.editor,
                 });
 
@@ -115,7 +129,11 @@ export const SlashCommandExtension =
               },
 
               onUpdate(props: SuggestionProps) {
-                component?.updateProps(props);
+                activeEditorView = props.editor.view;
+                component?.updateProps({
+                  ...props,
+                  onClose: closeSuggestionDropdown,
+                });
 
                 if (!props.clientRect) {
                   return;
@@ -124,9 +142,7 @@ export const SlashCommandExtension =
 
               onKeyDown(props: { event: KeyboardEvent }) {
                 if (props.event.key === "Escape") {
-                  component?.element?.remove();
-                  component?.destroy();
-                  component = null;
+                  closeSuggestionDropdown();
                   return true;
                 }
 
@@ -134,6 +150,7 @@ export const SlashCommandExtension =
               },
 
               onExit() {
+                activeEditorView = null;
                 component?.element?.remove();
                 component?.destroy();
                 component = null;


### PR DESCRIPTION
## Description

This PR updates the behavior of the slash-command dropdown used in the skill builder instructions editor for knowledge attachment.
This is in preparation of adding a `/skills` shortcut in the input bar.

- When hitting `Escape` or clicking outside, the dismissal goes through  `exitSuggestion(...)`.
- Enable dropdown collision handling so the menu can flip instead of running off-screen. The input bar is usually at the bottom of the screen, so we need to flip it to point upwards if needed.
- Keep the highlighted item scrolled into when navigating using arrow keys.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
