### PR TITLE
Fix posting a message via API key with "private URLs by default"

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -83,6 +83,7 @@ import { ConversationForkResource } from "@app/lib/resources/conversation_fork_r
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 // Mock rateLimiter from the utils module
 import * as rateLimiterModule from "@app/lib/utils/rate_limiter";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -1185,6 +1186,9 @@ describe("softDeleteAgentMessage", () => {
 describe("postUserMessage", () => {
   let auth: Authenticator;
   let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+  let globalGroup: Awaited<
+    ReturnType<typeof createResourceTest>
+  >["globalGroup"];
   let conversation: ConversationType;
   let agentConfig1: LightAgentConfigurationType;
 
@@ -1192,6 +1196,7 @@ describe("postUserMessage", () => {
     const setup = await createResourceTest({});
     auth = setup.authenticator;
     workspace = setup.workspace;
+    globalGroup = setup.globalGroup;
 
     agentConfig1 = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent 1",
@@ -2188,6 +2193,46 @@ describe("postUserMessage", () => {
         expect(result.value.userMessage.content).toBe(
           "Hello from a non-member to regular conversation"
         );
+      }
+    });
+  });
+
+  describe("API key auth on workspace with privateConversationUrlsByDefault", () => {
+    it("should succeed when posting via API key on a workspace with private URLs by default", async () => {
+      // Enable private conversation URLs by default for the workspace.
+      // Testing API key auth (which has no user), even though the message was just posted.
+      const updateResult = await WorkspaceResource.updateMetadata(
+        workspace.id,
+        {
+          privateConversationUrlsByDefault: true,
+        }
+      );
+      expect(updateResult.isOk()).toBe(true);
+
+      const apiKey = await KeyFactory.regular(globalGroup);
+      const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
+        apiKey,
+        workspace.sId
+      );
+
+      const result = await postUserMessage(apiKeyAuth, {
+        conversation,
+        content: "Hello from API key",
+        mentions: [],
+        context: {
+          username: "api-user",
+          timezone: "UTC",
+          fullName: null,
+          email: null,
+          profilePictureUrl: null,
+          origin: "api",
+        },
+        skipToolsValidation: false,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.userMessage.content).toBe("Hello from API key");
       }
     });
   });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1003,17 +1003,8 @@ export async function postUserMessage(
     });
   }
 
-  const conversationRes = await ConversationResource.fetchById(
-    auth,
-    conversation.sId
-  );
-  if (!conversationRes) {
-    throw new Error(
-      "Unexpected: Conversation not found after posting message."
-    );
-  }
   await triggerConversationUnreadNotifications(auth, {
-    conversationId: conversationRes.sId,
+    conversationId: conversation.sId,
     messageId: userMessage.sId,
   });
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Fixed this [monitor](https://dust4ai.slack.com/archives/C05F84CFP0E/p1776673922552129).

**What broke and why**

Since Friday's release of the "private conversation URLs by default" feature (#24453), calling `postUserMessage` via an API key (i.e. without an associated user) would throw:

```
Unexpected: Conversation not found after posting message.
```

<img width="1171" height="136" alt="image" src="https://github.com/user-attachments/assets/824c76f8-643e-4422-aac4-e73d6a39c725" />

After posting the message, the code fetched the conversation again using `ConversationResource.fetchById`. The new access-control logic filters out "participant-restricted" conversations for callers without a user. Which is exactly what an API key auth is. So the just-posted conversation would disappear from the result, triggering the error.

This PR removes the `fetchById` call which I presume was a leftover from when `triggerConversationUnreadNotifications` accepted a full `ConversationResource` object. That function was later refactored to take a plain `conversationId` string (and does its own internal fetch, gracefully returning early if the conversation isn't visible). 

Added one new test in `postUserMessage` to verify that posting via an API key on a workspace with `privateConversationUrlsByDefault: true` succeeds without throwing.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
