### PR TITLE
Stop escaping skill instructionsHtml in reinforcement context

### DIFF
--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -63,7 +63,7 @@ describe("buildSkillAnalysisPrompt", () => {
     });
     const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
 
-    expect(userMessage).toContain("<instructions>");
+    expect(userMessage).toContain('<instructions format="html">');
     expect(userMessage).toContain("Always verify data before responding.");
   });
 

--- a/front/lib/reinforcement/format_skill_context.ts
+++ b/front/lib/reinforcement/format_skill_context.ts
@@ -17,7 +17,7 @@ export function formatSkillContext(skill: SkillType): string {
     : "";
 
   const instructionsBlock = skill.instructionsHtml
-    ? `<instructions>${escapeXml(skill.instructionsHtml)}</instructions>`
+    ? `<instructions format="html">${skill.instructionsHtml}</instructions>`
     : "";
 
   return `<skill ID="${escapeXml(skill.sId)}" name="${escapeXml(skill.name)}">${toolsBlock}${descBlock}${instructionsBlock}</skill>`;


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/7623
* Can't escape the content of the instructions HTML because we need the agent to generate real HTML. There are a couple examples already for this leading to malformed output
* Simple solution to unescape and add a "format" tag. There is nothing special about this tag, but just gives llm so indicator html is unexpected in content

## Tests

* No change when running local tests

## Risk

* Low

## Deploy Plan

* Deploy front