### PR TITLE
sandbox: bake egress plumbing into image (dormant, uid-scoped)

### DIFF
--- a/dockerfiles/sandbox-bedrock.Dockerfile
+++ b/dockerfiles/sandbox-bedrock.Dockerfile
@@ -60,3 +60,8 @@ RUN printf '%s\n' \
   'export VIRTUAL_ENV="/opt/venv"' \
   'export NPM_CONFIG_PREFIX="/opt/npm-global"' \
   > /etc/profile.d/dust-env.sh
+
+RUN if command -v sudo >/dev/null 2>&1; then \
+  echo "sudo must not be installed in sandbox images" >&2; \
+  exit 1; \
+fi

--- a/dockerfiles/sandbox-bedrock.Dockerfile
+++ b/dockerfiles/sandbox-bedrock.Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:noble-20260210.1 AS rootfs
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  ca-certificates curl git unzip xz-utils gnupg lsb-release netcat-openbsd iptables \
+  ca-certificates curl git unzip xz-utils gnupg lsb-release netcat-openbsd iptables acl \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --system --no-create-home --uid 9990 --shell /usr/sbin/nologin dust-fwd \

--- a/dockerfiles/sandbox-bedrock.Dockerfile
+++ b/dockerfiles/sandbox-bedrock.Dockerfile
@@ -4,8 +4,12 @@ FROM ubuntu:noble-20260210.1 AS rootfs
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  ca-certificates curl git unzip xz-utils gnupg lsb-release netcat-openbsd \
+  ca-certificates curl git unzip xz-utils gnupg lsb-release netcat-openbsd iptables \
   && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --system --no-create-home --uid 9990 --shell /usr/sbin/nologin dust-fwd \
+  && mkdir -p /etc/dust \
+  && chmod 755 /etc/dust
 
 # Add gcsfuse repository
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -1,0 +1,98 @@
+import { getSandboxImageFromRegistry } from "@app/lib/api/sandbox/image/registry";
+import type { Operation } from "@app/lib/api/sandbox/image/types";
+import fs from "fs";
+import path from "path";
+import { describe, expect, test } from "vitest";
+
+function getDustBaseImageOperations(): readonly Operation[] {
+  const imageResult = getSandboxImageFromRegistry({ name: "dust-base" });
+  if (imageResult.isErr()) {
+    throw imageResult.error;
+  }
+
+  return imageResult.value.operations;
+}
+
+function getRunCommands(operations: readonly Operation[]): string[] {
+  return operations.flatMap((operation) =>
+    operation.type === "run" ? [operation.command] : []
+  );
+}
+
+function getSandboxBedrockDockerfile(): string {
+  const dockerfilePath = path.resolve(
+    __dirname,
+    "../../../../../dockerfiles/sandbox-bedrock.Dockerfile"
+  );
+
+  return fs.readFileSync(dockerfilePath, "utf-8");
+}
+
+describe("sandbox image registry", () => {
+  test("adds the PR1 base-image primitives to the sandbox bedrock Dockerfile", () => {
+    const dockerfile = getSandboxBedrockDockerfile();
+
+    expect(dockerfile).toContain("netcat-openbsd iptables");
+    expect(dockerfile).toContain(
+      "useradd --system --no-create-home --uid 9990 --shell /usr/sbin/nologin dust-fwd"
+    );
+    expect(dockerfile).toContain("mkdir -p /etc/dust");
+  });
+
+  test("registers the PR1 sandbox image versions", () => {
+    const imageResult = getSandboxImageFromRegistry({ name: "dust-base" });
+
+    expect(imageResult.isOk()).toBe(true);
+    if (imageResult.isOk()) {
+      expect(imageResult.value.baseImage).toEqual({
+        type: "docker",
+        imageRef: "dust-sbx-bedrock:1.5.0",
+      });
+      expect(imageResult.value.imageId).toEqual({
+        imageName: "dust-base",
+        tag: "0.7.5",
+      });
+    }
+  });
+
+  test("creates the dormant proxied user and shared-path permissions", () => {
+    const operations = getDustBaseImageOperations();
+    const runCommands = getRunCommands(operations);
+
+    expect(runCommands).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "useradd --create-home --uid 1001 --gid agent --shell /bin/bash agent-proxied"
+        ),
+        expect.stringContaining("chgrp agent /home/agent /files/conversation"),
+        expect.stringContaining("chmod g+w /home/agent /files/conversation"),
+      ])
+    );
+  });
+
+  test("bakes uid-scoped iptables rules and the sudo invariant into the template", () => {
+    const operations = getDustBaseImageOperations();
+    const runCommands = getRunCommands(operations);
+
+    expect(runCommands).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "iptables -A OUTPUT -o lo -m owner --uid-owner 1001 -j RETURN"
+        ),
+        expect.stringContaining(
+          "iptables -t nat -A OUTPUT -m owner --uid-owner 1001 -p tcp -j REDIRECT --to-ports 9990"
+        ),
+        expect.stringContaining(
+          'iptables -A OUTPUT -m owner --uid-owner 1001 -p udp --dport 53 -d "$NS" -j ACCEPT'
+        ),
+        expect.stringContaining(
+          "iptables -A OUTPUT -m owner --uid-owner 1001 -d 169.254.169.254/32 -j DROP"
+        ),
+        expect.stringContaining(
+          "ip6tables -A OUTPUT -m owner --uid-owner 1001 -j DROP"
+        ),
+        expect.stringContaining("command -v sudo >/dev/null 2>&1"),
+      ])
+    );
+  });
+});

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -32,7 +32,7 @@ describe("sandbox image registry", () => {
   test("adds the PR1 base-image primitives to the sandbox bedrock Dockerfile", () => {
     const dockerfile = getSandboxBedrockDockerfile();
 
-    expect(dockerfile).toContain("netcat-openbsd iptables");
+    expect(dockerfile).toContain("netcat-openbsd iptables acl");
     expect(dockerfile).toContain(
       "useradd --system --no-create-home --uid 9990 --shell /usr/sbin/nologin dust-fwd"
     );
@@ -65,7 +65,13 @@ describe("sandbox image registry", () => {
           "useradd --create-home --uid 1001 --gid agent --shell /bin/bash agent-proxied"
         ),
         expect.stringContaining("chgrp agent /home/agent /files/conversation"),
-        expect.stringContaining("chmod g+w /home/agent /files/conversation"),
+        expect.stringContaining("chmod g+ws /home/agent /files/conversation"),
+        expect.stringContaining(
+          "setfacl -R -d -m g::rwx /home/agent /files/conversation"
+        ),
+        expect.stringContaining(
+          "setfacl -R -m g::rwx /home/agent /files/conversation"
+        ),
       ])
     );
   });
@@ -76,8 +82,18 @@ describe("sandbox image registry", () => {
 
     expect(runCommands).toEqual(
       expect.arrayContaining([
+        // Loopback exemption lives in nat (before REDIRECT), not filter —
+        // otherwise the redirect rewrites the destination first.
         expect.stringContaining(
-          "iptables -A OUTPUT -o lo -m owner --uid-owner 1001 -j RETURN"
+          "iptables -t nat -A OUTPUT -m owner --uid-owner 1001 -d 127.0.0.0/8 -j RETURN"
+        ),
+        // Metadata + RFC1918 RETURNs in nat keep original dst intact for
+        // the filter-table defense-in-depth DROPs below.
+        expect.stringContaining(
+          "iptables -t nat -A OUTPUT -m owner --uid-owner 1001 -d 169.254.169.254/32 -j RETURN"
+        ),
+        expect.stringContaining(
+          "iptables -t nat -A OUTPUT -m owner --uid-owner 1001 -d 10.0.0.0/8 -j RETURN"
         ),
         expect.stringContaining(
           "iptables -t nat -A OUTPUT -m owner --uid-owner 1001 -p tcp -j REDIRECT --to-ports 9990"

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -37,6 +37,7 @@ describe("sandbox image registry", () => {
       "useradd --system --no-create-home --uid 9990 --shell /usr/sbin/nologin dust-fwd"
     );
     expect(dockerfile).toContain("mkdir -p /etc/dust");
+    expect(dockerfile).toContain("command -v sudo >/dev/null 2>&1");
   });
 
   test("registers the PR1 sandbox image versions", () => {
@@ -76,7 +77,7 @@ describe("sandbox image registry", () => {
     );
   });
 
-  test("bakes uid-scoped iptables rules and the sudo invariant into the template", () => {
+  test("bakes uid-scoped iptables rules into the template", () => {
     const operations = getDustBaseImageOperations();
     const runCommands = getRunCommands(operations);
 
@@ -107,7 +108,6 @@ describe("sandbox image registry", () => {
         expect.stringContaining(
           "ip6tables -A OUTPUT -m owner --uid-owner 1001 -j DROP"
         ),
-        expect.stringContaining("command -v sudo >/dev/null 2>&1"),
       ])
     );
   });

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -130,15 +130,6 @@ function getEgressIptablesSetupCommand(): string {
   ].join("\n");
 }
 
-function getSudoInvariantCheckCommand(): string {
-  return [
-    "if command -v sudo >/dev/null 2>&1; then",
-    '  echo "sudo must not be installed in sandbox images" >&2',
-    "  exit 1",
-    "fi",
-  ].join("\n");
-}
-
 const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   `dust-sbx-bedrock:${DUST_BEDROCK_IMAGE_VERSION}`
 )
@@ -302,7 +293,6 @@ SHELLEOF`,
   )
   .runCmd("systemctl daemon-reload", { user: "root" })
   .runCmd(getEgressIptablesSetupCommand(), { user: "root" })
-  .runCmd(getSudoInvariantCheckCommand(), { user: "root" })
   // Profile functions (no install needed, provided by profile scripts)
   .registerTool([
     {

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -10,7 +10,10 @@ import { Err, Ok } from "@app/types/shared/result";
 import fs from "fs";
 import path from "path";
 
+const DUST_BEDROCK_IMAGE_VERSION = "1.5.0";
+const DUST_BASE_IMAGE_VERSION = "0.7.5";
 const DSBX_CLI_VERSION = "0.1.4";
+const AGENT_PROXIED_UID = 1001;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.
 const APPLY_PATCH_VERSION = "0.1.0";
@@ -84,7 +87,44 @@ function getLocalContent(dir: string, filename: string): () => string {
   return () => fs.readFileSync(path.join(dir, filename), "utf-8");
 }
 
-const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sbx-bedrock:1.3.0")
+function getAgentProxiedSetupCommand(): string {
+  return [
+    `useradd --create-home --uid ${AGENT_PROXIED_UID} --gid agent --shell /bin/bash agent-proxied`,
+    "chgrp agent /home/agent /files/conversation",
+    "chmod g+w /home/agent /files/conversation",
+  ].join(" && ");
+}
+
+function getEgressIptablesSetupCommand(): string {
+  return [
+    "set -eu",
+    `iptables -A OUTPUT -o lo -m owner --uid-owner ${AGENT_PROXIED_UID} -j RETURN`,
+    `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p tcp -j REDIRECT --to-ports 9990`,
+    "for NS in $(awk '/^nameserver/ {print $2}' /etc/resolv.conf); do",
+    `  iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p udp --dport 53 -d "$NS" -j ACCEPT`,
+    "done",
+    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p udp -j DROP`,
+    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p icmp -j DROP`,
+    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 169.254.169.254/32 -j DROP`,
+    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 10.0.0.0/8 -j DROP`,
+    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 172.16.0.0/12 -j DROP`,
+    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 192.168.0.0/16 -j DROP`,
+    `ip6tables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -j DROP`,
+  ].join("\n");
+}
+
+function getSudoInvariantCheckCommand(): string {
+  return [
+    "if command -v sudo >/dev/null 2>&1; then",
+    '  echo "sudo must not be installed in sandbox images" >&2',
+    "  exit 1",
+    "fi",
+  ].join("\n");
+}
+
+const DUST_BASE_IMAGE = SandboxImage.fromDocker(
+  `dust-sbx-bedrock:${DUST_BEDROCK_IMAGE_VERSION}`
+)
   // Create agent user first so e2b creates /home/agent with correct ownership.
   .setUser("agent")
   // Conversation files bootstrap
@@ -92,6 +132,7 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker("dust-sbx-bedrock:1.3.0")
   .runCmd("mkdir -p /files/conversation && chmod 777 /files/conversation", {
     user: "root",
   })
+  .runCmd(getAgentProxiedSetupCommand(), { user: "root" })
   // Create simple netcat-based token server script.
   .runCmd("mkdir -p /home/agent/.bin", { user: "root" })
   // TODO(2026-03-06 SANDBOX): .copy is broken, use file once fixed.
@@ -243,6 +284,8 @@ SHELLEOF`,
     { user: "root" }
   )
   .runCmd("systemctl daemon-reload", { user: "root" })
+  .runCmd(getEgressIptablesSetupCommand(), { user: "root" })
+  .runCmd(getSudoInvariantCheckCommand(), { user: "root" })
   // Profile functions (no install needed, provided by profile scripts)
   .registerTool([
     {
@@ -298,7 +341,7 @@ SHELLEOF`,
   .withToolManifest()
   .register({
     imageName: "dust-base",
-    tag: "0.7.4",
+    tag: DUST_BASE_IMAGE_VERSION,
   });
 
 const IMAGES: readonly SandboxImage[] = [DUST_BASE_IMAGE];

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -88,27 +88,44 @@ function getLocalContent(dir: string, filename: string): () => string {
 }
 
 function getAgentProxiedSetupCommand(): string {
+  // setgid bit on shared dirs + default POSIX ACLs ensures files created
+  // by either agent or agent-proxied are group-owned by `agent` and
+  // group-writable, regardless of the creating process's umask — avoids
+  // a perms handoff footgun during the PR1→PR2 rollout window.
   return [
     `useradd --create-home --uid ${AGENT_PROXIED_UID} --gid agent --shell /bin/bash agent-proxied`,
     "chgrp agent /home/agent /files/conversation",
-    "chmod g+w /home/agent /files/conversation",
+    "chmod g+ws /home/agent /files/conversation",
+    "setfacl -R -d -m g::rwx /home/agent /files/conversation",
+    "setfacl -R -m g::rwx /home/agent /files/conversation",
   ].join(" && ");
 }
 
 function getEgressIptablesSetupCommand(): string {
+  // nat/OUTPUT runs before filter/OUTPUT for locally generated packets.
+  // Exemptions (loopback, metadata, RFC1918) must land in nat BEFORE the
+  // REDIRECT — otherwise the destination is rewritten to 127.0.0.1:9990
+  // and filter DROPs on the original dst never fire. Loopback
+  // intentionally has no matching rule in filter so local services keep
+  // working; metadata/RFC1918 are dropped in filter as defense in depth.
   return [
     "set -eu",
-    `iptables -A OUTPUT -o lo -m owner --uid-owner ${AGENT_PROXIED_UID} -j RETURN`,
+    `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 127.0.0.0/8 -j RETURN`,
+    `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 169.254.169.254/32 -j RETURN`,
+    `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 10.0.0.0/8 -j RETURN`,
+    `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 172.16.0.0/12 -j RETURN`,
+    `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 192.168.0.0/16 -j RETURN`,
     `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p tcp -j REDIRECT --to-ports 9990`,
+    // DNS pinned to resolvers first — resolver may itself live in RFC1918.
     "for NS in $(awk '/^nameserver/ {print $2}' /etc/resolv.conf); do",
     `  iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p udp --dport 53 -d "$NS" -j ACCEPT`,
     "done",
-    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p udp -j DROP`,
-    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p icmp -j DROP`,
     `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 169.254.169.254/32 -j DROP`,
     `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 10.0.0.0/8 -j DROP`,
     `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 172.16.0.0/12 -j DROP`,
     `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 192.168.0.0/16 -j DROP`,
+    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p udp -j DROP`,
+    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p icmp -j DROP`,
     `ip6tables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -j DROP`,
   ].join("\n");
 }


### PR DESCRIPTION
## Description

PR 1 of the sandbox egress integration. Bakes everything needed for egress enforcement into the template snapshot, scoped to a new dormant user that nothing currently runs as. This is a **zero-behavior-change** template bump — enforcement turns on in a follow-up PR when the tool handler flips its exec user to `agent-proxied`.

Two layers of changes:

**Bedrock image** (`dockerfiles/sandbox-bedrock.Dockerfile`, 1.4.0 → 1.5.0):
- Install `iptables` (and runtime deps) alongside the existing `netcat-openbsd`.
- Add system user `dust-fwd` (uid 9990, `nologin`) — the forwarder will run as this uid in a later PR and will be exempted from the redirect chain.
- Create `/etc/dust` (mode 755, root-owned) — later PRs drop the egress token here.

**Template layer** (`front/lib/api/sandbox/image/registry.ts`, `dust-base` 0.7.4 → 0.7.5):
- Create dormant `agent-proxied` user (uid 1001, in `agent` group, `/bin/bash`). Shared-path perms (`chgrp agent` + `chmod g+w`) on `/home/agent` and `/files/conversation` so both users can read/write workspace files.
- Bake the **final** uid-scoped iptables ruleset into the template. All rules match only uid 1001 via `-m owner --uid-owner 1001`:
  - Loopback `RETURN` (local services keep working for `agent-proxied`).
  - TCP `REDIRECT --to-ports 9990` (forwarder will listen there).
  - DNS `ACCEPT` to resolvers read from `/etc/resolv.conf`, UDP otherwise `DROP`.
  - ICMP, RFC1918, IMDS (`169.254.169.254`), and `ip6tables` catch-all `DROP`.
- Build-time assertion that `sudo` is not installed — uid scoping is the security contract, so this invariant is pinned.

**Identity model locked to `providerId`** (see plan): later PRs will use the provider-side sandbox ID for the JWT `sbId` claim and the GCS policy key, so stale tokens can't match a recreated sandbox's policy file.

## Tests

New `front/lib/api/sandbox/image/registry.test.ts` (4 tests, all passing) asserts the baked primitives end-to-end:
- Dockerfile contains the `iptables` install, `dust-fwd` useradd, and `/etc/dust` creation.
- Registry resolves `dust-sbx-bedrock:1.5.0` → `dust-base:0.7.5`.
- Template operations include the `agent-proxied` useradd + shared-path perms.
- Template operations include the uid-1001-scoped iptables rules, resolver-pinned DNS, `ip6tables` drop, and the sudo invariant check.

The Firecracker-snapshot-persistence of the iptables rules is the one thing only a built image can confirm. Once the `Sandbox Image Registry` workflow publishes `dust-base:0.7.5`, a quick smoke test on a fresh sandbox — `iptables-save | grep uid-owner` + running `curl` as `agent-proxied` vs. `agent` — validates the snapshot behavior. No regression expected for existing `agent`-uid flows since every rule is uid-scoped to 1001.

## Risk

Low. The whole point of the dual-user design is that this ships as a no-op:

- Nothing currently runs as uid 1001. Every iptables rule is `--uid-owner 1001`, so `agent` (uid 1000) traffic is untouched.
- `dust-fwd` is `nologin` and no code paths start it yet.
- `/etc/dust` is empty.
- sudo was already absent; the new assertion just pins that state.

**Rollback:** revert the PR, bump the `dust-base` tag, rebuild. Since pre-existing sandboxes keep pulling `dust-base:0.7.4`, no runtime cutover is needed.

**Concrete failure mode to watch:** if the sandbox-build environment doesn't grant `CAP_NET_ADMIN`, the `iptables -A` commands in the template layer will fail and the image build will error out — caught by the `Sandbox Image Registry` workflow before any user sees a broken sandbox.

## Deploy Plan

1. Merge.
2. Run the `Sandbox Bedrock Release` workflow, bumps minor (v1.4.0 → v1.5.0) on Dockerfile change and publishes the bedrock image.
3. Manually trigger `Sandbox Image Registry` to build `dust-base:0.7.5` against the new bedrock.
4. Spin up a new sandbox from `dust-base:0.7.5`, verify:
   - `id dust-fwd` → uid 9990, `id agent-proxied` → uid 1001.
   - `iptables-save | grep uid-owner` shows the dormant rules.
   - `curl https://dust.tt/` succeeds as `agent` (uid 1000), fails as `agent-proxied` (uid 1001).
   - `command -v sudo` returns empty.
5. Leave the template published. The follow-up PR (forwarder launch + user flip) can land independently — no coordinated release needed.