### PR TITLE
[analytics] add option to export as json 

### DIFF
--- a/front/pages/api/v1/w/[wId]/analytics/export.test.ts
+++ b/front/pages/api/v1/w/[wId]/analytics/export.test.ts
@@ -111,11 +111,13 @@ async function setupTest({
   startDate = "2024-06-01",
   endDate = "2024-06-30",
   timezone,
+  format,
 }: {
   table?: string;
   startDate?: string;
   endDate?: string;
   timezone?: string;
+  format?: string;
 } = {}) {
   const result = await createPublicApiMockRequest();
 
@@ -127,6 +129,9 @@ async function setupTest({
   };
   if (timezone) {
     query.timezone = timezone;
+  }
+  if (format) {
+    query.format = format;
   }
 
   result.req.query = query;
@@ -282,5 +287,55 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
     );
     expect(csv).toContain("msg-1");
     expect(csv).toContain("alice@example.com");
+  });
+
+  it("returns JSON when format=json", async () => {
+    const { req, res } = await setupTest({
+      table: "usage_metrics",
+      format: "json",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader("Content-Type")).toBe("application/json");
+    const data = res._getJSONData();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data[0]).toHaveProperty("date");
+    expect(data[0]).toHaveProperty("messages");
+    expect(data[0]).toHaveProperty("conversations");
+    expect(data[0]).toHaveProperty("activeUsers");
+  });
+
+  it("returns CSV by default (no format param)", async () => {
+    const { req, res } = await setupTest({ table: "usage_metrics" });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader("Content-Type")).toBe("text/csv");
+  });
+
+  it("returns CSV when format=csv", async () => {
+    const { req, res } = await setupTest({
+      table: "usage_metrics",
+      format: "csv",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader("Content-Type")).toBe("text/csv");
+  });
+
+  it("returns 400 for invalid format value", async () => {
+    const { req, res } = await setupTest({
+      table: "usage_metrics",
+      format: "xml",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
   });
 });

--- a/front/pages/api/v1/w/[wId]/analytics/export.ts
+++ b/front/pages/api/v1/w/[wId]/analytics/export.ts
@@ -142,6 +142,8 @@ async function handler(
         });
       }
 
+      // TODO: Avoid CSV→parse round-trip. Return structured data directly
+      // from exportTable() instead of converting CSV back to JSON.
       if (q.data.format === "json") {
         const records = parseCSV<Record<string, string>>(csv.value, {
           columns: true,

--- a/front/pages/api/v1/w/[wId]/analytics/export.ts
+++ b/front/pages/api/v1/w/[wId]/analytics/export.ts
@@ -2,8 +2,8 @@
  * @swagger
  * /api/v1/w/{wId}/analytics/export:
  *   get:
- *     summary: Export workspace analytics as CSV
- *     description: Export analytics data for the workspace identified by {wId} in CSV format.
+ *     summary: Export workspace analytics
+ *     description: Export analytics data for the workspace identified by {wId} in CSV or JSON format.
  *     tags:
  *       - Workspace
  *     security:
@@ -51,13 +51,25 @@
  *         description: IANA timezone name (defaults to UTC)
  *         schema:
  *           type: string
+ *       - in: query
+ *         name: format
+ *         required: false
+ *         description: Output format (defaults to csv)
+ *         schema:
+ *           type: string
+ *           enum: [csv, json]
  *     responses:
  *       200:
- *         description: The analytics data in CSV format
+ *         description: The analytics data in CSV or JSON format
  *         content:
  *           text/csv:
  *             schema:
  *               type: string
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
  *       400:
  *         description: Invalid request query parameters
  *       403:
@@ -72,11 +84,12 @@ import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { GetAnalyticsExportRequestSchema } from "@dust-tt/client";
+import { parse as parseCSV } from "csv-parse/sync";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<string>>,
+  res: NextApiResponse<WithAPIErrorResponse<string | Record<string, string>[]>>,
   auth: Authenticator
 ): Promise<void> {
   if (!auth.isKey() || !auth.isBuilder()) {
@@ -92,12 +105,13 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const { table, startDate, endDate, timezone } = req.query;
+      const { table, startDate, endDate, timezone, format } = req.query;
       const q = GetAnalyticsExportRequestSchema.safeParse({
         table,
         startDate,
         endDate,
         timezone,
+        format,
       });
       if (!q.success) {
         return apiError(req, res, {
@@ -126,6 +140,15 @@ async function handler(
             message: csv.error.message,
           },
         });
+      }
+
+      if (q.data.format === "json") {
+        const records = parseCSV<Record<string, string>>(csv.value, {
+          columns: true,
+          skip_empty_lines: true,
+        });
+        res.setHeader("Content-Type", "application/json");
+        return res.status(200).json(records);
       }
 
       res.setHeader("Content-Type", "text/csv");

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -230,8 +230,8 @@
     },
     "/api/v1/w/{wId}/analytics/export": {
       "get": {
-        "summary": "Export workspace analytics as CSV",
-        "description": "Export analytics data for the workspace identified by {wId} in CSV format.",
+        "summary": "Export workspace analytics",
+        "description": "Export analytics data for the workspace identified by {wId} in CSV or JSON format.",
         "tags": [
           "Workspace"
         ],
@@ -297,15 +297,36 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "description": "Output format (defaults to csv)",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "csv",
+                "json"
+              ]
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "The analytics data in CSV format",
+            "description": "The analytics data in CSV or JSON format",
             "content": {
               "text/csv": {
                 "schema": {
                   "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
                 }
               }
             }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2903,6 +2903,7 @@ export const GetAnalyticsExportRequestSchema = z
     startDate: AnalyticsDateSchema,
     endDate: AnalyticsDateSchema,
     timezone: Timezone.optional(),
+    format: z.enum(["csv", "json"]).optional(),
   })
   .refine((d) => d.startDate <= d.endDate, {
     message: "startDate must be before or equal to endDate",


### PR DESCRIPTION
## Description
This PR is add an option to export analytics with json format since we supported before migrating to the new version: https://github.com/dust-tt/dust/blob/912f8bf71a25b64bb284cb4912c24c74b550b220/front/pages/api/v1/w/%5BwId%5D/workspace-usage.ts#L63-L69 


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested it on front-edge  


<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
