### PR TITLE
feat: gate seat sync on contract package type

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -5,7 +5,10 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import type { Authenticator } from "@app/lib/auth";
-import { syncSeatCount } from "@app/lib/metronome/seats";
+import {
+  isSeatBasedMetronomeContract,
+  syncSeatCount,
+} from "@app/lib/metronome/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -20,7 +23,7 @@ import type {
   MembershipOriginType,
   MembershipRoleType,
 } from "@app/types/memberships";
-import { Ok, type Result } from "@app/types/shared/result";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import type {
   ActiveRoleType,
   LightWorkspaceType,
@@ -40,6 +43,20 @@ async function syncSeatCountForWorkspace(
   if (!subscription?.metronomeContractId) {
     return new Ok(undefined);
   }
+
+  const seatBasedResult = await isSeatBasedMetronomeContract({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    metronomeContractId: subscription.metronomeContractId,
+  });
+
+  if (seatBasedResult.isErr()) {
+    return new Err(seatBasedResult.error);
+  }
+
+  if (!seatBasedResult.value) {
+    return new Ok(undefined);
+  }
+
   return await syncSeatCount({
     metronomeCustomerId: workspace.metronomeCustomerId,
     contractId: subscription.metronomeContractId,

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -2,18 +2,64 @@ import type { EnterprisePricingCents } from "@app/lib/metronome/contracts";
 import {
   buildEnterpriseOverrides,
   extractEnterprisePricing,
+  provisionMetronomeCustomerAndContract,
+  switchMetronomeContractPackage,
 } from "@app/lib/metronome/contracts";
+import { Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
 import type Stripe from "stripe";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockPrices } = vi.hoisted(() => {
+const {
+  mockCreateMetronomeContract,
+  mockCreateMetronomeCustomer,
+  mockFindMetronomeCustomerByAlias,
+  mockPrices,
+  mockScheduleMetronomeContractEnd,
+  mockSyncMauCount,
+  mockSyncSeatCount,
+} = vi.hoisted(() => {
   const mockPrices = { retrieve: vi.fn() };
-  return { mockPrices };
+
+  return {
+    mockCreateMetronomeContract: vi.fn(),
+    mockCreateMetronomeCustomer: vi.fn(),
+    mockFindMetronomeCustomerByAlias: vi.fn(),
+    mockPrices,
+    mockScheduleMetronomeContractEnd: vi.fn(),
+    mockSyncMauCount: vi.fn(),
+    mockSyncSeatCount: vi.fn(),
+  };
 });
+
+vi.mock("@app/lib/metronome/client", () => ({
+  ceilToHourISO: (date: Date) => date.toISOString(),
+  createMetronomeContract: mockCreateMetronomeContract,
+  createMetronomeCustomer: mockCreateMetronomeCustomer,
+  epochSecondsToFloorHourISO: vi.fn(),
+  findMetronomeCustomerByAlias: mockFindMetronomeCustomerByAlias,
+  getMetronomeClient: vi.fn(),
+  scheduleMetronomeContractEnd: mockScheduleMetronomeContractEnd,
+}));
+
+vi.mock("@app/lib/metronome/mau_sync", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/mau_sync")
+  >("@app/lib/metronome/mau_sync");
+
+  return {
+    ...actual,
+    syncMauCount: mockSyncMauCount,
+  };
+});
+
+vi.mock("@app/lib/metronome/seats", () => ({
+  syncSeatCount: mockSyncSeatCount,
+}));
 
 vi.mock("@app/lib/plans/stripe", () => ({
   getStripeClient: () => ({ prices: mockPrices }),
@@ -42,6 +88,38 @@ const noopLogger = {
   warn: vi.fn(),
   error: vi.fn(),
 } as any;
+
+const WORKSPACE = {
+  id: 42,
+  sId: "w_123",
+  name: "Workspace",
+} as LightWorkspaceType;
+
+beforeEach(() => {
+  mockPrices.retrieve.mockReset();
+
+  mockFindMetronomeCustomerByAlias.mockReset();
+  mockFindMetronomeCustomerByAlias.mockResolvedValue(new Ok("m-customer"));
+
+  mockCreateMetronomeCustomer.mockReset();
+  mockCreateMetronomeCustomer.mockResolvedValue(
+    new Ok({ metronomeCustomerId: "m-customer" })
+  );
+
+  mockCreateMetronomeContract.mockReset();
+  mockCreateMetronomeContract.mockResolvedValue(
+    new Ok({ contractId: "m-contract", startingAt: START_DATE })
+  );
+
+  mockScheduleMetronomeContractEnd.mockReset();
+  mockScheduleMetronomeContractEnd.mockResolvedValue(new Ok(undefined));
+
+  mockSyncSeatCount.mockReset();
+  mockSyncSeatCount.mockResolvedValue(new Ok(undefined));
+
+  mockSyncMauCount.mockReset();
+  mockSyncMauCount.mockResolvedValue(new Ok(undefined));
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -561,5 +639,84 @@ describe("buildEnterpriseOverrides", () => {
 
     expect(result.recurring_commits![0].access_amount.unit_price).toBe(325000);
     expect(result.custom_fields?.MAU_TIERS).toBe("FLOOR-101-201");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract provisioning / switching
+// ---------------------------------------------------------------------------
+
+describe("provisionMetronomeCustomerAndContract", () => {
+  it("syncs seats and MAU for seat-based packages", async () => {
+    const result = await provisionMetronomeCustomerAndContract({
+      workspace: WORKSPACE,
+      stripeCustomerId: "stripe-customer",
+      packageAlias: "legacy-pro-monthly",
+      uniquenessKey: "uniq_123",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockSyncSeatCount).toHaveBeenCalledTimes(1);
+    expect(mockSyncSeatCount).toHaveBeenCalledWith({
+      metronomeCustomerId: "m-customer",
+      contractId: "m-contract",
+      workspace: WORKSPACE,
+      startingAt: START_DATE,
+    });
+    expect(mockSyncMauCount).toHaveBeenCalledTimes(1);
+    expect(mockSyncMauCount).toHaveBeenCalledWith({
+      metronomeCustomerId: "m-customer",
+      contractId: "m-contract",
+      workspace: WORKSPACE,
+      startingAt: START_DATE,
+    });
+  });
+
+  it("skips seats for enterprise packages and still syncs MAU", async () => {
+    const result = await provisionMetronomeCustomerAndContract({
+      workspace: WORKSPACE,
+      stripeCustomerId: "stripe-customer",
+      packageAlias: "legacy-enterprise",
+      uniquenessKey: "uniq_123",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockSyncSeatCount).not.toHaveBeenCalled();
+    expect(mockSyncMauCount).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("switchMetronomeContractPackage", () => {
+  it("syncs seats and MAU for seat-based packages", async () => {
+    const result = await switchMetronomeContractPackage({
+      metronomeCustomerId: "m-customer",
+      oldContractId: "old-contract",
+      workspace: WORKSPACE,
+      packageAlias: "legacy-business",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockScheduleMetronomeContractEnd).toHaveBeenCalledTimes(1);
+    expect(mockSyncSeatCount).toHaveBeenCalledTimes(1);
+    expect(mockSyncSeatCount).toHaveBeenCalledWith({
+      metronomeCustomerId: "m-customer",
+      contractId: "m-contract",
+      workspace: WORKSPACE,
+      startingAt: START_DATE,
+    });
+    expect(mockSyncMauCount).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips seats for enterprise packages and still syncs MAU", async () => {
+    const result = await switchMetronomeContractPackage({
+      metronomeCustomerId: "m-customer",
+      oldContractId: "old-contract",
+      workspace: WORKSPACE,
+      packageAlias: "legacy-enterprise-eur",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockSyncSeatCount).not.toHaveBeenCalled();
+    expect(mockSyncMauCount).toHaveBeenCalledTimes(1);
   });
 });

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -20,7 +20,10 @@ import {
   syncMauCount,
 } from "@app/lib/metronome/mau_sync";
 import { syncSeatCount } from "@app/lib/metronome/seats";
-import { LEGACY_ENTERPRISE_PACKAGE_ALIAS } from "@app/lib/metronome/types";
+import {
+  isSeatBasedMetronomePackageAlias,
+  LEGACY_ENTERPRISE_PACKAGE_ALIAS,
+} from "@app/lib/metronome/types";
 import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
 import { getStripeClient } from "@app/lib/plans/stripe";
 import { countActiveUsersForPeriodInWorkspace } from "@app/lib/plans/usage/mau";
@@ -76,24 +79,13 @@ export async function switchMetronomeContractPackage({
   }
 
   const { contractId: metronomeContractId, startingAt } = contractResult.value;
-
-  const syncFns = [
-    () =>
-      syncSeatCount({
-        metronomeCustomerId,
-        contractId: metronomeContractId,
-        workspace,
-        startingAt,
-      }),
-    () =>
-      syncMauCount({
-        metronomeCustomerId,
-        contractId: metronomeContractId,
-        workspace,
-        startingAt,
-      }),
-  ];
-  await concurrentExecutor(syncFns, (fn) => fn(), { concurrency: 2 });
+  await syncContractQuantities(
+    metronomeCustomerId,
+    metronomeContractId,
+    workspace,
+    startingAt,
+    packageAlias
+  );
 
   return new Ok({ metronomeContractId });
 }
@@ -146,25 +138,13 @@ export async function provisionMetronomeCustomerAndContract({
   }
 
   const { contractId: metronomeContractId, startingAt } = contractResult.value;
-
-  // Provision seats and MAU on the new contract.
-  const syncFns = [
-    () =>
-      syncSeatCount({
-        metronomeCustomerId,
-        contractId: metronomeContractId,
-        workspace,
-        startingAt,
-      }),
-    () =>
-      syncMauCount({
-        metronomeCustomerId,
-        contractId: metronomeContractId,
-        workspace,
-        startingAt,
-      }),
-  ];
-  await concurrentExecutor(syncFns, (fn) => fn(), { concurrency: 2 });
+  await syncContractQuantities(
+    metronomeCustomerId,
+    metronomeContractId,
+    workspace,
+    startingAt,
+    packageAlias
+  );
 
   return new Ok({
     metronomeCustomerId,
@@ -201,6 +181,39 @@ export interface EnterprisePricingCents {
   tiers: StripeTierCents[];
   /** Monthly floor amount in cents (flat_amount on first tier, or unit_amount for FIXED). */
   floorCents: number;
+}
+
+async function syncContractQuantities(
+  metronomeCustomerId: string,
+  metronomeContractId: string,
+  workspace: LightWorkspaceType,
+  startingAt: string,
+  packageAlias: string
+) {
+  const shouldSyncSeats = isSeatBasedMetronomePackageAlias(packageAlias);
+
+  // Provision seats and MAU on the new contract.
+  const syncFns = [
+    ...(shouldSyncSeats
+      ? [
+          () =>
+            syncSeatCount({
+              metronomeCustomerId,
+              contractId: metronomeContractId,
+              workspace,
+              startingAt,
+            }),
+        ]
+      : []),
+    () =>
+      syncMauCount({
+        metronomeCustomerId,
+        contractId: metronomeContractId,
+        workspace,
+        startingAt,
+      }),
+  ];
+  await concurrentExecutor(syncFns, (fn) => fn(), { concurrency: 2 });
 }
 
 /** Extract the MAU threshold number from a billing mode (MAU_1→1, MAU_5→5, MAU_10→10). */

--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -1,0 +1,68 @@
+import { isSeatBasedMetronomeContract } from "@app/lib/metronome/seats";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetMetronomeContractPackageAliases } = vi.hoisted(() => ({
+  mockGetMetronomeContractPackageAliases: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/client", () => ({
+  getMetronomeContractPackageAliases: mockGetMetronomeContractPackageAliases,
+  updateSubscriptionQuantity: vi.fn(),
+}));
+
+describe("isSeatBasedMetronomeContract", () => {
+  beforeEach(() => {
+    mockGetMetronomeContractPackageAliases.mockReset();
+  });
+
+  it("returns true for pro/business package aliases", async () => {
+    mockGetMetronomeContractPackageAliases.mockResolvedValue(
+      new Ok(["legacy-pro-monthly", "legacy-business-eur"])
+    );
+
+    const result = await isSeatBasedMetronomeContract({
+      metronomeCustomerId: "m-customer",
+      metronomeContractId: "m-contract",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isErr()).toBe(false);
+    if (result.isOk()) {
+      expect(result.value).toBe(true);
+    }
+  });
+
+  it("returns false for enterprise package aliases", async () => {
+    mockGetMetronomeContractPackageAliases.mockResolvedValue(
+      new Ok(["legacy-enterprise", "legacy-enterprise-eur"])
+    );
+
+    const result = await isSeatBasedMetronomeContract({
+      metronomeCustomerId: "m-customer",
+      metronomeContractId: "m-contract",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isErr()).toBe(false);
+    if (result.isOk()) {
+      expect(result.value).toBe(false);
+    }
+  });
+
+  it("returns Err when package alias lookup fails", async () => {
+    mockGetMetronomeContractPackageAliases.mockResolvedValue(
+      new Err(new Error("lookup failed"))
+    );
+
+    const result = await isSeatBasedMetronomeContract({
+      metronomeCustomerId: "m-customer",
+      metronomeContractId: "m-contract",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("lookup failed");
+    }
+  });
+});

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1,10 +1,14 @@
-import { updateSubscriptionQuantity } from "@app/lib/metronome/client";
+import {
+  getMetronomeContractPackageAliases,
+  updateSubscriptionQuantity,
+} from "@app/lib/metronome/client";
 import { getProductWorkspaceSeatId } from "@app/lib/metronome/constants";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
+import { isSeatBasedMetronomePackageAlias } from "@app/lib/metronome/types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
-import { Err } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 
 /**
@@ -25,6 +29,29 @@ async function getSeatSubscriptionId(
       s.subscription_rate.product.id === seatProductId
   );
   return seatSub?.id ?? undefined;
+}
+
+/**
+ * Returns whether Metronome contract belongs to a seat-based package family.
+ * MAU/FIXED enterprise contracts are not seat-based and should not call syncSeatCount.
+ */
+export async function isSeatBasedMetronomeContract({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<Result<boolean, Error>> {
+  const aliasesResult = await getMetronomeContractPackageAliases({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+
+  if (aliasesResult.isErr()) {
+    return new Err(aliasesResult.error);
+  }
+
+  return new Ok(aliasesResult.value.some(isSeatBasedMetronomePackageAlias));
 }
 
 /**

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -57,3 +57,9 @@ export interface MetronomeUsageWithGroupsResponse {
   value: number | null;
   group: Record<string, string> | null;
 }
+
+export function isSeatBasedMetronomePackageAlias(
+  packageAlias: string
+): boolean {
+  return PRO_OR_BUSINESS_PACKAGE_ALIASES.has(packageAlias);
+}


### PR DESCRIPTION
## Description

Context in [Slack thread](https://dust4ai.slack.com/archives/C0AFNMSL19N/p1776346701773229).

Skip seat count syncing for enterprise (MAU/fixed) contracts by checking the package alias before calling syncSeatCount, both at membership change time and during contract provisioning/switching.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
