### PR TITLE
[front] chore: improve typing on `streamActionProgress`

### DIFF
--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -6,7 +6,10 @@ import {
   parseDataAsMessageIdAndActionId,
   useConversationSidePanelContext,
 } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import type { AgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
+import type {
+  ActionProgressState,
+  AgentMessageWithStreaming,
+} from "@app/components/assistant/conversation/types";
 import { getIcon } from "@app/components/resources/resources_icons";
 import {
   useAgentMessageSkills,
@@ -273,7 +276,7 @@ function AgentActionsPanelContent({
       el.scrollHeight - el.clientHeight <= el.scrollTop + threshold;
   };
 
-  const streamActionProgress =
+  const streamActionProgress: ActionProgressState =
     messageStreamState?.streaming.actionProgress ?? new Map();
   const pendingToolCalls = messageStreamState?.streaming.pendingToolCalls ?? [];
   return (

--- a/front/components/assistant/conversation/actions/PanelAgentStep.tsx
+++ b/front/components/assistant/conversation/actions/PanelAgentStep.tsx
@@ -1,6 +1,7 @@
 import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
 import { PendingToolCallDetails } from "@app/components/assistant/conversation/actions/PendingToolCallDetails";
 import {
+  type ActionProgressState,
   getPendingToolCallKey,
   type PendingToolCall,
 } from "@app/components/assistant/conversation/types";
@@ -16,7 +17,7 @@ interface AgentStepProps {
   isStreaming?: boolean;
   pendingToolCalls?: PendingToolCall[];
   streamingActions?: AgentMCPActionWithOutputType[];
-  streamActionProgress: Map<number, any>;
+  streamActionProgress: ActionProgressState;
   owner: LightWorkspaceType;
   messageStatus:
     | "created"


### PR DESCRIPTION
## Description

- This PR improves the typing on the progress (e.g. notifications sent by tools) in the front-end, replacing a `Map<number, any>` with a rich type.

## Tests

- tsgo

## Risk

- N/A. No runtime change, only typing is affected.

## Deploy Plan

- Deploy front.
