### PR TITLE
[Sessions] Return fork conversation id only

### DIFF
--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -55,13 +55,14 @@ export function useBranchConversation({
           return false;
         }
 
-        const { conversation }: PostConversationForkResponseBody =
-          await res.json();
+        const {
+          conversationId: forkedConversationId,
+        }: PostConversationForkResponseBody = await res.json();
 
         void onConversationBranched?.();
 
         await router.push(
-          getConversationRoute(owner.sId, conversation.sId),
+          getConversationRoute(owner.sId, forkedConversationId),
           undefined,
           {
             shallow: true,

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -210,7 +210,10 @@ describe("createConversationFork", () => {
       throw result.error;
     }
 
-    const childConversation = result.value;
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
 
     expect(childConversation.title).toBe("Parent conversation (forked)");
     expect(childConversation.spaceId).toBe(globalSpace.sId);
@@ -309,7 +312,12 @@ describe("createConversationFork", () => {
       throw result.error;
     }
 
-    expect(result.value.forkedFrom?.sourceMessageId).toBe(
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
+
+    expect(childConversation.forkedFrom?.sourceMessageId).toBe(
       firstAgentMessage.sId
     );
   });
@@ -413,9 +421,14 @@ describe("createConversationFork", () => {
       throw result.error;
     }
 
-    const childMCPServerViews = await ConversationResource.fetchMCPServerViews(
+    const childConversation = await fetchConversationOrThrow(
       auth,
       result.value
+    );
+
+    const childMCPServerViews = await ConversationResource.fetchMCPServerViews(
+      auth,
+      childConversation
     );
 
     expect(childMCPServerViews).toHaveLength(1);
@@ -471,8 +484,13 @@ describe("createConversationFork", () => {
       throw result.error;
     }
 
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
+
     const childSkills = await SkillResource.listEnabledByConversation(auth, {
-      conversation: result.value,
+      conversation: childConversation,
     });
 
     expect(childSkills).toHaveLength(1);
@@ -536,8 +554,13 @@ describe("createConversationFork", () => {
       throw result.error;
     }
 
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
+
     const childAttachments = await listAttachments(auth, {
-      conversation: result.value,
+      conversation: childConversation,
     });
     const childFileAttachments = childAttachments.filter(isFileAttachmentType);
 
@@ -550,7 +573,7 @@ describe("createConversationFork", () => {
     ]);
     expect(copiedFiles).toHaveLength(1);
     expect(copiedFiles[0]?.useCaseMetadata?.conversationId).toBe(
-      result.value.sId
+      childConversation.sId
     );
     expect(copiedFiles[0]?.snippet).toBe(sourceFile.snippet);
 
@@ -634,8 +657,13 @@ describe("createConversationFork", () => {
       throw result.error;
     }
 
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
+
     const childAttachments = await listAttachments(auth, {
-      conversation: result.value,
+      conversation: childConversation,
     });
     const childFileAttachments = childAttachments.filter(isFileAttachmentType);
 
@@ -707,14 +735,19 @@ describe("createConversationFork", () => {
       throw result.error;
     }
 
-    expect(result.value.requestedSpaceIds).toEqual([
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
+
+    expect(childConversation.requestedSpaceIds).toEqual([
       globalSpace.sId,
       restrictedSpace.sId,
     ]);
 
     const childConversationForOtherUser = await ConversationResource.fetchById(
       otherAuth,
-      result.value.sId
+      childConversation.sId
     );
     expect(childConversationForOtherUser).toBeNull();
   });

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -447,6 +447,22 @@ export async function createConversationFork(
     sourceMessageRank: childConversationId.value.sourceMessageRank,
   });
 
+  if (copiedAttachmentCount === 0) {
+    return childConversation;
+  }
+
+  const updatedChildConversation = await getConversation(
+    auth,
+    childConversation.value.sId
+  );
+  if (updatedChildConversation.isErr()) {
+    return new Err(
+      new DustError(
+        "internal_error",
+        "The forked conversation could not be reloaded after copying file attachments."
+      )
+    );
+  }
 
   return updatedChildConversation;
 }

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -304,9 +304,7 @@ export async function createConversationFork(
     conversationId: string;
     sourceMessageId?: string;
   }
-): Promise<
-  Result<ConversationType, DustError<CreateConversationForkErrorCode>>
-> {
+): Promise<Result<string, DustError<CreateConversationForkErrorCode>>> {
   const parentConversation = await ConversationResource.fetchById(
     auth,
     conversationId
@@ -416,12 +414,17 @@ export async function createConversationFork(
     childConversationId.value.childConversationId
   );
   if (childConversation.isErr()) {
-    return new Err(
-      new DustError(
-        "internal_error",
-        "The forked conversation could not be loaded after creation."
-      )
+    logger.error(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        parentConversationId: conversationId,
+        childConversationId: childConversationId.value.childConversationId,
+        error: childConversation.error,
+      },
+      "Failed to reload child conversation for fork file attachment copy."
     );
+
+    return new Ok(childConversationId.value.childConversationId);
   }
 
   const parentConversationWithContent = await getConversation(
@@ -438,31 +441,14 @@ export async function createConversationFork(
       },
       "Failed to reload parent conversation for fork file attachment copy."
     );
-    return childConversation;
+    return new Ok(childConversation.value.sId);
   }
 
-  const copiedAttachmentCount = await copyConversationFileAttachments(auth, {
+  await copyConversationFileAttachments(auth, {
     parentConversation: parentConversationWithContent.value,
     childConversation: childConversation.value,
     sourceMessageRank: childConversationId.value.sourceMessageRank,
   });
 
-  if (copiedAttachmentCount === 0) {
-    return childConversation;
-  }
-
-  const updatedChildConversation = await getConversation(
-    auth,
-    childConversation.value.sId
-  );
-  if (updatedChildConversation.isErr()) {
-    return new Err(
-      new DustError(
-        "internal_error",
-        "The forked conversation could not be reloaded after copying file attachments."
-      )
-    );
-  }
-
-  return updatedChildConversation;
+  return new Ok(childConversation.value.sId);
 }

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -447,22 +447,6 @@ export async function createConversationFork(
     sourceMessageRank: childConversationId.value.sourceMessageRank,
   });
 
-  if (copiedAttachmentCount === 0) {
-    return childConversation;
-  }
-
-  const updatedChildConversation = await getConversation(
-    auth,
-    childConversation.value.sId
-  );
-  if (updatedChildConversation.isErr()) {
-    return new Err(
-      new DustError(
-        "internal_error",
-        "The forked conversation could not be reloaded after copying file attachments."
-      )
-    );
-  }
 
   return updatedChildConversation;
 }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -158,6 +158,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
 
     expect(res._getStatusCode()).toBe(200);
     const { conversationId } = res._getJSONData();
+    expect(res._getJSONData().conversation).toEqual({ sId: conversationId });
     const conversation = await fetchConversationOrThrow(auth, conversationId);
 
     expect(conversation.title).toBe("Parent conversation (forked)");
@@ -203,6 +204,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
 
     expect(res._getStatusCode()).toBe(200);
     const { conversationId } = res._getJSONData();
+    expect(res._getJSONData().conversation).toEqual({ sId: conversationId });
     const conversation = await fetchConversationOrThrow(auth, conversationId);
 
     expect(conversation.forkedFrom).toEqual({

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -158,7 +158,6 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
 
     expect(res._getStatusCode()).toBe(200);
     const { conversationId } = res._getJSONData();
-    expect(res._getJSONData().conversation).toEqual({ sId: conversationId });
     const conversation = await fetchConversationOrThrow(auth, conversationId);
 
     expect(conversation.title).toBe("Parent conversation (forked)");
@@ -204,7 +203,6 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
 
     expect(res._getStatusCode()).toBe(200);
     const { conversationId } = res._getJSONData();
-    expect(res._getJSONData().conversation).toEqual({ sId: conversationId });
     const conversation = await fetchConversationOrThrow(auth, conversationId);
 
     expect(conversation.forkedFrom).toEqual({

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -1,4 +1,5 @@
 import { createConversation } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   AgentMessageModel,
   MessageModel,
@@ -12,6 +13,18 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 import { describe, expect, it } from "vitest";
 
 import handler from "./index";
+
+async function fetchConversationOrThrow(
+  auth: Awaited<ReturnType<typeof createPrivateApiMockRequest>>["auth"],
+  conversationId: string
+) {
+  const result = await getConversation(auth, conversationId);
+  if (result.isErr()) {
+    throw result.error;
+  }
+
+  return result.value;
+}
 
 async function createUserMessage(
   auth: Awaited<ReturnType<typeof createPrivateApiMockRequest>>["auth"],
@@ -113,7 +126,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
     expect(res._getJSONData().error.type).toBe("feature_flag_not_found");
   });
 
-  it("creates a fork and returns the child conversation", async () => {
+  it("creates a fork and returns the child conversation id", async () => {
     const { req, res, auth, globalSpace } = await createPrivateApiMockRequest({
       method: "POST",
     });
@@ -144,17 +157,18 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(res._getJSONData().conversation.title).toBe(
-      "Parent conversation (forked)"
-    );
-    expect(res._getJSONData().conversation.forkedFrom).toEqual({
+    const { conversationId } = res._getJSONData();
+    const conversation = await fetchConversationOrThrow(auth, conversationId);
+
+    expect(conversation.title).toBe("Parent conversation (forked)");
+    expect(conversation.forkedFrom).toEqual({
       parentConversationId: parentConversation.sId,
       sourceMessageId: sourceMessage.sId,
       branchedAt: expect.any(Number),
       user: auth.getNonNullableUser().toJSON(),
     });
-    expect(res._getJSONData().conversation.depth).toBe(1);
-    expect(res._getJSONData().conversation.spaceId).toBe(globalSpace.sId);
+    expect(conversation.depth).toBe(1);
+    expect(conversation.spaceId).toBe(globalSpace.sId);
   });
 
   it("accepts an empty string body and resolves the latest source message", async () => {
@@ -188,7 +202,10 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(res._getJSONData().conversation.forkedFrom).toEqual({
+    const { conversationId } = res._getJSONData();
+    const conversation = await fetchConversationOrThrow(auth, conversationId);
+
+    expect(conversation.forkedFrom).toEqual({
       parentConversationId: parentConversation.sId,
       sourceMessageId: sourceMessage.sId,
       branchedAt: expect.any(Number),

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
@@ -4,7 +4,6 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
-import type { ConversationType } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
@@ -18,7 +17,7 @@ const PostConversationForkBodySchema = t.partial({
 });
 
 export type PostConversationForkResponseBody = {
-  conversation: ConversationType;
+  conversationId: string;
 };
 
 async function handler(
@@ -112,7 +111,7 @@ async function handler(
   }
 
   return res.status(200).json({
-    conversation: createRes.value,
+    conversationId: createRes.value,
   });
 }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
@@ -4,6 +4,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
+import type { ConversationType } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
@@ -18,6 +19,8 @@ const PostConversationForkBodySchema = t.partial({
 
 export type PostConversationForkResponseBody = {
   conversationId: string;
+  // TODO(sessions): Remove after all clients use `conversationId`.
+  conversation: Pick<ConversationType, "sId">;
 };
 
 async function handler(
@@ -112,6 +115,9 @@ async function handler(
 
   return res.status(200).json({
     conversationId: createRes.value,
+    conversation: {
+      sId: createRes.value,
+    },
   });
 }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
@@ -4,7 +4,6 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
-import type { ConversationType } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
@@ -19,8 +18,6 @@ const PostConversationForkBodySchema = t.partial({
 
 export type PostConversationForkResponseBody = {
   conversationId: string;
-  // TODO(sessions): Remove after all clients use `conversationId`.
-  conversation: Pick<ConversationType, "sId">;
 };
 
 async function handler(
@@ -115,9 +112,6 @@ async function handler(
 
   return res.status(200).json({
     conversationId: createRes.value,
-    conversation: {
-      sId: createRes.value,
-    },
   });
 }
 


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24411.
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

Shrinks the fork endpoint contract from a full conversation payload to `{ conversationId }`. The client already redirects and refetches the conversation from the route, so this removes an unnecessary backend reload after best-effort attachment copy.

## Risks
Blast radius: conversation branching API response shape and post-fork navigation
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/api/assistant/conversation/forks.test.ts pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts`
