### PR TITLE
[Devx skills] Add front skills for Elasticsearch, audit events, and webhooks

### DIFF
--- a/.claude/skills/dust-audit-log-event/SKILL.md
+++ b/.claude/skills/dust-audit-log-event/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: dust-audit-log-event
+description: Add a new audit log event in `front`. Use when instrumenting a new user or system action for WorkOS audit logging, including schema creation, `AuditAction` updates, and the correct emit call after the mutation path.
+---
+
+# Front Audit Log Events
+
+Add audit events in `front` by creating the schema, registering the action string, and emitting the
+event from the correct success or failure path. The goal is to produce a valid WorkOS event without
+blocking the request path.
+
+## Workflow
+
+### 1. Identify the event
+
+Before editing code, determine:
+
+- the action string, usually `<resource>.<verb>`
+- the mutation or failure path that should emit it
+- whether the actor is a request user, a known user outside an HTTP request, or the system
+- the event tier from the Notion audit events database
+
+### 2. Create the WorkOS schema
+
+Create `front/admin/audit_log_schemas/<action>.json`.
+
+Rules:
+
+- `targets` should start with `{ "type": "workspace" }` unless the event truly has no workspace
+  context
+- additional targets describe the affected entities, such as `user`, `space`, `trigger`, `tool`,
+  `agent`, or `api_key`
+- `metadata` is optional, but every metadata value must be declared as `"string"`
+- use camelCase metadata keys
+
+Example shape:
+
+```json
+{
+  "action": "resource.verb",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "resource" }
+  ],
+  "metadata": {
+    "fieldName": "string"
+  }
+}
+```
+
+### 3. Register the action string
+
+Update `front/lib/api/audit/workos_audit.ts`:
+
+- add the new string to the `AuditAction` union
+- place it in the right category section
+- keep the entries alphabetized inside that section
+
+### 4. Emit the event from the right path
+
+Emit after the mutation succeeds unless the event explicitly represents failure.
+
+For request-driven actions with an `Authenticator`, use:
+
+- `emitAuditLogEvent`
+- `buildWorkspaceTarget`
+- `getAuditLogContext`
+
+Pattern:
+
+```typescript
+void emitAuditLogEvent({
+  auth,
+  action: "resource.verb",
+  targets: [
+    buildWorkspaceTarget(auth.getNonNullableWorkspace()),
+    { type: "resource", id: resource.sId, name: resource.name },
+  ],
+  context: getAuditLogContext(auth, req),
+  metadata: {
+    fieldName: String(value),
+  },
+});
+```
+
+For system-driven actions such as Temporal or inbound webhooks, use `emitAuditLogEventDirect`
+with an explicit system actor:
+
+```typescript
+void emitAuditLogEventDirect({
+  workspace,
+  action: "resource.verb",
+  actor: { type: "system", id: "temporal", name: "Directory Sync" },
+  targets: [buildWorkspaceTarget(workspace)],
+  context: { location: "internal" },
+});
+```
+
+For non-HTTP code paths where you know the user but do not already have an `Authenticator`, create
+one with `Authenticator.fromUserIdAndWorkspaceId(...)` and then use `emitAuditLogEvent(...)`.
+
+### 5. Keep the emit call non-blocking
+
+Use `void`, not `await`, for audit emission. Audit logging should not block the main write path.
+
+### 6. Register the schema after merge
+
+WorkOS drops events whose schemas were never registered. After the PR is merged and before deploy,
+run one of:
+
+```bash
+npx tsx front/admin/register_audit_log_schemas.ts --changed
+npx tsx front/admin/register_audit_log_schemas.ts --execute --changed
+npx tsx front/admin/register_audit_log_schemas.ts --execute user.login api_key.created
+```
+
+## Validation
+
+Check all of the following:
+
+- the schema file exists at `front/admin/audit_log_schemas/<action>.json`
+- the action string was added to `AuditAction`
+- the emit call runs after the intended success path, or on the intended failure path for failure
+  events
+- `targets` start with the workspace target when a workspace exists
+- metadata values are wrapped with `String(...)` when needed
+- request-backed events use `getAuditLogContext(auth, req)` when `req` is available
+- the emit call uses `void`
+
+## References
+
+- `front/lib/api/audit/workos_audit.ts`
+- `front/admin/audit_log_schemas/`
+- `CODING_RULES.md` entries `[AUDIT1]` through `[AUDIT8]`

--- a/.claude/skills/dust-audit-log-event/SKILL.md
+++ b/.claude/skills/dust-audit-log-event/SKILL.md
@@ -131,4 +131,4 @@ Check all of the following:
 
 - `front/lib/api/audit/workos_audit.ts`
 - `front/admin/audit_log_schemas/`
-- `CODING_RULES.md` entries `[AUDIT1]` through `[AUDIT8]`
+- `front/CODING_RULES.md` entries `[AUDIT1]` through `[AUDIT8]`

--- a/.claude/skills/dust-audit-log-event/agents/openai.yaml
+++ b/.claude/skills/dust-audit-log-event/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dust Audit Log Event"
+  short_description: "Add a front audit log event"
+  default_prompt: "Add a new audit log event in front following Dust audit logging patterns."

--- a/.claude/skills/dust-elasticsearch/SKILL.md
+++ b/.claude/skills/dust-elasticsearch/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: dust-elasticsearch
+description: Create, migrate, or query Elasticsearch indices in `front`. Use when adding a new front Elasticsearch index, changing mappings or settings, wiring indexing logic, or exposing Elasticsearch-backed analytics/search endpoints.
+---
+
+# Front Elasticsearch
+
+Create Elasticsearch indices in `front` with the same patterns used by existing analytics and
+search code. Keep the skill self-contained: define the document shape, add versioned mappings and
+regional settings, register the alias, wire indexing/query helpers, and validate the resulting
+index.
+
+## Core Files
+
+Create or update the following files for a new index:
+
+- `front/types/<feature>/<index>.ts` for the document type
+- `front/lib/<feature>/indices/<index>_<version>.mappings.json`
+- `front/lib/<feature>/indices/<index>_<version>.settings.local.json`
+- `front/lib/<feature>/indices/<index>_<version>.settings.us-central1.json`
+- `front/lib/<feature>/indices/<index>_<version>.settings.europe-west1.json`
+- `front/lib/api/elasticsearch.ts` for the alias constant and `INDEX_DIRECTORIES`
+- `front/lib/<feature>/<index>.ts` or similar for indexing and query helpers
+
+Use these existing implementations as references:
+
+- `front/lib/user_search/indices/`
+- `front/lib/user_search/index.ts`
+- `core/src/search_stores/indices/data_sources_nodes_4.*` for advanced analyzers
+
+## Workflow
+
+### 1. Define the document type
+
+Create a TypeScript type that extends `ElasticsearchBaseDocument` from
+`front/lib/api/elasticsearch`. Do not redeclare `workspace_id`; it comes from the base type.
+
+Keep the document explicit and stable:
+
+- include the primary business identifier, usually as a `keyword`
+- include an update timestamp such as `updated_at`
+- use nested objects only when element-level relationships matter
+
+### 2. Create mappings
+
+Add `<index>_<version>.mappings.json` under `front/lib/<feature>/indices/`.
+
+Default mapping choices:
+
+- `keyword` for ids, enums, and fields used for exact filters or aggregations
+- `text` for full-text search
+- `date` for timestamps
+- `integer` / `long` / `short` for numeric values
+- `nested` only when array item relationships must be preserved
+- `"index": false` on large retrievable text that should not be searchable
+
+For fields that need multiple search modes, use multi-fields:
+
+- main `text` field for full-text
+- `.edge` with edge n-grams for prefix search
+- `.keyword` for exact match and sorting
+
+If indexing email addresses, prefer a `uax_url_email`-based analyzer so the address is preserved as
+one searchable token instead of being split into noisy fragments.
+
+### 3. Create regional settings
+
+Add settings files for `local`, `us-central1`, and `europe-west1`.
+
+Use these defaults unless the workload justifies something else:
+
+- local: `1` shard, `0` replicas, `1s` refresh interval
+- production: `3` shards, `1` replica, `30s` refresh interval
+
+Only add custom analyzers when the index genuinely needs search behavior beyond exact match or basic
+full-text. If you do, mirror the patterns used by `data_sources_nodes` in `core`.
+
+If you rely on ICU analyzers, make sure the Elasticsearch cluster has the ICU analysis plugin.
+
+### 4. Register the index alias
+
+In `front/lib/api/elasticsearch.ts`:
+
+- export `YOUR_INDEX_ALIAS_NAME = "front.<index_name>"`
+- add the index directory to `INDEX_DIRECTORIES`
+
+This is how the index creation script locates mappings and settings for the alias.
+
+### 5. Create the index
+
+Use the existing script:
+
+```bash
+tsx front/scripts/create_elasticsearch_index.ts \
+  --index-name <index_name> \
+  --index-version <version> \
+  --skip-confirmation
+```
+
+Use `--remove-previous-alias` only for migrations where the alias should stop writing to the
+previous version.
+
+The script creates:
+
+- index `front.<index_name>_<version>`
+- alias `front.<index_name>` with `is_write_index: true`
+
+### 6. Wire indexing helpers
+
+Add a helper module such as `front/lib/<feature>/<index>.ts`.
+
+Follow these rules:
+
+- generate stable document ids from workspace id plus business id
+- write through `withEs(...)`
+- use `client.index(...)` for full document upserts
+- use `client.update(...)` only for partial updates
+- use `client.bulk(...)` for batch writes with `refresh: false`
+
+Prefer asynchronous indexing via the shared Temporal ES indexation queue when the write does not
+need to block the user request.
+
+### 7. Add query helpers
+
+For analytics or search endpoints:
+
+- always filter by `workspace_id`
+- add the narrowest possible filters before aggregating
+- use `size: 0` for aggregation-only requests
+- keep query construction explicit; avoid post-filtering in application code
+
+Common aggregation patterns:
+
+- `terms` for breakdowns
+- `date_histogram` for time series
+- `avg`, `sum`, `percentiles` for metrics
+- `nested` aggregations only for nested fields
+
+### 8. Support relocation when needed
+
+If the index stores per-workspace data that must be rebuilt during region relocation:
+
+- add a recreation activity under
+  `front/temporal/relocation/activities/destination_region/front/es_indexation.ts`
+- call it from
+  `front/temporal/relocation/workflows.ts#workspaceRelocateFrontEsIndexationWorkflow`
+
+Use `recreateUserSearchIndex` as the model.
+
+## Validation
+
+Before considering the work complete, verify:
+
+- the document type matches the JSON mappings
+- settings exist for all three regions
+- the alias constant and `INDEX_DIRECTORIES` entry were added
+- the index creation script succeeds for the new version
+- indexing uses stable ids and the correct alias
+- query helpers always scope by workspace
+- relocation support exists if the data is workspace-scoped and must survive regional moves
+
+## Common Mistakes
+
+- indexing ids as `text` instead of `keyword`
+- using `nested` where a plain object array is enough
+- forgetting the production settings files
+- querying documents without a `workspace_id` filter
+- writing synchronously in a hot path when Temporal would be safer
+- adding custom analyzers without a concrete search requirement

--- a/.claude/skills/dust-elasticsearch/agents/openai.yaml
+++ b/.claude/skills/dust-elasticsearch/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dust Elasticsearch"
+  short_description: "Add or migrate front Elasticsearch indices"
+  default_prompt: "Create or update a Dust front Elasticsearch index following repository patterns."

--- a/.claude/skills/dust-webhook-source/SKILL.md
+++ b/.claude/skills/dust-webhook-source/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: dust-webhook-source
+description: Implement a new built-in webhook source provider in `front`. Use when adding a webhook provider such as Linear, GitHub, or Fathom, including provider research, OAuth prerequisites, provider-specific types and client code, preset registration, UI components, and end-to-end testing.
+---
+
+# Front Webhook Sources
+
+Implement built-in webhook providers under `front/lib/triggers/built-in-webhooks/<provider>/`.
+The work spans provider research, OAuth prerequisites, typed remote metadata, a provider client,
+the remote webhook service, preset registration, and the setup/details UI.
+
+## Hard Prerequisites
+
+Do not start implementation until both of these already exist:
+
+- `front/lib/api/oauth/providers/<provider>.ts`
+- `core/src/oauth/providers/<provider>.rs`
+
+The provider must support the `webhooks` use case and have scopes that can manage webhooks.
+
+If the provider only allows webhooks to be created manually in its UI, stop. It is not a fit for a
+built-in webhook source.
+
+## Research First
+
+Before writing code, document these answers from the provider docs:
+
+- how to create a webhook programmatically
+- required auth method and OAuth scopes
+- request and response payloads for create and delete
+- available event types and sample payloads
+- how the incoming event type is identified: header or body field
+- what user-configurable metadata is required, such as team or repository selection
+- whether webhook signatures exist and how to verify them
+
+This research determines the metadata types, client methods, event schemas, and UI.
+
+## Files To Touch
+
+Minimal implementation:
+
+- `front/types/triggers/webhooks.ts`
+- `front/lib/triggers/built-in-webhooks/<provider>/types.ts`
+- `front/lib/triggers/built-in-webhooks/<provider>/<provider>_client.ts`
+- `front/lib/triggers/built-in-webhooks/<provider>/service.ts`
+- `front/lib/triggers/built-in-webhooks/<provider>/preset.ts`
+- `front/lib/triggers/built-in-webhooks/<provider>/preset_ui.ts`
+- `front/lib/triggers/built-in-webhooks/<provider>/schemas/*`
+- `front/lib/triggers/built-in-webhooks/<provider>/components/*`
+
+Use existing providers as templates:
+
+- `fathom` for the simplest shape
+- `linear` for team-scoped webhook creation
+- `github` for repository-driven configuration
+
+## Workflow
+
+### 1. Register the provider
+
+In `front/types/triggers/webhooks.ts`:
+
+- add the provider to `WEBHOOK_PROVIDERS`
+- extend `WebhookProviderServiceDataMap` if the provider needs extra OAuth-fetched data
+- register the preset in `WEBHOOK_PRESETS`
+
+### 2. Define metadata and type guards
+
+In `types.ts`, define:
+
+- create-time metadata entered by the user
+- persisted metadata that also includes provider webhook ids
+- runtime type guards for both
+- optional additional OAuth data such as teams or repositories
+
+Always keep remote metadata serializable. No functions or class instances.
+
+### 3. Implement the provider client
+
+`<provider>_client.ts` should be a thin wrapper over the provider API.
+
+Typical methods:
+
+- `createWebhook(...)`
+- `deleteWebhook(...)`
+- `getTeams()` / `getRepositories()` / similar when setup requires selection data
+
+Return typed results and map the provider response into the local metadata shape.
+
+### 4. Implement the remote webhook service
+
+In `service.ts`, implement `RemoteWebhookService<"<provider>">`.
+
+Core responsibilities:
+
+- `getServiceData(oauthToken)` fetches setup data for the form
+- `createWebhooks(...)` validates metadata, creates provider-side webhooks, and returns
+  `updatedRemoteMetadata` including webhook ids
+- `deleteWebhooks(...)` removes provider-side webhooks using the persisted ids
+
+When multiple webhooks may be created, handle partial success explicitly and return user-facing
+errors without losing the successfully created ids.
+
+### 5. Define event schemas
+
+Create one schema file per event, or one per coherent event family, under `schemas/`.
+
+Each event entry should provide:
+
+- the event name/value exposed in the UI
+- a JSON schema for the payload
+- an optional sample payload when it clarifies the shape
+
+### 6. Build the presets
+
+Split preset code correctly:
+
+- `preset.ts` is data-only and worker-safe; do not import React there
+- `preset_ui.ts` adds the React components
+
+Set:
+
+- `eventCheck` to match how the provider exposes event type
+- the full list of supported events
+- the provider icon
+- optional `webhookPageUrl`
+- the concrete webhook service instance
+
+### 7. Build the UI components
+
+Create:
+
+- `CreateWebhook<Provider>Connection.tsx`
+- `WebhookSource<Provider>Details.tsx`
+
+The create form should:
+
+- drive OAuth with `useCreateOAuthConnection` and `useCase: "webhooks"`
+- fetch any provider-specific setup data once connected
+- call `onDataToCreateWebhookChange({ connectionId, remoteMetadata })`
+- call `onReadyToSubmitChange(true)` only when configuration is complete
+
+The details component should stay read-only and summarize the persisted remote metadata.
+
+## Common Gotchas
+
+- forgetting to add the preset to `WEBHOOK_PRESETS`
+- importing React from `preset.ts`
+- storing non-serializable remote metadata
+- skipping type guards before using `remoteMetadata`
+- assuming a single webhook when the provider needs one per team or repository
+- ignoring partial success during multi-webhook creation
+- forgetting to make local webhook URLs public during manual testing
+
+## Testing
+
+For local testing, expose the local app publicly and set `DUST_WEBHOOKS_PUBLIC_URL`.
+
+Manual checklist:
+
+- complete the OAuth flow successfully
+- create the webhook source in the UI without errors
+- verify the webhook exists in the provider dashboard
+- trigger a real provider event and inspect local logs
+- confirm the incoming payload matches the registered schema and event detection logic
+- delete the source and verify the provider-side webhook is removed
+
+## References
+
+- `front/lib/resources/webhook_source_resource.ts`
+- `front/types/triggers/remote_webhook_service.ts`
+- `front/types/triggers/webhooks_source_preset.ts`

--- a/.claude/skills/dust-webhook-source/SKILL.md
+++ b/.claude/skills/dust-webhook-source/SKILL.md
@@ -40,6 +40,7 @@ This research determines the metadata types, client methods, event schemas, and 
 Minimal implementation:
 
 - `front/types/triggers/webhooks.ts`
+- `front/types/triggers/webhooks_ui.ts`
 - `front/lib/triggers/built-in-webhooks/<provider>/types.ts`
 - `front/lib/triggers/built-in-webhooks/<provider>/<provider>_client.ts`
 - `front/lib/triggers/built-in-webhooks/<provider>/service.ts`
@@ -63,6 +64,11 @@ In `front/types/triggers/webhooks.ts`:
 - add the provider to `WEBHOOK_PROVIDERS`
 - extend `WebhookProviderServiceDataMap` if the provider needs extra OAuth-fetched data
 - register the preset in `WEBHOOK_PRESETS`
+
+In `front/types/triggers/webhooks_ui.ts`:
+
+- import the provider UI preset
+- register it in `WEBHOOK_PRESETS_UI`
 
 ### 2. Define metadata and type guards
 
@@ -135,8 +141,11 @@ Create:
 
 The create form should:
 
-- drive OAuth with `useCreateOAuthConnection` and `useCase: "webhooks"`
-- fetch any provider-specific setup data once connected
+- rely on `front/components/triggers/CreateWebhookSourceWithProviderForm.tsx` for the OAuth
+  connection flow via `setupOAuthConnection(...)`
+- treat `connectionId` as an input prop; do not recreate the OAuth flow inside the provider-specific
+  form
+- fetch provider-specific setup data with `useWebhookServiceData({ owner, connectionId, provider })`
 - call `onDataToCreateWebhookChange({ connectionId, remoteMetadata })`
 - call `onReadyToSubmitChange(true)` only when configuration is complete
 

--- a/.claude/skills/dust-webhook-source/agents/openai.yaml
+++ b/.claude/skills/dust-webhook-source/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dust Webhook Source"
+  short_description: "Implement a built-in webhook provider in front"
+  default_prompt: "Implement a new built-in webhook source provider in front following Dust patterns."


### PR DESCRIPTION
## Description
This adds self-contained skills for the `front` runbooks that still had no skill coverage:
- `dust-elasticsearch`
- `dust-audit-log-event`
- `dust-webhook-source`

This is meant to unblock a follow-up PR that removes the corresponding runbook references from `front/AGENTS.md`.

## Risks
Blast radius: Codex skill metadata and instructions under `.claude/skills` only.
Risk: low

## Deploy Plan
- none