### PR TITLE
[front] enh: improve performances of `messages/[mId]/reactions` endpoint handler

### DIFF
--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -3,25 +3,21 @@ import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/hel
 import {
   createMessageReaction,
   deleteMessageReaction,
-  getMessagesReactions,
 } from "@app/lib/api/assistant/reaction";
-import {
-  publishAgentMessagesEvents,
-  publishMessageEventsOnMessagePostOrEdit,
-} from "@app/lib/api/assistant/streaming/events";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { MessageReactionType } from "@app/types/assistant/conversation";
-import {
+import  {
   ConversationError,
-  isAgentMessageType,
+  MessageReactionType,
+} from "@app/types/assistant/conversation";
+import {
   isProjectConversation,
-  isUserMessageType,
 } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
@@ -42,7 +38,9 @@ async function handler(
 ): Promise<void> {
   const user = auth.getNonNullableUser();
 
-  if (!isString(req.query.cId) || !isString(req.query.mId)) {
+  const { cId, mId } = req.query;
+
+  if (!isString(cId) || !isString(mId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -53,10 +51,7 @@ async function handler(
     });
   }
 
-  const conversation = await ConversationResource.fetchById(
-    auth,
-    req.query.cId
-  );
+  const conversation = await ConversationResource.fetchById(auth, cId);
   if (!conversation) {
     return apiErrorForConversation(
       req,
@@ -89,7 +84,6 @@ async function handler(
     }
   }
 
-  const messageId = req.query.mId;
   const bodyValidation = MessageReactionRequestBodySchema.decode(req.body);
   if (isLeft(bodyValidation)) {
     const pathError = reporter.formatValidationErrors(bodyValidation.left);
@@ -102,7 +96,7 @@ async function handler(
     });
   }
 
-  const messageRes = await conversation.getMessageById(auth, messageId);
+  const messageRes = await conversation.getMessageById(auth, mId);
   // Preserve prior behavior: only main-branch user/agent messages are reactable.
   if (
     messageRes.isErr() ||
@@ -131,7 +125,7 @@ async function handler(
   switch (req.method) {
     case "POST":
       const created = await createMessageReaction(auth, {
-        messageId,
+        messageId: mId,
         conversation: serializedConversation,
         user: user.toJSON(),
         context: {
@@ -142,7 +136,6 @@ async function handler(
       });
 
       if (created) {
-        await publishMessageUpdate(req, res, auth, { conversation, message });
         res.status(200).json({ success: true });
         return;
       }
@@ -156,7 +149,7 @@ async function handler(
 
     case "DELETE":
       const deleted = await deleteMessageReaction(auth, {
-        messageId,
+        messageId: mId,
         conversation: serializedConversation,
         user: user.toJSON(),
         context: {
@@ -167,7 +160,6 @@ async function handler(
       });
 
       if (deleted) {
-        await publishMessageUpdate(req, res, auth, { conversation, message });
         res.status(200).json({ success: true });
         return;
       }
@@ -190,55 +182,5 @@ async function handler(
       });
   }
 }
-
-const publishMessageUpdate = async (
-  req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<
-      { reactions: MessageReactionType[] } | { success: boolean }
-    >
-  >,
-  auth: Authenticator,
-  {
-    conversation,
-    message,
-  }: {
-    conversation: ConversationType;
-    message: UserMessageType | ContentFragmentType | AgentMessageType;
-  }
-) => {
-  const reactions = await getMessagesReactions(auth, {
-    messageIds: [message.id],
-  });
-
-  if (isUserMessageType(message)) {
-    return publishMessageEventsOnMessagePostOrEdit(
-      conversation,
-      {
-        ...message,
-        contentFragments: getRelatedContentFragments(conversation, message),
-        reactions: reactions[message.id] ?? [],
-      },
-      []
-    );
-  }
-
-  if (isAgentMessageType(message)) {
-    return publishAgentMessagesEvents(conversation, [
-      {
-        ...message,
-        reactions: reactions[message.id] ?? [],
-      },
-    ]);
-  }
-
-  return apiError(req, res, {
-    status_code: 500,
-    api_error: {
-      type: "internal_server_error",
-      message: "Unexpected message type",
-    },
-  });
-};
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -47,7 +47,8 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Invalid query parameters, `cId` (string) and `mId` (string) are required.",
+        message:
+          "Invalid query parameters, `cId` (string) and `mId` (string) are required.",
       },
     });
   }
@@ -67,7 +68,10 @@ async function handler(
   const serializedConversation = conversation.toJSON();
 
   if (isProjectConversation(serializedConversation)) {
-    const space = await SpaceResource.fetchById(auth, serializedConversation.spaceId);
+    const space = await SpaceResource.fetchById(
+      auth,
+      serializedConversation.spaceId
+    );
     if (!space) {
       return apiError(req, res, {
         status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -1,6 +1,4 @@
 /** @ignoreswagger */
-import { getRelatedContentFragments } from "@app/lib/api/assistant/content_fragments";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import {
   createMessageReaction,
@@ -13,21 +11,16 @@ import {
 } from "@app/lib/api/assistant/streaming/events";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
-import type {
-  AgentMessageType,
-  ConversationType,
-  MessageReactionType,
-  UserMessageType,
-} from "@app/types/assistant/conversation";
+import type { MessageReactionType } from "@app/types/assistant/conversation";
 import {
+  ConversationError,
   isAgentMessageType,
-  isCompactionMessageType,
   isProjectConversation,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
-import type { ContentFragmentType } from "@app/types/content_fragment";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -49,27 +42,32 @@ async function handler(
 ): Promise<void> {
   const user = auth.getNonNullableUser();
 
-  if (!(typeof req.query.cId === "string")) {
+  if (!isString(req.query.cId) || !isString(req.query.mId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Invalid query parameters, `cId` (string) is required.",
+        message: "Invalid query parameters, `cId` (string) and `mId` (string) are required.",
       },
     });
   }
 
-  const conversationId = req.query.cId;
-  const conversationRes = await getConversation(auth, conversationId);
-
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    req.query.cId
+  );
+  if (!conversation) {
+    return apiErrorForConversation(
+      req,
+      res,
+      new ConversationError("conversation_not_found")
+    );
   }
 
-  const conversation = conversationRes.value;
+  const serializedConversation = conversation.toJSON();
 
-  if (isProjectConversation(conversation)) {
-    const space = await SpaceResource.fetchById(auth, conversation.spaceId);
+  if (isProjectConversation(serializedConversation)) {
+    const space = await SpaceResource.fetchById(auth, serializedConversation.spaceId);
     if (!space) {
       return apiError(req, res, {
         status_code: 404,
@@ -87,16 +85,6 @@ async function handler(
     }
   }
 
-  if (!(typeof req.query.mId === "string")) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid query parameters, `mId` (string) is required.",
-      },
-    });
-  }
-
   const messageId = req.query.mId;
   const bodyValidation = MessageReactionRequestBodySchema.decode(req.body);
   if (isLeft(bodyValidation)) {
@@ -110,8 +98,13 @@ async function handler(
     });
   }
 
-  const message = conversation.content.flat().find((m) => m.sId === messageId);
-  if (!message) {
+  const messageRes = await conversation.getMessageById(auth, messageId);
+  // Preserve prior behavior: only main-branch user/agent messages are reactable.
+  if (
+    messageRes.isErr() ||
+    messageRes.value.branchId !== null ||
+    messageRes.value.contentFragmentId
+  ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -120,7 +113,8 @@ async function handler(
       },
     });
   }
-  if (isCompactionMessageType(message)) {
+  const message = messageRes.value;
+  if (message.compactionMessageId) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -134,7 +128,7 @@ async function handler(
     case "POST":
       const created = await createMessageReaction(auth, {
         messageId,
-        conversation,
+        conversation: serializedConversation,
         user: user.toJSON(),
         context: {
           username: user.username,
@@ -159,7 +153,7 @@ async function handler(
     case "DELETE":
       const deleted = await deleteMessageReaction(auth, {
         messageId,
-        conversation,
+        conversation: serializedConversation,
         user: user.toJSON(),
         context: {
           username: user.username,


### PR DESCRIPTION
## Description

- This PR improves the performances of the endpoint by removing the fetch + rendering of the entire conversation.
- It does remove the publication of a `new_user_message` event, not fully sure why we needed it. Initial PR here https://github.com/dust-tt/dust/pull/19367

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy front.
