### PR TITLE
[Sessions] Carry over tool output attachments in forks

### DIFF
--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -28,7 +28,10 @@ import type {
 import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { SupportedFileContentType } from "@app/types/files";
-import { extensionsForContentType } from "@app/types/files";
+import {
+  extensionsForContentType,
+  isConversationFileUseCase,
+} from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -118,8 +121,10 @@ export async function getContentFragmentBlob(
       "File must have a supported content type."
     );
 
-    if (file.useCase !== "conversation") {
-      return new Err(new Error("File not meant to be used in a conversation."));
+    if (!isConversationFileUseCase(file.useCase)) {
+      return new Err(
+        new Error("File not meant to be attached in a conversation.")
+      );
     }
 
     if (!file.isReady) {

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -12,6 +12,11 @@ import { createConversationFork } from "@app/lib/api/assistant/conversation/fork
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { Authenticator } from "@app/lib/auth";
 import {
+  AgentMCPActionModel,
+  AgentMCPActionOutputItemModel,
+} from "@app/lib/models/agent/actions/mcp";
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import {
   AgentMessageModel,
   ConversationModel,
   MessageModel,
@@ -89,12 +94,14 @@ async function createAgentMessage(
     rank,
     parentId,
     status,
+    generatedFileId = null,
     branchId = null,
   }: {
     conversation: ConversationWithoutContentType;
     rank: number;
     parentId: ModelId;
     status: "created" | "succeeded";
+    generatedFileId?: ModelId | null;
     branchId?: ModelId | null;
   }
 ): Promise<MessageModel> {
@@ -109,7 +116,7 @@ async function createAgentMessage(
     completedAt: status === "created" ? null : new Date(),
   });
 
-  return MessageModel.create({
+  const message = await MessageModel.create({
     workspaceId: workspace.id,
     sId: generateRandomModelSId(),
     rank,
@@ -118,6 +125,79 @@ async function createAgentMessage(
     parentId,
     agentMessageId: agentMessage.id,
   });
+
+  if (!generatedFileId) {
+    return message;
+  }
+
+  const stepContent = await AgentStepContentModel.create({
+    workspaceId: workspace.id,
+    agentMessageId: agentMessage.id,
+    step: 1,
+    index: 0,
+    version: 0,
+    type: "function_call",
+    value: {
+      type: "function_call",
+      value: {
+        id: generateRandomModelSId(),
+        name: "test_tool",
+        arguments: "{}",
+      },
+    },
+  });
+
+  const action = await AgentMCPActionModel.create({
+    workspaceId: workspace.id,
+    agentMessageId: agentMessage.id,
+    stepContentId: stepContent.id,
+    mcpServerConfigurationId: generateRandomModelSId(),
+    version: 0,
+    status: "succeeded",
+    citationsAllocated: 0,
+    augmentedInputs: {},
+    toolConfiguration: {
+      id: 1,
+      sId: generateRandomModelSId(),
+      type: "mcp_configuration",
+      name: "test_tool",
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: "test-server-view",
+      dustAppConfiguration: null,
+      secretName: null,
+      dustProject: null,
+      internalMCPServerId: null,
+      availability: "auto",
+      permission: "low",
+      toolServerId: "test-server",
+      retryPolicy: "no_retry",
+      originalName: "test_tool",
+      mcpServerName: "test_server",
+    },
+    stepContext: {
+      citationsCount: 0,
+      citationsOffset: 0,
+      resumeState: null,
+      retrievalTopK: 10,
+      websearchResultCount: 0,
+    },
+  });
+
+  await AgentMCPActionOutputItemModel.create({
+    workspaceId: workspace.id,
+    agentMCPActionId: action.id,
+    content: { type: "text", text: "Tool output" },
+    contentGcsPath: null,
+    fileId: generatedFileId,
+    citations: null,
+  });
+
+  return message;
 }
 
 async function createConversationFile(
@@ -140,6 +220,34 @@ async function createConversationFile(
     useCase: "conversation",
     useCaseMetadata: {
       conversationId,
+    },
+    snippet,
+  });
+}
+
+async function createToolOutputFile(
+  auth: Authenticator,
+  {
+    conversationId,
+    fileName,
+    snippet = null,
+    hideFromUser = false,
+  }: {
+    conversationId: string;
+    fileName: string;
+    snippet?: string | null;
+    hideFromUser?: boolean;
+  }
+): Promise<FileResource> {
+  return FileFactory.create(auth, auth.getNonNullableUser(), {
+    contentType: "text/plain",
+    fileName,
+    fileSize: 16,
+    status: "ready",
+    useCase: "tool_output",
+    useCaseMetadata: {
+      conversationId,
+      ...(hideFromUser ? { hideFromUser: true } : {}),
     },
     snippet,
   });
@@ -697,6 +805,150 @@ describe("createConversationFork", () => {
 
     expect(childFileAttachments).toHaveLength(1);
     expect(childFileAttachments[0]?.title).toBe("First attachment");
+
+    copyToConversationSpy.mockRestore();
+  }, 15_000);
+
+  it("carries over tool output attachments from the selected source message", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+    const copyToConversationSpy = mockCopyToConversation();
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const sourceToolOutput = await createToolOutputFile(auth, {
+      conversationId: parentConversation.sId,
+      fileName: "before-fork.txt",
+      snippet: "before",
+    });
+    const laterToolOutput = await createToolOutputFile(auth, {
+      conversationId: parentConversation.sId,
+      fileName: "after-fork.txt",
+      snippet: "after",
+    });
+
+    const firstUserMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      content: "Fork from the next answer.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 2,
+      parentId: firstUserMessage.id,
+      status: "succeeded",
+      generatedFileId: sourceToolOutput.id,
+    });
+    const secondUserMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 3,
+      content: "Too late for the fork.",
+    });
+    await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 4,
+      parentId: secondUserMessage.id,
+      status: "succeeded",
+      generatedFileId: laterToolOutput.id,
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
+
+    const childAttachments = await listAttachments(auth, {
+      conversation: childConversation,
+    });
+    const childFileAttachments = childAttachments.filter(isFileAttachmentType);
+
+    expect(childFileAttachments).toHaveLength(1);
+    expect(childFileAttachments[0]?.title).toBe("before-fork.txt");
+    expect(childFileAttachments[0]?.fileId).not.toBe(sourceToolOutput.sId);
+
+    const copiedFiles = await FileResource.fetchByIds(auth, [
+      childFileAttachments[0]!.fileId,
+    ]);
+    expect(copiedFiles).toHaveLength(1);
+    expect(copiedFiles[0]?.useCase).toBe("tool_output");
+    expect(copiedFiles[0]?.useCaseMetadata?.conversationId).toBe(
+      childConversation.sId
+    );
+    expect(copiedFiles[0]?.snippet).toBe(sourceToolOutput.snippet);
+
+    copyToConversationSpy.mockRestore();
+  }, 15_000);
+
+  it("preserves hidden tool output attachments in the forked conversation", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+    const copyToConversationSpy = mockCopyToConversation();
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const hiddenToolOutput = await createToolOutputFile(auth, {
+      conversationId: parentConversation.sId,
+      fileName: "hidden-output.txt",
+      hideFromUser: true,
+    });
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      content: "Fork from the next answer.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 2,
+      parentId: userMessage.id,
+      status: "succeeded",
+      generatedFileId: hiddenToolOutput.id,
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
+
+    const childAttachments = await listAttachments(auth, {
+      conversation: childConversation,
+    });
+    const childFileAttachments = childAttachments.filter(isFileAttachmentType);
+
+    expect(childFileAttachments).toHaveLength(1);
+    expect(childFileAttachments[0]?.hidden).toBe(true);
+
+    const copiedFiles = await FileResource.fetchByIds(auth, [
+      childFileAttachments[0]!.fileId,
+    ]);
+    expect(copiedFiles).toHaveLength(1);
+    expect(copiedFiles[0]?.useCaseMetadata?.hideFromUser).toBe(true);
 
     copyToConversationSpy.mockRestore();
   }, 15_000);

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -239,13 +239,15 @@ async function carryOverConversationAttachments(
   const attachments = await listAttachments(auth, {
     conversation: parentConversationAtSource,
   });
-  // We carry over direct conversation attachments that were explicitly posted into the
-  // conversation. Project-context files remain accessible via the shared project, and agent-
-  // generated files still need a separate follow-up because they are not re-attached through
-  // content fragments today.
+  // We carry over direct conversation attachments and agent-generated tool outputs that were
+  // attached before the fork point. Project-context files remain accessible via the shared
+  // project and are therefore excluded here.
   const directConversationAttachments = attachments.filter((attachment) => {
     if (isFileAttachmentType(attachment)) {
-      return attachment.source === "user" && !attachment.isInProjectContext;
+      return (
+        (attachment.source === "user" || attachment.source === "agent") &&
+        !attachment.isInProjectContext
+      );
     }
 
     return isContentNodeAttachmentType(attachment);


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24493
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

This lets fork creation carry over agent-generated tool output files that existed at the selected source message. The fork path now accepts `tool_output` files in the existing file content-fragment flow, so copied tool outputs can be re-attached into the child while preserving hidden-file metadata.

## Risks
Blast radius: conversation branching attachment carryover for agent-generated tool output files
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/api/assistant/conversation/forks.test.ts pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts`