### PR TITLE
feat(metronome): gate MAU sync on contract subscription presence

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -5,8 +5,9 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import type { Authenticator } from "@app/lib/auth";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
-  isSeatBasedMetronomeContract,
+  getSeatSubscriptionIdFromContract,
   syncSeatCount,
 } from "@app/lib/metronome/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -23,7 +24,7 @@ import type {
   MembershipOriginType,
   MembershipRoleType,
 } from "@app/types/memberships";
-import { Err, Ok, type Result } from "@app/types/shared/result";
+import { Ok, type Result } from "@app/types/shared/result";
 import type {
   ActiveRoleType,
   LightWorkspaceType,
@@ -44,16 +45,13 @@ async function syncSeatCountForWorkspace(
     return new Ok(undefined);
   }
 
-  const seatBasedResult = await isSeatBasedMetronomeContract({
-    metronomeCustomerId: workspace.metronomeCustomerId,
-    metronomeContractId: subscription.metronomeContractId,
-  });
-
-  if (seatBasedResult.isErr()) {
-    return new Err(seatBasedResult.error);
+  const contract = await getActiveContract(workspace.sId);
+  if (!contract) {
+    return new Ok(undefined);
   }
 
-  if (!seatBasedResult.value) {
+  const seatSubscriptionId = getSeatSubscriptionIdFromContract(contract);
+  if (!seatSubscriptionId) {
     return new Ok(undefined);
   }
 
@@ -61,6 +59,7 @@ async function syncSeatCountForWorkspace(
     metronomeCustomerId: workspace.metronomeCustomerId,
     contractId: subscription.metronomeContractId,
     workspace,
+    seatSubscriptionId,
   });
 }
 

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -50,8 +50,9 @@ async function syncSeatCountForWorkspace(
     return new Ok(undefined);
   }
 
-  const seatSubscriptionId = getSeatSubscriptionIdFromContract(contract);
-  if (!seatSubscriptionId) {
+  // Gate on seat subscription presence — contracts without a seat product (e.g. enterprise)
+  // should not trigger a seat sync.
+  if (!getSeatSubscriptionIdFromContract(contract)) {
     return new Ok(undefined);
   }
 
@@ -59,7 +60,7 @@ async function syncSeatCountForWorkspace(
     metronomeCustomerId: workspace.metronomeCustomerId,
     contractId: subscription.metronomeContractId,
     workspace,
-    seatSubscriptionId,
+    contract,
   });
 }
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -371,6 +371,28 @@ export async function getMetronomeActiveContract(
 }
 
 /**
+ * Retrieve a specific Metronome contract by customer + contract ID.
+ */
+export async function getMetronomeContractById({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<Result<ContractV2, Error>> {
+  try {
+    const response = await getMetronomeClient().v2.contracts.retrieve({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+    });
+
+    return new Ok(response.data);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
  * Schedule a Metronome contract to end at the given date (defaults to now).
  * Metronome requires ending_before on an hour boundary; we ceil to avoid
  * dropping usage in the current partial hour.
@@ -452,13 +474,16 @@ export async function getMetronomeContractPackageAliases({
   metronomeContractId: string;
 }): Promise<Result<string[], Error>> {
   try {
-    const contractResponse = await getMetronomeClient().v2.contracts.retrieve({
-      customer_id: metronomeCustomerId,
-      contract_id: metronomeContractId,
+    const contractResult = await getMetronomeContractById({
+      metronomeCustomerId,
+      metronomeContractId,
     });
+    if (contractResult.isErr()) {
+      return new Err(contractResult.error);
+    }
 
     const packageId = (
-      contractResponse.data as ContractV2 & { package_id: string } // package_id is missing in ContractV2 but is actually returned
+      contractResult.value as ContractV2 & { package_id: string } // package_id is missing in ContractV2 but is actually returned
     ).package_id;
     if (!packageId) {
       return new Ok([]);

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -18,6 +18,9 @@ const {
   mockCreateMetronomeContract,
   mockCreateMetronomeCustomer,
   mockFindMetronomeCustomerByAlias,
+  mockGetMetronomeContractById,
+  mockGetSeatSubscriptionIdFromContract,
+  mockHasMauSubscriptionInContract,
   mockPrices,
   mockScheduleMetronomeContractEnd,
   mockSyncMauCount,
@@ -29,6 +32,9 @@ const {
     mockCreateMetronomeContract: vi.fn(),
     mockCreateMetronomeCustomer: vi.fn(),
     mockFindMetronomeCustomerByAlias: vi.fn(),
+    mockGetMetronomeContractById: vi.fn(),
+    mockGetSeatSubscriptionIdFromContract: vi.fn(),
+    mockHasMauSubscriptionInContract: vi.fn(),
     mockPrices,
     mockScheduleMetronomeContractEnd: vi.fn(),
     mockSyncMauCount: vi.fn(),
@@ -43,6 +49,7 @@ vi.mock("@app/lib/metronome/client", () => ({
   epochSecondsToFloorHourISO: vi.fn(),
   findMetronomeCustomerByAlias: mockFindMetronomeCustomerByAlias,
   getMetronomeClient: vi.fn(),
+  getMetronomeContractById: mockGetMetronomeContractById,
   scheduleMetronomeContractEnd: mockScheduleMetronomeContractEnd,
 }));
 
@@ -53,11 +60,13 @@ vi.mock("@app/lib/metronome/mau_sync", async () => {
 
   return {
     ...actual,
+    hasMauSubscriptionInContract: mockHasMauSubscriptionInContract,
     syncMauCount: mockSyncMauCount,
   };
 });
 
 vi.mock("@app/lib/metronome/seats", () => ({
+  getSeatSubscriptionIdFromContract: mockGetSeatSubscriptionIdFromContract,
   syncSeatCount: mockSyncSeatCount,
 }));
 
@@ -95,6 +104,11 @@ const WORKSPACE = {
   name: "Workspace",
 } as LightWorkspaceType;
 
+const CONTRACT = {
+  id: "m-contract",
+  subscriptions: [],
+};
+
 beforeEach(() => {
   mockPrices.retrieve.mockReset();
 
@@ -113,6 +127,15 @@ beforeEach(() => {
 
   mockScheduleMetronomeContractEnd.mockReset();
   mockScheduleMetronomeContractEnd.mockResolvedValue(new Ok(undefined));
+
+  mockGetMetronomeContractById.mockReset();
+  mockGetMetronomeContractById.mockResolvedValue(new Ok(CONTRACT));
+
+  mockGetSeatSubscriptionIdFromContract.mockReset();
+  mockGetSeatSubscriptionIdFromContract.mockReturnValue("seat-subscription");
+
+  mockHasMauSubscriptionInContract.mockReset();
+  mockHasMauSubscriptionInContract.mockReturnValue(true);
 
   mockSyncSeatCount.mockReset();
   mockSyncSeatCount.mockResolvedValue(new Ok(undefined));
@@ -647,7 +670,7 @@ describe("buildEnterpriseOverrides", () => {
 // ---------------------------------------------------------------------------
 
 describe("provisionMetronomeCustomerAndContract", () => {
-  it("syncs seats and MAU for seat-based packages", async () => {
+  it("syncs seats and MAU when the contract has both subscriptions", async () => {
     const result = await provisionMetronomeCustomerAndContract({
       workspace: WORKSPACE,
       stripeCustomerId: "stripe-customer",
@@ -656,12 +679,21 @@ describe("provisionMetronomeCustomerAndContract", () => {
     });
 
     expect(result.isOk()).toBe(true);
+    expect(mockGetMetronomeContractById).toHaveBeenCalledWith({
+      metronomeCustomerId: "m-customer",
+      metronomeContractId: "m-contract",
+    });
+    expect(mockGetSeatSubscriptionIdFromContract).toHaveBeenCalledWith(
+      CONTRACT
+    );
+    expect(mockHasMauSubscriptionInContract).toHaveBeenCalledWith(CONTRACT);
     expect(mockSyncSeatCount).toHaveBeenCalledTimes(1);
     expect(mockSyncSeatCount).toHaveBeenCalledWith({
       metronomeCustomerId: "m-customer",
       contractId: "m-contract",
       workspace: WORKSPACE,
       startingAt: START_DATE,
+      seatSubscriptionId: "seat-subscription",
     });
     expect(mockSyncMauCount).toHaveBeenCalledTimes(1);
     expect(mockSyncMauCount).toHaveBeenCalledWith({
@@ -669,10 +701,13 @@ describe("provisionMetronomeCustomerAndContract", () => {
       contractId: "m-contract",
       workspace: WORKSPACE,
       startingAt: START_DATE,
+      contract: CONTRACT,
     });
   });
 
-  it("skips seats for enterprise packages and still syncs MAU", async () => {
+  it("skips seat sync when the contract has no seat subscription", async () => {
+    mockGetSeatSubscriptionIdFromContract.mockReturnValue(undefined);
+
     const result = await provisionMetronomeCustomerAndContract({
       workspace: WORKSPACE,
       stripeCustomerId: "stripe-customer",
@@ -684,10 +719,25 @@ describe("provisionMetronomeCustomerAndContract", () => {
     expect(mockSyncSeatCount).not.toHaveBeenCalled();
     expect(mockSyncMauCount).toHaveBeenCalledTimes(1);
   });
+
+  it("skips MAU sync when the contract has no MAU subscription", async () => {
+    mockHasMauSubscriptionInContract.mockReturnValue(false);
+
+    const result = await provisionMetronomeCustomerAndContract({
+      workspace: WORKSPACE,
+      stripeCustomerId: "stripe-customer",
+      packageAlias: "legacy-pro-monthly",
+      uniquenessKey: "uniq_123",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockSyncSeatCount).toHaveBeenCalledTimes(1);
+    expect(mockSyncMauCount).not.toHaveBeenCalled();
+  });
 });
 
 describe("switchMetronomeContractPackage", () => {
-  it("syncs seats and MAU for seat-based packages", async () => {
+  it("syncs seats and MAU when the contract has both subscriptions", async () => {
     const result = await switchMetronomeContractPackage({
       metronomeCustomerId: "m-customer",
       oldContractId: "old-contract",
@@ -703,11 +753,14 @@ describe("switchMetronomeContractPackage", () => {
       contractId: "m-contract",
       workspace: WORKSPACE,
       startingAt: START_DATE,
+      seatSubscriptionId: "seat-subscription",
     });
     expect(mockSyncMauCount).toHaveBeenCalledTimes(1);
   });
 
-  it("skips seats for enterprise packages and still syncs MAU", async () => {
+  it("skips seat sync when the switched contract has no seat subscription", async () => {
+    mockGetSeatSubscriptionIdFromContract.mockReturnValue(undefined);
+
     const result = await switchMetronomeContractPackage({
       metronomeCustomerId: "m-customer",
       oldContractId: "old-contract",
@@ -718,5 +771,20 @@ describe("switchMetronomeContractPackage", () => {
     expect(result.isOk()).toBe(true);
     expect(mockSyncSeatCount).not.toHaveBeenCalled();
     expect(mockSyncMauCount).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips MAU sync when the switched contract has no MAU subscription", async () => {
+    mockHasMauSubscriptionInContract.mockReturnValue(false);
+
+    const result = await switchMetronomeContractPackage({
+      metronomeCustomerId: "m-customer",
+      oldContractId: "old-contract",
+      workspace: WORKSPACE,
+      packageAlias: "legacy-business",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockSyncSeatCount).toHaveBeenCalledTimes(1);
+    expect(mockSyncMauCount).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -693,7 +693,7 @@ describe("provisionMetronomeCustomerAndContract", () => {
       contractId: "m-contract",
       workspace: WORKSPACE,
       startingAt: START_DATE,
-      seatSubscriptionId: "seat-subscription",
+      contract: CONTRACT,
     });
     expect(mockSyncMauCount).toHaveBeenCalledTimes(1);
     expect(mockSyncMauCount).toHaveBeenCalledWith({
@@ -753,7 +753,7 @@ describe("switchMetronomeContractPackage", () => {
       contractId: "m-contract",
       workspace: WORKSPACE,
       startingAt: START_DATE,
-      seatSubscriptionId: "seat-subscription",
+      contract: CONTRACT,
     });
     expect(mockSyncMauCount).toHaveBeenCalledTimes(1);
   });

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -218,7 +218,7 @@ async function syncContractQuantities(
               contractId: metronomeContractId,
               workspace,
               startingAt,
-              seatSubscriptionId,
+              contract,
             }),
         ]
       : []),

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -5,6 +5,7 @@ import {
   epochSecondsToFloorHourISO,
   findMetronomeCustomerByAlias,
   getMetronomeClient,
+  getMetronomeContractById,
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
 import {
@@ -16,14 +17,15 @@ import {
 } from "@app/lib/metronome/constants";
 import {
   computeTierQuantity,
+  hasMauSubscriptionInContract,
   parseMauTiers,
   syncMauCount,
 } from "@app/lib/metronome/mau_sync";
-import { syncSeatCount } from "@app/lib/metronome/seats";
 import {
-  isSeatBasedMetronomePackageAlias,
-  LEGACY_ENTERPRISE_PACKAGE_ALIAS,
-} from "@app/lib/metronome/types";
+  getSeatSubscriptionIdFromContract,
+  syncSeatCount,
+} from "@app/lib/metronome/seats";
+import { LEGACY_ENTERPRISE_PACKAGE_ALIAS } from "@app/lib/metronome/types";
 import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
 import { getStripeClient } from "@app/lib/plans/stripe";
 import { countActiveUsersForPeriodInWorkspace } from "@app/lib/plans/usage/mau";
@@ -79,13 +81,15 @@ export async function switchMetronomeContractPackage({
   }
 
   const { contractId: metronomeContractId, startingAt } = contractResult.value;
-  await syncContractQuantities(
+  const syncResult = await syncContractQuantities(
     metronomeCustomerId,
     metronomeContractId,
     workspace,
-    startingAt,
-    packageAlias
+    startingAt
   );
+  if (syncResult.isErr()) {
+    return new Err(syncResult.error);
+  }
 
   return new Ok({ metronomeContractId });
 }
@@ -138,13 +142,15 @@ export async function provisionMetronomeCustomerAndContract({
   }
 
   const { contractId: metronomeContractId, startingAt } = contractResult.value;
-  await syncContractQuantities(
+  const syncResult = await syncContractQuantities(
     metronomeCustomerId,
     metronomeContractId,
     workspace,
-    startingAt,
-    packageAlias
+    startingAt
   );
+  if (syncResult.isErr()) {
+    return new Err(syncResult.error);
+  }
 
   return new Ok({
     metronomeCustomerId,
@@ -187,12 +193,22 @@ async function syncContractQuantities(
   metronomeCustomerId: string,
   metronomeContractId: string,
   workspace: LightWorkspaceType,
-  startingAt: string,
-  packageAlias: string
-) {
-  const shouldSyncSeats = isSeatBasedMetronomePackageAlias(packageAlias);
+  startingAt: string
+): Promise<Result<void, Error>> {
+  const contractResult = await getMetronomeContractById({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (contractResult.isErr()) {
+    return new Err(contractResult.error);
+  }
 
-  // Provision seats and MAU on the new contract.
+  const contract = contractResult.value;
+
+  const seatSubscriptionId = getSeatSubscriptionIdFromContract(contract);
+  const shouldSyncSeats = seatSubscriptionId !== undefined;
+  const shouldSyncMau = hasMauSubscriptionInContract(contract);
+
   const syncFns = [
     ...(shouldSyncSeats
       ? [
@@ -202,18 +218,34 @@ async function syncContractQuantities(
               contractId: metronomeContractId,
               workspace,
               startingAt,
+              seatSubscriptionId,
             }),
         ]
       : []),
-    () =>
-      syncMauCount({
-        metronomeCustomerId,
-        contractId: metronomeContractId,
-        workspace,
-        startingAt,
-      }),
+    ...(shouldSyncMau
+      ? [
+          () =>
+            syncMauCount({
+              metronomeCustomerId,
+              contractId: metronomeContractId,
+              workspace,
+              startingAt,
+              contract,
+            }),
+        ]
+      : []),
   ];
-  await concurrentExecutor(syncFns, (fn) => fn(), { concurrency: 2 });
+  const results = await concurrentExecutor(syncFns, (fn) => fn(), {
+    concurrency: 2,
+  });
+
+  for (const result of results) {
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+  }
+
+  return new Ok(undefined);
 }
 
 /** Extract the MAU threshold number from a billing mode (MAU_1→1, MAU_5→5, MAU_10→10). */

--- a/front/lib/metronome/mau_contract.test.ts
+++ b/front/lib/metronome/mau_contract.test.ts
@@ -1,0 +1,57 @@
+import { hasMauSubscriptionInContract } from "@app/lib/metronome/mau_sync";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", () => ({
+  getMetronomeContractById: vi.fn(),
+  updateSubscriptionQuantity: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/constants", () => ({
+  getProductMauId: () => "mau-product",
+  getProductMauTierIds: () => ["mau-tier-1", "mau-tier-2", "mau-tier-3"],
+}));
+
+describe("hasMauSubscriptionInContract", () => {
+  it("returns true when the contract contains the simple MAU product", () => {
+    expect(
+      hasMauSubscriptionInContract({
+        subscriptions: [
+          {
+            id: "sub_1",
+            subscription_rate: { product: { id: "mau-product" } },
+          },
+        ],
+      })
+    ).toBe(true);
+  });
+
+  it("returns true when the contract contains an MAU tier product", () => {
+    expect(
+      hasMauSubscriptionInContract({
+        subscriptions: [
+          {
+            id: "sub_1",
+            subscription_rate: { product: { id: "mau-tier-2" } },
+          },
+        ],
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when the contract has no MAU products", () => {
+    expect(
+      hasMauSubscriptionInContract({
+        subscriptions: [
+          {
+            id: "sub_1",
+            subscription_rate: { product: { id: "other-product" } },
+          },
+        ],
+      })
+    ).toBe(false);
+  });
+
+  it("returns false when the contract has no subscriptions", () => {
+    expect(hasMauSubscriptionInContract({})).toBe(false);
+  });
+});

--- a/front/lib/metronome/mau_sync.ts
+++ b/front/lib/metronome/mau_sync.ts
@@ -1,9 +1,11 @@
-import { updateSubscriptionQuantity } from "@app/lib/metronome/client";
+import {
+  getMetronomeContractById,
+  updateSubscriptionQuantity,
+} from "@app/lib/metronome/client";
 import {
   getProductMauId,
   getProductMauTierIds,
 } from "@app/lib/metronome/constants";
-import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { countActiveUsersForPeriodInWorkspace } from "@app/lib/plans/usage/mau";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -136,6 +138,34 @@ interface TieredMauInfo {
 
 type MauInfo = SimpleMauInfo | TieredMauInfo;
 
+interface MauContractLike {
+  id?: string;
+  custom_fields?: Record<string, string>;
+  subscriptions?: Array<{
+    id?: string;
+    subscription_rate: { product: { id: string } };
+    quantity_schedule?: Array<{ quantity: number }>;
+    billing_periods?: {
+      next?: { starting_at?: string };
+      current?: { starting_at?: string };
+    };
+  }>;
+}
+
+export function hasMauSubscriptionInContract(
+  contract: MauContractLike
+): boolean {
+  const subscriptions = contract.subscriptions ?? [];
+  const productIds = new Set(
+    subscriptions.map((s) => s.subscription_rate.product.id)
+  );
+
+  return (
+    productIds.has(getProductMauId()) ||
+    getProductMauTierIds().some((productId) => productIds.has(productId))
+  );
+}
+
 /**
  * Retrieve a contract and extract MAU info.
  *
@@ -143,10 +173,13 @@ type MauInfo = SimpleMauInfo | TieredMauInfo;
  * - Otherwise → simple mode (single MAU product).
  * - MAU_THRESHOLD custom field controls the threshold (default 1).
  */
-async function getContractMauInfo(
-  workspaceId: string
-): Promise<MauInfo | undefined> {
-  const contract = await getActiveContract(workspaceId);
+function getContractMauInfoFromContract({
+  workspaceId,
+  contract,
+}: {
+  workspaceId: string;
+  contract: MauContractLike;
+}): MauInfo | undefined {
   if (!contract?.subscriptions?.length) {
     return undefined;
   }
@@ -247,13 +280,31 @@ export async function syncMauCount({
   contractId,
   workspace,
   startingAt,
+  contract,
 }: {
   metronomeCustomerId: string;
   contractId: string;
   workspace: LightWorkspaceType;
   startingAt?: string;
+  contract?: MauContractLike;
 }): Promise<Result<void, Error>> {
-  const mauInfo = await getContractMauInfo(workspace.sId);
+  let contractData = contract;
+  if (!contractData) {
+    const contractResult = await getMetronomeContractById({
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+    });
+    if (contractResult.isErr()) {
+      return new Err(contractResult.error);
+    }
+    contractData = contractResult.value;
+  }
+  const mauInfo = contractData
+    ? getContractMauInfoFromContract({
+        workspaceId: workspace.sId,
+        contract: contractData,
+      })
+    : undefined;
   if (!mauInfo) {
     logger.warn(
       { workspaceId: workspace.sId, contractId },

--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -1,68 +1,43 @@
-import { isSeatBasedMetronomeContract } from "@app/lib/metronome/seats";
-import { Err, Ok } from "@app/types/shared/result";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const { mockGetMetronomeContractPackageAliases } = vi.hoisted(() => ({
-  mockGetMetronomeContractPackageAliases: vi.fn(),
-}));
+import { getSeatSubscriptionIdFromContract } from "@app/lib/metronome/seats";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/metronome/client", () => ({
-  getMetronomeContractPackageAliases: mockGetMetronomeContractPackageAliases,
+  getMetronomeContractById: vi.fn(),
   updateSubscriptionQuantity: vi.fn(),
 }));
 
-describe("isSeatBasedMetronomeContract", () => {
-  beforeEach(() => {
-    mockGetMetronomeContractPackageAliases.mockReset();
+vi.mock("@app/lib/metronome/constants", () => ({
+  getProductWorkspaceSeatId: () => "workspace-seat-product",
+}));
+
+describe("getSeatSubscriptionIdFromContract", () => {
+  it("returns the seat subscription ID when the contract contains the seat product", () => {
+    expect(
+      getSeatSubscriptionIdFromContract({
+        subscriptions: [
+          {
+            id: "sub_1",
+            subscription_rate: { product: { id: "workspace-seat-product" } },
+          },
+        ],
+      })
+    ).toBe("sub_1");
   });
 
-  it("returns true for pro/business package aliases", async () => {
-    mockGetMetronomeContractPackageAliases.mockResolvedValue(
-      new Ok(["legacy-pro-monthly", "legacy-business-eur"])
-    );
-
-    const result = await isSeatBasedMetronomeContract({
-      metronomeCustomerId: "m-customer",
-      metronomeContractId: "m-contract",
-    });
-
-    expect(result.isOk()).toBe(true);
-    expect(result.isErr()).toBe(false);
-    if (result.isOk()) {
-      expect(result.value).toBe(true);
-    }
+  it("returns undefined when the contract does not contain the seat product", () => {
+    expect(
+      getSeatSubscriptionIdFromContract({
+        subscriptions: [
+          {
+            id: "sub_1",
+            subscription_rate: { product: { id: "other-product" } },
+          },
+        ],
+      })
+    ).toBeUndefined();
   });
 
-  it("returns false for enterprise package aliases", async () => {
-    mockGetMetronomeContractPackageAliases.mockResolvedValue(
-      new Ok(["legacy-enterprise", "legacy-enterprise-eur"])
-    );
-
-    const result = await isSeatBasedMetronomeContract({
-      metronomeCustomerId: "m-customer",
-      metronomeContractId: "m-contract",
-    });
-
-    expect(result.isOk()).toBe(true);
-    expect(result.isErr()).toBe(false);
-    if (result.isOk()) {
-      expect(result.value).toBe(false);
-    }
-  });
-
-  it("returns Err when package alias lookup fails", async () => {
-    mockGetMetronomeContractPackageAliases.mockResolvedValue(
-      new Err(new Error("lookup failed"))
-    );
-
-    const result = await isSeatBasedMetronomeContract({
-      metronomeCustomerId: "m-customer",
-      metronomeContractId: "m-contract",
-    });
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.message).toBe("lookup failed");
-    }
+  it("returns undefined when the contract has no subscriptions", () => {
+    expect(getSeatSubscriptionIdFromContract({})).toBeUndefined();
   });
 });

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -73,17 +73,20 @@ export async function syncSeatCount({
   contractId,
   workspace,
   startingAt,
-  seatSubscriptionId,
+  contract,
 }: {
   metronomeCustomerId: string;
   contractId: string;
   workspace: LightWorkspaceType;
   startingAt?: string;
-  seatSubscriptionId?: string;
+  contract?: SeatContractLike;
 }): Promise<Result<void, Error>> {
-  let subscriptionId = seatSubscriptionId;
-
-  if (!subscriptionId) {
+  // When the contract is provided by the caller (provisioning, membership hooks),
+  // use it directly to avoid a redundant fetch. Mirrors the same pattern as syncMauCount.
+  let subscriptionId: string | undefined;
+  if (contract) {
+    subscriptionId = getSeatSubscriptionIdFromContract(contract);
+  } else {
     const subscriptionIdResult = await getSeatSubscriptionIdOnContract({
       metronomeCustomerId,
       metronomeContractId: contractId,

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1,57 +1,63 @@
 import {
-  getMetronomeContractPackageAliases,
+  getMetronomeContractById,
   updateSubscriptionQuantity,
 } from "@app/lib/metronome/client";
 import { getProductWorkspaceSeatId } from "@app/lib/metronome/constants";
-import { getActiveContract } from "@app/lib/metronome/plan_type";
-import { isSeatBasedMetronomePackageAlias } from "@app/lib/metronome/types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 
-/**
- * Find the seat subscription ID on a contract by matching the Workspace Seat product ID.
- */
-async function getSeatSubscriptionId(
-  workspaceId: string
-): Promise<string | undefined> {
+interface SeatContractLike {
+  subscriptions?: Array<{
+    id?: string;
+    subscription_rate: { product: { id: string } };
+  }>;
+}
+
+export function getSeatSubscriptionIdFromContract(
+  contract: SeatContractLike
+): string | undefined {
   const seatProductId = getProductWorkspaceSeatId();
 
-  const contract = await getActiveContract(workspaceId);
-  if (!contract?.subscriptions?.length) {
+  if (!contract.subscriptions?.length) {
     return undefined;
   }
 
   const seatSub = contract.subscriptions.find(
-    (s: { subscription_rate: { product: { id: string } } }) =>
-      s.subscription_rate.product.id === seatProductId
+    (s) => s.subscription_rate.product.id === seatProductId
   );
-  return seatSub?.id ?? undefined;
+  return seatSub?.id;
 }
 
 /**
- * Returns whether Metronome contract belongs to a seat-based package family.
- * MAU/FIXED enterprise contracts are not seat-based and should not call syncSeatCount.
+ * Find the seat subscription ID on the given contract by matching the Workspace Seat product ID.
  */
-export async function isSeatBasedMetronomeContract({
+async function getSeatSubscriptionIdOnContract({
   metronomeCustomerId,
   metronomeContractId,
 }: {
   metronomeCustomerId: string;
   metronomeContractId: string;
-}): Promise<Result<boolean, Error>> {
-  const aliasesResult = await getMetronomeContractPackageAliases({
+}): Promise<Result<string | undefined, Error>> {
+  const contractResult = await getMetronomeContractById({
     metronomeCustomerId,
     metronomeContractId,
   });
-
-  if (aliasesResult.isErr()) {
-    return new Err(aliasesResult.error);
+  if (contractResult.isErr()) {
+    logger.warn(
+      {
+        error: contractResult.error,
+        metronomeCustomerId,
+        metronomeContractId,
+      },
+      "[Metronome] Failed to retrieve contract while checking seat subscription"
+    );
+    return new Err(contractResult.error);
   }
 
-  return new Ok(aliasesResult.value.some(isSeatBasedMetronomePackageAlias));
+  return new Ok(getSeatSubscriptionIdFromContract(contractResult.value));
 }
 
 /**
@@ -67,13 +73,27 @@ export async function syncSeatCount({
   contractId,
   workspace,
   startingAt,
+  seatSubscriptionId,
 }: {
   metronomeCustomerId: string;
   contractId: string;
   workspace: LightWorkspaceType;
   startingAt?: string;
+  seatSubscriptionId?: string;
 }): Promise<Result<void, Error>> {
-  const subscriptionId = await getSeatSubscriptionId(workspace.sId);
+  let subscriptionId = seatSubscriptionId;
+
+  if (!subscriptionId) {
+    const subscriptionIdResult = await getSeatSubscriptionIdOnContract({
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+    });
+    if (subscriptionIdResult.isErr()) {
+      return new Err(subscriptionIdResult.error);
+    }
+
+    subscriptionId = subscriptionIdResult.value;
+  }
   if (!subscriptionId) {
     logger.warn(
       { workspaceId: workspace.sId, contractId },

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -57,9 +57,3 @@ export interface MetronomeUsageWithGroupsResponse {
   value: number | null;
   group: Record<string, string> | null;
 }
-
-export function isSeatBasedMetronomePackageAlias(
-  packageAlias: string
-): boolean {
-  return PRO_OR_BUSINESS_PACKAGE_ALIASES.has(packageAlias);
-}

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -10,7 +10,11 @@ import {
   buildLlmUsageEvents,
   buildToolUseEvents,
 } from "@app/lib/metronome/events";
-import { syncMauCount } from "@app/lib/metronome/mau_sync";
+import {
+  hasMauSubscriptionInContract,
+  syncMauCount,
+} from "@app/lib/metronome/mau_sync";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   AgentMessageModel,
   MessageModel,
@@ -413,11 +417,27 @@ export async function syncMauCountToMetronomeForAllWorkspacesActivity(): Promise
       }
 
       try {
-        await syncMauCount({
+        const contract = await getActiveContract(workspace.sId);
+        if (!contract) {
+          return;
+        }
+        if (!hasMauSubscriptionInContract(contract)) {
+          return;
+        }
+
+        const result = await syncMauCount({
           metronomeCustomerId: workspace.metronomeCustomerId,
           contractId: subscription.metronomeContractId,
           workspace: renderLightWorkspaceType({ workspace }),
+          contract,
         });
+        if (result.isErr()) {
+          logger.error(
+            { workspaceId: workspace.sId, error: result.error },
+            "[Metronome] Failed to sync MAU count for workspace"
+          );
+          return;
+        }
       } catch (err) {
         logger.error(
           { workspaceId: workspace.sId, error: err },


### PR DESCRIPTION
## Description

Instead of inferring seat/MAU eligibility from the package alias, inspect the contract's actual subscriptions directly.

Use getActiveContract and adding a `contract` argument to `syncMauCount` and `syncSeatCount` to avoid multiple calls to the Metronome API. As getActiveContract returns a `CachedContract`, introduce `MauContractLike` and `SeatContractLike` interfaces.

## Tests

Unit

## Risk

Low

## Deploy Plan

Front