### PR TITLE
Fix: mentions should let you invite people if the conversation url is not shareable.

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -85,13 +85,22 @@ export async function getMentionStatus(
     return "user_restricted_by_conversation_access";
   }
 
-  const canAccess = await canUserAccessConversation(auth, {
+  const access = await canUserAccessConversation(auth, {
     userId: mentionedUser.sId,
     conversationId: conversation.sId,
   });
-  if (!canAccess) {
-    return "user_restricted_by_conversation_access";
+  switch (access) {
+    case "conversation_not_found":
+    case "conversation_access_restricted":
+      return "user_restricted_by_conversation_access";
+    case "allowed":
+    case "conversation_access_restricted_by_private_by_default_url_restriction":
+      // Let the rest of the flow handle it.
+      break;
+    default:
+      assertNever(access);
   }
+
   if (isParticipant) {
     return "approved";
   }

--- a/front/lib/api/assistant/conversation/permissions.ts
+++ b/front/lib/api/assistant/conversation/permissions.ts
@@ -1,6 +1,9 @@
 import { getContentFragmentSpaceIds } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import {
+  type ConversationAccessType,
+  ConversationResource,
+} from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
@@ -23,19 +26,16 @@ export async function canUserAccessConversation(
     userId: string;
     conversationId: string;
   }
-): Promise<boolean> {
+): Promise<ConversationAccessType> {
   const workspace = auth.getNonNullableWorkspace();
   const fakeAuth = await Authenticator.fromUserIdAndWorkspaceId(
     userId,
     workspace.sId
   );
 
-  const canAccess = await ConversationResource.canAccess(
-    fakeAuth,
-    conversationId
-  );
+  const access = await ConversationResource.canAccess(fakeAuth, conversationId);
 
-  return canAccess === "allowed";
+  return access;
 }
 
 /**

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -72,6 +72,12 @@ interface UserParticipation {
   updated: number;
 }
 
+export type ConversationAccessType =
+  | "allowed"
+  | "conversation_not_found"
+  | "conversation_access_restricted"
+  | "conversation_access_restricted_by_private_by_default_url_restriction";
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -585,9 +591,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   static async canAccess(
     auth: Authenticator,
     sId: string
-  ): Promise<
-    "allowed" | "conversation_not_found" | "conversation_access_restricted"
-  > {
+  ): Promise<ConversationAccessType> {
     const workspace = auth.getNonNullableWorkspace();
     const { where } = this.getOptions();
     const conversation = await this.model.findOne({
@@ -620,7 +624,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         conversation
       ))
     ) {
-      return "conversation_access_restricted";
+      return "conversation_access_restricted_by_private_by_default_url_restriction";
     }
 
     return "allowed";


### PR DESCRIPTION
## Description

When `privateConversationUrlsByDefault` is on, `canAccess` returned `"conversation_access_restricted"` for both "you don't have space access" and "you're not a participant yet". `getMentionStatus` treated both the same — blocking the mention — which meant you couldn't @-mention someone into a private-by-default conversation even though mentioning is exactly how they're supposed to join.

The fix is to distinguish the two cases at the type level so callers can act on them differently.

- Extract `ConversationAccessType` union (`"allowed"` | `"conversation_not_found"` | `"conversation_access_restricted"` | `"conversation_access_restricted_by_private_by_default_url_restriction"`) and use it as the return type of `canAccess`
- Rename the private-by-default branch to return `"conversation_access_restricted_by_private_by_default_url_restriction"` instead of the generic `"conversation_access_restricted"`
- Change `canUserAccessConversation` to return `ConversationAccessType` instead of `boolean`
- In `getMentionStatus`, switch on the access type: only hard-block on `"conversation_not_found"` and `"conversation_access_restricted"`; let `"allowed"` and `"conversation_access_restricted_by_private_by_default_url_restriction"` fall through to the normal mention/invite flow

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`
