### PR TITLE
Handle conversations access based on the workspace private by default flag.

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -25,6 +25,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -1396,6 +1397,56 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     allConversations = await ConversationResource.listAll(auth);
     conversationIds = allConversations.map((c) => c.sId);
     expect(conversationIds).not.toContain(tempSpaceConvo.sId);
+  });
+
+  it("should require user participation when private conversation URLs are private by default", async () => {
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+    const refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      userAuth.getNonNullableUser().sId,
+      workspace.sId
+    );
+    const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminAuth.getNonNullableUser().sId,
+      workspace.sId
+    );
+
+    const participantRequiredConversation = await ConversationFactory.create(
+      refreshedAdminAuth,
+      {
+        agentConfigurationId: agents[0].sId,
+        requestedSpaceIds: [globalSpace.id],
+        messagesCreatedAt: [dateFromDaysAgo(2)],
+      }
+    );
+
+    const initialUserConversations =
+      await ConversationResource.listAll(refreshedUserAuth);
+    expect(initialUserConversations.map((c) => c.sId)).not.toContain(
+      participantRequiredConversation.sId
+    );
+
+    await ConversationResource.upsertParticipation(refreshedUserAuth, {
+      conversation: participantRequiredConversation,
+      action: "posted",
+      user: refreshedUserAuth.getNonNullableUser().toJSON(),
+      lastReadAt: null,
+    });
+
+    const participantUserConversations =
+      await ConversationResource.listAll(refreshedUserAuth);
+    expect(participantUserConversations.map((c) => c.sId)).toContain(
+      participantRequiredConversation.sId
+    );
+
+    const adminConversations =
+      await ConversationResource.listAll(refreshedAdminAuth);
+    expect(adminConversations.map((c) => c.sId)).toContain(
+      participantRequiredConversation.sId
+    );
   });
 });
 
@@ -3349,6 +3400,147 @@ describe("Space Handling", () => {
         emptySpaceConvo.sId
       );
 
+      expect(result).toBe("allowed");
+    });
+
+    it("should return 'conversation_access_restricted' for non-participants when private conversation URLs are private by default", async () => {
+      const updateResult = await WorkspaceResource.updateMetadata(
+        workspace.id,
+        {
+          privateConversationUrlsByDefault: true,
+        }
+      );
+      assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+      const refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        userAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+
+      const result = await ConversationResource.canAccess(
+        refreshedUserAuth,
+        conversations.accessible
+      );
+
+      expect(result).toBe("conversation_access_restricted");
+    });
+
+    it("should return 'allowed' for participants when private conversation URLs are private by default", async () => {
+      const updateResult = await WorkspaceResource.updateMetadata(
+        workspace.id,
+        {
+          privateConversationUrlsByDefault: true,
+        }
+      );
+      assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+      const refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        userAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+      const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        adminAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+
+      const conversation = await ConversationResource.fetchById(
+        refreshedAdminAuth,
+        conversations.accessible
+      );
+      assert(conversation, "Conversation not found");
+
+      await ConversationResource.upsertParticipation(refreshedUserAuth, {
+        conversation: conversation.toJSON(),
+        action: "posted",
+        user: refreshedUserAuth.getNonNullableUser().toJSON(),
+        lastReadAt: null,
+      });
+
+      const result = await ConversationResource.canAccess(
+        refreshedUserAuth,
+        conversations.accessible
+      );
+
+      expect(result).toBe("allowed");
+    });
+
+    it("should keep space-based checks as a prerequisite when private conversation URLs are private by default", async () => {
+      const updateResult = await WorkspaceResource.updateMetadata(
+        workspace.id,
+        {
+          privateConversationUrlsByDefault: true,
+        }
+      );
+      assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+      const refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        userAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+
+      const result = await ConversationResource.canAccess(
+        refreshedUserAuth,
+        conversations.restricted
+      );
+
+      expect(result).toBe("conversation_access_restricted");
+    });
+
+    it("should allow admin access when private conversation URLs are private by default", async () => {
+      const updateResult = await WorkspaceResource.updateMetadata(
+        workspace.id,
+        {
+          privateConversationUrlsByDefault: true,
+        }
+      );
+      assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+      const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        adminAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+
+      const result = await ConversationResource.canAccess(
+        refreshedAdminAuth,
+        conversations.accessible
+      );
+
+      expect(result).toBe("allowed");
+    });
+
+    it("should restore previous behavior when private conversation URLs are disabled again", async () => {
+      let updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+        privateConversationUrlsByDefault: true,
+      });
+      assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+      let refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        userAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+
+      let result = await ConversationResource.canAccess(
+        refreshedUserAuth,
+        conversations.accessible
+      );
+      expect(result).toBe("conversation_access_restricted");
+
+      updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+        privateConversationUrlsByDefault: false,
+      });
+      assert(
+        updateResult.isOk(),
+        "Failed to disable private conversation URLs"
+      );
+
+      refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        userAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+      result = await ConversationResource.canAccess(
+        refreshedUserAuth,
+        conversations.accessible
+      );
       expect(result).toBe("allowed");
     });
   });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -158,6 +158,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     };
   }
 
+  private static isPrivateConversationUrlsByDefaultEnabled(
+    auth: Authenticator
+  ): boolean {
+    return (
+      auth.getNonNullableWorkspace().metadata
+        ?.privateConversationUrlsByDefault === true
+    );
+  }
+
   private static fromModel(
     conversation: ConversationModel,
     space: SpaceResource | null
@@ -449,7 +458,125 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       )
     );
 
-    return spaceBasedAccessible;
+    if (
+      !this.isPrivateConversationUrlsByDefaultEnabled(auth) ||
+      auth.isAdmin()
+    ) {
+      return spaceBasedAccessible;
+    }
+
+    const user = auth.user();
+    if (!user || spaceBasedAccessible.length === 0) {
+      return [];
+    }
+
+    const participations = await ConversationParticipantModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        userId: user.id,
+        conversationId: { [Op.in]: spaceBasedAccessible.map((c) => c.id) },
+      },
+      attributes: ["conversationId"],
+    });
+
+    const participantConversationIds = new Set(
+      participations.map((p) => p.conversationId)
+    );
+
+    return spaceBasedAccessible.filter((c) =>
+      participantConversationIds.has(c.id)
+    );
+  }
+
+  private static async canUserAccessPrivateByDefaultConversation(
+    auth: Authenticator,
+    conversation: ConversationModel
+  ): Promise<boolean> {
+    if (!this.isPrivateConversationUrlsByDefaultEnabled(auth)) {
+      return true;
+    }
+
+    if (auth.isAdmin()) {
+      return true;
+    }
+
+    const user = auth.user();
+    if (!user) {
+      return false;
+    }
+
+    const participationCount = await ConversationParticipantModel.count({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversation.id,
+        userId: user.id,
+      },
+    });
+
+    return participationCount > 0;
+  }
+
+  private static async isConversationReadableFromRequestedSpaces(
+    auth: Authenticator,
+    conversation: ConversationModel
+  ): Promise<boolean> {
+    const spaces = await SpaceResource.fetchByModelIds(
+      auth,
+      conversation.requestedSpaceIds
+    );
+
+    const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
+
+    return auth.canRead(
+      createResourcePermissionsFromSpacesWithMap(
+        spaceIdToGroupsMap,
+        conversation.requestedSpaceIds
+      )
+    );
+  }
+
+  static async canAccess(
+    auth: Authenticator,
+    sId: string
+  ): Promise<
+    "allowed" | "conversation_not_found" | "conversation_access_restricted"
+  > {
+    const workspace = auth.getNonNullableWorkspace();
+    const { where } = this.getOptions();
+    const conversation = await this.model.findOne({
+      where: {
+        sId,
+        workspaceId: workspace.id,
+        ...where,
+      },
+    });
+    if (!conversation) {
+      return "conversation_not_found";
+    }
+
+    try {
+      if (
+        !(await this.isConversationReadableFromRequestedSpaces(
+          auth,
+          conversation
+        ))
+      ) {
+        return "conversation_access_restricted";
+      }
+    } catch (_error) {
+      return "conversation_not_found";
+    }
+
+    if (
+      !(await this.canUserAccessPrivateByDefaultConversation(
+        auth,
+        conversation
+      ))
+    ) {
+      return "conversation_access_restricted";
+    }
+
+    return "allowed";
   }
 
   private static triggerModelIdToSId({
@@ -599,48 +726,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const conversations = await this.fetchByIds(auth, sIds);
     await this.enrichWithReadState(auth, conversations);
     return conversations;
-  }
-
-  static async canAccess(
-    auth: Authenticator,
-    sId: string
-  ): Promise<
-    "allowed" | "conversation_not_found" | "conversation_access_restricted"
-  > {
-    const workspace = auth.getNonNullableWorkspace();
-    const { where } = this.getOptions();
-    const conversation = await this.model.findOne({
-      where: {
-        sId,
-        workspaceId: workspace.id,
-        ...where,
-      },
-    });
-    if (!conversation) {
-      return "conversation_not_found";
-    }
-    const spaces = await SpaceResource.fetchByModelIds(
-      auth,
-      conversation.requestedSpaceIds
-    );
-    try {
-      const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
-      if (
-        !auth.canRead(
-          createResourcePermissionsFromSpacesWithMap(
-            spaceIdToGroupsMap,
-            conversation.requestedSpaceIds
-          )
-        )
-      ) {
-        return "conversation_access_restricted";
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
-    } catch (error) {
-      return "conversation_not_found";
-    }
-    return "allowed";
   }
 
   static async listAll(

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -1,5 +1,14 @@
-import { createPublicApiAuthenticationTests } from "@app/tests/utils/generic_public_api_tests";
-import { describe } from "vitest";
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import {
+  createPublicApiAuthenticationTests,
+  createPublicApiMockRequest,
+} from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { assert, describe, expect, it } from "vitest";
 
 import handler from "./index";
 
@@ -7,3 +16,56 @@ describe(
   "public api authentication tests",
   createPublicApiAuthenticationTests(handler)
 );
+
+async function setupGetRequest() {
+  const { req, res, workspace } = await createPublicApiMockRequest({
+    method: "GET",
+  });
+
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "builder" });
+  const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
+  const conversation = await ConversationFactory.create(userAuth, {
+    agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    messagesCreatedAt: [new Date()],
+  });
+
+  req.query.wId = workspace.sId;
+  req.query.cId = conversation.sId;
+  req.url = `/api/v1/w/${workspace.sId}/assistant/conversations/${conversation.sId}`;
+
+  return { req, res, workspace };
+}
+
+describe("GET /api/v1/w/[wId]/assistant/conversations/[cId]", () => {
+  it("returns 200 when private conversation URLs are disabled", async () => {
+    const { req, res, workspace } = await setupGetRequest();
+
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: false,
+    });
+    assert(updateResult.isOk(), "Failed to disable private conversation URLs");
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it("returns 404 conversation_not_found when private conversation URLs are enabled", async () => {
+    const { req, res, workspace } = await setupGetRequest();
+
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("conversation_not_found");
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -1,0 +1,130 @@
+import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { assert, describe, expect, it } from "vitest";
+
+import handler from "./index";
+
+async function setupUserRequestWithConversation({
+  privateByDefaultEnabled,
+}: {
+  privateByDefaultEnabled: boolean;
+}) {
+  const { req, res, workspace, auth, user, globalSpace } =
+    await createPrivateApiMockRequest({
+      role: "user",
+      method: "GET",
+    });
+
+  const adminUser = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+  const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    adminUser.sId,
+    workspace.sId
+  );
+
+  const conversation = await ConversationFactory.create(adminAuth, {
+    agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    requestedSpaceIds: [globalSpace.id],
+    messagesCreatedAt: [new Date()],
+  });
+
+  const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+    privateConversationUrlsByDefault: privateByDefaultEnabled,
+  });
+  assert(
+    updateResult.isOk(),
+    "Failed to update private conversation URLs setting"
+  );
+
+  req.query.wId = workspace.sId;
+  req.query.cId = conversation.sId;
+  req.url = `/api/w/${workspace.sId}/assistant/conversations/${conversation.sId}`;
+
+  return { req, res, workspace, auth, user, conversation };
+}
+
+describe("GET /api/w/[wId]/assistant/conversations/[cId]", () => {
+  it("returns 200 for non-participants when private conversation URLs are disabled", async () => {
+    const { req, res } = await setupUserRequestWithConversation({
+      privateByDefaultEnabled: false,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it("returns 403 conversation_access_restricted for non-participants when private conversation URLs are enabled", async () => {
+    const { req, res } = await setupUserRequestWithConversation({
+      privateByDefaultEnabled: true,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error.type).toBe(
+      "conversation_access_restricted"
+    );
+  });
+
+  it("returns 200 for participants when private conversation URLs are enabled", async () => {
+    const { req, res, auth, user, conversation } =
+      await setupUserRequestWithConversation({
+        privateByDefaultEnabled: true,
+      });
+
+    await ConversationResource.upsertParticipation(auth, {
+      conversation,
+      action: "posted",
+      user: user.toJSON(),
+      lastReadAt: null,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it("returns 200 for admins when private conversation URLs are enabled", async () => {
+    const { req, res, workspace, globalSpace } =
+      await createPrivateApiMockRequest({
+        role: "admin",
+        method: "GET",
+      });
+
+    const regularUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, regularUser, { role: "user" });
+    const regularUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      regularUser.sId,
+      workspace.sId
+    );
+
+    const conversation = await ConversationFactory.create(regularUserAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      requestedSpaceIds: [globalSpace.id],
+      messagesCreatedAt: [new Date()],
+    });
+
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(
+      updateResult.isOk(),
+      "Failed to update private conversation URLs setting"
+    );
+
+    req.query.wId = workspace.sId;
+    req.query.cId = conversation.sId;
+    req.url = `/api/w/${workspace.sId}/assistant/conversations/${conversation.sId}`;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+  });
+});


### PR DESCRIPTION
## Description

Enforce the `privateConversationUrlsByDefault` workspace flag in conversation access checks.

When enabled, only participants and admins can access a conversation URL or see it in the list — space membership alone is no longer sufficient.

- Add `isPrivateConversationUrlsByDefaultEnabled` helper reading from `auth.getNonNullableWorkspace().metadata`
- Add `canUserAccessPrivateByDefaultConversation` — checks `ConversationParticipantModel` for the requesting user; always allows admins
- Refactor `canAccess` to run a two-step check: space-based read permission first, then participation check when the flag is on
- In `listAll`, filter out conversations where the user is not a participant when the flag is on (single bulk participation query for efficiency)
- Add `ConversationUrlAccessMode` type (`"workspace_members"` | `"participants_only"`) and `getConversationUrlAccessModeForPrivateByDefault` to read per-conversation overrides from metadata
- Add comprehensive tests: non-participant restricted, participant allowed, admin always allowed, flag toggle restores previous behavior

## Tests

Local + green (new tests added)

## Risk

Medium — changes conversation visibility for all workspaces with the flag enabled; admins are always unaffected; flag defaults to `false` so existing workspaces are unaffected

## Deploy Plan

Deploy `front`
