### PR TITLE
[front] enh: add more customization options to slash dropdown

### DIFF
--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -23,6 +23,7 @@ interface SlashCommandTooltip {
 
 export interface SlashCommand {
   action: string;
+  description?: string;
   icon: React.ComponentType<any>;
   id: string;
   label: string;
@@ -34,6 +35,10 @@ export interface SlashCommandDropdownProps
     SuggestionProps<SlashCommand>,
     "clientRect" | "command" | "items"
   > {
+  className?: string;
+  emptyMessage?: string;
+  header?: React.ReactNode;
+  itemsClassName?: string;
   onClose?: () => void;
 }
 
@@ -44,149 +49,169 @@ export interface SlashCommandDropdownRef {
 export const SlashCommandDropdown = forwardRef<
   SlashCommandDropdownRef,
   SlashCommandDropdownProps
->(({ items, command, clientRect, onClose }, ref) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLDivElement>(null);
-  const [virtualTriggerStyle, setVirtualTriggerStyle] =
-    useState<React.CSSProperties>({});
-
-  const selectItem = useCallback(
-    (index: number) => {
-      const item = items[index];
-      if (item) {
-        command(item);
-      }
+>(
+  (
+    {
+      items,
+      command,
+      clientRect,
+      className = "w-64",
+      emptyMessage = "No commands found",
+      header,
+      itemsClassName,
+      onClose,
     },
-    [command, items]
-  );
+    ref
+  ) => {
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLDivElement>(null);
+    const [virtualTriggerStyle, setVirtualTriggerStyle] =
+      useState<React.CSSProperties>({});
 
-  useImperativeHandle(
-    ref,
-    () => ({
-      onKeyDown: ({ event }) => {
-        if (items.length === 0) {
-          return false;
+    const selectItem = useCallback(
+      (index: number) => {
+        const item = items[index];
+        if (item) {
+          command(item);
         }
-
-        if (event.key === "ArrowDown") {
-          event.preventDefault();
-          setSelectedIndex((selectedIndex + 1) % items.length);
-          return true;
-        }
-
-        if (event.key === "ArrowUp") {
-          event.preventDefault();
-          setSelectedIndex((selectedIndex + items.length - 1) % items.length);
-          return true;
-        }
-
-        if (event.key === "Enter" || event.key === "Tab") {
-          event.preventDefault();
-          selectItem(selectedIndex);
-          return true;
-        }
-
-        return false;
       },
-    }),
-    [selectItem, selectedIndex, items.length]
-  );
+      [command, items]
+    );
 
-  // Reset selected index when items change.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
-  useEffect(() => {
-    setSelectedIndex(0);
-  }, [items.length]);
+    useImperativeHandle(
+      ref,
+      () => ({
+        onKeyDown: ({ event }) => {
+          if (items.length === 0) {
+            return false;
+          }
 
-  // Update virtual trigger position.
-  const updateTriggerPosition = useCallback(() => {
-    const triggerRect = clientRect?.();
-    if (triggerRect && triggerRef.current) {
-      setVirtualTriggerStyle({
-        position: "fixed",
-        left: triggerRect.left,
-        top: triggerRect.top + (window.visualViewport?.offsetTop ?? 0),
-        width: 1,
-        height: triggerRect.height || 1,
-        pointerEvents: "none",
-        zIndex: -1,
-      });
-    }
-  }, [clientRect]);
+          if (event.key === "ArrowDown") {
+            event.preventDefault();
+            setSelectedIndex((selectedIndex + 1) % items.length);
+            return true;
+          }
 
-  useEffect(() => {
-    updateTriggerPosition();
+          if (event.key === "ArrowUp") {
+            event.preventDefault();
+            setSelectedIndex((selectedIndex + items.length - 1) % items.length);
+            return true;
+          }
 
-    const viewport = window.visualViewport;
-    if (viewport) {
-      // Event triggered when hitting CMD +/-.
-      viewport.addEventListener("resize", updateTriggerPosition);
-      return () => {
-        viewport.removeEventListener("resize", updateTriggerPosition);
-      };
-    }
-  }, [updateTriggerPosition]);
+          if (event.key === "Enter" || event.key === "Tab") {
+            event.preventDefault();
+            selectItem(selectedIndex);
+            return true;
+          }
 
-  return (
-    <DropdownMenu open={true}>
-      <DropdownMenuTrigger asChild>
-        <div ref={triggerRef} style={virtualTriggerStyle} />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        ref={containerRef}
-        className="w-64"
-        align="start"
-        avoidCollisions
-        collisionPadding={12}
-        side="bottom"
-        sideOffset={4}
-        onEscapeKeyDown={onClose}
-        onInteractOutside={onClose}
-        onCloseAutoFocus={(e) => e.preventDefault()}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-      >
-        {items.length === 0 ? (
-          <div className="px-2 py-4 text-center text-sm text-muted-foreground">
-            No commands found
-          </div>
-        ) : (
-          items.map((item, index) => {
-            const menuItem = (
-              <DropdownMenuItem
-                key={item.id}
-                icon={item.icon}
-                label={item.label}
-                truncateText
-                onClick={() => selectItem(index)}
-                onMouseEnter={() => setSelectedIndex(index)}
-                className={
-                  index === selectedIndex ? "bg-gray-100 dark:bg-gray-800" : ""
+          return false;
+        },
+      }),
+      [selectItem, selectedIndex, items.length]
+    );
+
+    // Reset selected index when items change.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
+    useEffect(() => {
+      setSelectedIndex(0);
+    }, [items.length]);
+
+    // Update virtual trigger position.
+    const updateTriggerPosition = useCallback(() => {
+      const triggerRect = clientRect?.();
+      if (triggerRect && triggerRef.current) {
+        setVirtualTriggerStyle({
+          position: "fixed",
+          left: triggerRect.left,
+          top: triggerRect.top + (window.visualViewport?.offsetTop ?? 0),
+          width: 1,
+          height: triggerRect.height || 1,
+          pointerEvents: "none",
+          zIndex: -1,
+        });
+      }
+    }, [clientRect]);
+
+    useEffect(() => {
+      updateTriggerPosition();
+
+      const viewport = window.visualViewport;
+      if (viewport) {
+        // Event triggered when hitting CMD +/-.
+        viewport.addEventListener("resize", updateTriggerPosition);
+        return () => {
+          viewport.removeEventListener("resize", updateTriggerPosition);
+        };
+      }
+    }, [updateTriggerPosition]);
+
+    return (
+      <DropdownMenu open={true}>
+        <DropdownMenuTrigger asChild>
+          <div ref={triggerRef} style={virtualTriggerStyle} />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          ref={containerRef}
+          className={className}
+          align="start"
+          avoidCollisions
+          collisionPadding={12}
+          side="bottom"
+          sideOffset={4}
+          onEscapeKeyDown={onClose}
+          onInteractOutside={onClose}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          {header}
+          {items.length === 0 ? (
+            <div className="px-2 py-4 text-center text-sm text-muted-foreground">
+              {emptyMessage}
+            </div>
+          ) : (
+            <div className={itemsClassName}>
+              {items.map((item, index) => {
+                const menuItem = (
+                  <DropdownMenuItem
+                    key={item.id}
+                    icon={item.icon}
+                    label={item.label}
+                    description={item.description}
+                    truncateText
+                    onClick={() => selectItem(index)}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    className={
+                      index === selectedIndex
+                        ? "bg-gray-100 dark:bg-gray-800"
+                        : ""
+                    }
+                  />
+                );
+
+                // Wrap with DropdownTooltipTrigger if command has tooltip property.
+                if (item.tooltip) {
+                  return (
+                    <DropdownTooltipTrigger
+                      key={item.id}
+                      description={item.tooltip.description}
+                      media={item.tooltip.media}
+                      side="right"
+                      sideOffset={8}
+                    >
+                      {menuItem}
+                    </DropdownTooltipTrigger>
+                  );
                 }
-              />
-            );
 
-            // Wrap with DropdownTooltipTrigger if command has tooltip property.
-            if (item.tooltip) {
-              return (
-                <DropdownTooltipTrigger
-                  key={item.id}
-                  description={item.tooltip.description}
-                  media={item.tooltip.media}
-                  side="right"
-                  sideOffset={8}
-                >
-                  {menuItem}
-                </DropdownTooltipTrigger>
-              );
-            }
-
-            return menuItem;
-          })
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-});
+                return menuItem;
+              })}
+            </div>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  }
+);
 
 SlashCommandDropdown.displayName = "SlashCommandDropdown";

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -21,6 +21,8 @@ interface SlashCommandTooltip {
   media?: React.ReactNode;
 }
 
+const DEFAULT_EMPTY_MESSAGE = "No commands found";
+
 export interface SlashCommand {
   action: string;
   description?: string;
@@ -35,10 +37,8 @@ export interface SlashCommandDropdownProps
     SuggestionProps<SlashCommand>,
     "clientRect" | "command" | "items"
   > {
-  className?: string;
   emptyMessage?: string;
-  header?: React.ReactNode;
-  itemsClassName?: string;
+  header?: string;
   onClose?: () => void;
 }
 
@@ -55,10 +55,8 @@ export const SlashCommandDropdown = forwardRef<
       items,
       command,
       clientRect,
-      className = "w-64",
-      emptyMessage = "No commands found",
+      emptyMessage = DEFAULT_EMPTY_MESSAGE,
       header,
-      itemsClassName,
       onClose,
     },
     ref
@@ -153,7 +151,7 @@ export const SlashCommandDropdown = forwardRef<
         </DropdownMenuTrigger>
         <DropdownMenuContent
           ref={containerRef}
-          className={className}
+          className="w-64"
           align="start"
           avoidCollisions
           collisionPadding={12}
@@ -164,13 +162,17 @@ export const SlashCommandDropdown = forwardRef<
           onCloseAutoFocus={(e) => e.preventDefault()}
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
-          {header}
+          {header ? (
+            <div className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
+              {header}
+            </div>
+          ) : null}
           {items.length === 0 ? (
-            <div className="px-2 py-4 text-center text-sm text-muted-foreground">
+            <div className="px-2 py-4 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
               {emptyMessage}
             </div>
           ) : (
-            <div className={itemsClassName}>
+            <div className="max-h-96 overflow-y-auto">
               {items.map((item, index) => {
                 const menuItem = (
                   <DropdownMenuItem


### PR DESCRIPTION
## Description

This PR adds a few new features to `SlashCommandDropdown`.
These features will be useful for adding a `/skills` in the input bar, they are not used in the Skill Builder.

- Optional `header` that shows at the top
- Descriptions to each item, we'll show the name + description of each skill (description in a lighter color and smaller font)
- Custom message shown when the list is empty (was always the same before)

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
