### PR TITLE
fix(sbx): bump bedrock version to 1.6.0 for nftables

### DIFF
--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -73,7 +73,7 @@ describe("sandbox image registry", () => {
     if (imageResult.isOk()) {
       expect(imageResult.value.baseImage).toEqual({
         type: "docker",
-        imageRef: "dust-sbx-bedrock:1.5.0",
+        imageRef: "dust-sbx-bedrock:1.6.0",
       });
       expect(imageResult.value.imageId).toEqual({
         imageName: "dust-base",

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -10,7 +10,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import fs from "fs";
 import path from "path";
 
-const DUST_BEDROCK_IMAGE_VERSION = "1.5.0";
+const DUST_BEDROCK_IMAGE_VERSION = "1.6.0";
 const DUST_BASE_IMAGE_VERSION = "0.7.8";
 const DSBX_CLI_VERSION = "0.1.4";
 const AGENT_PROXIED_UID = 1003;


### PR DESCRIPTION
## Description

Bumps `DUST_BEDROCK_IMAGE_VERSION` from `1.5.0` to `1.6.0` in `registry.ts`.



## Tests

Updated `registry.test.ts` to expect `1.6.0`.

## Risk

**None.** `dust-sbx-bedrock:1.6.0` is already published. This just points the template build at it.

## Deploy Plan

1. Merge
2. Trigger **Sandbox Image Registry** workflow with `rebuild: true` (#24466) to build `dust-base:0.7.8`