### PR TITLE
Fix incorrect wording

### DIFF
--- a/front/components/workspace/settings/PrivateConversationUrlsToggle.tsx
+++ b/front/components/workspace/settings/PrivateConversationUrlsToggle.tsx
@@ -15,7 +15,7 @@ export function PrivateConversationUrlsToggle({
   return (
     <ContextItem
       title="Private conversation URLs by default"
-      subElement="Restrict conversation URL access to participants and workspace admins by default"
+      subElement="Restrict conversation URL access to participants only by default"
       visual={<LockIcon className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={


### PR DESCRIPTION
## Description

Follow-up to #24486 — the toggle's description still said "participants and workspace admins" but admins are no longer exempt from the restriction.

- Update `PrivateConversationUrlsToggle` subElement: "participants and workspace admins" → "participants only"

## Tests

Local

## Risk

Low — copy change only

## Deploy Plan

Deploy `front`
