### PR TITLE
Add toggle in admin settings to make conversations sharing private by default.

### DIFF
--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -1,5 +1,6 @@
 import { EmailAgentsToggle } from "@app/components/workspace/settings/EmailAgentsToggle";
 import { InteractiveContentSharingToggle } from "@app/components/workspace/settings/InteractiveContentSharingToggle";
+import { PrivateConversationUrlsToggle } from "@app/components/workspace/settings/PrivateConversationUrlsToggle";
 import { RestrictAgentsPublishingCapability } from "@app/components/workspace/settings/RestrictAgentsPublishingCapability";
 import { VoiceTranscriptionToggle } from "@app/components/workspace/settings/VoiceTranscriptionToggle";
 import { useAuth } from "@app/lib/auth/AuthContext";
@@ -27,6 +28,7 @@ export function CapabilitiesSection({
           <VoiceTranscriptionToggle owner={owner} />
         )}
         <EmailAgentsToggle owner={owner} />
+        <PrivateConversationUrlsToggle owner={owner} />
         {publishingRestrictionMessage && (
           <RestrictAgentsPublishingCapability
             subElement={publishingRestrictionMessage}

--- a/front/components/workspace/settings/PrivateConversationUrlsToggle.tsx
+++ b/front/components/workspace/settings/PrivateConversationUrlsToggle.tsx
@@ -1,0 +1,30 @@
+import { usePrivateConversationUrlsToggle } from "@app/hooks/usePrivateConversationUrlsToggle";
+import type { WorkspaceType } from "@app/types/user";
+import { ContextItem, LockIcon, SliderToggle } from "@dust-tt/sparkle";
+
+interface PrivateConversationUrlsToggleProps {
+  owner: WorkspaceType;
+}
+
+export function PrivateConversationUrlsToggle({
+  owner,
+}: PrivateConversationUrlsToggleProps) {
+  const { isEnabled, isChanging, doTogglePrivateConversationUrls } =
+    usePrivateConversationUrlsToggle({ owner });
+
+  return (
+    <ContextItem
+      title="Private conversation URLs by default"
+      subElement="Restrict conversation URL access to participants and workspace admins by default"
+      visual={<LockIcon className="h-6 w-6" />}
+      hasSeparatorIfLast={true}
+      action={
+        <SliderToggle
+          selected={isEnabled}
+          disabled={isChanging}
+          onClick={doTogglePrivateConversationUrls}
+        />
+      }
+    />
+  );
+}

--- a/front/hooks/usePrivateConversationUrlsToggle.ts
+++ b/front/hooks/usePrivateConversationUrlsToggle.ts
@@ -1,0 +1,54 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useState } from "react";
+
+interface UsePrivateConversationUrlsToggleProps {
+  owner: LightWorkspaceType;
+}
+
+export function usePrivateConversationUrlsToggle({
+  owner,
+}: UsePrivateConversationUrlsToggleProps) {
+  const [isChanging, setIsChanging] = useState(false);
+  const sendNotification = useSendNotification();
+  const [isEnabled, setIsEnabled] = useState(
+    owner.metadata?.privateConversationUrlsByDefault === true
+  );
+
+  const doTogglePrivateConversationUrls = async () => {
+    setIsChanging(true);
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          privateConversationUrlsByDefault: !isEnabled,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to update private conversation URLs setting");
+      }
+
+      setIsEnabled(!isEnabled);
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to update private conversation URLs setting",
+        description: normalizeError(error).message,
+      });
+    } finally {
+      setIsChanging(false);
+    }
+  };
+
+  return {
+    isEnabled,
+    isChanging,
+    doTogglePrivateConversationUrls,
+  };
+}

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -432,6 +432,7 @@ export interface WorkspaceMetadata {
   killSwitched?: WorkspaceKillSwitchValue;
   allowContentCreationFileSharing?: boolean;
   allowVoiceTranscription?: boolean;
+  privateConversationUrlsByDefault?: boolean;
   autoCreateSpaceForProvisionedGroups?: boolean;
   disableManualInvitations?: boolean;
   phoneCountry?: string;

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -71,6 +71,10 @@ const WorkspaceVoiceTranscriptionUpdateBodySchema = t.type({
   allowVoiceTranscription: t.boolean,
 });
 
+const WorkspacePrivateConversationUrlsUpdateBodySchema = t.type({
+  privateConversationUrlsByDefault: t.boolean,
+});
+
 const WorkspaceEmailAgentsUpdateBodySchema = t.type({
   allowEmailAgents: t.boolean,
 });
@@ -93,6 +97,7 @@ const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceInteractiveContentSharingUpdateBodySchema,
   WorkspaceSharingPolicyUpdateBodySchema,
   WorkspaceVoiceTranscriptionUpdateBodySchema,
+  WorkspacePrivateConversationUrlsUpdateBodySchema,
   WorkspaceEmailAgentsUpdateBodySchema,
   WorkspaceAgentReinforcementUpdateBodySchema,
   WorkspaceReinforcementBatchModeUpdateBodySchema,
@@ -216,6 +221,15 @@ async function handler(
         const newMetadata = {
           ...previousMetadata,
           allowVoiceTranscription: body.allowVoiceTranscription,
+        };
+        await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+        owner.metadata = newMetadata;
+      } else if ("privateConversationUrlsByDefault" in body) {
+        const previousMetadata = owner.metadata ?? {};
+        const newMetadata = {
+          ...previousMetadata,
+          privateConversationUrlsByDefault:
+            body.privateConversationUrlsByDefault,
         };
         await workspace.updateWorkspaceSettings({ metadata: newMetadata });
         owner.metadata = newMetadata;


### PR DESCRIPTION
## Description

Add a workspace-level toggle to make conversation URLs private by default, restricting access to participants and admins only.

- Add `privateConversationUrlsByDefault` to `WorkspaceMetadata`
- Add `WorkspacePrivateConversationUrlsUpdateBodySchema` to the `POST /api/w/[wId]` handler
- Add `PrivateConversationUrlsToggle` component and `usePrivateConversationUrlsToggle` hook
- Wire the toggle into `CapabilitiesSection` in admin settings

## Tests

Local
<img width="1105" height="68" alt="image" src="https://github.com/user-attachments/assets/a94a5d97-b2d8-450b-a73f-67f2fda38f41" />


## Risk

Low — additive only; no access logic changes in this PR

## Deploy Plan

Deploy `front`
