### PR TITLE
fix(sbx): use uid 1003 for agent-proxied (E2B uid 1001 collision)

### DIFF
--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -51,7 +51,7 @@ describe("sandbox image registry", () => {
       });
       expect(imageResult.value.imageId).toEqual({
         imageName: "dust-base",
-        tag: "0.7.5",
+        tag: "0.7.6",
       });
     }
   });
@@ -63,7 +63,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "useradd --create-home --uid 1001 --gid agent --shell /bin/bash agent-proxied"
+          "useradd --create-home --uid 1003 --gid agent --shell /bin/bash agent-proxied"
         ),
         expect.stringContaining("chgrp agent /home/agent /files/conversation"),
         expect.stringContaining("chmod g+ws /home/agent /files/conversation"),
@@ -86,27 +86,27 @@ describe("sandbox image registry", () => {
         // Loopback exemption lives in nat (before REDIRECT), not filter —
         // otherwise the redirect rewrites the destination first.
         expect.stringContaining(
-          "iptables -t nat -A OUTPUT -m owner --uid-owner 1001 -d 127.0.0.0/8 -j RETURN"
+          "iptables -t nat -A OUTPUT -m owner --uid-owner 1003 -d 127.0.0.0/8 -j RETURN"
         ),
         // Metadata + RFC1918 RETURNs in nat keep original dst intact for
         // the filter-table defense-in-depth DROPs below.
         expect.stringContaining(
-          "iptables -t nat -A OUTPUT -m owner --uid-owner 1001 -d 169.254.169.254/32 -j RETURN"
+          "iptables -t nat -A OUTPUT -m owner --uid-owner 1003 -d 169.254.169.254/32 -j RETURN"
         ),
         expect.stringContaining(
-          "iptables -t nat -A OUTPUT -m owner --uid-owner 1001 -d 10.0.0.0/8 -j RETURN"
+          "iptables -t nat -A OUTPUT -m owner --uid-owner 1003 -d 10.0.0.0/8 -j RETURN"
         ),
         expect.stringContaining(
-          "iptables -t nat -A OUTPUT -m owner --uid-owner 1001 -p tcp -j REDIRECT --to-ports 9990"
+          "iptables -t nat -A OUTPUT -m owner --uid-owner 1003 -p tcp -j REDIRECT --to-ports 9990"
         ),
         expect.stringContaining(
-          'iptables -A OUTPUT -m owner --uid-owner 1001 -p udp --dport 53 -d "$NS" -j ACCEPT'
+          'iptables -A OUTPUT -m owner --uid-owner 1003 -p udp --dport 53 -d "$NS" -j ACCEPT'
         ),
         expect.stringContaining(
-          "iptables -A OUTPUT -m owner --uid-owner 1001 -d 169.254.169.254/32 -j DROP"
+          "iptables -A OUTPUT -m owner --uid-owner 1003 -d 169.254.169.254/32 -j DROP"
         ),
         expect.stringContaining(
-          "ip6tables -A OUTPUT -m owner --uid-owner 1001 -j DROP"
+          "ip6tables -A OUTPUT -m owner --uid-owner 1003 -j DROP"
         ),
       ])
     );

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -13,7 +13,6 @@ import path from "path";
 const DUST_BEDROCK_IMAGE_VERSION = "1.5.0";
 const DUST_BASE_IMAGE_VERSION = "0.7.6";
 const DSBX_CLI_VERSION = "0.1.4";
-// E2B's default `user` account occupies uid 1001; `agent` is uid 1002.
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -11,9 +11,10 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.5.0";
-const DUST_BASE_IMAGE_VERSION = "0.7.5";
+const DUST_BASE_IMAGE_VERSION = "0.7.6";
 const DSBX_CLI_VERSION = "0.1.4";
-const AGENT_PROXIED_UID = 1001;
+// E2B's default `user` account occupies uid 1001; `agent` is uid 1002.
+const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.
 const APPLY_PATCH_VERSION = "0.1.0";


### PR DESCRIPTION
## Description

Fixes the sandbox image build failure caused by uid 1001 collision with E2B's default `user` account.

E2B sandboxes have this uid layout:
- 1000: `ubuntu`
- 1001: `user` (E2B default)
- 1002: `agent`
- 9990: `dust-fwd`

PR1 (#24424) chose uid 1001 for `agent-proxied`, which collides with E2B's `user`. The `useradd` command fails with exit code 4 (UID already in use) during template build, preventing `dust-base:0.7.5` from being published.

**Fix:** shift `AGENT_PROXIED_UID` to 1003 (next free after `agent` at 1002). Bump `dust-base` to 0.7.6.

Also fixed a latent issue: the `SBX_GCP_ARTIFACT_RO_SERVICE_ACCOUNT_JSON` GitHub secret was never created, so E2B's builder had empty GCR credentials. All previous builds worked only because the base image was cached. That secret is now set.

## Tests

- All 4 registry tests updated and passing (uid 1003, tag 0.7.6).

## Risk

Low — same zero-behavior-change design as PR1. Just shifts the dormant user to a different uid.

## Deploy Plan

1. Merge.
2. Trigger `Sandbox Image Registry` workflow — should now succeed (GCR auth fixed + uid collision resolved).
3. Verify `dust-base:0.7.6` builds and spawns correctly.