### PR TITLE
[front] - fix(analytics): include hidden agents in exports

### DIFF
--- a/front/lib/api/analytics/agents_export.ts
+++ b/front/lib/api/analytics/agents_export.ts
@@ -58,7 +58,8 @@ export const AGENT_EXPORT_HEADERS: (keyof AgentExportRow)[] = [
 
 export async function fetchAgentExportRows(
   baseQuery: estypes.QueryDslQueryContainer,
-  owner: WorkspaceType
+  owner: WorkspaceType,
+  includeHiddenAgents: boolean
 ): Promise<Result<AgentExportRow[], Error>> {
   const esResult = await searchAnalytics<never, TopAgentsExportAggs>(
     {
@@ -101,8 +102,7 @@ export async function fetchAgentExportRows(
     ])
   );
 
-  const scopeFilter =
-    owner.role === "admin" ? "" : `AND ac."scope" != 'hidden'`;
+  const scopeFilter = includeHiddenAgents ? "" : `AND ac."scope" != 'hidden'`;
 
   // TODO(BACK5): Migrate to AgentConfigurationResource when a suitable method exists.
   const readReplica = getFrontReplicaDbConnection();

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -55,12 +55,14 @@ export async function exportTable({
   endDate,
   timezone,
   owner,
+  includeHiddenAgents,
 }: {
   table: AnalyticsExportTable;
   startDate: string;
   endDate: string;
   timezone: string;
   owner: WorkspaceType;
+  includeHiddenAgents: boolean;
 }): Promise<Result<string, Error>> {
   switch (table) {
     case "usage_metrics":
@@ -70,7 +72,7 @@ export async function exportTable({
     case "source":
       return exportSource({ startDate, endDate, timezone, owner });
     case "agents":
-      return exportAgents({ startDate, endDate, owner });
+      return exportAgents({ startDate, endDate, owner, includeHiddenAgents });
     case "users":
       return exportUsers({ startDate, endDate, timezone, owner });
     case "skill_usage":
@@ -235,10 +237,12 @@ async function exportAgents({
   startDate,
   endDate,
   owner,
+  includeHiddenAgents,
 }: {
   startDate: string;
   endDate: string;
   owner: WorkspaceType;
+  includeHiddenAgents: boolean;
 }): Promise<Result<string, Error>> {
   const baseQuery = buildAgentAnalyticsBaseQuery({
     workspaceId: owner.sId,
@@ -246,7 +250,11 @@ async function exportAgents({
     endDate,
   });
 
-  const result = await fetchAgentExportRows(baseQuery, owner);
+  const result = await fetchAgentExportRows(
+    baseQuery,
+    owner,
+    includeHiddenAgents
+  );
 
   if (result.isErr()) {
     return new Err(

--- a/front/pages/api/v1/w/[wId]/analytics/export.ts
+++ b/front/pages/api/v1/w/[wId]/analytics/export.ts
@@ -130,6 +130,7 @@ async function handler(
         endDate: q.data.endDate,
         timezone: q.data.timezone ?? "UTC",
         owner,
+        includeHiddenAgents: auth.isKey(),
       });
 
       if (csv.isErr()) {

--- a/front/pages/api/w/[wId]/analytics/agents-export.ts
+++ b/front/pages/api/w/[wId]/analytics/agents-export.ts
@@ -53,7 +53,7 @@ async function handler(
         days: q.data.days,
       });
 
-      const result = await fetchAgentExportRows(baseQuery, owner);
+      const result = await fetchAgentExportRows(baseQuery, owner, true);
 
       if (result.isErr()) {
         return apiError(req, res, {


### PR DESCRIPTION
## Description

Previously, the agent analytics export filtered out hidden (unpublished) agents based on whether the requester was a workspace admin (`owner.role === "admin"`). This PR changes the logic to instead determine inclusion based on whether the request uses an API key (`auth.isKey()`), allowing API-authenticated requests to access hidden agents in exports regardless of role.

## Tests

Manually tested locally.

## Risk

Medium. The change only affects the analytics export endpoint and maintains access control through API key authentication.

## Deploy Plan

Deploy front