### PR TITLE
[front] enh: Remvove N+1 from api/w/[wId]/assistant/conversations

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -87,6 +87,7 @@ import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 
 import { ServerSideTracking } from "@app/lib/tracking/server";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
   getTimeframeSecondsFromLiteral,
   rateLimiter,
@@ -2614,8 +2615,9 @@ async function isMessagesLimitReached(
     activeSeats,
   });
   const agentMentions = mentions.filter(isAgentMention);
-  const remainingMentions = await Promise.all(
-    agentMentions.map(() =>
+  const remainingMentions = await concurrentExecutor(
+    agentMentions,
+    () =>
       rateLimiter({
         key: makeAgentMentionsRateLimitKeyForWorkspace(
           owner,
@@ -2624,8 +2626,8 @@ async function isMessagesLimitReached(
         maxPerTimeframe: effectiveMaxMessages,
         timeframeSeconds: getTimeframeSecondsFromLiteral(maxMessagesTimeframe),
         logger,
-      })
-    )
+      }),
+    { concurrency: 4 }
   );
   // We let the user talk to all agents if any of the rate limiter answered "ok".
   // Subsequent calls to this function would block the user anyway.

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -20,6 +20,7 @@ import { notifyProjectMembersAdded } from "@app/lib/notifications/workflows/proj
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { auditLog } from "@app/logger/logger";
 import type {
   AgentMessageType,
@@ -145,55 +146,63 @@ export const createUserMentions = async (
     (mention) => mention.userId
   );
 
-  // Store user mentions in the database
-  const mentionModels = await Promise.all(
-    uniqueMentions.map(async (mention) => {
+  if (uniqueMentions.length === 0) {
+    return [];
+  }
+
+  // Store user mentions in the database with bounded concurrency.
+  const mentionModels = await concurrentExecutor(
+    uniqueMentions,
+    async (mention) => {
       // check if the user exists in the workspace before creating the mention
       const user = await getUserForWorkspace(auth, {
         userId: mention.userId,
       });
-      if (user) {
-        usersById.set(user.id, user.toJSON());
+      if (!user) {
+        return undefined;
+      }
 
-        const isParticipant =
-          await ConversationResource.isConversationParticipant(auth, {
-            conversation,
-            user: user.toJSON(),
-          });
+      usersById.set(user.id, user.toJSON());
 
-        // TODO: Alternative approach would be to always set pending_project_membership for
-        // project conversations and decide at render time whether to show "add to project"
-        // (for editors) or "request access" (for non-editors). This would require building
-        // a request access flow. See https://github.com/dust-tt/dust/issues/20852
-        const status = await getMentionStatus(auth, {
+      const isParticipant =
+        await ConversationResource.isConversationParticipant(auth, {
           conversation,
-          message,
-          isParticipant,
-          mentionedUser: user,
+          user: user.toJSON(),
         });
 
-        const mentionModel = await MentionModel.create(
-          {
-            messageId: message.id,
-            userId: user.id,
-            workspaceId: auth.getNonNullableWorkspace().id,
-            status,
-          },
-          { transaction }
-        );
+      // TODO: Alternative approach would be to always set pending_project_membership for
+      // project conversations and decide at render time whether to show "add to project"
+      // (for editors) or "request access" (for non-editors). This would require building
+      // a request access flow. See https://github.com/dust-tt/dust/issues/20852
+      const status = await getMentionStatus(auth, {
+        conversation,
+        message,
+        isParticipant,
+        mentionedUser: user,
+      });
 
-        if (!isParticipant && status === "approved") {
-          await ConversationResource.upsertParticipation(auth, {
-            conversation,
-            action: "subscribed",
-            user: user.toJSON(),
-            lastReadAt: null,
-            transaction,
-          });
-        }
-        return mentionModel;
+      const mentionModel = await MentionModel.create(
+        {
+          messageId: message.id,
+          userId: user.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          status,
+        },
+        { transaction }
+      );
+
+      if (!isParticipant && status === "approved") {
+        await ConversationResource.upsertParticipation(auth, {
+          conversation,
+          action: "subscribed",
+          user: user.toJSON(),
+          lastReadAt: null,
+          transaction,
+        });
       }
-    })
+      return mentionModel;
+    },
+    { concurrency: 4 }
   );
 
   return getRichMentionsWithStatusForMessage(

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -259,7 +259,8 @@ function renderUserMessage(
 
 async function batchRenderUserMessages(
   auth: Authenticator,
-  messages: MessageModel[]
+  messages: MessageModel[],
+  mentionsByMessageId?: Map<ModelId, MentionModel[]>
 ): Promise<UserMessageType[]> {
   const userMessages = messages.filter(
     (m) => m.userMessage !== null && m.userMessage !== undefined
@@ -269,12 +270,14 @@ async function batchRenderUserMessages(
     return [];
   }
 
-  const mentionRows = await MentionModel.findAll({
-    where: {
-      workspaceId: auth.getNonNullableWorkspace().id,
-      messageId: userMessages.map((message) => message.id),
-    },
-  });
+  const mentionRows = mentionsByMessageId
+    ? userMessages.flatMap((m) => mentionsByMessageId.get(m.id) ?? [])
+    : await MentionModel.findAll({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          messageId: userMessages.map((message) => message.id),
+        },
+      });
 
   const userIds = [
     ...new Set(
@@ -969,7 +972,11 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
     }
   }
 
-  const userMessages = await batchRenderUserMessages(auth, messages);
+  const userMessages = await batchRenderUserMessages(
+    auth,
+    messages,
+    mentionsByMessageId
+  );
   const agentMessagesRes = await batchRenderAgentMessages(
     auth,
     messages,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -27,6 +27,7 @@ import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { ContentFragmentMessageTypeModel } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
@@ -623,8 +624,9 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
     );
 
     // Render all content fragments with pre-fetched files.
-    return Promise.all(
-      messagesWithContentFragment.map(async (message: MessageModel) => {
+    return concurrentExecutor(
+      messagesWithContentFragment,
+      async (message: MessageModel) => {
         const contentFragment = ContentFragmentResource.fromMessage(message);
         const file = contentFragment.fileId
           ? filesByModelId.get(contentFragment.fileId)
@@ -639,7 +641,8 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
           file,
           dataSourceView,
         });
-      })
+      },
+      { concurrency: 4 }
     );
   }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.test.ts
@@ -1,0 +1,124 @@
+import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/temporal/agent_loop/client", () => ({
+  launchAgentLoopWorkflow: vi.fn(),
+  launchCompactionWorkflow: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/assistant/streaming/events", () => ({
+  publishAgentMessagesEvents: vi.fn(),
+  publishConversationEvent: vi.fn(),
+  publishMessageEventsOnMessagePostOrEdit: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/assistant/conversation/content_fragment", () => ({
+  getContentFragmentBlob: vi.fn(),
+}));
+
+import handler from "./index";
+
+describe("POST /api/w/[wId]/assistant/conversations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a conversation with both content fragments and an initial message", async () => {
+    const { req, res, workspace, auth, globalSpace } =
+      await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+
+    const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+      auth,
+      {
+        name: "Route Test Agent",
+        description: "Route behavior test agent",
+      }
+    );
+
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      globalSpace,
+      auth.user() ?? null
+    );
+
+    vi.mocked(getContentFragmentBlob).mockImplementation(async (_auth, cf) => {
+      if (!("nodeId" in cf)) {
+        throw new Error("Expected a content-node fragment");
+      }
+
+      return new Ok({
+        contentType: "text/plain",
+        fileId: null,
+        nodeId: cf.nodeId,
+        nodeDataSourceViewId: dataSourceView.id,
+        nodeType: "document",
+        sourceUrl: null,
+        textBytes: null,
+        title: cf.title,
+      });
+    });
+
+    req.url = `/api/w/${workspace.sId}/assistant/conversations`;
+    req.body = {
+      title: "Conversation created from route",
+      visibility: "unlisted",
+      spaceId: null,
+      contentFragments: [
+        {
+          title: "Workspace context",
+          nodeId: "node-1",
+          nodeDataSourceViewId: dataSourceView.sId,
+          context: { profilePictureUrl: null },
+        },
+      ],
+      message: {
+        content: "Hello from the route",
+        mentions: [{ configurationId: agentConfiguration.sId }],
+        context: {
+          timezone: "Europe/Paris",
+          profilePictureUrl: null,
+        },
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData.contentFragments).toHaveLength(1);
+    expect(responseData.contentFragments[0]).toMatchObject({
+      type: "content_fragment",
+      title: "Workspace context",
+    });
+    expect(responseData.message).toMatchObject({
+      type: "user_message",
+      content: "Hello from the route",
+      mentions: [{ configurationId: agentConfiguration.sId }],
+    });
+
+    const flattenedContent = responseData.conversation.content.flat();
+    const contentFragmentIndex = flattenedContent.findIndex(
+      (item: { type: string }) => item.type === "content_fragment"
+    );
+    const userMessageIndex = flattenedContent.findIndex(
+      (item: { sId?: string; type: string }) =>
+        item.type === "user_message" && item.sId === responseData.message.sId
+    );
+
+    expect(contentFragmentIndex).toBeGreaterThanOrEqual(0);
+    expect(userMessageIndex).toBeGreaterThan(contentFragmentIndex);
+    expect(
+      flattenedContent.some(
+        (item: { type: string }) => item.type === "agent_message"
+      )
+    ).toBe(true);
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -165,6 +165,12 @@ export type PostConversationsResponseBody = {
   contentFragments: ContentFragmentType[];
 };
 
+function isConversationNotFoundError(err: unknown): err is ConversationError {
+  return (
+    err instanceof ConversationError && err.type === "conversation_not_found"
+  );
+}
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
@@ -302,53 +308,37 @@ async function handler(
       };
 
       if (contentFragments.length > 0) {
-        const newContentFragmentsRes = await Promise.all(
-          contentFragments.map((contentFragment) => {
-            return postNewContentFragment(auth, conversation, contentFragment, {
+        const newContentFragmentsRes = await concurrentExecutor(
+          contentFragments,
+          async (contentFragment) =>
+            postNewContentFragment(auth, conversation, contentFragment, {
               ...baseContext,
               profilePictureUrl: contentFragment.context.profilePictureUrl,
-            });
-          })
+            }),
+          { concurrency: 4 }
         );
 
         for (const r of newContentFragmentsRes) {
           if (r.isErr()) {
-            if (r.isErr()) {
-              return apiError(req, res, {
-                status_code: 400,
-                api_error: {
-                  type: "invalid_request_error",
-                  message: r.error.message,
-                },
-              });
-            }
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: r.error.message,
+              },
+            });
           }
 
           newContentFragments.push(r.value);
         }
 
-        const updatedConversationRes = await getConversation(
-          auth,
-          conversation.sId
-        );
-
-        if (updatedConversationRes.isErr()) {
-          // Preserving former code in which if the conversation was not found here, we do not error
-          if (
-            !(
-              updatedConversationRes.error instanceof ConversationError &&
-              updatedConversationRes.error.type === "conversation_not_found"
-            )
-          ) {
-            return apiErrorForConversation(
-              req,
-              res,
-              updatedConversationRes.error
-            );
-          }
-        } else {
-          conversation = updatedConversationRes.value;
-        }
+        conversation = {
+          ...conversation,
+          content: [
+            ...conversation.content,
+            ...newContentFragments.map((contentFragment) => [contentFragment]),
+          ],
+        };
       }
 
       if (message) {
@@ -445,11 +435,11 @@ async function handler(
         // streaming events from these agent messages directly.
         const updatedRes = await getConversation(auth, conversation.sId);
 
-        if (updatedRes.isErr()) {
+        if (updatedRes.isOk()) {
+          conversation = updatedRes.value;
+        } else if (!isConversationNotFoundError(updatedRes.error)) {
           return apiErrorForConversation(req, res, updatedRes.error);
         }
-
-        conversation = updatedRes.value;
       }
 
       res.status(200).json({


### PR DESCRIPTION
## Description

We can still observe peak concurrency on POST conversation of 100+ connections
This PR chases down every remaining unbounded promiseAll, replaces them with concurrent executors (with some small improvements) and reduces existing one concurrency from 10 to 4. 
The rationale is that we see in multiple codepath concurrentExecutor of concurrentExecutor, so even if 10 looks ok in a vacuum, it can quickly become 100 connections (from a pool of 40, shared)

easier to review like that: https://github.com/dust-tt/dust/pull/24506/changes?w=1

 
## Tests

Tested locally + unit tests.


## Risk

Low
Blast radius: conversation create

## Deploy Plan

- [ ] Deploy front