### PR TITLE
chore: fix n+1 queries on webhook endpoints

### DIFF
--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -275,6 +275,19 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     );
   }
 
+  static async listByWebhookSourceIds(
+    auth: Authenticator,
+    webhookSourceIds: ModelId[]
+  ): Promise<WebhookSourcesViewResource[]> {
+    if (webhookSourceIds.length === 0) {
+      return [];
+    }
+    const views = await this.baseFetch(auth, {
+      where: { webhookSourceId: { [Op.in]: webhookSourceIds } },
+    });
+    return views.filter((view) => view.canReadOrAdministrate(auth));
+  }
+
   /**
    * List all webhook source views for a webhook source without space permission filtering.
    * This is used internally for webhook trigger processing where authorization

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -8,11 +8,11 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateSecureSecret } from "@app/lib/resources/string_ids_server";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { buildWebhookUrl } from "@app/lib/webhookSource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import type { ModelId } from "@app/types/shared/model_id";
 import type {
   WebhookSourceForAdminType,
   WebhookSourceWithViewsAndUsageType,
@@ -66,32 +66,34 @@ async function handler(
         await WebhookSourceResource.listByWorkspace(auth);
 
       const usageBySourceId = await getWebhookSourcesUsage({ auth });
-      const webhookSourcesWithViews = await concurrentExecutor(
-        webhookSourceResources,
-        async (webhookSourceResource) => {
-          const webhookSource = webhookSourceResource.toJSONForAdmin();
-          const webhookSourceViewResources =
-            await WebhookSourcesViewResource.listByWebhookSource(
-              auth,
-              webhookSource.id
-            );
-          const views = webhookSourceViewResources.map((view) =>
-            view.toJSONForAdmin()
-          );
+      const allViewResources =
+        await WebhookSourcesViewResource.listByWebhookSourceIds(
+          auth,
+          webhookSourceResources.map((s) => s.id)
+        );
 
-          return { ...webhookSource, views };
-        },
-        {
-          concurrency: 10,
-        }
-      );
+      const viewsBySourceId = new Map<ModelId, WebhookSourcesViewResource[]>();
+      for (const view of allViewResources) {
+        const list = viewsBySourceId.get(view.webhookSourceId) ?? [];
+        list.push(view);
+        viewsBySourceId.set(view.webhookSourceId, list);
+      }
+
+      const webhookSourcesWithViews = webhookSourceResources.map((src) => {
+        const webhookSource = src.toJSONForAdmin();
+        const views = (viewsBySourceId.get(src.id) ?? []).map((v) =>
+          v.toJSONForAdmin()
+        );
+        return {
+          ...webhookSource,
+          views,
+          usage: usageBySourceId[webhookSource.id] ?? { count: 0, agents: [] },
+        };
+      });
 
       return res.status(200).json({
         success: true,
-        webhookSourcesWithViews: webhookSourcesWithViews.map((source) => ({
-          ...source,
-          usage: usageBySourceId[source.id] ?? { count: 0, agents: [] },
-        })),
+        webhookSourcesWithViews,
       });
     }
 

--- a/front/pages/api/w/[wId]/webhook_sources/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/index.ts
@@ -3,7 +3,6 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
@@ -60,29 +59,19 @@ async function handler(
         });
       }
 
-      const webhookSourceViews = await concurrentExecutor(
-        normalizedQuery.spaceIds,
-        async (spaceId) => {
-          const space = await SpaceResource.fetchById(auth, spaceId);
-          if (!space || !space.canReadOrAdministrate(auth)) {
-            return null;
-          }
-          const views = await WebhookSourcesViewResource.listBySpace(
-            auth,
-            space
-          );
-          return views.map((v) => v.toJSON());
-        },
-        { concurrency: 10 }
+      const spaces = await SpaceResource.fetchByIds(
+        auth,
+        normalizedQuery.spaceIds
       );
-
-      const flattenedWebhookSourceViews = webhookSourceViews
-        .flat()
-        .filter((v): v is WebhookSourceViewType => v !== null);
+      const allowedSpaces = spaces.filter((s) => s.canReadOrAdministrate(auth));
+      const views = await WebhookSourcesViewResource.listBySpaces(
+        auth,
+        allowedSpaces
+      );
 
       return res.status(200).json({
         success: true,
-        webhookSourceViews: flattenedWebhookSourceViews,
+        webhookSourceViews: views.map((v) => v.toJSON()),
       });
     }
     default: {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Eliminates two N+1 query patterns hidden behind concurrentExecutor(..., { concurrency: 10 }):
- GET /api/w/[wId]/webhook_sources: peak DB concurrency 10 → 1 (sequential batched queries).
- GET /api/w/[wId]/webhook_sources/views: peak DB concurrency 10 → 1, total queries 2N → 2.

Adds one new static WebhookSourcesViewResource.listByWebhookSourceIds(auth, ids) that does a single IN (...) query + the same canReadOrAdministrate permission filter as `listByWebhookSource`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Unit

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front