### PR TITLE
Improve the UI of suggestions in Poke

### DIFF
--- a/front-spa/src/poke/routes.tsx
+++ b/front-spa/src/poke/routes.tsx
@@ -23,6 +23,7 @@ import { PluginsPage } from "@dust-tt/front/components/poke/pages/PluginsPage";
 import { PokefyPage } from "@dust-tt/front/components/poke/pages/PokefyPage";
 import { ProductionChecksPage } from "@dust-tt/front/components/poke/pages/ProductionChecksPage";
 import { SkillDetailsPage } from "@dust-tt/front/components/poke/pages/SkillDetailsPage";
+import { SkillSuggestionDetailsPage } from "@dust-tt/front/components/poke/pages/SkillSuggestionDetailsPage";
 import { SpaceDataSourceViewPage } from "@dust-tt/front/components/poke/pages/SpaceDataSourceViewPage";
 import { SpacePage } from "@dust-tt/front/components/poke/pages/SpacePage";
 import { TemplateDetailPage } from "@dust-tt/front/components/poke/pages/TemplateDetailPage";
@@ -124,6 +125,10 @@ export const routes: RouteObject[] = [
           { path: "groups/:groupId", element: <GroupPage /> },
           { path: "files/:sId", element: <FramePage /> },
           { path: "skills/:sId", element: <SkillDetailsPage /> },
+          {
+            path: "suggestions/:suggestionId",
+            element: <SkillSuggestionDetailsPage />,
+          },
           { path: "spaces/:spaceId", element: <SpacePage /> },
           { path: "spaces/:spaceId/apps/:appId", element: <AppPage /> },
           {

--- a/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
+++ b/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
@@ -42,9 +42,7 @@ export function SkillSuggestionDetailsPage() {
 
   return (
     <div>
-      <h2 className="text-2xl font-bold">
-        {suggestion.title ?? "Suggestion"}
-      </h2>
+      <h2 className="text-2xl font-bold">{suggestion.title ?? "Suggestion"}</h2>
       <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
         {suggestion.sId} · Skill&nbsp;
         <LinkWrapper

--- a/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
+++ b/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
@@ -1,0 +1,87 @@
+import { SkillSuggestionCard } from "@app/components/skill_builder/SkillSuggestionCard";
+import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useRequiredPathParam } from "@app/lib/platform";
+import { usePokeSkillSuggestionDetails } from "@app/poke/swr/skill_suggestion_details";
+import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import { useCallback } from "react";
+
+export function SkillSuggestionDetailsPage() {
+  const owner = useWorkspace();
+  useDocumentTitle(`Poke - ${owner.name} - Suggestion`);
+
+  const suggestionId = useRequiredPathParam("suggestionId");
+
+  const { data, isLoading, isError } = usePokeSkillSuggestionDetails({
+    owner,
+    suggestionId,
+  });
+
+  const getSkillInstructionsHtml = useCallback(
+    () => data?.skillInstructionsHtml ?? "",
+    [data?.skillInstructionsHtml]
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>Error loading suggestion.</p>
+      </div>
+    );
+  }
+
+  const { suggestion } = data;
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold">
+        {suggestion.title ?? "Suggestion"}
+      </h2>
+      <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+        {suggestion.sId} · Skill&nbsp;
+        <LinkWrapper
+          href={`/${owner.sId}/skills/${suggestion.skillConfigurationId}`}
+          className="text-highlight-500"
+        >
+          {suggestion.skillConfigurationId}
+        </LinkWrapper>
+      </p>
+
+      <div className="mt-4 space-y-6">
+        <div>
+          <h2 className="text-md pb-2 font-bold">Analysis</h2>
+          <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
+            <pre className="overflow-x-auto whitespace-pre-wrap text-sm">
+              {suggestion.analysis ?? "No analysis"}
+            </pre>
+          </div>
+        </div>
+
+        <div>
+          <h2 className="text-md pb-2 font-bold">Content</h2>
+          <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
+            <pre className="overflow-x-auto whitespace-pre-wrap text-sm">
+              {JSON.stringify(suggestion.suggestion, null, 2)}
+            </pre>
+          </div>
+        </div>
+
+        <div>
+          <h2 className="text-md pb-2 font-bold">In context</h2>
+          <SkillSuggestionCard
+            suggestion={suggestion}
+            getSkillInstructionsHtml={getSkillInstructionsHtml}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
+++ b/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
@@ -1,10 +1,12 @@
+import { MCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { SkillSuggestionCard } from "@app/components/skill_builder/SkillSuggestionCard";
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
+import { usePokeMCPServerViews } from "@app/poke/swr/mcp_server_views";
 import { usePokeSkillSuggestionDetails } from "@app/poke/swr/skill_suggestion_details";
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 export function SkillSuggestionDetailsPage() {
   const owner = useWorkspace();
@@ -16,6 +18,20 @@ export function SkillSuggestionDetailsPage() {
     owner,
     suggestionId,
   });
+
+  const { data: mcpServerViews, isLoading: isMCPServerViewsLoading } =
+    usePokeMCPServerViews({ owner });
+
+  const mcpContextValue = useMemo(
+    () => ({
+      mcpServerViews,
+      mcpServerViewsWithKnowledge: [],
+      mcpServerViewsWithoutKnowledge: [],
+      isMCPServerViewsLoading,
+      isMCPServerViewsError: false,
+    }),
+    [mcpServerViews, isMCPServerViewsLoading]
+  );
 
   const getSkillInstructionsHtml = useCallback(
     () => data?.skillInstructionsHtml ?? "",
@@ -56,10 +72,12 @@ export function SkillSuggestionDetailsPage() {
       <div className="mt-4 space-y-6">
         <div>
           <h2 className="text-md pb-2 font-bold">Suggestion card</h2>
-          <SkillSuggestionCard
-            suggestion={suggestion}
-            getSkillInstructionsHtml={getSkillInstructionsHtml}
-          />
+          <MCPServerViewsContext.Provider value={mcpContextValue}>
+            <SkillSuggestionCard
+              suggestion={suggestion}
+              getSkillInstructionsHtml={getSkillInstructionsHtml}
+            />
+          </MCPServerViewsContext.Provider>
         </div>
 
         <div>

--- a/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
+++ b/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
@@ -55,15 +55,6 @@ export function SkillSuggestionDetailsPage() {
 
       <div className="mt-4 space-y-6">
         <div>
-          <h2 className="text-md pb-2 font-bold">Analysis</h2>
-          <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
-            <pre className="overflow-x-auto whitespace-pre-wrap text-sm">
-              {suggestion.analysis ?? "No analysis"}
-            </pre>
-          </div>
-        </div>
-
-        <div>
           <h2 className="text-md pb-2 font-bold">Content</h2>
           <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
             <pre className="overflow-x-auto whitespace-pre-wrap text-sm">

--- a/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
+++ b/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
@@ -55,20 +55,20 @@ export function SkillSuggestionDetailsPage() {
 
       <div className="mt-4 space-y-6">
         <div>
-          <h2 className="text-md pb-2 font-bold">Content</h2>
+          <h2 className="text-md pb-2 font-bold">Suggestion card</h2>
+          <SkillSuggestionCard
+            suggestion={suggestion}
+            getSkillInstructionsHtml={getSkillInstructionsHtml}
+          />
+        </div>
+
+        <div>
+          <h2 className="text-md pb-2 font-bold">Raw suggestion</h2>
           <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
             <pre className="overflow-x-auto whitespace-pre-wrap text-sm">
               {JSON.stringify(suggestion.suggestion, null, 2)}
             </pre>
           </div>
-        </div>
-
-        <div>
-          <h2 className="text-md pb-2 font-bold">In context</h2>
-          <SkillSuggestionCard
-            suggestion={suggestion}
-            getSkillInstructionsHtml={getSkillInstructionsHtml}
-          />
         </div>
       </div>
     </div>

--- a/front/components/poke/skill_suggestions/columns.tsx
+++ b/front/components/poke/skill_suggestions/columns.tsx
@@ -22,22 +22,25 @@ function truncate(text: string | null, maxLength: number): string {
 function ClickableCell({
   text,
   maxLength,
-  onClick,
+  href,
 }: {
   text: string | null;
   maxLength: number;
-  onClick: () => void;
+  href: string;
 }) {
   const truncated = truncate(text, maxLength);
   const isTruncated = text && text.length > maxLength;
+  if (!isTruncated) {
+    return <span>{truncated}</span>;
+  }
   return (
-    <span
-      onClick={isTruncated ? onClick : undefined}
-      className={isTruncated ? "cursor-pointer hover:underline" : ""}
-      title={isTruncated ? "Click to see full content" : undefined}
+    <a
+      href={href}
+      className="cursor-pointer hover:underline"
+      title="Click to see full content"
     >
       {truncated}
-    </span>
+    </a>
   );
 }
 
@@ -77,8 +80,7 @@ async function deleteSuggestion(
 export function makeColumnsForSkillSuggestions(
   owner: LightWorkspaceType,
   skillId: string,
-  onSuggestionDeleted: () => Promise<void>,
-  onSuggestionClick: (suggestion: SkillSuggestionType) => void
+  onSuggestionDeleted: () => Promise<void>
 ): ColumnDef<SkillSuggestionType>[] {
   return [
     {
@@ -86,6 +88,16 @@ export function makeColumnsForSkillSuggestions(
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="sId" />
       ),
+      cell: ({ row }) => {
+        return (
+          <a
+            href={`/${owner.sId}/suggestions/${row.original.sId}`}
+            className="text-action-500 hover:underline"
+          >
+            {row.original.sId}
+          </a>
+        );
+      },
     },
     {
       accessorKey: "kind",
@@ -168,7 +180,7 @@ export function makeColumnsForSkillSuggestions(
           <ClickableCell
             text={row.original.analysis}
             maxLength={MAX_ANALYSIS_LENGTH}
-            onClick={() => onSuggestionClick(row.original)}
+            href={`/${owner.sId}/suggestions/${row.original.sId}`}
           />
         );
       },
@@ -191,7 +203,7 @@ export function makeColumnsForSkillSuggestions(
           <ClickableCell
             text={content}
             maxLength={MAX_CONTENT_LENGTH}
-            onClick={() => onSuggestionClick(row.original)}
+            href={`/${owner.sId}/suggestions/${row.original.sId}`}
           />
         );
       },

--- a/front/components/poke/skill_suggestions/table.tsx
+++ b/front/components/poke/skill_suggestions/table.tsx
@@ -11,54 +11,6 @@ import {
   SKILL_SUGGESTION_STATES,
 } from "@app/types/suggestions/skill_suggestion";
 import type { LightWorkspaceType } from "@app/types/user";
-import {
-  Dialog,
-  DialogContainer,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@dust-tt/sparkle";
-import { useState } from "react";
-
-interface SkillSuggestionDetailsDialogProps {
-  onClose: () => void;
-  suggestion: SkillSuggestionType;
-}
-
-function SkillSuggestionDetailsDialog({
-  suggestion,
-  onClose,
-}: SkillSuggestionDetailsDialogProps) {
-  return (
-    <Dialog open onOpenChange={onClose}>
-      <DialogContent className="max-h-[80vh] max-w-4xl overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>Suggestion Details - {suggestion.sId}</DialogTitle>
-        </DialogHeader>
-        <DialogContainer>
-          <div className="space-y-6">
-            <div>
-              <h3 className="mb-2 text-sm font-semibold">Analysis</h3>
-              <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
-                <pre className="overflow-x-auto whitespace-pre-wrap text-sm">
-                  {suggestion.analysis ?? "No analysis"}
-                </pre>
-              </div>
-            </div>
-            <div>
-              <h3 className="mb-2 text-sm font-semibold">Content</h3>
-              <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-900">
-                <pre className="overflow-x-auto whitespace-pre-wrap text-sm">
-                  {JSON.stringify(suggestion.suggestion, null, 2)}
-                </pre>
-              </div>
-            </div>
-          </div>
-        </DialogContainer>
-      </DialogContent>
-    </Dialog>
-  );
-}
 
 interface SkillSuggestionDataTableProps {
   owner: LightWorkspaceType;
@@ -69,9 +21,6 @@ export function SkillSuggestionDataTable({
   owner,
   skillId,
 }: SkillSuggestionDataTableProps) {
-  const [selectedSuggestion, setSelectedSuggestion] =
-    useState<SkillSuggestionType | null>(null);
-
   const useSuggestionsWithSkill = (props: PokeConditionalFetchProps) =>
     usePokeSkillSuggestions({ ...props, skillId });
 
@@ -103,37 +52,28 @@ export function SkillSuggestionDataTable({
   ];
 
   return (
-    <>
-      {selectedSuggestion && (
-        <SkillSuggestionDetailsDialog
-          suggestion={selectedSuggestion}
-          onClose={() => setSelectedSuggestion(null)}
-        />
-      )}
-      <PokeDataTableConditionalFetch
-        header="Suggestions"
-        owner={owner}
-        useSWRHook={useSuggestionsWithSkill}
-      >
-        {(suggestions, mutate) => {
-          const columns = makeColumnsForSkillSuggestions(
-            owner,
-            skillId,
-            async () => {
-              await mutate();
-            },
-            setSelectedSuggestion
-          );
+    <PokeDataTableConditionalFetch
+      header="Suggestions"
+      owner={owner}
+      useSWRHook={useSuggestionsWithSkill}
+    >
+      {(suggestions, mutate) => {
+        const columns = makeColumnsForSkillSuggestions(
+          owner,
+          skillId,
+          async () => {
+            await mutate();
+          }
+        );
 
-          return (
-            <PokeDataTable<SkillSuggestionType, unknown>
-              columns={columns}
-              data={suggestions}
-              facets={facets}
-            />
-          );
-        }}
-      </PokeDataTableConditionalFetch>
-    </>
+        return (
+          <PokeDataTable<SkillSuggestionType, unknown>
+            columns={columns}
+            data={suggestions}
+            facets={facets}
+          />
+        );
+      }}
+    </PokeDataTableConditionalFetch>
   );
 }

--- a/front/components/shared/tools_picker/MCPServerViewsContext.tsx
+++ b/front/components/shared/tools_picker/MCPServerViewsContext.tsx
@@ -48,7 +48,7 @@ interface MCPServerViewsContextType {
   isMCPServerViewsError: boolean;
 }
 
-const MCPServerViewsContext = createContext<
+export const MCPServerViewsContext = createContext<
   MCPServerViewsContextType | undefined
 >(undefined);
 

--- a/front/components/shared/tools_picker/MCPServerViewsContext.tsx
+++ b/front/components/shared/tools_picker/MCPServerViewsContext.tsx
@@ -130,6 +130,10 @@ export const useMCPServerViewsContext = () => {
   return context;
 };
 
+export const useMaybeMCPServerViewsContext = () => {
+  return useContext(MCPServerViewsContext);
+};
+
 interface MCPServerViewsProviderProps {
   owner: LightWorkspaceType;
   children: ReactNode;

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -1,6 +1,6 @@
 import { buildAgentInstructionsReadOnlyExtensions } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
 import { InstructionSuggestionExtension } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
-import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { useMaybeMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { getBlockOuterHtml } from "@app/components/shared/utils";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type {
@@ -15,19 +15,19 @@ import { useMemo } from "react";
 function useToolDisplayNames(
   toolEdits: SkillToolEditItemType[]
 ): Map<string, string> {
-  const { mcpServerViews } = useMCPServerViewsContext();
+  const ctx = useMaybeMCPServerViewsContext();
 
   return useMemo(() => {
     const map = new Map<string, string>();
     for (const edit of toolEdits) {
-      const view = mcpServerViews.find((v) => v.sId === edit.toolId);
+      const view = ctx?.mcpServerViews.find((v) => v.sId === edit.toolId);
       map.set(
         edit.toolId,
         view ? getMcpServerViewDisplayName(view) : edit.toolId
       );
     }
     return map;
-  }, [toolEdits, mcpServerViews]);
+  }, [toolEdits, ctx]);
 }
 
 interface ToolEditsSectionProps {
@@ -128,11 +128,11 @@ function InstructionEditDiffBlock({
 
 interface SkillSuggestionCardProps {
   suggestion: SkillSuggestionType;
-  onAccept: (suggestion: SkillSuggestionType) => void;
-  onDecline: (suggestion: SkillSuggestionType) => void;
+  onAccept?: (suggestion: SkillSuggestionType) => void;
+  onDecline?: (suggestion: SkillSuggestionType) => void;
   getSkillInstructionsHtml: () => string;
-  isSelected: boolean;
-  onSelect: () => void;
+  isSelected?: boolean;
+  onSelect?: () => void;
 }
 
 export function SkillSuggestionCard({
@@ -140,14 +140,16 @@ export function SkillSuggestionCard({
   onAccept,
   onDecline,
   getSkillInstructionsHtml,
-  isSelected,
+  isSelected = false,
   onSelect,
 }: SkillSuggestionCardProps) {
   const { instructionEdits, toolEdits } = suggestion.suggestion;
+  const isClickable = !!onSelect;
+  const hasActions = !!onAccept && !!onDecline;
 
   return (
     <div
-      className={`cursor-pointer rounded-xl transition-shadow ${isSelected ? "ring-2 ring-highlight-300 dark:ring-highlight-300-night" : ""}`}
+      className={`rounded-xl ${isClickable ? "cursor-pointer transition-shadow" : ""} ${isSelected ? "ring-2 ring-highlight-300 dark:ring-highlight-300-night" : ""}`}
       onClick={onSelect}
     >
       <Card variant="primary" size="md" className="flex-col gap-3">
@@ -155,20 +157,22 @@ export function SkillSuggestionCard({
           <span className="heading-base text-foreground dark:text-foreground-night">
             {suggestion.title ?? "Suggestion"}
           </span>
-          <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
-            <Button
-              variant="outline"
-              size="sm"
-              label="Decline"
-              onClick={() => onDecline(suggestion)}
-            />
-            <Button
-              variant="highlight"
-              size="sm"
-              label="Accept"
-              onClick={() => onAccept(suggestion)}
-            />
-          </div>
+          {hasActions && (
+            <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
+              <Button
+                variant="outline"
+                size="sm"
+                label="Decline"
+                onClick={() => onDecline(suggestion)}
+              />
+              <Button
+                variant="highlight"
+                size="sm"
+                label="Accept"
+                onClick={() => onAccept(suggestion)}
+              />
+            </div>
+          )}
         </div>
 
         {suggestion.analysis && (

--- a/front/pages/api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
@@ -1,0 +1,82 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type PokeGetSkillSuggestionDetails = {
+  suggestion: SkillSuggestionType;
+  skillInstructionsHtml: string | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetSkillSuggestionDetails>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, suggestionId } = req.query;
+  if (!isString(wId) || !isString(suggestionId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or suggestion ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const suggestion = await SkillSuggestionResource.fetchById(
+    auth,
+    suggestionId
+  );
+  if (!suggestion) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "skill_not_found",
+        message: "The suggestion was not found.",
+      },
+    });
+  }
+
+  const skill = await SkillResource.fetchById(
+    auth,
+    suggestion.skillConfigurationSId
+  );
+
+  return res.status(200).json({
+    suggestion: suggestion.toJSON(),
+    skillInstructionsHtml: skill?.toJSON(auth).instructionsHtml ?? null,
+  });
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/poke/swr/skill_suggestion_details.ts
+++ b/front/poke/swr/skill_suggestion_details.ts
@@ -1,0 +1,31 @@
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetSkillSuggestionDetails } from "@app/pages/api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+interface UsePokeSkillSuggestionDetailsProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  suggestionId: string;
+}
+
+export function usePokeSkillSuggestionDetails({
+  disabled,
+  owner,
+  suggestionId,
+}: UsePokeSkillSuggestionDetailsProps) {
+  const { fetcher } = useFetcher();
+  const detailsFetcher: Fetcher<PokeGetSkillSuggestionDetails> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/skill_suggestions/${suggestionId}/details`,
+    detailsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Description

### Summary

- Adds a dedicated poke page for a skill suggestion at /:wId/suggestions/:suggestionId, replacing the previous in-table dialog that was not scrollable when content overflowed.
- The page shows the suggestion title, sId, a link back to the parent skill, the raw analysis/content, and an "In context" section that reuses SkillSuggestionCard from the skill builder to visualise tool edits and instruction diffs against the current skill instructions.
- The suggestion table rows now link to this page (`<a href>`), matching the existing conversation-link convention in the same file.

### Implementation notes

- New endpoint `GET /api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details` returns the suggestion plus the referenced skill's instructionsHtml (looked up via suggestion.skillConfigurationSId), so the page can render the instruction diff without a second round-trip.
- SkillSuggestionCard is made reusable outside the skill builder:
  - onAccept, onDecline, onSelect, isSelected are now optional — when omitted, the accept/decline buttons and click/selection chrome are not rendered.
  - The MCP server views lookup now uses a new useMaybeMCPServerViewsContext that returns undefined when no provider is present, falling back to raw toolIds. This avoids wrapping the poke page in SpacesProvider/MCPServerViewsProvider, which wouldn't work anyway — poke admins don't have access to /api/w/:wId/spaces (401).
- SPA route registered under the existing /:wId workspace layout in front-spa/src/poke/routes.tsx.

Fixes https://github.com/dust-tt/tasks/issues/7678

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Poke + under flag

## Deploy Plan

Front