### PR TITLE
[sessions]: Show file card and preview in tool generation slideout

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -29,7 +29,10 @@ import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MC
 import { MCPSandboxActionDetails } from "@app/components/actions/mcp/details/MCPSandboxActionDetails";
 import { MCPSkillEnableActionDetails } from "@app/components/actions/mcp/details/MCPSkillEnableActionDetails";
 import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details/MCPTablesQueryActionDetails";
-import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
+import {
+  SearchResultDetails,
+  ToolGeneratedFileDetails,
+} from "@app/components/actions/mcp/details/MCPToolOutputDetails";
 import { MCPToolsetsEnableActionDetails } from "@app/components/actions/mcp/details/MCPToolsetsEnableActionDetails";
 import type {
   ActionDetailsDisplayContext,
@@ -88,10 +91,8 @@ import {
   GET_DATABASE_SCHEMA_TOOL_NAME,
   TABLE_QUERY_V2_SERVER_NAME,
 } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
-import config from "@app/lib/api/config";
 import { isValidJSON } from "@app/lib/utils/json";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
-import { isSupportedImageContentType } from "@app/types/files";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -456,33 +457,13 @@ export function GenericActionDetails({
               <div className="flex flex-wrap gap-2">
                 {action.generatedFiles
                   .filter((f) => !f.hidden)
-                  .map((file) => {
-                    if (isSupportedImageContentType(file.contentType)) {
-                      return (
-                        <div
-                          key={file.fileId}
-                          className="h-24 w-24 flex-shrink-0"
-                        >
-                          <img
-                            className="h-full w-full rounded-xl object-cover"
-                            src={`${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`}
-                            alt={`${file.title}`}
-                          />
-                        </div>
-                      );
-                    }
-                    return (
-                      <div key={file.fileId}>
-                        <a
-                          href={`${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          {file.title}
-                        </a>
-                      </div>
-                    );
-                  })}
+                  .map((file) => (
+                    <ToolGeneratedFileDetails
+                      key={file.fileId}
+                      resource={file}
+                      owner={owner}
+                    />
+                  ))}
               </div>
             </>
           )}

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -1,7 +1,8 @@
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ActionDetailsDisplayContext } from "@app/components/actions/mcp/details/types";
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
-import { toolGeneratedFileToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
+import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
+import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
 import type {
   SqlQueryOutputType,
   ThinkingOutputType,
@@ -15,6 +16,7 @@ import {
   isWarningResourceType,
   isWebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import { getDocumentIcon } from "@app/lib/content_nodes";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -79,7 +81,7 @@ export function SqlQueryBlock({ resource }: SqlQueryBlockProps) {
 }
 
 interface ToolGeneratedFileDetailsProps {
-  resource: ToolGeneratedFileType;
+  resource: ToolGeneratedFileType | ActionGeneratedFileType;
   owner: LightWorkspaceType;
 }
 
@@ -87,15 +89,21 @@ export function ToolGeneratedFileDetails({
   resource,
   owner,
 }: ToolGeneratedFileDetailsProps) {
-  const file = {
-    ...resource,
-    sourceUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${resource.fileId}`,
+  const citation: MCPReferenceCitation = {
+    fileId: resource.fileId,
+    title: resource.title,
+    contentType: resource.contentType,
+    href: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${resource.fileId}`,
+    description:
+      "text" in resource ? resource.text : (resource.snippet ?? undefined),
   };
+
   return (
     <AttachmentCitation
-      attachmentCitation={toolGeneratedFileToAttachmentCitation(file)}
+      attachmentCitation={markdownCitationToAttachmentCitation(citation)}
       owner={owner}
       conversationId={null}
+      compact
     />
   );
 }

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -115,8 +115,11 @@ export function AttachmentCitation({
           ? {
               onClick: (e: React.MouseEvent<HTMLDivElement>) => {
                 e.preventDefault();
+                if (!attachmentCitation.fileId) {
+                  return;
+                }
                 setPreviewFile({
-                  sId: attachmentCitation.fileId as string,
+                  sId: attachmentCitation.fileId,
                   fileName: attachmentCitation.title,
                   contentType: attachmentCitation.contentType,
                 });

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -6,6 +6,10 @@ import {
 } from "@app/components/assistant/conversation/attachment/utils";
 import { ConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import {
+  FilePreviewSheet,
+  type MinimalFileForPreview,
+} from "@app/components/spaces/FilePreviewSheet";
+import {
   getFileFormat,
   isInteractiveContentType,
   isSupportedImageContentType,
@@ -38,6 +42,10 @@ export function AttachmentCitation({
   compact,
 }: AttachmentCitationProps) {
   const [viewerOpen, setViewerOpen] = useState(false);
+  const [previewFile, setPreviewFile] = useState<MinimalFileForPreview | null>(
+    null
+  );
+  const [showPreviewSheet, setShowPreviewSheet] = useState(false);
   const sidePanel = useContext(ConversationSidePanelContext);
 
   const tooltipContent =
@@ -76,6 +84,14 @@ export function AttachmentCitation({
     isInteractiveContentType(attachmentCitation.contentType) &&
     sidePanel != null;
 
+  const canOpenInSheet =
+    attachmentCitation.type === "file" &&
+    Boolean(attachmentCitation.fileId) &&
+    !attachmentCitation.isUploading &&
+    !canOpenInteractivePanel &&
+    !canOpenInDialog &&
+    !isImage;
+
   const dialogOrDownloadProps = canOpenInteractivePanel
     ? {
         onClick: (e: React.MouseEvent<HTMLDivElement>) => {
@@ -95,9 +111,21 @@ export function AttachmentCitation({
         }
       : isImage
         ? {} // ImagePreview handles click with its own zoom dialog
-        : {
-            href: attachmentCitation.sourceUrl ?? undefined,
-          };
+        : canOpenInSheet
+          ? {
+              onClick: (e: React.MouseEvent<HTMLDivElement>) => {
+                e.preventDefault();
+                setPreviewFile({
+                  sId: attachmentCitation.fileId as string,
+                  fileName: attachmentCitation.title,
+                  contentType: attachmentCitation.contentType,
+                });
+                setShowPreviewSheet(true);
+              },
+            }
+          : {
+              href: attachmentCitation.sourceUrl ?? undefined,
+            };
 
   return (
     <>
@@ -158,6 +186,14 @@ export function AttachmentCitation({
           viewerOpen={viewerOpen}
           attachmentCitation={attachmentCitation}
           owner={owner}
+        />
+      )}
+      {canOpenInSheet && (
+        <FilePreviewSheet
+          owner={owner}
+          file={previewFile}
+          isOpen={showPreviewSheet}
+          onOpenChange={setShowPreviewSheet}
         />
       )}
     </>

--- a/front/components/assistant/conversation/attachment/utils.tsx
+++ b/front/components/assistant/conversation/attachment/utils.tsx
@@ -17,7 +17,6 @@ import {
   isInternalAllowedIcon,
 } from "@app/components/resources/resources_icons";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import type { ToolGeneratedFileType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
@@ -292,28 +291,6 @@ export function markdownCitationToAttachmentCitation(
       />
     ),
     provider: citation.provider,
-    isUploading: false,
-  };
-}
-
-export function toolGeneratedFileToAttachmentCitation(
-  file: ToolGeneratedFileType & { sourceUrl: string }
-): MCPAttachmentCitation {
-  return {
-    id: file.fileId,
-    fileId: file.fileId,
-    attachmentCitationType: "mcp",
-    contentType: file.contentType,
-    sourceUrl: file.sourceUrl,
-    description: file.text,
-    title: file.title,
-    type: "file",
-    visual: (
-      <IconForAttachmentCitation
-        contentType={file.contentType}
-        fileName={file.title}
-      />
-    ),
     isUploading: false,
   };
 }


### PR DESCRIPTION
fix https://github.com/dust-tt/tasks/issues/7132
## Description
Previously, generated files in the tool detail panel were rendered as raw <a> links (or inline <img> for images). This changes them to use the same AttachmentCitation chip + FilePreviewSheet already used for file attachments in the conversation view.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Test manually:
<img width="834" height="654" alt="Screenshot 2026-04-20 at 1 37 00 PM" src="https://github.com/user-attachments/assets/8e639678-96c7-4b3a-b18a-2cb09bfb30c1" />
<img width="1190" height="861" alt="Screenshot 2026-04-20 at 1 36 50 PM" src="https://github.com/user-attachments/assets/6aa8c559-6c17-4d0e-a53a-7f9549545609" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
