### PR TITLE
[poke] make hash optional for dust app api in poke

### DIFF
--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -35,7 +35,7 @@ async function handler(
     });
   }
 
-  if (!isString(hash)) {
+  if (hash !== undefined && !isString(hash)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {


### PR DESCRIPTION
## Description
This PR is to fix the end point in poke to see dust app details. Currently you cannot see anything since it will return `{"error":{"type":"invalid_request_error","message":"Invalid hash parameter."}}`

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
