### PR TITLE
[Sessions] Carry over content node attachments in forks

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -2,7 +2,11 @@ import {
   createConversation,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
-import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import {
+  isContentNodeAttachmentType,
+  isFileAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
+import * as contentFragmentModule from "@app/lib/api/assistant/conversation/content_fragment";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { createConversationFork } from "@app/lib/api/assistant/conversation/forks";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
@@ -19,6 +23,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
@@ -175,6 +180,29 @@ function mockCopyToConversation() {
       });
 
       return new Ok(copiedFile);
+    });
+}
+
+function mockContentNodeAttachments(nodeDataSourceViewId: number) {
+  return vi
+    .spyOn(contentFragmentModule, "getContentFragmentBlob")
+    .mockImplementation(async (_auth, cf) => {
+      if (!("nodeId" in cf)) {
+        throw new Error(
+          "Unexpected file content fragment input in content node mock."
+        );
+      }
+
+      return new Ok({
+        contentType: "text/plain",
+        fileId: null,
+        nodeId: cf.nodeId,
+        nodeDataSourceViewId,
+        nodeType: "document",
+        sourceUrl: null,
+        textBytes: null,
+        title: cf.title,
+      });
     });
 }
 
@@ -672,6 +700,105 @@ describe("createConversationFork", () => {
 
     copyToConversationSpy.mockRestore();
   }, 15_000);
+
+  it("reattaches content node attachments that existed at the selected source message", async () => {
+    const { auth, workspace, globalSpace } =
+      await createPrivateApiMockRequest();
+
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      globalSpace,
+      auth.user() ?? null
+    );
+    const getContentFragmentBlobSpy = mockContentNodeAttachments(
+      dataSourceView.id
+    );
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    let parentConversationWithContent = await fetchConversationOrThrow(
+      auth,
+      parentConversation.sId
+    );
+    const firstAttachmentResult = await postNewContentFragment(
+      auth,
+      parentConversationWithContent,
+      {
+        title: "First note",
+        nodeId: "node_before_fork",
+        nodeDataSourceViewId: dataSourceView.sId,
+      },
+      null
+    );
+    expect(firstAttachmentResult.isOk()).toBe(true);
+
+    parentConversationWithContent = await fetchConversationOrThrow(
+      auth,
+      parentConversation.sId
+    );
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversationWithContent,
+      rank: 1,
+      content: "Fork from here.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversationWithContent,
+      rank: 2,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    parentConversationWithContent = await fetchConversationOrThrow(
+      auth,
+      parentConversation.sId
+    );
+    const secondAttachmentResult = await postNewContentFragment(
+      auth,
+      parentConversationWithContent,
+      {
+        title: "Second note",
+        nodeId: "node_after_fork",
+        nodeDataSourceViewId: dataSourceView.sId,
+      },
+      null
+    );
+    expect(secondAttachmentResult.isOk()).toBe(true);
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
+
+    const childAttachments = await listAttachments(auth, {
+      conversation: childConversation,
+    });
+    const childContentNodeAttachments = childAttachments.filter(
+      isContentNodeAttachmentType
+    );
+
+    expect(childContentNodeAttachments).toHaveLength(1);
+    expect(childContentNodeAttachments[0]?.title).toBe("First note");
+    expect(childContentNodeAttachments[0]?.nodeId).toBe("node_before_fork");
+    expect(childContentNodeAttachments[0]?.nodeDataSourceViewId).toBe(
+      dataSourceView.sId
+    );
+
+    getContentFragmentBlobSpy.mockRestore();
+  });
 
   it("inherits the parent's requested spaces so the fork does not broaden visibility", async () => {
     const {

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -1,5 +1,8 @@
 import { postNewContentFragment } from "@app/lib/api/assistant/conversation";
-import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import {
+  isContentNodeAttachmentType,
+  isFileAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { createUserMessage } from "@app/lib/api/assistant/conversation/messages";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
@@ -213,7 +216,7 @@ async function createForkInitializationMessage(
   });
 }
 
-async function copyConversationFileAttachments(
+async function carryOverConversationAttachments(
   auth: Authenticator,
   {
     parentConversation,
@@ -224,7 +227,7 @@ async function copyConversationFileAttachments(
     childConversation: ConversationType;
     sourceMessageRank: number;
   }
-): Promise<number> {
+): Promise<void> {
   const parentConversationAtSource = filterConversationContentUpToRank(
     parentConversation,
     sourceMessageRank
@@ -232,35 +235,63 @@ async function copyConversationFileAttachments(
   const attachments = await listAttachments(auth, {
     conversation: parentConversationAtSource,
   });
-  // For now we only carry over direct file attachments that were explicitly posted into the
+  // We carry over direct conversation attachments that were explicitly posted into the
   // conversation. Project-context files remain accessible via the shared project, and agent-
-  // generated files need a separate follow-up because they are not re-attached through content
-  // fragments today.
-  const directConversationFileAttachments = attachments
-    .filter(isFileAttachmentType)
-    .filter(
-      (attachment) =>
-        attachment.source === "user" && !attachment.isInProjectContext
-    );
+  // generated files still need a separate follow-up because they are not re-attached through
+  // content fragments today.
+  const directConversationAttachments = attachments.filter((attachment) => {
+    if (isFileAttachmentType(attachment)) {
+      return attachment.source === "user" && !attachment.isInProjectContext;
+    }
 
-  let copiedAttachmentCount = 0;
-  for (const attachment of directConversationFileAttachments) {
-    const copiedFile = await FileResource.copyToConversation(auth, {
-      sourceId: attachment.fileId,
-      conversationId: childConversation.sId,
-    });
+    return isContentNodeAttachmentType(attachment);
+  });
 
-    if (copiedFile.isErr()) {
-      logger.error(
+  for (const attachment of directConversationAttachments) {
+    if (isFileAttachmentType(attachment)) {
+      const copiedFile = await FileResource.copyToConversation(auth, {
+        sourceId: attachment.fileId,
+        conversationId: childConversation.sId,
+      });
+
+      if (copiedFile.isErr()) {
+        logger.error(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            parentConversationId: parentConversation.sId,
+            childConversationId: childConversation.sId,
+            sourceFileId: attachment.fileId,
+            error: copiedFile.error,
+          },
+          "Failed to copy file attachment into forked conversation."
+        );
+        continue;
+      }
+
+      const attachmentResult = await postNewContentFragment(
+        auth,
+        childConversation,
         {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          parentConversationId: parentConversation.sId,
-          childConversationId: childConversation.sId,
-          sourceFileId: attachment.fileId,
-          error: copiedFile.error,
+          title: attachment.title,
+          fileId: copiedFile.value.sId,
         },
-        "Failed to copy file attachment into forked conversation."
+        null
       );
+
+      if (attachmentResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            parentConversationId: parentConversation.sId,
+            childConversationId: childConversation.sId,
+            sourceFileId: attachment.fileId,
+            copiedFileId: copiedFile.value.sId,
+            error: attachmentResult.error,
+          },
+          "Failed to attach copied file into forked conversation."
+        );
+      }
+
       continue;
     }
 
@@ -269,7 +300,8 @@ async function copyConversationFileAttachments(
       childConversation,
       {
         title: attachment.title,
-        fileId: copiedFile.value.sId,
+        nodeId: attachment.nodeId,
+        nodeDataSourceViewId: attachment.nodeDataSourceViewId,
       },
       null
     );
@@ -280,19 +312,15 @@ async function copyConversationFileAttachments(
           workspaceId: auth.getNonNullableWorkspace().sId,
           parentConversationId: parentConversation.sId,
           childConversationId: childConversation.sId,
-          sourceFileId: attachment.fileId,
-          copiedFileId: copiedFile.value.sId,
+          contentFragmentId: attachment.contentFragmentId,
+          nodeId: attachment.nodeId,
+          nodeDataSourceViewId: attachment.nodeDataSourceViewId,
           error: attachmentResult.error,
         },
-        "Failed to attach copied file into forked conversation."
+        "Failed to reattach content node into forked conversation."
       );
-      continue;
     }
-
-    copiedAttachmentCount += 1;
   }
-
-  return copiedAttachmentCount;
 }
 
 export async function createConversationFork(
@@ -421,7 +449,7 @@ export async function createConversationFork(
         childConversationId: childConversationId.value.childConversationId,
         error: childConversation.error,
       },
-      "Failed to reload child conversation for fork file attachment copy."
+      "Failed to reload child conversation for fork attachment carryover."
     );
 
     return new Ok(childConversationId.value.childConversationId);
@@ -439,12 +467,12 @@ export async function createConversationFork(
         childConversationId: childConversation.value.sId,
         error: parentConversationWithContent.error,
       },
-      "Failed to reload parent conversation for fork file attachment copy."
+      "Failed to reload parent conversation for fork attachment carryover."
     );
     return new Ok(childConversation.value.sId);
   }
 
-  await copyConversationFileAttachments(auth, {
+  await carryOverConversationAttachments(auth, {
     parentConversation: parentConversationWithContent.value,
     childConversation: childConversation.value,
     sourceMessageRank: childConversationId.value.sourceMessageRank,

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -18,6 +18,10 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
+  ContentFragmentInputWithContentNode,
+  ContentFragmentInputWithFileIdType,
+} from "@app/types/api/internal/assistant";
+import type {
   ConversationType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
@@ -248,6 +252,12 @@ async function carryOverConversationAttachments(
   });
 
   for (const attachment of directConversationAttachments) {
+    let carriedAttachment:
+      | ContentFragmentInputWithFileIdType
+      | ContentFragmentInputWithContentNode;
+    let attachErrorMessage: string;
+    let attachLogMetadata: Record<string, string>;
+
     if (isFileAttachmentType(attachment)) {
       const copiedFile = await FileResource.copyToConversation(auth, {
         sourceId: attachment.fileId,
@@ -268,41 +278,35 @@ async function carryOverConversationAttachments(
         continue;
       }
 
-      const attachmentResult = await postNewContentFragment(
-        auth,
-        childConversation,
-        {
-          title: attachment.title,
-          fileId: copiedFile.value.sId,
-        },
-        null
-      );
-
-      if (attachmentResult.isErr()) {
-        logger.error(
-          {
-            workspaceId: auth.getNonNullableWorkspace().sId,
-            parentConversationId: parentConversation.sId,
-            childConversationId: childConversation.sId,
-            sourceFileId: attachment.fileId,
-            copiedFileId: copiedFile.value.sId,
-            error: attachmentResult.error,
-          },
-          "Failed to attach copied file into forked conversation."
-        );
-      }
-
-      continue;
+      carriedAttachment = {
+        title: attachment.title,
+        fileId: copiedFile.value.sId,
+      };
+      attachErrorMessage =
+        "Failed to attach copied file into forked conversation.";
+      attachLogMetadata = {
+        sourceFileId: attachment.fileId,
+        copiedFileId: copiedFile.value.sId,
+      };
+    } else {
+      carriedAttachment = {
+        title: attachment.title,
+        nodeId: attachment.nodeId,
+        nodeDataSourceViewId: attachment.nodeDataSourceViewId,
+      };
+      attachErrorMessage =
+        "Failed to reattach content node into forked conversation.";
+      attachLogMetadata = {
+        contentFragmentId: attachment.contentFragmentId,
+        nodeId: attachment.nodeId,
+        nodeDataSourceViewId: attachment.nodeDataSourceViewId,
+      };
     }
 
     const attachmentResult = await postNewContentFragment(
       auth,
       childConversation,
-      {
-        title: attachment.title,
-        nodeId: attachment.nodeId,
-        nodeDataSourceViewId: attachment.nodeDataSourceViewId,
-      },
+      carriedAttachment,
       null
     );
 
@@ -312,12 +316,10 @@ async function carryOverConversationAttachments(
           workspaceId: auth.getNonNullableWorkspace().sId,
           parentConversationId: parentConversation.sId,
           childConversationId: childConversation.sId,
-          contentFragmentId: attachment.contentFragmentId,
-          nodeId: attachment.nodeId,
-          nodeDataSourceViewId: attachment.nodeDataSourceViewId,
+          ...attachLogMetadata,
           error: attachmentResult.error,
         },
-        "Failed to reattach content node into forked conversation."
+        attachErrorMessage
       );
     }
   }


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24411.
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

Extends fork attachment carryover to content-node attachments. Unlike conversation files, these are re-posted into the child conversation by reference through `postNewContentFragment(...)`; no blob copy is needed.

## Risks
Blast radius: conversation branching attachment carryover for connected-data attachments
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/api/assistant/conversation/forks.test.ts pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts`
