### PR TITLE
[Public API] Ignore content fragment IDs in steering checks

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1448,6 +1448,94 @@ describe("postUserMessage", () => {
     }
   });
 
+  describe("steering with unresolved mention ids", () => {
+    async function createConversationWithRunningAgent() {
+      const { messageRow: userMessageRow } =
+        await ConversationFactory.createUserMessage({
+          auth,
+          workspace,
+          conversation,
+          content: "Initial message",
+        });
+
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        parentId: userMessageRow.id,
+        agentConfigurationId: agentConfig1.sId,
+        agentConfigurationVersion: agentConfig1.version,
+      });
+
+      const fetchedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation with running agent");
+      }
+
+      vi.clearAllMocks();
+
+      return fetchedConversationResult.value;
+    }
+
+    it("should still reject a different running agent when unresolved ids are present", async () => {
+      const agentConfig2 = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent 2",
+          description: "Second test agent",
+        }
+      );
+      const user = auth.getNonNullableUser();
+      const userJson = user.toJSON();
+      const rateLimiterSpy = vi
+        .spyOn(rateLimiterModule, "rateLimiter")
+        .mockResolvedValue(100);
+      const contentFragmentId = generateRandomModelSId("cf");
+
+      try {
+        const runningConversation = await createConversationWithRunningAgent();
+
+        const result = await postUserMessage(auth, {
+          conversation: runningConversation,
+          content: `Switch to @${agentConfig2.name}`,
+          mentions: [
+            {
+              configurationId: agentConfig2.sId,
+            } satisfies AgentMention,
+            {
+              configurationId: contentFragmentId,
+            } satisfies AgentMention,
+          ],
+          context: {
+            username: userJson.username,
+            timezone: "UTC",
+            fullName: userJson.fullName,
+            email: userJson.email,
+            profilePictureUrl: userJson.image,
+            origin: "api",
+          },
+          skipToolsValidation: false,
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isOk()) {
+          return;
+        }
+
+        expect(result.error.status_code).toBe(400);
+        expect(result.error.api_error.message).toBe(
+          "Cannot run a different agent while one is running."
+        );
+        expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
+      } finally {
+        rateLimiterSpy.mockRestore();
+      }
+    });
+  });
+
   describe("compaction blocking", () => {
     it("should reject posting when a compaction message is running", async () => {
       const user = auth.getNonNullableUser();

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -657,13 +657,46 @@ export async function postUserMessage(
     });
   }
 
-  const agentMentions = mentions.filter(isAgentMention);
+  const rawAgentMentions = mentions.filter(isAgentMention);
   let runningAgentMessage = conversation.content
     .flat()
     .find(
       (m): m is AgentMessageType =>
         isAgentMessageType(m) && m.status === "created"
     );
+
+  // `getAgentConfiguration` checks that we're only pulling a configuration from the
+  // same workspace or a global one.
+  const results = await Promise.all([
+    getAgentConfigurations(auth, {
+      agentIds: rawAgentMentions.map((mention) => mention.configurationId),
+      variant: "extra_light",
+    }),
+    (() => {
+      // If the origin of the user message is "run_agent", we do not want to update the
+      // participation of the user so that the conversation does not appear in the user's history.
+      if (agenticMessageData?.type === "run_agent") {
+        return;
+      }
+
+      return ConversationResource.upsertParticipation(auth, {
+        conversation,
+        action: "posted",
+        user: user?.toJSON() ?? null,
+      });
+    })(),
+  ]);
+
+  const fetchedAgentConfigurations = removeNulls(results[0]);
+  const resolvedAgentConfigurationIds = new Set(
+    fetchedAgentConfigurations.map((config) => config.sId)
+  );
+  // Ignore unresolved IDs here so non-agent references do not interfere with steering checks.
+  const agentMentions = rawAgentMentions.filter((mention) =>
+    resolvedAgentConfigurationIds.has(mention.configurationId)
+  );
+  let agentConfigurations = fetchedAgentConfigurations;
+  let shouldCreateBranch = false;
 
   // Steering invariants: enforce single agent loop per conversation.
   if (agentMentions.length > 1) {
@@ -696,33 +729,6 @@ export async function postUserMessage(
       },
     });
   }
-
-  // `getAgentConfiguration` checks that we're only pulling a configuration from the
-  // same workspace or a global one.
-  const results = await Promise.all([
-    getAgentConfigurations(auth, {
-      agentIds: mentions
-        .filter(isAgentMention)
-        .map((mention) => mention.configurationId),
-      variant: "extra_light",
-    }),
-    (() => {
-      // If the origin of the user message is "run_agent", we do not want to update the
-      // participation of the user so that the conversation does not appear in the user's history.
-      if (agenticMessageData?.type === "run_agent") {
-        return;
-      }
-
-      return ConversationResource.upsertParticipation(auth, {
-        conversation,
-        action: "posted",
-        user: user?.toJSON() ?? null,
-      });
-    })(),
-  ]);
-
-  let agentConfigurations = removeNulls(results[0]);
-  let shouldCreateBranch = false;
 
   // Check if no mentions, in that case, we might automatically append an @dust mention.
   if (


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7663

- Resolve steering checks against actual agent configurations before enforcing the single-agent and running-agent guards.
- This keeps content fragment IDs from being treated as extra agent mentions in public API message posts.
- Add a regression test for the running-agent path with an unresolved mention ID.

## Risks
Blast radius: public API conversation message posting when agent mentions are mixed with attachment or content fragment references
Risk: low

## Deploy Plan
- deploy front

## Test
- [ ] `npm test conversation.test.ts` in `front` (blocked locally by an unrelated `front/admin/db.ts` test DB setup failure on `agent_suggestions_agentConfigurationId_fkey`)
