### PR TITLE
fix(sbx): move iptables rules to systemd oneshot (E2B CAP_NET_ADMIN workaround)

### DIFF
--- a/front/lib/api/sandbox/image/egress/dust-egress-iptables.service
+++ b/front/lib/api/sandbox/image/egress/dust-egress-iptables.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Dust egress iptables rules for agent-proxied
+After=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/etc/dust/egress-iptables.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/front/lib/api/sandbox/image/egress/egress-iptables.sh
+++ b/front/lib/api/sandbox/image/egress/egress-iptables.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eu
+
+PROXIED_UID=1003
+
+# nat/OUTPUT runs before filter/OUTPUT for locally generated packets.
+# Exemptions (loopback, metadata, RFC1918) must land in nat BEFORE the
+# REDIRECT — otherwise the destination is rewritten to 127.0.0.1:9990
+# and filter DROPs on the original dst never fire.
+iptables -t nat -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -d 127.0.0.0/8 -j RETURN
+iptables -t nat -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -d 169.254.169.254/32 -j RETURN
+iptables -t nat -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -d 10.0.0.0/8 -j RETURN
+iptables -t nat -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -d 172.16.0.0/12 -j RETURN
+iptables -t nat -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -d 192.168.0.0/16 -j RETURN
+iptables -t nat -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -p tcp -j REDIRECT --to-ports 9990
+
+# DNS pinned to resolvers first — resolver may itself live in RFC1918.
+for NS in $(awk '/^nameserver/ {print $2}' /etc/resolv.conf); do
+  iptables -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -p udp --dport 53 -d "$NS" -j ACCEPT
+done
+iptables -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -d 169.254.169.254/32 -j DROP
+iptables -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -d 10.0.0.0/8 -j DROP
+iptables -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -d 172.16.0.0/12 -j DROP
+iptables -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -d 192.168.0.0/16 -j DROP
+iptables -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -p udp -j DROP
+iptables -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -p icmp -j DROP
+ip6tables -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -j DROP

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -19,6 +19,32 @@ function getRunCommands(operations: readonly Operation[]): string[] {
   );
 }
 
+function getCopyOperations(
+  operations: readonly Operation[]
+): Extract<Operation, { type: "copy" }>[] {
+  return operations.flatMap((operation) =>
+    operation.type === "copy" ? [operation] : []
+  );
+}
+
+function getCopiedContent(
+  copyOperations: readonly Extract<Operation, { type: "copy" }>[],
+  dest: string
+): string {
+  const operation = copyOperations.find(
+    (copyOperation) => copyOperation.dest === dest
+  );
+  expect(operation).toBeDefined();
+  expect(operation?.src.type).toBe("content");
+
+  if (!operation || operation.src.type !== "content") {
+    throw new Error(`missing copied content for ${dest}`);
+  }
+
+  const content = operation.src.getContent();
+  return typeof content === "string" ? content : content.toString("utf-8");
+}
+
 function getSandboxBedrockDockerfile(): string {
   const dockerfilePath = path.resolve(
     __dirname,
@@ -51,7 +77,7 @@ describe("sandbox image registry", () => {
       });
       expect(imageResult.value.imageId).toEqual({
         imageName: "dust-base",
-        tag: "0.7.6",
+        tag: "0.7.7",
       });
     }
   });
@@ -77,38 +103,47 @@ describe("sandbox image registry", () => {
     );
   });
 
-  test("bakes uid-scoped iptables rules into the template", () => {
+  test("copies the boot-time iptables script and enables its systemd unit", () => {
     const operations = getDustBaseImageOperations();
     const runCommands = getRunCommands(operations);
+    const copyOperations = getCopyOperations(operations);
+    const iptablesScript = getCopiedContent(
+      copyOperations,
+      "/etc/dust/egress-iptables.sh"
+    );
+    const serviceUnit = getCopiedContent(
+      copyOperations,
+      "/etc/systemd/system/dust-egress-iptables.service"
+    );
 
     expect(runCommands).toEqual(
       expect.arrayContaining([
-        // Loopback exemption lives in nat (before REDIRECT), not filter —
-        // otherwise the redirect rewrites the destination first.
-        expect.stringContaining(
-          "iptables -t nat -A OUTPUT -m owner --uid-owner 1003 -d 127.0.0.0/8 -j RETURN"
-        ),
-        // Metadata + RFC1918 RETURNs in nat keep original dst intact for
-        // the filter-table defense-in-depth DROPs below.
-        expect.stringContaining(
-          "iptables -t nat -A OUTPUT -m owner --uid-owner 1003 -d 169.254.169.254/32 -j RETURN"
-        ),
-        expect.stringContaining(
-          "iptables -t nat -A OUTPUT -m owner --uid-owner 1003 -d 10.0.0.0/8 -j RETURN"
-        ),
-        expect.stringContaining(
-          "iptables -t nat -A OUTPUT -m owner --uid-owner 1003 -p tcp -j REDIRECT --to-ports 9990"
-        ),
-        expect.stringContaining(
-          'iptables -A OUTPUT -m owner --uid-owner 1003 -p udp --dport 53 -d "$NS" -j ACCEPT'
-        ),
-        expect.stringContaining(
-          "iptables -A OUTPUT -m owner --uid-owner 1003 -d 169.254.169.254/32 -j DROP"
-        ),
-        expect.stringContaining(
-          "ip6tables -A OUTPUT -m owner --uid-owner 1003 -j DROP"
-        ),
+        "chmod 755 /etc/dust/egress-iptables.sh",
+        "systemctl daemon-reload && systemctl enable dust-egress-iptables.service",
       ])
     );
+
+    expect(runCommands.join("\n")).not.toContain("iptables -t nat -A OUTPUT");
+
+    expect(iptablesScript).toContain(
+      'iptables -t nat -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -d 127.0.0.0/8 -j RETURN'
+    );
+    expect(iptablesScript).toContain(
+      'iptables -t nat -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -p tcp -j REDIRECT --to-ports 9990'
+    );
+    expect(iptablesScript).toContain(
+      'iptables -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -p udp --dport 53 -d "$NS" -j ACCEPT'
+    );
+    expect(iptablesScript).toContain(
+      'iptables -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -d 169.254.169.254/32 -j DROP'
+    );
+    expect(iptablesScript).toContain(
+      'ip6tables -A OUTPUT -m owner --uid-owner "$PROXIED_UID" -j DROP'
+    );
+
+    expect(serviceUnit).toContain("Type=oneshot");
+    expect(serviceUnit).toContain("RemainAfterExit=yes");
+    expect(serviceUnit).toContain("ExecStart=/etc/dust/egress-iptables.sh");
+    expect(serviceUnit).toContain("WantedBy=multi-user.target");
   });
 });

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -11,12 +11,13 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.5.0";
-const DUST_BASE_IMAGE_VERSION = "0.7.6";
+const DUST_BASE_IMAGE_VERSION = "0.7.7";
 const DSBX_CLI_VERSION = "0.1.4";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.
 const APPLY_PATCH_VERSION = "0.1.0";
+const EGRESS_LOCAL_DIR = path.resolve(__dirname, "egress");
 const PROFILE_LOCAL_DIR = path.resolve(__dirname, "profile");
 const TELEMETRY_LOCAL_DIR = path.resolve(__dirname, "telemetry");
 
@@ -99,35 +100,6 @@ function getAgentProxiedSetupCommand(): string {
     "setfacl -R -d -m g::rwx /home/agent /files/conversation",
     "setfacl -R -m g::rwx /home/agent /files/conversation",
   ].join(" && ");
-}
-
-function getEgressIptablesSetupCommand(): string {
-  // nat/OUTPUT runs before filter/OUTPUT for locally generated packets.
-  // Exemptions (loopback, metadata, RFC1918) must land in nat BEFORE the
-  // REDIRECT — otherwise the destination is rewritten to 127.0.0.1:9990
-  // and filter DROPs on the original dst never fire. Loopback
-  // intentionally has no matching rule in filter so local services keep
-  // working; metadata/RFC1918 are dropped in filter as defense in depth.
-  return [
-    "set -eu",
-    `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 127.0.0.0/8 -j RETURN`,
-    `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 169.254.169.254/32 -j RETURN`,
-    `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 10.0.0.0/8 -j RETURN`,
-    `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 172.16.0.0/12 -j RETURN`,
-    `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 192.168.0.0/16 -j RETURN`,
-    `iptables -t nat -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p tcp -j REDIRECT --to-ports 9990`,
-    // DNS pinned to resolvers first — resolver may itself live in RFC1918.
-    "for NS in $(awk '/^nameserver/ {print $2}' /etc/resolv.conf); do",
-    `  iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p udp --dport 53 -d "$NS" -j ACCEPT`,
-    "done",
-    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 169.254.169.254/32 -j DROP`,
-    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 10.0.0.0/8 -j DROP`,
-    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 172.16.0.0/12 -j DROP`,
-    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -d 192.168.0.0/16 -j DROP`,
-    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p udp -j DROP`,
-    `iptables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -p icmp -j DROP`,
-    `ip6tables -A OUTPUT -m owner --uid-owner ${AGENT_PROXIED_UID} -j DROP`,
-  ].join("\n");
 }
 
 const DUST_BASE_IMAGE = SandboxImage.fromDocker(
@@ -291,8 +263,23 @@ SHELLEOF`,
     "/etc/systemd/system/fluent-bit.service",
     { user: "root" }
   )
-  .runCmd("systemctl daemon-reload", { user: "root" })
-  .runCmd(getEgressIptablesSetupCommand(), { user: "root" })
+  .copy(
+    getLocalContent(EGRESS_LOCAL_DIR, "egress-iptables.sh"),
+    "/etc/dust/egress-iptables.sh",
+    { user: "root" }
+  )
+  .runCmd("chmod 755 /etc/dust/egress-iptables.sh", { user: "root" })
+  .copy(
+    getLocalContent(EGRESS_LOCAL_DIR, "dust-egress-iptables.service"),
+    "/etc/systemd/system/dust-egress-iptables.service",
+    { user: "root" }
+  )
+  .runCmd(
+    "systemctl daemon-reload && systemctl enable dust-egress-iptables.service",
+    {
+      user: "root",
+    }
+  )
   // Profile functions (no install needed, provided by profile scripts)
   .registerTool([
     {


### PR DESCRIPTION
## Description

E2B's Firecracker-based template builder lacks `CAP_NET_ADMIN`, causing all `iptables` commands to fail with exit status 4 at build time. This was discovered when trying to build `dust-base:0.7.6` — the iptables ruleset baked via `runCmd` in `registry.ts` failed every build attempt.

The fix moves the uid-scoped egress iptables rules out of build-time `runCmd` and into a **systemd oneshot service** that applies the rules at sandbox boot:

- **`egress-iptables.sh`** — shell script with the full iptables ruleset (nat RETURN exemptions, REDIRECT to proxy port 9990, filter DROPs for metadata/RFC1918/UDP/ICMP, ip6tables DROP)
- **`dust-egress-iptables.service`** — oneshot unit that runs the script at boot (`After=network.target`, `RemainAfterExit=yes`)
- Both files are `.copy()`'d into the template at build time (no capabilities needed for file writes), then `systemctl enable` wires up the boot-time activation
- Removes the now-unnecessary `getEgressIptablesSetupCommand()` function
- Bumps `dust-base` to `0.7.7`

The iptables rules themselves are unchanged — same ordering, same uid scoping (1003), same defense-in-depth DROPs. Only the delivery mechanism changes (build-time runCmd → boot-time systemd).

Related PRs: #24424 (PR1 base), #24449 (uid 1003 fix)

## Tests

- Updated `registry.test.ts`: verifies `.copy()` operations deliver the script and unit file with correct content, verifies `systemctl enable` in run commands, asserts no iptables commands remain in runCommands
- All 4 registry tests pass locally
- Full E2E verification requires triggering the Sandbox Image Registry workflow post-merge to build `dust-base:0.7.7`, then running the smoke test against a live sandbox

## Risk

**Low.** The iptables rules are identical — only the delivery mechanism changes. If the systemd service fails to start at boot, the sandbox operates without egress restrictions (same as pre-PR1 behavior), so this is a fail-open scenario. The `RemainAfterExit=yes` ensures `systemctl status` shows the service as active after the rules are applied.

## Deploy Plan

1. Merge this PR
2. Trigger the **Sandbox Image Registry** workflow to build `dust-base:0.7.7` (the E2B template)
3. Verify the build succeeds (iptables no longer runs at build time)
4. Run the smoke test against the new template to confirm rules are applied at boot