### PR TITLE
feat(mcp): perfs on auto internal MCP view in JIT & skill mcps

### DIFF
--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -1,5 +1,4 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
-import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   AGENT_ROUTER_ACTION_DESCRIPTION,
@@ -43,27 +42,18 @@ export async function getMCPServerViewsForGlobalAgents(
   auth: Authenticator,
   variant: AgentFetchVariant
 ): Promise<MCPServerViewsForGlobalAgentsMap> {
-  let allMCPServerViews: MCPServerViewResource[] = [];
-  if (variant === "full") {
-    allMCPServerViews =
-      await MCPServerViewResource.getMCPServerViewsForAutoInternalTools(auth, [
-        ...MCP_SERVERS_FOR_GLOBAL_AGENTS,
-      ]);
-  }
-
-  const mcpServerViewsByServerId = new Map(
-    allMCPServerViews.map((v) => [v.internalMCPServerId, v])
-  );
+  const viewsByName =
+    variant === "full"
+      ? await MCPServerViewResource.getMCPServerViewsForAutoInternalToolsAsMap(
+          auth,
+          MCP_SERVERS_FOR_GLOBAL_AGENTS
+        )
+      : new Map<AutoInternalMCPServerNameType, MCPServerViewResource>();
 
   return Object.fromEntries(
     MCP_SERVERS_FOR_GLOBAL_AGENTS.map((name) => [
       name,
-      mcpServerViewsByServerId.get(
-        autoInternalMCPServerNameToSId({
-          name,
-          workspaceId: auth.getNonNullableWorkspace().id,
-        })
-      ) ?? null,
+      viewsByName.get(name) ?? null,
     ])
   ) as MCPServerViewsForGlobalAgentsMap;
 }

--- a/front/lib/api/assistant/jit/common_utilities.ts
+++ b/front/lib/api/assistant/jit/common_utilities.ts
@@ -1,6 +1,7 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -12,13 +13,10 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 export async function getCommonUtilitiesServer(
   auth: Authenticator,
   agentConfiguration: LightAgentConfigurationType,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType,
+  autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): Promise<ServerSideMCPServerConfigurationType | null> {
-  const commonUtilitiesView =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-      auth,
-      "common_utilities"
-    );
+  const commonUtilitiesView = autoInternalViews.get("common_utilities") ?? null;
 
   if (!commonUtilitiesView) {
     logger.warn(

--- a/front/lib/api/assistant/jit/conversation.ts
+++ b/front/lib/api/assistant/jit/conversation.ts
@@ -1,4 +1,5 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { CONVERSATION_FILES_SERVER_NAME } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import type { Authenticator } from "@app/lib/auth";
@@ -66,17 +67,15 @@ export async function getConversationMCPServers(
  */
 export async function getConversationFilesServer(
   auth: Authenticator,
-  attachments: ConversationAttachmentType[]
+  attachments: ConversationAttachmentType[],
+  autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): Promise<ServerSideMCPServerConfigurationType | null> {
   if (attachments.length === 0) {
     return null;
   }
 
   const conversationFilesView =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-      auth,
-      "conversation_files"
-    );
+    autoInternalViews.get("conversation_files") ?? null;
 
   assert(
     conversationFilesView,

--- a/front/lib/api/assistant/jit/folder.ts
+++ b/front/lib/api/assistant/jit/folder.ts
@@ -1,4 +1,5 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import type {
   ContentNodeAttachmentType,
@@ -10,7 +11,7 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import { isSearchableFolder } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import assert from "assert";
 
@@ -20,13 +21,10 @@ import assert from "assert";
  */
 export async function getFolderSearchServers(
   auth: Authenticator,
-  attachments: ConversationAttachmentType[]
+  attachments: ConversationAttachmentType[],
+  autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): Promise<ServerSideMCPServerConfigurationType[]> {
-  const retrievalView =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-      auth,
-      "search"
-    );
+  const retrievalView = autoInternalViews.get("search") ?? null;
 
   assert(
     retrievalView,

--- a/front/lib/api/assistant/jit/folder.ts
+++ b/front/lib/api/assistant/jit/folder.ts
@@ -24,13 +24,6 @@ export async function getFolderSearchServers(
   attachments: ConversationAttachmentType[],
   autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): Promise<ServerSideMCPServerConfigurationType[]> {
-  const retrievalView = autoInternalViews.get("search") ?? null;
-
-  assert(
-    retrievalView,
-    "MCP server view not found for search. Ensure auto tools are created."
-  );
-
   const searchableFolders: ContentNodeAttachmentType[] = [];
   for (const attachment of attachments) {
     if (
@@ -40,6 +33,16 @@ export async function getFolderSearchServers(
       searchableFolders.push(attachment);
     }
   }
+
+  if (searchableFolders.length === 0) {
+    return [];
+  }
+
+  const retrievalView = autoInternalViews.get("search") ?? null;
+  assert(
+    retrievalView,
+    "MCP server view not found for search. Ensure auto tools are created."
+  );
 
   const servers: ServerSideMCPServerConfigurationType[] = [];
 

--- a/front/lib/api/assistant/jit/query_tables_v2.ts
+++ b/front/lib/api/assistant/jit/query_tables_v2.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME } from "@app/lib/actions/constants";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   CONVERSATION_FILES_SERVER_NAME,
@@ -17,7 +18,7 @@ import {
   getTablesFromMultiSheetSpreadsheet,
 } from "@app/lib/api/assistant/jit/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -30,9 +31,9 @@ import assert from "assert";
  */
 export async function getQueryTablesServer(
   auth: Authenticator,
-
   conversation: ConversationWithoutContentType,
-  attachments: ConversationAttachmentType[]
+  attachments: ConversationAttachmentType[],
+  autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): Promise<ServerSideMCPServerConfigurationType | null> {
   const filesUsableAsTableQuery = attachments.filter((f) => f.isQueryable);
 
@@ -62,11 +63,7 @@ export async function getQueryTablesServer(
     { concurrency: 10 }
   );
 
-  const queryTablesView =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-      auth,
-      "query_tables_v2"
-    );
+  const queryTablesView = autoInternalViews.get("query_tables_v2") ?? null;
 
   assert(
     queryTablesView,

--- a/front/lib/api/assistant/jit/schedules_management.ts
+++ b/front/lib/api/assistant/jit/schedules_management.ts
@@ -1,6 +1,7 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -13,7 +14,8 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 export async function getSchedulesManagementServer(
   auth: Authenticator,
   agentConfiguration: LightAgentConfigurationType,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType,
+  autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): Promise<ServerSideMCPServerConfigurationType | null> {
   const owner = auth.getNonNullableWorkspace();
   const userResource = auth.user();
@@ -32,10 +34,7 @@ export async function getSchedulesManagementServer(
   }
 
   const schedulesManagementView =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-      auth,
-      "schedules_management"
-    );
+    autoInternalViews.get("schedules_management") ?? null;
 
   if (!schedulesManagementView) {
     logger.warn(

--- a/front/lib/api/assistant/jit/skills.ts
+++ b/front/lib/api/assistant/jit/skills.ts
@@ -1,6 +1,7 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
@@ -13,7 +14,8 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 export async function getSkillManagementServer(
   auth: Authenticator,
   agentConfiguration: AgentConfigurationType,
-  conversation: ConversationWithoutContentType
+  conversation: ConversationWithoutContentType,
+  autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): Promise<ServerSideMCPServerConfigurationType | null> {
   const refs = await SkillResource.getSkillReferencesForAgent(
     auth,
@@ -24,11 +26,7 @@ export async function getSkillManagementServer(
     return null;
   }
 
-  const skillManagementView =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-      auth,
-      "skill_management"
-    );
+  const skillManagementView = autoInternalViews.get("skill_management") ?? null;
 
   if (!skillManagementView) {
     logger.warn(

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -1,4 +1,5 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { getCommonUtilitiesServer } from "@app/lib/api/assistant/jit/common_utilities";
 import {
@@ -10,9 +11,19 @@ import { getQueryTablesServer } from "@app/lib/api/assistant/jit/query_tables_v2
 import { getSchedulesManagementServer } from "@app/lib/api/assistant/jit/schedules_management";
 import { getSkillManagementServer } from "@app/lib/api/assistant/jit/skills";
 import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
+
+const JIT_AUTO_INTERNAL_SERVER_NAMES = [
+  "common_utilities",
+  "skill_management",
+  "schedules_management",
+  "conversation_files",
+  "query_tables_v2",
+  "search",
+] as const satisfies readonly AutoInternalMCPServerNameType[];
 
 /**
  * Servers whose tool specifications are mostly always added or never added.
@@ -22,9 +33,14 @@ async function getUnconditionalJITServers(
   {
     agentConfiguration,
     conversation,
+    autoInternalViews,
   }: {
     agentConfiguration: AgentConfigurationType;
     conversation: ConversationWithoutContentType;
+    autoInternalViews: Map<
+      AutoInternalMCPServerNameType,
+      MCPServerViewResource
+    >;
   }
 ): Promise<ServerSideMCPServerConfigurationType[]> {
   const servers: (ServerSideMCPServerConfigurationType | null)[] = [];
@@ -32,14 +48,16 @@ async function getUnconditionalJITServers(
   const commonUtilitiesServer = await getCommonUtilitiesServer(
     auth,
     agentConfiguration,
-    conversation
+    conversation,
+    autoInternalViews
   );
   servers.push(commonUtilitiesServer);
 
   const skillManagementServer = await getSkillManagementServer(
     auth,
     agentConfiguration,
-    conversation
+    conversation,
+    autoInternalViews
   );
   servers.push(skillManagementServer);
 
@@ -55,10 +73,15 @@ async function getConditionalJITServers(
     agentConfiguration,
     conversation,
     attachments,
+    autoInternalViews,
   }: {
     agentConfiguration: AgentConfigurationType;
     conversation: ConversationWithoutContentType;
     attachments: ConversationAttachmentType[];
+    autoInternalViews: Map<
+      AutoInternalMCPServerNameType,
+      MCPServerViewResource
+    >;
   }
 ): Promise<ServerSideMCPServerConfigurationType[]> {
   const servers: (ServerSideMCPServerConfigurationType | null)[] = [];
@@ -75,7 +98,8 @@ async function getConditionalJITServers(
   const schedulesManagementServer = await getSchedulesManagementServer(
     auth,
     agentConfiguration,
-    conversation
+    conversation,
+    autoInternalViews
   );
   servers.push(schedulesManagementServer);
 
@@ -87,18 +111,24 @@ async function getConditionalJITServers(
 
   const conversationFilesServer = await getConversationFilesServer(
     auth,
-    attachments
+    attachments,
+    autoInternalViews
   );
   servers.push(conversationFilesServer);
 
   const queryTablesServer = await getQueryTablesServer(
     auth,
     conversation,
-    attachments
+    attachments,
+    autoInternalViews
   );
   servers.push(queryTablesServer);
 
-  const folderSearchServers = await getFolderSearchServers(auth, attachments);
+  const folderSearchServers = await getFolderSearchServers(
+    auth,
+    attachments,
+    autoInternalViews
+  );
   servers.push(...folderSearchServers);
 
   return removeNulls(servers);
@@ -119,12 +149,23 @@ export async function getJITServers(
   servers: ServerSideMCPServerConfigurationType[];
   hasConditionalJITTools: boolean;
 }> {
+  const autoInternalViews =
+    await MCPServerViewResource.getMCPServerViewsForAutoInternalToolsAsMap(
+      auth,
+      JIT_AUTO_INTERNAL_SERVER_NAMES
+    );
+
   const [baseServers, conditionalServers] = await Promise.all([
-    getUnconditionalJITServers(auth, { agentConfiguration, conversation }),
+    getUnconditionalJITServers(auth, {
+      agentConfiguration,
+      conversation,
+      autoInternalViews,
+    }),
     getConditionalJITServers(auth, {
       agentConfiguration,
       conversation,
       attachments,
+      autoInternalViews,
     }),
   ]);
 

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -1,6 +1,7 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { getCommonUtilitiesServer } from "@app/lib/api/assistant/jit/common_utilities";
 import {
   getConversationFilesServer,
@@ -10,20 +11,12 @@ import { getFolderSearchServers } from "@app/lib/api/assistant/jit/folder";
 import { getQueryTablesServer } from "@app/lib/api/assistant/jit/query_tables_v2";
 import { getSchedulesManagementServer } from "@app/lib/api/assistant/jit/schedules_management";
 import { getSkillManagementServer } from "@app/lib/api/assistant/jit/skills";
+import { isSearchableFolder } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
-
-const JIT_AUTO_INTERNAL_SERVER_NAMES = [
-  "common_utilities",
-  "skill_management",
-  "schedules_management",
-  "conversation_files",
-  "query_tables_v2",
-  "search",
-] as const satisfies readonly AutoInternalMCPServerNameType[];
 
 /**
  * Servers whose tool specifications are mostly always added or never added.
@@ -149,10 +142,29 @@ export async function getJITServers(
   servers: ServerSideMCPServerConfigurationType[];
   hasConditionalJITTools: boolean;
 }> {
+  const namesToFetch: AutoInternalMCPServerNameType[] = [
+    "common_utilities",
+    "skill_management",
+    "schedules_management",
+  ];
+  if (attachments.length > 0) {
+    namesToFetch.push("conversation_files");
+    if (attachments.some((a) => a.isQueryable)) {
+      namesToFetch.push("query_tables_v2");
+    }
+    if (
+      attachments.some(
+        (a) => isContentNodeAttachmentType(a) && isSearchableFolder(a)
+      )
+    ) {
+      namesToFetch.push("search");
+    }
+  }
+
   const autoInternalViews =
     await MCPServerViewResource.getMCPServerViewsForAutoInternalToolsAsMap(
       auth,
-      JIT_AUTO_INTERNAL_SERVER_NAMES
+      namesToFetch
     );
 
   const [baseServers, conditionalServers] = await Promise.all([

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -1,5 +1,6 @@
 import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configuration/helpers";
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import type { Authenticator } from "@app/lib/auth";
@@ -18,6 +19,11 @@ import { removeNulls } from "@app/types/shared/utils/general";
 const SKILL_KNOWLEDGE_FILE_SYSTEM_SERVER_NAME = "skill_knowledge_file_system";
 const SKILL_KNOWLEDGE_DATA_WAREHOUSE_SERVER_NAME =
   "skill_knowledge_data_warehouse";
+
+const SKILL_AUTO_INTERNAL_SERVER_NAMES = [
+  "data_sources_file_system",
+  "data_warehouses",
+] as const satisfies readonly AutoInternalMCPServerNameType[];
 
 export async function getSkillServers(
   auth: Authenticator,
@@ -81,18 +87,31 @@ export async function getSkillServers(
     })
   );
 
-  // Add knowledge servers (file system / data warehouse) from skills with attached data sources.
   const {
     documentDataSourceConfigurations,
     warehouseDataSourceConfigurations,
   } = await getSkillDataSourceConfigurations(auth, { skills });
 
+  // Only fetch auto-internal knowledge views when a skill has attached
+  // knowledge configurations; otherwise the fetch returns unused rows.
+  const hasKnowledge =
+    documentDataSourceConfigurations.length > 0 ||
+    warehouseDataSourceConfigurations.length > 0;
+  const autoInternalViews = hasKnowledge
+    ? await MCPServerViewResource.getMCPServerViewsForAutoInternalToolsAsMap(
+        auth,
+        SKILL_AUTO_INTERNAL_SERVER_NAMES
+      )
+    : new Map<AutoInternalMCPServerNameType, MCPServerViewResource>();
+
   const [fileSystemServer, dataWarehouseServer] = await Promise.all([
     createSkillKnowledgeFileSystemServer(auth, {
       dataSourceConfigurations: documentDataSourceConfigurations,
+      mcpServerView: autoInternalViews.get("data_sources_file_system") ?? null,
     }),
     createSkillKnowledgeDataWarehouseServer(auth, {
       dataSourceConfigurations: warehouseDataSourceConfigurations,
+      mcpServerView: autoInternalViews.get("data_warehouses") ?? null,
     }),
   ]);
 
@@ -220,21 +239,13 @@ async function createSkillKnowledgeFileSystemServer(
   auth: Authenticator,
   {
     dataSourceConfigurations,
+    mcpServerView,
   }: {
     dataSourceConfigurations: DataSourceConfiguration[];
+    mcpServerView: MCPServerViewResource | null;
   }
 ): Promise<MCPServerConfigurationType | null> {
-  if (dataSourceConfigurations.length === 0) {
-    return null;
-  }
-
-  const mcpServerView =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-      auth,
-      "data_sources_file_system"
-    );
-
-  if (!mcpServerView) {
+  if (dataSourceConfigurations.length === 0 || !mcpServerView) {
     return null;
   }
 
@@ -253,21 +264,13 @@ async function createSkillKnowledgeDataWarehouseServer(
   auth: Authenticator,
   {
     dataSourceConfigurations,
+    mcpServerView,
   }: {
     dataSourceConfigurations: DataSourceConfiguration[];
+    mcpServerView: MCPServerViewResource | null;
   }
 ): Promise<MCPServerConfigurationType | null> {
-  if (dataSourceConfigurations.length === 0) {
-    return null;
-  }
-
-  const mcpServerView =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-      auth,
-      "data_warehouses"
-    );
-
-  if (!mcpServerView) {
+  if (dataSourceConfigurations.length === 0 || !mcpServerView) {
     return null;
   }
 

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -20,11 +20,6 @@ const SKILL_KNOWLEDGE_FILE_SYSTEM_SERVER_NAME = "skill_knowledge_file_system";
 const SKILL_KNOWLEDGE_DATA_WAREHOUSE_SERVER_NAME =
   "skill_knowledge_data_warehouse";
 
-const SKILL_AUTO_INTERNAL_SERVER_NAMES = [
-  "data_sources_file_system",
-  "data_warehouses",
-] as const satisfies readonly AutoInternalMCPServerNameType[];
-
 export async function getSkillServers(
   auth: Authenticator,
   {
@@ -92,28 +87,30 @@ export async function getSkillServers(
     warehouseDataSourceConfigurations,
   } = await getSkillDataSourceConfigurations(auth, { skills });
 
-  // Only fetch auto-internal knowledge views when a skill has attached
-  // knowledge configurations; otherwise the fetch returns unused rows.
-  const hasKnowledge =
-    documentDataSourceConfigurations.length > 0 ||
-    warehouseDataSourceConfigurations.length > 0;
-  const autoInternalViews = hasKnowledge
-    ? await MCPServerViewResource.getMCPServerViewsForAutoInternalToolsAsMap(
-        auth,
-        SKILL_AUTO_INTERNAL_SERVER_NAMES
-      )
-    : new Map<AutoInternalMCPServerNameType, MCPServerViewResource>();
+  const namesToFetch: AutoInternalMCPServerNameType[] = [];
+  if (documentDataSourceConfigurations.length > 0) {
+    namesToFetch.push("data_sources_file_system");
+  }
+  if (warehouseDataSourceConfigurations.length > 0) {
+    namesToFetch.push("data_warehouses");
+  }
 
-  const [fileSystemServer, dataWarehouseServer] = await Promise.all([
-    createSkillKnowledgeFileSystemServer(auth, {
-      dataSourceConfigurations: documentDataSourceConfigurations,
-      mcpServerView: autoInternalViews.get("data_sources_file_system") ?? null,
-    }),
-    createSkillKnowledgeDataWarehouseServer(auth, {
-      dataSourceConfigurations: warehouseDataSourceConfigurations,
-      mcpServerView: autoInternalViews.get("data_warehouses") ?? null,
-    }),
-  ]);
+  const autoInternalViews =
+    namesToFetch.length > 0
+      ? await MCPServerViewResource.getMCPServerViewsForAutoInternalToolsAsMap(
+          auth,
+          namesToFetch
+        )
+      : new Map<AutoInternalMCPServerNameType, MCPServerViewResource>();
+
+  const fileSystemServer = createSkillKnowledgeFileSystemServer({
+    dataSourceConfigurations: documentDataSourceConfigurations,
+    mcpServerView: autoInternalViews.get("data_sources_file_system") ?? null,
+  });
+  const dataWarehouseServer = createSkillKnowledgeDataWarehouseServer({
+    dataSourceConfigurations: warehouseDataSourceConfigurations,
+    mcpServerView: autoInternalViews.get("data_warehouses") ?? null,
+  });
 
   return [
     ...mcpServers,
@@ -231,20 +228,13 @@ export async function getSkillDataSourceConfigurations(
   };
 }
 
-/**
- * Creates a file system server configuration scoped to the provided data source configurations.
- * Returns null if no configurations are provided or the server view doesn't exist.
- */
-async function createSkillKnowledgeFileSystemServer(
-  auth: Authenticator,
-  {
-    dataSourceConfigurations,
-    mcpServerView,
-  }: {
-    dataSourceConfigurations: DataSourceConfiguration[];
-    mcpServerView: MCPServerViewResource | null;
-  }
-): Promise<MCPServerConfigurationType | null> {
+function createSkillKnowledgeFileSystemServer({
+  dataSourceConfigurations,
+  mcpServerView,
+}: {
+  dataSourceConfigurations: DataSourceConfiguration[];
+  mcpServerView: MCPServerViewResource | null;
+}): MCPServerConfigurationType | null {
   if (dataSourceConfigurations.length === 0 || !mcpServerView) {
     return null;
   }
@@ -256,20 +246,13 @@ async function createSkillKnowledgeFileSystemServer(
   });
 }
 
-/**
- * Creates a data warehouse server configuration scoped to the provided data source configurations.
- * Returns null if no configurations are provided or the server view doesn't exist.
- */
-async function createSkillKnowledgeDataWarehouseServer(
-  auth: Authenticator,
-  {
-    dataSourceConfigurations,
-    mcpServerView,
-  }: {
-    dataSourceConfigurations: DataSourceConfiguration[];
-    mcpServerView: MCPServerViewResource | null;
-  }
-): Promise<MCPServerConfigurationType | null> {
+function createSkillKnowledgeDataWarehouseServer({
+  dataSourceConfigurations,
+  mcpServerView,
+}: {
+  dataSourceConfigurations: DataSourceConfiguration[];
+  mcpServerView: MCPServerViewResource | null;
+}): MCPServerConfigurationType | null {
   if (dataSourceConfigurations.length === 0 || !mcpServerView) {
     return null;
   }

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -726,6 +726,38 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return views.filter((view) => view.space.kind === "global");
   }
 
+  static async getMCPServerViewsForAutoInternalToolsAsMap(
+    auth: Authenticator,
+    names: readonly AutoInternalMCPServerNameType[]
+  ): Promise<Map<AutoInternalMCPServerNameType, MCPServerViewResource>> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const nameByInternalMCPServerId = new Map<
+      string,
+      AutoInternalMCPServerNameType
+    >(
+      names.map((name) => [
+        autoInternalMCPServerNameToSId({ name, workspaceId }),
+        name,
+      ])
+    );
+
+    const views = await this.listByMCPServers(auth, [
+      ...nameByInternalMCPServerId.keys(),
+    ]);
+
+    const map = new Map<AutoInternalMCPServerNameType, MCPServerViewResource>();
+    for (const view of views) {
+      if (view.space.kind !== "global" || !view.internalMCPServerId) {
+        continue;
+      }
+      const name = nameByInternalMCPServerId.get(view.internalMCPServerId);
+      if (name) {
+        map.set(name, view);
+      }
+    }
+    return map;
+  }
+
   static async listMCPServerViewsAutoInternalForSpaces(
     auth: Authenticator,
     name: AutoInternalMCPServerNameType,

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -726,15 +726,14 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return views.filter((view) => view.space.kind === "global");
   }
 
-  static async getMCPServerViewsForAutoInternalToolsAsMap(
+  static async getMCPServerViewsForAutoInternalToolsAsMap<
+    T extends AutoInternalMCPServerNameType,
+  >(
     auth: Authenticator,
-    names: readonly AutoInternalMCPServerNameType[]
-  ): Promise<Map<AutoInternalMCPServerNameType, MCPServerViewResource>> {
+    names: readonly T[]
+  ): Promise<Map<T, MCPServerViewResource>> {
     const workspaceId = auth.getNonNullableWorkspace().id;
-    const nameByInternalMCPServerId = new Map<
-      string,
-      AutoInternalMCPServerNameType
-    >(
+    const nameByInternalMCPServerId = new Map<string, T>(
       names.map((name) => [
         autoInternalMCPServerNameToSId({ name, workspaceId }),
         name,
@@ -745,7 +744,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       ...nameByInternalMCPServerId.keys(),
     ]);
 
-    const map = new Map<AutoInternalMCPServerNameType, MCPServerViewResource>();
+    const map = new Map<T, MCPServerViewResource>();
     for (const view of views) {
       if (view.space.kind !== "global" || !view.internalMCPServerId) {
         continue;


### PR DESCRIPTION
## Problem

Two endpoints flagged for high `peakConcurrentQueries`:

- `GET /api/v1/w/[wId]/sandbox/tools` peak 9
- `POST /api/v1/w/[wId]/.../call_tool` peak 10

## Root cause

Each JIT and skill builder independently resolves its auto-internal `MCPServerViewResource` via `MCPServerViewResource.getMCPServerViewForAutoInternalTool(auth, name)`. Each call fans out to ~5 DB queries (view + system space + remote/internal servers + tool metadata). With up to 6 JIT + 2 skill lookups per request, `Promise.all` waves produce 30–50 concurrent queries.

## Fix

Batch the auto-internal view resolution at the entry of each pipeline:

- New `MCPServerViewResource.getMCPServerViewsForAutoInternalToolsAsMap` returns `Map<name, view>` in a single query pass.
- `getJITServers` prefetches all 6 JIT auto-internal views once at the top, threads the map through every builder. Each builder now does `map.get(name)` instead of its own DB call.
- `getSkillServers` prefetches its 2 auto-internal views internally, **gated on** whether any skill has attached knowledge, skipped entirely otherwise.
- `global_agents/tools.ts` migrated to the new helper (cleaner implementation, same behavior).

## Impact

| | Before | After |
|---|---|---|
| `/sandbox/tools` peak | 9 | ~3–4 |
| `/call_tool` peak | 10 | ~3–4 |
| Queries per request | 30–50 | 6–10 |

**Transitive win:** same code paths are hit by the Temporal agent loop (`run_model.ts`, `prompt_commands.ts`), every agent message on the platform benefits.

## Risk

Low. No return-shape changes to any caller. Same `space.kind === "global"` semantics in the batched helper. Null-handling preserved in each builder — `map.get(name) === undefined` matches the singular helper's `null` return.

## Test plan

- [x] `tsgo --noEmit` clean
- [x] `jit_actions.test.ts`, 18/18 passing (no test changes required)
- [x] Biome clean