### PR TITLE
Add deny action to MCP authentication prompt

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -160,7 +160,7 @@ export function MCPActionDetails({
     if (status === "denied") {
       const deniedMessage = {
         type: "text" as const,
-        text: "Tool execution rejected by the user.",
+        text: "Tool execution rejected or skipped by the user.",
       };
 
       if (baseOutput === null) {

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -16,7 +16,7 @@ import {
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { ActionCardBlock, Button } from "@dust-tt/sparkle";
+import { ActionCardBlock, Button, CheckIcon, XMarkIcon } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
 interface MCPServerPersonalAuthenticationRequiredProps {
@@ -60,7 +60,7 @@ export function MCPServerPersonalAuthenticationRequired({
   const overridableInputs = getOverridablePersonalAuthInputs({ provider });
 
   const visual = mcpServer?.icon
-    ? getAvatarFromIcon(mcpServer.icon, "sm")
+    ? getAvatarFromIcon(mcpServer.icon, "xs")
     : undefined;
 
   const serverDisplayName =
@@ -141,31 +141,31 @@ export function MCPServerPersonalAuthenticationRequired({
     cardState = "disabled";
   } else if (isConnected) {
     cardState = "accepted";
-  } else if (isConnecting || isResolving) {
+  } else if (isConnecting) {
     cardState = "disabled";
   } else {
     cardState = "active";
   }
 
-  const title = serverDisplayName ?? "Personal authentication required";
+  const title = `${serverDisplayName ?? "Personal"} authentication`;
 
   // Build description based on current state.
   let description: React.ReactNode;
   if (!isTriggeredByCurrentUser) {
     description = (
-      <>
+      <div className="text-sm">
         {`${triggeringUser?.fullName} is trying to use ${serverDisplayName ?? "a tool"}.`}
         <br />
         <span className="font-semibold">
           Waiting on them to connect their account to continue...
         </span>
-      </>
+      </div>
     );
   } else if (connectionError) {
     description = connectionError;
   } else if (!isConnected) {
     description = (
-      <>
+      <div className="text-sm">
         {`Your agent is trying to use ${serverDisplayName ?? "a tool"}.`}
         <br />
         <span className="font-semibold">Connect your account to continue.</span>
@@ -184,35 +184,34 @@ export function MCPServerPersonalAuthenticationRequired({
             />
           </div>
         )}
-      </>
+      </div>
     );
   }
 
   // Build actions — only show Connect/Retry button for current user when not yet connected.
   const actions =
     isTriggeredByCurrentUser && !isConnected && mcpServer ? (
-      <div className="flex justify-end gap-2">
+      <div className="flex justify-end gap-3">
         <Button
           variant="outline"
-          size="sm"
-          label="Skip this tool"
-          disabled={isConnecting || isResolving}
-          isLoading={isResolving}
+          size="xs"
+          label="Skip"
+          icon={XMarkIcon}
+          disabled={isConnecting}
           onClick={() => void onSkipClick()}
         />
         <Button
           variant="highlight"
-          size="sm"
+          size="xs"
           label={connectionError ? "Retry" : "Connect"}
+          icon={CheckIcon}
           disabled={
             isConnecting ||
-            isResolving ||
             !areCredentialOverridesValid(
               overridableInputs,
               overriddenCredentials
             )
           }
-          isLoading={isConnecting || isResolving}
           onClick={() => void onConnectClick(mcpServer)}
         />
       </div>
@@ -226,6 +225,7 @@ export function MCPServerPersonalAuthenticationRequired({
         title={title}
         visual={visual}
         state={cardState}
+        size="compact"
         acceptedTitle="Connected successfully"
         description={description}
         actions={actions}

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -16,7 +16,12 @@ import {
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { ActionCardBlock, Button, CheckIcon, XMarkIcon } from "@dust-tt/sparkle";
+import {
+  ActionCardBlock,
+  Button,
+  CheckIcon,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
 interface MCPServerPersonalAuthenticationRequiredProps {
@@ -141,7 +146,7 @@ export function MCPServerPersonalAuthenticationRequired({
     cardState = "disabled";
   } else if (isConnected) {
     cardState = "accepted";
-  } else if (isConnecting) {
+  } else if (isConnecting || isResolving) {
     cardState = "disabled";
   } else {
     cardState = "active";
@@ -197,7 +202,7 @@ export function MCPServerPersonalAuthenticationRequired({
           size="xs"
           label="Skip"
           icon={XMarkIcon}
-          disabled={isConnecting}
+          disabled={isConnecting || isResolving}
           onClick={() => void onSkipClick()}
         />
         <Button
@@ -207,6 +212,7 @@ export function MCPServerPersonalAuthenticationRequired({
           icon={CheckIcon}
           disabled={
             isConnecting ||
+            isResolving ||
             !areCredentialOverridesValid(
               overridableInputs,
               overriddenCredentials

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -118,6 +118,23 @@ export function MCPServerPersonalAuthenticationRequired({
     }
   };
 
+  const onSkipClick = async () => {
+    setConnectionError(null);
+
+    const denyRes = await resolveAuthentication({
+      outcome: "denied",
+      actionId: blockedAction.actionId,
+      conversationId: blockedAction.conversationId,
+      messageId: blockedAction.messageId,
+    });
+
+    if (!denyRes.success) {
+      return;
+    }
+
+    removeCompletedAction(blockedAction.actionId);
+  };
+
   // Determine the ActionCardBlock state.
   let cardState: "active" | "disabled" | "accepted";
   if (!isTriggeredByCurrentUser) {
@@ -174,7 +191,15 @@ export function MCPServerPersonalAuthenticationRequired({
   // Build actions — only show Connect/Retry button for current user when not yet connected.
   const actions =
     isTriggeredByCurrentUser && !isConnected && mcpServer ? (
-      <div className="flex justify-end">
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          label="Skip this tool"
+          disabled={isConnecting || isResolving}
+          isLoading={isResolving}
+          onClick={() => void onSkipClick()}
+        />
         <Button
           variant="highlight"
           size="sm"

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -4,7 +4,7 @@ import {
   PersonalAuthCredentialOverrides,
 } from "@app/components/oauth/PersonalAuthCredentialOverrides";
 import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
-import { useCompleteAuthentication } from "@app/hooks/useCompleteAuthentication";
+import { useResolveAuthentication } from "@app/hooks/useResolveAuthentication";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType } from "@app/lib/api/mcp";
@@ -53,7 +53,7 @@ export function MCPServerPersonalAuthenticationRequired({
     Record<string, string>
   >({});
 
-  const { completeAuthentication, isCompleting } = useCompleteAuthentication({
+  const { resolveAuthentication, isResolving } = useResolveAuthentication({
     owner,
   });
 
@@ -99,7 +99,8 @@ export function MCPServerPersonalAuthenticationRequired({
         return;
       }
 
-      const completionRes = await completeAuthentication({
+      const completionRes = await resolveAuthentication({
+        outcome: "completed",
         actionId: blockedAction.actionId,
         conversationId: blockedAction.conversationId,
         messageId: blockedAction.messageId,
@@ -123,7 +124,7 @@ export function MCPServerPersonalAuthenticationRequired({
     cardState = "disabled";
   } else if (isConnected) {
     cardState = "accepted";
-  } else if (isConnecting || isCompleting) {
+  } else if (isConnecting || isResolving) {
     cardState = "disabled";
   } else {
     cardState = "active";
@@ -180,13 +181,13 @@ export function MCPServerPersonalAuthenticationRequired({
           label={connectionError ? "Retry" : "Connect"}
           disabled={
             isConnecting ||
-            isCompleting ||
+            isResolving ||
             !areCredentialOverridesValid(
               overridableInputs,
               overriddenCredentials
             )
           }
-          isLoading={isConnecting || isCompleting}
+          isLoading={isConnecting || isResolving}
           onClick={() => void onConnectClick(mcpServer)}
         />
       </div>

--- a/front/hooks/useResolveAuthentication.ts
+++ b/front/hooks/useResolveAuthentication.ts
@@ -4,38 +4,42 @@ import { isAPIErrorResponse } from "@app/types/error";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
 
-interface UseCompleteAuthenticationParams {
+type ResolveAuthenticationOutcome = "completed" | "denied";
+
+interface UseResolveAuthenticationParams {
   owner: LightWorkspaceType;
 }
 
-export function useCompleteAuthentication({
+export function useResolveAuthentication({
   owner,
-}: UseCompleteAuthenticationParams) {
+}: UseResolveAuthenticationParams) {
   const sendNotification = useSendNotification();
   const { fetcher } = useFetcher();
   const [isCompleting, setIsCompleting] = useState(false);
 
-  const completeAuthentication = useCallback(
+  const resolveAuthentication = useCallback(
     async ({
       conversationId,
       messageId,
       actionId,
+      outcome,
     }: {
       conversationId: string;
       messageId: string;
       actionId: string;
+      outcome: ResolveAuthenticationOutcome;
     }) => {
       setIsCompleting(true);
 
       try {
         await fetcher(
-          `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}/complete-authentication`,
+          `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}/resolve-authentication`,
           {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
             },
-            body: JSON.stringify({ actionId }),
+            body: JSON.stringify({ actionId, outcome }),
           }
         );
 
@@ -47,7 +51,7 @@ export function useCompleteAuthentication({
 
         sendNotification({
           type: "error",
-          title: "Failed to resume tool",
+          title: "Failed to resolve authentication",
           description:
             "Failed to resume the authenticated tool. Please try again.",
         });
@@ -59,5 +63,5 @@ export function useCompleteAuthentication({
     [owner.sId, sendNotification, fetcher]
   );
 
-  return { completeAuthentication, isCompleting };
+  return { resolveAuthentication, isResolving: isCompleting };
 }

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -11,15 +11,19 @@ import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-export async function completeAuthentication(
+export type ResolveAuthenticationOutcome = "completed" | "denied";
+
+export async function resolveAuthentication(
   auth: Authenticator,
   conversation: ConversationResource,
   {
     actionId,
     messageId,
+    outcome,
   }: {
     actionId: string;
     messageId: string;
+    outcome: ResolveAuthenticationOutcome;
   }
 ): Promise<Result<void, DustError>> {
   const owner = auth.getNonNullableWorkspace();
@@ -31,10 +35,11 @@ export async function completeAuthentication(
       actionId,
       messageId,
       conversationId,
+      outcome,
       workspaceId: owner.sId,
       userId: user?.sId,
     },
-    "Complete authentication action request"
+    "Resolve authentication request"
   );
 
   const {
@@ -53,7 +58,7 @@ export async function completeAuthentication(
     return new Err(
       new DustError(
         "unauthorized",
-        "User is not authorized to complete authentication for this action"
+        "User is not authorized to resolve authentication for this action"
       )
     );
   }
@@ -74,7 +79,9 @@ export async function completeAuthentication(
     );
   }
 
-  const [updatedCount] = await action.updateStatus("ready_allowed_explicitly");
+  const [updatedCount] = await action.updateStatus(
+    outcome === "completed" ? "ready_allowed_explicitly" : "denied"
+  );
 
   if (updatedCount === 0) {
     logger.info(
@@ -84,7 +91,7 @@ export async function completeAuthentication(
         workspaceId: owner.sId,
         userId: user?.sId,
       },
-      "Authentication action already resumed"
+      "Authentication action already resolved"
     );
 
     return new Ok(undefined);
@@ -133,8 +140,9 @@ export async function completeAuthentication(
       conversationId,
       messageId,
       actionId,
+      outcome,
     },
-    "Authentication completed, agent loop resumed"
+    `Authentication ${outcome}, agent loop resumed`
   );
 
   return new Ok(undefined);

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -57,7 +57,7 @@ export function renderActionForMultiActionsModel(
       name: action.functionCallName,
       function_call_id: action.functionCallId,
       content:
-        "The user rejected this specific action execution. Using this action is hence forbidden for this message.",
+        "The user rejected or skipped this specific action execution. Using this action is hence forbidden for this message.",
     };
   }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/resolve-authentication.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/resolve-authentication.ts
@@ -1,5 +1,5 @@
 /** @ignoreswagger */
-import { completeAuthentication } from "@app/lib/api/assistant/conversation/complete_authentication";
+import { resolveAuthentication } from "@app/lib/api/assistant/conversation/resolve_authentication";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -9,17 +9,18 @@ import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-const CompleteAuthenticationSchema = z.object({
+const ResolveAuthenticationSchema = z.object({
   actionId: z.string(),
+  outcome: z.enum(["completed", "denied"]),
 });
 
-export type CompleteAuthenticationResponse = {
+export type ResolveAuthenticationResponse = {
   success: boolean;
 };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<CompleteAuthenticationResponse>>,
+  res: NextApiResponse<WithAPIErrorResponse<ResolveAuthenticationResponse>>,
   auth: Authenticator
 ): Promise<void> {
   const { cId, mId } = req.query;
@@ -43,7 +44,7 @@ async function handler(
     });
   }
 
-  const parseResult = CompleteAuthenticationSchema.safeParse(req.body);
+  const parseResult = ResolveAuthenticationSchema.safeParse(req.body);
   if (!parseResult.success) {
     return apiError(req, res, {
       status_code: 400,
@@ -66,11 +67,12 @@ async function handler(
     });
   }
 
-  const { actionId } = parseResult.data;
+  const { actionId, outcome } = parseResult.data;
 
-  const result = await completeAuthentication(auth, conversation, {
+  const result = await resolveAuthentication(auth, conversation, {
     actionId,
     messageId: mId,
+    outcome,
   });
 
   if (result.isErr()) {
@@ -99,7 +101,7 @@ async function handler(
             status_code: 500,
             api_error: {
               type: "internal_server_error",
-              message: "Failed to complete authentication action",
+              message: "Failed to resolve authentication",
             },
           },
           result.error


### PR DESCRIPTION
## Description

Add a deny action to the MCP personal authentication prompt and polish the card UI to better match the tool validation widget. This also includes the auth resolution endpoint rename introduced to support resolving authentication with a single action-oriented flow.

Fixes: https://github.com/dust-tt/tasks/issues/7650

Aligned design with the action approval flow:

<img width="716" height="405" alt="Screenshot 2026-04-19 at 18 17 16" src="https://github.com/user-attachments/assets/b8163a5b-d7eb-4f91-a46d-01a8d2c095d4" />

## Tests

N/A, tested locally

## Risk

Low. The change is scoped to the MCP personal authentication prompt and its auth resolution flow.

## Deploy Plan

- deploy `front`
