### PR TITLE
chore: bump dsbx to 0.1.4

### DIFF
--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -10,7 +10,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import fs from "fs";
 import path from "path";
 
-const DSBX_CLI_VERSION = "0.1.3";
+const DSBX_CLI_VERSION = "0.1.4";
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.
 const APPLY_PATCH_VERSION = "0.1.0";
@@ -298,7 +298,7 @@ SHELLEOF`,
   .withToolManifest()
   .register({
     imageName: "dust-base",
-    tag: "0.7.2",
+    tag: "0.7.3",
   });
 
 const IMAGES: readonly SandboxImage[] = [DUST_BASE_IMAGE];


### PR DESCRIPTION
## Description

Picks up the `forward` subcommand added in #24375 into the sandbox image.

- `DSBX_CLI_VERSION`: `0.1.3` → `0.1.4` (`dsbx-v0.1.4` was cut via the `release-dsbx-cli` workflow: https://github.com/dust-tt/dust/releases/tag/dsbx-v0.1.4).
- `dust-base` image tag: `0.7.2` → `0.7.3` — new binary content, new tag so the sandbox image registry build picks it up instead of overwriting.

Same shape as the previous bump (#23381).

## Tests

`npx tsx scripts/sandbox_image_check.ts` will flag `dust-base:0.7.3` as missing on merge, which triggers `sandbox-img-registry` to build + publish it. The build's `curl https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.4/...` step will pull the just-published artifact.

## Risk

Low. If the new image has a regression we can revert or bump back. The `forward` subcommand is inert until something invokes it, and the existing `version`/`tools` behaviour is unchanged.

## Deploy Plan

Merge → sandbox image registry build kicks off automatically → `dust-base:0.7.3` is published → next sandbox spawn uses the new image.