### PR TITLE
Make takeaways -> todos work.

### DIFF
--- a/connectors/src/connectors/dust_project/lib/conversation_formatting.ts
+++ b/connectors/src/connectors/dust_project/lib/conversation_formatting.ts
@@ -30,7 +30,8 @@ export function buildConversationMessageSections(
     if (msg.type === "user_message") {
       const userName = msg.user?.fullName || msg.user?.username || "User";
       const userEmail = msg.user?.email || "Unknown";
-      prefix = `>> User (${userName}, ${userEmail}) [${dateStr}]:\n`;
+      const userId = msg.user?.sId || "Unknown";
+      prefix = `>> User (name: ${userName}, email: ${userEmail}, id: ${userId}) [${dateStr}]:\n`;
       content = msg.content ? msg.content + "\n" : "\n";
     } else if (msg.type === "agent_message") {
       const agentName = msg.configuration?.name || "Assistant";

--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -4,7 +4,6 @@ import {
   useProjectTodos,
   useUpdateProjectTodo,
 } from "@app/lib/swr/projects";
-import { getConversationRoute } from "@app/lib/utils/router";
 import type {
   ProjectTodoCategory,
   ProjectTodoType,
@@ -84,9 +83,7 @@ function TodoSources({
             type="button"
             className="underline hover:no-underline"
             onClick={() => {
-              void router.push(
-                getConversationRoute(owner.sId, source.sourceId)
-              );
+              void router.push(source.sourceUrl ?? "");
             }}
           >
             {source.sourceTitle ?? source.sourceId}

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -97,7 +97,7 @@ export interface AuthenticatorType {
  * This is a class that will be used to check if a user can perform an action on a resource.
  * It acts as a central place to enforce permissioning across all of Dust.
  *
- * It explicitely does not store a reference to the current user to make sure our permissions are
+ * It explicitly does not store a reference to the current user to make sure our permissions are
  * workspace oriented. Use `getUserFromSession` if needed.
  */
 export class Authenticator {

--- a/front/lib/project_todo/analyze_document/action_items.test.ts
+++ b/front/lib/project_todo/analyze_document/action_items.test.ts
@@ -1,7 +1,7 @@
 import {
   buildActionItems,
   buildPromptActionItems,
-} from "@app/lib/project_todo/analyze_conversation/action_items";
+} from "@app/lib/project_todo/analyze_document/action_items";
 import type { TodoVersionedActionItem } from "@app/types/takeaways";
 import { describe, expect, it } from "vitest";
 
@@ -15,7 +15,7 @@ describe("buildActionItems", () => {
         status: "open" as const,
       },
     ];
-    const result = buildActionItems(raw, new Set([knownSId]), new Set());
+    const result = buildActionItems(raw, [{ sId: knownSId }], new Set());
     expect(result[0].sId).toBe(knownSId);
   });
 
@@ -26,7 +26,7 @@ describe("buildActionItems", () => {
         status: "open" as const,
       },
     ];
-    const result = buildActionItems(raw, new Set(), new Set());
+    const result = buildActionItems(raw, [], new Set());
     expect(result[0].status).toBe("open");
     expect(result[0].detectedDoneAt).toBeNull();
     expect(result[0].detectedDoneRationale).toBeNull();
@@ -41,7 +41,7 @@ describe("buildActionItems", () => {
         detected_done_rationale: "User confirmed it was sent",
       },
     ];
-    const result = buildActionItems(raw, new Set(), new Set());
+    const result = buildActionItems(raw, [], new Set());
     const after = new Date().toISOString();
 
     expect(result[0].status).toBe("done");
@@ -63,14 +63,14 @@ describe("buildActionItems", () => {
         status: "open" as const,
       },
     ];
-    const result = buildActionItems(raw, new Set(), new Set());
+    const result = buildActionItems(raw, [], new Set());
     expect(result[0].assigneeName).toBe("Alice");
     expect(result[1].assigneeName).toBeNull();
   });
 
   it("sets assigneeUserId to null when no participants match", () => {
     const raw = [{ short_description: "Task", status: "open" as const }];
-    const result = buildActionItems(raw, new Set(), new Set());
+    const result = buildActionItems(raw, [], new Set());
     expect(result[0].assigneeUserId).toBeNull();
   });
 
@@ -84,7 +84,7 @@ describe("buildActionItems", () => {
       },
     ];
     const participants = new Set(["user-abc", "user-def"]);
-    const result = buildActionItems(raw, new Set(), participants);
+    const result = buildActionItems(raw, [], participants);
     expect(result[0].assigneeUserId).toBe("user-abc");
     expect(result[0].assigneeName).toBe("Alice");
   });
@@ -99,7 +99,7 @@ describe("buildActionItems", () => {
       },
     ];
     const participants = new Set(["user-abc"]);
-    const result = buildActionItems(raw, new Set(), participants);
+    const result = buildActionItems(raw, [], participants);
     expect(result[0].assigneeUserId).toBeNull();
     expect(result[0].assigneeName).toBe("Alice");
   });

--- a/front/lib/project_todo/analyze_document/action_items.ts
+++ b/front/lib/project_todo/analyze_document/action_items.ts
@@ -1,29 +1,37 @@
-import type { ActionItemSchema } from "@app/lib/project_todo/analyze_conversation/types";
+import type { ActionItem } from "@app/lib/project_todo/analyze_document/types";
 import type { TodoVersionedActionItem } from "@app/types/takeaways";
 import { v4 as uuidv4 } from "uuid";
-import type { z } from "zod";
 
 export function buildActionItems(
-  rawItems: z.infer<typeof ActionItemSchema>[],
-  previousSIds: Set<string>,
-  participantSIds: Set<string>
+  rawItems: ActionItem[],
+  previousItems: ActionItem[],
+  validUserIds: Set<string>
 ): TodoVersionedActionItem[] {
+  const previousItemsBySId = new Map(
+    previousItems.map((item) => [item.sId, item])
+  );
   const now = new Date().toISOString();
-  return rawItems.map((item) => ({
-    sId:
-      item.sId !== undefined && previousSIds.has(item.sId)
-        ? item.sId
-        : uuidv4(),
-    shortDescription: item.short_description,
-    assigneeUserId:
-      item.assignee_user_id && participantSIds.has(item.assignee_user_id)
-        ? item.assignee_user_id
-        : null,
-    assigneeName: item.assignee_name ?? null,
-    status: item.status,
-    detectedDoneAt: item.status === "done" ? now : null,
-    detectedDoneRationale: item.detected_done_rationale ?? null,
-  }));
+  return rawItems.map((item) => {
+    const previousItem = previousItemsBySId.get(item.sId);
+
+    return {
+      sId: previousItem?.sId ?? uuidv4(),
+      shortDescription:
+        item.short_description ?? previousItem?.short_description ?? "",
+      assigneeUserId:
+        item.assignee_user_id && validUserIds.has(item.assignee_user_id)
+          ? item.assignee_user_id
+          : null,
+      assigneeName: item.assignee_name ?? null,
+      status: item.status ?? previousItem?.status ?? "open",
+      detectedDoneAt:
+        item.status === "done" && previousItem?.status !== "done" ? now : null,
+      detectedDoneRationale:
+        item.detected_done_rationale ??
+        previousItem?.detected_done_rationale ??
+        null,
+    };
+  });
 }
 
 export function buildPromptActionItems(
@@ -35,13 +43,15 @@ export function buildPromptActionItems(
     "- An action item is a concrete task that someone committed to doing, or was asked to do.\n" +
     "- If an action item was explicitly completed or resolved in the document, set status to 'done'.\n" +
     "- Include an assignee_name only when clearly stated in the document.\n" +
-    "- Include an assignee_user_id (from the participant list) when the assignee matches a known participant.\n" +
+    "- Include an assignee_user_id (from the project members list) when the assignee matches a known project member.\n" +
     "- Be concise: one action item per distinct task.\n" +
+    "- In the description, mention users and agents by their name, NOT via their id or via a generic term like User, Agent or Bot.\n" +
+    "- In the description, refer to the assignee by Your pronouns (e.g., 'You', 'Your', 'Yours'), not by their name.\n" +
     "- Do not include vague or aspirational items — only concrete commitments.\n\n";
   if (previousActionItems.length > 0) {
     prompt +=
       "The following action items were detected in a previous analysis of this document. " +
-      "If you detect the same task again, copy its sId exactly into the output and keep the other required fields the same. " +
+      "If you detect the same task again, copy its sId exactly into the output, update the other fields when appropriate. " +
       "Omit the sId field for brand-new tasks that were not previously tracked.\n\n" +
       "Known action items:\n";
     for (const item of previousActionItems) {

--- a/front/lib/project_todo/analyze_document/index.ts
+++ b/front/lib/project_todo/analyze_document/index.ts
@@ -1,91 +1,54 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getFastestWhitelistedModel } from "@app/lib/assistant";
+import { getSmallWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import {
   buildActionItems,
   buildPromptActionItems,
-} from "@app/lib/project_todo/analyze_conversation/action_items";
+} from "@app/lib/project_todo/analyze_document/action_items";
 import {
   buildKeyDecisions,
   buildPromptKeyDecisions,
-} from "@app/lib/project_todo/analyze_conversation/key_decisions";
+} from "@app/lib/project_todo/analyze_document/key_decisions";
 import {
   buildNotableFacts,
   buildPromptNotableFacts,
-} from "@app/lib/project_todo/analyze_conversation/notable_facts";
+} from "@app/lib/project_todo/analyze_document/notable_facts";
 import {
   type ExtractionResult,
   ExtractTakeawaysInputSchema,
-} from "@app/lib/project_todo/analyze_conversation/types";
-import { buildSpec } from "@app/lib/project_todo/analyze_conversation/utils";
+} from "@app/lib/project_todo/analyze_document/types";
+import { buildSpec } from "@app/lib/project_todo/analyze_document/utils";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   type TakeawaySourceDocument,
   TakeawaysResource,
 } from "@app/lib/resources/takeaways_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
-import type {
-  ConversationType,
-  UserMessageType,
-} from "@app/types/assistant/conversation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { startActiveObservation } from "@langfuse/tracing";
+import { buildPromptForSourceType } from "./prompts";
 
-export type ConversationParticipant = {
-  sId: string;
-  fullName: string;
-};
-
-// Extracts a deduplicated list of human participants from the conversation
-// content. Only user messages with an authenticated user (non-null .user) are
-// included, since programmatic senders lack a stable sId.
-export function getConversationParticipants(
-  conversation: ConversationType
-): ConversationParticipant[] {
-  const seen = new Map<string, string>();
-  for (const group of conversation.content) {
-    for (const message of group) {
-      if (message.type === "user_message") {
-        const userMsg = message as UserMessageType;
-        if (userMsg.user && !seen.has(userMsg.user.sId)) {
-          seen.set(userMsg.user.sId, userMsg.user.fullName);
-        }
-      }
-    }
+async function buildPromptProjectMembers(
+  auth: Authenticator,
+  { spaceId }: { spaceId: string }
+): Promise<string> {
+  const space = await SpaceResource.fetchById(auth, spaceId);
+  if (!space) {
+    throw new Error("Space not found for project members prompt");
   }
-  return Array.from(seen.entries()).map(([sId, fullName]) => ({
-    sId,
-    fullName,
-  }));
-}
 
-function _buildParticipantRoster(
-  participants: ConversationParticipant[]
-): string {
-  if (participants.length === 0) {
-    return "";
-  }
-  const lines = participants.map(
-    (p) => `- id: "${p.sId}" | name: "${p.fullName}"`
-  );
-  return (
-    "Conversation participants (human users only):\n" +
-    lines.join("\n") +
-    "\n\n"
-  );
-}
+  const r = await space.fetchManualGroupsMemberships(auth, {
+    shouldIncludeAllMembers: true,
+  });
 
-const _AGENTIC_CONTEXT_PREAMBLE =
-  "IMPORTANT CONTEXT: This is a conversation between human users and a Dust AI assistant.\n" +
-  "Messages from the assistant are AI-generated responses, NOT from a human participant.\n" +
-  "- Do NOT treat user questions that the AI assistant already answered as open action items.\n" +
-  "- Only extract action items that represent real commitments between human participants, " +
-  "or tasks that a human explicitly stated they need to do outside the conversation.\n" +
-  "- A user asking the AI assistant to do something (e.g., 'can you check X?', 'please look into Y') " +
-  "is NOT an action item — it is a query being handled in real-time by the assistant.\n" +
-  "- Assignees and relevant users must always be human participants, never the AI assistant.\n\n";
+  const members = await UserResource.fetchByModelIds(
+    r.allGroupMemberships.map((m) => m.userId)
+  );
+  return `Project members:\n\n${members.map((m) => `- ${m.fullName()} (email: ${m.email}, id: ${m.sId})`).join("\n")}`;
+}
 
 // Calls the LLM with a forced extract_action_items tool call and parses the result.
 // Returns null if the call fails, produces no tool call, or the output fails parsing.
@@ -199,7 +162,7 @@ export async function extractDocumentTakeaways(
 
   // Fetch the model and the previous version concurrently — they are independent.
   const [model, previousVersion] = await Promise.all([
-    getFastestWhitelistedModel(auth),
+    getSmallWhitelistedModel(auth),
     TakeawaysResource.fetchLatestBySourceIdAndType(auth, {
       sourceId: document.id,
       sourceType: document.type,
@@ -220,11 +183,10 @@ export async function extractDocumentTakeaways(
   const previousActionItems = previousVersion?.actionItems ?? [];
   const previousNotableFacts = previousVersion?.notableFacts ?? [];
   const previousKeyDecisions = previousVersion?.keyDecisions ?? [];
-  // const participants = getConversationParticipants(conversation);
-  // const participantSIds = new Set(participants.map((p) => p.sId));
+
   const prompt = [
-    //AGENTIC_CONTEXT_PREAMBLE,
-    //buildParticipantRoster(participants),
+    await buildPromptProjectMembers(auth, { spaceId }),
+    buildPromptForSourceType(document.type),
     buildPromptActionItems(previousActionItems),
     buildPromptNotableFacts(previousNotableFacts),
     buildPromptKeyDecisions(previousKeyDecisions),
@@ -263,22 +225,22 @@ export async function extractDocumentTakeaways(
     ])
   );
 
-  const existingAssignees = new Set(assignees.map((u) => u.sId));
+  const validAssigneesUserIds = new Set(assignees.map((u) => u.sId));
 
   const actionItems = buildActionItems(
     extraction.action_items,
-    new Set(previousActionItems.map((item) => item.sId)),
-    existingAssignees
+    previousActionItems,
+    validAssigneesUserIds
   );
   const notableFacts = buildNotableFacts(
     extraction.notable_facts,
-    new Set(previousNotableFacts.map((fact) => fact.sId)),
-    existingAssignees
+    previousNotableFacts,
+    validAssigneesUserIds
   );
   const keyDecisions = buildKeyDecisions(
     extraction.key_decisions,
-    new Set(previousKeyDecisions.map((d) => d.sId)),
-    existingAssignees
+    previousKeyDecisions,
+    validAssigneesUserIds
   );
 
   if (
@@ -292,7 +254,7 @@ export async function extractDocumentTakeaways(
         sourceType: document.type,
         workspaceId: owner.sId,
       },
-      "Conversation todo: no takeaways extracted"
+      "Document takeaway: no takeaways extracted"
     );
     return;
   }
@@ -314,6 +276,6 @@ export async function extractDocumentTakeaways(
       notableFactCount: notableFacts.length,
       keyDecisionCount: keyDecisions.length,
     },
-    "Conversation todo: analysis complete"
+    "Document takeaway: analysis complete"
   );
 }

--- a/front/lib/project_todo/analyze_document/key_decisions.test.ts
+++ b/front/lib/project_todo/analyze_document/key_decisions.test.ts
@@ -1,7 +1,7 @@
 import {
   buildKeyDecisions,
   buildPromptKeyDecisions,
-} from "@app/lib/project_todo/analyze_conversation/key_decisions";
+} from "@app/lib/project_todo/analyze_document/key_decisions";
 import type { TodoVersionedKeyDecision } from "@app/types/takeaways";
 import { describe, expect, it } from "vitest";
 
@@ -15,7 +15,7 @@ describe("buildKeyDecisions", () => {
         status: "decided" as const,
       },
     ];
-    const result = buildKeyDecisions(raw, new Set([knownSId]), new Set());
+    const result = buildKeyDecisions(raw, [{ sId: knownSId }], new Set());
     expect(result[0].sId).toBe(knownSId);
   });
 
@@ -26,7 +26,7 @@ describe("buildKeyDecisions", () => {
         status: "decided" as const,
       },
     ];
-    const result = buildKeyDecisions(raw, new Set(), new Set());
+    const result = buildKeyDecisions(raw, [], new Set());
     expect(result[0].status).toBe("decided");
   });
 
@@ -37,7 +37,7 @@ describe("buildKeyDecisions", () => {
         status: "open" as const,
       },
     ];
-    const result = buildKeyDecisions(raw, new Set(), new Set());
+    const result = buildKeyDecisions(raw, [], new Set());
     expect(result[0].status).toBe("open");
   });
 
@@ -48,7 +48,7 @@ describe("buildKeyDecisions", () => {
         status: "decided" as const,
       },
     ];
-    const result = buildKeyDecisions(raw, new Set(), new Set());
+    const result = buildKeyDecisions(raw, [], new Set());
     expect(result[0].relevantUserIds).toEqual([]);
   });
 
@@ -61,7 +61,7 @@ describe("buildKeyDecisions", () => {
       },
     ];
     const participants = new Set(["user-abc", "user-def"]);
-    const result = buildKeyDecisions(raw, new Set(), participants);
+    const result = buildKeyDecisions(raw, [], participants);
     expect(result[0].relevantUserIds).toEqual(["user-abc"]);
   });
 
@@ -72,12 +72,12 @@ describe("buildKeyDecisions", () => {
         status: "decided" as const,
       },
     ];
-    const result = buildKeyDecisions(raw, new Set(), new Set());
+    const result = buildKeyDecisions(raw, [], new Set());
     expect(result[0].shortDescription).toBe("Launch in Europe first");
   });
 
   it("returns an empty array for empty input", () => {
-    expect(buildKeyDecisions([], new Set(), new Set())).toEqual([]);
+    expect(buildKeyDecisions([], [], new Set())).toEqual([]);
   });
 });
 

--- a/front/lib/project_todo/analyze_document/key_decisions.ts
+++ b/front/lib/project_todo/analyze_document/key_decisions.ts
@@ -1,24 +1,28 @@
-import type { KeyDecisionSchema } from "@app/lib/project_todo/analyze_conversation/types";
+import type { KeyDecision } from "@app/lib/project_todo/analyze_document/types";
 import type { TodoVersionedKeyDecision } from "@app/types/takeaways";
 import { v4 as uuidv4 } from "uuid";
-import type { z } from "zod";
 
 export function buildKeyDecisions(
-  rawDecisions: z.infer<typeof KeyDecisionSchema>[],
-  previousSIds: Set<string>,
-  participantSIds: Set<string>
+  rawDecisions: KeyDecision[],
+  previousDecisions: KeyDecision[],
+  validUserIds: Set<string>
 ): TodoVersionedKeyDecision[] {
-  return rawDecisions.map((decision) => ({
-    sId:
-      decision.sId !== undefined && previousSIds.has(decision.sId)
-        ? decision.sId
-        : uuidv4(),
-    shortDescription: decision.short_description,
-    relevantUserIds: (decision.relevant_user_ids ?? []).filter((id) =>
-      participantSIds.has(id)
-    ),
-    status: decision.status,
-  }));
+  const previousDecisionsBySId = new Map(
+    previousDecisions.map((decision) => [decision.sId, decision])
+  );
+
+  return rawDecisions.map((decision) => {
+    const previousDecision = previousDecisionsBySId.get(decision.sId);
+    return {
+      sId: previousDecision?.sId ?? uuidv4(),
+      shortDescription:
+        decision.short_description ?? previousDecision?.short_description ?? "",
+      relevantUserIds: (decision.relevant_user_ids ?? []).filter((id) =>
+        validUserIds.has(id)
+      ),
+      status: decision.status ?? previousDecision?.status ?? "open",
+    };
+  });
 }
 
 export function buildPromptKeyDecisions(
@@ -30,11 +34,13 @@ export function buildPromptKeyDecisions(
     "(e.g., a technical approach chosen, a scope change agreed upon, a trade-off accepted).\n" +
     "- Set status to 'decided' if the decision is finalized, 'open' if it is still being deliberated.\n" +
     "- Do not include minor preferences or passing comments — only significant, consequential decisions.\n" +
-    "- Include relevant_user_ids (from the participant list) for people involved in making this decision.\n\n";
+    "- In the description, mention users and agents by their name, NOT via their id or via a generic term like User, Agent or Bot.\n" +
+    "- In the description, refer to the assignee by Your pronouns (e.g., 'You', 'Your', 'Yours'), not by their name.\n" +
+    "- Include relevant_user_ids (from the project members list) for people involved in making this decision.\n\n";
   if (previousKeyDecisions.length > 0) {
     prompt +=
       "The following key decisions were detected in a previous analysis of this document. " +
-      "If you detect the same decision again, copy its sId exactly into the output and keep the other required fields the same. " +
+      "If you detect the same decision again, copy its sId exactly into the output, update the other fields when appropriate. " +
       "Omit the sId field for brand-new decisions that were not previously tracked.\n\n" +
       "Known key decisions:\n";
     for (const decision of previousKeyDecisions) {

--- a/front/lib/project_todo/analyze_document/notable_facts.test.ts
+++ b/front/lib/project_todo/analyze_document/notable_facts.test.ts
@@ -1,7 +1,7 @@
 import {
   buildNotableFacts,
   buildPromptNotableFacts,
-} from "@app/lib/project_todo/analyze_conversation/notable_facts";
+} from "@app/lib/project_todo/analyze_document/notable_facts";
 import type { TodoVersionedNotableFact } from "@app/types/takeaways";
 import { describe, expect, it } from "vitest";
 
@@ -9,13 +9,13 @@ describe("buildNotableFacts", () => {
   it("reuses sId when it matches a previous sId", () => {
     const knownSId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
     const raw = [{ sId: knownSId, short_description: "Launch date is Q3" }];
-    const result = buildNotableFacts(raw, new Set([knownSId]), new Set());
+    const result = buildNotableFacts(raw, [{ sId: knownSId }], new Set());
     expect(result[0].sId).toBe(knownSId);
   });
 
   it("returns empty relevantUserIds when no user ids provided", () => {
     const raw = [{ short_description: "Some fact" }];
-    const result = buildNotableFacts(raw, new Set(), new Set());
+    const result = buildNotableFacts(raw, [], new Set());
     expect(result[0].relevantUserIds).toEqual([]);
   });
 
@@ -27,18 +27,18 @@ describe("buildNotableFacts", () => {
       },
     ];
     const participants = new Set(["user-abc", "user-def"]);
-    const result = buildNotableFacts(raw, new Set(), participants);
+    const result = buildNotableFacts(raw, [], participants);
     expect(result[0].relevantUserIds).toEqual(["user-abc", "user-def"]);
   });
 
   it("preserves shortDescription", () => {
     const raw = [{ short_description: "Deadline is Friday" }];
-    const result = buildNotableFacts(raw, new Set(), new Set());
+    const result = buildNotableFacts(raw, [], new Set());
     expect(result[0].shortDescription).toBe("Deadline is Friday");
   });
 
   it("returns an empty array for empty input", () => {
-    expect(buildNotableFacts([], new Set(), new Set())).toEqual([]);
+    expect(buildNotableFacts([], [], new Set())).toEqual([]);
   });
 });
 

--- a/front/lib/project_todo/analyze_document/notable_facts.ts
+++ b/front/lib/project_todo/analyze_document/notable_facts.ts
@@ -1,23 +1,26 @@
-import type { NotableFactSchema } from "@app/lib/project_todo/analyze_conversation/types";
+import type { NotableFact } from "@app/lib/project_todo/analyze_document/types";
 import type { TodoVersionedNotableFact } from "@app/types/takeaways";
 import { v4 as uuidv4 } from "uuid";
-import type { z } from "zod";
 
 export function buildNotableFacts(
-  rawFacts: z.infer<typeof NotableFactSchema>[],
-  previousSIds: Set<string>,
-  participantSIds: Set<string>
+  rawFacts: NotableFact[],
+  previousFacts: NotableFact[],
+  validUserIds: Set<string>
 ): TodoVersionedNotableFact[] {
-  return rawFacts.map((fact) => ({
-    sId:
-      fact.sId !== undefined && previousSIds.has(fact.sId)
-        ? fact.sId
-        : uuidv4(),
-    shortDescription: fact.short_description,
-    relevantUserIds: (fact.relevant_user_ids ?? []).filter((id) =>
-      participantSIds.has(id)
-    ),
-  }));
+  const previousFactsBySId = new Map(
+    previousFacts.map((fact) => [fact.sId, fact])
+  );
+  return rawFacts.map((fact) => {
+    const previousFact = previousFactsBySId.get(fact.sId);
+    return {
+      sId: previousFact?.sId ?? uuidv4(),
+      shortDescription:
+        fact.short_description ?? previousFact?.short_description ?? "",
+      relevantUserIds: (fact.relevant_user_ids ?? []).filter((id) =>
+        validUserIds.has(id)
+      ),
+    };
+  });
 }
 
 export function buildPromptNotableFacts(
@@ -29,11 +32,13 @@ export function buildPromptNotableFacts(
     "that is worth remembering (e.g., a decision made, a key constraint, an important context).\n" +
     "- Be concise and specific — one fact per distinct piece of information.\n" +
     "- Do not include trivial or already widely known information.\n" +
-    "- Include relevant_user_ids (from the participant list) for people this fact is relevant to or was stated by.\n\n";
+    "- In the description, mention users and agents by their name, NOT via their id or via a generic term like User, Agent or Bot.\n" +
+    "- In the description, refer to the assignee by Your pronouns (e.g., 'You', 'Your', 'Yours'), not by their name.\n" +
+    "- Include relevant_user_ids (from the project members list) for people this fact is relevant to or was stated by.\n\n";
   if (previousNotableFacts.length > 0) {
     prompt +=
       "The following notable facts were detected in a previous analysis of this document. " +
-      "If you detect the same fact again, copy its sId exactly into the output and keep the other required fields the same. " +
+      "If you detect the same fact again, copy its sId exactly into the output, update the other fields when appropriate. " +
       "Omit the sId field for brand-new facts that were not previously tracked.\n\n" +
       "Known notable facts:\n";
     for (const fact of previousNotableFacts) {

--- a/front/lib/project_todo/analyze_document/prompts.ts
+++ b/front/lib/project_todo/analyze_document/prompts.ts
@@ -1,0 +1,47 @@
+import type { ProjectTodoSourceType } from "@app/types/project_todo";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export function buildPromptForSourceType(
+  sourceType: ProjectTodoSourceType
+): string {
+  switch (sourceType) {
+    case "project_conversation":
+      return (
+        "IMPORTANT CONTEXT: This is a conversation between human users and Dust AI agents.\n" +
+        "Messages from the agents are AI-generated responses, NOT from a human participant.\n" +
+        "- Do NOT treat user questions that the agents already answered as open action items.\n" +
+        "- Only extract action items that represent real commitments between human participants, " +
+        "or tasks that a human explicitly stated they need to do outside the conversation.\n" +
+        "- A user asking the agents to do something (e.g., 'can you check X?', 'please look into Y') " +
+        "is NOT an action item — it is a query being handled in real-time by the agents.\n" +
+        "- Assignees and relevant users must always be human participants, never the agents.\n\n"
+      );
+    case "project_knowledge":
+      return (
+        "IMPORTANT CONTEXT: This is a project knowledge document.\n" +
+        "It has been added to the project knowledge base explicitly\n\n"
+      );
+    case "slack":
+      return (
+        "IMPORTANT CONTEXT: This is a slack thread mostly between human users but sometimes humans can interact with Bots.\n" +
+        "- Do NOT treat user questions that the bots already answered as open action items.\n" +
+        "- Only extract action items that represent real commitments between human participants, " +
+        "or tasks that a human explicitly stated they need to do outside the thread.\n" +
+        "- A user asking the bots to do something (e.g., 'can you check X?', 'please look into Y') " +
+        "is NOT an action item — it is a query being handled in real-time by the bots.\n" +
+        "- Assignees and relevant users must always be human participants, never the bots.\n\n"
+      );
+    case "notion":
+      return (
+        "IMPORTANT CONTEXT: This is a notion document.\n" +
+        "It has been added to the project knowledge base explicitly\n\n"
+      );
+    case "gdrive":
+      return (
+        "IMPORTANT CONTEXT: This is a gdrive document.\n" +
+        "It has been added to the project knowledge base explicitly\n\n"
+      );
+    default:
+      assertNever(sourceType);
+  }
+}

--- a/front/lib/project_todo/analyze_document/types.ts
+++ b/front/lib/project_todo/analyze_document/types.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const EXTRACT_DOCUMENT_TAKEAWAYS_FUNCTION_NAME =
   "extract_document_takeaways";
 
-export const ActionItemSchema = z.object({
+const ActionItemSchema = z.object({
   // Present when the item matches a previously known action item. The LLM
   // should copy the sId verbatim from the list provided in the prompt.
   sId: z
@@ -14,6 +14,7 @@ export const ActionItemSchema = z.object({
     ),
   short_description: z
     .string()
+    .optional()
     .describe("Short description of the action item."),
   assignee_name: z.string().optional(),
   assignee_user_id: z
@@ -24,6 +25,7 @@ export const ActionItemSchema = z.object({
     ),
   status: z
     .enum(["open", "done"])
+    .optional()
     .describe(
       "'done' if the item was explicitly resolved in the document, 'open' otherwise."
     ),
@@ -35,7 +37,7 @@ export const ActionItemSchema = z.object({
     ),
 });
 
-export const NotableFactSchema = z.object({
+const NotableFactSchema = z.object({
   // Present when the fact matches a previously known notable fact. The LLM
   // should copy the sId verbatim from the list provided in the prompt.
   sId: z
@@ -46,6 +48,7 @@ export const NotableFactSchema = z.object({
     ),
   short_description: z
     .string()
+    .optional()
     .describe("Short description of the notable fact."),
   relevant_user_ids: z
     .array(z.string())
@@ -55,7 +58,7 @@ export const NotableFactSchema = z.object({
     ),
 });
 
-export const KeyDecisionSchema = z.object({
+const KeyDecisionSchema = z.object({
   // Present when the decision matches a previously known key decision. The LLM
   // should copy the sId verbatim from the list provided in the prompt.
   sId: z
@@ -66,6 +69,7 @@ export const KeyDecisionSchema = z.object({
     ),
   short_description: z
     .string()
+    .optional()
     .describe("Short description of the key decision."),
   relevant_user_ids: z
     .array(z.string())
@@ -75,10 +79,15 @@ export const KeyDecisionSchema = z.object({
     ),
   status: z
     .enum(["decided", "open"])
+    .optional()
     .describe(
       "'decided' if the decision is finalized, 'open' if still being deliberated."
     ),
 });
+
+export type ActionItem = z.infer<typeof ActionItemSchema>;
+export type NotableFact = z.infer<typeof NotableFactSchema>;
+export type KeyDecision = z.infer<typeof KeyDecisionSchema>;
 
 export const ExtractTakeawaysInputSchema = z.object({
   topic: z

--- a/front/lib/project_todo/analyze_document/utils.ts
+++ b/front/lib/project_todo/analyze_document/utils.ts
@@ -2,7 +2,7 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import {
   EXTRACT_DOCUMENT_TAKEAWAYS_FUNCTION_NAME,
   ExtractTakeawaysInputSchema,
-} from "@app/lib/project_todo/analyze_conversation/types";
+} from "@app/lib/project_todo/analyze_document/types";
 import type { JSONSchema7 } from "json-schema";
 import zodToJsonSchema from "zod-to-json-schema";
 

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -1,7 +1,7 @@
 // This module merges the latest takeaway snapshots for all conversations in a
 // project into project_todo rows. It is called by mergeTodosForProjectActivity,
-// which itself is invoked by the per-project projectMergeWorkflow at most once
-// per MERGE_THROTTLE_MS (1 hour by default).
+// which itself is invoked by the per-project projectTodoWorkflow at most once
+// per hour (based on the cron schedule).
 //
 // High-level algorithm (3 phases):
 //
@@ -33,7 +33,7 @@
 //   notableFacts           → "to_know", status: "todo"
 
 import { getFastestWhitelistedModel } from "@app/lib/assistant";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import {
   batchDeduplicateCandidates,
   type DeduplicateCandidate,
@@ -41,14 +41,16 @@ import {
   makeDedupGroupKey,
   makeDedupResultKey,
 } from "@app/lib/project_todo/deduplicate_candidates";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
-import { TakeawaysResource } from "@app/lib/resources/takeaways_resource";
+import {
+  TakeawaysResource,
+  type TakeawaysWithSource,
+} from "@app/lib/resources/takeaways_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { ProjectTodoSourceType } from "@app/types/project_todo";
+import type { ProjectTodoSourceInfo } from "@app/types/project_todo";
 import type { ModelId } from "@app/types/shared/model_id";
 import type {
   TodoVersionedActionItem,
@@ -76,39 +78,39 @@ type PendingCandidate = {
   itemId: string;
   userId: ModelId;
   blob: TodoBlob;
-  conversationSId: string;
+  source: ProjectTodoSourceInfo;
 };
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
-export async function mergeTakeawaysIntoProject(
-  auth: Authenticator,
-  { spaceId }: { spaceId: string }
-): Promise<void> {
+export async function mergeTakeawaysIntoProject({
+  workspaceId,
+  spaceId,
+}: {
+  workspaceId: string;
+  spaceId: string;
+}): Promise<void> {
   const spaceModelId = getResourceIdFromSId(spaceId);
   if (spaceModelId === null) {
     logger.error({ spaceId }, "Project todo merge: invalid space sId");
     return;
   }
 
+  const adminAuth = await Authenticator.internalAdminForWorkspace(workspaceId);
+
   // Fetch all latest takeaways for the space directly.
   const takeawaysWithSource = await TakeawaysResource.fetchLatestBySpaceId(
-    auth,
+    adminAuth,
     { spaceModelId }
   );
 
   if (takeawaysWithSource.length === 0) {
+    logger.info(
+      { spaceId },
+      "Project todo merge: no takeaways found, skipping"
+    );
     return;
   }
-
-  // Batch-fetch conversations by sId.
-  const sourceIds = [
-    ...new Set(takeawaysWithSource.map(({ source }) => source.sourceId)),
-  ];
-  const conversations = await ConversationResource.fetchByIds(auth, sourceIds);
-  const conversationBySId = new Map<string, ConversationResource>(
-    conversations.map((c) => [c.sId, c])
-  );
 
   // Collect all user sIds referenced across all takeaways so we can batch-fetch
   // the corresponding UserResources in a single query.
@@ -137,26 +139,29 @@ export async function mergeTakeawaysIntoProject(
 
   // ── Phase 1: collect new candidates, update already-linked items ──────────
 
-  const newCandidates = await collectNewCandidates(auth, {
+  const newCandidates = await collectNewCandidates(adminAuth, {
     takeawaysWithSource,
-    conversationBySId,
     usersById,
   });
 
   if (newCandidates.length === 0) {
+    logger.info(
+      { spaceId },
+      "Project todo merge: no new candidates found, skipping"
+    );
     return;
   }
 
   // ── Phase 2: semantic deduplication ──────────────────────────────────────
 
-  const dedupMap = await buildDeduplicationMap(auth, {
+  const dedupMap = await buildDeduplicationMap(adminAuth, {
     newCandidates,
     spaceModelId,
   });
 
   // ── Phase 3: create or link ───────────────────────────────────────────────
 
-  await createOrLinkTodos(auth, {
+  await createOrLinkTodos(adminAuth, {
     newCandidates,
     dedupMap,
     spaceModelId,
@@ -172,17 +177,9 @@ async function collectNewCandidates(
   auth: Authenticator,
   {
     takeawaysWithSource,
-    conversationBySId,
     usersById,
   }: {
-    takeawaysWithSource: Array<{
-      takeaway: TakeawaysResource;
-      source: {
-        sourceType: ProjectTodoSourceType;
-        sourceId: string;
-      };
-    }>;
-    conversationBySId: Map<string, ConversationResource>;
+    takeawaysWithSource: TakeawaysWithSource[];
     usersById: Map<string, UserResource>;
   }
 ): Promise<PendingCandidate[]> {
@@ -190,18 +187,9 @@ async function collectNewCandidates(
 
   await concurrentExecutor(
     takeawaysWithSource,
-    async ({ takeaway, source }) => {
-      const conversation = conversationBySId.get(source.sourceId);
-      if (!conversation) {
-        logger.warn(
-          { sourceId: source.sourceId },
-          "Project todo merge: conversation not found, skipping takeaway"
-        );
-        return;
-      }
-      const candidates = await collectConversationCandidates(auth, {
-        conversationSId: source.sourceId,
-        takeaway,
+    async (takeawayWithSource) => {
+      const candidates = await collectDocumentCandidates(auth, {
+        takeawayWithSource,
         usersById,
       });
       newCandidates.push(...candidates);
@@ -212,22 +200,18 @@ async function collectNewCandidates(
   return newCandidates;
 }
 
-// Processes one conversation's takeaway: updates todos whose source link already
+// Processes one document's takeaway: updates todos whose source link already
 // exists, and returns items that need to go through dedup + creation.
-async function collectConversationCandidates(
+async function collectDocumentCandidates(
   auth: Authenticator,
   {
-    conversationSId,
-    takeaway,
+    takeawayWithSource,
     usersById,
   }: {
-    conversationSId: string;
-    takeaway: TakeawaysResource;
+    takeawayWithSource: TakeawaysWithSource;
     usersById: Map<string, UserResource>;
   }
 ): Promise<PendingCandidate[]> {
-  const candidates: PendingCandidate[] = [];
-
   function resolveTargetUserIds(userSIds: string[]): ModelId[] {
     return userSIds
       .map((sId) => usersById.get(sId)?.id)
@@ -241,19 +225,19 @@ async function collectConversationCandidates(
     targetUserIds: ModelId[];
     blob: TodoBlob;
   }> = [
-    ...takeaway.actionItems.map((item) => ({
+    ...takeawayWithSource.takeaway.actionItems.map((item) => ({
       itemId: item.sId,
       targetUserIds: resolveTargetUserIds(
         item.assigneeUserId ? [item.assigneeUserId] : []
       ),
       blob: actionItemBlob(item),
     })),
-    ...takeaway.keyDecisions.map((item) => ({
+    ...takeawayWithSource.takeaway.keyDecisions.map((item) => ({
       itemId: item.sId,
       targetUserIds: resolveTargetUserIds(item.relevantUserIds),
       blob: keyDecisionBlob(item),
     })),
-    ...takeaway.notableFacts.map((item) => ({
+    ...takeawayWithSource.takeaway.notableFacts.map((item) => ({
       itemId: item.sId,
       targetUserIds: resolveTargetUserIds(item.relevantUserIds),
       blob: notableFactBlob(item),
@@ -262,11 +246,11 @@ async function collectConversationCandidates(
 
   // Batch-fetch all existing source links for this takeaway in 3 queries
   // instead of one per (item, user) pair.
-  const allItemIds = itemTriples.map((t) => t.itemId);
   const existingByKey = await ProjectTodoResource.fetchBySourceIds(auth, {
-    sourceIds: allItemIds,
+    sourceIds: [takeawayWithSource.source.sourceId],
   });
 
+  const candidates: PendingCandidate[] = [];
   for (const { itemId, targetUserIds, blob } of itemTriples) {
     for (const userId of targetUserIds) {
       const existing = existingByKey.get(`${itemId}:${userId}`) ?? null;
@@ -274,7 +258,12 @@ async function collectConversationCandidates(
         // Source link exists — update content if it has changed.
         await updateTodoIfChanged(existing, auth, blob);
       } else {
-        candidates.push({ itemId, userId, blob, conversationSId });
+        candidates.push({
+          itemId,
+          userId,
+          blob,
+          source: takeawayWithSource.source,
+        });
       }
     }
   }
@@ -370,9 +359,8 @@ async function createOrLinkTodos(
 
       if (match !== null) {
         // Semantic duplicate found — link the new source to the existing todo.
-        await match.addSource(auth, {
-          sourceType: "project_conversation",
-          sourceId: candidate.itemId,
+        await match.upsertSource(auth, {
+          source: candidate.source,
         });
 
         // For agent-created todos also propagate content updates. User-created
@@ -386,7 +374,7 @@ async function createOrLinkTodos(
             existingTodoSId: match.sId,
             itemId: candidate.itemId,
             userId: candidate.userId,
-            conversationSId: candidate.conversationSId,
+            source: candidate.source,
             createdByType: match.createdByType,
           },
           "Project todo merge: linked source to existing todo (semantic duplicate)"
@@ -411,9 +399,8 @@ async function createOrLinkTodos(
         markedAsDoneByAgentConfigurationId: null,
       });
 
-      await todo.addSource(auth, {
-        sourceType: "project_conversation",
-        sourceId: candidate.itemId,
+      await todo.upsertSource(auth, {
+        source: candidate.source,
       });
 
       logger.info(
@@ -421,7 +408,7 @@ async function createOrLinkTodos(
           todoSId: todo.sId,
           itemId: candidate.itemId,
           userId: candidate.userId,
-          conversationSId: candidate.conversationSId,
+          source: candidate.source,
         },
         "Project todo merge: created new todo"
       );

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -13,7 +13,6 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   ProjectTodoSourceInfo,
-  ProjectTodoSourceType,
   ProjectTodoType,
 } from "@app/types/project_todo";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -337,26 +336,41 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
 
   // ── Source links (* => todo) ─────────────────────────────────────────────
 
-  async addSource(
+  async upsertSource(
     auth: Authenticator,
     {
-      sourceType,
-      sourceId,
+      source,
     }: {
-      sourceType: ProjectTodoSourceType;
-      sourceId: string;
+      source: ProjectTodoSourceInfo;
     },
     transaction?: Transaction
   ): Promise<void> {
-    await ProjectTodoSourceModel.create(
+    const where = {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      projectTodoId: this.id,
+      sourceType: source.sourceType,
+      sourceId: source.sourceId,
+    };
+    const [sourceInstance, created] = await ProjectTodoSourceModel.findOrCreate(
       {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        projectTodoId: this.id,
-        sourceType,
-        sourceId,
-      },
-      { transaction }
+        where,
+        defaults: {
+          ...where,
+          sourceTitle: source.sourceTitle,
+          sourceUrl: source.sourceUrl,
+        },
+        transaction,
+      }
     );
+    if (!created) {
+      await sourceInstance.update(
+        {
+          sourceTitle: source.sourceTitle,
+          sourceUrl: source.sourceUrl,
+        },
+        { transaction }
+      );
+    }
   }
 
   // ── Serialization ──────────────────────────────────────────────────────────

--- a/front/lib/resources/storage/models/project_todo.ts
+++ b/front/lib/resources/storage/models/project_todo.ts
@@ -421,6 +421,12 @@ ProjectTodoSourceModel.init(
         fields: ["sourceType", "sourceId"],
         concurrently: true,
       },
+      {
+        name: "project_todo_sources_ws_unique_idx",
+        fields: ["workspaceId", "projectTodoId", "sourceType", "sourceId"],
+        unique: true,
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/lib/resources/takeaways_resource.ts
+++ b/front/lib/resources/takeaways_resource.ts
@@ -38,6 +38,11 @@ export type TakeawaySourceDocument = {
   uri: string;
 };
 
+export type TakeawaysWithSource = {
+  takeaway: TakeawaysResource;
+  source: ProjectTodoSourceInfo;
+};
+
 type TakeawaysVersionCreationAttributes = CreationAttributes<TakeawaysModel> & {
   takeawaysId: ModelId;
   version: number;
@@ -289,12 +294,7 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
   static async fetchLatestBySpaceId(
     auth: Authenticator,
     { spaceModelId }: { spaceModelId: ModelId }
-  ): Promise<
-    {
-      takeaway: TakeawaysResource;
-      source: { sourceType: ProjectTodoSourceType; sourceId: string };
-    }[]
-  > {
+  ): Promise<TakeawaysWithSource[]> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
     const rows = await TakeawaysModel.findAll({
@@ -326,10 +326,7 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
       ])
     );
 
-    const result: {
-      takeaway: TakeawaysResource;
-      source: ProjectTodoSourceInfo;
-    }[] = [];
+    const result: TakeawaysWithSource[] = [];
     for (const row of rows) {
       const source = sourceByTakeawaysId.get(row.id);
       if (!source) {

--- a/front/migrations/db/migration_587.sql
+++ b/front/migrations/db/migration_587.sql
@@ -1,3 +1,10 @@
 -- Migration created on Apr 16, 2026
-ALTER TABLE project_todos ADD COLUMN "deletedAt" TIMESTAMP WITH TIME ZONE;
-ALTER TABLE project_todo_versions ADD COLUMN "deletedAt" TIMESTAMP WITH TIME ZONE;
+ALTER TABLE project_todos
+ADD COLUMN "deletedAt" TIMESTAMP
+WITH
+    TIME ZONE;
+
+ALTER TABLE project_todo_versions
+ADD COLUMN "deletedAt" TIMESTAMP
+WITH
+    TIME ZONE;

--- a/front/migrations/db/migration_588.sql
+++ b/front/migrations/db/migration_588.sql
@@ -1,0 +1,6 @@
+CREATE UNIQUE INDEX CONCURRENTLY "project_todo_sources_ws_unique_idx" ON "project_todo_sources" (
+    "workspaceId",
+    "projectTodoId",
+    "sourceType",
+    "sourceId"
+)

--- a/front/scripts/dev/launch_project_todo_one_off.ts
+++ b/front/scripts/dev/launch_project_todo_one_off.ts
@@ -1,10 +1,12 @@
 import { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import { makeScript } from "@app/scripts/helpers";
+import {
+  analyzeProjectTodosActivity,
+  mergeTodosForProjectActivity,
+} from "@app/temporal/project_todo/activities";
 import { QUEUE_NAME } from "@app/temporal/project_todo/config";
-import { projectTodoWorkflow } from "@app/temporal/project_todo/workflows";
 
 makeScript(
   {
@@ -67,16 +69,7 @@ makeScript(
       return;
     }
 
-    const client = await getTemporalClientForFrontNamespace();
-    await client.workflow.start(projectTodoWorkflow, {
-      args: [{ workspaceId, spaceId: space.sId }],
-      taskQueue: QUEUE_NAME,
-      workflowId: oneOffWorkflowId,
-      memo: {
-        workspaceId,
-        spaceId: space.sId,
-        trigger: "manual_one_off_dev",
-      },
-    });
+    await analyzeProjectTodosActivity({ workspaceId, spaceId });
+    await mergeTodosForProjectActivity({ workspaceId, spaceId });
   }
 );

--- a/front/temporal/project_todo/activities.ts
+++ b/front/temporal/project_todo/activities.ts
@@ -2,14 +2,15 @@ import { isIncludeResultResourceType } from "@app/lib/actions/mcp_internal_actio
 import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
 import { buildProjectRetrieveDataSources } from "@app/lib/api/actions/servers/project_manager/helpers";
 import { Authenticator } from "@app/lib/auth";
-import { extractDocumentTakeaways } from "@app/lib/project_todo/analyze_conversation";
+import { extractDocumentTakeaways } from "@app/lib/project_todo/analyze_document";
+import { mergeTakeawaysIntoProject } from "@app/lib/project_todo/merge_into_project";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { TakeawaySourceDocument } from "@app/lib/resources/takeaways_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import { signalOrStartProjectMergeWorkflow } from "@app/temporal/project_todo/client";
+import type { ConnectorProvider } from "@app/types/data_source";
 import type { ProjectTodoSourceType } from "@app/types/project_todo";
 import { removeNulls } from "@app/types/shared/utils/general";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
@@ -20,7 +21,7 @@ function resultToTakeawaySourceDocument(
 ): TakeawaySourceDocument | null {
   if (isIncludeResultResourceType(result)) {
     let sourceType: ProjectTodoSourceType | null = null;
-    switch (result.resource.source.provider) {
+    switch (result.resource.source.provider as ConnectorProvider) {
       case "dust_project":
         sourceType =
           result.resource.source.mimeType ===
@@ -28,9 +29,31 @@ function resultToTakeawaySourceDocument(
             ? "project_conversation"
             : "project_knowledge";
         break;
+      case "slack":
+      case "slack_bot":
+        sourceType = "slack";
+        break;
+      case "google_drive":
+        sourceType = "gdrive";
+        break;
+      case "notion":
+        sourceType = "notion";
+        break;
       default:
+        logger.info(
+          {
+            provider: result.resource.source.provider,
+            mimeType: result.resource.source.mimeType,
+          },
+          "[resultToTakeawaySourceDocument] Unknown provider"
+        );
         return null;
     }
+
+    if (!sourceType) {
+      return null;
+    }
+
     return {
       title: result.resource.text,
       id: result.resource.id,
@@ -91,7 +114,7 @@ export async function analyzeProjectTodosActivity({
     retrievalTopK: 128,
     dataSources: await buildProjectRetrieveDataSources(auth, space),
     // TODO: compute this from the last time the project todo was analyzed.
-    timeFrame: { duration: 7, unit: "day" },
+    timeFrame: { duration: 1, unit: "day" },
   });
 
   if (results.isErr()) {
@@ -131,19 +154,7 @@ export async function analyzeProjectTodosActivity({
   );
 }
 
-// Starts or signals `projectMergeWorkflow` (signalWithStart). Used when merge is driven
-// via signals; the cron `projectTodoWorkflow` path calls `mergeTodosForProjectActivity` directly.
-export async function signalOrStartMergeWorkflowActivity({
-  workspaceId,
-  spaceId,
-}: {
-  workspaceId: string;
-  spaceId: string;
-}): Promise<void> {
-  await signalOrStartProjectMergeWorkflow({ workspaceId, spaceId });
-}
-
-// Called by projectMergeWorkflow. Merges the latest takeaway snapshots
+// Called by projectTodoWorkflow. Merges the latest takeaway snapshots
 // for all conversations in the project into project_todo rows.
 export async function mergeTodosForProjectActivity({
   workspaceId,
@@ -152,23 +163,5 @@ export async function mergeTodosForProjectActivity({
   workspaceId: string;
   spaceId: string;
 }): Promise<void> {
-  /*
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    logger.error(
-      { spaceId, error: authResult.error },
-      "Project todo merge: failed to deserialize authenticator"
-    );
-    return;
-  }
-
-  const auth = authResult.value;
-
-  logger.info(
-    { spaceId, workspaceId: auth.getNonNullableWorkspace().sId },
-    "Project todo merge: activity invoked (not yet implemented)"
-  );
-
-  await mergeTakeawaysIntoProject(auth, { spaceId });
-  */
+  await mergeTakeawaysIntoProject({ workspaceId, spaceId });
 }

--- a/front/temporal/project_todo/client.ts
+++ b/front/temporal/project_todo/client.ts
@@ -2,11 +2,7 @@ import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/project_todo/config";
-import { mergeRequestSignal } from "@app/temporal/project_todo/signals";
-import {
-  projectMergeWorkflow,
-  projectTodoWorkflow,
-} from "@app/temporal/project_todo/workflows";
+import { projectTodoWorkflow } from "@app/temporal/project_todo/workflows";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import {
   WorkflowExecutionAlreadyStartedError,
@@ -18,13 +14,6 @@ function makeProjectTodoWorkflowId(
   spaceId: string
 ): string {
   return `project-todo-${workspaceId}-${spaceId}`;
-}
-
-function makeProjectMergeWorkflowId(
-  workspaceId: string,
-  spaceId: string
-): string {
-  return `project-merge-todo-${workspaceId}-${spaceId}`;
 }
 
 export async function launchOrSignalProjectTodoWorkflow({
@@ -100,44 +89,5 @@ export async function stopProjectTodoWorkflow({
         "Failed terminating project todo workflow"
       );
     }
-  }
-}
-
-// Called from `signalOrStartMergeWorkflowActivity` to fan-in into the per-project merge
-// workflow. Uses signalWithStart so the merge workflow is created if not already running.
-export async function signalOrStartProjectMergeWorkflow({
-  workspaceId,
-  spaceId,
-}: {
-  workspaceId: string;
-  spaceId: string;
-}): Promise<void> {
-  const client = await getTemporalClientForFrontNamespace();
-  const workflowId = makeProjectMergeWorkflowId(workspaceId, spaceId);
-
-  try {
-    await client.workflow.signalWithStart(projectMergeWorkflow, {
-      args: [{ workspaceId, spaceId }],
-      taskQueue: QUEUE_NAME,
-      workflowId,
-      signal: mergeRequestSignal,
-      signalArgs: [],
-      workflowExecutionTimeout: "7 days",
-      memo: {
-        workspaceId,
-        spaceId,
-      },
-    });
-  } catch (e) {
-    // Swallow errors — merge workflow failures must not block the analysis workflow.
-    logger.error(
-      {
-        workflowId,
-        workspaceId,
-        spaceId,
-        error: normalizeError(e),
-      },
-      "Failed signaling project merge workflow"
-    );
   }
 }

--- a/front/temporal/project_todo/config.ts
+++ b/front/temporal/project_todo/config.ts
@@ -2,7 +2,3 @@ const QUEUE_VERSION = 1;
 
 // TODO: rename this queue
 export const QUEUE_NAME = `conversation-todo-queue-v${QUEUE_VERSION}`;
-
-// The merge workflow (projectMergeWorkflow) calls an LLM to update project todos.
-// This throttle prevents more than one LLM merge per project per hour.
-export const MERGE_THROTTLE_MS = 60 * 60 * 1_000; // 1 hour

--- a/front/temporal/project_todo/signals.ts
+++ b/front/temporal/project_todo/signals.ts
@@ -6,9 +6,3 @@ export const todoRefreshSignal = defineSignal<[string]>(
 export const todoCompleteSignal = defineSignal<[string]>(
   "project_todo_complete_signal"
 );
-
-// Sent to projectMergeWorkflow to request a merge. Carries no payload — the merge workflow
-// only needs to know there is work to do.
-export const mergeRequestSignal = defineSignal<[]>(
-  "project_todo_merge_request_signal"
-);

--- a/front/temporal/project_todo/workflows.ts
+++ b/front/temporal/project_todo/workflows.ts
@@ -1,12 +1,5 @@
 import type * as activities from "@app/temporal/project_todo/activities";
-import { MERGE_THROTTLE_MS } from "@app/temporal/project_todo/config";
-import { mergeRequestSignal } from "@app/temporal/project_todo/signals";
-import {
-  condition,
-  proxyActivities,
-  setHandler,
-  sleep,
-} from "@temporalio/workflow";
+import { proxyActivities } from "@temporalio/workflow";
 
 const { analyzeProjectTodosActivity, mergeTodosForProjectActivity } =
   proxyActivities<typeof activities>({
@@ -24,35 +17,5 @@ export async function projectTodoWorkflow({
   spaceId: string;
 }): Promise<void> {
   await analyzeProjectTodosActivity({ workspaceId, spaceId });
-  // await mergeTodosForProjectActivity({ authType, spaceId });
-}
-
-// One long-running workflow per (workspace, project/space). Receives merge-request signals
-// and runs the LLM merge at most once per MERGE_THROTTLE_MS, batching dirty conversations.
-export async function projectMergeWorkflow({
-  workspaceId,
-  spaceId,
-}: {
-  workspaceId: string;
-  spaceId: string;
-}): Promise<void> {
-  let hasPendingWork = false;
-  let isCoolingDown = false;
-
-  setHandler(mergeRequestSignal, () => {
-    hasPendingWork = true;
-  });
-
-  // Process merge requests, throttled to at most once per MERGE_THROTTLE_MS.
-  // Signals that arrive during the cool-down are coalesced into the next run.
-  while (true) {
-    await condition(() => hasPendingWork && !isCoolingDown);
-    hasPendingWork = false;
-    isCoolingDown = true;
-
-    await mergeTodosForProjectActivity({ workspaceId, spaceId });
-
-    await sleep(MERGE_THROTTLE_MS);
-    isCoolingDown = false;
-  }
+  await mergeTodosForProjectActivity({ workspaceId, spaceId });
 }


### PR DESCRIPTION
## Description

Several issues were preventing the takeaways → todos pipeline from working end-to-end: participant detection was unreliable (only users who had spoken were included), the LLM couldn't reference user IDs in message headers, field merging on re-analysis was too lossy, and `sourceUrl` wasn't being used in the panel navigation despite being stored.

- **Rename `analyze_conversation/` → `analyze_document/`** — follows through on the source-agnostic rename from #24348
- **Replace conversation participant detection with project member roster** — fetch all project members via `SpaceResource.fetchManualGroupsMemberships` instead of scanning message history; the roster now includes `name`, `email`, and `id`, matching the `id:` field added to message headers
- **Add user `sId` to message prefix in `conversation_formatting`** — so the LLM can resolve assignee IDs directly from the transcript
- **Add `buildPromptForSourceType`** — source-type-specific prompt additions (agentic context preamble for conversations) moved to a dedicated `prompts.ts`
- **Fix `buildActionItems` / `buildKeyDecisions` / `buildNotableFacts` signatures** — take `previousItems: T[]` instead of `previousSIds: Set<string>`, enabling proper field merging: `status`, `detectedDoneAt`, `detectedDoneRationale`, `shortDescription` all fall back to the previous version when the LLM omits them
- **Fix `detectedDoneAt` logic** — only set to `now` when transitioning `→ done` (i.e. `previousItem.status !== "done"`), avoiding timestamp reset on re-analysis
- **Switch from `getFastestWhitelistedModel` to `getSmallWhitelistedModel`** — cheapest models aren't sufficient for structured extraction
- **Fix panel navigation** — use stored `sourceUrl` directly instead of recomputing `getConversationRoute(owner.sId, source.sourceId)` at render time
- **Update prompt instructions** — reference "project members" instead of "conversation participants"; instruct the LLM to refer to the assignee with "You/Your" pronouns; allow updating fields (not just copying sId) when re-detecting a known task
- Update tests for the new builder signatures

## Tests

Local + green (tests updated)

## Risk

Medium — changes extraction prompt, participant sourcing, and field merging logic; existing stored takeaways are unaffected (schema unchanged)

## Deploy Plan

Deploy `front`, deploy `connectors`
