### PR TITLE
Fix: restore :latest image tag for main branch builds

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -171,6 +171,13 @@ runs:
           build_args+=("--build-arg NEXT_PUBLIC_DUST_APP_URL=https://${CF_BRANCH}--app.preview.dust.tt")
         fi
 
+        # Tag with 'latest' for main branch prod non-canary builds
+        LATEST_TAGS=()
+        if [[ "$ENV" == "prod" && "$COMPONENT" == "$BASE_COMPONENT" && "${{ github.ref_name }}" == "main" ]]; then
+          REGISTRY="${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images"
+          LATEST_TAGS+=("-t" "${REGISTRY}/${COMPONENT}:latest")
+        fi
+
         # Special handling for front component, build both front and workers targets
         if [[ "$BASE_COMPONENT" == "front" ]]; then
           echo "🏗️ Building front component with dual targets (front + workers)"
@@ -187,6 +194,7 @@ runs:
             --cache-to type=gha,mode=max,scope=${{ inputs.component }}-front \
             -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
             -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}:${{ inputs.commit_sha }} \
+            "${LATEST_TAGS[@]}" \
             --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
             --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
             ${build_args[@]} \
@@ -194,6 +202,10 @@ runs:
             .
 
           # Build workers target
+          LATEST_TAGS_WORKERS=()
+          if [[ "$ENV" == "prod" && "$COMPONENT" == "$BASE_COMPONENT" && "${{ github.ref_name }}" == "main" ]]; then
+            LATEST_TAGS_WORKERS+=("-t" "${REGISTRY}/${COMPONENT}-workers:latest")
+          fi
           depot build \
             --project $DEPOT_PROJECT_ID \
             --platform linux/amd64 \
@@ -205,6 +217,7 @@ runs:
             --cache-to type=gha,mode=max,scope=${{ inputs.component }}-workers \
             -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
             -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}-workers:${{ inputs.commit_sha }} \
+            "${LATEST_TAGS_WORKERS[@]}" \
             --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
             --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
             ${build_args[@]} \
@@ -220,6 +233,7 @@ runs:
             --cache-to type=gha,mode=max,scope=${{ inputs.component }} \
             -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
             -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}:${{ inputs.commit_sha }} \
+            "${LATEST_TAGS[@]}" \
             --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
             --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
             ${build_args[@]} \


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Back in March 2025, a workflow refactor consolidated our build pipeline into a single build-image action. In doing so, the `:latest` Docker tag that used to be pushed alongside the SHA tag was accidentally dropped.

This went unnoticed for over a year because most services use SHA-based tags in their deployments. The `oauth` service was deployed with the `:latest` tag reference, meaning every pod restart has been pulling a March 4, 2025 image instead of the current one.

This PR restores the `:latest` tag, pushed only for `main` branch and prod builds (QA, edge, and canary are unaffected). Both the SHA tag and `:latest` are pushed in the same depot build call, pointing to the same image digest.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
