### PR TITLE
Fix connection pool pressure on message edit endpoint

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -449,13 +449,22 @@ export const ConversationViewer = ({
                 } else {
                   ref.current.data.append([userMessage], scroll);
                 }
-                // Using else if with the type guard just to please the type checker as we already know it's a user message from the predicate.
+                // Using else if with the type guard just to please the type checker as we already
+                // know it's a user message from the predicate.
               } else if (isUserMessage(exists)) {
                 // We only update if the version is greater or equals than the existing version.
                 if (exists.version <= event.message.version) {
-                  ref.current.data.map((m) =>
-                    areSameRankAndBranch(m, userMessage) ? userMessage : m
-                  );
+                  ref.current.data.map((m) => {
+                    if (!areSameRankAndBranch(m, userMessage)) {
+                      return m;
+                    }
+                    // Preserve existing content fragments: edits only change the text, so content
+                    // fragments from the event can be empty and we keep the ones already in the
+                    // client state.
+                    return isUserMessage(m)
+                      ? { ...userMessage, contentFragments: m.contentFragments }
+                      : userMessage;
+                  });
                 }
               }
 

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -2604,18 +2604,15 @@ describe("editUserMessage", () => {
     }
     conversation = fetchedConversationResult.value;
 
-    // Create an original user message with agent mentions
+    // Create an original user message without agent mentions so no placeholder agent
+    // message is created in the DB (edit tests verify hasAgentMessagesAfter = false).
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
     const postResult = await postUserMessage(auth, {
       conversation,
-      content: `Original message with @${agentConfig1.name}`,
-      mentions: [
-        {
-          configurationId: agentConfig1.sId,
-        } satisfies AgentMention,
-      ],
+      content: "Original message",
+      mentions: [],
       context: {
         username: userJson.username,
         timezone: "UTC",
@@ -2843,6 +2840,41 @@ describe("editUserMessage", () => {
       // Verify launchAgentLoopWorkflow was NOT called (no agent mentions)
       expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
     }
+  });
+
+  it("should not re-trigger the agent loop when editing a message that already has an agent response after it", async () => {
+    // Post a second message with an agent mention so a placeholder agent message row
+    // lands in the DB at a rank > originalUserMessage.rank.
+    const user = auth.getNonNullableUser();
+    const userJson = user.toJSON();
+    await postUserMessage(auth, {
+      conversation,
+      content: `Follow-up message with @${agentConfig1.name}`,
+      mentions: [{ configurationId: agentConfig1.sId } satisfies AgentMention],
+      context: {
+        username: userJson.username,
+        timezone: "UTC",
+        fullName: userJson.fullName,
+        email: userJson.email,
+        profilePictureUrl: userJson.image,
+        origin: "web",
+      },
+      skipToolsValidation: false,
+    });
+    vi.clearAllMocks();
+
+    // Now edit the original message (which has an agent message after it).
+    const result = await editUserMessage(auth, {
+      conversation,
+      message: originalUserMessage,
+      content: `Edited with @${agentConfig1.name}`,
+      mentions: [{ configurationId: agentConfig1.sId } satisfies AgentMention],
+      skipToolsValidation: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    // Edit should succeed but not kick off a new agent loop since one already exists after.
+    expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
   });
 
   it("should preserve mentions when editing a message without agent mentions (only user mentions)", async () => {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -14,6 +14,7 @@ import {
   createAgentMessages,
   createCompactionMessage,
   createUserMessage,
+  hasAgentMessageAfterRank,
 } from "@app/lib/api/assistant/conversation/messages";
 import {
   canAgentBeUsedInProjectConversation,
@@ -1118,7 +1119,7 @@ export async function editUserMessage(
     mentions,
     skipToolsValidation,
   }: {
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
     message: UserMessageType;
     content: string;
     mentions: MentionType[];
@@ -1133,7 +1134,7 @@ export async function editUserMessage(
   const user = auth.user();
   const owner = auth.workspace();
 
-  if (!owner || owner.id !== conversation.owner.id) {
+  if (!owner) {
     return new Err({
       status_code: 400,
       api_error: {
@@ -1272,16 +1273,13 @@ export async function editUserMessage(
 
       if (hasAgentMentions) {
         // Check if there are any agent messages after the edited user message
-        // by checking conversation.content (which is indexed by rank)
-        const hasAgentMessagesAfter = conversation.content
-          .slice(messageRow.rank + 1)
-          .some((versions) => {
-            if (versions.length === 0) {
-              return false;
-            }
-            const latestVersion = versions[versions.length - 1];
-            return isAgentMessageType(latestVersion);
-          });
+        // by querying the DB within the same transaction.
+        const hasAgentMessagesAfter = await hasAgentMessageAfterRank(auth, {
+          conversation,
+          rank: messageRow.rank,
+          branchId: messageRow.branchId ?? null,
+          transaction: t,
+        });
 
         const agentMessages: AgentMessageType[] = [];
 
@@ -1376,11 +1374,13 @@ export async function editUserMessage(
   // TODO(DURABLE-AGENTS 2025-07-17): Publish message events to all open tabs to maintain
   // conversation state synchronization in multiplex mode. This is a temporary solution -
   // we should move this to a dedicated real-time sync mechanism.
+  // Content fragments are omitted: edits only change the text, and the client preserves
+  // existing content fragments when handling edit events.
   await publishMessageEventsOnMessagePostOrEdit(
     conversation,
     {
       ...userMessage,
-      contentFragments: getRelatedContentFragments(conversation, userMessage),
+      contentFragments: [],
     },
     agentMessages
   );

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -686,3 +686,36 @@ export async function createCompactionMessage(
     content: null,
   };
 }
+
+/**
+ * Returns true if there is at least one agent message in the conversation after the given rank,
+ * in the same branch. Must be called within a transaction to be consistent with concurrent writes.
+ */
+export async function hasAgentMessageAfterRank(
+  auth: Authenticator,
+  {
+    conversation,
+    rank,
+    branchId,
+    transaction,
+  }: {
+    conversation: ConversationWithoutContentType;
+    rank: number;
+    branchId: number | null;
+    transaction: Transaction;
+  }
+): Promise<boolean> {
+  const owner = auth.getNonNullableWorkspace();
+  const messageAfterRank = await MessageModel.findOne({
+    where: {
+      workspaceId: owner.id,
+      conversationId: conversation.id,
+      rank: { [Op.gt]: rank },
+      agentMessageId: { [Op.ne]: null },
+      branchId,
+    },
+    transaction,
+  });
+
+  return !!messageAfterRank;
+}

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -1,9 +1,8 @@
 import { editUserMessage } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import { isUserMessageType } from "@app/types/assistant/conversation";
@@ -142,19 +141,24 @@ async function handler(
   }
 
   const branchId = messageRes.value.getBranchId() ?? null;
+  const conversation = { ...conversationResource.toJSON(), branchId };
 
-  const conversationRes = await getConversation(
+  const renderedMessagesRes = await batchRenderMessages(
     auth,
-    conversationId,
-    false,
-    branchId
+    conversationResource,
+    [messageRes.value],
+    "full"
   );
 
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
+  if (renderedMessagesRes.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to render message.",
+      },
+    });
   }
-
-  const conversation = conversationRes.value;
 
   switch (req.method) {
     case "POST":
@@ -170,9 +174,9 @@ async function handler(
         });
       }
 
-      const message = conversation.content
-        .flat()
-        .find((m) => m.sId === messageId);
+      const message = renderedMessagesRes.value.find(
+        (m) => m.sId === messageId
+      );
       if (!message || !isUserMessageType(message)) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -1,8 +1,8 @@
 import { editUserMessage } from "@app/lib/api/assistant/conversation";
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
-import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import { isUserMessageType } from "@app/types/assistant/conversation";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -57,9 +57,9 @@
  *         description: Unauthorized
  */
 import { editUserMessage } from "@app/lib/api/assistant/conversation";
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { UserMessageType } from "@app/types/assistant/conversation";
@@ -174,7 +174,9 @@ async function handler(
         });
       }
 
-      const message = renderedMessagesRes.value.find((m) => m.sId === messageId);
+      const message = renderedMessagesRes.value.find(
+        (m) => m.sId === messageId
+      );
       if (!message || !isUserMessageType(message)) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -57,10 +57,9 @@
  *         description: Unauthorized
  */
 import { editUserMessage } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { UserMessageType } from "@app/types/assistant/conversation";
@@ -140,19 +139,24 @@ async function handler(
   }
 
   const branchId = messageRes.value.getBranchId() ?? null;
+  const conversation = { ...conversationResource.toJSON(), branchId };
 
-  const conversationRes = await getConversation(
+  const renderedMessagesRes = await batchRenderMessages(
     auth,
-    conversationId,
-    false,
-    branchId
+    conversationResource,
+    [messageRes.value],
+    "full"
   );
 
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
+  if (renderedMessagesRes.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to render message.",
+      },
+    });
   }
-
-  const conversation = conversationRes.value;
 
   switch (req.method) {
     case "POST":
@@ -170,9 +174,7 @@ async function handler(
         });
       }
 
-      const message = conversation.content
-        .flat()
-        .find((m) => m.sId === messageId);
+      const message = renderedMessagesRes.value.find((m) => m.sId === messageId);
       if (!message || !isUserMessageType(message)) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -1,7 +1,4 @@
 /** @ignoreswagger */
-import { getRelatedContentFragments } from "@app/lib/api/assistant/content_fragments";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import {
   createMessageReaction,
   deleteMessageReaction,
@@ -12,22 +9,24 @@ import {
   publishMessageEventsOnMessagePostOrEdit,
 } from "@app/lib/api/assistant/streaming/events";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type {
   AgentMessageType,
-  ConversationType,
+  ConversationWithoutContentType,
   MessageReactionType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
+import type { ContentFragmentType } from "@app/types/content_fragment";
 import {
   isAgentMessageType,
   isCompactionMessageType,
   isProjectConversation,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
-import type { ContentFragmentType } from "@app/types/content_fragment";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -59,14 +58,32 @@ async function handler(
     });
   }
 
-  const conversationId = req.query.cId;
-  const conversationRes = await getConversation(auth, conversationId);
-
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
+  if (!(typeof req.query.mId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `mId` (string) is required.",
+      },
+    });
   }
 
-  const conversation = conversationRes.value;
+  const conversationId = req.query.cId;
+  const messageId = req.query.mId;
+
+  const conversationResource = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+
+  if (!conversationResource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: { type: "conversation_not_found", message: "Conversation not found." },
+    });
+  }
+
+  const conversation = conversationResource.toJSON();
 
   if (isProjectConversation(conversation)) {
     const space = await SpaceResource.fetchById(auth, conversation.spaceId);
@@ -87,17 +104,6 @@ async function handler(
     }
   }
 
-  if (!(typeof req.query.mId === "string")) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid query parameters, `mId` (string) is required.",
-      },
-    });
-  }
-
-  const messageId = req.query.mId;
   const bodyValidation = MessageReactionRequestBodySchema.decode(req.body);
   if (isLeft(bodyValidation)) {
     const pathError = reporter.formatValidationErrors(bodyValidation.left);
@@ -110,7 +116,34 @@ async function handler(
     });
   }
 
-  const message = conversation.content.flat().find((m) => m.sId === messageId);
+  const messageRes = await conversationResource.getMessageById(auth, messageId);
+  if (messageRes.isErr()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The message you're trying to react to does not exist.",
+      },
+    });
+  }
+
+  const renderedMessagesRes = await batchRenderMessages(
+    auth,
+    conversationResource,
+    [messageRes.value],
+    "full"
+  );
+  if (renderedMessagesRes.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to render message.",
+      },
+    });
+  }
+
+  const message = renderedMessagesRes.value.find((m) => m.sId === messageId);
   if (!message) {
     return apiError(req, res, {
       status_code: 400,
@@ -120,6 +153,7 @@ async function handler(
       },
     });
   }
+
   if (isCompactionMessageType(message)) {
     return apiError(req, res, {
       status_code: 400,
@@ -205,7 +239,7 @@ const publishMessageUpdate = async (
     conversation,
     message,
   }: {
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
     message: UserMessageType | ContentFragmentType | AgentMessageType;
   }
 ) => {
@@ -218,7 +252,8 @@ const publishMessageUpdate = async (
       conversation,
       {
         ...message,
-        contentFragments: getRelatedContentFragments(conversation, message),
+        // Content fragments are not changed by reactions; client preserves existing ones.
+        contentFragments: [],
         reactions: reactions[message.id] ?? [],
       },
       []

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -1,4 +1,7 @@
 /** @ignoreswagger */
+import { getRelatedContentFragments } from "@app/lib/api/assistant/content_fragments";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import {
   createMessageReaction,
   deleteMessageReaction,
@@ -9,24 +12,22 @@ import {
   publishMessageEventsOnMessagePostOrEdit,
 } from "@app/lib/api/assistant/streaming/events";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type {
   AgentMessageType,
-  ConversationWithoutContentType,
+  ConversationType,
   MessageReactionType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
-import type { ContentFragmentType } from "@app/types/content_fragment";
 import {
   isAgentMessageType,
   isCompactionMessageType,
   isProjectConversation,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
+import type { ContentFragmentType } from "@app/types/content_fragment";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -58,32 +59,14 @@ async function handler(
     });
   }
 
-  if (!(typeof req.query.mId === "string")) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid query parameters, `mId` (string) is required.",
-      },
-    });
-  }
-
   const conversationId = req.query.cId;
-  const messageId = req.query.mId;
+  const conversationRes = await getConversation(auth, conversationId);
 
-  const conversationResource = await ConversationResource.fetchById(
-    auth,
-    conversationId
-  );
-
-  if (!conversationResource) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: { type: "conversation_not_found", message: "Conversation not found." },
-    });
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
   }
 
-  const conversation = conversationResource.toJSON();
+  const conversation = conversationRes.value;
 
   if (isProjectConversation(conversation)) {
     const space = await SpaceResource.fetchById(auth, conversation.spaceId);
@@ -104,6 +87,17 @@ async function handler(
     }
   }
 
+  if (!(typeof req.query.mId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `mId` (string) is required.",
+      },
+    });
+  }
+
+  const messageId = req.query.mId;
   const bodyValidation = MessageReactionRequestBodySchema.decode(req.body);
   if (isLeft(bodyValidation)) {
     const pathError = reporter.formatValidationErrors(bodyValidation.left);
@@ -116,34 +110,7 @@ async function handler(
     });
   }
 
-  const messageRes = await conversationResource.getMessageById(auth, messageId);
-  if (messageRes.isErr()) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "The message you're trying to react to does not exist.",
-      },
-    });
-  }
-
-  const renderedMessagesRes = await batchRenderMessages(
-    auth,
-    conversationResource,
-    [messageRes.value],
-    "full"
-  );
-  if (renderedMessagesRes.isErr()) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to render message.",
-      },
-    });
-  }
-
-  const message = renderedMessagesRes.value.find((m) => m.sId === messageId);
+  const message = conversation.content.flat().find((m) => m.sId === messageId);
   if (!message) {
     return apiError(req, res, {
       status_code: 400,
@@ -153,7 +120,6 @@ async function handler(
       },
     });
   }
-
   if (isCompactionMessageType(message)) {
     return apiError(req, res, {
       status_code: 400,
@@ -239,7 +205,7 @@ const publishMessageUpdate = async (
     conversation,
     message,
   }: {
-    conversation: ConversationWithoutContentType;
+    conversation: ConversationType;
     message: UserMessageType | ContentFragmentType | AgentMessageType;
   }
 ) => {
@@ -252,8 +218,7 @@ const publishMessageUpdate = async (
       conversation,
       {
         ...message,
-        // Content fragments are not changed by reactions; client preserves existing ones.
-        contentFragments: [],
+        contentFragments: getRelatedContentFragments(conversation, message),
         reactions: reactions[message.id] ?? [],
       },
       []


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread with full context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1776415118956069).

The private and public edit endpoints (`/api/w/.../messages/[mId]/edit`) were loading the full conversation. All messages, fully rendered just to find one message by `sId` and check if an agent response already exists. On long conversations this could hit 100+ concurrent DB connections per request.

What changed:
- Edit endpoints (private + public): removed the `getConversation` call entirely. The conversation resource is already fetched
earlier for auth. The single message being edited is now rendered on its own via `batchRenderMessages` with just that one message.
- `editUserMessage`: accepts `ConversationWithoutContentType` instead of `ConversationType`. It never needed the rendered message tree. The `hasAgentMessagesAfter` check (which previously scanned `conversation.content`) is replaced with a targeted DB query inside the existing advisory-lock transaction, extracted as `hasAgentMessageAfterRank`.
- Real-time event: the edit event was re-fetching related content fragments from the full conversation. Edits
don't change attachments, so the server now sends `contentFragments: []`. The client (in `ConversationViewer`) is updated to preserve existing content fragments when handling an edit event rather than overwriting them.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Added one more test and tested locally the multiplex setup to confirm it still works as expected.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
