### PR TITLE
[Sessions] Add parent fork lineage payload

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -3688,4 +3688,117 @@ describe("conversation fetch forkedFrom", () => {
       });
     }
   });
+
+  it("includes forkedChildren in the conversation detail payload", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Fork Fetch Agent",
+      description: "Fork fetch agent",
+    });
+
+    const parentConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date("2026-01-05T00:00:00.000Z")],
+    });
+    const firstChildConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const secondChildConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+
+    await ConversationModel.update(
+      { title: "Later fork" },
+      { where: { id: firstChildConversation.id, workspaceId: workspace.id } }
+    );
+    await ConversationModel.update(
+      { title: "Earlier fork" },
+      { where: { id: secondChildConversation.id, workspaceId: workspace.id } }
+    );
+
+    const parentConversationResource = await ConversationResource.fetchById(
+      auth,
+      parentConversation.sId
+    );
+    const firstChildConversationResource = await ConversationResource.fetchById(
+      auth,
+      firstChildConversation.sId
+    );
+    const secondChildConversationResource =
+      await ConversationResource.fetchById(auth, secondChildConversation.sId);
+
+    expect(parentConversationResource).not.toBeNull();
+    expect(firstChildConversationResource).not.toBeNull();
+    expect(secondChildConversationResource).not.toBeNull();
+
+    if (
+      !parentConversationResource ||
+      !firstChildConversationResource ||
+      !secondChildConversationResource
+    ) {
+      throw new Error("Failed to fetch fork conversations");
+    }
+
+    const sourceMessage = await MessageModel.findOne({
+      where: {
+        conversationId: parentConversation.id,
+        workspaceId: workspace.id,
+        rank: 1,
+      },
+    });
+    expect(sourceMessage).not.toBeNull();
+    if (!sourceMessage) {
+      throw new Error("Failed to fetch source message");
+    }
+
+    const laterBranchedAt = new Date("2026-01-06T11:00:00.000Z");
+    const earlierBranchedAt = new Date("2026-01-06T10:00:00.000Z");
+
+    await ConversationForkResource.makeNew(auth, {
+      parentConversation: parentConversationResource,
+      childConversation: firstChildConversationResource,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt: laterBranchedAt,
+    });
+    await ConversationForkResource.makeNew(auth, {
+      parentConversation: parentConversationResource,
+      childConversation: secondChildConversationResource,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt: earlierBranchedAt,
+    });
+
+    const expectedForkedChildren = [
+      {
+        childConversationId: secondChildConversation.sId,
+        childConversationTitle: "Earlier fork",
+        sourceMessageId: sourceMessage.sId,
+        branchedAt: earlierBranchedAt.getTime(),
+        user: auth.getNonNullableUser().toJSON(),
+      },
+      {
+        childConversationId: firstChildConversation.sId,
+        childConversationTitle: "Later fork",
+        sourceMessageId: sourceMessage.sId,
+        branchedAt: laterBranchedAt.getTime(),
+        user: auth.getNonNullableUser().toJSON(),
+      },
+    ];
+
+    const conversationDetailResult =
+      await ConversationResource.fetchConversationDetail(
+        auth,
+        parentConversation.sId
+      );
+    expect(conversationDetailResult.isOk()).toBe(true);
+
+    if (conversationDetailResult.isOk()) {
+      expect(conversationDetailResult.value.forkedChildren).toEqual(
+        expectedForkedChildren
+      );
+    }
+  });
 });

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -3788,15 +3788,16 @@ describe("conversation fetch forkedFrom", () => {
       },
     ];
 
-    const conversationDetailResult =
-      await ConversationResource.fetchConversationDetail(
+    const conversationResult =
+      await ConversationResource.fetchConversationWithoutContent(
         auth,
-        parentConversation.sId
+        parentConversation.sId,
+        { includeForkedChildrenInfo: true }
       );
-    expect(conversationDetailResult.isOk()).toBe(true);
+    expect(conversationResult.isOk()).toBe(true);
 
-    if (conversationDetailResult.isOk()) {
-      expect(conversationDetailResult.value.forkedChildren).toEqual(
+    if (conversationResult.isOk()) {
+      expect(conversationResult.value.forkedChildren).toEqual(
         expectedForkedChildren
       );
     }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -33,7 +33,6 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
-  ConversationForkedChildType,
   ConversationForkedFromType,
   ConversationMCPServerViewType,
   ConversationVisibility,
@@ -69,6 +68,14 @@ interface UserParticipation {
   actionRequired: boolean;
   updated: number;
 }
+
+type ForkedChildInfo = {
+  childConversationId: string;
+  childConversationTitle: string | null;
+  sourceMessageId: string;
+  branchedAt: number;
+  user: ReturnType<UserResource["toJSON"]>;
+};
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -217,7 +224,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   static async listReadableForkedChildren(
     auth: Authenticator,
     conversation: ConversationResource
-  ): Promise<ConversationForkedChildType[]> {
+  ): Promise<ForkedChildInfo[]> {
     const workspace = auth.getNonNullableWorkspace();
 
     const forks = await ConversationForkModel.findAll({

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -33,6 +33,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
+  ConversationForkedChildType,
   ConversationForkedFromType,
   ConversationMCPServerViewType,
   ConversationVisibility,
@@ -68,14 +69,6 @@ interface UserParticipation {
   actionRequired: boolean;
   updated: number;
 }
-
-type ForkedChildInfo = {
-  childConversationId: string;
-  childConversationTitle: string | null;
-  sourceMessageId: string;
-  branchedAt: number;
-  user: ReturnType<UserResource["toJSON"]>;
-};
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -221,10 +214,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return this.forkedFromData;
   }
 
-  static async listReadableForkedChildren(
+  private static async listSerializedChildForks(
     auth: Authenticator,
     conversation: ConversationResource
-  ): Promise<ForkedChildInfo[]> {
+  ): Promise<ConversationForkedChildType[]> {
     const workspace = auth.getNonNullableWorkspace();
 
     const forks = await ConversationForkModel.findAll({
@@ -1156,10 +1149,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       );
 
     const forkedChildren = options?.includeForkedChildrenInfo
-      ? await ConversationResource.listReadableForkedChildren(
-          auth,
-          conversation
-        )
+      ? await ConversationResource.listSerializedChildForks(auth, conversation)
       : [];
 
     return new Ok({

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -33,7 +33,6 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
-  ConversationDetailType,
   ConversationForkedChildType,
   ConversationForkedFromType,
   ConversationMCPServerViewType,
@@ -62,6 +61,7 @@ export type FetchConversationOptions = {
   includeDeleted?: boolean;
   excludeTest?: boolean; // Explicitly exclude test conversations
   dangerouslySkipPermissionFiltering?: boolean;
+  includeForkedChildrenInfo?: boolean;
   updatedSince?: number; // Filter conversations updated after this timestamp (milliseconds)
 };
 
@@ -1130,9 +1130,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   static async fetchConversationWithoutContent(
     auth: Authenticator,
     sId: string,
-    options?: FetchConversationOptions & {
-      dangerouslySkipPermissionFiltering?: boolean;
-    }
+    options?: FetchConversationOptions
   ): Promise<Result<ConversationWithoutContentType, ConversationError>> {
     const conversation = await this.fetchById(auth, sId, {
       includeDeleted: options?.includeDeleted,
@@ -1149,6 +1147,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         auth,
         conversation.id
       );
+
+    const forkedChildren = options?.includeForkedChildrenInfo
+      ? await ConversationResource.listReadableForkedChildren(
+          auth,
+          conversation
+        )
+      : [];
 
     return new Ok({
       id: conversation.id,
@@ -1170,41 +1175,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       ...(conversation.forkedFromInfo && {
         forkedFrom: conversation.forkedFromInfo,
       }),
-    });
-  }
-
-  static async fetchConversationDetail(
-    auth: Authenticator,
-    sId: string,
-    options?: FetchConversationOptions & {
-      dangerouslySkipPermissionFiltering?: boolean;
-    }
-  ): Promise<Result<ConversationDetailType, ConversationError>> {
-    const conversationResult = await this.fetchConversationWithoutContent(
-      auth,
-      sId,
-      options
-    );
-
-    if (conversationResult.isErr()) {
-      return conversationResult;
-    }
-
-    const conversation = await this.fetchById(auth, sId, {
-      includeDeleted: options?.includeDeleted,
-      dangerouslySkipPermissionFiltering:
-        options?.dangerouslySkipPermissionFiltering,
-    });
-
-    if (!conversation) {
-      return new Err(new ConversationError("conversation_not_found"));
-    }
-
-    const forkedChildren =
-      await ConversationResource.listReadableForkedChildren(auth, conversation);
-
-    return new Ok({
-      ...conversationResult.value,
       ...(forkedChildren.length > 0 && { forkedChildren }),
     });
   }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -10,7 +10,7 @@ import {
   UserConversationReadsModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
-import "@app/lib/models/agent/conversation_fork";
+import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { REINFORCEMENT_METADATA_KEYS } from "@app/lib/reinforced_agent/types";
 import { REINFORCED_SKILLS_METADATA_KEYS } from "@app/lib/reinforcement/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -24,6 +24,7 @@ import { RunResource } from "@app/lib/resources/run_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
@@ -32,6 +33,8 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
+  ConversationDetailType,
+  ConversationForkedChildType,
   ConversationForkedFromType,
   ConversationMCPServerViewType,
   ConversationVisibility,
@@ -209,6 +212,106 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   get forkedFromInfo(): ConversationForkedFromType | undefined {
     return this.forkedFromData;
+  }
+
+  static async listReadableForkedChildren(
+    auth: Authenticator,
+    conversation: ConversationResource
+  ): Promise<ConversationForkedChildType[]> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const forks = await ConversationForkModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        parentConversationId: conversation.id,
+      },
+      order: [
+        ["branchedAt", "ASC"],
+        ["id", "ASC"],
+      ],
+      include: [
+        {
+          model: ConversationModel,
+          as: "childConversation",
+          required: true,
+          attributes: ["sId", "title"],
+        },
+        {
+          model: MessageModel,
+          as: "sourceMessage",
+          required: true,
+          attributes: ["sId"],
+        },
+        {
+          model: UserModel,
+          as: "createdByUser",
+          required: true,
+          attributes: [
+            "id",
+            "sId",
+            "createdAt",
+            "provider",
+            "username",
+            "email",
+            "firstName",
+            "lastName",
+            "imageUrl",
+            "lastLoginAt",
+          ],
+        },
+      ],
+    });
+
+    if (forks.length === 0) {
+      return [];
+    }
+
+    const childConversationIds = forks.flatMap((fork) => {
+      assert(
+        fork.childConversation,
+        "Forked child conversation must be loaded for parent lineage."
+      );
+
+      return [fork.childConversation.sId];
+    });
+
+    const readableChildConversationIds = new Set(
+      (await this.fetchByIds(auth, childConversationIds)).map(
+        (childConversation) => childConversation.sId
+      )
+    );
+
+    return forks.flatMap((fork) => {
+      assert(
+        fork.childConversation,
+        "Forked child conversation must be loaded for parent lineage."
+      );
+      assert(
+        fork.sourceMessage,
+        "Forked source message must be loaded for parent lineage."
+      );
+      assert(
+        fork.createdByUser,
+        "Forked creator must be loaded for parent lineage."
+      );
+
+      if (!readableChildConversationIds.has(fork.childConversation.sId)) {
+        return [];
+      }
+
+      return [
+        {
+          childConversationId: fork.childConversation.sId,
+          childConversationTitle: fork.childConversation.title,
+          sourceMessageId: fork.sourceMessage.sId,
+          branchedAt: fork.branchedAt.getTime(),
+          user: new UserResource(
+            UserResource.model,
+            fork.createdByUser.get()
+          ).toJSON(),
+        },
+      ];
+    });
   }
 
   get space(): SpaceResource | null {
@@ -1067,6 +1170,42 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       ...(conversation.forkedFromInfo && {
         forkedFrom: conversation.forkedFromInfo,
       }),
+    });
+  }
+
+  static async fetchConversationDetail(
+    auth: Authenticator,
+    sId: string,
+    options?: FetchConversationOptions & {
+      dangerouslySkipPermissionFiltering?: boolean;
+    }
+  ): Promise<Result<ConversationDetailType, ConversationError>> {
+    const conversationResult = await this.fetchConversationWithoutContent(
+      auth,
+      sId,
+      options
+    );
+
+    if (conversationResult.isErr()) {
+      return conversationResult;
+    }
+
+    const conversation = await this.fetchById(auth, sId, {
+      includeDeleted: options?.includeDeleted,
+      dangerouslySkipPermissionFiltering:
+        options?.dangerouslySkipPermissionFiltering,
+    });
+
+    if (!conversation) {
+      return new Err(new ConversationError("conversation_not_found"));
+    }
+
+    const forkedChildren =
+      await ConversationResource.listReadableForkedChildren(auth, conversation);
+
+    return new Ok({
+      ...conversationResult.value,
+      ...(forkedChildren.length > 0 && { forkedChildren }),
     });
   }
 

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -147,6 +147,59 @@
  *           type: array
  *           items:
  *             type: string
+ *     PrivateConversationForkUser:
+ *       type: object
+ *       properties:
+ *         sId:
+ *           type: string
+ *         id:
+ *           type: integer
+ *         createdAt:
+ *           type: integer
+ *         provider:
+ *           type: string
+ *           nullable: true
+ *           enum: [auth0, github, google, okta, samlp, waad]
+ *         username:
+ *           type: string
+ *         email:
+ *           type: string
+ *         firstName:
+ *           type: string
+ *         lastName:
+ *           type: string
+ *           nullable: true
+ *         fullName:
+ *           type: string
+ *         image:
+ *           type: string
+ *           nullable: true
+ *         lastLoginAt:
+ *           type: integer
+ *           nullable: true
+ *     PrivateConversationForkedChild:
+ *       type: object
+ *       properties:
+ *         childConversationId:
+ *           type: string
+ *         childConversationTitle:
+ *           type: string
+ *           nullable: true
+ *         sourceMessageId:
+ *           type: string
+ *         branchedAt:
+ *           type: integer
+ *         user:
+ *           $ref: '#/components/schemas/PrivateConversationForkUser'
+ *     PrivateConversationDetail:
+ *       allOf:
+ *         - $ref: '#/components/schemas/PrivateConversation'
+ *         - type: object
+ *           properties:
+ *             forkedChildren:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/PrivateConversationForkedChild'
  *     PrivateFullConversation:
  *       type: object
  *       description: Full conversation including content, owner, and visibility.

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -147,6 +147,10 @@
  *           type: array
  *           items:
  *             type: string
+ *         forkedChildren:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/PrivateConversationForkedChild'
  *     PrivateConversationForkUser:
  *       type: object
  *       properties:
@@ -191,15 +195,6 @@
  *           type: integer
  *         user:
  *           $ref: '#/components/schemas/PrivateConversationForkUser'
- *     PrivateConversationDetail:
- *       allOf:
- *         - $ref: '#/components/schemas/PrivateConversation'
- *         - type: object
- *           properties:
- *             forkedChildren:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/PrivateConversationForkedChild'
  *     PrivateFullConversation:
  *       type: object
  *       description: Full conversation including content, owner, and visibility.

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -30,7 +30,7 @@
  *               type: object
  *               properties:
  *                 conversation:
- *                   $ref: '#/components/schemas/PrivateConversation'
+ *                   $ref: '#/components/schemas/PrivateConversationDetail'
  *       401:
  *         description: Unauthorized
  *   delete:
@@ -129,8 +129,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import {
+  type ConversationDetailType,
   ConversationError,
-  type ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -157,7 +157,7 @@ export type PatchConversationsRequestBody = t.TypeOf<
 >;
 
 export type GetConversationResponseBody = {
-  conversation: ConversationWithoutContentType;
+  conversation: ConversationDetailType;
 };
 
 export type PatchConversationResponseBody = {
@@ -187,7 +187,7 @@ async function handler(
   switch (req.method) {
     case "GET": {
       const conversationRes =
-        await ConversationResource.fetchConversationWithoutContent(auth, cId);
+        await ConversationResource.fetchConversationDetail(auth, cId);
 
       if (conversationRes.isErr()) {
         // Distinguish between "not found" and "access restricted" for the UI.

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -30,7 +30,7 @@
  *               type: object
  *               properties:
  *                 conversation:
- *                   $ref: '#/components/schemas/PrivateConversationDetail'
+ *                   $ref: '#/components/schemas/PrivateConversation'
  *       401:
  *         description: Unauthorized
  *   delete:
@@ -128,10 +128,8 @@ import { moveConversationToProject } from "@app/lib/api/projects/conversations";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
-import {
-  type ConversationDetailType,
-  ConversationError,
-} from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { ConversationError } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
@@ -157,7 +155,7 @@ export type PatchConversationsRequestBody = t.TypeOf<
 >;
 
 export type GetConversationResponseBody = {
-  conversation: ConversationDetailType;
+  conversation: ConversationWithoutContentType;
 };
 
 export type PatchConversationResponseBody = {
@@ -187,7 +185,9 @@ async function handler(
   switch (req.method) {
     case "GET": {
       const conversationRes =
-        await ConversationResource.fetchConversationDetail(auth, cId);
+        await ConversationResource.fetchConversationWithoutContent(auth, cId, {
+          includeForkedChildrenInfo: true,
+        });
 
       if (conversationRes.isErr()) {
         // Distinguish between "not found" and "access restricted" for the UI.

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -6452,7 +6452,7 @@
                   "type": "object",
                   "properties": {
                     "conversation": {
-                      "$ref": "#/components/schemas/PrivateConversation"
+                      "$ref": "#/components/schemas/PrivateConversationDetail"
                     }
                   }
                 }
@@ -9547,6 +9547,95 @@
             }
           }
         }
+      },
+      "PrivateConversationForkUser": {
+        "type": "object",
+        "properties": {
+          "sId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "createdAt": {
+            "type": "integer"
+          },
+          "provider": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "auth0",
+              "github",
+              "google",
+              "okta",
+              "samlp",
+              "waad"
+            ]
+          },
+          "username": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastLoginAt": {
+            "type": "integer",
+            "nullable": true
+          }
+        }
+      },
+      "PrivateConversationForkedChild": {
+        "type": "object",
+        "properties": {
+          "childConversationId": {
+            "type": "string"
+          },
+          "childConversationTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "sourceMessageId": {
+            "type": "string"
+          },
+          "branchedAt": {
+            "type": "integer"
+          },
+          "user": {
+            "$ref": "#/components/schemas/PrivateConversationForkUser"
+          }
+        }
+      },
+      "PrivateConversationDetail": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PrivateConversation"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "forkedChildren": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PrivateConversationForkedChild"
+                }
+              }
+            }
+          }
+        ]
       },
       "PrivateFullConversation": {
         "type": "object",

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -6452,7 +6452,7 @@
                   "type": "object",
                   "properties": {
                     "conversation": {
-                      "$ref": "#/components/schemas/PrivateConversationDetail"
+                      "$ref": "#/components/schemas/PrivateConversation"
                     }
                   }
                 }
@@ -9545,6 +9545,12 @@
             "items": {
               "type": "string"
             }
+          },
+          "forkedChildren": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateConversationForkedChild"
+            }
           }
         }
       },
@@ -9618,24 +9624,6 @@
             "$ref": "#/components/schemas/PrivateConversationForkUser"
           }
         }
-      },
-      "PrivateConversationDetail": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PrivateConversation"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "forkedChildren": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/PrivateConversationForkedChild"
-                }
-              }
-            }
-          }
-        ]
       },
       "PrivateFullConversation": {
         "type": "object",

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -382,6 +382,9 @@ export type ConversationForkedFromType = {
   user: UserType;
 };
 
+/**
+ * @swaggerschema PrivateConversationForkedChild (swagger_private_schemas.ts)
+ */
 export type ConversationForkedChildType = {
   childConversationId: string;
   childConversationTitle: string | null;
@@ -416,6 +419,9 @@ export type ConversationWithoutContentType = {
   requestedSpaceIds: string[];
 };
 
+/**
+ * @swaggerschema PrivateConversationDetail (swagger_private_schemas.ts)
+ */
 export type ConversationDetailType = ConversationWithoutContentType & {
   forkedChildren?: ConversationForkedChildType[];
 };

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -414,16 +414,10 @@ export type ConversationWithoutContentType = {
   metadata: ConversationMetadata;
   branchId: string | null;
   forkedFrom?: ConversationForkedFromType;
+  forkedChildren?: ConversationForkedChildType[];
 
   // Ideally, this property should be moved to the ConversationType.
   requestedSpaceIds: string[];
-};
-
-/**
- * @swaggerschema PrivateConversationDetail (swagger_private_schemas.ts)
- */
-export type ConversationDetailType = ConversationWithoutContentType & {
-  forkedChildren?: ConversationForkedChildType[];
 };
 
 /**

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -382,6 +382,14 @@ export type ConversationForkedFromType = {
   user: UserType;
 };
 
+export type ConversationForkedChildType = {
+  childConversationId: string;
+  childConversationTitle: string | null;
+  sourceMessageId: string;
+  branchedAt: number;
+  user: UserType;
+};
+
 /**
  * A lighter version of Conversation without the content (for menu display).
  *
@@ -406,6 +414,10 @@ export type ConversationWithoutContentType = {
 
   // Ideally, this property should be moved to the ConversationType.
   requestedSpaceIds: string[];
+};
+
+export type ConversationDetailType = ConversationWithoutContentType & {
+  forkedChildren?: ConversationForkedChildType[];
 };
 
 /**


### PR DESCRIPTION
## Description
Part 1 on 2 of rendering branching in parent conversation
<img width="1818" height="737" alt="image" src="https://github.com/user-attachments/assets/d1c03f8e-5192-4224-b145-1e28cd9fe91e" />


Adds `forkedChildren` to the conversation detail payload used by the conversation page.

## Risks
Blast radius: conversation detail fetches for assistant conversations and their private API schema
Risk: low

## Deploy Plan
- pmrr
- deploy front