### PR TITLE
[tracking] Cookie handling update

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -9,9 +9,9 @@ import { useAppRouter } from "@app/lib/platform";
 import { useUser } from "@app/lib/swr/user";
 import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import {
-  DUST_ANONYMOUS_ID_COOKIE,
   getOrCreateAnonymousId,
   getPostHogCookieDomain,
+  readAnonymousIdFromDocumentCookie,
 } from "@app/lib/utils/anonymous_id";
 import {
   getStoredLandingContext,
@@ -157,12 +157,10 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
 
     const cookieDomain = getPostHogCookieDomain();
 
-    // Use the persistent _dust_aid cookie as the initial distinct_id so that
-    // anonymous events share a stable identity across page loads. Without this,
-    // memory persistence generates a new throwaway distinct_id on every page
-    // load, and only the last one gets stitched when identify() fires — all
-    // prior anonymous browsing events are orphaned.
-    const anonymousId = getOrCreateAnonymousId();
+    // Bootstrap from existing _dust_aid (set post-consent) so returning
+    // consented visitors keep a stable id. Absent -> PostHog generates an
+    // ephemeral memory-only distinct_id; pre-consent events stay orphaned.
+    const anonymousId = readAnonymousIdFromDocumentCookie();
 
     posthog.init(POSTHOG_KEY, {
       api_host: `${config.getApiBaseUrl()}/subtle1`,
@@ -250,14 +248,8 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
           };
         }
 
-        // Inject the persistent anonymous device ID from the _dust_aid cookie
-        // so pre-signup events can be stitched to identified users later.
-        const aidCookie = document.cookie
-          .split("; ")
-          .find((c) => c.startsWith(`${DUST_ANONYMOUS_ID_COOKIE}=`));
-        if (aidCookie) {
-          event.properties["dust_anonymous_id"] = aidCookie.split("=")[1];
-        }
+        // Post-consent, dust_anonymous_id is set as a super property via
+        // posthog.register() in Phase 2, so every event carries it.
 
         // Inject referrer and user-agent as non-PII event properties.
         if (document.referrer) {

--- a/front/hooks/useStripUtmParams.ts
+++ b/front/hooks/useStripUtmParams.ts
@@ -15,10 +15,11 @@ import { useCookies } from "react-cookie";
 const DUST_COOKIES_ACCEPTED_NAME = "dust-cookies-accepted";
 
 /**
- * Captures UTM parameters from the URL, stores them in sessionStorage,
- * then strips them from the URL bar via a shallow router replace.
- * Also ensures the `_dust_aid` anonymous device ID cookie exists once
- * cookies have been accepted (consent banner or non-GDPR auto-accept).
+ * Post-consent only: captures UTM params, click IDs, landing context, and
+ * the `dust_aid` URL param into first-party cookies/sessionStorage, then
+ * strips tracking params from the URL. Also ensures the `_dust_aid` cookie
+ * exists. Pre-consent, nothing is written and the URL is left untouched so
+ * UTMs can still be captured if consent arrives later in the same page.
  */
 export function useStripUtmParams() {
   const router = useAppRouter();
@@ -28,15 +29,12 @@ export function useStripUtmParams() {
   );
 
   useEffect(() => {
-    if (!router.isReady) {
+    if (!router.isReady || !cookiesAccepted) {
       return;
     }
 
     try {
-      // Re-establish anonymous device ID from email CTA links (?dust_aid=...).
       persistDustAidFromURL();
-
-      // Capture first-touch landing context (referrer, host, url, pathname).
       persistLandingContext();
 
       const params = Object.fromEntries(
@@ -49,7 +47,6 @@ export function useStripUtmParams() {
         persistUTMCookies(utmData);
       }
 
-      // Strip tracking params (UTMs, click IDs, dust_aid) from the URL bar.
       const url = new URL(window.location.href);
       let hasTrackingParam = false;
       for (const key of MARKETING_PARAMS) {
@@ -68,9 +65,8 @@ export function useStripUtmParams() {
     } catch {
       // Ignore errors (e.g. sessionStorage unavailable).
     }
-  }, [router.isReady]);
+  }, [router.isReady, cookiesAccepted]);
 
-  // Create the anonymous device ID cookie once consent is given.
   useEffect(() => {
     if (cookiesAccepted) {
       getOrCreateAnonymousId();

--- a/front/lib/utils/anonymous_id.ts
+++ b/front/lib/utils/anonymous_id.ts
@@ -65,10 +65,10 @@ export function getOrCreateAnonymousId(): string | null {
 }
 
 /**
- * Reads the `_dust_aid` value from `document.cookie`.
+ * Reads the `_dust_aid` value from `document.cookie` without creating one.
  * Returns `null` if the cookie is not present or we're not in a browser.
  */
-function readAnonymousIdFromDocumentCookie(): string | null {
+export function readAnonymousIdFromDocumentCookie(): string | null {
   if (typeof document === "undefined") {
     return null;
   }


### PR DESCRIPTION
## Description

Gate writes of `_dust_aid` and the UTM / click-ID / landing-context cookies on cookie consent. A couple of paths (PostHog init, UTM capture on mount) were setting these first-party cookies without checking the banner state.

## Tests

Manual: declined banner -> no `_dust_*` cookies, no `utm_data` in sessionStorage, no `dust_anonymous_id` on PostHog events. Accepted banner -> cookies set, `dust_anonymous_id` super property registered in Phase 2, `identify()` stitches pre- and post-consent events for the consented  session.

## Risk

Low: analytics-related.
