### PR TITLE
fix: message width

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -403,6 +403,7 @@ export function UserMessage({
                   ) : (
                     <div
                       className={cn(
+                        "min-w-0",
                         isPending &&
                           "text-muted-foreground dark:text-muted-foreground-night"
                       )}


### PR DESCRIPTION
## Description

This PR fixes the message width display by adding a minimum width constraint to the user message component.
This fixes a regression introduced in https://github.com/dust-tt/dust/issues/24324

- Added `min-w-0` Tailwind CSS class to the message container's className in `UserMessage.tsx` to prevent overflow issues


Before:
<img width="1107" height="801" alt="Capture d’écran 2026-04-17 à 11 57 07" src="https://github.com/user-attachments/assets/2ff1afc1-89ea-4b7b-b32e-a63dc08ebeab" />

After:
<img width="1038" height="690" alt="Capture d’écran 2026-04-17 à 11 59 29" src="https://github.com/user-attachments/assets/5a94748e-1184-4dc2-86b5-5d7b885b5315" />


## Tests

Manually

## Risks

Low risk.

## Deploy Plan

Standard deployment - no special considerations needed.
