### PR TITLE
[sessions]: Stop disabling input bar editor during submission

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -459,7 +459,6 @@ export const InputBar = React.memo(function InputBar({
             isSubmitting={
               isLocalSubmitting || fileUploaderService.isProcessingFiles
             }
-            disableInput={isLocalSubmitting}
             onNodeSelect={handleNodesAttachmentSelect}
             onNodeUnselect={handleNodesAttachmentRemove}
             selectedMCPServerViews={selectedMCPServerViews}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -64,7 +64,6 @@ interface InputBarProps {
   isFloating?: boolean;
   isFloatingWithoutMargin?: boolean;
   isSubmitting?: boolean;
-  disable?: boolean;
   isAgentBuilder?: boolean;
   submitBlockMessage?: string | null;
 }
@@ -83,7 +82,6 @@ export const InputBar = React.memo(function InputBar({
   isAgentBuilder = false,
   isFloating = true,
   isSubmitting = false,
-  disable = false,
   submitBlockMessage = null,
 }: InputBarProps) {
   const [isLocalSubmitting, setIsLocalSubmitting] = useState(isSubmitting);
@@ -422,7 +420,6 @@ export const InputBar = React.memo(function InputBar({
           "border-border-dark dark:border-border-dark/10",
           "sm:border-border-dark/50 sm:focus-within:border-border-dark",
           "dark:focus-within:border-border-dark-night sm:focus-within:border-border-dark",
-          disable && "cursor-not-allowed opacity-75",
           isFloating
             ? classNames(
                 "focus-within:ring-1 dark:focus-within:ring-1",
@@ -445,7 +442,6 @@ export const InputBar = React.memo(function InputBar({
               onRemove: handleNodesAttachmentRemove,
             }}
             conversationId={conversation?.sId}
-            disable={disable}
           />
           <InputBarContainer
             actions={actions}
@@ -463,7 +459,7 @@ export const InputBar = React.memo(function InputBar({
             isSubmitting={
               isLocalSubmitting || fileUploaderService.isProcessingFiles
             }
-            disableInput={disable || isLocalSubmitting}
+            disableInput={isLocalSubmitting}
             onNodeSelect={handleNodesAttachmentSelect}
             onNodeUnselect={handleNodesAttachmentRemove}
             selectedMCPServerViews={selectedMCPServerViews}

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -30,7 +30,6 @@ interface InputBarButtonsProps {
   clientType: string;
   conversation?: ConversationWithoutContentType;
   disableAgentSelector: boolean;
-  disableInput: boolean;
   editorService: ReturnType<typeof useCustomEditor>["editorService"];
   fileInputRef: React.MutableRefObject<HTMLInputElement | null>;
   fileUploaderService: FileUploaderService;
@@ -55,7 +54,6 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   clientType,
   conversation,
   disableAgentSelector,
-  disableInput,
   editorService,
   fileInputRef,
   fileUploaderService,
@@ -95,7 +93,6 @@ export const InputBarButtons = React.memo(function InputBarButtons({
         actions.includes("agents-list-with-actions") &&
         clientType !== "extension"
       }
-      disabled={disableInput}
       pickerButton={
         selectedAgent ? (
           <Button
@@ -129,7 +126,6 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       onSelect={onMCPServerViewSelect}
       selectedSkills={selectedSkills}
       onSkillSelect={onSkillSelect}
-      disabled={disableInput}
       buttonSize={buttonSize}
     />
   );
@@ -157,7 +153,6 @@ export const InputBarButtons = React.memo(function InputBarButtons({
           onNodeSelect={onNodeSelect}
           onNodeUnselect={onNodeUnselect}
           attachedNodes={attachedNodes}
-          disabled={disableInput}
           buttonSize={buttonSize}
           toolFileUpload={{
             useCase: "conversation",

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -128,7 +128,6 @@ export interface InputBarContainerProps {
   conversation?: ConversationWithoutContentType;
   space?: SpaceType;
   disableAutoFocus: boolean;
-  disableInput: boolean;
   disableUserMentions?: boolean;
   fileUploaderService: FileUploaderService;
   getDraft: () => {
@@ -168,7 +167,6 @@ const InputBarContainer = ({
   disableAutoFocus,
   disableUserMentions,
   isSubmitting,
-  disableInput,
   fileUploaderService,
   getDraft,
   isAgentBuilder = false,
@@ -881,7 +879,6 @@ const InputBarContainer = ({
   const isSubmitDisabled =
     (isEmpty && !canSubmitEmpty) ||
     isSubmitting ||
-    disableInput ||
     isSubmitBlocked ||
     voiceTranscriberService.status !== "idle";
 
@@ -915,13 +912,11 @@ const InputBarContainer = ({
       <div className="flex w-0 flex-grow flex-col">
         <div className="relative">
           <EditorContent
-            disabled={disableInput}
             editor={editor}
             className={classNames(
               contentEditableClasses,
               "scrollbar-hide",
               "overflow-y-auto",
-              disableInput && "cursor-not-allowed",
               hideButtons
                 ? "max-h-[40vh] pr-20"
                 : "max-h-[40vh] min-h-14 sm:min-h-16"
@@ -965,13 +960,9 @@ const InputBarContainer = ({
                   }
                   target="_blank"
                   className="m-0.5 hidden bg-background text-foreground dark:bg-background-night dark:text-foreground-night xs:flex"
-                  onRemove={
-                    disableInput
-                      ? undefined
-                      : () => {
-                          onSkillDeselect(skill);
-                        }
-                  }
+                  onRemove={() => {
+                    onSkillDeselect(skill);
+                  }}
                 />
                 <Chip
                   size="xs"
@@ -983,13 +974,9 @@ const InputBarContainer = ({
                   }
                   target="_blank"
                   className="m-0.5 flex bg-background text-foreground dark:bg-background-night dark:text-foreground-night xs:hidden"
-                  onRemove={
-                    disableInput
-                      ? undefined
-                      : () => {
-                          onSkillDeselect(skill);
-                        }
-                  }
+                  onRemove={() => {
+                    onSkillDeselect(skill);
+                  }}
                 />
               </React.Fragment>
             ))}
@@ -1001,25 +988,17 @@ const InputBarContainer = ({
                   label={getMcpServerViewDisplayName(msv)}
                   icon={getIcon(msv.server.icon)}
                   className="m-0.5 hidden bg-background text-foreground dark:bg-background-night dark:text-foreground-night xs:flex"
-                  onRemove={
-                    disableInput
-                      ? undefined
-                      : () => {
-                          onMCPServerViewDeselect(msv);
-                        }
-                  }
+                  onRemove={() => {
+                    onMCPServerViewDeselect(msv);
+                  }}
                 />
                 <Chip
                   size="xs"
                   icon={getIcon(msv.server.icon)}
                   className="m-0.5 flex bg-background text-foreground dark:bg-background-night dark:text-foreground-night xs:hidden"
-                  onRemove={
-                    disableInput
-                      ? undefined
-                      : () => {
-                          onMCPServerViewDeselect(msv);
-                        }
-                  }
+                  onRemove={() => {
+                    onMCPServerViewDeselect(msv);
+                  }}
                 />
               </React.Fragment>
             ))}
@@ -1071,7 +1050,6 @@ const InputBarContainer = ({
                     clientType={clientType}
                     conversation={conversation}
                     disableAgentSelector={disableAgentSelector}
-                    disableInput={disableInput}
                     editorService={editorService}
                     fileInputRef={fileInputRef}
                     fileUploaderService={fileUploaderService}
@@ -1112,7 +1090,6 @@ const InputBarContainer = ({
                       variant="ghost-secondary"
                       icon={PlusIcon}
                       size={buttonSize}
-                      disabled={disableInput}
                     />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
@@ -1171,7 +1148,6 @@ const InputBarContainer = ({
                   onNodeSelect={onNodeSelect}
                   onNodeUnselect={onNodeUnselect}
                   attachedNodes={attachedNodes}
-                  disabled={disableInput}
                   buttonSize={buttonSize}
                   toolFileUpload={{
                     useCase: "conversation",
@@ -1206,7 +1182,6 @@ const InputBarContainer = ({
                   elapsedSeconds={voiceTranscriberService.elapsedSeconds}
                   onRecordStart={voiceTranscriberService.startRecording}
                   onRecordStop={voiceTranscriberService.stopRecording}
-                  disabled={disableInput}
                   size={buttonSize}
                   showStopLabel={!isMobile}
                 />

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -631,13 +631,6 @@ const InputBarContainer = ({
     };
   }, [editor, editorService, saveDraft]);
 
-  // Disable the editor when disableInput is true.
-  useEffect(() => {
-    if (editor) {
-      editor.setEditable(!disableInput);
-    }
-  }, [editor, disableInput]);
-
   useUrlHandler(editor, selectedNode, nodeOrUrlCandidate, handleUrlReplaced);
 
   const { spaces, isSpacesLoading } = useSpaces({


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/7620#event-24572095058
## Description
There was a lot of old and seemingly left behind code to disable the input bar when a message is submitting. With steering, I can't think of a reason we'd want to do this. I'm maintaining all logic that disables the submit button itself but allowing users to freely interact with tool additions/removals and all other aspects of the input bar even when a previous message is mid-send.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually by sequencing many messages one after the other
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
One thing I'm not 100p sure about is that we should allow addition/removal of skills and tools 
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
