### PR TITLE
fix: close conversation side panel when navigating to project

### DIFF
--- a/front/components/assistant/conversation/sidebar/ProjectsList.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsList.tsx
@@ -107,6 +107,8 @@ const ProjectListItem = memo(
         icon={getSpaceIcon(space)}
         selected={isSpaceSelected && !isDragOver}
         label={space.name}
+        href={spacePath}
+        shallow
         hasActivity={hasUnread}
         count={unreadCount > 0 ? unreadCount : undefined}
         onClick={async () => {
@@ -116,9 +118,6 @@ const ProjectListItem = memo(
             // Wait a bit before moving to the new space to avoid the sidebar from flickering.
             await new Promise((resolve) => setTimeout(resolve, 600));
           }
-          await router.push(spacePath, undefined, {
-            shallow: true,
-          });
         }}
         moreMenu={
           <ProjectMenu

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -118,13 +118,20 @@ export function SpaceConversationsPage() {
       const newTab = getCurrentTabFromHash();
       setCurrentTab(newTab);
 
-      // Ensure URL has a hash
+      // Ensure URL has a hash. Defer with setTimeout so the route-change
+      // event fires with the empty hash first (otherwise useHashParam sees a
+      // non-empty hash and won't clear the conversation side-panel state when
+      // navigating into a project).
       if (!window.location.hash) {
-        window.history.replaceState(
-          null,
-          "",
-          `${window.location.pathname}${window.location.search}#${newTab}`
-        );
+        setTimeout(() => {
+          if (!window.location.hash) {
+            window.history.replaceState(
+              null,
+              "",
+              `${window.location.pathname}${window.location.search}#${newTab}`
+            );
+          }
+        }, 0);
       }
     };
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7577

This PR fixes an issue where the conversation side panel was not closing when navigating to a project.

- Deferred the hash initialization with `setTimeout` in `SpaceConversationsPage.tsx` to ensure the route-change event fires with an empty hash first, allowing `useHashParam` to properly clear the conversation side-panel state.

Before:

https://github.com/user-attachments/assets/b86f5dd8-29c8-4fdc-9455-f5898a676b90

After:

https://github.com/user-attachments/assets/eee8b37c-e546-4d74-aaee-86a5b1911f67



## Tests

Manually

## Risks

Low.

## Deploy Plan

Standard deployment
