### PR TITLE
[Runbooks] Rewrite audit event runbook in skill form

### DIFF
--- a/front/runbooks/NEW_AUDIT_EVENT.md
+++ b/front/runbooks/NEW_AUDIT_EVENT.md
@@ -1,139 +1,129 @@
-# Adding a New Audit Log Event
+# Front Audit Log Events
 
-This runbook covers how to add a new audit log event to the Dust platform. Each event requires a schema, a type entry, and an emit call.
+Add audit events in `front` by creating the schema, registering the action string, and emitting the
+event from the correct success or failure path. The goal is to produce a valid WorkOS event without
+blocking the request path.
 
-## Prerequisites
+## Workflow
 
-- Know which action you are instrumenting (e.g., `resource.verb`)
-- Identify the code location where the mutation happens
-- Determine the tier (1-4) from the audit events database in Notion
+### 1. Identify the event
 
-## Steps
+Before editing code, determine:
 
-### 1. Create the JSON schema
+- the action string, usually `<resource>.<verb>`
+- the mutation or failure path that should emit it
+- whether the actor is a request user, a known user outside an HTTP request, or the system
+- the event tier from the Notion audit events database
 
-Create `front/admin/audit_log_schemas/<action>.json`:
+### 2. Create the WorkOS schema
+
+Create `front/admin/audit_log_schemas/<action>.json`.
+
+Rules:
+
+- `targets` should start with `{ "type": "workspace" }` unless the event truly has no workspace
+  context
+- additional targets describe the affected entities, such as `user`, `space`, `trigger`, `tool`,
+  `agent`, or `api_key`
+- `metadata` is optional, but every metadata value must be declared as `"string"`
+- use camelCase metadata keys
+
+Example shape:
 
 ```json
 {
-  "action": "<resource>.<verb>",
+  "action": "resource.verb",
   "targets": [
     { "type": "workspace" },
-    { "type": "<target_resource>" }
+    { "type": "resource" }
   ],
   "metadata": {
-    "<key>": "string"
+    "fieldName": "string"
   }
 }
 ```
 
-**Rules:**
-- `targets` always starts with `{ "type": "workspace" }` unless the event has no workspace context (rare)
-- Additional targets represent the affected resource(s): `user`, `api_key`, `space`, `trigger`, `agent`, `tool`, `group`, etc.
-- `metadata` is optional. All values must be `"string"` (the WorkOS SDK serializer handles the wrapping)
-- Use camelCase for metadata keys
+### 3. Register the action string
 
-### 2. Add the action to the AuditAction type
+Update `front/lib/api/audit/workos_audit.ts`:
 
-In `front/lib/api/audit/workos_audit.ts`, add the new action string to the `AuditAction` union type. Insert it in the correct category section (see existing comments) in alphabetical order within that section.
+- add the new string to the `AuditAction` union
+- place it in the right category section
+- keep the entries alphabetized inside that section
+
+### 4. Emit the event from the right path
+
+Emit after the mutation succeeds unless the event explicitly represents failure.
+
+For request-driven actions with an `Authenticator`, use:
+
+- `emitAuditLogEvent`
+- `buildWorkspaceTarget`
+- `getAuditLogContext`
+
+Pattern:
 
 ```typescript
-type AuditAction =
-  // ... existing actions ...
-  | "resource.verb"  // <-- add here
-```
-
-### 3. Add the emit call
-
-**For user-initiated actions (API routes with Authenticator):**
-
-```typescript
-import {
-  emitAuditLogEvent,
-  buildWorkspaceTarget,
-  getAuditLogContext,
-} from "@app/lib/api/audit/workos_audit";
-
-// After the mutation succeeds:
 void emitAuditLogEvent({
   auth,
   action: "resource.verb",
   targets: [
     buildWorkspaceTarget(auth.getNonNullableWorkspace()),
-    { type: "target_resource", id: resource.sId, name: resource.name },
+    { type: "resource", id: resource.sId, name: resource.name },
   ],
   context: getAuditLogContext(auth, req),
   metadata: {
-    relevantField: String(value),
+    fieldName: String(value),
   },
 });
 ```
 
-**For system-initiated actions (Temporal, webhooks, no Authenticator):**
+For system-driven actions such as Temporal or inbound webhooks, use `emitAuditLogEventDirect`
+with an explicit system actor:
 
 ```typescript
-import {
-  emitAuditLogEventDirect,
-  buildWorkspaceTarget,
-} from "@app/lib/api/audit/workos_audit";
-
 void emitAuditLogEventDirect({
   workspace,
   action: "resource.verb",
   actor: { type: "system", id: "temporal", name: "Directory Sync" },
-  targets: [
-    buildWorkspaceTarget(workspace),
-    { type: "user", id: user.sId, name: user.fullName },
-  ],
+  targets: [buildWorkspaceTarget(workspace)],
   context: { location: "internal" },
-  metadata: {
-    directoryId: String(directoryId),
-  },
 });
 ```
 
-**For non-HTTP contexts with a known user but no Authenticator:**
+For non-HTTP code paths where you know the user but do not already have an `Authenticator`, create
+one with `Authenticator.fromUserIdAndWorkspaceId(...)` and then use `emitAuditLogEvent(...)`.
 
-Build an Authenticator from the known user:
-```typescript
-const auth = await Authenticator.fromUserIdAndWorkspaceId(userId, workspaceId);
-void emitAuditLogEvent({
-  auth,
-  action: "resource.verb",
-  // ...
-});
-```
+### 5. Keep the emit call non-blocking
 
-### 4. Verify
+Use `void`, not `await`, for audit emission. Audit logging should not block the main write path.
 
-- [ ] Schema file exists at `front/admin/audit_log_schemas/<action>.json`
-- [ ] Action string is in the `AuditAction` union type
-- [ ] Emit call is placed after the mutation succeeds (or on the failure path for failure events)
-- [ ] Emit call uses `void` (not `await`)
-- [ ] Context includes `getAuditLogContext(auth, req)` when a request object is available
-- [ ] Metadata values are all strings (use `String()` for numbers/booleans)
-- [ ] Targets start with the workspace target
+### 6. Register the schema after merge
 
-### 5. Register schemas with WorkOS (post-merge)
-
-After your PR is merged and before deploying, register the new schema(s) with WorkOS:
+WorkOS drops events whose schemas were never registered. After the PR is merged and before deploy,
+run one of:
 
 ```bash
-# Preview what will be registered
 npx tsx front/admin/register_audit_log_schemas.ts --changed
-
-# Register only schemas changed since main
 npx tsx front/admin/register_audit_log_schemas.ts --execute --changed
-
-# Or register specific actions by name
 npx tsx front/admin/register_audit_log_schemas.ts --execute user.login api_key.created
 ```
 
-WorkOS silently rejects events without a registered schema. This step is required before the events will appear in customer audit logs.
+## Validation
 
-## Reference
+Check all of the following:
 
-- Audit module: `front/lib/api/audit/workos_audit.ts`
-- Schemas: `front/admin/audit_log_schemas/`
-- Coding rules: See `[AUDIT1]`-`[AUDIT8]` in `CODING_RULES.md`
-- Event database: Notion, "Audit: Access and Audit Logging for Enterprise Compliance"
+- the schema file exists at `front/admin/audit_log_schemas/<action>.json`
+- the action string was added to `AuditAction`
+- the emit call runs after the intended success path, or on the intended failure path for failure
+  events
+- `targets` start with the workspace target when a workspace exists
+- metadata values are wrapped with `String(...)` when needed
+- request-backed events use `getAuditLogContext(auth, req)` when `req` is available
+- the emit call uses `void`
+
+## References
+
+- `front/lib/api/audit/workos_audit.ts`
+- `front/admin/audit_log_schemas/`
+- `front/CODING_RULES.md` entries `[AUDIT1]` through `[AUDIT8]`


### PR DESCRIPTION
## Description
Context: [slack thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1776409966304359)

Follows https://github.com/dust-tt/dust/pull/24432

This rewrites `front/runbooks/NEW_AUDIT_EVENT.md` into the condensed, self-contained guidance we want to keep when moving this runbook into a skill.

## Risks
Blast radius: developer documentation for the audit event runbook only.
Risk: low

## Deploy Plan
- none
