### PR TITLE
[front] feat: GA skills import from GitHub repository/files

### DIFF
--- a/front/components/assistant/CreateDropdown.tsx
+++ b/front/components/assistant/CreateDropdown.tsx
@@ -1,6 +1,5 @@
 import { ImportSkillsDialog } from "@app/components/skills/import/ImportSkillsDialog";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import {
@@ -40,8 +39,6 @@ export const CreateDropdown = ({
   const { isUploading: isUploadingYAML, triggerYAMLUpload } = useYAMLUpload({
     owner,
   });
-
-  const { hasFeature } = useFeatureFlags();
 
   return (
     <DropdownMenu>
@@ -95,9 +92,7 @@ export const CreateDropdown = ({
           <>
             <DropdownMenuLabel label="Skills" />
             <DropdownMenuItem
-              label={
-                hasFeature("sandbox_tools") ? "skill from scratch" : "skill"
-              }
+              label="skill from scratch"
               icon={PuzzleIcon}
               onClick={withTracking(
                 TRACKING_AREAS.BUILDER,
@@ -108,13 +103,11 @@ export const CreateDropdown = ({
                 }
               )}
             />
-            {hasFeature("sandbox_tools") && (
-              <DropdownMenuItem
-                label="skill from existing"
-                icon={FolderOpenIcon}
-                onClick={() => setIsImportSkillDialogOpen(true)}
-              />
-            )}
+            <DropdownMenuItem
+              label="skill from existing"
+              icon={FolderOpenIcon}
+              onClick={() => setIsImportSkillDialogOpen(true)}
+            />
           </>
         )}
       </DropdownMenuContent>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -974,37 +974,26 @@ export function AgentSidebarMenu({
                         {isBuilder(owner) && (
                           <>
                             <DropdownMenuLabel>Skills</DropdownMenuLabel>
-                            {hasFeature("sandbox_tools") ? (
-                              <DropdownMenuSub>
-                                <DropdownMenuSubTrigger
-                                  icon={PlusIcon}
-                                  label="New skill"
-                                />
-                                <DropdownMenuSubContent>
-                                  <DropdownMenuItem
-                                    href={getSkillBuilderRoute(
-                                      owner.sId,
-                                      "new"
-                                    )}
-                                    icon={SKILL_ICON}
-                                    label="From scratch"
-                                  />
-                                  <DropdownMenuItem
-                                    icon={FolderOpenIcon}
-                                    label="From existing"
-                                    onClick={() =>
-                                      setIsImportSkillDialogOpen(true)
-                                    }
-                                  />
-                                </DropdownMenuSubContent>
-                              </DropdownMenuSub>
-                            ) : (
-                              <DropdownMenuItem
-                                href={getSkillBuilderRoute(owner.sId, "new")}
+                            <DropdownMenuSub>
+                              <DropdownMenuSubTrigger
                                 icon={PlusIcon}
                                 label="New skill"
                               />
-                            )}
+                              <DropdownMenuSubContent>
+                                <DropdownMenuItem
+                                  href={getSkillBuilderRoute(owner.sId, "new")}
+                                  icon={SKILL_ICON}
+                                  label="From scratch"
+                                />
+                                <DropdownMenuItem
+                                  icon={FolderOpenIcon}
+                                  label="From existing"
+                                  onClick={() =>
+                                    setIsImportSkillDialogOpen(true)
+                                  }
+                                />
+                              </DropdownMenuSubContent>
+                            </DropdownMenuSub>
                             <DropdownMenuItem
                               href={getSkillBuilderRoute(owner.sId, "manage")}
                               icon={SKILL_ICON}

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -10,11 +10,7 @@ import {
   useSetPageTitle,
 } from "@app/components/sparkle/AppLayoutContext";
 import { useHashParam } from "@app/hooks/useHashParams";
-import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { SKILL_ICON } from "@app/lib/skill";
 import { useSkillsWithRelations } from "@app/lib/swr/skill_configurations";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
@@ -88,7 +84,6 @@ function sortSkillsByName(skills: SkillWithRelationsType[]) {
 export function ManageSkillsPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
-  const { hasFeature } = useFeatureFlags();
   const [selectedSkill, setSelectedSkill] =
     useState<SkillWithRelationsType | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
@@ -268,32 +263,23 @@ export function ManageSkillsPage() {
                 setSkillSearch(s);
               }}
             />
-            {hasFeature("sandbox_tools") ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button label="Create skill" icon={PlusIcon} isSelect />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent>
-                  <DropdownMenuItem
-                    label="From scratch"
-                    icon={SKILL_ICON}
-                    href={getSkillBuilderRoute(owner.sId, "new")}
-                  />
-                  <DropdownMenuItem
-                    label="From existing"
-                    icon={FolderOpenIcon}
-                    onClick={() => setIsImportDialogOpen(true)}
-                  />
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : (
-              <Button
-                label="Create skill"
-                href={getSkillBuilderRoute(owner.sId, "new")}
-                icon={PlusIcon}
-                tooltip="Create a new skill"
-              />
-            )}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button label="Create skill" icon={PlusIcon} isSelect />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem
+                  label="From scratch"
+                  icon={SKILL_ICON}
+                  href={getSkillBuilderRoute(owner.sId, "new")}
+                />
+                <DropdownMenuItem
+                  label="From existing"
+                  icon={FolderOpenIcon}
+                  onClick={() => setIsImportDialogOpen(true)}
+                />
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
           <div className="flex flex-col pt-3">
             <Tabs value={activeTab}>

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -66,7 +66,7 @@ export async function importSkillsFromFiles(
   }
 ): Promise<Result<ImportSkillsResult, Error>> {
   const allSkills: ZipDetectedSkill[] = [];
-  const featureFlags = await getFeatureFlags(auth)
+  const featureFlags = await getFeatureFlags(auth);
   const allowFileAttachments = featureFlags.includes("sandbox_tools");
 
   // Readers are keyed by skill to avoid re-opening the same zip for each

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/api/skills/detection/zip/detect_skills";
 import type { ZipDetectedSkill } from "@app/lib/api/skills/detection/zip/types";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -66,6 +66,8 @@ export async function importSkillsFromFiles(
   }
 ): Promise<Result<ImportSkillsResult, Error>> {
   const allSkills: ZipDetectedSkill[] = [];
+  const featureFlags = await getFeatureFlags(auth)
+  const allowFileAttachments = featureFlags.includes("sandbox_tools");
 
   // Readers are keyed by skill to avoid re-opening the same zip for each
   // attachment. Each zip buffer produces one reader shared across its skills.
@@ -84,16 +86,23 @@ export async function importSkillsFromFiles(
       return new Err(new Error(detectResult.error.message));
     }
 
-    const readerResult = createZipAttachmentReader(buffer);
-    if (readerResult.isErr()) {
-      await cleanupTempFiles(uploadedFiles);
-      return new Err(readerResult.error);
+    let reader:
+      | ((originalEntryName: string) => Result<Buffer, Error>)
+      | undefined;
+    if (allowFileAttachments) {
+      const readerResult = createZipAttachmentReader(buffer);
+      if (readerResult.isErr()) {
+        await cleanupTempFiles(uploadedFiles);
+        return new Err(readerResult.error);
+      }
+      reader = readerResult.value;
     }
-    const reader = readerResult.value;
 
     for (const skill of detectResult.value) {
       allSkills.push(skill);
-      readerBySkill.set(skill, reader);
+      if (reader) {
+        readerBySkill.set(skill, reader);
+      }
     }
   }
 
@@ -144,31 +153,34 @@ export async function importSkillsFromFiles(
         return;
       }
 
-      const readEntry = readerBySkill.get(skill);
-      if (!readEntry) {
-        skipped.push({
-          name: skill.name,
-          message: "Internal error: no zip reader for skill.",
-        });
-        return;
+      let fileAttachments: FileResource[] = [];
+      if (allowFileAttachments) {
+        const readEntry = readerBySkill.get(skill);
+        if (!readEntry) {
+          skipped.push({
+            name: skill.name,
+            message: "Internal error: no zip reader for skill.",
+          });
+          return;
+        }
+
+        const skillDirPath = path.dirname(skill.skillMdPath);
+        const uploadResults = await concurrentExecutor(
+          skill.attachments,
+          (attachment) =>
+            uploadAttachment(auth, {
+              originalEntryName: attachment.originalEntryName,
+              contentType: attachment.contentType,
+              fileName: path.relative(skillDirPath, attachment.path),
+              readEntry,
+            }),
+          { concurrency: IMPORT_CONCURRENCY }
+        );
+
+        fileAttachments = uploadResults.filter(
+          (r): r is FileResource => r !== null
+        );
       }
-
-      const skillDirPath = path.dirname(skill.skillMdPath);
-      const uploadResults = await concurrentExecutor(
-        skill.attachments,
-        (attachment) =>
-          uploadAttachment(auth, {
-            originalEntryName: attachment.originalEntryName,
-            contentType: attachment.contentType,
-            fileName: path.relative(skillDirPath, attachment.path),
-            readEntry,
-          }),
-        { concurrency: IMPORT_CONCURRENCY }
-      );
-
-      const fileAttachments = uploadResults.filter(
-        (r): r is FileResource => r !== null
-      );
 
       if (existing) {
         const attachedKnowledge = await existing.getAttachedKnowledge(auth);
@@ -182,14 +194,16 @@ export async function importSkillsFromFiles(
           mcpServerViews: existing.mcpServerViews,
           attachedKnowledge,
           requestedSpaceIds: existing.requestedSpaceIds,
-          fileAttachments,
+          ...(allowFileAttachments ? { fileAttachments } : {}),
           source,
           sourceMetadata: { filePath: skill.skillMdPath },
         });
 
-        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-          skillId: existing.sId,
-        });
+        if (allowFileAttachments) {
+          await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+            skillId: existing.sId,
+          });
+        }
 
         updated.push(existing);
       } else {
@@ -231,14 +245,16 @@ export async function importSkillsFromFiles(
           },
           {
             mcpServerViews: suggestedMCPServerViews,
-            fileAttachments,
+            ...(allowFileAttachments ? { fileAttachments } : {}),
             addCurrentUserAsEditor: auth.user() !== null,
           }
         );
 
-        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-          skillId: skillResource.sId,
-        });
+        if (allowFileAttachments) {
+          await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+            skillId: skillResource.sId,
+          });
+        }
 
         imported.push(skillResource);
       }

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -15,7 +15,7 @@ import type {
 import { suggestMCPServersForDetectedSkill } from "@app/lib/api/skills/detection/suggest_mcp_servers";
 import { validateSkillsForImport } from "@app/lib/api/skills/detection/validate_skills";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -49,6 +49,8 @@ export async function importSkillsFromGitHub(
     onConflict?: "error" | "skip";
   }
 ): Promise<Result<ImportSkillsResult, GitHubSkillDetectionError>> {
+  const featureFlags = await getFeatureFlags(auth);
+  const allowFileAttachments = featureFlags.includes("sandbox_tools");
   const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
   const clientResult = initGitHubRepoClient({ repoUrl, accessToken });
   if (clientResult.isErr()) {
@@ -114,23 +116,26 @@ export async function importSkillsFromGitHub(
         return;
       }
 
-      const skillDirPath = path.dirname(skill.skillMdPath);
-      const uploadResults = await concurrentExecutor(
-        skill.attachments,
-        (attachment) =>
-          uploadAttachment(auth, {
-            octokit,
-            owner,
-            repo,
-            attachment,
-            skillDirPath,
-          }),
-        { concurrency: IMPORT_CONCURRENCY }
-      );
+      let fileAttachments: FileResource[] = [];
+      if (allowFileAttachments) {
+        const skillDirPath = path.dirname(skill.skillMdPath);
+        const uploadResults = await concurrentExecutor(
+          skill.attachments,
+          (attachment) =>
+            uploadAttachment(auth, {
+              octokit,
+              owner,
+              repo,
+              attachment,
+              skillDirPath,
+            }),
+          { concurrency: IMPORT_CONCURRENCY }
+        );
 
-      const fileAttachments = uploadResults.filter(
-        (r): r is FileResource => r !== null
-      );
+        fileAttachments = uploadResults.filter(
+          (r): r is FileResource => r !== null
+        );
+      }
 
       if (existing) {
         const attachedKnowledge = await existing.getAttachedKnowledge(auth);
@@ -144,7 +149,7 @@ export async function importSkillsFromGitHub(
           mcpServerViews: existing.mcpServerViews,
           attachedKnowledge,
           requestedSpaceIds: existing.requestedSpaceIds,
-          fileAttachments,
+          ...(allowFileAttachments ? { fileAttachments } : {}),
           source: "github",
           sourceMetadata: {
             repoUrl,
@@ -152,9 +157,11 @@ export async function importSkillsFromGitHub(
           },
         });
 
-        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-          skillId: existing.sId,
-        });
+        if (allowFileAttachments) {
+          await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+            skillId: existing.sId,
+          });
+        }
 
         updated.push(existing);
       } else {
@@ -197,12 +204,17 @@ export async function importSkillsFromGitHub(
             },
             isDefault: false,
           },
-          { mcpServerViews: detectedMCPServerViews, fileAttachments }
+          {
+            mcpServerViews: detectedMCPServerViews,
+            ...(allowFileAttachments ? { fileAttachments } : {}),
+          }
         );
 
-        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-          skillId: skillResource.sId,
-        });
+        if (allowFileAttachments) {
+          await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+            skillId: skillResource.sId,
+          });
+        }
 
         imported.push(skillResource);
       }

--- a/front/pages/api/v1/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.test.ts
@@ -1,4 +1,3 @@
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import {
   createPublicApiAuthenticationTests,
   createPublicApiMockRequest,
@@ -35,11 +34,9 @@ describe("POST /api/v1/w/[wId]/skills", () => {
   });
 
   it("returns 400 when no files are uploaded", async () => {
-    const { req, res, auth } = await createPublicApiMockRequest({
+    const { req, res } = await createPublicApiMockRequest({
       method: "POST",
     });
-
-    await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
     mockParse.mockResolvedValue([{}, {}]);
 
@@ -50,22 +47,6 @@ describe("POST /api/v1/w/[wId]/skills", () => {
       error: {
         type: "invalid_request_error",
         message: "No files uploaded.",
-      },
-    });
-  });
-
-  it("returns 403 when the workspace does not support skill import", async () => {
-    const { req, res } = await createPublicApiMockRequest({
-      method: "POST",
-    });
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({
-      error: {
-        type: "invalid_request_error",
-        message: "Skill import is not supported.",
       },
     });
   });

--- a/front/pages/api/v1/w/[wId]/skills/index.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.ts
@@ -5,7 +5,7 @@ import {
   isImportConflictStrategy,
 } from "@app/lib/api/skills/detection/files/import_skills";
 import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_skills";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { ImportSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/import";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -30,17 +30,6 @@ async function handler(
       api_error: {
         type: "method_not_supported_error",
         message: "The method passed is not supported, POST is expected.",
-      },
-    });
-  }
-
-  const featureFlags = await getFeatureFlags(auth);
-  if (!featureFlags.includes("sandbox_tools")) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Skill import is not supported.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/skills/detect/index.ts
+++ b/front/pages/api/w/[wId]/skills/detect/index.ts
@@ -6,7 +6,7 @@ import {
 } from "@app/lib/api/skills/detection/github/detect_skills";
 import { initGitHubRepoClient } from "@app/lib/api/skills/detection/github/github_api";
 import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/detection/github/github_auth";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { DetectedSkillSummary } from "@app/lib/skill_detection";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -36,17 +36,6 @@ async function handler(
           api_error: {
             type: "app_auth_error",
             message: "User is not a builder.",
-          },
-        });
-      }
-
-      const featureFlags = await getFeatureFlags(auth);
-      if (!featureFlags.includes("sandbox_tools")) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Skill import from GitHub is not supported.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/skills/detect/upload.ts
+++ b/front/pages/api/w/[wId]/skills/detect/upload.ts
@@ -2,7 +2,7 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { detectSkillsFromUploadedFiles } from "@app/lib/api/skills/detection/files/detect_skills";
 import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_skills";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { DetectedSkillSummary } from "@app/lib/skill_detection";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -32,17 +32,6 @@ async function handler(
           api_error: {
             type: "app_auth_error",
             message: "User is not a builder.",
-          },
-        });
-      }
-
-      const featureFlags = await getFeatureFlags(auth);
-      if (!featureFlags.includes("sandbox_tools")) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Skill import is not supported.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/skills/import/index.ts
+++ b/front/pages/api/w/[wId]/skills/import/index.ts
@@ -1,7 +1,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { importSkillsFromGitHub } from "@app/lib/api/skills/detection/github/import_skills";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -42,17 +42,6 @@ async function handler(
           api_error: {
             type: "app_auth_error",
             message: "User is not a builder.",
-          },
-        });
-      }
-
-      const featureFlags = await getFeatureFlags(auth);
-      if (!featureFlags.includes("sandbox_tools")) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Skill import from GitHub is not supported.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/skills/import/upload.ts
+++ b/front/pages/api/w/[wId]/skills/import/upload.ts
@@ -2,7 +2,7 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { importSkillsFromFiles } from "@app/lib/api/skills/detection/files/import_skills";
 import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_skills";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { ImportSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/import";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -29,17 +29,6 @@ async function handler(
           api_error: {
             type: "app_auth_error",
             message: "User is not a builder.",
-          },
-        });
-      }
-
-      const featureFlags = await getFeatureFlags(auth);
-      if (!featureFlags.includes("sandbox_tools")) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Skill import is not supported.",
           },
         });
       }


### PR DESCRIPTION
## Description

- This PR ungates the features of importing skills from a GitHub repository or from a zip files.
- Also opens the public endpoint, allowing imports via the GitHub action in https://github.com/dust-tt/dust-github-action.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
