### PR TITLE
[audit logs] fill a few gaps in our logging 

### DIFF
--- a/front/admin/audit_log_schemas/agent.archived.json
+++ b/front/admin/audit_log_schemas/agent.archived.json
@@ -9,6 +9,7 @@
     }
   ],
   "metadata": {
-    "agentName": "string"
+    "agentName": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/agent.created.json
+++ b/front/admin/audit_log_schemas/agent.created.json
@@ -11,6 +11,7 @@
   "metadata": {
     "agentName": "string",
     "scope": "string",
-    "model": "string"
+    "model": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/agent.executed.json
+++ b/front/admin/audit_log_schemas/agent.executed.json
@@ -12,6 +12,7 @@
     "conversationId": "string",
     "agentName": "string",
     "origin": "string",
+    "triggerId": "string",
     "actor_type": "string",
     "initiating_user_id": "string",
     "initiating_user_email": "string"

--- a/front/admin/audit_log_schemas/agent.executed.json
+++ b/front/admin/audit_log_schemas/agent.executed.json
@@ -11,6 +11,9 @@
   "metadata": {
     "conversationId": "string",
     "agentName": "string",
-    "origin": "string"
+    "origin": "string",
+    "actor_type": "string",
+    "initiating_user_id": "string",
+    "initiating_user_email": "string"
   }
 }

--- a/front/admin/audit_log_schemas/agent.restored.json
+++ b/front/admin/audit_log_schemas/agent.restored.json
@@ -9,6 +9,7 @@
     }
   ],
   "metadata": {
-    "agentName": "string"
+    "agentName": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/agent.scope_changed.json
+++ b/front/admin/audit_log_schemas/agent.scope_changed.json
@@ -11,6 +11,7 @@
   "metadata": {
     "agentName": "string",
     "previousScope": "string",
-    "newScope": "string"
+    "newScope": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/agent.updated.json
+++ b/front/admin/audit_log_schemas/agent.updated.json
@@ -11,6 +11,7 @@
   "metadata": {
     "agentName": "string",
     "scope": "string",
-    "model": "string"
+    "model": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/api_key.created.json
+++ b/front/admin/audit_log_schemas/api_key.created.json
@@ -9,6 +9,7 @@
     }
   ],
   "metadata": {
-    "groupId": "string"
+    "groupId": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/api_key.revoked.json
+++ b/front/admin/audit_log_schemas/api_key.revoked.json
@@ -7,5 +7,8 @@
     {
       "type": "api_key"
     }
-  ]
+  ],
+  "metadata": {
+    "actor_type": "string"
+  }
 }

--- a/front/admin/audit_log_schemas/api_key.updated.json
+++ b/front/admin/audit_log_schemas/api_key.updated.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "previousSpendingCap": "string",
-    "newSpendingCap": "string"
+    "newSpendingCap": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/audit_log.export_configured.json
+++ b/front/admin/audit_log_schemas/audit_log.export_configured.json
@@ -4,5 +4,8 @@
     {
       "type": "workspace"
     }
-  ]
+  ],
+  "metadata": {
+    "actor_type": "string"
+  }
 }

--- a/front/admin/audit_log_schemas/audit_log.viewed.json
+++ b/front/admin/audit_log_schemas/audit_log.viewed.json
@@ -4,5 +4,8 @@
     {
       "type": "workspace"
     }
-  ]
+  ],
+  "metadata": {
+    "actor_type": "string"
+  }
 }

--- a/front/admin/audit_log_schemas/conversation.accessed.json
+++ b/front/admin/audit_log_schemas/conversation.accessed.json
@@ -9,6 +9,7 @@
     }
   ],
   "metadata": {
-    "conversationId": "string"
+    "conversationId": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/credentials.invalidated.json
+++ b/front/admin/audit_log_schemas/credentials.invalidated.json
@@ -1,5 +1,5 @@
 {
-  "action": "credentials.created",
+  "action": "credentials.invalidated",
   "targets": [
     {
       "type": "workspace"
@@ -9,10 +9,8 @@
     }
   ],
   "metadata": {
-    "provider": "string",
     "providerId": "string",
-    "credentialType": "string",
-    "credentialId": "string",
+    "reason": "string",
     "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/credentials.revoked.json
+++ b/front/admin/audit_log_schemas/credentials.revoked.json
@@ -1,5 +1,5 @@
 {
-  "action": "credentials.created",
+  "action": "credentials.revoked",
   "targets": [
     {
       "type": "workspace"
@@ -9,10 +9,8 @@
     }
   ],
   "metadata": {
-    "provider": "string",
     "providerId": "string",
-    "credentialType": "string",
-    "credentialId": "string",
+    "reason": "string",
     "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/credentials.updated.json
+++ b/front/admin/audit_log_schemas/credentials.updated.json
@@ -1,5 +1,5 @@
 {
-  "action": "credentials.created",
+  "action": "credentials.updated",
   "targets": [
     {
       "type": "workspace"
@@ -9,10 +9,7 @@
     }
   ],
   "metadata": {
-    "provider": "string",
     "providerId": "string",
-    "credentialType": "string",
-    "credentialId": "string",
     "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/datasource.created.json
+++ b/front/admin/audit_log_schemas/datasource.created.json
@@ -11,6 +11,7 @@
   "metadata": {
     "dataSourceName": "string",
     "provider": "string",
-    "spaceId": "string"
+    "spaceId": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/datasource.deleted.json
+++ b/front/admin/audit_log_schemas/datasource.deleted.json
@@ -11,6 +11,7 @@
   "metadata": {
     "dataSourceName": "string",
     "provider": "string",
-    "spaceId": "string"
+    "spaceId": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/datasource.deleted_admin.json
+++ b/front/admin/audit_log_schemas/datasource.deleted_admin.json
@@ -11,6 +11,7 @@
   "metadata": {
     "dataSourceName": "string",
     "provider": "string",
-    "deletedBy": "string"
+    "deletedBy": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/datasource.reauthorized.json
+++ b/front/admin/audit_log_schemas/datasource.reauthorized.json
@@ -1,0 +1,17 @@
+{
+  "action": "datasource.reauthorized",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "data_source"
+    }
+  ],
+  "metadata": {
+    "dataSourceName": "string",
+    "provider": "string",
+    "newConnectionId": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/datasource.updated.json
+++ b/front/admin/audit_log_schemas/datasource.updated.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "dataSourceName": "string",
-    "field": "string"
+    "field": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/domain.removed.json
+++ b/front/admin/audit_log_schemas/domain.removed.json
@@ -6,6 +6,7 @@
     }
   ],
   "metadata": {
-    "domain": "string"
+    "domain": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/domain.verification_failed.json
+++ b/front/admin/audit_log_schemas/domain.verification_failed.json
@@ -7,6 +7,7 @@
   ],
   "metadata": {
     "domain": "string",
-    "reason": "string"
+    "reason": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/domain.verified.json
+++ b/front/admin/audit_log_schemas/domain.verified.json
@@ -6,6 +6,7 @@
     }
   ],
   "metadata": {
-    "domain": "string"
+    "domain": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/dsync.connection_deleted.json
+++ b/front/admin/audit_log_schemas/dsync.connection_deleted.json
@@ -6,6 +6,7 @@
     }
   ],
   "metadata": {
-    "directoryType": "string"
+    "directoryType": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/invitation.revoked.json
+++ b/front/admin/audit_log_schemas/invitation.revoked.json
@@ -9,6 +9,7 @@
     }
   ],
   "metadata": {
-    "invitedEmail": "string"
+    "invitedEmail": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/invitation.role_updated.json
+++ b/front/admin/audit_log_schemas/invitation.role_updated.json
@@ -11,6 +11,7 @@
   "metadata": {
     "invitedEmail": "string",
     "previousRole": "string",
-    "newRole": "string"
+    "newRole": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/mcp_connection.created.json
+++ b/front/admin/audit_log_schemas/mcp_connection.created.json
@@ -1,0 +1,17 @@
+{
+  "action": "mcp_connection.created",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "mcp_connection"
+    }
+  ],
+  "metadata": {
+    "connectionType": "string",
+    "serverType": "string",
+    "authType": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/mcp_connection.deleted.json
+++ b/front/admin/audit_log_schemas/mcp_connection.deleted.json
@@ -1,0 +1,17 @@
+{
+  "action": "mcp_connection.deleted",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "mcp_connection"
+    }
+  ],
+  "metadata": {
+    "connectionType": "string",
+    "serverType": "string",
+    "authType": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/member.bulk_invited.json
+++ b/front/admin/audit_log_schemas/member.bulk_invited.json
@@ -8,6 +8,7 @@
   "metadata": {
     "invitedEmails": "string",
     "count": "string",
-    "source": "string"
+    "source": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/member.bulk_revoked.json
+++ b/front/admin/audit_log_schemas/member.bulk_revoked.json
@@ -8,6 +8,7 @@
   "metadata": {
     "revokedEmails": "string",
     "count": "string",
-    "source": "string"
+    "source": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/member.invited.json
+++ b/front/admin/audit_log_schemas/member.invited.json
@@ -7,6 +7,7 @@
   ],
   "metadata": {
     "invitedCount": "string",
-    "emails": "string"
+    "emails": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/membership.created.json
+++ b/front/admin/audit_log_schemas/membership.created.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "role": "string",
-    "origin": "string"
+    "origin": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/membership.origin_updated.json
+++ b/front/admin/audit_log_schemas/membership.origin_updated.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "previousOrigin": "string",
-    "newOrigin": "string"
+    "newOrigin": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/membership.revoked.json
+++ b/front/admin/audit_log_schemas/membership.revoked.json
@@ -9,6 +9,7 @@
     }
   ],
   "metadata": {
-    "previousRole": "string"
+    "previousRole": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/membership.role_updated.json
+++ b/front/admin/audit_log_schemas/membership.role_updated.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "previousRole": "string",
-    "newRole": "string"
+    "newRole": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/oauth.authorized.json
+++ b/front/admin/audit_log_schemas/oauth.authorized.json
@@ -7,6 +7,7 @@
   ],
   "metadata": {
     "provider": "string",
-    "connectionId": "string"
+    "connectionId": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/oauth.initiated.json
+++ b/front/admin/audit_log_schemas/oauth.initiated.json
@@ -7,6 +7,7 @@
   ],
   "metadata": {
     "provider": "string",
-    "connectionId": "string"
+    "connectionId": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/oauth.revoked.json
+++ b/front/admin/audit_log_schemas/oauth.revoked.json
@@ -1,0 +1,17 @@
+{
+  "action": "oauth.revoked",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "mcp_connection"
+    }
+  ],
+  "metadata": {
+    "provider": "string",
+    "connectionId": "string",
+    "connectionType": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/project.joined.json
+++ b/front/admin/audit_log_schemas/project.joined.json
@@ -9,6 +9,7 @@
     }
   ],
   "metadata": {
-    "spaceName": "string"
+    "spaceName": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/project.left.json
+++ b/front/admin/audit_log_schemas/project.left.json
@@ -9,6 +9,7 @@
     }
   ],
   "metadata": {
-    "spaceName": "string"
+    "spaceName": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/scim.group_created.json
+++ b/front/admin/audit_log_schemas/scim.group_created.json
@@ -11,6 +11,7 @@
   "metadata": {
     "groupName": "string",
     "directoryId": "string",
-    "spaceCreated": "string"
+    "spaceCreated": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/scim.group_deleted.json
+++ b/front/admin/audit_log_schemas/scim.group_deleted.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "groupName": "string",
-    "directoryId": "string"
+    "directoryId": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/scim.group_user_added.json
+++ b/front/admin/audit_log_schemas/scim.group_user_added.json
@@ -15,6 +15,7 @@
     "groupName": "string",
     "userEmail": "string",
     "directoryId": "string",
-    "roleGranted": "string"
+    "roleGranted": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/scim.group_user_removed.json
+++ b/front/admin/audit_log_schemas/scim.group_user_removed.json
@@ -15,6 +15,7 @@
     "groupName": "string",
     "userEmail": "string",
     "directoryId": "string",
-    "roleChange": "string"
+    "roleChange": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/scim.user_deprovisioned.json
+++ b/front/admin/audit_log_schemas/scim.user_deprovisioned.json
@@ -11,6 +11,7 @@
   "metadata": {
     "email": "string",
     "directoryId": "string",
-    "triggersDeleted": "string"
+    "triggersDeleted": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/scim.user_provisioned.json
+++ b/front/admin/audit_log_schemas/scim.user_provisioned.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "email": "string",
-    "directoryId": "string"
+    "directoryId": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/scim.user_updated.json
+++ b/front/admin/audit_log_schemas/scim.user_updated.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "directoryId": "string",
-    "updatedAttributes": "string"
+    "updatedAttributes": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/space.accessed.json
+++ b/front/admin/audit_log_schemas/space.accessed.json
@@ -1,0 +1,18 @@
+{
+  "action": "space.accessed",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "space"
+    }
+  ],
+  "metadata": {
+    "spaceName": "string",
+    "spaceKind": "string",
+    "isRestricted": "string",
+    "accessMethod": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/space.created.json
+++ b/front/admin/audit_log_schemas/space.created.json
@@ -11,6 +11,7 @@
   "metadata": {
     "spaceName": "string",
     "spaceKind": "string",
-    "isRestricted": "string"
+    "isRestricted": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/space.deleted.json
+++ b/front/admin/audit_log_schemas/space.deleted.json
@@ -10,6 +10,7 @@
   ],
   "metadata": {
     "spaceName": "string",
-    "spaceKind": "string"
+    "spaceKind": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/space.permissions_updated.json
+++ b/front/admin/audit_log_schemas/space.permissions_updated.json
@@ -15,6 +15,7 @@
     "memberIds": "string",
     "editorIds": "string",
     "groupIds": "string",
-    "editorGroupIds": "string"
+    "editorGroupIds": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/sso.connection_deleted.json
+++ b/front/admin/audit_log_schemas/sso.connection_deleted.json
@@ -6,6 +6,7 @@
     }
   ],
   "metadata": {
-    "connectionType": "string"
+    "connectionType": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/tool.executed.json
+++ b/front/admin/audit_log_schemas/tool.executed.json
@@ -14,6 +14,9 @@
   "metadata": {
     "toolName": "string",
     "toolType": "string",
-    "conversationId": "string"
+    "conversationId": "string",
+    "actor_type": "string",
+    "initiating_user_id": "string",
+    "initiating_user_email": "string"
   }
 }

--- a/front/admin/audit_log_schemas/tool.executed.json
+++ b/front/admin/audit_log_schemas/tool.executed.json
@@ -14,7 +14,10 @@
   "metadata": {
     "toolName": "string",
     "toolType": "string",
+    "mcpServerName": "string",
     "conversationId": "string",
+    "accessedDataSourceIds": "string",
+    "accessedTableIds": "string",
     "actor_type": "string",
     "initiating_user_id": "string",
     "initiating_user_email": "string"

--- a/front/admin/audit_log_schemas/tool.executed.json
+++ b/front/admin/audit_log_schemas/tool.executed.json
@@ -16,6 +16,7 @@
     "toolType": "string",
     "mcpServerName": "string",
     "conversationId": "string",
+    "triggerId": "string",
     "accessedDataSourceIds": "string",
     "accessedTableIds": "string",
     "actor_type": "string",

--- a/front/admin/audit_log_schemas/trigger.email_received.json
+++ b/front/admin/audit_log_schemas/trigger.email_received.json
@@ -10,6 +10,9 @@
   ],
   "metadata": {
     "senderEmail": "string",
-    "agentId": "string"
+    "agentId": "string",
+    "actor_type": "string",
+    "initiating_user_id": "string",
+    "initiating_user_email": "string"
   }
 }

--- a/front/admin/audit_log_schemas/trigger.fired.json
+++ b/front/admin/audit_log_schemas/trigger.fired.json
@@ -10,6 +10,9 @@
   ],
   "metadata": {
     "triggerType": "string",
-    "agentId": "string"
+    "agentId": "string",
+    "actor_type": "string",
+    "initiating_user_id": "string",
+    "initiating_user_email": "string"
   }
 }

--- a/front/admin/audit_log_schemas/user.identity_merged.json
+++ b/front/admin/audit_log_schemas/user.identity_merged.json
@@ -7,6 +7,7 @@
   ],
   "metadata": {
     "primaryUserId": "string",
-    "mergedUserId": "string"
+    "mergedUserId": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/user.login.json
+++ b/front/admin/audit_log_schemas/user.login.json
@@ -7,6 +7,7 @@
   ],
   "metadata": {
     "isSSO": "string",
-    "authenticationMethod": "string"
+    "authenticationMethod": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/user.login_failed.json
+++ b/front/admin/audit_log_schemas/user.login_failed.json
@@ -7,6 +7,7 @@
   ],
   "metadata": {
     "reason": "string",
-    "authenticationMethod": "string"
+    "authenticationMethod": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/user.logout.json
+++ b/front/admin/audit_log_schemas/user.logout.json
@@ -4,5 +4,8 @@
     {
       "type": "user"
     }
-  ]
+  ],
+  "metadata": {
+    "actor_type": "string"
+  }
 }

--- a/front/admin/audit_log_schemas/user.relocated.json
+++ b/front/admin/audit_log_schemas/user.relocated.json
@@ -7,6 +7,7 @@
   ],
   "metadata": {
     "fromRegion": "string",
-    "toRegion": "string"
+    "toRegion": "string",
+    "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/workspace.deleted.json
+++ b/front/admin/audit_log_schemas/workspace.deleted.json
@@ -6,6 +6,7 @@
     }
   ],
   "metadata": {
-    "relocated": "string"
+    "relocated": "string",
+    "actor_type": "string"
   }
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1022,19 +1022,6 @@ export async function postUserMessage(
 
   // Emit agent.executed for each agent being invoked.
   for (const agentMessage of agentMessages) {
-    const metadata: Record<string, string> = {
-      conversationId: conversation.sId,
-      agentName: agentMessage.configuration.name,
-      origin: context.origin,
-    };
-
-    // When the actor is not a human user (API key context), record unknown
-    // initiating-user fields so the downstream audit log schema stays populated.
-    if (!auth.user()) {
-      metadata.initiating_user_id = "unknown";
-      metadata.initiating_user_email = "unknown";
-    }
-
     void emitAuditLogEvent({
       auth,
       action: "agent.executed",
@@ -1042,7 +1029,13 @@ export async function postUserMessage(
         buildAuditLogTarget("workspace", conversation.owner),
         buildAuditLogTarget("agent", agentMessage.configuration),
       ],
-      metadata,
+      metadata: {
+        conversationId: conversation.sId,
+        agentName: agentMessage.configuration.name,
+        origin: context.origin,
+        initiating_user_id: auth.user()?.sId ?? "unknown",
+        initiating_user_email: auth.user()?.email ?? "unknown",
+      },
     });
   }
 
@@ -2924,19 +2917,6 @@ export async function updateAgentMessageWithFinalStatus(
   if (newAgentMessage) {
     await publishAgentMessagesEvents(conversation, [newAgentMessage]);
 
-    const steeringMetadata: Record<string, string> = {
-      conversationId: conversation.sId,
-      agentName: newAgentMessage.configuration.name,
-      origin: "steering",
-    };
-
-    // When the actor is not a human user (API key context), record unknown
-    // initiating-user fields so the downstream audit log schema stays populated.
-    if (!promotedAuth.user()) {
-      steeringMetadata.initiating_user_id = "unknown";
-      steeringMetadata.initiating_user_email = "unknown";
-    }
-
     void emitAuditLogEvent({
       auth: promotedAuth,
       action: "agent.executed",
@@ -2944,7 +2924,13 @@ export async function updateAgentMessageWithFinalStatus(
         buildAuditLogTarget("workspace", owner),
         buildAuditLogTarget("agent", newAgentMessage.configuration),
       ],
-      metadata: steeringMetadata,
+      metadata: {
+        conversationId: conversation.sId,
+        agentName: newAgentMessage.configuration.name,
+        origin: "steering",
+        initiating_user_id: promotedAuth.user()?.sId ?? "unknown",
+        initiating_user_email: promotedAuth.user()?.email ?? "unknown",
+      },
     });
 
     await runAgentLoopWorkflow({

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1022,6 +1022,19 @@ export async function postUserMessage(
 
   // Emit agent.executed for each agent being invoked.
   for (const agentMessage of agentMessages) {
+    const metadata: Record<string, string> = {
+      conversationId: conversation.sId,
+      agentName: agentMessage.configuration.name,
+      origin: context.origin,
+    };
+
+    // When the actor is not a human user (API key context), record unknown
+    // initiating-user fields so the downstream audit log schema stays populated.
+    if (!auth.user()) {
+      metadata.initiating_user_id = "unknown";
+      metadata.initiating_user_email = "unknown";
+    }
+
     void emitAuditLogEvent({
       auth,
       action: "agent.executed",
@@ -1029,11 +1042,7 @@ export async function postUserMessage(
         buildAuditLogTarget("workspace", conversation.owner),
         buildAuditLogTarget("agent", agentMessage.configuration),
       ],
-      metadata: {
-        conversationId: conversation.sId,
-        agentName: agentMessage.configuration.name,
-        origin: context.origin,
-      },
+      metadata,
     });
   }
 
@@ -2915,6 +2924,19 @@ export async function updateAgentMessageWithFinalStatus(
   if (newAgentMessage) {
     await publishAgentMessagesEvents(conversation, [newAgentMessage]);
 
+    const steeringMetadata: Record<string, string> = {
+      conversationId: conversation.sId,
+      agentName: newAgentMessage.configuration.name,
+      origin: "steering",
+    };
+
+    // When the actor is not a human user (API key context), record unknown
+    // initiating-user fields so the downstream audit log schema stays populated.
+    if (!promotedAuth.user()) {
+      steeringMetadata.initiating_user_id = "unknown";
+      steeringMetadata.initiating_user_email = "unknown";
+    }
+
     void emitAuditLogEvent({
       auth: promotedAuth,
       action: "agent.executed",
@@ -2922,11 +2944,7 @@ export async function updateAgentMessageWithFinalStatus(
         buildAuditLogTarget("workspace", owner),
         buildAuditLogTarget("agent", newAgentMessage.configuration),
       ],
-      metadata: {
-        conversationId: conversation.sId,
-        agentName: newAgentMessage.configuration.name,
-        origin: "steering",
-      },
+      metadata: steeringMetadata,
     });
 
     await runAgentLoopWorkflow({

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1033,6 +1033,9 @@ export async function postUserMessage(
         conversationId: conversation.sId,
         agentName: agentMessage.configuration.name,
         origin: context.origin,
+        ...(conversation.triggerId
+          ? { triggerId: conversation.triggerId }
+          : {}),
         initiating_user_id: auth.user()?.sId ?? "unknown",
         initiating_user_email: auth.user()?.email ?? "unknown",
       },
@@ -2928,6 +2931,9 @@ export async function updateAgentMessageWithFinalStatus(
         conversationId: conversation.sId,
         agentName: newAgentMessage.configuration.name,
         origin: "steering",
+        ...(conversation.triggerId
+          ? { triggerId: conversation.triggerId }
+          : {}),
         initiating_user_id: promotedAuth.user()?.sId ?? "unknown",
         initiating_user_email: promotedAuth.user()?.email ?? "unknown",
       },

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -45,7 +45,14 @@ type AuditAction =
   // OAuth & Credentials.
   | "oauth.initiated"
   | "oauth.authorized"
+  | "oauth.revoked"
   | "credentials.created"
+  | "credentials.updated"
+  | "credentials.revoked"
+  | "credentials.invalidated"
+  // MCP Connections.
+  | "mcp_connection.created"
+  | "mcp_connection.deleted"
   // Projects.
   | "project.joined"
   | "project.left"
@@ -70,6 +77,7 @@ type AuditAction =
   | "agent.restored"
   | "agent.scope_changed"
   // Spaces.
+  | "space.accessed"
   | "space.created"
   | "space.deleted"
   | "space.permissions_updated"
@@ -80,6 +88,7 @@ type AuditAction =
   | "datasource.updated"
   | "datasource.deleted"
   | "datasource.deleted_admin"
+  | "datasource.reauthorized"
   // Audit Logs.
   | "audit_log.viewed"
   | "audit_log.export_configured";
@@ -91,6 +100,23 @@ export type EmitAuditLogEventParams = {
   context?: AuditLogContext;
   metadata?: Record<string, string | number | boolean>;
 };
+
+/**
+ * Serializes all metadata values to strings so the emitted event matches the
+ * schema definitions, which declare every metadata value as `"string"`.
+ */
+function serializeMetadata(
+  metadata: Record<string, string | number | boolean> | undefined
+): Record<string, string> | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    result[key] = typeof value === "string" ? value : String(value);
+  }
+  return result;
+}
 
 /**
  * Returns true if audit logs are enabled for the workspace,
@@ -127,14 +153,22 @@ export async function emitAuditLogEvent({
       return;
     }
 
+    const actor = buildAuditActor(auth);
+    if (!actor.type) {
+      logger.warn({ action }, "Audit event emitted without actor_type");
+    }
+
     await createAuditLogEvent({
       workspace,
       event: {
         action,
-        actor: buildAuditActor(auth),
+        actor,
         targets,
         context: context ?? { location: auth.clientIp() ?? "internal" },
-        metadata,
+        metadata: serializeMetadata({
+          ...metadata,
+          actor_type: actor.type,
+        }),
       },
     });
   } catch (error) {
@@ -187,6 +221,10 @@ export async function emitAuditLogEventDirect({
       return;
     }
 
+    if (!actor.type) {
+      logger.warn({ action }, "Audit event emitted without actor_type");
+    }
+
     await createAuditLogEvent({
       workspace,
       event: {
@@ -194,7 +232,10 @@ export async function emitAuditLogEventDirect({
         actor,
         targets,
         context,
-        metadata,
+        metadata: serializeMetadata({
+          ...metadata,
+          actor_type: actor.type,
+        }),
       },
     });
   } catch (error) {
@@ -251,7 +292,9 @@ type AuditTargetType =
   | "trigger"
   | "api_key"
   | "invitation"
-  | "group";
+  | "group"
+  | "credential"
+  | "mcp_connection";
 
 /**
  * Resource shape required for each audit target type.

--- a/front/lib/api/resource_wrappers.ts
+++ b/front/lib/api/resource_wrappers.ts
@@ -1,3 +1,8 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -6,6 +11,14 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+function deriveAccessMethod(auth: Authenticator): string {
+  const key = auth.key();
+  if (key) {
+    return key.isSystem ? "system_key" : "api_key";
+  }
+  return "ui";
+}
 
 const RESOURCE_KEYS = ["space", "dataSource", "dataSourceView"] as const;
 
@@ -198,6 +211,27 @@ function withSpaceFromRoute<T, A extends SessionOrKeyAuthType>(
           api_error: {
             type: "space_not_found",
             message: "The space you requested was not found.",
+          },
+        });
+      }
+
+      // Emit space.accessed for restricted spaces only — unrestricted spaces
+      // would produce high-volume noise with limited security value.
+      const spaceJSON = space.toJSON();
+      if (spaceJSON.isRestricted) {
+        void emitAuditLogEvent({
+          auth,
+          action: "space.accessed",
+          targets: [
+            buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+            buildAuditLogTarget("space", space),
+          ],
+          context: getAuditLogContext(auth, req),
+          metadata: {
+            spaceName: space.name,
+            spaceKind: spaceJSON.kind,
+            isRestricted: "true",
+            accessMethod: deriveAccessMethod(auth),
           },
         });
       }

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -4,6 +4,10 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { matchesInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
@@ -68,9 +72,31 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
       workspaceId: auth.getNonNullableWorkspace().id,
       userId: user.id,
     });
-    return new this(MCPServerConnectionModel, server.get(), {
+
+    const resource = new this(MCPServerConnectionModel, server.get(), {
       user,
     });
+
+    void emitAuditLogEvent({
+      auth,
+      action: "mcp_connection.created",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("mcp_connection", {
+          sId: resource.sId,
+          name:
+            resource.internalMCPServerId ??
+            String(resource.remoteMCPServerId ?? "unknown"),
+        }),
+      ],
+      metadata: {
+        connectionType: blob.connectionType ?? "unknown",
+        serverType: resource.internalMCPServerId ? "internal" : "remote",
+        authType: blob.connectionId ? "oauth" : "keypair",
+      },
+    });
+
+    return resource;
   }
 
   // Fetching.
@@ -307,6 +333,17 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
       );
     }
 
+    // Capture fields needed for audit logging before destruction.
+    const auditMetadata = {
+      sId: this.sId,
+      name:
+        this.internalMCPServerId ?? String(this.remoteMCPServerId ?? "unknown"),
+      connectionType: this.connectionType,
+      serverType: this.internalMCPServerId ? "internal" : "remote",
+      authType: this.connectionId ? "oauth" : "keypair",
+      connectionId: this.connectionId,
+    };
+
     try {
       await this.model.destroy({
         where: {
@@ -339,6 +376,45 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
           transaction,
         });
       }
+
+      void emitAuditLogEvent({
+        auth,
+        action: "mcp_connection.deleted",
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("mcp_connection", {
+            sId: auditMetadata.sId,
+            name: auditMetadata.name,
+          }),
+        ],
+        metadata: {
+          connectionType: auditMetadata.connectionType,
+          serverType: auditMetadata.serverType,
+          authType: auditMetadata.authType,
+        },
+      });
+
+      // Only emit oauth.revoked for OAuth-based connections, since keypair
+      // connections hold no refresh token to revoke.
+      if (auditMetadata.connectionId) {
+        void emitAuditLogEvent({
+          auth,
+          action: "oauth.revoked",
+          targets: [
+            buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+            buildAuditLogTarget("mcp_connection", {
+              sId: auditMetadata.sId,
+              name: auditMetadata.name,
+            }),
+          ],
+          metadata: {
+            provider: auditMetadata.name,
+            connectionId: auditMetadata.connectionId,
+            connectionType: auditMetadata.connectionType,
+          },
+        });
+      }
+
       return new Ok(undefined);
     } catch (err) {
       return new Err(normalizeError(err));

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -3,7 +3,10 @@ import {
   remoteMCPServerNameToSId,
 } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import { matchesInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  getInternalMCPServerNameFromSId,
+  matchesInternalMCPServerName,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
@@ -85,6 +88,7 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
         buildAuditLogTarget("mcp_connection", {
           sId: resource.sId,
           name:
+            getInternalMCPServerNameFromSId(resource.internalMCPServerId) ??
             resource.internalMCPServerId ??
             String(resource.remoteMCPServerId ?? "unknown"),
         }),
@@ -337,7 +341,9 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
     const auditMetadata = {
       sId: this.sId,
       name:
-        this.internalMCPServerId ?? String(this.remoteMCPServerId ?? "unknown"),
+        getInternalMCPServerNameFromSId(this.internalMCPServerId) ??
+        this.internalMCPServerId ??
+        String(this.remoteMCPServerId ?? "unknown"),
       connectionType: this.connectionType,
       serverType: this.internalMCPServerId ? "internal" : "remote",
       authType: this.connectionId ? "oauth" : "keypair",

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -396,13 +396,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     await this.invalidateProviderCredentialCache(workspace.id);
   }
 
-  /**
-   * Marks credentials as unhealthy if the provider actually returns an auth
-   * error. Returns the credential that was invalidated so the caller can
-   * emit a `credentials.invalidated` audit event, or `null` if no change was
-   * made (credential missing, provider returned a non-auth error, or the row
-   * was already unhealthy).
-   */
+  // Returns the invalidated credential so the caller can emit credentials.invalidated, or null if no change was made.
   static async markAsUnhealthy(
     auth: Authenticator,
     { providerId }: { providerId: ByokModelProviderIdType }

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -396,10 +396,17 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     await this.invalidateProviderCredentialCache(workspace.id);
   }
 
+  /**
+   * Marks credentials as unhealthy if the provider actually returns an auth
+   * error. Returns the credential that was invalidated so the caller can
+   * emit a `credentials.invalidated` audit event, or `null` if no change was
+   * made (credential missing, provider returned a non-auth error, or the row
+   * was already unhealthy).
+   */
   static async markAsUnhealthy(
     auth: Authenticator,
     { providerId }: { providerId: ByokModelProviderIdType }
-  ): Promise<void> {
+  ): Promise<ProviderCredentialResource | null> {
     const workspace = auth.getNonNullableWorkspace();
     assert(
       auth.getNonNullablePlan().isByok,
@@ -408,7 +415,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
 
     const credential = await this.fetchByProvider(auth, providerId);
     if (!credential) {
-      return;
+      return null;
     }
 
     const isAuthError = await hasCredentialAuthError({
@@ -417,7 +424,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     });
 
     if (!isAuthError) {
-      return;
+      return null;
     }
 
     const [affectedCount] = await ProviderCredentialModel.update(
@@ -425,10 +432,14 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       { where: { workspaceId: workspace.id, providerId, isHealthy: true } }
     );
 
-    if (affectedCount > 0) {
-      await this.invalidateProviderCredentialCache(workspace.id);
-      notifyProviderCredentialsHealthUpdated(auth);
+    if (affectedCount === 0) {
+      return null;
     }
+
+    await this.invalidateProviderCredentialCache(workspace.id);
+    notifyProviderCredentialsHealthUpdated(auth);
+
+    return credential;
   }
 
   async delete(

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -559,6 +559,8 @@ async function handler(
         metadata: {
           senderEmail: email.sender.email,
           agentId: agentConfigurations.map((a) => a.sId).join(","),
+          initiating_user_id: auth.user()?.sId ?? "unknown",
+          initiating_user_email: auth.user()?.email ?? "unknown",
         },
       });
 

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/update.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/update.ts
@@ -1,6 +1,11 @@
 /** @ignoreswagger */
 // Public API types are okay to use here because it's front/connectors communication.
 
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { registerSlackWebhookRouterEntry } from "@app/lib/api/data_sources";
@@ -172,6 +177,21 @@ async function handler(
         dataSource: dataSource.toJSON(),
         user,
         workspace: owner,
+      });
+
+      void emitAuditLogEvent({
+        auth,
+        action: "datasource.reauthorized",
+        targets: [
+          buildAuditLogTarget("workspace", owner),
+          buildAuditLogTarget("data_source", dataSource),
+        ],
+        context: getAuditLogContext(auth, req),
+        metadata: {
+          dataSourceName: dataSource.name,
+          provider: dataSource.connectorProvider ?? "unknown",
+          newConnectionId: bodyValidation.right.connectionId,
+        },
       });
 
       res.status(200).json(updateRes.value);

--- a/front/pages/api/w/[wId]/provider_credentials/[providerId]/index.ts
+++ b/front/pages/api/w/[wId]/provider_credentials/[providerId]/index.ts
@@ -1,4 +1,9 @@
 /** @ignoreswagger */
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
@@ -96,6 +101,22 @@ async function handler(
         });
       }
 
+      void emitAuditLogEvent({
+        auth,
+        action: "credentials.created",
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("credential", {
+            sId: providerCredential.sId,
+            name: providerId,
+          }),
+        ],
+        context: getAuditLogContext(auth, req),
+        metadata: {
+          providerId,
+        },
+      });
+
       return res.status(201).json({
         providerCredential: providerCredential.toJSON(),
       });
@@ -143,6 +164,22 @@ async function handler(
         });
       }
 
+      void emitAuditLogEvent({
+        auth,
+        action: "credentials.updated",
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("credential", {
+            sId: providerCredential.sId,
+            name: providerId,
+          }),
+        ],
+        context: getAuditLogContext(auth, req),
+        metadata: {
+          providerId,
+        },
+      });
+
       return res.status(200).json({
         providerCredential: providerCredential.toJSON(),
       });
@@ -175,6 +212,23 @@ async function handler(
           },
         });
       }
+
+      void emitAuditLogEvent({
+        auth,
+        action: "credentials.revoked",
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("credential", {
+            sId: existing.sId,
+            name: providerId,
+          }),
+        ],
+        context: getAuditLogContext(auth, req),
+        metadata: {
+          providerId,
+          reason: "user_deleted",
+        },
+      });
 
       res.status(204).end();
       return;

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -372,6 +372,9 @@ async function executeToolStreaming(
               : "internal",
             mcpServerName: action.toolConfiguration.mcpServerName,
             conversationId: conversation.sId,
+            ...(conversation.triggerId
+              ? { triggerId: conversation.triggerId }
+              : {}),
             initiating_user_id: auth.user()?.sId ?? "unknown",
             initiating_user_email: auth.user()?.email ?? "unknown",
             ...extractDataSourceIds(action.augmentedInputs),

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -349,6 +349,8 @@ async function executeToolStreaming(
               ? "remote"
               : "internal",
             conversationId: conversation.sId,
+            initiating_user_id: auth.user()?.sId ?? "unknown",
+            initiating_user_email: auth.user()?.email ?? "unknown",
           },
         });
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -32,6 +32,28 @@ import assert from "assert";
 
 const CONVERSATION_CACHE_TTL_MS = 5000;
 
+// Extracts sIds of accessed datasources/tables from tool augmentedInputs.
+// All datasource-accessing tools use a standard `dataSources` or `tables` array
+// of { uri } objects whose last path segment is the configuration sId.
+function extractDataSourceIds(
+  inputs: Record<string, unknown>
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  const ds = inputs.dataSources;
+  const tables = inputs.tables;
+  if (Array.isArray(ds) && ds.length > 0) {
+    result.accessedDataSourceIds = ds
+      .map((d: { uri: string }) => d.uri.split("/").pop() ?? "")
+      .join(",");
+  }
+  if (Array.isArray(tables) && tables.length > 0) {
+    result.accessedTableIds = tables
+      .map((t: { uri: string }) => t.uri.split("/").pop() ?? "")
+      .join(",");
+  }
+  return result;
+}
+
 export async function runToolActivity(
   authType: AuthenticatorType,
   {
@@ -348,9 +370,11 @@ async function executeToolStreaming(
             )
               ? "remote"
               : "internal",
+            mcpServerName: action.toolConfiguration.mcpServerName,
             conversationId: conversation.sId,
             initiating_user_id: auth.user()?.sId ?? "unknown",
             initiating_user_email: auth.user()?.email ?? "unknown",
+            ...extractDataSourceIds(action.augmentedInputs),
           },
         });
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -31,6 +31,10 @@ import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { isLegacyAgentConfiguration } from "@app/lib/api/assistant/legacy_agent";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEventDirect,
+} from "@app/lib/api/audit/workos_audit";
 import { getLLM } from "@app/lib/api/llm";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import {
@@ -613,9 +617,37 @@ export async function runModel(
           isByokProviderId(model.providerId) &&
           (type === "authentication_error" || type === "permission_error")
         ) {
-          await ProviderCredentialResource.markAsUnhealthy(auth, {
-            providerId: model.providerId,
-          });
+          const invalidatedCredential =
+            await ProviderCredentialResource.markAsUnhealthy(auth, {
+              providerId: model.providerId,
+            });
+
+          if (invalidatedCredential) {
+            void emitAuditLogEventDirect({
+              workspace: auth.getNonNullableWorkspace(),
+              action: "credentials.invalidated",
+              actor: {
+                type: "system",
+                id: "byok_health_check",
+                name: "BYOK Health Check",
+              },
+              targets: [
+                buildAuditLogTarget(
+                  "workspace",
+                  auth.getNonNullableWorkspace()
+                ),
+                buildAuditLogTarget("credential", {
+                  sId: invalidatedCredential.sId,
+                  name: model.providerId,
+                }),
+              ],
+              context: { location: "internal" },
+              metadata: {
+                providerId: model.providerId,
+                reason: "authentication_failed",
+              },
+            });
+          }
         }
 
         const errorMessage =

--- a/front/temporal/triggers/common/activities.ts
+++ b/front/temporal/triggers/common/activities.ts
@@ -163,6 +163,8 @@ export async function runTriggeredAgentsActivity({
     metadata: {
       triggerType: trigger.kind,
       agentId: trigger.agentConfigurationId,
+      initiating_user_id: auth.user()?.sId ?? "unknown",
+      initiating_user_email: auth.user()?.email ?? "unknown",
     },
   });
 


### PR DESCRIPTION
## Description
### Infrastructure (`workos_audit.ts`)
- Auto-injects `actor_type` into all event metadata via `buildAuditActor(auth)`
- Adds `serializeMetadata()` to enforce string values on all metadata (AUDIT5)
- New `AuditAction` entries: `credentials.updated`, `credentials.revoked`, `credentials.invalidated`, `mcp_connection.created`, `mcp_connection.deleted`, `oauth.revoked`, `space.accessed`, `datasource.reauthorized`
- New `AuditTargetType` entries: `credential`, `mcp_connection`

### New events
- **`credentials.created/updated/revoked`** — BYOK credential lifecycle (API layer)
- **`credentials.invalidated`** — BYOK health check failure (Temporal, system actor)
- **`mcp_connection.created/deleted`** + **`oauth.revoked`** — MCP server connection lifecycle
- **`space.accessed`** — every request to a restricted space via `withSpaceFromRoute`
- **`datasource.reauthorized`** — managed connector reauthorization

### Schema changes
- `actor_type` added to all 54 existing schemas
- 8 new schemas, all with corresponding emit calls
- `agent.executed`: added `triggerId`, `initiating_user_id`, `initiating_user_email`
- `tool.executed`: added `mcpServerName`, `triggerId`, `accessedDataSourceIds`, `accessedTableIds`, `initiating_user_id`, `initiating_user_email`
- `trigger.fired`, `trigger.email_received`: added `initiating_user_id`, `initiating_user_email`

### Actor attribution improvements
- `initiating_user_id` / `initiating_user_email` on all agent/tool/trigger events, always populated (`auth.user()?.sId ?? "unknown"`)
- `actor_type` distinguishes `"user"` / `"api_key"` / `"system_key"` / `"system"` on every event
- `tool.executed` actor is `type: "agent"` with agent sId/name — distinguishes AI-driven actions from human ones

### Datasource access tracking
- `mcpServerName` on all `tool.executed` events — allows filtering connector knowledge access from other tool calls
- `accessedDataSourceIds` / `accessedTableIds` extracted from `augmentedInputs` for all 22 datasource-querying tools across 6 internal servers (`search`, `include_data`, `extract_data`, `data_sources_file_system`, `data_warehouses`, `query_tables_v2`)

### Workflow attribution chain
- `conversation.triggerId` (already stored on `ConversationType`) is now included in `agent.executed` and `tool.executed` metadata when present — enables full correlation: `trigger.fired` → `agent.executed` → `tool.executed` via `conversationId` + `triggerId`

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Should verify this meets expectations and that the logs are emitting as expected
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, audit log changes only
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] Register schema changes
- [ ] Deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
