### PR TITLE
Add poke link to reinforcement schedule

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -137,6 +137,7 @@ export function WorkspacePage() {
     extensionConfig,
     programmaticUsageConfig,
     workosEnvironmentId,
+    temporalFrontNamespace,
   } = workspaceInfo;
 
   return (
@@ -214,6 +215,7 @@ export function WorkspacePage() {
                   dataRetention={dataRetention}
                   workosEnvironmentId={workosEnvironmentId}
                   hasDummyFeature={hasDummyFeature}
+                  temporalFrontNamespace={temporalFrontNamespace}
                 />
               </TabsContent>
               <TabsContent value="subscriptions">

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -24,6 +24,7 @@ export function WorkspaceInfoTable({
   dataRetention,
   workosEnvironmentId,
   hasDummyFeature,
+  temporalFrontNamespace,
 }: {
   owner: WorkspaceType;
   metronomeCustomerId: string | null;
@@ -33,6 +34,7 @@ export function WorkspaceInfoTable({
   dataRetention: DataRetentionConfig | undefined;
   workosEnvironmentId: string;
   hasDummyFeature: boolean;
+  temporalFrontNamespace: string;
 }) {
   const { dsyncStatus } = usePokeWorkOSDSyncStatus({ owner });
 
@@ -219,6 +221,18 @@ export function WorkspaceInfoTable({
                 </PokeTableRow>
               </>
             )}
+            <PokeTableRow>
+              <PokeTableCell>Reinforcement</PokeTableCell>
+              <PokeTableCell>
+                <LinkWrapper
+                  href={`https://cloud.temporal.io/namespaces/${temporalFrontNamespace}/schedules?query=%60ScheduleId%60%3D%22reinforcement-workspace-${owner.sId}%22`}
+                  target="_blank"
+                  className="text-xs text-highlight-400"
+                >
+                  Schedule
+                </LinkWrapper>
+              </PokeTableCell>
+            </PokeTableRow>
             {hasDummyFeature && (
               <PokeTableRow>
                 <PokeTableCell>Dummy feature</PokeTableCell>

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -445,6 +445,9 @@ const config = {
   getTemporalAgentNamespace: () => {
     return EnvironmentConfig.getOptionalEnvVariable("TEMPORAL_AGENT_NAMESPACE");
   },
+  getTemporalFrontNamespace: () => {
+    return EnvironmentConfig.getOptionalEnvVariable("TEMPORAL_NAMESPACE");
+  },
   // Deployment component name. Set via DD_SERVICE in helm values per deployment.
   getServiceName: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("DD_SERVICE");

--- a/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
+++ b/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
@@ -31,6 +31,7 @@ export type PokeGetWorkspaceInfo = {
   stripeSubscription: Stripe.Subscription | null;
   subscriptions: SubscriptionType[];
   whitelistableFeatures: WhitelistableFeature[];
+  temporalFrontNamespace: string;
   workspaceCreationDay: string;
   workspaceVerifiedDomains: WorkspaceDomain[];
   workosEnvironmentId: string;
@@ -118,6 +119,7 @@ async function handler(
         programmaticUsageConfig: programmaticUsageConfig?.toJSON() ?? null,
         baseUrl: config.getApiBaseUrl(),
         workosEnvironmentId: config.getWorkOSEnvironmentId(),
+        temporalFrontNamespace: config.getTemporalFrontNamespace() ?? "",
       });
 
     default:

--- a/front/temporal/reinforcement/client.ts
+++ b/front/temporal/reinforcement/client.ts
@@ -33,7 +33,7 @@ export function makeWorkspaceWorkflowId(workspaceId: string): string {
  */
 async function getReinforcementWorkspaceIds(): Promise<string[]> {
   const allWorkspaces = await WorkspaceResource.listAll();
-  const flaggedIds: string[] = [];
+  const reinforcementWorkspaceIds: string[] = [];
 
   for (const workspace of allWorkspaces) {
     try {
@@ -48,7 +48,7 @@ async function getReinforcementWorkspaceIds(): Promise<string[]> {
         continue;
       }
 
-      flaggedIds.push(workspace.sId);
+      reinforcementWorkspaceIds.push(workspace.sId);
     } catch (e) {
       logger.error(
         { error: e, workspaceId: workspace.sId },
@@ -57,7 +57,7 @@ async function getReinforcementWorkspaceIds(): Promise<string[]> {
     }
   }
 
-  return flaggedIds;
+  return reinforcementWorkspaceIds;
 }
 
 // ---------------------------------------------------------------------------
@@ -162,6 +162,10 @@ export async function ensureReinforcementWorkspaceSchedules(): Promise<{
 }> {
   const client = await getTemporalClientForFrontNamespace();
   const reinforcedWorkspaceIds = new Set(await getReinforcementWorkspaceIds());
+  logger.info(
+    { reinforcedWorkspaceCount: reinforcedWorkspaceIds.size },
+    "[Reinforcement] Ensuring workspace schedules."
+  );
 
   // Find existing schedules by ID prefix.
   const runningWorkspaceIds = new Set<string>();
@@ -172,6 +176,10 @@ export async function ensureReinforcementWorkspaceSchedules(): Promise<{
       );
     }
   }
+  logger.info(
+    { runningWorkspaceCount: runningWorkspaceIds.size },
+    "[Reinforcement] Found existing workspace schedules."
+  );
 
   // Workspaces that need a schedule started / stopped.
   const toStart = [...reinforcedWorkspaceIds].filter(
@@ -179,6 +187,10 @@ export async function ensureReinforcementWorkspaceSchedules(): Promise<{
   );
   const toStop = [...runningWorkspaceIds].filter(
     (id) => !reinforcedWorkspaceIds.has(id)
+  );
+  logger.info(
+    { toStartCount: toStart.length, toStopCount: toStop.length },
+    "[Reinforcement] Schedules to start/stop."
   );
 
   const CONCURRENCY = 5;


### PR DESCRIPTION
## Description

- Add a "Reinforcement" row to the Poke workspace info pane with a "Schedule" link pointing to the Temporal Cloud schedule page filtered on reinforcement-workspace-<workspaceSId>.
- Plumb the front Temporal namespace (TEMPORAL_NAMESPACE) through config.getTemporalFrontNamespace() → workspace-info API → WorkspacePage → WorkspaceInfoTable so the link resolves to the correct region (e.g. eu-dust-front-prod.gmnlm).
- Misc cleanup

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front