### PR TITLE
hotfix handoff

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -679,7 +679,9 @@ export async function postUserMessage(
   if (
     runningAgentMessage &&
     agentMentions.length > 0 &&
-    agentMentions[0].configurationId !== runningAgentMessage.configuration.sId
+    agentMentions[0].configurationId !==
+      runningAgentMessage.configuration.sId &&
+    agenticMessageData?.type !== "agent_handover"
   ) {
     return new Err({
       status_code: 400,


### PR DESCRIPTION
## Description

Allow handoff user messages (agenticMessageData.type === "agent_handover") to bypass the "Cannot run a different agent while one is running" steering invariant in postUserMessage.


## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front.