### PR TITLE
Allow egress proxy in sandbox image network policy

### DIFF
--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -298,7 +298,7 @@ SHELLEOF`,
   .withToolManifest()
   .register({
     imageName: "dust-base",
-    tag: "0.7.3",
+    tag: "0.7.4",
   });
 
 const IMAGES: readonly SandboxImage[] = [DUST_BASE_IMAGE];

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -94,6 +94,8 @@ export const ALLOWLIST_NETWORK_POLICY: NetworkPolicy = {
     // Datadog EU — sandbox telemetry
     "http-intake.logs.datadoghq.eu",
     "api.datadoghq.eu",
+    // Regional egress proxy (eu.sandbox-egress.dust.tt, us.sandbox-egress.dust.tt, ...)
+    "*.sandbox-egress.dust.tt",
   ],
 };
 


### PR DESCRIPTION
## Description

Adds `*.sandbox-egress.dust.tt` to `ALLOWLIST_NETWORK_POLICY` so sandboxes built from `dust-base` can reach the regional egress proxy (`eu.sandbox-egress.dust.tt`, `us.sandbox-egress.dust.tt`). Wildcard covers both regions in one entry. The JWT secret is regional so cross-region calls can't authenticate.

Bumps `dust-base` tag from `0.7.3` to `0.7.4` so this ships as a new image rather than silently changing the contract of an existing one.

Paired infra change: both regions' `egress-proxy-ALLOWED_DOMAINS` GSM secrets were updated to mirror the sandbox allowlist (`storage.googleapis.com,dust.tt,*.dust.tt,http-intake.logs.datadoghq.eu,api.datadoghq.eu`) so the proxy accepts the same destinations the sandbox allows today, preparing for the upcoming `dsbx forward` integration.

## Tests

- Type-checked.
- No behavioral tests added — this is two constants and a tag bump. The image build/publish pipeline will re-build `dust-base:0.7.4` on merge.

## Risk

Low. Additive change to an allowlist + a tag bump. No existing sandbox behavior is removed.

Rollback: revert the PR. Existing sandboxes on `dust-base:0.7.3` are unaffected.

## Deploy Plan

1. Merge.
2. Image build pipeline publishes `dust-base:0.7.4` to E2B.
3. New sandboxes pick up 0.7.4 on their next spawn; no action needed on running sandboxes.