### PR TITLE
[front] fix empty message

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -227,7 +227,7 @@ export function UserMessage({
   const pendingMessageCount = methods.data
     .get()
     .filter((m) => isUserMessage(m) && m.visibility === "pending").length;
-  const isEmpty = !message.content && message.contentFragments.length === 0;
+  const isEmpty = !message.content;
   const isCurrentUser = message.user?.sId === currentUserId;
   const canDelete =
     (isCurrentUser || isAdmin) && !isDeleted && !isProjectArchived;


### PR DESCRIPTION
## Description
This PR is to fix the empty bubble when there is no text message but there is a file attachment. We used to show attached files inside the user message bubble, but since we take it out we need to show something to indicate that it's empty, otherwise it looks very weird. We should probably not let the message bubble grow based on the attachment size, I will fix it at some point

before
<img width="784" height="366" alt="CleanShot 2026-04-18 at 21 41 06@2x" src="https://github.com/user-attachments/assets/5df5c0c0-e9cb-4b59-aaa4-856fca2cd58c" />

after
<img width="638" height="512" alt="CleanShot 2026-04-18 at 21 41 10@2x" src="https://github.com/user-attachments/assets/84839447-010b-482a-ba85-f9bb52990db1" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
