### PR TITLE
[slack] remove slack bot mcp feature flag

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -556,9 +556,7 @@ export const INTERNAL_MCP_SERVERS = {
     id: 31,
     availability: "manual" as const,
     allowMultipleInstances: true,
-    isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("slack_bot_mcp");
-    },
+    isRestricted: undefined,
     isPreview: true,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -73,14 +73,11 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
             "mpim:read",
             "team:read",
             "im:read",
+            "reactions:read",
+            "reactions:write",
             "users:read",
             "users:read.email",
           ];
-
-          // TODO: This is temporary until our Slack app scope is approved.
-          if (extraConfig?.slack_bot_mcp_feature_flag) {
-            scopes.push("reactions:read", "reactions:write");
-          }
 
           return scopes;
         case "labs_transcripts":
@@ -200,13 +197,6 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
         ...restConfig
       } = extraConfig;
       return restConfig;
-    } else if (useCase === "platform_actions") {
-      const feature_flags = await getFeatureFlags(auth);
-      const config = { ...extraConfig };
-      if (feature_flags.includes("slack_bot_mcp")) {
-        config.slack_bot_mcp_feature_flag = "true";
-      }
-      return config;
     }
 
     return extraConfig;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -172,10 +172,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable splitting agent responses into multiple Slack messages for Slack (instead of truncation)",
     stage: "dust_only",
   },
-  slack_bot_mcp: {
-    description: "Slack bot MCP server for workspace-level Slack integration",
-    stage: "on_demand",
-  },
   legacy_dust_apps: {
     description: "Access to legacy Dust Apps (editor and associated tools)",
     stage: "on_demand",


### PR DESCRIPTION
## Description
This PR is to remove the feature flag to add `reactions:write` & `reactions:read` scopes per discussion [here](https://github.com/dust-tt/tasks/issues/7612). If I understand it correctly customers need to re-authorize the app to obtain the new permission. I am not familiar with the process but is there anything else we need to do? 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
