### PR TITLE
[front] chore: remove retrocompatilibity check on webhook filter generation

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -10,7 +10,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { ScheduleConfig } from "@app/types/assistant/triggers";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
@@ -62,26 +61,8 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "POST": {
-      let { body } = req;
-
-      // String check for retro-compatibility w.r.t. old clients.
-      // TODO(2026-03-18 aubin): remove this once we do not get calls from clients that predate the front-end change.
-      if (isString(body)) {
-        try {
-          body = JSON.parse(body);
-        } catch {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "Invalid request body, expected JSON.",
-            },
-          });
-        }
-      }
-
       const bodyValidation =
-        PostTextAsCronRuleRequestBodySchema.safeParse(body);
+        PostTextAsCronRuleRequestBodySchema.safeParse(req.body);
 
       if (!bodyValidation.success) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -61,8 +61,9 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "POST": {
-      const bodyValidation =
-        PostTextAsCronRuleRequestBodySchema.safeParse(req.body);
+      const bodyValidation = PostTextAsCronRuleRequestBodySchema.safeParse(
+        req.body
+      );
 
       if (!bodyValidation.success) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
@@ -4,7 +4,6 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isString } from "@app/types/shared/utils/general";
 import {
   WEBHOOK_PRESETS,
   WEBHOOK_PROVIDERS,
@@ -38,26 +37,8 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "POST": {
-      let { body } = req;
-
-      // String check for retro-compatibility w.r.t. old clients.
-      // TODO(2026-03-18 aubin): remove this once we do not get calls from clients that predate the front-end change.
-      if (isString(body)) {
-        try {
-          body = JSON.parse(body);
-        } catch {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "Invalid request body, expected JSON.",
-            },
-          });
-        }
-      }
-
       const bodyValidation =
-        PostWebhookFilterGeneratorRequestBodySchema.safeParse(body);
+        PostWebhookFilterGeneratorRequestBodySchema.safeParse(req.body);
 
       if (!bodyValidation.success) {
         return apiError(req, res, {


### PR DESCRIPTION
## Description

- This PR removes two checks added for retro-compatibility over old front-ends over a month ago.
- The old version of the front-end returned a stringified JSON string instead of an object (was missing a content type header)

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
