### PR TITLE
feat(sbx): add rebuild option to Sandbox Image Registry workflow

### DIFF
--- a/.github/workflows/sandbox-img-registry.yml
+++ b/.github/workflows/sandbox-img-registry.yml
@@ -7,6 +7,12 @@ on:
         description: "Number of images built"
         value: ${{ jobs.summary.outputs.built-count }}
   workflow_dispatch:
+    inputs:
+      rebuild:
+        description: "Force rebuild all images (even if templates already exist)"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -38,7 +44,8 @@ jobs:
         working-directory: front
         run: |
           set -eo pipefail
-          echo "Running sandbox image check..."
+          REBUILD="${{ inputs.rebuild || 'false' }}"
+          echo "Running sandbox image check... (rebuild=$REBUILD)"
           if ! RESULT=$(npx tsx scripts/sandbox_image_check.ts --json 2>&1); then
             echo "::error::Sandbox image check failed"
             echo "$RESULT"
@@ -47,9 +54,16 @@ jobs:
           echo "Check result:"
           echo "$RESULT"
 
-          MISSING=$(echo "$RESULT" | jq -c '.result.missing')
-          MATRIX=$(echo "$RESULT" | jq -c '{include: .result.buildMatrix}')
-          HAS_MISSING=$(echo "$RESULT" | jq -r 'if (.result.missing | length) > 0 then "true" else "false" end')
+          if [ "$REBUILD" == "true" ]; then
+            MISSING=$(echo "$RESULT" | jq -c '.result.required')
+            MATRIX=$(echo "$RESULT" | jq -c '{include: .result.allBuildMatrix}')
+            HAS_MISSING=$(echo "$RESULT" | jq -r 'if (.result.required | length) > 0 then "true" else "false" end')
+            echo "Force rebuild: treating all images as needing build"
+          else
+            MISSING=$(echo "$RESULT" | jq -c '.result.missing')
+            MATRIX=$(echo "$RESULT" | jq -c '{include: .result.buildMatrix}')
+            HAS_MISSING=$(echo "$RESULT" | jq -r 'if (.result.missing | length) > 0 then "true" else "false" end')
+          fi
 
           echo "missing=$MISSING" >> $GITHUB_OUTPUT
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
@@ -81,11 +95,16 @@ jobs:
         env:
           SBX_GCP_ARTIFACT_SERVICE_ACCOUNT: /tmp/service-account.json
         run: |
+          REBUILD_FLAG=""
+          if [ "${{ inputs.rebuild || 'false' }}" == "true" ]; then
+            REBUILD_FLAG="--rebuild"
+          fi
           npx tsx scripts/sandbox_image_build.ts \
             --image ${{ matrix.image }} \
             --tag ${{ matrix.tag }} \
             --docker-registry us-central1-docker.pkg.dev/or1g1n-186209/dust-sbx \
-            --confirm
+            --confirm \
+            $REBUILD_FLAG
 
       - name: Cleanup service account JSON
         if: always()

--- a/front/scripts/sandbox_image_check.ts
+++ b/front/scripts/sandbox_image_check.ts
@@ -13,6 +13,7 @@ interface CheckResult {
   existing: string[];
   missing: string[];
   buildMatrix: Array<{ image: string; tag: string }>;
+  allBuildMatrix: Array<{ image: string; tag: string }>;
 }
 
 interface CheckArgs {
@@ -74,11 +75,17 @@ async function checkSandboxImages(args: CheckArgs): Promise<void> {
     }
   }
 
+  const allBuildMatrix = requiredImages.map((imageId) => ({
+    image: imageId.imageName,
+    tag: imageId.tag,
+  }));
+
   const result: CheckResult = {
     required: requiredIds,
     existing,
     missing,
     buildMatrix,
+    allBuildMatrix,
   };
 
   if (json) {


### PR DESCRIPTION
## Description

Adds a `rebuild` boolean input to the Sandbox Image Registry workflow's `workflow_dispatch` trigger. When enabled, all registered images are force-rebuilt regardless of whether their templates already exist on E2B.


Changes:
- **Workflow**: new `rebuild` input, check step branches on it to use all images (not just missing), build step passes `--rebuild` flag
- **Check script**: adds `allBuildMatrix` to JSON output (all registered images, not just missing ones)

## Tests

No

## Risk

**None for existing behavior.** The rebuild input defaults to `false`. Normal workflow_dispatch and workflow_call paths are unchanged — the `inputs.rebuild` evaluates to empty/false.

## Deploy Plan

Merge, then trigger the workflow with `rebuild: true` to force-rebuild `dust-base:0.7.8`.