### PR TITLE
[front] fix: disable hook `useConversationContextUsage` when used only to mutate

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -254,6 +254,7 @@ export const ConversationViewer = ({
   const { mutateContextUsage } = useConversationContextUsage({
     conversationId: isCompactionEnabled ? conversationId : null,
     workspaceId: owner.sId,
+    options: { disabled: true },
   });
 
   const submitMessage = useSubmitMessage({

--- a/front/hooks/conversations/useConversationContextUsage.ts
+++ b/front/hooks/conversations/useConversationContextUsage.ts
@@ -5,9 +5,11 @@ import type { Fetcher } from "swr";
 export function useConversationContextUsage({
   conversationId,
   workspaceId,
+  options,
 }: {
   conversationId?: string | null;
   workspaceId: string;
+  options?: { disabled: boolean };
 }) {
   const { fetcher } = useFetcher();
   const contextUsageFetcher: Fetcher<GetConversationContextUsageResponse> =
@@ -17,7 +19,8 @@ export function useConversationContextUsage({
     conversationId
       ? `/api/w/${workspaceId}/assistant/conversations/${conversationId}/context-usage`
       : null,
-    contextUsageFetcher
+    contextUsageFetcher,
+    options
   );
 
   return {

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -292,6 +292,7 @@ export function useAgentMessageStream({
   const { mutateContextUsage } = useConversationContextUsage({
     conversationId,
     workspaceId: owner.sId,
+    options: { disabled: true },
   });
   const methods = useVirtuosoMethods<
     VirtuosoMessage,


### PR DESCRIPTION
## Description

- We are getting a lot of errors in the `/context-usage` endpoint (logs [here](https://app.datadoghq.eu/logs?query=%40dd.env%3Aprod%20status%3Aerror%20%40apiError.api_error.type%3Aconversation_context_usage_not_found&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40apiError.api_error.message&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1776097118824&to_ts=1776356318824&live=true)).
- These errors are actually expected at the very start of a run.
- This PR disables the hook in cases where it's only used to mutate, which will at least prevent having errors outside of the feature flag.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
