### PR TITLE
[Sessions] Copy direct file attachments into forks

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -1,5 +1,11 @@
-import { createConversation } from "@app/lib/api/assistant/conversation";
+import {
+  createConversation,
+  postNewContentFragment,
+} from "@app/lib/api/assistant/conversation";
+import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { createConversationFork } from "@app/lib/api/assistant/conversation/forks";
+import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
@@ -10,8 +16,10 @@ import {
 import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -20,9 +28,13 @@ import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type {
+  ConversationType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
-import { describe, expect, it } from "vitest";
+import { Ok } from "@app/types/shared/result";
+import { describe, expect, it, vi } from "vitest";
 
 async function createUserMessage(
   auth: Authenticator,
@@ -101,6 +113,69 @@ async function createAgentMessage(
     parentId,
     agentMessageId: agentMessage.id,
   });
+}
+
+async function createConversationFile(
+  auth: Authenticator,
+  {
+    conversationId,
+    fileName,
+    snippet = null,
+  }: {
+    conversationId: string;
+    fileName: string;
+    snippet?: string | null;
+  }
+): Promise<FileResource> {
+  return FileFactory.create(auth, auth.getNonNullableUser(), {
+    contentType: "text/plain",
+    fileName,
+    fileSize: 16,
+    status: "ready",
+    useCase: "conversation",
+    useCaseMetadata: {
+      conversationId,
+    },
+    snippet,
+  });
+}
+
+async function fetchConversationOrThrow(
+  auth: Authenticator,
+  conversationId: string
+): Promise<ConversationType> {
+  const result = await getConversation(auth, conversationId);
+  if (result.isErr()) {
+    throw result.error;
+  }
+
+  return result.value;
+}
+
+function mockCopyToConversation() {
+  return vi
+    .spyOn(FileResource, "copyToConversation")
+    .mockImplementation(async (auth, { sourceId, conversationId }) => {
+      const sourceFile = await FileResource.fetchById(auth, sourceId);
+      if (!sourceFile) {
+        throw new Error(`Missing source file in test: ${sourceId}`);
+      }
+
+      const copiedFile = await FileFactory.create(auth, auth.user(), {
+        contentType: sourceFile.contentType,
+        fileName: sourceFile.fileName,
+        fileSize: sourceFile.fileSize,
+        status: "ready",
+        useCase: sourceFile.useCase,
+        useCaseMetadata: {
+          ...(sourceFile.useCaseMetadata ?? {}),
+          conversationId,
+        },
+        snippet: sourceFile.snippet,
+      });
+
+      return new Ok(copiedFile);
+    });
 }
 
 describe("createConversationFork", () => {
@@ -403,6 +478,172 @@ describe("createConversationFork", () => {
     expect(childSkills).toHaveLength(1);
     expect(childSkills[0].sId).toBe(enabledSkill.sId);
   });
+
+  it("copies direct conversation file attachments into the child conversation", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+    const copyToConversationSpy = mockCopyToConversation();
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const sourceFile = await createConversationFile(auth, {
+      conversationId: parentConversation.sId,
+      fileName: "notes.txt",
+      snippet: "fork me",
+    });
+
+    let parentConversationWithContent = await fetchConversationOrThrow(
+      auth,
+      parentConversation.sId
+    );
+    const attachmentResult = await postNewContentFragment(
+      auth,
+      parentConversationWithContent,
+      {
+        title: "Notes",
+        fileId: sourceFile.sId,
+      },
+      null
+    );
+    expect(attachmentResult.isOk()).toBe(true);
+
+    parentConversationWithContent = await fetchConversationOrThrow(
+      auth,
+      parentConversation.sId
+    );
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversationWithContent,
+      rank: 1,
+      content: "Please branch this.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversationWithContent,
+      rank: 2,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childAttachments = await listAttachments(auth, {
+      conversation: result.value,
+    });
+    const childFileAttachments = childAttachments.filter(isFileAttachmentType);
+
+    expect(childFileAttachments).toHaveLength(1);
+    expect(childFileAttachments[0]?.title).toBe("Notes");
+    expect(childFileAttachments[0]?.fileId).not.toBe(sourceFile.sId);
+
+    const copiedFiles = await FileResource.fetchByIds(auth, [
+      childFileAttachments[0]!.fileId,
+    ]);
+    expect(copiedFiles).toHaveLength(1);
+    expect(copiedFiles[0]?.useCaseMetadata?.conversationId).toBe(
+      result.value.sId
+    );
+    expect(copiedFiles[0]?.snippet).toBe(sourceFile.snippet);
+
+    copyToConversationSpy.mockRestore();
+  }, 15_000);
+
+  it("only copies attachments that existed at the selected source message", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+    const copyToConversationSpy = mockCopyToConversation();
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const firstFile = await createConversationFile(auth, {
+      conversationId: parentConversation.sId,
+      fileName: "first.txt",
+      snippet: "first",
+    });
+    const secondFile = await createConversationFile(auth, {
+      conversationId: parentConversation.sId,
+      fileName: "second.txt",
+      snippet: "second",
+    });
+
+    let parentConversationWithContent = await fetchConversationOrThrow(
+      auth,
+      parentConversation.sId
+    );
+    const firstAttachmentResult = await postNewContentFragment(
+      auth,
+      parentConversationWithContent,
+      {
+        title: "First attachment",
+        fileId: firstFile.sId,
+      },
+      null
+    );
+    expect(firstAttachmentResult.isOk()).toBe(true);
+
+    parentConversationWithContent = await fetchConversationOrThrow(
+      auth,
+      parentConversation.sId
+    );
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversationWithContent,
+      rank: 1,
+      content: "Fork from here.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversationWithContent,
+      rank: 2,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    parentConversationWithContent = await fetchConversationOrThrow(
+      auth,
+      parentConversation.sId
+    );
+    const secondAttachmentResult = await postNewContentFragment(
+      auth,
+      parentConversationWithContent,
+      {
+        title: "Second attachment",
+        fileId: secondFile.sId,
+      },
+      null
+    );
+    expect(secondAttachmentResult.isOk()).toBe(true);
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childAttachments = await listAttachments(auth, {
+      conversation: result.value,
+    });
+    const childFileAttachments = childAttachments.filter(isFileAttachmentType);
+
+    expect(childFileAttachments).toHaveLength(1);
+    expect(childFileAttachments[0]?.title).toBe("First attachment");
+
+    copyToConversationSpy.mockRestore();
+  }, 15_000);
 
   it("inherits the parent's requested spaces so the fork does not broaden visibility", async () => {
     const {

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -446,22 +446,6 @@ export async function createConversationFork(
     sourceMessageRank: childConversationId.value.sourceMessageRank,
   });
 
-  if (copiedAttachmentCount === 0) {
-    return childConversation;
-  }
-
-  const updatedChildConversation = await getConversation(
-    auth,
-    childConversation.value.sId
-  );
-  if (updatedChildConversation.isErr()) {
-    return new Err(
-      new DustError(
-        "internal_error",
-        "The forked conversation could not be reloaded after copying file attachments."
-      )
-    );
-  }
 
   return updatedChildConversation;
 }

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -446,6 +446,22 @@ export async function createConversationFork(
     sourceMessageRank: childConversationId.value.sourceMessageRank,
   });
 
+  if (copiedAttachmentCount === 0) {
+    return childConversation;
+  }
+
+  const updatedChildConversation = await getConversation(
+    auth,
+    childConversation.value.sId
+  );
+  if (updatedChildConversation.isErr()) {
+    return new Err(
+      new DustError(
+        "internal_error",
+        "The forked conversation could not be reloaded after copying file attachments."
+      )
+    );
+  }
 
   return updatedChildConversation;
 }

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -1,14 +1,19 @@
+import { postNewContentFragment } from "@app/lib/api/assistant/conversation";
+import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { createUserMessage } from "@app/lib/api/assistant/conversation/messages";
+import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import logger from "@app/logger/logger";
 import type {
   ConversationType,
   ConversationWithoutContentType,
@@ -40,6 +45,19 @@ function getForkedConversationTitle(title: string | null): string | null {
 
 function escapeMarkdownLinkText(text: string): string {
   return text.replace(/[\\[\]]/g, "\\$&");
+}
+
+function filterConversationContentUpToRank(
+  conversation: ConversationType,
+  maxRank: number
+): ConversationType {
+  return {
+    ...conversation,
+    content: conversation.content.filter((versions) => {
+      const latestVersion = versions[versions.length - 1];
+      return latestVersion ? latestVersion.rank <= maxRank : false;
+    }),
+  };
 }
 
 function getForkInitializationMessageContent(
@@ -194,6 +212,88 @@ async function createForkInitializationMessage(
   });
 }
 
+async function copyConversationFileAttachments(
+  auth: Authenticator,
+  {
+    parentConversation,
+    childConversation,
+    sourceMessageRank,
+  }: {
+    parentConversation: ConversationType;
+    childConversation: ConversationType;
+    sourceMessageRank: number;
+  }
+): Promise<number> {
+  const parentConversationAtSource = filterConversationContentUpToRank(
+    parentConversation,
+    sourceMessageRank
+  );
+  const attachments = await listAttachments(auth, {
+    conversation: parentConversationAtSource,
+  });
+  // For now we only carry over direct file attachments that were explicitly posted into the
+  // conversation. Project-context files remain accessible via the shared project, and agent-
+  // generated files need a separate follow-up because they are not re-attached through content
+  // fragments today.
+  const directConversationFileAttachments = attachments
+    .filter(isFileAttachmentType)
+    .filter(
+      (attachment) =>
+        attachment.source === "user" && !attachment.isInProjectContext
+    );
+
+  let copiedAttachmentCount = 0;
+  for (const attachment of directConversationFileAttachments) {
+    const copiedFile = await FileResource.copyToConversation(auth, {
+      sourceId: attachment.fileId,
+      conversationId: childConversation.sId,
+    });
+
+    if (copiedFile.isErr()) {
+      logger.error(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          parentConversationId: parentConversation.sId,
+          childConversationId: childConversation.sId,
+          sourceFileId: attachment.fileId,
+          error: copiedFile.error,
+        },
+        "Failed to copy file attachment into forked conversation."
+      );
+      continue;
+    }
+
+    const attachmentResult = await postNewContentFragment(
+      auth,
+      childConversation,
+      {
+        title: attachment.title,
+        fileId: copiedFile.value.sId,
+      },
+      null
+    );
+
+    if (attachmentResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          parentConversationId: parentConversation.sId,
+          childConversationId: childConversation.sId,
+          sourceFileId: attachment.fileId,
+          copiedFileId: copiedFile.value.sId,
+          error: attachmentResult.error,
+        },
+        "Failed to attach copied file into forked conversation."
+      );
+      continue;
+    }
+
+    copiedAttachmentCount += 1;
+  }
+
+  return copiedAttachmentCount;
+}
+
 export async function createConversationFork(
   auth: Authenticator,
   {
@@ -300,7 +400,10 @@ export async function createConversationFork(
       { transaction }
     );
 
-    return new Ok(childConversation.sId);
+    return new Ok({
+      childConversationId: childConversation.sId,
+      sourceMessageRank: sourceMessage.value.rank,
+    });
   });
 
   if (childConversationId.isErr()) {
@@ -309,7 +412,7 @@ export async function createConversationFork(
 
   const childConversation = await getConversation(
     auth,
-    childConversationId.value
+    childConversationId.value.childConversationId
   );
   if (childConversation.isErr()) {
     return new Err(
@@ -320,5 +423,45 @@ export async function createConversationFork(
     );
   }
 
-  return childConversation;
+  const parentConversationWithContent = await getConversation(
+    auth,
+    conversationId
+  );
+  if (parentConversationWithContent.isErr()) {
+    logger.error(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        parentConversationId: conversationId,
+        childConversationId: childConversation.value.sId,
+        error: parentConversationWithContent.error,
+      },
+      "Failed to reload parent conversation for fork file attachment copy."
+    );
+    return childConversation;
+  }
+
+  const copiedAttachmentCount = await copyConversationFileAttachments(auth, {
+    parentConversation: parentConversationWithContent.value,
+    childConversation: childConversation.value,
+    sourceMessageRank: childConversationId.value.sourceMessageRank,
+  });
+
+  if (copiedAttachmentCount === 0) {
+    return childConversation;
+  }
+
+  const updatedChildConversation = await getConversation(
+    auth,
+    childConversation.value.sId
+  );
+  if (updatedChildConversation.isErr()) {
+    return new Err(
+      new DustError(
+        "internal_error",
+        "The forked conversation could not be reloaded after copying file attachments."
+      )
+    );
+  }
+
+  return updatedChildConversation;
 }


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24156, https://github.com/dust-tt/dust/pull/24213, and https://github.com/dust-tt/dust/pull/24319.
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

Copies direct user-posted conversation file attachments into the child fork, scoped to the selected source message.

The file carryover happens after the DB transaction and is best-effort per attachment. Project-context files and agent-generated files are intentionally left for follow-up slices.

## Risks
Blast radius: fork creation file carryover for direct conversation attachments
Risk: standard

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/api/assistant/conversation/forks.test.ts pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts`
