### PR TITLE
Remove admin override to access conversation when private url is enabled.

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1399,7 +1399,7 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     expect(conversationIds).not.toContain(tempSpaceConvo.sId);
   });
 
-  it("should require user participation when private conversation URLs are private by default", async () => {
+  it("should require user participation when private conversation URLs are private by default (including admins)", async () => {
     const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
       privateConversationUrlsByDefault: true,
     });
@@ -1444,7 +1444,7 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
 
     const adminConversations =
       await ConversationResource.listAll(refreshedAdminAuth);
-    expect(adminConversations.map((c) => c.sId)).toContain(
+    expect(adminConversations.map((c) => c.sId)).not.toContain(
       participantRequiredConversation.sId
     );
   });
@@ -3422,7 +3422,9 @@ describe("Space Handling", () => {
         conversations.accessible
       );
 
-      expect(result).toBe("conversation_access_restricted");
+      expect(result).toBe(
+        "conversation_access_restricted_by_private_by_default_url_restriction"
+      );
     });
 
     it("should return 'allowed' for non-participants when URL access mode is workspace_members", async () => {
@@ -3481,7 +3483,10 @@ describe("Space Handling", () => {
 
       const conversation = await ConversationResource.fetchById(
         refreshedAdminAuth,
-        conversations.accessible
+        conversations.accessible,
+        {
+          dangerouslySkipPermissionFiltering: true,
+        }
       );
       assert(conversation, "Conversation not found");
 
@@ -3581,7 +3586,7 @@ describe("Space Handling", () => {
       expect(result).toBe("conversation_access_restricted");
     });
 
-    it("should allow admin access when private conversation URLs are private by default", async () => {
+    it("should restrict admin access when private conversation URLs are private by default and admin is not a participant", async () => {
       const updateResult = await WorkspaceResource.updateMetadata(
         workspace.id,
         {
@@ -3600,7 +3605,9 @@ describe("Space Handling", () => {
         conversations.accessible
       );
 
-      expect(result).toBe("allowed");
+      expect(result).toBe(
+        "conversation_access_restricted_by_private_by_default_url_restriction"
+      );
     });
 
     it("should restore previous behavior when private conversation URLs are disabled again", async () => {
@@ -3618,7 +3625,9 @@ describe("Space Handling", () => {
         refreshedUserAuth,
         conversations.accessible
       );
-      expect(result).toBe("conversation_access_restricted");
+      expect(result).toBe(
+        "conversation_access_restricted_by_private_by_default_url_restriction"
+      );
 
       updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
         privateConversationUrlsByDefault: false,

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -483,16 +483,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       )
     );
 
-    if (
-      !this.isPrivateConversationUrlsByDefaultEnabled(auth) ||
-      auth.isAdmin()
-    ) {
+    if (!this.isPrivateConversationUrlsByDefaultEnabled(auth)) {
       return spaceBasedAccessible;
-    }
-
-    const user = auth.user();
-    if (!user || spaceBasedAccessible.length === 0) {
-      return [];
     }
 
     const participantRestrictedConversations = spaceBasedAccessible.filter(
@@ -501,6 +493,19 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         this.getConversationUrlAccessModeForPrivateByDefault(conversation) ===
           "participants_only"
     );
+
+    const user = auth.user();
+    if (!user || spaceBasedAccessible.length === 0) {
+      const participantRestrictedConversationIds = new Set(
+        participantRestrictedConversations.map(
+          (conversation) => conversation.id
+        )
+      );
+      return spaceBasedAccessible.filter(
+        (conversation) =>
+          !participantRestrictedConversationIds.has(conversation.id)
+      );
+    }
 
     if (participantRestrictedConversations.length === 0) {
       return spaceBasedAccessible;
@@ -535,10 +540,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     conversation: ConversationModel
   ): Promise<boolean> {
     if (!this.isPrivateConversationUrlsByDefaultEnabled(auth)) {
-      return true;
-    }
-
-    if (auth.isAdmin()) {
       return true;
     }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -62,17 +62,15 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]", () => {
     expect(res._getStatusCode()).toBe(200);
   });
 
-  it("returns 403 conversation_access_restricted for non-participants when private conversation URLs are enabled", async () => {
+  it("returns 404 conversation_not_found for non-participants when private conversation URLs are enabled", async () => {
     const { req, res } = await setupUserRequestWithConversation({
       privateByDefaultEnabled: true,
     });
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData().error.type).toBe(
-      "conversation_access_restricted"
-    );
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("conversation_not_found");
   });
 
   it("returns 200 for participants when private conversation URLs are enabled", async () => {
@@ -140,7 +138,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]", () => {
     expect(res._getStatusCode()).toBe(200);
   });
 
-  it("returns 200 for admins when private conversation URLs are enabled", async () => {
+  it("returns 404 conversation_not_found for admins when private conversation URLs are enabled and they are not participants", async () => {
     const { req, res, workspace, globalSpace } =
       await createPrivateApiMockRequest({
         role: "admin",
@@ -174,7 +172,8 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]", () => {
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(200);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("conversation_not_found");
   });
 });
 


### PR DESCRIPTION
## Description

The initial implementation gave admins a blanket pass on `privateConversationUrlsByDefault` — they could always access any conversation regardless of participation. This defeats the purpose of the feature: if the whole point is that even workspace members can't access a conversation they weren't part of, admins should be subject to the same rule.

- Remove the `auth.isAdmin()` bypass from both `canUserAccessPrivateByDefaultConversation` and `listAll`'s participation filter
- Admins now need to be actual participants to access a private-by-default conversation, just like regular users
- Change the API response for non-participant access from `403 conversation_access_restricted` → `404 conversation_not_found` (avoids leaking conversation existence to non-participants)
- Update tests: admin non-participant now expects `"conversation_access_restricted_by_private_by_default_url_restriction"` / 404; `listAll` for admins no longer includes conversations they haven't participated in

## Tests

Local + green (tests updated)

## Risk

Low — tightens access; only affects workspaces that have explicitly enabled the flag

## Deploy Plan

Deploy `front`
