### PR TITLE
Fix notifyWorkflow error

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2872,6 +2872,17 @@ export async function updateAgentMessageWithFinalStatus(
       };
     }
 
+    if (!agentMessage.configuration) {
+      // Configuration is not available (e.g., workflow error path where the agent
+      // message is reconstructed without its configuration). Promote pending user
+      // messages but don't attempt to create a new agent message.
+      return {
+        promotedUserMessages,
+        promotedAuth,
+        agentMessage: null,
+      };
+    }
+
     const nextMessageRank = await getNextConversationMessageRank(auth, {
       conversation,
       transaction: t,


### PR DESCRIPTION
## Description

Root cause: notifyWorkflowError (common.ts:529) constructs a minimal AgentMessageType with configuration: null as unknown as LightAgentConfigurationType. This was fine before steering was introduced, but now updateAgentMessageWithFinalStatus (conversation.ts:2885) accesses agentMessage.configuration.sId when there are pending steering messages to promote, causing the NPE.

Fix: Added a guard in updateAgentMessageWithFinalStatus (conversation.ts:2874) that checks if (!agentMessage.configuration) and returns early, promoting pending user messages but skipping new agent message creation. This matches the existing cancelled status behavior and is the correct semantics for workflow errors where the configuration isn't available.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
