### PR TITLE
fix: duplicate content and stop button during agent handoff

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -426,8 +426,21 @@ export function AgentMessage({
   // GenerationContext: to know if we are generating or not.
   const generationContext = useGenerationContext();
 
+  // Once a handoff user message exists for this agent message, the agent has
+  // effectively handed over: the child agent owns the generation from here.
+  // Treat this message as no longer generating so we don't show duplicate
+  // "Stop agent" buttons / streaming affordances alongside the child.
+  const isAgentMessageHandingOver = methods.data
+    .get()
+    .some(
+      (m) =>
+        isUserMessage(m) &&
+        isHandoverUserMessage(m) &&
+        m.agenticMessageData?.originMessageId === sId
+    );
+
   useEffect(() => {
-    if (shouldStream) {
+    if (shouldStream && !isAgentMessageHandingOver) {
       generationContext.addGeneratingMessage({
         messageId: sId,
         conversationId,
@@ -438,6 +451,7 @@ export function AgentMessage({
     }
   }, [
     shouldStream,
+    isAgentMessageHandingOver,
     generationContext,
     sId,
     conversationId,
@@ -552,15 +566,6 @@ export function AgentMessage({
       />
     );
   }
-
-  const isAgentMessageHandingOver = methods.data
-    .get()
-    .some(
-      (m) =>
-        isUserMessage(m) &&
-        isHandoverUserMessage(m) &&
-        m.agenticMessageData?.originMessageId === sId
-    );
 
   const parentAgentMessage = methods.data
     .get()
@@ -952,6 +957,7 @@ export function AgentMessage({
           activeReferences={activeReferences}
           setActiveReferences={setActiveReferences}
           triggeringUser={triggeringUser}
+          isAgentMessageHandingOver={isAgentMessageHandingOver}
           additionalMarkdownComponents={additionalMarkdownComponents}
           additionalMarkdownPlugins={additionalMarkdownPlugins}
         />
@@ -1043,6 +1049,7 @@ function AgentMessageContent({
   reloadMessage,
   isRetryHandlerProcessing,
   onQuickReplySend,
+  isAgentMessageHandingOver,
   additionalMarkdownComponents: propsAdditionalMarkdownComponents,
   additionalMarkdownPlugins,
 }: {
@@ -1074,6 +1081,10 @@ function AgentMessageContent({
     }[]
   ) => void;
   onQuickReplySend: (message: string) => Promise<void>;
+  // True once a handoff user message pointing to this agent message exists —
+  // the child agent owns generation from that point, so this message should
+  // collapse its inline activity (no more "Thinking…") and drop its stop button.
+  isAgentMessageHandingOver: boolean;
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
 }) {
@@ -1278,7 +1289,11 @@ function AgentMessageContent({
       <div className="flex flex-col gap-y-4">
         <InlineActivitySteps
           agentMessage={agentMessage}
-          lastAgentStateClassification={agentMessage.streaming.agentState}
+          lastAgentStateClassification={
+            isAgentMessageHandingOver
+              ? "done"
+              : agentMessage.streaming.agentState
+          }
           completedSteps={agentMessage.streaming.inlineActivitySteps}
           pendingToolCalls={agentMessage.streaming.pendingToolCalls}
           onOpenDetails={onOpenDetails}

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -633,13 +633,27 @@ export function useAgentMessageStream({
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
               return m;
             }
-            const steps = cotAtSuccess
+            let steps = cotAtSuccess
               ? appendThinkingStep(
                   m.streaming.inlineActivitySteps,
                   cotAtSuccess,
                   `thinking-final-${Date.now()}`
                 )
               : m.streaming.inlineActivitySteps;
+            // When no tokens streamed after the last tool call (e.g. the agent
+            // handed off or otherwise terminated right after a tool), the text
+            // we flushed as a content step at the last `tool_params` is also
+            // what the server keeps as the message body. Drop that trailing
+            // content step so the same text isn't rendered twice — aligning
+            // with `contentsToActivitySteps`, which is what runs after reload.
+            if (!hadStreamedTokens) {
+              for (let i = steps.length - 1; i >= 0; i--) {
+                if (steps[i].type === "content") {
+                  steps = [...steps.slice(0, i), ...steps.slice(i + 1)];
+                  break;
+                }
+              }
+            }
             return {
               ...m,
               ...getLightAgentMessageFromAgentMessage(messageSuccess.message),


### PR DESCRIPTION
## Description

During a handoff via the Run agent tool, the inline activity stream rendered the parent agent's pre-handoff text twice (as an activity step and as the message body), and the UI showed two Stop agent buttons and two loading indicators at once, one on the parent and one on the child. Reloading the page already produced the correct single-copy render, so this PR aligns the live streaming state with what the server emits after reload.

Fixes: 

The first fix lives in `useAgentMessageStream`. When `agent_message_success` fires and no tokens were streamed after the last tool call (so the last text segment is whatever was flushed as an inline content step at `tool_params`), the server still keeps that text as the canonical message body. We now drop the trailing content step in that case, which mirrors
`contentsToActivitySteps`, the logic that runs on reload.

The second fix lives in `AgentMessage`. Once a handoff user message pointing to this agent message exists, the parent has effectively handed over and the child owns generation from there. We now treat the parent as no longer generating, which removes it from the GenerationContext and switches its `InlineActivitySteps` to a done state. This collapses the
parent's Thinking loader and removes the per-message Stop agent button that was showing alongside the child's, leaving only the single global Stop button.


## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 