### PR TITLE
Use eager streaming for all Anthropic tool calls, wrap invalid JSON in inside a JSON so the model can see the mistake

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -33,6 +33,8 @@ import { isRecord } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import cloneDeep from "lodash/cloneDeep";
 
+const MAX_EAGER_VALIDATION_INPUT_LENGTH = 5_000;
+
 export async function* streamLLMEvents(
   messageStreamEvents: AsyncIterable<BetaRawMessageStreamEvent>,
   metadata: LLMClientMetadata,
@@ -272,7 +274,6 @@ function* handleContentBlockStop(
       // invalid JSON and send it back as a tool result so the model can see
       // its mistake and self-correct.
       // https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming#handling-invalid-json-in-tool-responses
-      const MAX_EAGER_VALIDATION_INPUT_LENGTH = 5_000;
       if (
         input.length < MAX_EAGER_VALIDATION_INPUT_LENGTH &&
         input.trim() !== ""

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -30,6 +30,7 @@ import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isRecord } from "@app/types/shared/utils/general";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import cloneDeep from "lodash/cloneDeep";
 
 export async function* streamLLMEvents(
@@ -39,7 +40,7 @@ export async function* streamLLMEvents(
     body: MessageCountTokensParams
   ) => APIPromise<MessageTokensCount>
 ): AsyncGenerator<LLMEvent> {
-  const stateContainer = { state: null };
+  const stateContainer: { state: StreamState } = { state: null };
   // Aggregate output items to build a SuccessCompletionEvent at the end of a turn.
   const aggregate = new SuccessAggregate();
   // Accumulate token usage to return later
@@ -262,12 +263,45 @@ function* handleContentBlockStop(
         stateContainer.state.signature ?? ""
       );
       break;
-    case "tool_use":
+    case "tool_use": {
+      const input = stateContainer.state.accumulator;
+
+      // With eager_input_streaming enabled on all tools, the model may produce
+      // invalid JSON. We validate inputs below a size limit to avoid spending
+      // time parsing very large payloads. Per Anthropic docs, we wrap the
+      // invalid JSON and send it back as a tool result so the model can see
+      // its mistake and self-correct.
+      // https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming#handling-invalid-json-in-tool-responses
+      const MAX_EAGER_VALIDATION_INPUT_LENGTH = 5_000;
+      if (
+        input.length < MAX_EAGER_VALIDATION_INPUT_LENGTH &&
+        input.trim() !== ""
+      ) {
+        const parsed = safeParseJSON(input);
+        if (parsed.isErr()) {
+          logger.warn(
+            {
+              toolName: stateContainer.state.toolInfo.name,
+              inputLength: input.length,
+            },
+            "Tool input failed JSON validation, wrapping as INVALID_JSON tool call"
+          );
+          yield toolCallWithInvalidJson({
+            ...stateContainer.state.toolInfo,
+            invalidJson: input,
+            metadata,
+          });
+          break;
+        }
+      }
+
       yield toolCall({
         ...stateContainer.state.toolInfo,
-        input: stateContainer.state.accumulator,
+        input,
         metadata,
       });
+      break;
+    }
   }
   stateContainer.state = null;
 }
@@ -470,6 +504,34 @@ function toolCall({
       id: id,
       name: name,
       arguments: parseToolArguments(input, name),
+    },
+    metadata,
+  };
+}
+
+/**
+ * Creates a ToolCallEvent wrapping invalid JSON from the model.
+ * Per Anthropic docs for eager_input_streaming, invalid JSON should be wrapped
+ * and sent back as a tool result so the model can see its mistake and retry.
+ * https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming#handling-invalid-json-in-tool-responses
+ */
+function toolCallWithInvalidJson({
+  id,
+  name,
+  invalidJson,
+  metadata,
+}: {
+  id: string;
+  name: string;
+  invalidJson: string;
+  metadata: LLMClientMetadata;
+}): ToolCallEvent {
+  return {
+    type: "tool_call",
+    content: {
+      id,
+      name,
+      arguments: { INVALID_JSON: invalidJson },
     },
     metadata,
   };

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -7,60 +7,7 @@ import type {
   ToolResultBlockParam,
   ToolUseBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
-import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import {
-  AGENT_SIDEKICK_CONTEXT_TOOL_NAME,
-  AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/agent_sidekick_context/metadata";
-import {
-  CONFLUENCE_TOOL_NAME,
-  CONFLUENCE_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/confluence/metadata";
-import {
-  FILE_GENERATION_TOOL_NAME,
-  FILE_GENERATION_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/file_generation/metadata";
-import {
-  GMAIL_TOOL_NAME,
-  GMAIL_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/gmail/metadata";
-import {
-  GOOGLE_DRIVE_TOOL_NAME,
-  GOOGLE_DRIVE_WRITE_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/google_drive/metadata";
-import {
-  GOOGLE_SHEETS_TOOL_NAME,
-  GOOGLE_SHEETS_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/google_sheets/metadata";
-import {
-  INTERACTIVE_CONTENT_SERVER_NAME,
-  INTERACTIVE_CONTENT_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/interactive_content/metadata";
-import {
-  MICROSOFT_DRIVE_SERVER_NAME,
-  MICROSOFT_DRIVE_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/microsoft_drive/metadata";
-import {
-  MICROSOFT_EXCEL_SERVER_NAME,
-  MICROSOFT_EXCEL_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/microsoft_excel/metadata";
-import {
-  NOTION_TOOL_NAME,
-  NOTION_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/notion/metadata";
-import {
-  OUTLOOK_TOOL_NAME,
-  OUTLOOK_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/outlook/mail_metadata";
-import {
-  SANDBOX_TOOL_NAME,
-  SANDBOX_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/sandbox/metadata";
-import {
-  SLIDESHOW_SERVER_NAME,
-  SLIDESHOW_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/slideshow/metadata";
 import { extractEncryptedContentFromMetadata } from "@app/lib/api/llm/utils";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
 import type {
@@ -221,53 +168,16 @@ export function toMessage(
   }
 }
 
-// Tool names sent to the model are prefixed with the server name
-// (e.g. "file_generation__generate_file").
-const TOOLS_WITH_POTENTIAL_LARGE_INPUTS = new Set<string>([
-  // File generation and interactive content: generates full file content.
-  `${FILE_GENERATION_TOOL_NAME}${TOOL_NAME_SEPARATOR}${FILE_GENERATION_TOOLS_METADATA["generate_file"].name}`,
-  `${INTERACTIVE_CONTENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${INTERACTIVE_CONTENT_TOOLS_METADATA["create_interactive_content_file"].name}`,
-  `${INTERACTIVE_CONTENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${INTERACTIVE_CONTENT_TOOLS_METADATA["edit_interactive_content_file"].name}`,
-  // Sandbox: bash commands can include large inline scripts.
-  `${SANDBOX_TOOL_NAME}${TOOL_NAME_SEPARATOR}${SANDBOX_TOOLS_METADATA["bash"].name}`,
-  // Sidekick: rewrites the full agent prompt which can be very large.
-  `${AGENT_SIDEKICK_CONTEXT_TOOL_NAME}${TOOL_NAME_SEPARATOR}${AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA["suggest_prompt_edits"].name}`,
-  // Confluence: page body can contain large storage/ADF content.
-  `${CONFLUENCE_TOOL_NAME}${TOOL_NAME_SEPARATOR}${CONFLUENCE_TOOLS_METADATA["create_page"].name}`,
-  `${CONFLUENCE_TOOL_NAME}${TOOL_NAME_SEPARATOR}${CONFLUENCE_TOOLS_METADATA["update_page"].name}`,
-  // Gmail / Outlook: email drafts can contain large body content.
-  `${GMAIL_TOOL_NAME}${TOOL_NAME_SEPARATOR}${GMAIL_TOOLS_METADATA["create_draft"].name}`,
-  `${OUTLOOK_TOOL_NAME}${TOOL_NAME_SEPARATOR}${OUTLOOK_TOOLS_METADATA["create_draft"].name}`,
-  // Notion: page content can contain large arrays of recursive block structures.
-  `${NOTION_TOOL_NAME}${TOOL_NAME_SEPARATOR}${NOTION_TOOLS_METADATA["add_page_content"].name}`,
-  // Google Drive: document/spreadsheet/presentation updates carry large request arrays.
-  `${GOOGLE_DRIVE_TOOL_NAME}${TOOL_NAME_SEPARATOR}${GOOGLE_DRIVE_WRITE_TOOLS_METADATA["update_document"].name}`,
-  `${GOOGLE_DRIVE_TOOL_NAME}${TOOL_NAME_SEPARATOR}${GOOGLE_DRIVE_WRITE_TOOLS_METADATA["append_to_spreadsheet"].name}`,
-  `${GOOGLE_DRIVE_TOOL_NAME}${TOOL_NAME_SEPARATOR}${GOOGLE_DRIVE_WRITE_TOOLS_METADATA["update_spreadsheet"].name}`,
-  `${GOOGLE_DRIVE_TOOL_NAME}${TOOL_NAME_SEPARATOR}${GOOGLE_DRIVE_WRITE_TOOLS_METADATA["update_presentation"].name}`,
-  // Google Sheets: 2D arrays of cell data.
-  `${GOOGLE_SHEETS_TOOL_NAME}${TOOL_NAME_SEPARATOR}${GOOGLE_SHEETS_TOOLS_METADATA["update_cells"].name}`,
-  `${GOOGLE_SHEETS_TOOL_NAME}${TOOL_NAME_SEPARATOR}${GOOGLE_SHEETS_TOOLS_METADATA["append_data"].name}`,
-  // Microsoft Drive: full Word document XML content.
-  `${MICROSOFT_DRIVE_SERVER_NAME}${TOOL_NAME_SEPARATOR}${MICROSOFT_DRIVE_TOOLS_METADATA["update_word_document"].name}`,
-  // Microsoft Excel: 2D array of cell data.
-  `${MICROSOFT_EXCEL_SERVER_NAME}${TOOL_NAME_SEPARATOR}${MICROSOFT_EXCEL_TOOLS_METADATA["write_worksheet"].name}`,
-  // Slideshow: up to 1MB of TSX/JSX content.
-  `${SLIDESHOW_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SLIDESHOW_TOOLS_METADATA["create_slideshow_file"].name}`,
-  `${SLIDESHOW_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SLIDESHOW_TOOLS_METADATA["edit_slideshow_file"].name}`,
-]);
-
 export function toTool(tool: AgentActionSpecification): Tool {
   return {
     name: tool.name,
     description: tool.description,
     // Eager input streaming allows the LLM to start streaming tool call arguments before
-    // the full input is generated, which avoid hanging for long tool call arguments generation.
-    // This is at the cost that JSON can be invalid so we only enabled for tools with
-    // potentially large inputs.
-    ...(TOOLS_WITH_POTENTIAL_LARGE_INPUTS.has(tool.name) && {
-      eager_input_streaming: true,
-    }),
+    // the full input is generated, which avoids hanging for long tool call arguments generation,
+    // but it can generates invalid input inputs as Anthropic no longer validate them.
+    // JSON validity is checked at content_block_stop in anthropic_to_events.ts.
+    // See https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming#handling-invalid-json-in-tool-responses
+    eager_input_streaming: true,
     input_schema: { ...tool.inputSchema, type: "object" },
   };
 }


### PR DESCRIPTION
## Description

We clearly keep seeing some timeout it large tool calls with Anthropic (hundreds per day)
So I think the strategy of whitelisting some tools is not working.
I'm trying to turn them all to `eager_input_streaming` so we no longer timeout
To avoid the issue with badly generated input, I'm trying to parse all the input as JSON and wrap them in a JSON `{"INVALID_JSON": "<your invalid json string>"}`when it happens (as per [this doc](https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming#handling-invalid-json-in-tool-responses)) The tool call will fail (bad input) and the model will see the badly formatted input.

Error generated by model when input is bad is 
> Unknown error from anthropic: Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: SyntaxError: Expected ',' or '}' after property value in JSON at position 31. JSON: {"keywords": Dave, "relativeTimeFrame": "1d"}

## Tests

Tested a tool call locally

## Risk

May increase the number of invalid JSON
I will monitor this 

## Deploy Plan

deploy front
