### PR TITLE
Add skill suggestion pruning when skill is updated

### DIFF
--- a/front/lib/editor/instructions_block_conflict.ts
+++ b/front/lib/editor/instructions_block_conflict.ts
@@ -32,6 +32,21 @@ export function getDescendantBlockIds(
 }
 
 /**
+ * Returns every `data-block-id` present anywhere in serialized instructions HTML.
+ */
+export function getAllBlockIds(instructionsHtml: string): Set<string> {
+  const doc = new JSDOM(instructionsHtml).window.document;
+  const blockIds = new Set<string>();
+  doc.querySelectorAll("[data-block-id]").forEach((element) => {
+    const id = element.getAttribute("data-block-id");
+    if (id) {
+      blockIds.add(id);
+    }
+  });
+  return blockIds;
+}
+
+/**
  * Parses instructions HTML once and returns a map of blockId -> descendant block IDs
  * for the given block IDs. Use this to avoid repeated HTML parsing when checking
  * conflicts for multiple block IDs.

--- a/front/lib/reinforcement/skill_suggestion_pruning.test.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.test.ts
@@ -2,11 +2,16 @@ import { buildDescendantMap } from "@app/lib/editor/instructions_block_conflict"
 import {
   hasSuggestionSelfConflict,
   instructionEditSetsConflict,
+  pruneOutdatedSkillEditSuggestions,
   toolEditSetsConflict,
 } from "@app/lib/reinforcement/skill_suggestion_pruning";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import type { SkillEditSuggestionType } from "@app/types/suggestions/skill_suggestion";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 const HIERARCHY_HTML = `
   <div data-block-id="section-1">
@@ -302,5 +307,110 @@ describe("hasSuggestionSelfConflict", () => {
         HIERARCHY_HTML
       )
     ).toBe(false);
+  });
+});
+
+describe("pruneOutdatedSkillEditSuggestions", () => {
+  let authenticator: Awaited<
+    ReturnType<typeof createResourceTest>
+  >["authenticator"];
+
+  beforeEach(async () => {
+    ({ authenticator } = await createResourceTest({ role: "admin" }));
+  });
+
+  describe("instruction edits", () => {
+    it("marks a suggestion outdated when its target block no longer exists in the skill", async () => {
+      const skill = await SkillFactory.create(authenticator, {
+        instructionsHtml: '<p data-block-id="block-1">Content.</p>',
+      });
+      const suggestion = await SkillSuggestionFactory.createEdit(
+        authenticator,
+        skill,
+        { suggestion: { instructionEdits: [makeInstructionEdit("block-1")] } }
+      );
+
+      // Simulate the user removing the block by saving a new HTML without it.
+      await skill.updateSkill(authenticator, {
+        name: skill.name,
+        agentFacingDescription: skill.agentFacingDescription,
+        userFacingDescription: skill.userFacingDescription,
+        instructions: skill.instructions,
+        instructionsHtml: '<p data-block-id="block-2">New content.</p>',
+        icon: skill.icon,
+        isDefault: skill.isDefault,
+        mcpServerViews: skill.mcpServerViews,
+        requestedSpaceIds: [],
+        attachedKnowledge: [],
+      });
+
+      await pruneOutdatedSkillEditSuggestions(authenticator, skill);
+
+      const fetched = await SkillSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched?.state).toBe("outdated");
+    });
+
+    it("keeps a suggestion pending when its target block still exists", async () => {
+      const skill = await SkillFactory.create(authenticator, {
+        instructionsHtml:
+          '<p data-block-id="block-1">A.</p><p data-block-id="block-2">B.</p>',
+      });
+      const suggestion = await SkillSuggestionFactory.createEdit(
+        authenticator,
+        skill,
+        { suggestion: { instructionEdits: [makeInstructionEdit("block-1")] } }
+      );
+
+      // Save with block-1 still present.
+      await skill.updateSkill(authenticator, {
+        name: skill.name,
+        agentFacingDescription: skill.agentFacingDescription,
+        userFacingDescription: skill.userFacingDescription,
+        instructions: skill.instructions,
+        instructionsHtml:
+          '<p data-block-id="block-1">Updated A.</p><p data-block-id="block-2">B.</p>',
+        icon: skill.icon,
+        isDefault: skill.isDefault,
+        mcpServerViews: skill.mcpServerViews,
+        requestedSpaceIds: [],
+        attachedKnowledge: [],
+      });
+
+      await pruneOutdatedSkillEditSuggestions(authenticator, skill);
+
+      const fetched = await SkillSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched?.state).toBe("pending");
+    });
+
+    it("marks a root-rewrite suggestion outdated after any save", async () => {
+      const skill = await SkillFactory.create(authenticator, {
+        instructionsHtml: '<p data-block-id="block-1">Content.</p>',
+      });
+      const suggestion = await SkillSuggestionFactory.createEdit(
+        authenticator,
+        skill,
+        {
+          suggestion: {
+            instructionEdits: [
+              makeInstructionEdit(INSTRUCTIONS_ROOT_TARGET_BLOCK_ID),
+            ],
+          },
+        }
+      );
+
+      await pruneOutdatedSkillEditSuggestions(authenticator, skill);
+
+      const fetched = await SkillSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched?.state).toBe("outdated");
+    });
   });
 });

--- a/front/lib/reinforcement/skill_suggestion_pruning.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.ts
@@ -111,9 +111,8 @@ export async function pruneConflictingSkillEditSuggestions(
     return;
   }
 
-  const newData = newSuggestion.toJSON();
-  const newInstructionEdits = newData.suggestion.instructionEdits ?? [];
-  const newToolEdits = newData.suggestion.toolEdits ?? [];
+  const newInstructionEdits = newSuggestion.suggestion.instructionEdits ?? [];
+  const newToolEdits = newSuggestion.suggestion.toolEdits ?? [];
 
   // Full rewrite — everything is outdated.
   if (
@@ -136,7 +135,7 @@ export async function pruneConflictingSkillEditSuggestions(
     allInstructionTargetIds.add(e.targetBlockId);
   }
   for (const p of existingPending) {
-    for (const e of p.toJSON().suggestion.instructionEdits ?? []) {
+    for (const e of p.suggestion.instructionEdits ?? []) {
       allInstructionTargetIds.add(e.targetBlockId);
     }
   }
@@ -146,18 +145,14 @@ export async function pruneConflictingSkillEditSuggestions(
       : new Map<string, Set<string>>();
 
   const toMarkOutdated = existingPending.filter((existing) => {
-    const existingData = existing.toJSON();
     return (
       instructionEditSetsConflict(
         newInstructionEdits,
-        existingData.suggestion.instructionEdits ?? [],
+        existing.suggestion.instructionEdits ?? [],
         skill.instructionsHtml,
         descendantMap
       ) ||
-      toolEditSetsConflict(
-        newToolEdits,
-        existingData.suggestion.toolEdits ?? []
-      )
+      toolEditSetsConflict(newToolEdits, existing.suggestion.toolEdits ?? [])
     );
   });
 
@@ -191,7 +186,7 @@ export async function pruneOutdatedSkillEditSuggestions(
     : new Set<string>();
 
   const outdated = pending.filter((p) => {
-    const { instructionEdits, toolEdits } = p.toJSON().suggestion;
+    const { instructionEdits, toolEdits } = p.suggestion;
 
     for (const edit of toolEdits ?? []) {
       const cannotApply =

--- a/front/lib/reinforcement/skill_suggestion_pruning.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
   buildDescendantMap,
+  getAllBlockIds,
   instructionBlockSetsConflict,
 } from "@app/lib/editor/instructions_block_conflict";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -165,4 +166,56 @@ export async function pruneConflictingSkillEditSuggestions(
     toMarkOutdated,
     "outdated"
   );
+}
+
+/**
+ * Marks pending skill edit suggestions as outdated when they can no longer be applied
+ * to the skill's current state.
+ */
+export async function pruneOutdatedSkillEditSuggestions(
+  auth: Authenticator,
+  skill: SkillResource
+): Promise<void> {
+  const pending = await SkillSuggestionResource.listBySkillConfigurationId(
+    auth,
+    skill.sId,
+    { states: ["pending"], kind: "edit" }
+  );
+  if (pending.length === 0) {
+    return;
+  }
+
+  const currentToolSIds = new Set(skill.mcpServerViews.map((v) => v.sId));
+  const currentBlockIds = skill.instructionsHtml
+    ? getAllBlockIds(skill.instructionsHtml)
+    : new Set<string>();
+
+  const outdated = pending.filter((p) => {
+    const { instructionEdits, toolEdits } = p.toJSON().suggestion;
+
+    for (const edit of toolEdits ?? []) {
+      const cannotApply =
+        edit.action === "add"
+          ? currentToolSIds.has(edit.toolId)
+          : !currentToolSIds.has(edit.toolId);
+      if (cannotApply) {
+        return true;
+      }
+    }
+
+    // We do not do a diff check to determine if the content of a specific instruction block has changed.
+    // Taking this simplification as it is a low impact edge case.
+    for (const edit of instructionEdits ?? []) {
+      if (
+        edit.targetBlockId === INSTRUCTIONS_ROOT_TARGET_BLOCK_ID ||
+        !currentBlockIds.has(edit.targetBlockId)
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+
+  await SkillSuggestionResource.bulkUpdateState(auth, outdated, "outdated");
 }

--- a/front/lib/reinforcement/skill_suggestion_pruning.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.ts
@@ -180,7 +180,7 @@ export async function pruneOutdatedSkillEditSuggestions(
     return;
   }
 
-  const currentToolSIds = new Set(skill.mcpServerViews.map((v) => v.sId));
+  const currentToolIds = new Set(skill.mcpServerViews.map((v) => v.sId));
   const currentBlockIds = skill.instructionsHtml
     ? getAllBlockIds(skill.instructionsHtml)
     : new Set<string>();
@@ -191,8 +191,8 @@ export async function pruneOutdatedSkillEditSuggestions(
     for (const edit of toolEdits ?? []) {
       const cannotApply =
         edit.action === "add"
-          ? currentToolSIds.has(edit.toolId)
-          : !currentToolSIds.has(edit.toolId);
+          ? currentToolIds.has(edit.toolId)
+          : !currentToolIds.has(edit.toolId);
       if (cannotApply) {
         return true;
       }
@@ -201,6 +201,8 @@ export async function pruneOutdatedSkillEditSuggestions(
     // We do not do a diff check to determine if the content of a specific instruction block has changed.
     // Taking this simplification as it is a low impact edge case.
     for (const edit of instructionEdits ?? []) {
+      // If the target block is the instructions root block or the block no longer exists, mark the suggestion as outdated.
+      // The root block suggestion would overwrite the entire instructions, so we mark it as outdated as we know it is missing the new updates.
       if (
         edit.targetBlockId === INSTRUCTIONS_ROOT_TARGET_BLOCK_ID ||
         !currentBlockIds.has(edit.targetBlockId)

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -327,6 +328,8 @@ async function handler(
         userFacingDescription: body.userFacingDescription,
         ...(shouldActivate ? { status: "active" as const } : {}),
       });
+
+      await pruneOutdatedSkillEditSuggestions(auth, skill);
 
       return res.status(200).json({
         skill: skill.toJSON(auth),


### PR DESCRIPTION
## Description

- Prune pending skill edit suggestions that can no longer be applied after a skill update:
  - tool edits targeting tools that are no longer attached (or re-adding tools already attached)
  - instruction edits whose target block no longer exists in the saved HTML
  - root-rewrite instruction edits (always outdated on any save)
- Wire pruneOutdatedSkillEditSuggestions into the skill PATCH handler so pruning runs right after the update succeeds.
- Add getAllBlockIds helper in instructions_block_conflict.ts to enumerate every data-block-id in a single JSDOM parse.
- Drop redundant toJSON() calls in pruneConflictingSkillEditSuggestions now that the resource exposes suggestion directly.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
