### PR TITLE
[front] fix: don't track describe_tables schema errors

### DIFF
--- a/front/lib/api/actions/servers/data_warehouses/tools/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/tools/index.ts
@@ -176,9 +176,14 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
     });
 
     if (schemaResult.isErr()) {
+      // Not tracked: schema retrieval failures typically reflect customer-side
+      // warehouse configuration (IP allowlists, credentials, network) that Dust
+      // cannot action. The underlying error message is surfaced to the model so
+      // it can relay actionable guidance (e.g. IP to allowlist) to the user.
       return new Err(
         new MCPError(
-          `Error retrieving database schema: ${schemaResult.error.message}`
+          `Error retrieving database schema: ${schemaResult.error.message}`,
+          { tracked: false }
         )
       );
     }


### PR DESCRIPTION
## Description

Schema retrieval failures in `describe_tables` (e.g. Snowflake rejecting our egress IP when it's not on the customer's allowlist) are customer-side config issues we can't fix, but they currently log at error level and page on-call.

Mark them with `{ tracked: false }` to match what `query_tables_v2` already does. The underlying error message still reaches the model, so the agent can tell the user what to do (e.g. which IP to allowlist).

## Tests

Type-checked. No logic change, only the log level and alerting flag.

## Risk

Low. Same trade-off we already made in `query_tables_v2`. Easy revert.

## Deploy Plan

Standard front deploy.