### PR TITLE
Exclude project conversations from the private urls setting.

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -48,6 +48,8 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   ExternalLinkIcon,
+  EyeIcon,
+  EyeSlashIcon,
   LinkIcon,
   PencilSquareIcon,
   PlusCircleIcon,
@@ -288,14 +290,18 @@ export function ConversationMenu({
   const canDelete = conversationParticipationOptions.includes("delete");
   const isPrivateConversationUrlsByDefaultEnabled =
     owner.metadata?.privateConversationUrlsByDefault === true;
+  const isProjectConversationWithOwnUrl =
+    conversation !== undefined && isProjectConversation(conversation);
   const conversationUrlAccessMode = getConversationUrlAccessMode(
     conversation?.metadata
   );
   const canMakeUrlAccessible =
     isPrivateConversationUrlsByDefaultEnabled &&
+    !isProjectConversationWithOwnUrl &&
     conversationUrlAccessMode !== "workspace_members";
   const canRestrictUrlAccess =
     isPrivateConversationUrlsByDefaultEnabled &&
+    !isProjectConversationWithOwnUrl &&
     conversationUrlAccessMode === "workspace_members";
 
   return (
@@ -478,7 +484,7 @@ export function ConversationMenu({
                     : "workspace_members"
                 );
               }}
-              icon={LinkIcon}
+              icon={canRestrictUrlAccess ? EyeSlashIcon : EyeIcon}
               disabled={isUpdatingConversationUrlAccessMode}
             />
           )}

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3500,6 +3500,65 @@ describe("Space Handling", () => {
       expect(result).toBe("allowed");
     });
 
+    it("should keep project conversations accessible to non-participants when private conversation URLs are private by default", async () => {
+      const updateResult = await WorkspaceResource.updateMetadata(
+        workspace.id,
+        {
+          privateConversationUrlsByDefault: true,
+        }
+      );
+      assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+      const refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        userAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+      const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        adminAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+
+      const projectSpace = await SpaceFactory.project(
+        workspace,
+        refreshedAdminAuth.getNonNullableUser().id
+      );
+      const addMemberResult = await projectSpace.addMembers(
+        refreshedAdminAuth,
+        {
+          userIds: [
+            refreshedAdminAuth.getNonNullableUser().sId,
+            refreshedUserAuth.getNonNullableUser().sId,
+          ],
+        }
+      );
+      assert(addMemberResult.isOk(), "Failed to add users to project space");
+      const projectCreatorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        refreshedAdminAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+      const projectReaderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        refreshedUserAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+
+      const projectConversation = await ConversationFactory.create(
+        projectCreatorAuth,
+        {
+          agentConfigurationId: agents[0].sId,
+          requestedSpaceIds: [projectSpace.id],
+          spaceId: projectSpace.id,
+          messagesCreatedAt: [dateFromDaysAgo(2)],
+        }
+      );
+
+      const result = await ConversationResource.canAccess(
+        projectReaderAuth,
+        projectConversation.sId
+      );
+
+      expect(result).toBe("allowed");
+    });
+
     it("should keep space-based checks as a prerequisite when private conversation URLs are private by default", async () => {
       const updateResult = await WorkspaceResource.updateMetadata(
         workspace.id,

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -180,6 +180,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
   }
 
+  private static shouldApplyPrivateByDefaultUrlRestriction(conversation: {
+    spaceId: ModelId | null;
+  }): boolean {
+    return conversation.spaceId === null;
+  }
+
   private static fromModel(
     conversation: ConversationModel,
     space: SpaceResource | null
@@ -485,8 +491,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const participantRestrictedConversations = spaceBasedAccessible.filter(
       (conversation) =>
+        this.shouldApplyPrivateByDefaultUrlRestriction(conversation) &&
         this.getConversationUrlAccessModeForPrivateByDefault(conversation) ===
-        "participants_only"
+          "participants_only"
     );
 
     if (participantRestrictedConversations.length === 0) {
@@ -510,8 +517,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     return spaceBasedAccessible.filter(
       (conversation) =>
+        !this.shouldApplyPrivateByDefaultUrlRestriction(conversation) ||
         this.getConversationUrlAccessModeForPrivateByDefault(conversation) ===
-          "workspace_members" || participantConversationIds.has(conversation.id)
+          "workspace_members" ||
+        participantConversationIds.has(conversation.id)
     );
   }
 
@@ -524,6 +533,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     }
 
     if (auth.isAdmin()) {
+      return true;
+    }
+
+    if (!this.shouldApplyPrivateByDefaultUrlRestriction(conversation)) {
       return true;
     }
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -6,6 +6,7 @@ import {
   createPublicApiMockRequest,
 } from "@app/tests/utils/generic_public_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { assert, describe, expect, it } from "vitest";
@@ -67,5 +68,48 @@ describe("GET /api/v1/w/[wId]/assistant/conversations/[cId]", () => {
 
     expect(res._getStatusCode()).toBe(404);
     expect(res._getJSONData().error.type).toBe("conversation_not_found");
+  });
+
+  it("returns 200 for project conversations when private conversation URLs are enabled", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      method: "GET",
+      systemKey: true,
+    });
+
+    const adminUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    const projectSpace = await SpaceFactory.project(workspace, adminUser.id);
+    const addMemberResult = await projectSpace.addMembers(adminAuth, {
+      userIds: [adminUser.sId],
+    });
+    assert(addMemberResult.isOk(), "Failed to add admin user to project space");
+    const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+    const conversation = await ConversationFactory.create(refreshedAdminAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      requestedSpaceIds: [projectSpace.id],
+      spaceId: projectSpace.id,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+    req.query.wId = workspace.sId;
+    req.query.cId = conversation.sId;
+    req.url = `/api/v1/w/${workspace.sId}/assistant/conversations/${conversation.sId}`;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
   });
 });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -4,6 +4,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { getConversationUrlAccessMode } from "@app/types/assistant/conversation";
@@ -86,6 +87,53 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]", () => {
       user: user.toJSON(),
       lastReadAt: null,
     });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it("returns 200 for project conversations for non-participants when private conversation URLs are enabled", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      role: "user",
+      method: "GET",
+    });
+
+    const adminUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    const projectSpace = await SpaceFactory.project(workspace, adminUser.id);
+    const addMemberResult = await projectSpace.addMembers(adminAuth, {
+      userIds: [adminUser.sId, user.sId],
+    });
+    assert(addMemberResult.isOk(), "Failed to add users to project space");
+    const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    const conversation = await ConversationFactory.create(refreshedAdminAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      requestedSpaceIds: [projectSpace.id],
+      spaceId: projectSpace.id,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(
+      updateResult.isOk(),
+      "Failed to enable private conversation URLs setting"
+    );
+
+    req.query.wId = workspace.sId;
+    req.query.cId = conversation.sId;
+    req.url = `/api/w/${workspace.sId}/assistant/conversations/${conversation.sId}`;
 
     await handler(req, res);
 


### PR DESCRIPTION
## Description

Project conversations are scoped to project space members — they already have their own access model that makes the workspace-level "private by default" restriction redundant and incorrect (a project member who hasn't posted in a conversation would be blocked from seeing it).

- Add `shouldApplyPrivateByDefaultUrlRestriction` — returns `true` only when `conversation.spaceId === null` (non-project conversations)
- Skip the participant-only restriction in both `listAll` and `canAccess` for project conversations
- Hide "Make URL accessible" / "Restrict URL access" menu items for project conversations in `ConversationMenu`
- Add tests verifying project conversations remain accessible to project members regardless of the workspace flag

## Tests

Local + green (new tests added)

## Risk

Low

## Deploy Plan

Deploy `front`
