### PR TITLE
Batch-fetch users in getMembers to avoid N+1 queries

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -146,41 +146,45 @@ export async function getMembers(
         transaction,
       });
 
-  const usersWithWorkspaces = await Promise.all(
-    memberships.map(async (m) => {
-      let role = "none" as RoleType;
-      let origin: MembershipOriginType | undefined = undefined;
-      if (!m.isRevoked()) {
-        switch (m.role) {
-          case "admin":
-          case "builder":
-          case "user":
-            role = m.role;
-            break;
-          default:
-            role = "none";
-        }
-      }
-      origin = m.origin;
+  // Batch-fetch users that weren't preloaded to avoid N+1 queries.
+  const missingUserModelIds = memberships
+    .filter((m) => !m.user)
+    .map((m) => m.userId);
+  const fetchedUsers = missingUserModelIds.length
+    ? await UserResource.fetchByModelIds(missingUserModelIds, { transaction })
+    : [];
+  const userByModelId = new Map(fetchedUsers.map((u) => [u.id, u]));
 
-      let user: UserResource | null;
-      if (!m.user) {
-        user = await UserResource.fetchByModelId(m.userId, transaction);
-      } else {
-        user = new UserResource(UserModel, m.user);
+  const usersWithWorkspaces = memberships.map((m) => {
+    let role = "none" as RoleType;
+    let origin: MembershipOriginType | undefined = undefined;
+    if (!m.isRevoked()) {
+      switch (m.role) {
+        case "admin":
+        case "builder":
+        case "user":
+          role = m.role;
+          break;
+        default:
+          role = "none";
       }
+    }
+    origin = m.origin;
 
-      if (!user) {
-        return null;
-      }
+    const user = m.user
+      ? new UserResource(UserModel, m.user)
+      : (userByModelId.get(m.userId) ?? null);
 
-      return {
-        ...user.toJSON(),
-        workspaces: [{ ...owner, role, flags: null }],
-        origin,
-      };
-    })
-  );
+    if (!user) {
+      return null;
+    }
+
+    return {
+      ...user.toJSON(),
+      workspaces: [{ ...owner, role, flags: null }],
+      origin,
+    };
+  });
 
   return {
     members: removeNulls(usersWithWorkspaces),

--- a/front/pages/api/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -62,18 +62,12 @@ async function handler(
       const groupMembers = await group.getActiveMembers(auth);
       const memberships = await getMembers(auth);
 
-      const userWithWorkspaces = groupMembers.reduce<UserTypeWithWorkspaces[]>(
-        (acc, user) => {
-          const member = memberships.members.find((m) => m.sId === user.sId);
+      const memberById = new Map(memberships.members.map((m) => [m.sId, m]));
 
-          if (member) {
-            acc.push(member);
-          }
-
-          return acc;
-        },
-        []
-      );
+      const userWithWorkspaces = groupMembers.flatMap((user) => {
+        const member = memberById.get(user.sId);
+        return member ? [member] : [];
+      });
 
       return res.status(200).json({
         members: userWithWorkspaces,

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -67,21 +67,14 @@ async function handler(
       );
 
       const memberships = await getMembers(auth);
+      const memberById = new Map(memberships.members.map((m) => [m.sId, m]));
 
       for (const group of allGroups) {
         const groupMembers = await group.getActiveMembers(auth);
-        members[group.name] = groupMembers.reduce<UserTypeWithWorkspaces[]>(
-          (acc, user) => {
-            const member = memberships.members.find((m) => m.sId === user.sId);
-
-            if (member) {
-              acc.push(member);
-            }
-
-            return acc;
-          },
-          []
-        );
+        members[group.name] = groupMembers.flatMap((user) => {
+          const member = memberById.get(user.sId);
+          return member ? [member] : [];
+        });
       }
 
       return res.status(200).json({

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -162,7 +162,6 @@ async function handler(
   }
 
   const messageRes = await conversation.getMessageById(auth, mId);
-
   if (messageRes.isErr()) {
     return apiError(req, res, {
       status_code: 404,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1776415118956069).

We had a workspace with 1203 members that was firing 1203 concurrent DB queries every time the poke memberships page loaded. One SELECT per member to fetch their user record. This was holding 1203 connections simultaneously from a pool of 40, starving every other request on the pod.

**Bonus**
Both poke details endpoints were doing a linear `.find()` scan over all workspace members for each group member. The classic nested loop.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
