### PR TITLE
Adding a case study link under the Profound logo

### DIFF
--- a/front/components/home/TrustedBy.tsx
+++ b/front/components/home/TrustedBy.tsx
@@ -30,6 +30,8 @@ const CASE_STUDIES: Record<string, string> = {
     "/customers/less-admin-more-selling-how-dust-frees-up-payfits-sales-team-to-close-more-deals",
   pennylane: "/customers/pennylane-customer-support-journey",
   persona: "/customers/how-persona-hit-80-ai-agent-adoption-with-dust",
+  profound:
+    "/customers/profound-post-sales-team-reclaimed-1800-hours",
   qonto: "/customers/qonto-dust-ai-partnership",
   wakam:
     "/customers/how-wakam-cut-legal-contract-analysis-time-by-50-with-dust",
@@ -259,7 +261,12 @@ export default function TrustedBy({
           )}
         >
           {logos.map((logo, index) => {
-            const caseStudyUrl = CASE_STUDIES[logo.name];
+            const caseStudyPath = CASE_STUDIES[logo.name];
+            const caseStudyUrl =
+              caseStudyPath &&
+              (logo.name !== "profound" || region === "us")
+                ? caseStudyPath
+                : undefined;
             return (
               <div
                 key={`${logo.name}-${index}`}

--- a/front/components/home/TrustedBy.tsx
+++ b/front/components/home/TrustedBy.tsx
@@ -30,8 +30,7 @@ const CASE_STUDIES: Record<string, string> = {
     "/customers/less-admin-more-selling-how-dust-frees-up-payfits-sales-team-to-close-more-deals",
   pennylane: "/customers/pennylane-customer-support-journey",
   persona: "/customers/how-persona-hit-80-ai-agent-adoption-with-dust",
-  profound:
-    "/customers/profound-post-sales-team-reclaimed-1800-hours",
+  profound: "/customers/profound-post-sales-team-reclaimed-1800-hours",
   qonto: "/customers/qonto-dust-ai-partnership",
   wakam:
     "/customers/how-wakam-cut-legal-contract-analysis-time-by-50-with-dust",
@@ -263,8 +262,7 @@ export default function TrustedBy({
           {logos.map((logo, index) => {
             const caseStudyPath = CASE_STUDIES[logo.name];
             const caseStudyUrl =
-              caseStudyPath &&
-              (logo.name !== "profound" || region === "us")
+              caseStudyPath && (logo.name !== "profound" || region === "us")
                 ? caseStudyPath
                 : undefined;
             return (


### PR DESCRIPTION
## Description

Adding a "Case study →" hyperlink under the Profound logo in the TrustedBy/case studies block, following the same pattern as Vanta. The link points to https://dust.tt/customers/profound-post-sales-team-reclaimed-1800-hours and is only shown for non-EU visitors, consistent with how the Profound logo is already gated.

## Tests
Cursor confirmed lint is clean with no errors.