### PR TITLE
Fix skill name conflicts

### DIFF
--- a/.claude/skills/dust-react-hook-form-writer/SKILL.md
+++ b/.claude/skills/dust-react-hook-form-writer/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: react-hook-form-writer
+name: dust-react-hook-form-writer
 description: Write and refactor React forms using react-hook-form with Zod validation. Use when creating new form components, converting existing forms to react-hook-form, or implementing form validation patterns.
 ---
 

--- a/.claude/skills/dust-writing-react-effects/SKILL.md
+++ b/.claude/skills/dust-writing-react-effects/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: writing-react-effects
+name: dust-writing-react-effects
 description: Writes React components without unnecessary useEffect. Use when creating/reviewing React components, refactoring effects, or when code uses useEffect to transform data or handle events.
 ---
 


### PR DESCRIPTION
## Description

Rename the two conflicting skill names so they match their parent directory names and no longer trigger skill conflict warnings.

## Tests

N/A, tested locally

## Risk

Low. This only updates skill metadata names.

## Deploy Plan

None.