### PR TITLE
[front] remove outdated `conversationSId` field in `send-onboarding` response

### DIFF
--- a/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
@@ -9,8 +9,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 export type PostSendOnboardingResponseBody = {
   conversationId: string | null;
-  // TODO(2026-04-08 aubin): field kept for retro-compatibility over older front-end, to remove once.
-  conversationSId: string | null;
 };
 
 async function handler(
@@ -51,7 +49,6 @@ async function handler(
 
   return res.status(200).json({
     conversationId: result.value,
-    conversationSId: result.value,
   });
 }
 


### PR DESCRIPTION
## Description

- This PR removes a field that was kept for retro-compatibility over old versions of the front-end.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
