### PR TITLE
Fix the creation of credits from Poke

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -184,8 +184,6 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
         consumedAmountMicroUsd: 0,
         discount: null,
         invoiceOrLineItemId: idempotencyKey,
-        startDate,
-        expirationDate,
       });
 
       const startResult = await credit.start(auth, {
@@ -206,8 +204,8 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
           productId: getProductFreeMonthlyCreditId(),
           creditTypeId: getCreditTypeProgrammaticUsdId(),
           amount,
-          startingAt: startDate.toISOString(),
-          endingBefore: expirationDate.toISOString(),
+          startingAt: startResult.value.startDate.toISOString(),
+          endingBefore: startResult.value.expirationDate.toISOString(),
           name: `Free poke credit ($${originalAmount.toFixed(2)})`,
           idempotencyKey,
         });


### PR DESCRIPTION
## Description

Fixes the creation of free credits from the Poke plugin. The `startDate` and `expirationDate` were incorrectly being passed to `CreditResource.makeNew()`, which raises a "Credit already started" error later. These dates are now correctly obtained from the `credit.start()` method's return value and used when syncing to Metronome.

## Tests

Manually tested free credit creation via Poke plugin for Metronome-provisioned workspaces.

## Risk

Low.

## Deploy Plan

Deploy front.