### PR TITLE
[Sessions] Keep final streamed answer visible when collapsing thinking

### DIFF
--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx
@@ -1,0 +1,96 @@
+import { InlineActivitySteps } from "@app/components/assistant/conversation/actions/inline/InlineActivitySteps";
+import type { LightAgentMessageType } from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/components/assistant/AgentMessageMarkdown", () => ({
+  AgentMessageMarkdown: ({ content }: { content: string }) =>
+    React.createElement("div", null, content),
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/actions/inline/ThinkingStep",
+  () => ({
+    ThinkingStep: ({ content }: { content: string }) =>
+      React.createElement("div", null, content),
+  })
+);
+
+vi.mock(
+  "@app/components/assistant/conversation/ConversationSidePanelContext",
+  () => ({
+    useConversationSidePanelContext: () => ({
+      openPanel: vi.fn(),
+    }),
+  })
+);
+
+const mockOwner: WorkspaceType = {
+  id: 1,
+  sId: "w_test",
+  name: "Test Workspace",
+  role: "admin",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+};
+
+const mockAgentMessage: LightAgentMessageType = {
+  type: "agent_message",
+  sId: "msg_123",
+  version: 0,
+  rank: 0,
+  branchId: null,
+  created: Date.now(),
+  completedTs: null,
+  parentMessageId: "parent_msg_123",
+  parentAgentMessageId: null,
+  status: "created",
+  content: "Live final answer",
+  chainOfThought: "",
+  error: null,
+  visibility: "visible",
+  richMentions: [],
+  completionDurationMs: null,
+  reactions: [],
+  configuration: {
+    sId: "agent_123",
+    name: "dust",
+    pictureUrl: "",
+    status: "active",
+    canRead: true,
+  },
+  citations: {},
+  generatedFiles: [],
+  activitySteps: [],
+};
+
+describe("InlineActivitySteps", () => {
+  it("keeps the live answer visible when collapsing during writing", () => {
+    render(
+      <InlineActivitySteps
+        agentMessage={mockAgentMessage}
+        lastAgentStateClassification="writing"
+        completedSteps={[
+          {
+            type: "thinking",
+            content: "Historical reasoning step",
+            id: "thinking-1",
+          },
+        ]}
+        pendingToolCalls={[]}
+        owner={mockOwner}
+        isLastMessage
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Thinking/i }));
+
+    expect(screen.getByText("Historical reasoning step")).not.toBeVisible();
+    expect(screen.getByText("Live final answer")).toBeVisible();
+  });
+});

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -321,7 +321,9 @@ export function InlineActivitySteps({
             )}
 
             {/* Active writing (streaming content tokens) */}
-            {showActiveWriting && agentMessage.content ? (
+            {showActiveWriting &&
+            agentMessage.content &&
+            completedSteps.length === 0 ? (
               <div>
                 <AgentMessageMarkdown
                   content={agentMessage.content}
@@ -379,6 +381,20 @@ export function InlineActivitySteps({
           </div>
         </div>
       </div>
+
+      {showActiveWriting &&
+      agentMessage.content &&
+      completedSteps.length > 0 ? (
+        <div className="mt-3">
+          <AgentMessageMarkdown
+            content={agentMessage.content}
+            owner={owner}
+            isStreaming={false}
+            streamingState="streaming"
+            isLastMessage={false}
+          />
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7624

Only move the live writing block outside the collapsible Thinking section once completed steps already exist, so writing-only messages keep their current behavior.

## Risks
Blast radius: conversation message rendering while an agent is streaming a final answer after completed steps
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] Collapse a streaming message after completed steps and confirm the final answer stays visible
