### PR TITLE
Stop loading full conversation in sandbox status endpoint

### DIFF
--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
@@ -1,8 +1,7 @@
 /** @ignoreswagger */
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { apiError } from "@app/logger/withlogging";
@@ -42,9 +41,15 @@ async function handler(
     });
   }
 
-  const conversationRes = await getConversation(auth, cId);
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
+  const conversation = await ConversationResource.fetchById(auth, cId);
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "The conversation you're trying to access was not found.",
+      },
+    });
   }
 
   const sandbox = await SandboxResource.fetchByConversationId(auth, cId);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread for context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1776415118956069).

The sandbox status endpoint (`GET /api/w/[wId]/assistant/conversations/[cId]/sandbox`) was calling `getConversation` which loads every message in the conversation, renders each one, and returns the full conversation tree, just to check that the conversation exists before returning a single `sandboxStatus` field.

For a long conversation this was firing ~1 query per message, all concurrently. We measured a peak of 100+ concurrent queries from a single request to this endpoint.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
