### PR TITLE
server id not unique

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1103,7 +1103,7 @@ export const INTERNAL_MCP_SERVERS = {
     metadata: ASK_USER_QUESTION_SERVER,
   },
   clari_copilot: {
-    id: 1029,
+    id: 1030,
     availability: "manual",
     allowMultipleInstances: true,
     isRestricted: ({ featureFlags }) =>


### PR DESCRIPTION
## Description

Fixes a duplicate server ID conflict between `clari_copilot` and `project_todos` internal MCP servers. Both were assigned ID `1029`, which violates the uniqueness constraint enforced by the test suite. Updates `clari_copilot` server ID to `1030`.

## Tests

Existing test `should have unique IDs for all servers` in `constants.test.ts` validates the fix.

## Risk

None. Simple ID change with no functional impact.

## Deploy Plan

Deploy front.