### PR TITLE
Simplify knowledge node html format

### DIFF
--- a/front/components/editor/extensions/skill_builder/KnowledgeNode.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNode.tsx
@@ -7,7 +7,7 @@ import {
   isFullKnowledgeItem,
   KnowledgeNodeView,
 } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
-import { mergeAttributes, Node } from "@tiptap/core";
+import { Node } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 
 export interface KnowledgeNodeAttributes {
@@ -24,12 +24,9 @@ declare module "@tiptap/core" {
 
 export const KNOWLEDGE_NODE_TYPE = "knowledgeNode";
 
-// The markdown tag name used for serialization: <knowledge id="..." title="..." />.
-// This format is intentionally HTML-like for LLM readability.
-const KNOWLEDGE_MARKDOWN_TAG = "knowledge";
-
-const KNOWLEDGE_MARKDOWN_REGEX = new RegExp(
-  `^<${KNOWLEDGE_MARKDOWN_TAG}\\s+([^>]+)\\s*/>`
+const KNOWLEDGE_TAG = "knowledge";
+export const KNOWLEDGE_TAG_REGEX = new RegExp(
+  `^<${KNOWLEDGE_TAG}\\s+([^>]+)\\s*/>`
 );
 
 export const KnowledgeNode = Node.create<{}>({
@@ -44,10 +41,10 @@ export const KnowledgeNode = Node.create<{}>({
     name: "knowledgeNode",
     level: "inline",
     start: (src) => {
-      return src.indexOf(`<${KNOWLEDGE_MARKDOWN_TAG}`);
+      return src.indexOf(`<${KNOWLEDGE_TAG}`);
     },
     tokenize: (src) => {
-      const match = KNOWLEDGE_MARKDOWN_REGEX.exec(src);
+      const match = KNOWLEDGE_TAG_REGEX.exec(src);
       if (!match) {
         return undefined;
       }
@@ -82,20 +79,7 @@ export const KnowledgeNode = Node.create<{}>({
       selectedItems: {
         default: [],
         parseHTML: (element) => {
-          // Primary path: deserialization from renderHTML (span with JSON data).
-          const data = element.getAttribute("data-selected-items");
-          if (data) {
-            return JSON.parse(decodeURIComponent(data));
-          }
-
-          // Fallback path: deserialization from a <knowledge> HTML element.
-          //
-          // This handles a markdown round-trip edge case: when a knowledge node
-          // is alone on its own line, marked.js treats the <knowledge .../> tag
-          // as block-level HTML (instead of routing it through our inline
-          // markdownTokenizer). The tag then goes through TipTap's parseHTML
-          // pipeline, so we need to extract the attributes here.
-          if (element.tagName.toLowerCase() === KNOWLEDGE_MARKDOWN_TAG) {
+          if (element.tagName.toLowerCase() === KNOWLEDGE_TAG) {
             const id = element.getAttribute("id");
             const title = element.getAttribute("title");
             if (id && title) {
@@ -110,24 +94,33 @@ export const KnowledgeNode = Node.create<{}>({
             }
           }
 
+          // Maintaing for backwards compatibility with old serialized data.
+          // Previously, the renderHTML output was a span with data-selected-items.
+          // But now we use the <knowledge> tag for all serialization.
+          const data = element.getAttribute("data-selected-items");
+          if (data) {
+            return JSON.parse(decodeURIComponent(data));
+          }
+
           return [];
         },
         renderHTML: (attributes) => {
-          // Strip down to BaseKnowledgeItem fields only to avoid persisting
-          // the full DataSourceViewContentNode which bloats the HTML.
-          const items = (attributes.selectedItems as KnowledgeItem[]).map(
-            (item): BaseKnowledgeItem => ({
-              dataSourceViewId: item.dataSourceViewId,
-              hasChildren: isFullKnowledgeItem(item)
-                ? computeHasChildren(item.node)
-                : item.hasChildren,
-              label: item.label,
-              nodeId: item.nodeId,
-              spaceId: item.spaceId,
-            })
-          );
+          // TipTap passes attribute values loosely typed.
+          // We only serialize one <knowledge> element, so map the first selected item to
+          // DOM attrs.
+          const item = (attributes.selectedItems as KnowledgeItem[])[0];
+          if (!item) {
+            return {};
+          }
+          const hasChildren = isFullKnowledgeItem(item)
+            ? computeHasChildren(item.node)
+            : item.hasChildren;
           return {
-            "data-selected-items": encodeURIComponent(JSON.stringify(items)),
+            id: item.nodeId,
+            title: item.label,
+            space: item.spaceId,
+            dsv: item.dataSourceViewId,
+            hasChildren: String(hasChildren),
           };
         },
       },
@@ -138,13 +131,14 @@ export const KnowledgeNode = Node.create<{}>({
 
   parseHTML() {
     return [
+      // Maintaining for backwards compatibility with old serialized data.
+      // Previously, renderHTML output was a span with data-type="knowledge-node".
+      // But now we use the <knowledge> tag for all serialization.
       {
         tag: 'span[data-type="knowledge-node"]',
       },
-      // Fallback: match <knowledge> tags that marked.js parsed as block HTML.
-      // See the comment in addAttributes().parseHTML for details.
       {
-        tag: KNOWLEDGE_MARKDOWN_TAG,
+        tag: KNOWLEDGE_TAG,
       },
     ];
   },
@@ -153,34 +147,11 @@ export const KnowledgeNode = Node.create<{}>({
     const { selectedItems } = node.attrs;
 
     if (selectedItems.length > 0) {
-      // Render selected knowledge as semantic HTML with full data preservation
-      return [
-        "span",
-        mergeAttributes(
-          {
-            "data-type": "knowledge-node",
-            "data-knowledge-id": selectedItems[0].id,
-            "data-knowledge-label": selectedItems[0].label,
-            "data-knowledge-description": selectedItems[0].description ?? "",
-          },
-          HTMLAttributes
-        ),
-        selectedItems[0].label,
-      ];
+      return [KNOWLEDGE_TAG, HTMLAttributes];
     }
 
-    // For search state, render as empty placeholder (shouldn't normally be serialized)
-    return [
-      "span",
-      mergeAttributes(
-        {
-          "data-type": "knowledge-node",
-          "data-is-searching": "true",
-        },
-        HTMLAttributes
-      ),
-      "[Knowledge search]",
-    ];
+    // Search state is transient UI — nothing to serialize.
+    return ["span", {}];
   },
 
   // Markdown serialization and deserialization.
@@ -208,7 +179,7 @@ export const KnowledgeNode = Node.create<{}>({
 
       // Serialize essential data for model understanding and API fetching.
       // Format kept aligned with renderNode() output for consistency.
-      return `<${KNOWLEDGE_MARKDOWN_TAG} id="${item.nodeId}" title="${item.label}" space="${item.spaceId}" dsv="${item.dataSourceViewId}" hasChildren="${hasChildren}" />`;
+      return `<${KNOWLEDGE_TAG} id="${item.nodeId}" title="${item.label}" space="${item.spaceId}" dsv="${item.dataSourceViewId}" hasChildren="${hasChildren}" />`;
     }
 
     // Don't serialize search state, empty nodes shouldn't be saved.

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,7 +1,6 @@
 import { editorVariants } from "@app/components/editor/editorStyles";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
-import { stripHtmlAttributes } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import {
   SkillInstructionsEditorContent,
   useSkillInstructionsEditor,
@@ -18,6 +17,8 @@ import {
 import { cn } from "@dust-tt/sparkle";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
+import type { Config } from "dompurify";
+import DOMPurify from "dompurify";
 import debounce from "lodash/debounce";
 import { useCallback, useEffect, useMemo } from "react";
 import { useController, useFormContext } from "react-hook-form";
@@ -46,6 +47,19 @@ function toAttachedKnowledge(
     spaceId: item.spaceId,
     title: item.label,
   }));
+}
+
+function sanitizeSkillInstructionsHtml(html: string): string {
+  try {
+    const config: Config = {
+      ADD_TAGS: ["knowledge"],
+      ADD_ATTR: ["space", "dsv", "hasChildren"],
+      FORBID_ATTR: ["style", "class"],
+    };
+    return DOMPurify.sanitize(html, config);
+  } catch {
+    return html;
+  }
 }
 
 const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
@@ -93,7 +107,7 @@ export function SkillBuilderInstructionsEditor({
           );
           setValue(
             INSTRUCTIONS_HTML_FIELD_NAME,
-            stripHtmlAttributes(editor.getHTML()),
+            sanitizeSkillInstructionsHtml(editor.getHTML()),
             { shouldDirty: true }
           );
           setValue(
@@ -211,7 +225,7 @@ export function SkillBuilderInstructionsEditor({
       // Sync the editor's new content back to the form.
       setValue(
         INSTRUCTIONS_HTML_FIELD_NAME,
-        stripHtmlAttributes(editor.getHTML()),
+        sanitizeSkillInstructionsHtml(editor.getHTML()),
         { shouldDirty: true }
       );
       setValue(
@@ -316,7 +330,7 @@ export function SkillBuilderInstructionsEditor({
     }
 
     const incomingHtml = instructionsHtmlField.value;
-    const currentHtml = stripHtmlAttributes(editor.getHTML());
+    const currentHtml = sanitizeSkillInstructionsHtml(editor.getHTML());
     if (currentHtml !== incomingHtml) {
       editor.commands.setContent(incomingHtml, { emitUpdate: false });
     }

--- a/front/lib/reinforcement/skill_instructions_html.test.ts
+++ b/front/lib/reinforcement/skill_instructions_html.test.ts
@@ -126,7 +126,8 @@ describe("convertMarkdownToBlockHtml", () => {
     const html = convertMarkdownToBlockHtml(md);
 
     expect(html).not.toContain("&lt;knowledge");
-    expect(html).toContain('data-type="knowledge-node"');
-    expect(html).toContain("My Doc");
+    expect(html).toContain("<knowledge");
+    expect(html).toContain('id="n1"');
+    expect(html).toContain('title="My Doc"');
   });
 });

--- a/front/lib/reinforcement/skill_instructions_html.ts
+++ b/front/lib/reinforcement/skill_instructions_html.ts
@@ -3,6 +3,7 @@ import {
   BLOCK_ID_UNIQUE_ID_NODE_TYPES,
 } from "@app/components/editor/extensions/instructions/BlockIdExtension";
 import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
+import { KNOWLEDGE_TAG_REGEX } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import { buildSkillInstructionsExtensions } from "@app/lib/editor/build_skill_instructions_extensions";
 import { preprocessMarkdownForEditor } from "@app/lib/editor/skill_instructions_preprocessing";
 import { generateShortBlockId } from "@app/lib/generate_short_block_id";
@@ -81,7 +82,8 @@ function stripPresentationAttributes(html: string): string {
   // the round-trip mechanism for recovering the language on generateJSON
   $("[class]").not("code").removeAttr("class");
   $("[style]").removeAttr("style");
-  $("[id]").removeAttr("id");
+  // Must maintain id on <knowledge> elements for knowledgeNode parsing
+  $("[id]").not("knowledge").removeAttr("id");
   return $.html();
 }
 
@@ -92,8 +94,6 @@ function stripPresentationAttributes(html: string): string {
  * parsed JSON tree and restore any such nodes back to proper knowledgeNode
  * JSONContent before rendering to HTML.
  */
-const KNOWLEDGE_TAG_REGEX = /^<knowledge\s+([^>]+)\s*\/>$/;
-
 function recoverKnowledgeNodes(node: JSONContent): JSONContent {
   if (node.type === "paragraph" && node.content?.length === 1) {
     const child = node.content[0];


### PR DESCRIPTION
## Description

* Step 1 for https://github.com/dust-tt/tasks/issues/7591
* Simplifying knowledge node format so that it is LLM friendly

## Tests

Example:
```
        "instructionsHtml": "<div data-type=\"instructions-root\" data-block-id=\"instructions-root\"><p data-block-id=\"053f03c3\"></p><p data-block-id=\"60a0fa86\"><knowledge id=\"test\" title=\"Test\" space=\"vlt_M3noynRxIM\" dsv=\"dsv_Q8Ac4uf35L\" haschildren=\"false\"></knowledge></p><p data-block-id=\"e34d0f6d\"></p><p data-block-id=\"d878aa7a\">Yo <knowledge id=\"test\" title=\"Test\" space=\"vlt_M3noynRxIM\" dsv=\"dsv_Q8Ac4uf35L\" haschildren=\"false\"></knowledge> to</p><p data-block-id=\"cfb4fae0\"></p></div>",

```
<img width="736" height="337" alt="Screenshot 2026-04-17 at 5 03 24 PM" src="https://github.com/user-attachments/assets/a84e1751-1ac4-4597-bc10-a4816fb08c2f" />

## Risk

No impact expected as we made this backwards compatible

## Deploy Plan

* Deploy front