### PR TITLE
[front] chore: update tags in Time to provider call dd metric

### DIFF
--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -122,8 +122,7 @@ async function _runModelAndCreateActionsActivity({
   const { auth, ...runAgentData } = runAgentDataRes.value;
   const isRootAgentMessage = !runAgentData.userMessage.agenticMessageData;
   const durationRecorder = DurationRecorder.create([
-    `model:${runAgentData.agentConfiguration.model.modelId}`,
-    `provider:${runAgentData.agentConfiguration.model.providerId}`,
+    `plan:${auth.getNonNullablePlan().code}`,
   ]);
 
   // Intentionally check at step start (not step end) to early exit if dollar amount too high.

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -122,7 +122,8 @@ async function _runModelAndCreateActionsActivity({
   const { auth, ...runAgentData } = runAgentDataRes.value;
   const isRootAgentMessage = !runAgentData.userMessage.agenticMessageData;
   const durationRecorder = DurationRecorder.create([
-    `workspace:${auth.getNonNullableWorkspace().sId}`,
+    `model:${runAgentData.agentConfiguration.model.modelId}`,
+    `provider:${runAgentData.agentConfiguration.model.providerId}`,
   ]);
 
   // Intentionally check at step start (not step end) to early exit if dollar amount too high.


### PR DESCRIPTION
## Description

- This PR changes the tags on the Time-to-provider-call Datadog metric, removing the workspace ID and adding the plan ID.
- Goal is to reduce cardinality and add a useful segmentation.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front,
