### PR TITLE
[front] fix: handle files not found in GCS in `getFileContentType`

### DIFF
--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -60,14 +60,14 @@ export async function isSelfHostedImageWithValidContentType(
   }
 
   // Attempt to decode the URL, since Google Cloud Storage URL encodes the filename.
-  const contentType = await getPublicUploadBucket().getFileContentType(
+  const contentTypeResult = await getPublicUploadBucket().getFileContentType(
     decodeURIComponent(filename)
   );
-  if (!contentType) {
+  if (contentTypeResult.isErr() || !contentTypeResult.value) {
     return false;
   }
 
-  return contentType.includes("image");
+  return contentTypeResult.value.includes("image");
 }
 
 export async function getAgentIdFromName(

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -108,11 +108,19 @@ export class FileStorage {
   }
 
   async getFileContentType(filename: string): Promise<string | undefined> {
-    const gcsFile = this.file(filename);
+    try {
+      const gcsFile = this.file(filename);
 
-    const [metadata] = await gcsFile.getMetadata();
+      const [metadata] = await gcsFile.getMetadata();
 
-    return metadata.contentType;
+      return metadata.contentType;
+    } catch (error) {
+      if (isGCSNotFoundError(error)) {
+        return undefined;
+      }
+
+      throw error;
+    }
   }
 
   async getSignedUrl(

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -1,9 +1,14 @@
 import config from "@app/lib/file_storage/config";
-import { isGCSNotFoundError } from "@app/lib/file_storage/types";
+import {
+  type GCSAPIError,
+  isGCSNotFoundError,
+} from "@app/lib/file_storage/types";
 import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { frameContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { stripNullBytes } from "@app/types/shared/utils/string_utils";
 import type { Bucket } from "@google-cloud/storage";
@@ -107,16 +112,18 @@ export class FileStorage {
     return textTypes.some((type) => contentType.startsWith(type));
   }
 
-  async getFileContentType(filename: string): Promise<string | undefined> {
+  async getFileContentType(
+    filename: string
+  ): Promise<Result<string | undefined, GCSAPIError>> {
     try {
       const gcsFile = this.file(filename);
 
       const [metadata] = await gcsFile.getMetadata();
 
-      return metadata.contentType;
+      return new Ok(metadata.contentType);
     } catch (error) {
       if (isGCSNotFoundError(error)) {
-        return undefined;
+        return new Err(error);
       }
 
       throw error;

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.test.ts
@@ -1,10 +1,11 @@
 import handler from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files/download";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { Ok } from "@app/types/shared/result";
 import type { RequestMethod } from "node-mocks-http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockGetFileContentType, mockCreateReadStream } = vi.hoisted(() => ({
-  mockGetFileContentType: vi.fn().mockResolvedValue("application/pdf"),
+  mockGetFileContentType: vi.fn().mockResolvedValue(new Ok("application/pdf")),
   mockCreateReadStream: vi.fn().mockReturnValue({
     on: vi.fn().mockReturnThis(),
     pipe: vi.fn(),

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.test.ts
@@ -5,11 +5,8 @@ import type { RequestMethod } from "node-mocks-http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockGetFileContentType, mockCreateReadStream } = vi.hoisted(() => ({
-  mockGetFileContentType: vi.fn().mockResolvedValue(new Ok("application/pdf")),
-  mockCreateReadStream: vi.fn().mockReturnValue({
-    on: vi.fn().mockReturnThis(),
-    pipe: vi.fn(),
-  }),
+  mockGetFileContentType: vi.fn(),
+  mockCreateReadStream: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/auth_wrappers", async () => {
@@ -56,6 +53,11 @@ async function setupTest(method: RequestMethod = "POST") {
 describe("POST /api/w/[wId]/assistant/conversations/[cId]/files/download", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetFileContentType.mockResolvedValue(new Ok("application/pdf"));
+    mockCreateReadStream.mockReturnValue({
+      on: vi.fn().mockReturnThis(),
+      pipe: vi.fn(),
+    });
   });
 
   it("should return 405 for non-POST methods", async () => {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.ts
@@ -81,9 +81,9 @@ async function handler(
   const bucket = getPrivateUploadBucket();
 
   try {
-    const contentType = await bucket.getFileContentType(normalizedPath);
-    if (contentType) {
-      res.setHeader("Content-Type", contentType);
+    const contentTypeResult = await bucket.getFileContentType(normalizedPath);
+    if (contentTypeResult.isOk() && contentTypeResult.value) {
+      res.setHeader("Content-Type", contentTypeResult.value);
     }
 
     const fileName = path.posix.basename(normalizedPath);


### PR DESCRIPTION
## Description

- Context in this [thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1776345782191239). Trace [here](https://app.datadoghq.eu/apm/trace/69e0e259000000003b379821d6a9f3ff?graphType=waterfall&shouldShowLegend=true&spanID=4706099133375873636&timeHint=1776345689847.0015&traceQuery=).
- When uploading an agent from a yaml, for picture URLs that are not hosted static Dust avatars (the droids images) we check the file content type on GCS.
- This check can fail if a YAML file was exported from a workspace in one region and uploaded to a workspace in the other region.
- The error is a 500 in this case.
- This PR makes it a 400 with an error `"Invalid picture url."`.
- This is the only usage of `isSelfHostedImageWithValidContentType`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
