### PR TITLE
[front] enh: improve smoothness of sub agent streaming

### DIFF
--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -395,11 +395,11 @@ export async function updateResourceAndPublishEvent(
   // All events go through the coalescer, which handles batching logic internally.
   const key = `${conversation.sId}-${event.messageId}-${step}`;
   const flushIntervalMs =
-    conversation.depth > 0
-      ? conversation.depth > 1
-        : DEEP_CONVERSATION_FLUSH_INTERVAL_MS
+    conversation.depth > 1
+      ? DEEP_CONVERSATION_FLUSH_INTERVAL_MS
+      : conversation.depth > 0
         ? SUB_AGENT_FLUSH_INTERVAL_MS
-      : undefined;
+        : undefined;
 
   await globalCoalescer.handleEvent({
     conversationId: conversation.sId,

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -13,7 +13,10 @@ import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
-import { globalCoalescer } from "@app/temporal/agent_loop/lib/event_coalescer";
+import {
+  DEFAULT_EVENT_FLUSH_INTERVAL_MS,
+  globalCoalescer,
+} from "@app/temporal/agent_loop/lib/event_coalescer";
 import type {
   LightAgentConfigurationType,
   ToolErrorEvent,
@@ -37,7 +40,10 @@ import {
   type WhereOptions,
 } from "sequelize";
 
-const DEEP_CONVERSATION_FLUSH_INTERVAL_MS = 1000;
+const SUB_AGENT_FLUSH_INTERVAL_MS = 2 * DEFAULT_EVENT_FLUSH_INTERVAL_MS;
+// Conversations that are more than one level deep will seldom be viewed in real-time.
+const DEEP_CONVERSATION_FLUSH_INTERVAL_MS =
+  10 * DEFAULT_EVENT_FLUSH_INTERVAL_MS;
 
 /**
  * Update in database as well as in-memory agent message.
@@ -388,9 +394,13 @@ export async function updateResourceAndPublishEvent(
 
   // All events go through the coalescer, which handles batching logic internally.
   const key = `${conversation.sId}-${event.messageId}-${step}`;
-  // Flush every DEEP_CONVERSATION_FLUSH_INTERVAL_MS for deep conversations to avoid flooding the Redis stream with events, use the default flush interval for main conversations.
   const flushIntervalMs =
-    conversation.depth > 0 ? DEEP_CONVERSATION_FLUSH_INTERVAL_MS : undefined;
+    conversation.depth > 0
+      ? conversation.depth > 1
+        : DEEP_CONVERSATION_FLUSH_INTERVAL_MS
+        ? SUB_AGENT_FLUSH_INTERVAL_MS
+      : undefined;
+
   await globalCoalescer.handleEvent({
     conversationId: conversation.sId,
     event,

--- a/front/temporal/agent_loop/lib/event_coalescer.ts
+++ b/front/temporal/agent_loop/lib/event_coalescer.ts
@@ -3,7 +3,7 @@ import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types"
 import logger from "@app/logger/logger";
 import type { GenerationTokensEvent } from "@app/types/assistant/generation";
 
-const FLUSH_INTERVAL_MS = 100;
+export const DEFAULT_EVENT_FLUSH_INTERVAL_MS = 100;
 const MAX_BUFFER_AGE_MS = 60_000; // 1 minute
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -72,7 +72,7 @@ class EventCoalescer {
     event,
     key,
     step,
-    flushIntervalMs = FLUSH_INTERVAL_MS,
+    flushIntervalMs = DEFAULT_EVENT_FLUSH_INTERVAL_MS,
   }: {
     conversationId: string;
     event: AgentMessageEvents;


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/7625
- The streaming of sub agent's answers currently often looks stuck, due to our flush mechanism that only flushes events every second.
- This PR makes a distinction between sub agents and deeper conversations. For deeper conversations we barely need a very reactive streaming compared to sub agents, that are still streamed.
- Improves the situation during the streaming, but it seems we also have a lag when starting to stream.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
