### PR TITLE
Retain redis events if not matching request ID

### DIFF
--- a/front/lib/api/assistant/mcp_events.ts
+++ b/front/lib/api/assistant/mcp_events.ts
@@ -127,7 +127,7 @@ export async function publishMCPResults(
       }
 
       // Different request ID — keep it.
-      return false;    
+      return false;
     },
     getMCPServerChannelId(auth, { mcpServerId })
   );

--- a/front/lib/api/assistant/mcp_events.ts
+++ b/front/lib/api/assistant/mcp_events.ts
@@ -121,8 +121,13 @@ export async function publishMCPResults(
         return true;
       }
 
-      // If it's a notification (no id, then let's drop it).
-      return true;
+      // If it's a notification (no id), drop it.
+      if (!("id" in payload)) {
+        return true;
+      }
+
+      // Different request ID — keep it.
+      return false;    
     },
     getMCPServerChannelId(auth, { mcpServerId })
   );


### PR DESCRIPTION
## Description

* Happen to come across what I think is a bug, but want to confirm.
* As currently written, it is always removes all events no matter what after MCP results are published. This means that concurrent client side MCP calls for the stream will not complete, which I assume is not intended as we create the ID to support parallel processing

## Deploy Plan

* Deploy front