### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/cli/dust-cli/tsup.config.ts
+++ b/cli/dust-cli/tsup.config.ts
@@ -1,6 +1,5 @@
 /// <reference types="node" />
 
-import dotenvFlow from "dotenv-flow";
 import { readFileSync } from "fs";
 import { defineConfig } from "tsup";
 
@@ -8,10 +7,6 @@ const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
 
 const nodeEnv = process.env.NODE_ENV || "development";
 
-// Load environment variables based on NODE_ENV
-const { parsed } = dotenvFlow.config({
-  node_env: nodeEnv,
-});
 
 console.log(`Building for environment: ${nodeEnv}`);
 
@@ -21,8 +16,6 @@ export default defineConfig({
   platform: "node",
   dts: true,
   clean: true,
-  // Inject environment variables into the build
-  env: parsed,
   define: {
     __CLI_VERSION__: JSON.stringify(pkg.version),
   },

--- a/connectors/src/api/get_webhook_router_config.ts
+++ b/connectors/src/api/get_webhook_router_config.ts
@@ -3,8 +3,10 @@ import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
 import type { Request, Response } from "express";
+import { timingSafeEqual } from "node:crypto";
 
 type WebhookRouterEntryParams = {
+  webhook_secret: string;
   provider: "slack" | "notion";
   providerWorkspaceId: string;
 };
@@ -21,7 +23,28 @@ const _getWebhookRouterEntryHandler = async (
   req: Request<WebhookRouterEntryParams, GetWebhookRouterEntryResBody>,
   res: Response<GetWebhookRouterEntryResBody>
 ) => {
-  const { provider, providerWorkspaceId } = req.params;
+  const { webhook_secret, provider, providerWorkspaceId } = req.params;
+
+  const providedSecretBuffer = Buffer.from(webhook_secret);
+  const configuredSecretBuffer = Buffer.from(
+    process.env.WEBHOOK_ROUTER_SECRET ?? ""
+  );
+
+  const isWebhookSecretValid =
+    providedSecretBuffer.length === configuredSecretBuffer.length &&
+    timingSafeEqual(providedSecretBuffer, configuredSecretBuffer);
+
+  if (!isWebhookSecretValid) {
+    logger.info({ provider, providerWorkspaceId }, "Invalid webhook secret");
+
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "not_found",
+        message: "Webhook router entry not found",
+      },
+    });
+  }
 
   const service = new WebhookRouterConfigService();
   const entry = await service.getEntry(provider, providerWorkspaceId);


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Critical` | **File**: `connectors/src/api/get_webhook_router_config.ts:L14`

The handler returns `entry.signingSecret` based only on `provider` and `providerWorkspaceId` route params. The documented route includes `:webhook_secret`, but the handler does not read or validate it, and no authorization check is visible in this function. If this endpoint is reachable without strong upstream auth, an attacker could enumerate workspace IDs and extract webhook signing secrets, enabling webhook forgery.

## Solution

Require strong authentication and authorization before returning secrets. Validate the `webhook_secret` route token (or remove the route pattern if unused), use constant-time comparison for secret checks, and avoid returning raw signing secrets unless absolutely necessary. Prefer returning a boolean/config state instead of secret material.

## Changes

- `connectors/src/api/get_webhook_router_config.ts` (modified)
- `cli/dust-cli/tsup.config.ts` (modified)