### PR TITLE
feat: remove conversation from project frontend

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -38,6 +38,7 @@ import {
   ActionGitBranchIcon,
   ArrowRightIcon,
   Avatar,
+  ChatBubbleBottomCenterTextIcon,
   ContactsUserIcon,
   DropdownMenu,
   DropdownMenuContent,
@@ -408,7 +409,7 @@ export function ConversationMenu({
                   {canMoveOutOfProject && (
                     <>
                       <DropdownMenuItem
-                        icon={XMarkIcon}
+                        icon={ChatBubbleBottomCenterTextIcon}
                         label="Personal conversations"
                         onClick={async () =>
                           moveConversationOutOfProject(conversation)

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -19,7 +19,7 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
-import { useSpaces } from "@app/lib/swr/spaces";
+import { useSpaceInfo, useSpaces } from "@app/lib/swr/spaces";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import {
   getAgentBuilderRoute,
@@ -230,6 +230,19 @@ export function ConversationMenu({
     disabled: shouldWaitBeforeFetching || !hasFeature("projects"),
   });
 
+  const conversationSpaceId =
+    conversation && isProjectConversation(conversation)
+      ? conversation.spaceId
+      : null;
+  const { spaceInfo: conversationSpaceInfo } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId: conversationSpaceId,
+    disabled: shouldWaitBeforeFetching || !conversationSpaceId,
+  });
+  const isProjectEditor = conversationSpaceInfo?.isEditor ?? false;
+  const canMoveOutOfProject =
+    conversation && isProjectConversation(conversation) && isProjectEditor;
+
   const moveConversationToProject = useMoveConversationToProject(owner);
   const moveConversationOutOfProject = useMoveConversationOutOfProject(
     owner,
@@ -384,11 +397,7 @@ export function ConversationMenu({
             <DropdownMenuSub>
               <DropdownMenuSubTrigger
                 icon={ArrowRightIcon}
-                label={
-                  conversation && isProjectConversation(conversation)
-                    ? "Move to..."
-                    : "Move to project"
-                }
+                label={canMoveOutOfProject ? "Move to..." : "Move to project"}
                 disabled={!projects.length}
               />
               <DropdownMenuPortal>
@@ -396,7 +405,7 @@ export function ConversationMenu({
                   collisionPadding={16}
                   className="max-w-60"
                 >
-                  {conversation && isProjectConversation(conversation) && (
+                  {canMoveOutOfProject && (
                     <>
                       <DropdownMenuItem
                         icon={XMarkIcon}

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -10,6 +10,7 @@ import {
   useJoinConversation,
 } from "@app/hooks/conversations";
 import { useDeleteConversation } from "@app/hooks/useDeleteConversation";
+import { useMoveConversationOutOfProject } from "@app/hooks/useMoveConversationOutOfProject";
 import { useMoveConversationToProject } from "@app/hooks/useMoveConversationToProject";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useURLSheet } from "@app/hooks/useURLSheet";
@@ -41,6 +42,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuPortal,
   DropdownMenuSeparator,
   DropdownMenuSub,
@@ -229,6 +231,10 @@ export function ConversationMenu({
   });
 
   const moveConversationToProject = useMoveConversationToProject(owner);
+  const moveConversationOutOfProject = useMoveConversationOutOfProject(
+    owner,
+    activeConversationId
+  );
 
   const joinConversation = useJoinConversation({
     ownerId: owner.sId,
@@ -378,11 +384,31 @@ export function ConversationMenu({
             <DropdownMenuSub>
               <DropdownMenuSubTrigger
                 icon={ArrowRightIcon}
-                label="Move to project"
+                label={
+                  conversation && isProjectConversation(conversation)
+                    ? "Move to..."
+                    : "Move to project"
+                }
                 disabled={!projects.length}
               />
               <DropdownMenuPortal>
-                <DropdownMenuSubContent>
+                <DropdownMenuSubContent
+                  collisionPadding={16}
+                  className="max-w-60"
+                >
+                  {conversation && isProjectConversation(conversation) && (
+                    <>
+                      <DropdownMenuItem
+                        icon={XMarkIcon}
+                        label="Personal conversations"
+                        onClick={async () =>
+                          moveConversationOutOfProject(conversation)
+                        }
+                      />
+                      <DropdownMenuSeparator />
+                      <DropdownMenuLabel label="Projects" />
+                    </>
+                  )}
                   {projects
                     .filter((project) => project.sId !== conversation?.spaceId)
                     .map((project) => (
@@ -390,6 +416,7 @@ export function ConversationMenu({
                         key={project.sId}
                         icon={getSpaceIcon(project)}
                         label={project.name}
+                        truncateText
                         onClick={async () =>
                           conversation
                             ? moveConversationToProject(conversation, project)

--- a/front/hooks/useMoveConversationOutOfProject.tsx
+++ b/front/hooks/useMoveConversationOutOfProject.tsx
@@ -1,0 +1,94 @@
+import { ConfirmContext } from "@app/components/Confirm";
+import {
+  useConversation,
+  useConversations,
+  useSpaceConversationsSummary,
+} from "@app/hooks/conversations";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { getErrorFromResponse } from "@app/lib/swr/swr";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useContext } from "react";
+
+export function useMoveConversationOutOfProject(
+  owner: LightWorkspaceType,
+  conversationId: string | null
+) {
+  const sendNotification = useSendNotification();
+  const confirm = useContext(ConfirmContext);
+
+  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
+
+  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
+
+  const { mutateConversation } = useConversation({
+    conversationId,
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
+
+  return useCallback(
+    async (conversation: ConversationWithoutContentType): Promise<boolean> => {
+      const confirmed = await confirm({
+        title: "Remove from project?",
+        message: (
+          <div>
+            <strong>{conversation.title}</strong> will be removed from the
+            project. Participants who no longer have access to the required
+            spaces will be removed from the conversation.
+          </div>
+        ),
+        validateLabel: "Remove",
+        validateVariant: "primary",
+      });
+
+      if (!confirmed) {
+        return false;
+      }
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/assistant/conversations/${conversation.sId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ removeFromProject: true }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+
+        sendNotification({
+          title: "Error removing conversation from project.",
+          description: errorData.message,
+          type: "error",
+        });
+        return false;
+      }
+
+      void mutateConversations();
+      void mutateSpaceSummary();
+      void mutateConversation();
+      void sendNotification({
+        title: "Conversation removed.",
+        description: "The conversation has been removed from the project.",
+        type: "success",
+      });
+
+      return true;
+    },
+    [
+      owner.sId,
+      mutateConversations,
+      mutateSpaceSummary,
+      mutateConversation,
+      sendNotification,
+      confirm,
+    ]
+  );
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7412

This PR adds the ability to remove a conversation from a project in the frontend.

- Implements a new `useMoveConversationOutOfProject` hook that handles the removal flow with confirmation dialog, API call, and cache invalidation
- Updates the conversation menu to display a "Move to..." submenu for project conversations, allowing users to move them back to personal conversations or to other projects

<img width="461" height="281" alt="Capture d’écran 2026-04-17 à 15 08 54" src="https://github.com/user-attachments/assets/6b9b234e-b8ba-40fa-8c45-e2e8933620d7" />
<img width="507" height="294" alt="Capture d’écran 2026-04-17 à 15 09 21" src="https://github.com/user-attachments/assets/e792f21c-6212-41a6-b7e0-2e115e942cc5" />


## Tests

Manually

## Risks

Low risk.

## Deploy Plan

Standard deployment. This PR should be deployed after PR #24480 (backend changes) is merged and deployed.
