### PR TITLE
feat(sbx): egress forwarder setup and user flip

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -1,0 +1,276 @@
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockCheckEgressForwarderHealth,
+  mockGenerateExecId,
+  mockGenerateSandboxExecToken,
+  mockGetSandboxImage,
+  mockMountConversationFiles,
+  mockRecordToolDuration,
+  mockRefreshGcsToken,
+  mockRevokeExecToken,
+  mockSandboxSupportsEgressForwarding,
+  mockSetupEgressForwarder,
+  mockStartTelemetry,
+  mockWrapCommand,
+  mockEnsureActive,
+} = vi.hoisted(() => ({
+  mockCheckEgressForwarderHealth: vi.fn(),
+  mockGenerateExecId: vi.fn(),
+  mockGenerateSandboxExecToken: vi.fn(),
+  mockGetSandboxImage: vi.fn(),
+  mockMountConversationFiles: vi.fn(),
+  mockRecordToolDuration: vi.fn(),
+  mockRefreshGcsToken: vi.fn(),
+  mockRevokeExecToken: vi.fn(),
+  mockSandboxSupportsEgressForwarding: vi.fn(),
+  mockSetupEgressForwarder: vi.fn(),
+  mockStartTelemetry: vi.fn(),
+  mockWrapCommand: vi.fn(),
+  mockEnsureActive: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getClientFacingUrl: () => "https://dust.tt",
+    getSandboxDevFrontHostName: () => undefined,
+  },
+}));
+
+vi.mock("@app/lib/api/sandbox/egress", () => ({
+  checkEgressForwarderHealth: mockCheckEgressForwarderHealth,
+  sandboxSupportsEgressForwarding: mockSandboxSupportsEgressForwarding,
+  setupEgressForwarder: mockSetupEgressForwarder,
+}));
+
+vi.mock("@app/lib/api/sandbox/access_tokens", () => ({
+  generateExecId: mockGenerateExecId,
+  generateSandboxExecToken: mockGenerateSandboxExecToken,
+  revokeExecToken: mockRevokeExecToken,
+}));
+
+vi.mock("@app/lib/api/sandbox/gcs/mount", () => ({
+  mountConversationFiles: mockMountConversationFiles,
+  refreshGcsToken: mockRefreshGcsToken,
+}));
+
+vi.mock("@app/lib/api/sandbox/image", () => ({
+  getSandboxImage: mockGetSandboxImage,
+}));
+
+vi.mock("@app/lib/api/sandbox/image/profile", () => ({
+  wrapCommand: mockWrapCommand,
+}));
+
+vi.mock("@app/lib/api/sandbox/instrumentation", () => ({
+  recordToolDuration: mockRecordToolDuration,
+}));
+
+vi.mock("@app/lib/api/sandbox/telemetry", () => ({
+  startTelemetry: mockStartTelemetry,
+}));
+
+vi.mock("@app/lib/resources/sandbox_resource", () => ({
+  SandboxResource: {
+    ensureActive: mockEnsureActive,
+  },
+}));
+
+vi.mock("@app/logger/logger", () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { runSandboxBashTool } from "./index";
+
+describe("runSandboxBashTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGenerateExecId.mockReturnValue("exec-1");
+    mockGenerateSandboxExecToken.mockResolvedValue("sandbox-token");
+    mockGetSandboxImage.mockReturnValue(new Ok({}));
+    mockMountConversationFiles.mockResolvedValue(new Ok(undefined));
+    mockRefreshGcsToken.mockResolvedValue(new Ok(undefined));
+    mockRevokeExecToken.mockResolvedValue(undefined);
+    mockSetupEgressForwarder.mockResolvedValue(new Ok(undefined));
+    mockStartTelemetry.mockResolvedValue(undefined);
+    mockWrapCommand.mockImplementation(
+      (command: string) => `wrapped:${command}`
+    );
+  });
+
+  function makeExtra() {
+    return {
+      auth: {
+        getNonNullableWorkspace: () => ({ sId: "workspace-id" }),
+      },
+      agentLoopContext: {
+        runContext: {
+          agentConfiguration: {
+            model: { providerId: "openai" },
+            sId: "agent-id",
+          },
+          agentMessage: { sId: "message-id" },
+          conversation: { sId: "conversation-id" },
+        },
+      },
+      signal: new AbortController().signal,
+    } as never;
+  }
+
+  it("keeps executing as the default user when the sandbox is pre-PR1", async () => {
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi
+        .fn()
+        .mockResolvedValue(
+          new Ok({ exitCode: 0, stdout: "hello", stderr: "" })
+        ),
+    };
+
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockSandboxSupportsEgressForwarding.mockResolvedValue(new Ok(false));
+
+    const result = await runSandboxBashTool(
+      { command: "echo hello", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockSetupEgressForwarder).not.toHaveBeenCalled();
+    expect(mockCheckEgressForwarderHealth).not.toHaveBeenCalled();
+    expect(sandbox.exec).toHaveBeenCalledWith(
+      expect.anything(),
+      "wrapped:echo hello",
+      expect.objectContaining({
+        envVars: expect.objectContaining({
+          DUST_SANDBOX_TOKEN: "sandbox-token",
+        }),
+      })
+    );
+    expect(sandbox.exec.mock.calls[0][2]).not.toHaveProperty("user");
+  });
+
+  it("executes as agent-proxied when the forwarder is healthy", async () => {
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi
+        .fn()
+        .mockResolvedValue(
+          new Ok({ exitCode: 0, stdout: "hello", stderr: "" })
+        ),
+    };
+
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockSandboxSupportsEgressForwarding.mockResolvedValue(new Ok(true));
+    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(true));
+
+    const result = await runSandboxBashTool(
+      { command: "echo hello", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockSetupEgressForwarder).not.toHaveBeenCalled();
+    expect(sandbox.exec).toHaveBeenCalledWith(
+      expect.anything(),
+      "wrapped:echo hello",
+      expect.objectContaining({
+        user: "agent-proxied",
+      })
+    );
+  });
+
+  it("restarts the forwarder when the health check fails", async () => {
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi
+        .fn()
+        .mockResolvedValue(
+          new Ok({ exitCode: 0, stdout: "hello", stderr: "" })
+        ),
+    };
+
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: true,
+      })
+    );
+    mockSandboxSupportsEgressForwarding.mockResolvedValue(new Ok(true));
+    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(false));
+
+    const result = await runSandboxBashTool(
+      { command: "echo hello", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockSetupEgressForwarder).toHaveBeenCalledTimes(1);
+    expect(sandbox.exec).toHaveBeenCalledWith(
+      expect.anything(),
+      "wrapped:echo hello",
+      expect.objectContaining({
+        user: "agent-proxied",
+      })
+    );
+    expect(mockRecordToolDuration).toHaveBeenCalledWith(
+      "bash",
+      expect.any(Number),
+      { workspaceId: "workspace-id" },
+      "success"
+    );
+  });
+
+  it("returns an MCP error when egress setup fails", async () => {
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi.fn(),
+    };
+
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockSandboxSupportsEgressForwarding.mockResolvedValue(new Ok(true));
+    mockSetupEgressForwarder.mockResolvedValue(
+      new Err(new Error("setup failed"))
+    );
+
+    const result = await runSandboxBashTool(
+      { command: "echo hello", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("setup failed");
+    }
+    expect(sandbox.exec).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -1,6 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   ToolDefinition,
+  ToolHandlerExtra,
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -12,6 +13,11 @@ import {
   generateSandboxExecToken,
   revokeExecToken,
 } from "@app/lib/api/sandbox/access_tokens";
+import {
+  checkEgressForwarderHealth,
+  sandboxSupportsEgressForwarding,
+  setupEgressForwarder,
+} from "@app/lib/api/sandbox/egress";
 import {
   mountConversationFiles,
   refreshGcsToken,
@@ -31,7 +37,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import { isDevelopment } from "@app/types/shared/env";
-import { Err, Ok } from "@app/types/shared/result";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 
 const DEFAULT_WORKING_DIRECTORY = "/home/agent";
 const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
@@ -90,111 +96,7 @@ export function createSandboxTools(
   _agentLoopContext?: AgentLoopContextType
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof SANDBOX_TOOLS_METADATA> = {
-    bash: async (
-      { command, workingDirectory, timeoutMs },
-      { auth, agentLoopContext }
-    ) => {
-      const conversation = agentLoopContext?.runContext?.conversation;
-      const agentConfiguration =
-        agentLoopContext?.runContext?.agentConfiguration;
-      const agentMessage = agentLoopContext?.runContext?.agentMessage;
-      if (!conversation || !agentConfiguration || !agentMessage) {
-        return new Err(new MCPError("No conversation context available."));
-      }
-
-      const ensureResult = await SandboxResource.ensureActive(
-        auth,
-        conversation
-      );
-      if (ensureResult.isErr()) {
-        return new Err(new MCPError(ensureResult.error.message));
-      }
-
-      const { sandbox, freshlyCreated, wokeFromSleep } = ensureResult.value;
-
-      // Mount GCS conversation files (fire-and-forget).
-      // On fresh creation or wake-from-sleep, /tmp is empty so we need a full mount.
-      // For already-running sandboxes we just refresh the token.
-      const imageResult = getSandboxImage(auth);
-      if (imageResult.isOk()) {
-        const image = imageResult.value;
-
-        void startTelemetry(auth, sandbox, conversation).catch((err) =>
-          logger.error({ err }, "Telemetry start failed (fire-and-forget)")
-        );
-
-        if (freshlyCreated || wokeFromSleep) {
-          void mountConversationFiles(auth, sandbox, conversation, image).catch(
-            (err) => logger.error({ err }, "GCS mount failed (fire-and-forget)")
-          );
-        } else {
-          void refreshGcsToken(auth, sandbox, conversation, image).catch(
-            (err) =>
-              logger.error(
-                { err },
-                "GCS token refresh failed (fire-and-forget)"
-              )
-          );
-        }
-      } else {
-        logger.error(
-          { err: imageResult.error },
-          "Failed to get sandbox image for GCS mount"
-        );
-      }
-
-      const execId = generateExecId();
-      const sandboxToken = await generateSandboxExecToken(auth, {
-        agentConfiguration,
-        agentMessage,
-        conversation,
-        sandbox,
-        execId,
-        expiryMs: DEFAULT_EXEC_TIMEOUT_MS,
-      });
-
-      const metricsCtx = { workspaceId: auth.getNonNullableWorkspace().sId };
-      const startMs = performance.now();
-
-      const providerId = agentConfiguration.model.providerId;
-      const timeoutSec = timeoutMs ? Math.ceil(timeoutMs / 1000) : 60;
-      const wrappedCommand = wrapCommand(command, providerId, {
-        timeoutSec,
-      });
-
-      const sandboxAPIBase =
-        isDevelopment() && config.getSandboxDevFrontHostName()
-          ? `https://${config.getSandboxDevFrontHostName()}`
-          : config.getClientFacingUrl();
-
-      const execResult = await sandbox.exec(auth, wrappedCommand, {
-        workingDirectory: workingDirectory ?? DEFAULT_WORKING_DIRECTORY,
-        envVars: {
-          DUST_SANDBOX_TOKEN: sandboxToken,
-          DUST_API_URL: `${sandboxAPIBase}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
-        },
-      });
-
-      const durationMs = performance.now() - startMs;
-      recordToolDuration(
-        "bash",
-        durationMs,
-        metricsCtx,
-        execResult.isOk() ? "success" : "error"
-      );
-
-      void revokeExecToken({ sbId: sandbox.sId, execId }).catch((err) =>
-        logger.error({ error: err }, "Failed to revoke exec token")
-      );
-
-      if (execResult.isErr()) {
-        return new Err(new MCPError(execResult.error.message));
-      }
-
-      const output = formatExecOutput(execResult.value);
-
-      return new Ok([{ type: "text" as const, text: output }]);
-    },
+    bash: runSandboxBashTool,
     describe_toolset: async ({ format }, { auth, agentLoopContext }) => {
       const providerId =
         agentLoopContext?.runContext?.agentConfiguration.model.providerId;
@@ -216,4 +118,166 @@ export function createSandboxTools(
   };
 
   return buildTools(SANDBOX_TOOLS_METADATA, handlers);
+}
+
+export async function runSandboxBashTool(
+  {
+    command,
+    workingDirectory,
+    timeoutMs,
+  }: {
+    command: string;
+    description: string;
+    timeoutMs?: number;
+    workingDirectory?: string;
+  },
+  { auth, agentLoopContext }: ToolHandlerExtra
+): Promise<Result<Array<{ type: "text"; text: string }>, MCPError>> {
+  const conversation = agentLoopContext?.runContext?.conversation;
+  const agentConfiguration = agentLoopContext?.runContext?.agentConfiguration;
+  const agentMessage = agentLoopContext?.runContext?.agentMessage;
+  if (!conversation || !agentConfiguration || !agentMessage) {
+    return new Err(new MCPError("No conversation context available."));
+  }
+
+  const ensureResult = await SandboxResource.ensureActive(auth, conversation);
+  if (ensureResult.isErr()) {
+    return new Err(new MCPError(ensureResult.error.message));
+  }
+
+  const { sandbox, freshlyCreated, wokeFromSleep } = ensureResult.value;
+
+  const imageResult = getSandboxImage(auth);
+  if (imageResult.isOk()) {
+    const image = imageResult.value;
+
+    void startTelemetry(auth, sandbox, conversation).catch((err) =>
+      logger.error({ err }, "Telemetry start failed (fire-and-forget)")
+    );
+
+    if (freshlyCreated || wokeFromSleep) {
+      void mountConversationFiles(auth, sandbox, conversation, image).catch(
+        (err) => logger.error({ err }, "GCS mount failed (fire-and-forget)")
+      );
+    } else {
+      void refreshGcsToken(auth, sandbox, conversation, image).catch((err) =>
+        logger.error({ err }, "GCS token refresh failed (fire-and-forget)")
+      );
+    }
+  } else {
+    logger.error(
+      { err: imageResult.error },
+      "Failed to get sandbox image for GCS mount"
+    );
+  }
+
+  const egressCompatResult = await sandboxSupportsEgressForwarding(
+    auth,
+    sandbox
+  );
+  if (egressCompatResult.isErr()) {
+    return new Err(new MCPError(egressCompatResult.error.message));
+  }
+
+  let execUser: string | undefined;
+  if (!egressCompatResult.value) {
+    logger.info(
+      {
+        event: "egress.compat_skip",
+        providerId: sandbox.providerId,
+        sandboxId: sandbox.sId,
+      },
+      "Skipping sandbox egress setup for an incompatible sandbox"
+    );
+  } else {
+    if (freshlyCreated) {
+      const setupResult = await setupEgressForwarder(auth, sandbox);
+      if (setupResult.isErr()) {
+        return new Err(new MCPError(setupResult.error.message));
+      }
+    }
+
+    const healthResult = await checkEgressForwarderHealth(auth, sandbox);
+    if (healthResult.isErr()) {
+      return new Err(new MCPError(healthResult.error.message));
+    }
+
+    if (!healthResult.value) {
+      logger.warn(
+        {
+          event: "egress.health_fail",
+          providerId: sandbox.providerId,
+          sandboxId: sandbox.sId,
+        },
+        "Sandbox egress forwarder health check failed, restarting"
+      );
+      const setupResult = await setupEgressForwarder(auth, sandbox);
+      if (setupResult.isErr()) {
+        return new Err(new MCPError(setupResult.error.message));
+      }
+    } else {
+      logger.info(
+        {
+          event: "egress.health_ok",
+          providerId: sandbox.providerId,
+          sandboxId: sandbox.sId,
+        },
+        "Sandbox egress forwarder health check succeeded"
+      );
+    }
+
+    execUser = "agent-proxied";
+  }
+
+  const execId = generateExecId();
+  const sandboxToken = await generateSandboxExecToken(auth, {
+    agentConfiguration,
+    agentMessage,
+    conversation,
+    sandbox,
+    execId,
+    expiryMs: DEFAULT_EXEC_TIMEOUT_MS,
+  });
+
+  const metricsCtx = { workspaceId: auth.getNonNullableWorkspace().sId };
+  const startMs = performance.now();
+
+  const providerId = agentConfiguration.model.providerId;
+  const timeoutSec = timeoutMs ? Math.ceil(timeoutMs / 1000) : 60;
+  const wrappedCommand = wrapCommand(command, providerId, {
+    timeoutSec,
+  });
+
+  const sandboxAPIBase =
+    isDevelopment() && config.getSandboxDevFrontHostName()
+      ? `https://${config.getSandboxDevFrontHostName()}`
+      : config.getClientFacingUrl();
+
+  const execResult = await sandbox.exec(auth, wrappedCommand, {
+    workingDirectory: workingDirectory ?? DEFAULT_WORKING_DIRECTORY,
+    envVars: {
+      DUST_SANDBOX_TOKEN: sandboxToken,
+      DUST_API_URL: `${sandboxAPIBase}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
+    },
+    ...(execUser ? { user: execUser } : {}),
+  });
+
+  const durationMs = performance.now() - startMs;
+  recordToolDuration(
+    "bash",
+    durationMs,
+    metricsCtx,
+    execResult.isOk() ? "success" : "error"
+  );
+
+  void revokeExecToken({ sbId: sandbox.sId, execId }).catch((err) =>
+    logger.error({ error: err }, "Failed to revoke exec token")
+  );
+
+  if (execResult.isErr()) {
+    return new Err(new MCPError(execResult.error.message));
+  }
+
+  const output = formatExecOutput(execResult.value);
+  return new Ok([{ type: "text" as const, text: output }]);
 }

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -191,6 +191,26 @@ const config = {
   getSandboxJwtSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_SANDBOX_JWT_SECRET");
   },
+  getEgressProxyJwtSecret: (): string => {
+    return EnvironmentConfig.getEnvVariable("EGRESS_PROXY_JWT_SECRET");
+  },
+  getEgressProxyHost: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("EGRESS_PROXY_HOST");
+  },
+  getEgressProxyPort: (): number => {
+    const value =
+      EnvironmentConfig.getOptionalEnvVariable("EGRESS_PROXY_PORT") ?? "4443";
+    const port = Number.parseInt(value, 10);
+
+    if (Number.isNaN(port) || port <= 0) {
+      throw new Error("EGRESS_PROXY_PORT must be a positive integer");
+    }
+
+    return port;
+  },
+  getEgressProxyTlsName: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("EGRESS_PROXY_TLS_NAME");
+  },
   getOAuthAPIConfig: (): { url: string; apiKey: string | null } => {
     return {
       url: EnvironmentConfig.getEnvVariable("OAUTH_API"),

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -93,7 +93,11 @@ describe("sandbox egress helpers", () => {
     expect(result).toEqual(new Ok(false));
     expect(sandbox.exec).toHaveBeenCalledWith(
       {},
-      expect.stringContaining("test -d /etc/dust")
+      expect.stringContaining("test -x /opt/bin/dsbx")
+    );
+    expect(sandbox.exec).toHaveBeenCalledWith(
+      {},
+      expect.stringContaining("grep -q 'skuid 1003'")
     );
   });
 

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -1,0 +1,169 @@
+import { Err, Ok } from "@app/types/shared/result";
+import jwt from "jsonwebtoken";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetEgressProxyHost,
+  mockGetEgressProxyJwtSecret,
+  mockGetEgressProxyPort,
+  mockGetEgressProxyTlsName,
+  mockGetCurrentRegion,
+  mockLoggerInfo,
+  mockLookup,
+} = vi.hoisted(() => ({
+  mockGetEgressProxyHost: vi.fn(),
+  mockGetEgressProxyJwtSecret: vi.fn(),
+  mockGetEgressProxyPort: vi.fn(),
+  mockGetEgressProxyTlsName: vi.fn(),
+  mockGetCurrentRegion: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+  mockLookup: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getEgressProxyHost: mockGetEgressProxyHost,
+    getEgressProxyJwtSecret: mockGetEgressProxyJwtSecret,
+    getEgressProxyPort: mockGetEgressProxyPort,
+    getEgressProxyTlsName: mockGetEgressProxyTlsName,
+  },
+}));
+
+vi.mock("@app/lib/api/regions/config", () => ({
+  config: {
+    getCurrentRegion: mockGetCurrentRegion,
+  },
+}));
+
+vi.mock("@app/logger/logger", () => ({
+  default: {
+    info: mockLoggerInfo,
+  },
+}));
+
+vi.mock("node:dns/promises", () => ({
+  default: {
+    lookup: mockLookup,
+  },
+  lookup: mockLookup,
+}));
+
+import {
+  mintEgressJwt,
+  sandboxSupportsEgressForwarding,
+  setupEgressForwarder,
+} from "./egress";
+
+describe("sandbox egress helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGetEgressProxyHost.mockReturnValue(undefined);
+    mockGetEgressProxyJwtSecret.mockReturnValue("egress-secret");
+    mockGetEgressProxyPort.mockReturnValue(4443);
+    mockGetEgressProxyTlsName.mockReturnValue(undefined);
+    mockGetCurrentRegion.mockReturnValue("europe-west1");
+    mockLookup.mockResolvedValue({ address: "203.0.113.10", family: 4 });
+  });
+
+  it("mints a proxy JWT bound to the provider sandbox id", () => {
+    const token = mintEgressJwt("provider-sandbox-id");
+    const payload = jwt.verify(token, "egress-secret", {
+      algorithms: ["HS256"],
+      audience: "dust-egress-proxy",
+      issuer: "dust-front",
+    }) as jwt.JwtPayload;
+
+    expect(payload.sbId).toBe("provider-sandbox-id");
+    expect(payload.exp).toBeGreaterThan(payload.iat ?? 0);
+  });
+
+  it("detects incompatible sandboxes from the compat probe exit code", async () => {
+    const sandbox = {
+      exec: vi
+        .fn()
+        .mockResolvedValue(new Ok({ exitCode: 1, stdout: "", stderr: "" })),
+    };
+
+    const result = await sandboxSupportsEgressForwarding(
+      {} as never,
+      sandbox as never
+    );
+
+    expect(result).toEqual(new Ok(false));
+    expect(sandbox.exec).toHaveBeenCalledWith(
+      {},
+      expect.stringContaining("test -d /etc/dust")
+    );
+  });
+
+  it("writes the token, starts the forwarder, and waits for health", async () => {
+    const sandbox = {
+      providerId: "provider-sandbox-id",
+      sId: "sandbox-id",
+      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
+      exec: vi
+        .fn()
+        .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
+        .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
+        .mockResolvedValueOnce(new Ok({ exitCode: 1, stdout: "", stderr: "" }))
+        .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
+    };
+
+    const result = await setupEgressForwarder({} as never, sandbox as never);
+
+    expect(result).toEqual(new Ok(undefined));
+    expect(mockLookup).toHaveBeenCalledWith("eu.sandbox-egress.dust.tt", {
+      family: 4,
+    });
+    expect(sandbox.writeFile).toHaveBeenCalledWith(
+      {},
+      "/etc/dust/egress-token",
+      expect.anything()
+    );
+    expect(sandbox.exec).toHaveBeenNthCalledWith(
+      1,
+      {},
+      expect.stringContaining("chown dust-fwd:dust-fwd"),
+      { user: "root" }
+    );
+    expect(sandbox.exec).toHaveBeenNthCalledWith(
+      2,
+      {},
+      expect.stringContaining("--proxy-addr '203.0.113.10:4443'"),
+      { user: "dust-fwd" }
+    );
+    expect(sandbox.exec).toHaveBeenNthCalledWith(
+      2,
+      {},
+      expect.stringContaining("--proxy-tls-name 'eu.sandbox-egress.dust.tt'"),
+      { user: "dust-fwd" }
+    );
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "egress.setup",
+        providerId: "provider-sandbox-id",
+        sandboxId: "sandbox-id",
+      }),
+      "Sandbox egress forwarder is healthy"
+    );
+  });
+
+  it("surfaces setup failures from sandbox commands", async () => {
+    const sandbox = {
+      providerId: "provider-sandbox-id",
+      sId: "sandbox-id",
+      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
+      exec: vi
+        .fn()
+        .mockResolvedValue(new Err(new Error("sandbox command failed"))),
+    };
+
+    const result = await setupEgressForwarder({} as never, sandbox as never);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("sandbox command failed");
+    }
+  });
+});

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -1,0 +1,190 @@
+import { lookup } from "node:dns/promises";
+import config from "@app/lib/api/config";
+import { config as regionConfig } from "@app/lib/api/regions/config";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import jwt from "jsonwebtoken";
+
+const EGRESS_FORWARDER_LISTEN_ADDR = "127.0.0.1:9990";
+const EGRESS_TOKEN_PATH = "/etc/dust/egress-token";
+const EGRESS_DENY_LOG_PATH = "/tmp/dust-egress-denied.log";
+const EGRESS_FORWARDER_LOG_PATH = "/tmp/dust-forwarder.log";
+const EGRESS_SETUP_WAIT_RETRIES = 6;
+const EGRESS_SETUP_WAIT_MS = 500;
+const EGRESS_JWT_TTL_SECONDS = 24 * 60 * 60;
+
+const REGION_PROXY_PREFIX = {
+  "europe-west1": "eu",
+  "us-central1": "us",
+} as const;
+
+function getDefaultProxyHost(): string {
+  const region = regionConfig.getCurrentRegion();
+  return `${REGION_PROXY_PREFIX[region]}.sandbox-egress.dust.tt`;
+}
+
+function getProxyHost(): string {
+  return config.getEgressProxyHost() ?? getDefaultProxyHost();
+}
+
+function getProxyTlsName(): string {
+  return config.getEgressProxyTlsName() ?? getProxyHost();
+}
+
+function shellEscape(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+async function sleep(delayMs: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function resolveProxyAddr(): Promise<string> {
+  const proxyHost = getProxyHost();
+  const { address } = await lookup(proxyHost, { family: 4 });
+  return address;
+}
+
+async function runSuccessfulSandboxCommand(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  command: string,
+  user?: string
+): Promise<Result<void, Error>> {
+  const result = await sandbox.exec(auth, command, user ? { user } : undefined);
+  if (result.isErr()) {
+    return result;
+  }
+
+  if (result.value.exitCode !== 0) {
+    return new Err(
+      new Error(
+        `Sandbox command failed with exit code ${result.value.exitCode}: ${result.value.stderr || result.value.stdout || command}`
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}
+
+export function mintEgressJwt(providerId: string): string {
+  return jwt.sign(
+    {
+      iss: "dust-front",
+      aud: "dust-egress-proxy",
+      sbId: providerId,
+    },
+    config.getEgressProxyJwtSecret(),
+    {
+      algorithm: "HS256",
+      expiresIn: EGRESS_JWT_TTL_SECONDS,
+    }
+  );
+}
+
+export async function sandboxSupportsEgressForwarding(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<boolean, Error>> {
+  const probeResult = await sandbox.exec(
+    auth,
+    "test -d /etc/dust && id agent-proxied >/dev/null 2>&1 && id dust-fwd >/dev/null 2>&1 && command -v dsbx >/dev/null 2>&1"
+  );
+
+  if (probeResult.isErr()) {
+    return probeResult;
+  }
+
+  return new Ok(probeResult.value.exitCode === 0);
+}
+
+export async function checkEgressForwarderHealth(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<boolean, Error>> {
+  const healthResult = await sandbox.exec(auth, "nc -z 127.0.0.1 9990", {
+    timeoutMs: 1_000,
+  });
+
+  if (healthResult.isErr()) {
+    return healthResult;
+  }
+
+  return new Ok(healthResult.value.exitCode === 0);
+}
+
+export async function setupEgressForwarder(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<void, Error>> {
+  const logContext = {
+    event: "egress.setup",
+    providerId: sandbox.providerId,
+    sandboxId: sandbox.sId,
+  };
+
+  let proxyAddr: string;
+  try {
+    proxyAddr = await resolveProxyAddr();
+  } catch (error) {
+    return new Err(error instanceof Error ? error : new Error(String(error)));
+  }
+
+  const token = mintEgressJwt(sandbox.providerId);
+  const tokenWriteResult = await sandbox.writeFile(
+    auth,
+    EGRESS_TOKEN_PATH,
+    new TextEncoder().encode(token).buffer
+  );
+  if (tokenWriteResult.isErr()) {
+    return tokenWriteResult;
+  }
+
+  const chmodResult = await runSuccessfulSandboxCommand(
+    auth,
+    sandbox,
+    `chown dust-fwd:dust-fwd ${shellEscape(EGRESS_TOKEN_PATH)} && chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)}`,
+    "root"
+  );
+  if (chmodResult.isErr()) {
+    return chmodResult;
+  }
+
+  const startForwarderCommand =
+    "nohup /opt/bin/dsbx forward " +
+    `--token-file ${shellEscape(EGRESS_TOKEN_PATH)} ` +
+    `--proxy-addr ${shellEscape(`${proxyAddr}:${config.getEgressProxyPort()}`)} ` +
+    `--proxy-tls-name ${shellEscape(getProxyTlsName())} ` +
+    `--listen ${shellEscape(EGRESS_FORWARDER_LISTEN_ADDR)} ` +
+    `--deny-log ${shellEscape(EGRESS_DENY_LOG_PATH)} ` +
+    `>${shellEscape(EGRESS_FORWARDER_LOG_PATH)} 2>&1 &`;
+
+  const startResult = await runSuccessfulSandboxCommand(
+    auth,
+    sandbox,
+    startForwarderCommand,
+    "dust-fwd"
+  );
+  if (startResult.isErr()) {
+    return startResult;
+  }
+
+  for (let i = 0; i < EGRESS_SETUP_WAIT_RETRIES; i++) {
+    const healthResult = await checkEgressForwarderHealth(auth, sandbox);
+    if (healthResult.isErr()) {
+      return healthResult;
+    }
+    if (healthResult.value) {
+      logger.info(logContext, "Sandbox egress forwarder is healthy");
+      return new Ok(undefined);
+    }
+
+    await sleep(EGRESS_SETUP_WAIT_MS);
+  }
+
+  return new Err(
+    new Error("Sandbox egress forwarder did not become healthy in time")
+  );
+}

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -90,7 +90,7 @@ export async function sandboxSupportsEgressForwarding(
 ): Promise<Result<boolean, Error>> {
   const probeResult = await sandbox.exec(
     auth,
-    "test -d /etc/dust && id agent-proxied >/dev/null 2>&1 && id dust-fwd >/dev/null 2>&1 && command -v dsbx >/dev/null 2>&1"
+    "test -d /etc/dust && id agent-proxied >/dev/null 2>&1 && id dust-fwd >/dev/null 2>&1 && test -x /opt/bin/dsbx && nft list ruleset 2>/dev/null | grep -q 'skuid 1003'"
   );
 
   if (probeResult.isErr()) {

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -720,7 +720,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   /**
    * Write a file to the sandbox filesystem.
    */
-  private async writeFile(
+  async writeFile(
     auth: Authenticator,
     path: string,
     data: ArrayBuffer


### PR DESCRIPTION
## Description

PR 2 of sandbox egress. Wires the egress proxy into tool execution so compatible sandboxes route outbound traffic through the forwarder.

- New `egress.ts` module: JWT minting, compat detection, forwarder startup, health checks
- Tool handler refactored: on compatible sandboxes, exec as `agent-proxied` (uid 1003) so nftables redirects traffic to the forwarder on port 9990
- Pre-PR1 sandboxes: unchanged, exec as default user
- Compat gate verifies nftables enforcement is active (`nft list ruleset | grep skuid 1003`), not just that PR1 artifacts exist
- Health check on every exec, auto-restart forwarder if unhealthy

## Tests

- `egress.test.ts`: JWT minting, compat probe (including nftables check), full setup flow, error propagation
- `tools/index.test.ts`: pre-PR1 fallback, healthy forwarder path, unhealthy restart, setup failure

## Risk

Medium. Compat gate ensures only sandboxes with active nftables rules get the user flip. Pre-existing sandboxes untouched. Forwarder failures surface as MCP errors, not silent bypass.

Rollback: revert PR, redeploy. No schema changes.

## Deploy Plan

1. Merge (requires dust-base:0.7.9 template already published)
2. Set env vars: `EGRESS_PROXY_JWT_SECRET`, optionally `EGRESS_PROXY_HOST`/`EGRESS_PROXY_PORT`/`EGRESS_PROXY_TLS_NAME`
3. Deploy front. New sandboxes get egress enforcement; existing ones unchanged.