### PR TITLE
[front] chore: add members count in poke workspace info table

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -128,6 +128,7 @@ export function WorkspacePage() {
   const {
     activeSubscription,
     hasDummyFeature,
+    membersCount,
     metronomeCustomerId,
     stripeSubscription,
     subscriptions,
@@ -208,6 +209,7 @@ export function WorkspacePage() {
               <TabsContent value="workspace">
                 <WorkspaceInfoTable
                   owner={owner}
+                  membersCount={membersCount}
                   metronomeCustomerId={metronomeCustomerId}
                   workspaceVerifiedDomains={workspaceVerifiedDomains}
                   workspaceCreationDay={workspaceCreationDay}

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -137,7 +137,7 @@ export function WorkspaceInfoTable({
               <PokeTableCell>{workspaceCreationDay}</PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>
-              <PokeTableCell>Members</PokeTableCell>
+              <PokeTableCell>Members count</PokeTableCell>
               <PokeTableCell>{membersCount}</PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -17,6 +17,7 @@ import { Chip, LinkWrapper } from "@dust-tt/sparkle";
 
 export function WorkspaceInfoTable({
   owner,
+  membersCount,
   metronomeCustomerId,
   workspaceVerifiedDomains,
   workspaceCreationDay,
@@ -27,6 +28,7 @@ export function WorkspaceInfoTable({
   temporalFrontNamespace,
 }: {
   owner: WorkspaceType;
+  membersCount: number;
   metronomeCustomerId: string | null;
   workspaceVerifiedDomains: WorkspaceDomain[];
   workspaceCreationDay: string;
@@ -133,6 +135,10 @@ export function WorkspaceInfoTable({
             <PokeTableRow>
               <PokeTableCell>Creation</PokeTableCell>
               <PokeTableCell>{workspaceCreationDay}</PokeTableCell>
+            </PokeTableRow>
+            <PokeTableRow>
+              <PokeTableCell>Members</PokeTableCell>
+              <PokeTableCell>{membersCount}</PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>
               <PokeTableCell>SSO Enforced</PokeTableCell>

--- a/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
+++ b/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
@@ -6,6 +6,7 @@ import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -26,6 +27,7 @@ export type PokeGetWorkspaceInfo = {
   baseUrl: string;
   extensionConfig: ExtensionConfigurationType | null;
   hasDummyFeature: boolean;
+  membersCount: number;
   metronomeCustomerId: string | null;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
   stripeSubscription: Stripe.Subscription | null;
@@ -99,6 +101,13 @@ async function handler(
         "dummy_feature_for_flag_testing"
       );
 
+      const membersCount = await MembershipResource.getMembersCountForWorkspace(
+        {
+          workspace: owner,
+          activeOnly: true,
+        }
+      );
+
       let stripeSubscription: Stripe.Subscription | null = null;
       if (activeSubscription.stripeSubscriptionId) {
         stripeSubscription = await getStripeSubscription(
@@ -109,6 +118,7 @@ async function handler(
       return res.status(200).json({
         activeSubscription,
         hasDummyFeature,
+        membersCount,
         metronomeCustomerId: workspaceResource.metronomeCustomerId ?? null,
         stripeSubscription,
         subscriptions,


### PR DESCRIPTION
## Description

- This PR adds the number of members in the workspace info table.
- Requested [here](https://dust4ai.slack.com/archives/C0A42UMFUM6/p1776438224293169?thread_ts=1776437425.963719&cid=C0A42UMFUM6).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
