### PR TITLE
Batch group member counts to eliminate N+1 on /api/w/[wId]/groups

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -171,6 +171,13 @@ runs:
           build_args+=("--build-arg NEXT_PUBLIC_DUST_APP_URL=https://${CF_BRANCH}--app.preview.dust.tt")
         fi
 
+        # Tag with 'latest' for main branch prod non-canary builds
+        LATEST_TAGS=()
+        if [[ "$ENV" == "prod" && "$COMPONENT" == "$BASE_COMPONENT" && "${{ github.ref_name }}" == "main" ]]; then
+          REGISTRY="${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images"
+          LATEST_TAGS+=("-t" "${REGISTRY}/${COMPONENT}:latest")
+        fi
+
         # Special handling for front component, build both front and workers targets
         if [[ "$BASE_COMPONENT" == "front" ]]; then
           echo "🏗️ Building front component with dual targets (front + workers)"
@@ -187,6 +194,7 @@ runs:
             --cache-to type=gha,mode=max,scope=${{ inputs.component }}-front \
             -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
             -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}:${{ inputs.commit_sha }} \
+            "${LATEST_TAGS[@]}" \
             --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
             --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
             ${build_args[@]} \
@@ -194,6 +202,10 @@ runs:
             .
 
           # Build workers target
+          LATEST_TAGS_WORKERS=()
+          if [[ "$ENV" == "prod" && "$COMPONENT" == "$BASE_COMPONENT" && "${{ github.ref_name }}" == "main" ]]; then
+            LATEST_TAGS_WORKERS+=("-t" "${REGISTRY}/${COMPONENT}-workers:latest")
+          fi
           depot build \
             --project $DEPOT_PROJECT_ID \
             --platform linux/amd64 \
@@ -205,6 +217,7 @@ runs:
             --cache-to type=gha,mode=max,scope=${{ inputs.component }}-workers \
             -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
             -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}-workers:${{ inputs.commit_sha }} \
+            "${LATEST_TAGS_WORKERS[@]}" \
             --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
             --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
             ${build_args[@]} \
@@ -220,6 +233,7 @@ runs:
             --cache-to type=gha,mode=max,scope=${{ inputs.component }} \
             -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
             -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}:${{ inputs.commit_sha }} \
+            "${LATEST_TAGS[@]}" \
             --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
             --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
             ${build_args[@]} \

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1061,6 +1061,36 @@ export class GroupResource extends BaseResource<GroupModel> {
     return groups.map((group) => new this(GroupModel, group.get()));
   }
 
+  static async getMemberCountsForGroups(
+    auth: Authenticator,
+    groups: GroupResource[]
+  ): Promise<Map<ModelId, number>> {
+    const owner = auth.getNonNullableWorkspace();
+    const counts = new Map<ModelId, number>();
+
+    const globalGroup = groups.find((g) => g.isGlobal());
+    const regularGroups = groups.filter((g) => !g.isGlobal());
+
+    // Global group count comes from workspace active memberships.
+    if (globalGroup) {
+      const { total } = await MembershipResource.getActiveMemberships({
+        workspace: owner,
+      });
+      counts.set(globalGroup.id, total);
+    }
+
+    // All regular group counts in one query, reusing the existing method.
+    if (regularGroups.length > 0) {
+      const membershipsByGroup =
+        await GroupResource.getActiveMembershipsForGroups(auth, regularGroups);
+      for (const [groupId, userIds] of Object.entries(membershipsByGroup)) {
+        counts.set(Number(groupId), userIds.length);
+      }
+    }
+
+    return counts;
+  }
+
   static async getActiveMembershipsForGroups(
     auth: Authenticator,
     groups: GroupResource[]

--- a/front/pages/api/w/[wId]/groups.test.ts
+++ b/front/pages/api/w/[wId]/groups.test.ts
@@ -1,0 +1,121 @@
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { describe, expect, it } from "vitest";
+
+import handler from "./groups";
+
+describe("GET /api/w/[wId]/groups", () => {
+  it("returns groups with correct member counts", async () => {
+    const { req, res, workspace, user, auth } =
+      await createPrivateApiMockRequest({ method: "GET", role: "admin" });
+
+    const group = await GroupFactory.regular(workspace, "Engineering");
+    await GroupFactory.withMembers(auth, group, [user]);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { groups } = res._getJSONData();
+
+    const globalGroup = groups.find(
+      (g: { kind: string }) => g.kind === "global"
+    );
+    expect(globalGroup).toBeDefined();
+    expect(globalGroup.memberCount).toBe(1);
+
+    const engineeringGroup = groups.find(
+      (g: { name: string }) => g.name === "Engineering"
+    );
+    expect(engineeringGroup).toBeDefined();
+    expect(engineeringGroup.memberCount).toBe(1);
+  });
+
+  it("reflects multiple members correctly", async () => {
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const group = await GroupFactory.regular(workspace, "Design");
+
+    const extraUsers = await Promise.all([
+      UserFactory.basic(),
+      UserFactory.basic(),
+    ]);
+    await Promise.all(
+      extraUsers.map((u) =>
+        MembershipFactory.associate(workspace, u, { role: "user" })
+      )
+    );
+    await GroupFactory.withMembers(auth, group, extraUsers);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { groups } = res._getJSONData();
+
+    const designGroup = groups.find(
+      (g: { name: string }) => g.name === "Design"
+    );
+    expect(designGroup).toBeDefined();
+    expect(designGroup.memberCount).toBe(2);
+
+    // Global group count should include all workspace members.
+    const globalGroup = groups.find(
+      (g: { kind: string }) => g.kind === "global"
+    );
+    expect(globalGroup.memberCount).toBe(3); // 1 original + 2 extra.
+  });
+
+  it("returns 0 for a group with no members", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await GroupFactory.regular(workspace, "Empty");
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { groups } = res._getJSONData();
+
+    const emptyGroup = groups.find((g: { name: string }) => g.name === "Empty");
+    expect(emptyGroup).toBeDefined();
+    expect(emptyGroup.memberCount).toBe(0);
+  });
+
+  it("filters groups by kind", async () => {
+    const { req, res, workspace, auth, user } =
+      await createPrivateApiMockRequest({ method: "GET", role: "admin" });
+
+    const group = await GroupFactory.regular(workspace, "Backend");
+    await GroupFactory.withMembers(auth, group, [user]);
+
+    req.query.kind = "regular";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { groups } = res._getJSONData();
+
+    expect(groups.every((g: { kind: string }) => g.kind === "regular")).toBe(
+      true
+    );
+    const backendGroup = groups.find(
+      (g: { name: string }) => g.name === "Backend"
+    );
+    expect(backendGroup).toBeDefined();
+    expect(backendGroup.memberCount).toBe(1);
+  });
+
+  it("returns 405 for unsupported methods", async () => {
+    for (const method of ["POST", "PUT", "PATCH", "DELETE"] as const) {
+      const { req, res } = await createPrivateApiMockRequest({ method });
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(405);
+    }
+  });
+});

--- a/front/pages/api/w/[wId]/groups.ts
+++ b/front/pages/api/w/[wId]/groups.ts
@@ -60,9 +60,15 @@ async function handler(
         });
       }
 
-      const groupsWithMemberCount = await Promise.all(
-        groups.map((group) => group.toJSONWithMemberCount(auth))
+      const memberCounts = await GroupResource.getMemberCountsForGroups(
+        auth,
+        groups
       );
+
+      const groupsWithMemberCount = groups.map((group) => ({
+        ...group.toJSON(),
+        memberCount: memberCounts.get(group.id) ?? 0,
+      }));
 
       return res.status(200).json({
         groups: groupsWithMemberCount,

--- a/front/tests/utils/GroupFactory.ts
+++ b/front/tests/utils/GroupFactory.ts
@@ -1,8 +1,28 @@
+import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceType } from "@app/types/user";
 
 export class GroupFactory {
   static async defaults(workspace: WorkspaceType) {
     return GroupResource.makeDefaultsForWorkspace(workspace);
+  }
+
+  static async regular(workspace: WorkspaceType, name: string) {
+    return GroupResource.makeNew({
+      name,
+      kind: "regular",
+      workspaceId: workspace.id,
+    });
+  }
+
+  static async withMembers(
+    auth: Authenticator,
+    group: GroupResource,
+    users: UserResource[]
+  ) {
+    return group.dangerouslyAddMembers(auth, {
+      users: users.map((u) => u.toJSON()),
+    });
   }
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1776415118956069) for full context.

Each call to this endpoint was firing one `COUNT` query per group to compute member counts, all in parallel via `Promise.all`. A workspace with 248 groups = 248 concurrent DB queries from a single request.

Fixed by adding `getMemberCountsForGroups` on `GroupResource`, which gets all counts in two queries regardless of how many groups there are. One call to the existing `getActiveMembershipsForGroups` for regular groups (one `SELECT` for all of them), and one membership count for the global group. The endpoint then does a synchronous Map lookup per group.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
