### PR TITLE
chore: fix n+1 queries on trigger endpoint

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -117,7 +117,9 @@ async function handler(
       const triggersWithIsSubscriber = await Promise.all(
         allTriggers.map(async (trigger) => ({
           ...trigger.toJSON(),
-          isSubscriber: await trigger.isSubscriber(auth),
+          // TODO: when introducing subscribers functionnality,
+          // query the subscribers outside the promise.all loop to avoid the N^2 query
+          isSubscriber: false, // await trigger.isSubscriber(auth),
           isEditor: trigger.editor === auth.getNonNullableUser().id,
           editorName: editorNamesMap.get(trigger.editor),
         }))


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

`GET /api/w/[wId]/assistant/agent_configurations/[aId]/triggers` was peaking at ~67 concurrent DB queries because `trigger.isSubscriber(auth)` ran one `COUNT(*)` per trigger inside a `Promise.all` over all triggers, N+1 and a violation of [BACK7]. Short-circuited `isSubscriber` to `false` with a `TODO` (we haven't implemented this feature yet); when subscribers ship, it'll be a single batched query instead.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Unit

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front