### PR TITLE
Revert "fix(google_drive): refresh OAuth token on expiry to prevent infinite retry loops"

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -251,14 +251,11 @@ export async function getAuthObject(
     connectionId,
   });
 
-  // Do not set expiry_date: without it, googleapis will not attempt to
-  // auto-refresh the token (which fails because we don't set a refresh_token,
-  // by design). If a token expires mid-activity, the API returns a 401 and
-  // Temporal retries the activity with a fresh token.
   oauth2Client.setCredentials({
     access_token: token.access_token,
     scope: (token.scrubbed_raw_json as { scope: string }).scope,
     token_type: (token.scrubbed_raw_json as { token_type: string }).token_type,
+    expiry_date: token.access_token_expiry,
   });
 
   return oauth2Client;


### PR DESCRIPTION
Reverts dust-tt/dust#24042

Attempting to revert as we observe numerous Google Drive token expiring after 1-2 days.