### PR TITLE
feat: remove conversations from project backend

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2053,7 +2053,7 @@ export async function postNewContentFragment(
 
     if (isContentFragmentInputWithContentNode(cf)) {
       await updateConversationRequirements(auth, {
-        contentFragmentDsvIds: [cf.nodeDataSourceViewId],
+        contentFragmentDatasourceViewIds: [cf.nodeDataSourceViewId],
         conversation,
         t,
       });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2053,7 +2053,7 @@ export async function postNewContentFragment(
 
     if (isContentFragmentInputWithContentNode(cf)) {
       await updateConversationRequirements(auth, {
-        contentFragment: cf,
+        contentFragmentDsvIds: [cf.nodeDataSourceViewId],
         conversation,
         t,
       });

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -6,7 +6,6 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
 import type { WorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -286,13 +285,6 @@ describe("updateConversationRequirements", () => {
         auth.user() ?? null
       );
 
-      // Create content fragment input
-      const contentFragment: ContentFragmentInputWithContentNode = {
-        title: "Test Fragment",
-        nodeId: "test-node-id",
-        nodeDataSourceViewId: dsView.sId,
-      };
-
       // Fetch conversation
       const fetchedConversationResult = await getConversation(
         auth,
@@ -303,9 +295,9 @@ describe("updateConversationRequirements", () => {
       }
       const regularConversation = fetchedConversationResult.value;
 
-      // Call updateConversationRequirements with content fragment
+      // Call updateConversationRequirements with content fragment DSV ID
       await updateConversationRequirements(auth, {
-        contentFragment,
+        contentFragmentDsvIds: [dsView.sId],
         conversation: regularConversation,
       });
 
@@ -361,12 +353,6 @@ describe("updateConversationRequirements", () => {
         auth.user() ?? null
       );
 
-      const contentFragment: ContentFragmentInputWithContentNode = {
-        title: "Test Fragment",
-        nodeId: "test-node-id",
-        nodeDataSourceViewId: dsView.sId,
-      };
-
       // Fetch agents and conversation
       const { getAgentConfigurations } = await import(
         "@app/lib/api/assistant/configuration/agent"
@@ -388,7 +374,7 @@ describe("updateConversationRequirements", () => {
       // Call updateConversationRequirements with both
       await updateConversationRequirements(auth, {
         agents,
-        contentFragment,
+        contentFragmentDsvIds: [dsView.sId],
         conversation: regularConversation,
       });
 

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -1,5 +1,8 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { updateConversationRequirements } from "@app/lib/api/assistant/conversation/permissions";
+import {
+  rebuildConversationRequirements,
+  updateConversationRequirements,
+} from "@app/lib/api/assistant/conversation/permissions";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -295,9 +298,9 @@ describe("updateConversationRequirements", () => {
       }
       const regularConversation = fetchedConversationResult.value;
 
-      // Call updateConversationRequirements with content fragment DSV ID
+      // Call updateConversationRequirements with content fragment datasource view ID
       await updateConversationRequirements(auth, {
-        contentFragmentDsvIds: [dsView.sId],
+        contentFragmentDatasourceViewIds: [dsView.sId],
         conversation: regularConversation,
       });
 
@@ -374,7 +377,7 @@ describe("updateConversationRequirements", () => {
       // Call updateConversationRequirements with both
       await updateConversationRequirements(auth, {
         agents,
-        contentFragmentDsvIds: [dsView.sId],
+        contentFragmentDatasourceViewIds: [dsView.sId],
         conversation: regularConversation,
       });
 
@@ -633,5 +636,138 @@ describe("updateConversationRequirements", () => {
         anotherProjectSpace.sId
       );
     });
+  });
+});
+
+// rebuildConversationRequirements is called after a project conversation is
+// moved out of its project. While in the project, the conversation's
+// requestedSpaceIds is forced to [projectSpace.sId]. After moving out, it
+// must be recomputed from the actual agents and content fragments mentioned
+// in the conversation.
+describe("rebuildConversationRequirements", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let projectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
+  let regularSpace: Awaited<ReturnType<typeof SpaceFactory.regular>>;
+  let anotherRegularSpace: Awaited<ReturnType<typeof SpaceFactory.regular>>;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    projectSpace = await SpaceFactory.project(workspace);
+    regularSpace = await SpaceFactory.regular(workspace);
+    anotherRegularSpace = await SpaceFactory.regular(workspace);
+
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const userJson = auth.getNonNullableUser().toJSON();
+
+    for (const space of [projectSpace, regularSpace, anotherRegularSpace]) {
+      const group = space.groups.find((g) => g.kind === "regular");
+      if (!group) {
+        continue;
+      }
+      const addRes = await group.dangerouslyAddMember(internalAdminAuth, {
+        user: userJson,
+      });
+      if (addRes.isErr()) {
+        throw new Error(
+          `Failed to add user to ${space.name}: ${addRes.error.message}`
+        );
+      }
+    }
+
+    await auth.refresh();
+  });
+
+  const fetchConversationResource = async (conversationSId: string) => {
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversationSId
+    );
+    if (!conversationResource) {
+      throw new Error("Failed to fetch conversation resource");
+    }
+    return conversationResource;
+  };
+
+  // Sets up a project conversation in the invariant state: spaceId points to
+  // the project and requestedSpaceIds is [projectSpace.sId].
+  const createProjectConversation = async ({
+    agentConfigurationId,
+    withAgentMessage,
+  }: {
+    agentConfigurationId: string;
+    withAgentMessage: boolean;
+  }) => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId,
+      messagesCreatedAt: withAgentMessage ? [new Date()] : [],
+      spaceId: projectSpace.id,
+    });
+    await ConversationResource.updateRequirements(auth, conversation.sId, [
+      projectSpace.id,
+    ]);
+
+    const initialResource = await fetchConversationResource(conversation.sId);
+    expect(initialResource.requestedSpaceIds).toEqual([projectSpace.id]);
+
+    return conversation;
+  };
+
+  // Simulates the move-out flow: clear the space association and rebuild.
+  const moveOutAndRebuild = async (conversationSId: string) => {
+    const conversationResource =
+      await fetchConversationResource(conversationSId);
+    await conversationResource.clearSpaceId();
+    await rebuildConversationRequirements(auth, conversationResource);
+  };
+
+  it("replaces the project requirement with the mentioned agent's requested spaces", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Agent 1",
+      requestedSpaceIds: [regularSpace.id],
+    });
+
+    const conversation = await createProjectConversation({
+      agentConfigurationId: agent.sId,
+      withAgentMessage: true,
+    });
+
+    await moveOutAndRebuild(conversation.sId);
+
+    const updatedResource = await fetchConversationResource(conversation.sId);
+    expect(updatedResource.requestedSpaceIds).toEqual([regularSpace.id]);
+  });
+
+  it("clears the project requirement when no agents or content fragments are present", async () => {
+    const conversation = await createProjectConversation({
+      agentConfigurationId: "test-agent",
+      withAgentMessage: false,
+    });
+
+    await moveOutAndRebuild(conversation.sId);
+
+    const updatedResource = await fetchConversationResource(conversation.sId);
+    expect(updatedResource.requestedSpaceIds).toEqual([]);
+  });
+
+  it("clears the project requirement when the mentioned agent has no required spaces", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Agent 1",
+    });
+
+    const conversation = await createProjectConversation({
+      agentConfigurationId: agent.sId,
+      withAgentMessage: true,
+    });
+
+    await moveOutAndRebuild(conversation.sId);
+
+    const updatedResource = await fetchConversationResource(conversation.sId);
+    expect(updatedResource.requestedSpaceIds).toEqual([]);
   });
 });

--- a/front/lib/api/assistant/conversation/permissions.ts
+++ b/front/lib/api/assistant/conversation/permissions.ts
@@ -139,12 +139,12 @@ export async function updateConversationRequirements(
   auth: Authenticator,
   {
     agents,
-    contentFragmentDsvIds,
+    contentFragmentDatasourceViewIds,
     conversation,
     t,
   }: {
     agents?: LightAgentConfigurationType[];
-    contentFragmentDsvIds?: string[];
+    contentFragmentDatasourceViewIds?: string[];
     conversation: ConversationWithoutContentType;
     t?: Transaction;
   }
@@ -178,10 +178,10 @@ export async function updateConversationRequirements(
   if (agents) {
     newSpaceRequirements = agents.flatMap((agent) => agent.requestedSpaceIds);
   }
-  if (contentFragmentDsvIds) {
+  if (!!contentFragmentDatasourceViewIds?.length) {
     const requestedSpaceIds = await getContentFragmentsSpaceIds(
       auth,
-      contentFragmentDsvIds
+      contentFragmentDatasourceViewIds
     );
     newSpaceRequirements.push(...requestedSpaceIds);
   }
@@ -245,7 +245,7 @@ export async function rebuildConversationRequirements(
   // Clear existing requirements so that updateConversationRequirements starts from a clean state.
   await conversationResource.updateRequirements([]);
 
-  const { agentConfigurationIds, contentFragmentDsvIds } =
+  const { agentConfigurationIds, contentFragmentDatasourceViewIds } =
     await conversationResource.fetchAgentConfigurationAndContentFragmentIds(
       auth
     );
@@ -260,7 +260,7 @@ export async function rebuildConversationRequirements(
 
   await updateConversationRequirements(auth, {
     agents,
-    contentFragmentDsvIds,
+    contentFragmentDatasourceViewIds,
     conversation: conversationResource.toJSON(),
   });
 }

--- a/front/lib/api/assistant/conversation/permissions.ts
+++ b/front/lib/api/assistant/conversation/permissions.ts
@@ -1,14 +1,12 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { getContentFragmentSpaceIds } from "@app/lib/api/assistant/permissions";
+import { getContentFragmentsSpaceIds } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
 import {
   type ConversationAccessType,
   ConversationResource,
 } from "@app/lib/resources/conversation_resource";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
-import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isProjectConversation } from "@app/types/assistant/conversation";
@@ -141,12 +139,12 @@ export async function updateConversationRequirements(
   auth: Authenticator,
   {
     agents,
-    contentFragment,
+    contentFragmentDsvIds,
     conversation,
     t,
   }: {
     agents?: LightAgentConfigurationType[];
-    contentFragment?: ContentFragmentInputWithContentNode;
+    contentFragmentDsvIds?: string[];
     conversation: ConversationWithoutContentType;
     t?: Transaction;
   }
@@ -180,13 +178,12 @@ export async function updateConversationRequirements(
   if (agents) {
     newSpaceRequirements = agents.flatMap((agent) => agent.requestedSpaceIds);
   }
-  if (contentFragment) {
-    const requestedSpaceId = await getContentFragmentSpaceIds(
+  if (contentFragmentDsvIds) {
+    const requestedSpaceIds = await getContentFragmentsSpaceIds(
       auth,
-      contentFragment
+      contentFragmentDsvIds
     );
-
-    newSpaceRequirements.push(requestedSpaceId);
+    newSpaceRequirements.push(...requestedSpaceIds);
   }
 
   newSpaceRequirements = uniq(newSpaceRequirements);
@@ -244,31 +241,26 @@ export async function updateConversationRequirements(
 export async function rebuildConversationRequirements(
   auth: Authenticator,
   conversationResource: ConversationResource
-): Promise<number[]> {
-  const { agentConfigurationIds, contentFragmentDsvModelIds } =
-    await conversationResource.fetchSpaceRequirementSourceData(auth);
+): Promise<void> {
+  // Clear existing requirements so that updateConversationRequirements starts from a clean state.
+  await conversationResource.updateRequirements([]);
 
-  let agentSpaceModelIds: number[] = [];
-  if (agentConfigurationIds.length > 0) {
-    const agents = await getAgentConfigurations(auth, {
-      agentIds: agentConfigurationIds,
-      variant: "light",
-    });
-
-    agentSpaceModelIds = agents
-      .flatMap((a) => a.requestedSpaceIds)
-      .map((sId) => getResourceIdFromSId(sId))
-      .filter((modelId): modelId is number => modelId !== null);
-  }
-
-  let cfSpaceModelIds: number[] = [];
-  if (contentFragmentDsvModelIds.length > 0) {
-    const dsvs = await DataSourceViewResource.fetchByModelIds(
-      auth,
-      contentFragmentDsvModelIds
+  const { agentConfigurationIds, contentFragmentDsvIds } =
+    await conversationResource.fetchAgentConfigurationAndContentFragmentIds(
+      auth
     );
-    cfSpaceModelIds = dsvs.map((dsv) => dsv.space.id);
-  }
 
-  return uniq([...agentSpaceModelIds, ...cfSpaceModelIds]);
+  const agents =
+    agentConfigurationIds.length > 0
+      ? await getAgentConfigurations(auth, {
+          agentIds: agentConfigurationIds,
+          variant: "light",
+        })
+      : [];
+
+  await updateConversationRequirements(auth, {
+    agents,
+    contentFragmentDsvIds,
+    conversation: conversationResource.toJSON(),
+  });
 }

--- a/front/lib/api/assistant/conversation/permissions.ts
+++ b/front/lib/api/assistant/conversation/permissions.ts
@@ -1,9 +1,11 @@
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getContentFragmentSpaceIds } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
 import {
   type ConversationAccessType,
   ConversationResource,
 } from "@app/lib/resources/conversation_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
@@ -229,4 +231,44 @@ export async function updateConversationRequirements(
     allSpaceRequirements,
     t
   );
+}
+
+/**
+ * Rebuild the requestedSpaceIds for a conversation by collecting space requirements
+ * from all agents mentioned and all content fragments with content nodes.
+ *
+ * This function recalculates the full set of requirements from scratch. Used when moving
+ * a conversation out of a project, since project conversations have their requirements
+ * set to [projectSpaceId] only.
+ */
+export async function rebuildConversationRequirements(
+  auth: Authenticator,
+  conversationResource: ConversationResource
+): Promise<number[]> {
+  const { agentConfigurationIds, contentFragmentDsvModelIds } =
+    await conversationResource.fetchSpaceRequirementSourceData(auth);
+
+  let agentSpaceModelIds: number[] = [];
+  if (agentConfigurationIds.length > 0) {
+    const agents = await getAgentConfigurations(auth, {
+      agentIds: agentConfigurationIds,
+      variant: "light",
+    });
+
+    agentSpaceModelIds = agents
+      .flatMap((a) => a.requestedSpaceIds)
+      .map((sId) => getResourceIdFromSId(sId))
+      .filter((modelId): modelId is number => modelId !== null);
+  }
+
+  let cfSpaceModelIds: number[] = [];
+  if (contentFragmentDsvModelIds.length > 0) {
+    const dsvs = await DataSourceViewResource.fetchByModelIds(
+      auth,
+      contentFragmentDsvModelIds
+    );
+    cfSpaceModelIds = dsvs.map((dsv) => dsv.space.id);
+  }
+
+  return uniq([...agentSpaceModelIds, ...cfSpaceModelIds]);
 }

--- a/front/lib/api/assistant/permissions.ts
+++ b/front/lib/api/assistant/permissions.ts
@@ -127,20 +127,22 @@ export async function getContentFragmentGroupIds(
   return [groups].filter((arr) => arr.length > 0);
 }
 
-export async function getContentFragmentSpaceIds(
+export async function getContentFragmentsSpaceIds(
   auth: Authenticator,
-  contentFragment: ContentFragmentInputWithContentNode
-): Promise<string> {
-  const dsView = await DataSourceViewResource.fetchById(
+  nodeDataSourceViewIds: string[]
+): Promise<string[]> {
+  const dsViews = await DataSourceViewResource.fetchByIds(
     auth,
-    contentFragment.nodeDataSourceViewId
+    nodeDataSourceViewIds
   );
-  if (!dsView) {
+  if (!dsViews || dsViews.length === 0) {
     throw new Error(`Unexpected dataSourceView not found`);
   }
 
-  return SpaceResource.modelIdToSId({
-    id: dsView.space.id,
-    workspaceId: auth.getNonNullableWorkspace().id,
-  });
+  return dsViews.map((dsView) =>
+    SpaceResource.modelIdToSId({
+      id: dsView.space.id,
+      workspaceId: auth.getNonNullableWorkspace().id,
+    })
+  );
 }

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -1,4 +1,7 @@
-import { moveConversationToProject } from "@app/lib/api/projects/conversations";
+import {
+  moveConversationOutOfProject,
+  moveConversationToProject,
+} from "@app/lib/api/projects/conversations";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { UserConversationReadsModel } from "@app/lib/models/agent/conversation";
@@ -674,6 +677,424 @@ describe("moveConversationToProject", () => {
       expect(result.error.message).toBe(
         "Conversation is already in the project"
       );
+    }
+  });
+});
+
+describe("moveConversationOutOfProject", () => {
+  let auth: Authenticator;
+  let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+  });
+
+  it("moves a project conversation out and clears its spaceId", async () => {
+    const user = auth.getNonNullableUser();
+
+    // Create project with user as editor and add user as member.
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const projectSpaceGroup = projectSpace.groups.find(
+      (g) => g.kind === "regular"
+    );
+    if (!projectSpaceGroup) {
+      throw new Error("Project space regular group not found");
+    }
+    await projectSpaceGroup.dangerouslyAddMember(internalAdminAuth, {
+      user: user.toJSON(),
+    });
+
+    // Create conversation in the project.
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent Description",
+    });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+    });
+
+    await auth.refresh();
+
+    // Verify conversation is in the project.
+    expect(isProjectConversation(conversation)).toBe(true);
+
+    const result = await moveConversationOutOfProject(auth, {
+      conversation,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const updatedConversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    expect(updatedConversationResource).not.toBeNull();
+    if (!updatedConversationResource) {
+      throw new Error("Conversation not found after move");
+    }
+    const updatedConversation = updatedConversationResource.toJSON();
+
+    // The conversation should no longer be associated to a project.
+    expect(updatedConversation.spaceId).toBeNull();
+    expect(isProjectConversation(updatedConversation)).toBe(false);
+  });
+
+  it("returns internal_error when conversation is not in a project", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const result = await moveConversationOutOfProject(auth, {
+      conversation,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(DustError);
+      expect(result.error.code).toBe("internal_error");
+      expect(result.error.message).toBe("Conversation is not in a project");
+    }
+  });
+
+  it("returns unauthorized when user is not an editor of the project", async () => {
+    const user = auth.getNonNullableUser();
+
+    // Create another user who will be the editor of the project.
+    const editorUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, editorUser, { role: "user" });
+
+    // Create project with editorUser as editor (not the current user).
+    const projectSpace = await SpaceFactory.project(workspace, editorUser.id);
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    // Add current user as member (but not editor) of project.
+    const projectSpaceGroup = projectSpace.groups.find(
+      (g) => g.kind === "regular"
+    );
+    if (!projectSpaceGroup) {
+      throw new Error("Project space regular group not found");
+    }
+    await projectSpaceGroup.dangerouslyAddMember(internalAdminAuth, {
+      user: user.toJSON(),
+    });
+
+    // Create conversation in the project.
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent Description",
+    });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+    });
+
+    await auth.refresh();
+
+    const result = await moveConversationOutOfProject(auth, {
+      conversation,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(DustError);
+      expect(result.error.code).toBe("unauthorized");
+      expect(result.error.message).toContain("You must be an editor of");
+      expect(result.error.message).toContain(projectSpace.name);
+    }
+  });
+
+  it("preserves unread status for participants when moving conversation out of project", async () => {
+    // Create multiple users.
+    const user1 = auth.getNonNullableUser();
+    const user2 = await UserFactory.basic();
+    const user3 = await UserFactory.basic();
+
+    // Add users to workspace.
+    await MembershipFactory.associate(workspace, user2, { role: "user" });
+    await MembershipFactory.associate(workspace, user3, { role: "user" });
+
+    // Create authenticators for each user.
+    const auth1 = auth;
+    const auth2 = await Authenticator.fromUserIdAndWorkspaceId(
+      user2.sId,
+      workspace.sId
+    );
+    const auth3 = await Authenticator.fromUserIdAndWorkspaceId(
+      user3.sId,
+      workspace.sId
+    );
+
+    // Create project with user1 as editor and add all users as members.
+    const projectSpace = await SpaceFactory.project(workspace, user1.id);
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const projectSpaceGroup = projectSpace.groups.find(
+      (g) => g.kind === "regular"
+    );
+    if (!projectSpaceGroup) {
+      throw new Error("Project space regular group not found");
+    }
+
+    await projectSpaceGroup.dangerouslyAddMember(internalAdminAuth, {
+      user: user1.toJSON(),
+    });
+    await projectSpaceGroup.dangerouslyAddMember(internalAdminAuth, {
+      user: user2.toJSON(),
+    });
+    await projectSpaceGroup.dangerouslyAddMember(internalAdminAuth, {
+      user: user3.toJSON(),
+    });
+
+    await auth1.refresh();
+    await auth2.refresh();
+    await auth3.refresh();
+
+    // Create agent and conversation in the project.
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth1, {
+      name: "Test Agent",
+      description: "Test Agent Description",
+    });
+
+    const conversation = await ConversationFactory.create(auth1, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+    });
+
+    // Add all users as participants.
+    // user1 and user2 will be marked as read later, user3 should remain unread.
+    await ConversationResource.upsertParticipation(auth1, {
+      conversation,
+      action: "posted",
+      user: user1.toJSON(),
+    });
+    await ConversationResource.upsertParticipation(auth2, {
+      conversation,
+      action: "posted",
+      user: user2.toJSON(),
+    });
+    // Explicitly set lastReadAt to null for user3 to keep them unread.
+    await ConversationResource.upsertParticipation(auth3, {
+      conversation,
+      action: "posted",
+      user: user3.toJSON(),
+      lastReadAt: null,
+    });
+
+    // Get conversation resource to check updatedAt.
+    const conversationResourceBefore = await ConversationResource.fetchById(
+      auth1,
+      conversation.sId
+    );
+    if (!conversationResourceBefore) {
+      throw new Error("Conversation not found");
+    }
+    const oldUpdatedAt = conversationResourceBefore.updatedAt;
+
+    // Mark user1 and user2 as read (they have read the conversation).
+    await ConversationResource.markAsReadForAuthUser(auth1, {
+      conversation,
+    });
+    await ConversationResource.markAsReadForAuthUser(auth2, {
+      conversation,
+    });
+    // user3 remains unread (no markAsRead call).
+
+    // Verify initial state: user1 and user2 are read, user3 is unread.
+    const participantsBefore =
+      await conversationResourceBefore.listParticipants(auth1);
+    const user1Before = participantsBefore.find((p) => p.sId === user1.sId);
+    const user2Before = participantsBefore.find((p) => p.sId === user2.sId);
+    const user3Before = participantsBefore.find((p) => p.sId === user3.sId);
+
+    expect(user1Before).toBeDefined();
+    expect(user2Before).toBeDefined();
+    expect(user3Before).toBeDefined();
+    expect(user1Before?.lastReadAt).not.toBeNull();
+    expect(user2Before?.lastReadAt).not.toBeNull();
+    expect(user3Before?.lastReadAt).toBeNull();
+
+    if (user1Before?.lastReadAt) {
+      expect(user1Before.lastReadAt >= oldUpdatedAt).toBe(true);
+    }
+    if (user2Before?.lastReadAt) {
+      expect(user2Before.lastReadAt >= oldUpdatedAt).toBe(true);
+    }
+
+    // Move conversation out of the project.
+    const result = await moveConversationOutOfProject(auth1, {
+      conversation,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    // Get updated conversation resource.
+    const conversationResourceAfter = await ConversationResource.fetchById(
+      auth1,
+      conversation.sId
+    );
+    if (!conversationResourceAfter) {
+      throw new Error("Conversation not found after move");
+    }
+    const newUpdatedAt = conversationResourceAfter.updatedAt;
+
+    // Verify conversation was moved out.
+    const updatedConversation = conversationResourceAfter.toJSON();
+    expect(updatedConversation.spaceId).toBeNull();
+    expect(isProjectConversation(updatedConversation)).toBe(false);
+
+    // Get participants after move.
+    const participantsAfter =
+      await conversationResourceAfter.listParticipants(auth1);
+    const user1After = participantsAfter.find((p) => p.sId === user1.sId);
+    const user2After = participantsAfter.find((p) => p.sId === user2.sId);
+    const user3After = participantsAfter.find((p) => p.sId === user3.sId);
+
+    expect(user1After).toBeDefined();
+    expect(user2After).toBeDefined();
+    expect(user3After).toBeDefined();
+
+    // Verify user1 and user2 remain read (lastReadAt should be >= newUpdatedAt).
+    expect(user1After?.lastReadAt).not.toBeNull();
+    expect(user2After?.lastReadAt).not.toBeNull();
+    if (user1After?.lastReadAt) {
+      expect(user1After.lastReadAt >= newUpdatedAt).toBe(true);
+    }
+    if (user2After?.lastReadAt) {
+      expect(user2After.lastReadAt >= newUpdatedAt).toBe(true);
+    }
+
+    // Verify user3 remains unread (lastReadAt should still be null).
+    expect(user3After?.lastReadAt).toBeNull();
+  });
+
+  it("preserves unread status when some participants have old lastReadAt", async () => {
+    // Create users.
+    const user1 = auth.getNonNullableUser();
+    const user2 = await UserFactory.basic();
+
+    await MembershipFactory.associate(workspace, user2, { role: "user" });
+
+    const auth1 = auth;
+    const auth2 = await Authenticator.fromUserIdAndWorkspaceId(
+      user2.sId,
+      workspace.sId
+    );
+
+    // Create project with user1 as editor and add both users as members.
+    const projectSpace = await SpaceFactory.project(workspace, user1.id);
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const projectSpaceGroup = projectSpace.groups.find(
+      (g) => g.kind === "regular"
+    );
+    if (!projectSpaceGroup) {
+      throw new Error("Project space regular group not found");
+    }
+
+    await projectSpaceGroup.dangerouslyAddMember(internalAdminAuth, {
+      user: user1.toJSON(),
+    });
+    await projectSpaceGroup.dangerouslyAddMember(internalAdminAuth, {
+      user: user2.toJSON(),
+    });
+
+    await auth1.refresh();
+    await auth2.refresh();
+
+    // Create conversation in the project.
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth1);
+    const conversation = await ConversationFactory.create(auth1, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+    });
+
+    // Add participants.
+    await ConversationResource.upsertParticipation(auth1, {
+      conversation,
+      action: "posted",
+      user: user1.toJSON(),
+    });
+    await ConversationResource.upsertParticipation(auth2, {
+      conversation,
+      action: "posted",
+      user: user2.toJSON(),
+    });
+
+    // Get conversation resource.
+    const conversationResource = await ConversationResource.fetchById(
+      auth1,
+      conversation.sId
+    );
+    if (!conversationResource) {
+      throw new Error("Conversation not found");
+    }
+    const oldUpdatedAt = conversationResource.updatedAt;
+
+    // Mark user1 as read with a timestamp that's >= oldUpdatedAt.
+    await ConversationResource.markAsReadForAuthUser(auth1, {
+      conversation,
+    });
+
+    // Manually set user2's lastReadAt to be before oldUpdatedAt (simulating an old read).
+    const oldReadTime = new Date(oldUpdatedAt.getTime() - 10000); // 10 seconds before
+    await UserConversationReadsModel.upsert({
+      conversationId: conversation.id,
+      userId: user2.id,
+      workspaceId: workspace.id,
+      lastReadAt: oldReadTime,
+    });
+
+    // Move conversation out of the project.
+    const result = await moveConversationOutOfProject(auth1, {
+      conversation,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    // Verify results.
+    const conversationResourceAfter = await ConversationResource.fetchById(
+      auth1,
+      conversation.sId
+    );
+    if (!conversationResourceAfter) {
+      throw new Error("Conversation not found after move");
+    }
+    const newUpdatedAt = conversationResourceAfter.updatedAt;
+
+    const participantsAfter =
+      await conversationResourceAfter.listParticipants(auth1);
+    const user1After = participantsAfter.find((p) => p.sId === user1.sId);
+    const user2After = participantsAfter.find((p) => p.sId === user2.sId);
+
+    // user1 should remain read (was read before move).
+    expect(user1After?.lastReadAt).not.toBeNull();
+    if (user1After?.lastReadAt) {
+      expect(user1After.lastReadAt >= newUpdatedAt).toBe(true);
+    }
+
+    // user2 should remain unread (had old read timestamp, so was effectively unread).
+    // Their lastReadAt should not have been updated.
+    expect(user2After?.lastReadAt).not.toBeNull();
+    if (user2After?.lastReadAt) {
+      expect(user2After.lastReadAt < newUpdatedAt).toBe(true);
     }
   });
 });

--- a/front/lib/api/projects/conversations.ts
+++ b/front/lib/api/projects/conversations.ts
@@ -1,3 +1,7 @@
+import {
+  canUserAccessConversation,
+  rebuildConversationRequirements,
+} from "@app/lib/api/assistant/conversation/permissions";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -121,6 +125,110 @@ export async function moveConversationToProject(
       }
     }
   }, transaction);
+
+  return new Ok(undefined);
+}
+
+export async function moveConversationOutOfProject(
+  auth: Authenticator,
+  {
+    conversation,
+  }: {
+    conversation: ConversationWithoutContentType;
+  }
+): Promise<
+  Result<
+    void,
+    DustError<
+      | "internal_error"
+      | "unauthorized"
+      | "conversation_not_found"
+      | "space_not_found"
+    >
+  >
+> {
+  if (!isProjectConversation(conversation)) {
+    return new Err(
+      new DustError("internal_error", "Conversation is not in a project")
+    );
+  }
+
+  const project = await SpaceResource.fetchById(auth, conversation.spaceId);
+  if (!project) {
+    return new Err(new DustError("space_not_found", "Project not found"));
+  }
+
+  if (!project.canAdministrate(auth)) {
+    return new Err(
+      new DustError(
+        "unauthorized",
+        `You must be an editor of "${project.name}".`
+      )
+    );
+  }
+
+  const conversationResource = await ConversationResource.fetchById(
+    auth,
+    conversation.sId
+  );
+  if (!conversationResource) {
+    return new Err(
+      new DustError("conversation_not_found", "Conversation not found")
+    );
+  }
+
+  // Before moving the conversation, capture the current state:
+  // - Current updatedAt timestamp
+  // - All participants with their lastReadAt status
+  const oldUpdatedAt = conversationResource.updatedAt;
+  const participants = await conversationResource.listParticipants(auth);
+
+  // Remove the project association.
+  await conversationResource.clearSpaceId();
+
+  // Rebuild requestedSpaceIds from all agents and content fragments in the conversation.
+  // When a conversation is in a project, its requestedSpaceIds is set to [projectSpaceId] only.
+  // Moving out requires recalculating the full set of space requirements.
+  const requestedSpaceModelIds = await rebuildConversationRequirements(
+    auth,
+    conversationResource
+  );
+  await conversationResource.updateRequirements(requestedSpaceModelIds);
+
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+
+  for (const participant of participants) {
+    // After moving out of a project, some participants may no longer have access
+    // to the conversation's required spaces. Remove those participants.
+    const hasAccess = await canUserAccessConversation(auth, {
+      userId: participant.sId,
+      conversationId: conversation.sId,
+    });
+
+    if (!hasAccess) {
+      const participantAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        participant.sId,
+        workspaceId
+      );
+      await conversationResource.leaveConversation(participantAuth);
+      continue;
+    }
+
+    // For participants who still have access and had already read the conversation,
+    // mark them as read to preserve their read status.
+    const wasRead =
+      participant.lastReadAt !== null && participant.lastReadAt >= oldUpdatedAt;
+
+    if (wasRead) {
+      const participantAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        participant.sId,
+        workspaceId
+      );
+      await ConversationResource.markAsReadForAuthUser(participantAuth, {
+        conversation,
+      });
+    }
+  }
 
   return new Ok(undefined);
 }

--- a/front/lib/api/projects/conversations.ts
+++ b/front/lib/api/projects/conversations.ts
@@ -189,11 +189,7 @@ export async function moveConversationOutOfProject(
   // Rebuild requestedSpaceIds from all agents and content fragments in the conversation.
   // When a conversation is in a project, its requestedSpaceIds is set to [projectSpaceId] only.
   // Moving out requires recalculating the full set of space requirements.
-  const requestedSpaceModelIds = await rebuildConversationRequirements(
-    auth,
-    conversationResource
-  );
-  await conversationResource.updateRequirements(requestedSpaceModelIds);
+  await rebuildConversationRequirements(auth, conversationResource);
 
   const workspaceId = auth.getNonNullableWorkspace().sId;
 

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -6135,4 +6135,103 @@ describe("ConversationResource cleanup on delete", () => {
       expect(modelsWithMessageFK).toEqual(knownModels);
     });
   });
+
+  describe("fetchSpaceRequirementSourceData", () => {
+    it("returns distinct agent configuration ids from agent messages", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      const agent1 = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Agent 1",
+        description: "Agent 1 Description",
+      });
+      const agent2 = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Agent 2",
+        description: "Agent 2 Description",
+      });
+
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent1.sId,
+        messagesCreatedAt: [],
+      });
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      assert(conversationResource, "Conversation not found");
+
+      // Add agent messages from two different agents (including a duplicate).
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversationResource.id,
+        rank: 1,
+        agentConfigurationId: agent1.sId,
+      });
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversationResource.id,
+        rank: 3,
+        agentConfigurationId: agent2.sId,
+      });
+      // Duplicate agent1 message — should be deduplicated.
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversationResource.id,
+        rank: 5,
+        agentConfigurationId: agent1.sId,
+      });
+
+      const { agentConfigurationIds, contentFragmentDsvModelIds } =
+        await conversationResource.fetchSpaceRequirementSourceData(auth);
+
+      // Should return exactly 2 distinct agent configuration ids.
+      expect(agentConfigurationIds).toHaveLength(2);
+      expect(agentConfigurationIds).toContain(agent1.sId);
+      expect(agentConfigurationIds).toContain(agent2.sId);
+
+      // No content fragments, so should be empty.
+      expect(contentFragmentDsvModelIds).toHaveLength(0);
+    });
+
+    it("returns empty arrays when conversation has no agent or content fragment messages", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Agent",
+        description: "Agent Description",
+      });
+
+      // Create conversation with no messages (empty messagesCreatedAt).
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+      });
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      assert(conversationResource, "Conversation not found");
+
+      const { agentConfigurationIds, contentFragmentDsvModelIds } =
+        await conversationResource.fetchSpaceRequirementSourceData(auth);
+
+      expect(agentConfigurationIds).toHaveLength(0);
+      expect(contentFragmentDsvModelIds).toHaveLength(0);
+    });
+  });
 });

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -6188,8 +6188,10 @@ describe("ConversationResource cleanup on delete", () => {
         agentConfigurationId: agent1.sId,
       });
 
-      const { agentConfigurationIds, contentFragmentDsvModelIds } =
-        await conversationResource.fetchSpaceRequirementSourceData(auth);
+      const { agentConfigurationIds, contentFragmentDsvIds } =
+        await conversationResource.fetchAgentConfigurationAndContentFragmentIds(
+          auth
+        );
 
       // Should return exactly 2 distinct agent configuration ids.
       expect(agentConfigurationIds).toHaveLength(2);
@@ -6197,7 +6199,7 @@ describe("ConversationResource cleanup on delete", () => {
       expect(agentConfigurationIds).toContain(agent2.sId);
 
       // No content fragments, so should be empty.
-      expect(contentFragmentDsvModelIds).toHaveLength(0);
+      expect(contentFragmentDsvIds).toHaveLength(0);
     });
 
     it("returns empty arrays when conversation has no agent or content fragment messages", async () => {
@@ -6227,11 +6229,13 @@ describe("ConversationResource cleanup on delete", () => {
       );
       assert(conversationResource, "Conversation not found");
 
-      const { agentConfigurationIds, contentFragmentDsvModelIds } =
-        await conversationResource.fetchSpaceRequirementSourceData(auth);
+      const { agentConfigurationIds, contentFragmentDsvIds } =
+        await conversationResource.fetchAgentConfigurationAndContentFragmentIds(
+          auth
+        );
 
       expect(agentConfigurationIds).toHaveLength(0);
-      expect(contentFragmentDsvModelIds).toHaveLength(0);
+      expect(contentFragmentDsvIds).toHaveLength(0);
     });
   });
 });

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -6188,7 +6188,7 @@ describe("ConversationResource cleanup on delete", () => {
         agentConfigurationId: agent1.sId,
       });
 
-      const { agentConfigurationIds, contentFragmentDsvIds } =
+      const { agentConfigurationIds, contentFragmentDatasourceViewIds } =
         await conversationResource.fetchAgentConfigurationAndContentFragmentIds(
           auth
         );
@@ -6199,7 +6199,7 @@ describe("ConversationResource cleanup on delete", () => {
       expect(agentConfigurationIds).toContain(agent2.sId);
 
       // No content fragments, so should be empty.
-      expect(contentFragmentDsvIds).toHaveLength(0);
+      expect(contentFragmentDatasourceViewIds).toHaveLength(0);
     });
 
     it("returns empty arrays when conversation has no agent or content fragment messages", async () => {
@@ -6229,13 +6229,13 @@ describe("ConversationResource cleanup on delete", () => {
       );
       assert(conversationResource, "Conversation not found");
 
-      const { agentConfigurationIds, contentFragmentDsvIds } =
+      const { agentConfigurationIds, contentFragmentDatasourceViewIds } =
         await conversationResource.fetchAgentConfigurationAndContentFragmentIds(
           auth
         );
 
       expect(agentConfigurationIds).toHaveLength(0);
-      expect(contentFragmentDsvIds).toHaveLength(0);
+      expect(contentFragmentDatasourceViewIds).toHaveLength(0);
     });
   });
 });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -15,6 +15,7 @@ import { REINFORCEMENT_METADATA_KEYS } from "@app/lib/reinforced_agent/types";
 import { REINFORCED_SKILLS_METADATA_KEYS } from "@app/lib/reinforcement/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import {
   createResourcePermissionsFromSpacesWithMap,
@@ -2772,13 +2773,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   }
 
   /**
-   * Get the distinct agent configurations and content fragment DataSourceViews
+   * Get the distinct agent configuration IDs and content fragment DataSourceView ids
    * used in this conversation. This data is needed to rebuild the conversation's
    * requestedSpaceIds when moving out of a project.
    */
-  async fetchSpaceRequirementSourceData(auth: Authenticator): Promise<{
+  async fetchAgentConfigurationAndContentFragmentIds(
+    auth: Authenticator
+  ): Promise<{
     agentConfigurationIds: string[];
-    contentFragmentDsvModelIds: number[];
+    contentFragmentDsvIds: string[];
   }> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
@@ -2821,13 +2824,22 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       ],
     });
 
-    const contentFragmentDsvModelIds = uniq(
+    const contentFragmentDsvIds = uniq(
       cfMessages
-        .map((m) => m.contentFragment?.nodeDataSourceViewId)
-        .filter((modelId): modelId is number => modelId != null)
+        .map((m) => {
+          const modelId = m.contentFragment?.nodeDataSourceViewId;
+          if (modelId == null) {
+            return null;
+          }
+          return DataSourceViewResource.modelIdToSId({
+            id: modelId,
+            workspaceId,
+          });
+        })
+        .filter((sId): sId is string => sId !== null)
     );
 
-    return { agentConfigurationIds, contentFragmentDsvModelIds };
+    return { agentConfigurationIds, contentFragmentDsvIds };
   }
 
   static async markHasError(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -98,7 +98,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   constructor(
     model: ModelStaticWorkspaceAware<ConversationModel>,
     blob: Attributes<ConversationModel>,
-    private readonly _space: SpaceResource | null
+    private _space: SpaceResource | null
   ) {
     super(ConversationModel, blob);
   }
@@ -2770,6 +2770,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   async clearSpaceId() {
     await this.update({ spaceId: null });
+    this._space = null;
   }
 
   /**
@@ -2781,7 +2782,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     auth: Authenticator
   ): Promise<{
     agentConfigurationIds: string[];
-    contentFragmentDsvIds: string[];
+    contentFragmentDatasourceViewIds: string[];
   }> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
@@ -2824,7 +2825,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       ],
     });
 
-    const contentFragmentDsvIds = uniq(
+    const contentFragmentDatasourceViewIds = uniq(
       cfMessages
         .map((m) => {
           const modelId = m.contentFragment?.nodeDataSourceViewId;
@@ -2839,7 +2840,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         .filter((sId): sId is string => sId !== null)
     );
 
-    return { agentConfigurationIds, contentFragmentDsvIds };
+    return { agentConfigurationIds, contentFragmentDatasourceViewIds };
   }
 
   static async markHasError(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2767,6 +2767,69 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     await this.update({ spaceId: space.id }, transaction);
   }
 
+  async clearSpaceId() {
+    await this.update({ spaceId: null });
+  }
+
+  /**
+   * Get the distinct agent configurations and content fragment DataSourceViews
+   * used in this conversation. This data is needed to rebuild the conversation's
+   * requestedSpaceIds when moving out of a project.
+   */
+  async fetchSpaceRequirementSourceData(auth: Authenticator): Promise<{
+    agentConfigurationIds: string[];
+    contentFragmentDsvModelIds: number[];
+  }> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const agentMessages = await MessageModel.findAll({
+      where: {
+        conversationId: this.id,
+        workspaceId,
+        agentMessageId: { [Op.ne]: null },
+        branchId: { [Op.is]: null },
+      },
+      include: [
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          required: true,
+          attributes: ["agentConfigurationId"],
+        },
+      ],
+    });
+
+    const agentConfigurationIds = uniq(
+      agentMessages
+        .map((m) => m.agentMessage?.agentConfigurationId)
+        .filter((id): id is string => Boolean(id))
+    );
+
+    const cfMessages = await MessageModel.findAll({
+      where: {
+        conversationId: this.id,
+        workspaceId,
+        contentFragmentId: { [Op.ne]: null },
+        branchId: { [Op.is]: null },
+      },
+      include: [
+        {
+          model: ContentFragmentModel,
+          as: "contentFragment",
+          required: true,
+        },
+      ],
+    });
+
+    const contentFragmentDsvModelIds = uniq(
+      cfMessages
+        .map((m) => m.contentFragment?.nodeDataSourceViewId)
+        .filter((modelId): modelId is number => modelId != null)
+    );
+
+    return { agentConfigurationIds, contentFragmentDsvModelIds };
+  }
+
   static async markHasError(
     auth: Authenticator,
     { conversation }: { conversation: ConversationWithoutContentType },

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -133,7 +133,10 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { moveConversationToProject } from "@app/lib/api/projects/conversations";
+import {
+  moveConversationOutOfProject,
+  moveConversationToProject,
+} from "@app/lib/api/projects/conversations";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -164,6 +167,9 @@ const PatchConversationsRequestBodySchema = t.union([
       participants_only: null,
       workspace_members: null,
     }),
+  }),
+  t.type({
+    removeFromProject: t.literal(true),
   }),
 ]);
 
@@ -359,6 +365,50 @@ async function handler(
           }
 
           return res.status(200).json({ success: true });
+        } else if ("removeFromProject" in bodyValidation.right) {
+          const r = await moveConversationOutOfProject(auth, {
+            conversation,
+          });
+          if (r.isOk()) {
+            return res.status(200).json({ success: true });
+          } else {
+            switch (r.error.code) {
+              case "unauthorized":
+                return apiError(req, res, {
+                  status_code: 404,
+                  api_error: {
+                    type: "user_not_found",
+                    message: r.error.message,
+                  },
+                });
+              case "space_not_found":
+                return apiError(req, res, {
+                  status_code: 404,
+                  api_error: {
+                    type: "space_not_found",
+                    message: "Space not found",
+                  },
+                });
+              case "conversation_not_found":
+                return apiError(req, res, {
+                  status_code: 404,
+                  api_error: {
+                    type: "conversation_not_found",
+                    message: "Conversation not found",
+                  },
+                });
+              case "internal_error":
+                return apiError(req, res, {
+                  status_code: 500,
+                  api_error: {
+                    type: "internal_server_error",
+                    message: "Internal server error",
+                  },
+                });
+              default:
+                assertNever(r.error.code);
+            }
+          }
         } else {
           return apiError(req, res, {
             status_code: 400,

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -5,6 +5,7 @@ import type {
   ModelIdType,
   ModelProviderIdType,
 } from "@app/types/assistant/models/types";
+import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 
 export class AgentConfigurationFactory {
@@ -19,6 +20,7 @@ export class AgentConfigurationFactory {
         modelId: ModelIdType;
         temperature?: number;
       };
+      requestedSpaceIds: ModelId[];
     }> = {}
   ): Promise<AgentConfigurationType> {
     const name = overrides.name ?? "Test Agent";
@@ -27,6 +29,7 @@ export class AgentConfigurationFactory {
     const providerId = overrides.model?.providerId ?? "openai";
     const modelId = overrides.model?.modelId ?? "gpt-4-turbo";
     const temperature = overrides.model?.temperature ?? 0.7;
+    const requestedSpaceIds = overrides.requestedSpaceIds ?? [];
 
     const user = auth.user();
     assert(user, "User is required");
@@ -45,7 +48,7 @@ export class AgentConfigurationFactory {
         temperature,
       },
       templateId: null,
-      requestedSpaceIds: [],
+      requestedSpaceIds,
       tags: [], // Added missing tags property
       editors: [user.toJSON()],
       authorId: user.id,


### PR DESCRIPTION
## Description

This PR adds support for removing conversations from projects.

- Introduces `moveConversationOutOfProject` function that handles the removal of a conversation from a project by clearing the space association
- Adds `rebuildConversationRequirements` function that recalculates the full set of space requirements from all agents and content fragments in a conversation 
- Implements participant access validation after moving out of a project, automatically removing participants who no longer have access to the conversation's required spaces
- Preserves read status for participants who retain access by marking them as read if they had already read the conversation before the move

## Tests
Added unit tests

## Risk
Low

## Deploy Plan

Standard deployment - no special steps required.
