### PR TITLE
Reduce get agent config timeout

### DIFF
--- a/front/components/agent_builder/sidekick/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/sidekick/tools/getAgentConfig.ts
@@ -20,9 +20,10 @@ export function registerGetAgentConfigTool(
   const { getFormValues, getPendingSuggestions, getCommittedInstructionsHtml } =
     callbacks;
 
-  mcpServer.tool(
+  mcpServer.registerTool(
     "get_agent_config",
-    `Get the current (unsaved) agent configuration from the agent builder form.
+    {
+      description: `Get the current (unsaved) agent configuration from the agent builder form.
 Use this to understand what the user is currently configuring for their agent.
 
 The response includes:
@@ -30,7 +31,12 @@ The response includes:
 - instructionsHtml: HTML version of instructions with data-block-id attributes on each block.
   Use these block IDs when making instruction suggestions to target specific blocks.
 - pendingSuggestions: Array of suggestions that have been made but not yet accepted/rejected by the user`,
-    {},
+      _meta: {
+        dust: {
+          timeoutMs: 10_000,
+        },
+      },
+    },
     () => {
       const formData = getFormValues();
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -258,6 +258,7 @@ function makeClientSideMCPToolConfigurations(
     icon: config.icon,
     argumentsRequiringApproval: tool.argumentsRequiringApproval,
     displayLabels: tool.displayLabels,
+    ...(tool.timeoutMs && { timeoutMs: tool.timeoutMs }),
   }));
 }
 
@@ -1279,6 +1280,7 @@ async function listToolsForClientSideMCPServer(
           stakeLevel:
             dustMeta?.stake ?? DEFAULT_CLIENT_SIDE_MCP_TOOL_STAKE_LEVEL,
           argumentsRequiringApproval: dustMeta?.argumentsRequiringApproval,
+          ...(dustMeta?.timeoutMs && { timeoutMs: dustMeta.timeoutMs }),
         };
       }),
     ];

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -775,6 +775,7 @@ export type DustToolMeta = {
   stake?: MCPToolStakeLevelType;
   displayLabels?: ToolDisplayLabels;
   argumentsRequiringApproval?: string[];
+  timeoutMs?: number;
 };
 
 function isValidStake(value: unknown): value is MCPToolStakeLevelType {
@@ -799,6 +800,10 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((v) => typeof v === "string");
 }
 
+function isValidTimeout(value: unknown): value is number {
+  return typeof value === "number" && value > 0;
+}
+
 export function getDustToolMeta(
   _meta: Record<string, unknown> | undefined
 ): DustToolMeta | undefined {
@@ -817,6 +822,9 @@ export function getDustToolMeta(
   }
   if (isStringArray(dust.argumentsRequiringApproval)) {
     result.argumentsRequiringApproval = dust.argumentsRequiringApproval;
+  }
+  if (isValidTimeout(dust.timeoutMs)) {
+    result.timeoutMs = dust.timeoutMs;
   }
 
   return Object.keys(result).length > 0 ? result : undefined;

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -119,6 +119,7 @@ export type ServerSideMCPToolTypeWithStakeAndRetryPolicy =
 export type ClientSideMCPToolTypeWithStakeLevel =
   WithStakeLevelType<MCPToolWithAvailabilityType> & {
     argumentsRequiringApproval?: string[];
+    timeoutMs?: number;
   };
 
 export type RemoteMCPServerType = MCPServerType & {


### PR DESCRIPTION
## Description

* The get_agent_config tool is a client side tool in sidekick. It should be very quick to respond. If there is a client side issue, like SSE disconnect, then this may delay for 3 minutes with no action at all. We should fail fast on this so the agent can choose to retry.

## Tests

* Validated no change in local behavior 

## Risk

* Unlikely risk that this tool actually does need a higher timeout than 10 seconds. Can bump it again if we run into this

## Deploy Plan

* Deploy front