### PR TITLE
fix(sbx): apply nftables egress rules at boot via systemd oneshot

### DIFF
--- a/front/lib/api/sandbox/image/egress/dust-egress-nftables.service
+++ b/front/lib/api/sandbox/image/egress/dust-egress-nftables.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Dust egress nftables rules for agent-proxied
+After=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/etc/dust/egress-nftables.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/front/lib/api/sandbox/image/egress/egress-nftables.sh
+++ b/front/lib/api/sandbox/image/egress/egress-nftables.sh
@@ -3,7 +3,7 @@ set -eu
 
 PROXIED_UID=1003
 
-# Build-time application should leave the snapshot with a single canonical ruleset.
+# Reinstall a single canonical ruleset on every sandbox boot.
 nft delete table ip dust-egress 2>/dev/null || true
 nft delete table ip6 dust-egress 2>/dev/null || true
 

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -77,7 +77,7 @@ describe("sandbox image registry", () => {
       });
       expect(imageResult.value.imageId).toEqual({
         imageName: "dust-base",
-        tag: "0.7.8",
+        tag: "0.7.9",
       });
     }
   });
@@ -103,7 +103,7 @@ describe("sandbox image registry", () => {
     );
   });
 
-  test("copies the build-time nftables script and executes it during image assembly", () => {
+  test("copies the nftables boot assets and enables the systemd oneshot", () => {
     const operations = getDustBaseImageOperations();
     const runCommands = getRunCommands(operations);
     const copyOperations = getCopyOperations(operations);
@@ -111,15 +111,30 @@ describe("sandbox image registry", () => {
       copyOperations,
       "/etc/dust/egress-nftables.sh"
     );
+    const serviceUnit = getCopiedContent(
+      copyOperations,
+      "/etc/systemd/system/dust-egress-nftables.service"
+    );
 
     expect(runCommands).toEqual(
       expect.arrayContaining([
-        "chmod 755 /etc/dust/egress-nftables.sh && /etc/dust/egress-nftables.sh",
+        "chmod 755 /etc/dust/egress-nftables.sh",
+        "systemctl daemon-reload && systemctl enable dust-egress-nftables.service",
       ])
     );
 
-    expect(runCommands.join("\n")).not.toContain("systemctl enable");
+    expect(runCommands.join("\n")).not.toContain(
+      "chmod 755 /etc/dust/egress-nftables.sh && /etc/dust/egress-nftables.sh"
+    );
     expect(runCommands.join("\n")).not.toContain("iptables");
+
+    expect(serviceUnit).toContain(
+      "Description=Dust egress nftables rules for agent-proxied"
+    );
+    expect(serviceUnit).toContain("Type=oneshot");
+    expect(serviceUnit).toContain("RemainAfterExit=yes");
+    expect(serviceUnit).toContain("ExecStart=/etc/dust/egress-nftables.sh");
+    expect(serviceUnit).toContain("WantedBy=multi-user.target");
 
     expect(nftablesScript).toContain("nft add table ip dust-egress");
     expect(nftablesScript).toContain(

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -11,7 +11,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.6.0";
-const DUST_BASE_IMAGE_VERSION = "0.7.8";
+const DUST_BASE_IMAGE_VERSION = "0.7.9";
 const DSBX_CLI_VERSION = "0.1.4";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
@@ -268,8 +268,14 @@ SHELLEOF`,
     "/etc/dust/egress-nftables.sh",
     { user: "root" }
   )
+  .runCmd("chmod 755 /etc/dust/egress-nftables.sh", { user: "root" })
+  .copy(
+    getLocalContent(EGRESS_LOCAL_DIR, "dust-egress-nftables.service"),
+    "/etc/systemd/system/dust-egress-nftables.service",
+    { user: "root" }
+  )
   .runCmd(
-    "chmod 755 /etc/dust/egress-nftables.sh && /etc/dust/egress-nftables.sh",
+    "systemctl daemon-reload && systemctl enable dust-egress-nftables.service",
     { user: "root" }
   )
   // Profile functions (no install needed, provided by profile scripts)


### PR DESCRIPTION
## Description

nft rules applied at build time work fine (exit 0) but don't survive the Firecracker snapshot. After boot, `nft list ruleset` is empty. Confirmed on dust-base:0.7.8.

Fix: systemd oneshot that re-applies nftables on every boot (~291ms). Rules persist across execs and pause/resume.

- New `dust-egress-nftables.service` oneshot unit
- `registry.ts`: swap build-time exec for `systemctl enable`, bump to 0.7.9
- Tests updated for systemd pattern

## Tests

Unit tests in `registry.test.ts` check the service unit content, systemctl enable in run commands, and no leftover build-time execution or iptables refs.

After template build: `systemctl status dust-egress-nftables` should be active, `nft list ruleset | grep skuid` should show 14 rules.

## Risk

Low. Same nft script as 0.7.8, just delivered via systemd instead of baked at build time. Rollback to 0.7.8 is safe (rules just won't be enforced).

## Deploy Plan

1. Merge
2. Trigger Sandbox Image Registry workflow with `rebuild=true` to build dust-base:0.7.9
3. Verify on live sandbox