### PR TITLE
chore: fix n+1 query and sId in whs resource

### DIFF
--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -102,6 +102,14 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     return res.map((c) => new this(this.model, c.get()));
   }
 
+  static async fetchByModelIds(auth: Authenticator, ids: ModelId[]) {
+    return this.baseFetch(auth, {
+      where: {
+        id: ids,
+      },
+    });
+  }
+
   static async fetchByIds(auth: Authenticator, sIds: string[]) {
     const ids = sIds
       .map((sId) => getResourceIdFromSId(sId))

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -36,7 +36,12 @@ export interface WebhookSourcesViewResource
 export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSourcesViewModel> {
   static model: ModelStatic<WebhookSourcesViewModel> = WebhookSourcesViewModel;
   readonly editedByUser?: Attributes<UserModel>;
-  private webhookSource?: WebhookSourceResource;
+  private _webhookSource: WebhookSourceResource | null = null;
+
+  get webhookSource(): WebhookSourceResource {
+    assert(this._webhookSource, "webhookSource not loaded");
+    return this._webhookSource;
+  }
 
   constructor(
     model: ModelStatic<WebhookSourcesViewModel>,
@@ -47,33 +52,6 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     super(WebhookSourcesViewModel, blob, space);
 
     this.editedByUser = editedByUser;
-  }
-
-  private async init(auth: Authenticator): Promise<Result<void, DustError>> {
-    if (this.webhookSourceId) {
-      const webhookSourceResource = await WebhookSourceResource.findByPk(
-        auth,
-        this.webhookSourceId
-      );
-      if (!webhookSourceResource) {
-        return new Err(
-          new DustError(
-            "webhook_source_not_found",
-            "Webhook source not found, it should have been fetched by the base fetch."
-          )
-        );
-      }
-
-      this.webhookSource = webhookSourceResource;
-      return new Ok(undefined);
-    }
-
-    return new Err(
-      new DustError(
-        "internal_error",
-        "We could not find the webhook source because it was missing."
-      )
-    );
   }
 
   private static async makeNew(
@@ -87,6 +65,19 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     transaction?: Transaction
   ) {
     assert(auth.isAdmin(), "Only admins can create a webhook sources view");
+
+    assert(blob.webhookSourceId, "webhookSourceId is required");
+
+    const webhookSource = await WebhookSourceResource.findByPk(
+      auth,
+      blob.webhookSourceId
+    );
+    if (!webhookSource) {
+      throw new DustError(
+        "webhook_source_not_found",
+        "Webhook source not found for the new view."
+      );
+    }
 
     const view = await WebhookSourcesViewModel.create(
       {
@@ -104,11 +95,7 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
       view.get(),
       space
     );
-
-    const r = await resource.init(auth);
-    if (r.isErr()) {
-      throw r.error;
-    }
+    resource._webhookSource = webhookSource;
 
     return resource;
   }
@@ -164,21 +151,30 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
       ],
     });
 
-    const filteredViews: WebhookSourcesViewResource[] = [];
+    // Batch-fetch all referenced webhook sources.
+    const webhookSourceIds = [
+      ...new Set(removeNulls(views.map((v) => v.webhookSourceId))),
+    ];
+    const webhookSources = await WebhookSourceResource.fetchByModelIds(
+      auth,
+      webhookSourceIds
+    );
+    const webhookSourceById = new Map(webhookSources.map((ws) => [ws.id, ws]));
 
-    if (options.includeDeleted) {
-      filteredViews.push(...views);
-    } else {
-      for (const view of views) {
-        const r = await view.init(auth);
-
-        if (r.isOk()) {
-          filteredViews.push(view);
-        }
+    // Assign webhook sources; filter out views whose source no longer exists
+    // unless includeDeleted is set.
+    const result: WebhookSourcesViewResource[] = [];
+    for (const view of views) {
+      const ws = webhookSourceById.get(view.webhookSourceId);
+      if (ws) {
+        view._webhookSource = ws;
+        result.push(view);
+      } else if (options.includeDeleted) {
+        result.push(view);
       }
     }
 
-    return filteredViews;
+    return result;
   }
 
   static async fetchById(
@@ -299,10 +295,10 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
 
   static async getWebhookSourceViewForSystemSpace(
     auth: Authenticator,
-    webhookSourceSId: string
+    webhookSourceId: string
   ): Promise<WebhookSourcesViewResource | null> {
-    const webhookSourceId = getResourceIdFromSId(webhookSourceSId);
-    if (!webhookSourceId) {
+    const webhookSourceModelId = getResourceIdFromSId(webhookSourceId);
+    if (!webhookSourceModelId) {
       return null;
     }
 
@@ -311,7 +307,7 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     const views = await this.baseFetch(auth, {
       where: {
         vaultId: systemSpace.id,
-        webhookSourceId,
+        webhookSourceId: webhookSourceModelId,
       },
     });
 
@@ -466,25 +462,11 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     return new Ok(deletedCount);
   }
 
-  private getWebhookSourceResource(): WebhookSourceResource {
-    if (!this.webhookSource) {
-      throw new Error(
-        "This webhook sources view is referencing a non-existent webhook source"
-      );
-    }
-
-    return this.webhookSource;
-  }
-
   get sId(): string {
     return WebhookSourcesViewResource.modelIdToSId({
       id: this.id,
       workspaceId: this.workspaceId,
     });
-  }
-
-  get webhookSourceSId(): string {
-    return this.getWebhookSourceResource().sId;
   }
 
   static modelIdToSId({
@@ -518,44 +500,42 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
   }
 
   toJSON(): WebhookSourceViewType {
-    const webhookSource = this.getWebhookSourceResource();
     return {
       id: this.id,
       sId: this.sId,
-      customName: this.customName ?? webhookSource.name,
+      customName: this.customName ?? this.webhookSource.name,
       description: this.description,
       icon: normalizeWebhookIcon(this.icon),
-      provider: webhookSource.provider,
-      subscribedEvents: webhookSource.subscribedEvents,
+      provider: this.webhookSource.provider,
+      subscribedEvents: this.webhookSource.subscribedEvents,
       createdAt: this.createdAt.getTime(),
       updatedAt: this.updatedAt.getTime(),
       spaceId: this.space.sId,
-      webhookSource: webhookSource.toJSON(),
+      webhookSource: this.webhookSource.toJSON(),
       editedByUser: this.makeEditedBy(
         this.editedByUser,
-        this.webhookSource ? this.webhookSource.updatedAt : this.updatedAt
+        this.webhookSource.updatedAt
       ),
     };
   }
 
   // Serialization.
   toJSONForAdmin(): WebhookSourceViewForAdminType {
-    const webhookSource = this.getWebhookSourceResource();
     return {
       id: this.id,
       sId: this.sId,
-      customName: this.customName ?? webhookSource.name,
+      customName: this.customName ?? this.webhookSource.name,
       description: this.description,
       icon: normalizeWebhookIcon(this.icon),
-      provider: webhookSource.provider,
-      subscribedEvents: webhookSource.subscribedEvents,
+      provider: this.webhookSource.provider,
+      subscribedEvents: this.webhookSource.subscribedEvents,
       createdAt: this.createdAt.getTime(),
       updatedAt: this.updatedAt.getTime(),
       spaceId: this.space.sId,
-      webhookSource: webhookSource.toJSONForAdmin(),
+      webhookSource: this.webhookSource.toJSONForAdmin(),
       editedByUser: this.makeEditedBy(
         this.editedByUser,
-        this.webhookSource ? this.webhookSource.updatedAt : this.updatedAt
+        this.webhookSource.updatedAt
       ),
     };
   }

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -159,13 +159,15 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
       auth,
       webhookSourceIds
     );
-    const webhookSourceById = new Map(webhookSources.map((ws) => [ws.id, ws]));
+    const webhookSourceByModelId = new Map(
+      webhookSources.map((ws) => [ws.id, ws])
+    );
 
     // Assign webhook sources; filter out views whose source no longer exists
     // unless includeDeleted is set.
     const result: WebhookSourcesViewResource[] = [];
     for (const view of views) {
-      const ws = webhookSourceById.get(view.webhookSourceId);
+      const ws = webhookSourceByModelId.get(view.webhookSourceId);
       if (ws) {
         view._webhookSource = ws;
         result.push(view);

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
@@ -297,7 +297,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/views/[viewId]", () => {
 
     // Create additional views in global space for the same webhook source
     await webhookSourceViewFactory.create(globalSpace, {
-      webhookSourceId: systemView.webhookSourceSId,
+      webhookSourceId: systemView.webhookSource.sId,
     });
 
     // Verify initial state
@@ -373,7 +373,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/views/[viewId]", () => {
 
     // Create additional views in global space for the same webhook source
     await webhookSourceViewFactory.create(globalSpace, {
-      webhookSourceId: systemView.webhookSourceSId,
+      webhookSourceId: systemView.webhookSource.sId,
     });
 
     // Verify initial state

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -259,7 +259,7 @@ async function editWebhookSourceViewsName(
   const systemView =
     await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
       auth,
-      webhookSourceView.webhookSourceSId
+      webhookSourceView.webhookSource.sId
     );
 
   if (!systemView) {
@@ -310,7 +310,7 @@ async function editWebhookSourceDescriptionAndIcon(
   const systemView =
     await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
       auth,
-      webhookSourceView.webhookSourceSId
+      webhookSourceView.webhookSource.sId
     );
 
   if (!systemView) {

--- a/front/scripts/seed/factories/seedWebhookSources.ts
+++ b/front/scripts/seed/factories/seedWebhookSources.ts
@@ -15,7 +15,7 @@ export interface WebhookSourceAsset {
 }
 
 export interface CreatedWebhookSourceView {
-  webhookSourceSId: string;
+  webhookSourceId: string;
   viewId: number;
   name: string;
 }
@@ -48,7 +48,7 @@ export async function seedWebhookSources(
         );
       if (systemView) {
         created.set(asset.name, {
-          webhookSourceSId: existing.sId,
+          webhookSourceId: existing.sId,
           viewId: systemView.id,
           name: asset.name,
         });
@@ -96,7 +96,7 @@ export async function seedWebhookSources(
       await ensureGlobalSpaceView(auth, systemView, globalSpace, logger);
 
       created.set(asset.name, {
-        webhookSourceSId: webhookSource.sId,
+        webhookSourceId: webhookSource.sId,
         viewId: systemView.id,
         name: asset.name,
       });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

 - Refactor `WebhookSourcesViewResource` to expose `webhookSource` as a non-nullable getter backed by a private field with an assert, replacing the previous ? field + `getWebhookSourceResource()` pattern
 - Replace the N+1 `init()` method (one `findByPk` per view) with a single batch query via `WebhookSourceResource.fetchByModelIds` in `baseFetch`
 - Remove the `webhookSourceSId` getter — callers now use `view.webhookSource.sId` directly

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Unit tested

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front