### PR TITLE
Add: conversation menu item to toggle url accessibility

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -6,6 +6,7 @@ import {
   useBranchConversation,
   useConversationParticipants,
   useConversationParticipationOptions,
+  useConversationUrlAccessMode,
   useJoinConversation,
 } from "@app/hooks/conversations";
 import { useDeleteConversation } from "@app/hooks/useDeleteConversation";
@@ -26,7 +27,10 @@ import {
   setQueryParam,
 } from "@app/lib/utils/router";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import { isProjectConversation } from "@app/types/assistant/conversation";
+import {
+  getConversationUrlAccessMode,
+  isProjectConversation,
+} from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
 import { isBuilder } from "@app/types/user";
 import {
@@ -267,6 +271,13 @@ export function ConversationMenu({
   const openConversationInBrowser = () => {
     window.open(conversationLink, "_blank");
   };
+  const {
+    isUpdatingConversationUrlAccessMode,
+    updateConversationUrlAccessMode,
+  } = useConversationUrlAccessMode({
+    owner,
+    conversationId: activeConversationId,
+  });
 
   if (!activeConversationId) {
     return null;
@@ -275,6 +286,17 @@ export function ConversationMenu({
   const canJoin = conversationParticipationOptions.includes("join");
   const canLeave = conversationParticipationOptions.includes("leave");
   const canDelete = conversationParticipationOptions.includes("delete");
+  const isPrivateConversationUrlsByDefaultEnabled =
+    owner.metadata?.privateConversationUrlsByDefault === true;
+  const conversationUrlAccessMode = getConversationUrlAccessMode(
+    conversation?.metadata
+  );
+  const canMakeUrlAccessible =
+    isPrivateConversationUrlsByDefaultEnabled &&
+    conversationUrlAccessMode !== "workspace_members";
+  const canRestrictUrlAccess =
+    isPrivateConversationUrlsByDefaultEnabled &&
+    conversationUrlAccessMode === "workspace_members";
 
   return (
     <div
@@ -440,6 +462,24 @@ export function ConversationMenu({
               label="Copy link"
               onClick={copyConversationLink}
               icon={LinkIcon}
+            />
+          )}
+          {(canMakeUrlAccessible || canRestrictUrlAccess) && (
+            <DropdownMenuItem
+              label={
+                canRestrictUrlAccess
+                  ? "Restrict URL access"
+                  : "Make URL accessible"
+              }
+              onClick={() => {
+                void updateConversationUrlAccessMode(
+                  canRestrictUrlAccess
+                    ? "participants_only"
+                    : "workspace_members"
+                );
+              }}
+              icon={LinkIcon}
+              disabled={isUpdatingConversationUrlAccessMode}
             />
           )}
           {canTurnIntoAgent && (

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -28,6 +28,7 @@ export {
   useAddDeleteConversationTool,
   useConversationTools,
 } from "./useConversationTools";
+export { useConversationUrlAccessMode } from "./useConversationUrlAccessMode";
 export { usePostOnboardingFollowUp } from "./usePostOnboardingFollowUp";
 export { useSearchPrivateConversations } from "./useSearchPrivateConversations";
 export { useSearchProjectConversations } from "./useSearchProjectConversations";

--- a/front/hooks/conversations/useConversationUrlAccessMode.ts
+++ b/front/hooks/conversations/useConversationUrlAccessMode.ts
@@ -1,0 +1,118 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import type { PatchConversationsRequestBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]";
+import type { ConversationUrlAccessMode } from "@app/types/assistant/conversation";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useState } from "react";
+import { useConversation } from "./useConversation";
+import { useConversations } from "./useConversations";
+
+interface UseConversationUrlAccessModeProps {
+  owner: LightWorkspaceType;
+  conversationId: string | null;
+}
+
+export function useConversationUrlAccessMode({
+  owner,
+  conversationId,
+}: UseConversationUrlAccessModeProps) {
+  const sendNotification = useSendNotification();
+  const { mutateConversation } = useConversation({
+    conversationId,
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
+  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
+  const [
+    isUpdatingConversationUrlAccessMode,
+    setIsUpdatingConversationUrlAccessMode,
+  ] = useState(false);
+
+  const updateConversationUrlAccessMode = useCallback(
+    async (accessMode: ConversationUrlAccessMode): Promise<boolean> => {
+      if (!conversationId || isUpdatingConversationUrlAccessMode) {
+        return false;
+      }
+
+      setIsUpdatingConversationUrlAccessMode(true);
+      try {
+        const response = await clientFetch(
+          `/api/w/${owner.sId}/assistant/conversations/${conversationId}`,
+          {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              accessMode,
+            } satisfies PatchConversationsRequestBody),
+          }
+        );
+
+        if (!response.ok) {
+          sendNotification({
+            type: "error",
+            title: "Failed to update URL access",
+          });
+          return false;
+        }
+
+        const metadataPatch = { urlAccessMode: accessMode };
+        void mutateConversation(
+          (previousData) =>
+            previousData?.conversation
+              ? {
+                  ...previousData,
+                  conversation: {
+                    ...previousData.conversation,
+                    metadata: {
+                      ...previousData.conversation.metadata,
+                      ...metadataPatch,
+                    },
+                  },
+                }
+              : previousData,
+          { revalidate: false }
+        );
+        void mutateConversations(
+          (previousConversations) =>
+            previousConversations?.map((conversation) =>
+              conversation.sId === conversationId
+                ? {
+                    ...conversation,
+                    metadata: {
+                      ...conversation.metadata,
+                      ...metadataPatch,
+                    },
+                  }
+                : conversation
+            ),
+          { revalidate: false }
+        );
+        sendNotification({
+          type: "success",
+          title:
+            accessMode === "workspace_members"
+              ? "URL is now accessible"
+              : "URL access restricted",
+        });
+        return true;
+      } finally {
+        setIsUpdatingConversationUrlAccessMode(false);
+      }
+    },
+    [
+      conversationId,
+      isUpdatingConversationUrlAccessMode,
+      mutateConversation,
+      mutateConversations,
+      owner.sId,
+      sendNotification,
+    ]
+  );
+
+  return {
+    isUpdatingConversationUrlAccessMode,
+    updateConversationUrlAccessMode,
+  };
+}

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3425,6 +3425,42 @@ describe("Space Handling", () => {
       expect(result).toBe("conversation_access_restricted");
     });
 
+    it("should return 'allowed' for non-participants when URL access mode is workspace_members", async () => {
+      const updateResult = await WorkspaceResource.updateMetadata(
+        workspace.id,
+        {
+          privateConversationUrlsByDefault: true,
+        }
+      );
+      assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+      await ConversationModel.update(
+        {
+          metadata: {
+            urlAccessMode: "workspace_members",
+          },
+        },
+        {
+          where: {
+            workspaceId: workspace.id,
+            sId: conversations.accessible,
+          },
+        }
+      );
+
+      const refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        userAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+
+      const result = await ConversationResource.canAccess(
+        refreshedUserAuth,
+        conversations.accessible
+      );
+
+      expect(result).toBe("allowed");
+    });
+
     it("should return 'allowed' for participants when private conversation URLs are private by default", async () => {
       const updateResult = await WorkspaceResource.updateMetadata(
         workspace.id,

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -34,11 +34,16 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ConversationForkedFromType,
   ConversationMCPServerViewType,
+  ConversationMetadata,
+  ConversationUrlAccessMode,
   ConversationVisibility,
   ConversationWithoutContentType,
   ParticipantActionType,
 } from "@app/types/assistant/conversation";
-import { ConversationError } from "@app/types/assistant/conversation";
+import {
+  ConversationError,
+  getConversationUrlAccessMode,
+} from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -164,6 +169,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return (
       auth.getNonNullableWorkspace().metadata
         ?.privateConversationUrlsByDefault === true
+    );
+  }
+
+  private static getConversationUrlAccessModeForPrivateByDefault(conversation: {
+    metadata: ConversationMetadata;
+  }): ConversationUrlAccessMode {
+    return (
+      getConversationUrlAccessMode(conversation.metadata) ?? "participants_only"
     );
   }
 
@@ -470,11 +483,23 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return [];
     }
 
+    const participantRestrictedConversations = spaceBasedAccessible.filter(
+      (conversation) =>
+        this.getConversationUrlAccessModeForPrivateByDefault(conversation) ===
+        "participants_only"
+    );
+
+    if (participantRestrictedConversations.length === 0) {
+      return spaceBasedAccessible;
+    }
+
     const participations = await ConversationParticipantModel.findAll({
       where: {
         workspaceId: workspace.id,
         userId: user.id,
-        conversationId: { [Op.in]: spaceBasedAccessible.map((c) => c.id) },
+        conversationId: {
+          [Op.in]: participantRestrictedConversations.map((c) => c.id),
+        },
       },
       attributes: ["conversationId"],
     });
@@ -483,8 +508,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       participations.map((p) => p.conversationId)
     );
 
-    return spaceBasedAccessible.filter((c) =>
-      participantConversationIds.has(c.id)
+    return spaceBasedAccessible.filter(
+      (conversation) =>
+        this.getConversationUrlAccessModeForPrivateByDefault(conversation) ===
+          "workspace_members" || participantConversationIds.has(conversation.id)
     );
   }
 
@@ -497,6 +524,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     }
 
     if (auth.isAdmin()) {
+      return true;
+    }
+
+    if (
+      this.getConversationUrlAccessModeForPrivateByDefault(conversation) ===
+      "workspace_members"
+    ) {
       return true;
     }
 
@@ -2518,6 +2552,27 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       },
       transaction
     );
+  }
+
+  static async updateUrlAccessMode(
+    auth: Authenticator,
+    sId: string,
+    accessMode: ConversationUrlAccessMode,
+    transaction?: Transaction
+  ) {
+    const conversation = await this.fetchById(auth, sId);
+    if (conversation == null) {
+      return new Err(new ConversationError("conversation_not_found"));
+    }
+
+    const metadata: ConversationMetadata = {
+      ...conversation.metadata,
+      urlAccessMode: accessMode,
+    };
+
+    await conversation.update({ metadata }, transaction);
+
+    return new Ok(undefined);
   }
 
   static async fetchMCPServerViews(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -6,6 +6,7 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { getConversationUrlAccessMode } from "@app/types/assistant/conversation";
 import { assert, describe, expect, it } from "vitest";
 
 import handler from "./index";
@@ -126,5 +127,62 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
+  });
+});
+
+describe("PATCH /api/w/[wId]/assistant/conversations/[cId]", () => {
+  it("updates conversation URL access mode", async () => {
+    const { req, res, workspace, auth, globalSpace } =
+      await createPrivateApiMockRequest({
+        role: "admin",
+        method: "PATCH",
+      });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      requestedSpaceIds: [globalSpace.id],
+      messagesCreatedAt: [new Date()],
+    });
+
+    req.query.wId = workspace.sId;
+    req.query.cId = conversation.sId;
+    req.url = `/api/w/${workspace.sId}/assistant/conversations/${conversation.sId}`;
+    req.body = { accessMode: "workspace_members" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const updatedConversation = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    assert(updatedConversation, "Expected conversation to exist");
+    expect(getConversationUrlAccessMode(updatedConversation.metadata)).toBe(
+      "workspace_members"
+    );
+  });
+
+  it("returns 400 on unsupported URL access mode", async () => {
+    const { req, res, workspace, auth, globalSpace } =
+      await createPrivateApiMockRequest({
+        role: "admin",
+        method: "PATCH",
+      });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      requestedSpaceIds: [globalSpace.id],
+      messagesCreatedAt: [new Date()],
+    });
+
+    req.query.wId = workspace.sId;
+    req.query.cId = conversation.sId;
+    req.url = `/api/w/${workspace.sId}/assistant/conversations/${conversation.sId}`;
+    req.body = { accessMode: "everyone" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
   });
 });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -60,7 +60,7 @@
  *         description: Unauthorized
  *   patch:
  *     summary: Update a conversation
- *     description: Update a conversation's title, mark it as read, or move it to a different space.
+ *     description: Update a conversation's title, mark it as read, move it to a different space, or control URL access mode.
  *     tags:
  *       - Private Conversations
  *     parameters:
@@ -102,6 +102,15 @@
  *                 properties:
  *                   spaceId:
  *                     type: string
+ *               - type: object
+ *                 required:
+ *                   - accessMode
+ *                 properties:
+ *                   accessMode:
+ *                     type: string
+ *                     enum:
+ *                       - participants_only
+ *                       - workspace_members
  *     responses:
  *       200:
  *         description: Successfully updated conversation
@@ -149,6 +158,12 @@ const PatchConversationsRequestBodySchema = t.union([
   }),
   t.type({
     spaceId: t.string,
+  }),
+  t.type({
+    accessMode: t.keyof({
+      participants_only: null,
+      workspace_members: null,
+    }),
   }),
 ]);
 
@@ -333,6 +348,17 @@ async function handler(
                 assertNever(r.error.code);
             }
           }
+        } else if ("accessMode" in bodyValidation.right) {
+          const result = await ConversationResource.updateUrlAccessMode(
+            auth,
+            conversation.sId,
+            bodyValidation.right.accessMode
+          );
+          if (result.isErr()) {
+            return apiErrorForConversation(req, res, result.error);
+          }
+
+          return res.status(200).json({ success: true });
         } else {
           return apiError(req, res, {
             status_code: 400,

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -6527,7 +6527,7 @@
       },
       "patch": {
         "summary": "Update a conversation",
-        "description": "Update a conversation's title, mark it as read, or move it to a different space.",
+        "description": "Update a conversation's title, mark it as read, move it to a different space, or control URL access mode.",
         "tags": [
           "Private Conversations"
         ],
@@ -6592,6 +6592,21 @@
                     "properties": {
                       "spaceId": {
                         "type": "string"
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "accessMode"
+                    ],
+                    "properties": {
+                      "accessMode": {
+                        "type": "string",
+                        "enum": [
+                          "participants_only",
+                          "workspace_members"
+                        ]
                       }
                     }
                   }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -373,7 +373,32 @@ export function isCompactionMessageType(
  */
 export type ConversationVisibility = "unlisted" | "deleted" | "test";
 
-export type ConversationMetadata = Record<string, unknown>;
+export const CONVERSATION_URL_ACCESS_MODES = [
+  "participants_only",
+  "workspace_members",
+] as const;
+
+export type ConversationUrlAccessMode =
+  (typeof CONVERSATION_URL_ACCESS_MODES)[number];
+
+export const CONVERSATION_METADATA_URL_ACCESS_MODE_KEY = "urlAccessMode";
+
+export type ConversationMetadata = Record<string, unknown> & {
+  urlAccessMode?: ConversationUrlAccessMode;
+};
+
+export function isConversationUrlAccessMode(
+  value: unknown
+): value is ConversationUrlAccessMode {
+  return value === "participants_only" || value === "workspace_members";
+}
+
+export function getConversationUrlAccessMode(
+  metadata: ConversationMetadata | null | undefined
+): ConversationUrlAccessMode | null {
+  const accessMode = metadata?.[CONVERSATION_METADATA_URL_ACCESS_MODE_KEY];
+  return isConversationUrlAccessMode(accessMode) ? accessMode : null;
+}
 
 export type ConversationForkedFromType = {
   parentConversationId: string;


### PR DESCRIPTION
## Description

Let conversation participants override the workspace default on a per-conversation basis via the conversation menu.

- Add `useConversationUrlAccessMode` hook — PATCHes `accessMode` on the conversation and mutates both the single-conversation and list SWR caches
- Add "Make URL accessible" / "Restrict URL access" menu items in `ConversationMenu`, shown only when `privateConversationUrlsByDefault` is enabled
- Toggling switches the conversation between `"workspace_members"` (accessible to all workspace members) and `"participants_only"` (default restricted)

## Tests

Local

<img width="215" height="44" alt="image" src="https://github.com/user-attachments/assets/c97cc4ec-27e1-460c-ada6-a183db4822cc" />


## Risk

Low

## Deploy Plan

Deploy `front`
