### PR TITLE
[front] fix display of action approval 

### DIFF
--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -140,7 +140,13 @@ export function MCPToolValidationRequired({
     const args = blockedAction.argumentsRequiringApproval ?? [];
     const argValues = args
       .filter((arg) => blockedAction.inputs[arg] != null)
-      .map((arg) => JSON.stringify(blockedAction.inputs[arg]));
+      .flatMap((arg) => {
+        const value = blockedAction.inputs[arg];
+        if (Array.isArray(value)) {
+          return value.map((v) => String(v));
+        }
+        return [JSON.stringify(value)];
+      });
     return `Always allow @${blockedAction.metadata.agentName} to ${asDisplayName(blockedAction.metadata.toolName)} ${
       argValues.length > 0
         ? ` for the following parameters: ${argValues.join(", ")}`
@@ -169,8 +175,9 @@ export function MCPToolValidationRequired({
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:mt-3">
             {(blockedAction.stake === "low" ||
               blockedAction.stake === "medium") && (
-              <Label className="flex w-fit cursor-pointer flex-row items-center gap-2 py-1 pr-2 text-xs">
+              <Label htmlFor="never-ask-again" className="flex w-fit cursor-pointer flex-row items-center gap-2 py-1 pr-2 text-xs">
                 <Checkbox
+                  id="never-ask-again"
                   checked={neverAskAgain}
                   onCheckedChange={(check) => {
                     setNeverAskAgain(!!check);

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -172,10 +172,13 @@ export function MCPToolValidationRequired({
               {errorMessage}
             </div>
           )}
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:mt-3">
+          <div className="flex flex-col gap-3 sm:mt-3">
             {(blockedAction.stake === "low" ||
               blockedAction.stake === "medium") && (
-              <Label htmlFor="never-ask-again" className="flex w-fit cursor-pointer flex-row items-center gap-2 py-1 pr-2 text-xs">
+              <Label
+                htmlFor="never-ask-again"
+                className="flex w-fit cursor-pointer flex-row items-center gap-2 py-1 pr-2 text-xs"
+              >
                 <Checkbox
                   id="never-ask-again"
                   checked={neverAskAgain}
@@ -189,7 +192,7 @@ export function MCPToolValidationRequired({
               </Label>
             )}
             <div className="hidden sm:block sm:flex-grow" />
-            <div className="flex flex-row gap-3">
+            <div className="flex flex-row gap-3 self-end">
               <Button
                 label="Decline"
                 variant="outline"

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -140,12 +140,12 @@ export function MCPToolValidationRequired({
     const args = blockedAction.argumentsRequiringApproval ?? [];
     const argValues = args
       .filter((arg) => blockedAction.inputs[arg] != null)
-      .flatMap((arg) => {
+      .map((arg) => {
         const value = blockedAction.inputs[arg];
         if (Array.isArray(value)) {
-          return value.map((v) => String(v));
+          return value.map(String).join(", ");
         }
-        return [JSON.stringify(value)];
+        return JSON.stringify(value);
       });
     return `Always allow @${blockedAction.metadata.agentName} to ${asDisplayName(blockedAction.metadata.toolName)} ${
       argValues.length > 0


### PR DESCRIPTION
## Description
This PR is to fix the display issue on Tool Approval card. I don't have much context to improve it further, but at least 
we don't use JSON.stringify if the value is an array so that we can format it correclty: 
before:
<img width="1384" height="448" alt="CleanShot 2026-04-17 at 22 19 50@2x" src="https://github.com/user-attachments/assets/91b15703-7286-4276-b8e7-6d5b1b93a8d9" />


after:
<img width="1158" height="454" alt="CleanShot 2026-04-17 at 22 35 51@2x" src="https://github.com/user-attachments/assets/e56680f3-821c-4c74-98c9-1215e83b56ac" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
