### PR TITLE
[front] - chore(analytics): revive detailed activity report

### DIFF
--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -1,5 +1,6 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { ActivityReport } from "@app/components/workspace/ActivityReport";
 import { WorkspaceAnalyticsOverviewCards } from "@app/components/workspace/analytics/WorkspaceAnalyticsOverviewCards";
 import { WorkspaceAnalyticsTimeRangeSelector } from "@app/components/workspace/analytics/WorkspaceAnalyticsTimeRangeSelector";
 import { WorkspaceSkillUsageChart } from "@app/components/workspace/analytics/WorkspaceSkillUsageChart";
@@ -9,13 +10,141 @@ import { WorkspaceTopAgentsTable } from "@app/components/workspace/analytics/Wor
 import { WorkspaceTopUsersTable } from "@app/components/workspace/analytics/WorkspaceTopUsersTable";
 import { WorkspaceUsageChart } from "@app/components/workspace/analytics/WorkspaceUsageChart";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { clientFetch } from "@app/lib/egress/client";
+import { useWorkspaceSubscriptions } from "@app/lib/swr/workspaces";
+import datadogLogger from "@app/logger/datadogLogger";
+import { isAPIErrorResponse } from "@app/types/error";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { BarChartIcon, Page } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 export function AnalyticsPage() {
   const owner = useWorkspace();
+  const [downloadingMonth, setDownloadingMonth] = useState<string | null>(null);
+  const [includeInactive, setIncludeInactive] = useState(true);
   const [period, setPeriod] =
     useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
+
+  const { subscriptions } = useWorkspaceSubscriptions({
+    owner,
+  });
+
+  const handleDownload = async (selectedMonth: string | null) => {
+    if (!selectedMonth) {
+      return;
+    }
+
+    const queryParams = new URLSearchParams({
+      mode: "month",
+      start: selectedMonth,
+      table: "all",
+    });
+    if (includeInactive) {
+      queryParams.set("includeInactive", "true");
+    }
+
+    setDownloadingMonth(selectedMonth);
+    try {
+      const response = await clientFetch(
+        `/api/w/${owner.sId}/workspace-usage?${queryParams.toString()}`
+      );
+
+      if (!response.ok) {
+        const responseBody = await response.json().catch(() => null);
+        if (isAPIErrorResponse(responseBody)) {
+          throw new Error(responseBody.error.message);
+        }
+
+        throw new Error(`Error: ${response.status}`);
+      }
+
+      const contentType = response.headers.get("Content-Type");
+      const isZip = contentType === "application/zip";
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+
+      const [year, month] = selectedMonth.split("-");
+
+      const getMonthName = (monthIndex: number) => {
+        const months = [
+          "jan",
+          "feb",
+          "mar",
+          "apr",
+          "may",
+          "jun",
+          "jul",
+          "aug",
+          "sep",
+          "oct",
+          "nov",
+          "dec",
+        ];
+        return months[monthIndex - 1];
+      };
+
+      const monthName = getMonthName(Number(month));
+
+      const fileExtension = isZip ? "zip" : "csv";
+      const filename = `dust_${owner.name}_activity_${year}_${monthName}.${fileExtension}`;
+
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", filename);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } catch (error) {
+      const normalizedError = normalizeError(error);
+      datadogLogger.error(
+        {
+          error: normalizedError.message,
+          workspaceId: owner.sId,
+          month: selectedMonth,
+        },
+        "[Analytics] Failed to download activity data"
+      );
+      window.alert(normalizedError.message);
+    } finally {
+      setDownloadingMonth(null);
+    }
+  };
+
+  const monthOptions: string[] = [];
+
+  if (subscriptions.length > 0) {
+    const oldestStartDate = subscriptions.reduce(
+      (oldest, current) => {
+        if (!current.startDate) {
+          return oldest;
+        }
+        if (!oldest) {
+          return new Date(current.startDate);
+        }
+        return new Date(current.startDate) < oldest
+          ? new Date(current.startDate)
+          : oldest;
+      },
+      null as Date | null
+    );
+
+    if (oldestStartDate) {
+      const startDateYear = oldestStartDate.getFullYear();
+      const startDateMonth = oldestStartDate.getMonth();
+
+      const currentYear = new Date().getFullYear();
+      const currentMonth = new Date().getMonth();
+
+      for (let year = currentYear; year >= startDateYear; year--) {
+        const startMonth = year === startDateYear ? startDateMonth : 0;
+        const endMonth = year === currentYear ? currentMonth : 11;
+        for (let month = endMonth; month >= startMonth; month--) {
+          monthOptions.push(`${year}-${String(month + 1).padStart(2, "0")}`);
+        }
+      }
+    }
+  }
 
   return (
     <Page.Vertical align="stretch" gap="xl">
@@ -47,6 +176,13 @@ export function AnalyticsPage() {
         <WorkspaceSkillUsageChart workspaceId={owner.sId} period={period} />
         <WorkspaceTopUsersTable workspaceId={owner.sId} period={period} />
         <WorkspaceTopAgentsTable workspaceId={owner.sId} period={period} />
+        <ActivityReport
+          downloadingMonth={downloadingMonth}
+          monthOptions={monthOptions}
+          handleDownload={handleDownload}
+          includeInactive={includeInactive}
+          onIncludeInactiveChange={setIncludeInactive}
+        />
       </div>
     </Page.Vertical>
   );

--- a/front/components/workspace/ActivityReport.tsx
+++ b/front/components/workspace/ActivityReport.tsx
@@ -1,8 +1,17 @@
 import {
   Button,
   Checkbox,
+  ContentMessage,
   ContextItem,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   GoogleSpreadsheetLogo,
+  Hoverable,
   Icon,
   Pagination,
 } from "@dust-tt/sparkle";
@@ -19,6 +28,9 @@ interface ActivityReportProps {
 
 const maxItemsPerPage = 4;
 
+const ANALYTICS_EXPORT_DOCS_URL =
+  "https://docs.dust.tt/reference/get_api-v1-w-wid-analytics-export";
+
 export function ActivityReport({
   monthOptions,
   downloadingMonth,
@@ -30,6 +42,7 @@ export function ActivityReport({
     pageIndex: 0,
     pageSize: maxItemsPerPage,
   });
+  const [pendingMonth, setPendingMonth] = useState<string | null>(null);
 
   const toPrettyDate = (date: string) => {
     const months = [
@@ -91,7 +104,7 @@ export function ActivityReport({
                       size="xs"
                       tooltip="Download"
                       onClick={() => {
-                        handleDownload(item);
+                        setPendingMonth(item);
                       }}
                       disabled={downloadingMonth !== null}
                       isLoading={downloadingMonth === item}
@@ -111,6 +124,54 @@ export function ActivityReport({
           </div>
         </div>
       )}
+      <Dialog
+        open={pendingMonth !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingMonth(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Deprecated download</DialogTitle>
+          </DialogHeader>
+          <DialogContainer>
+            <ContentMessage variant="warning" title="Scheduled for removal">
+              This activity report download will be removed on June 1st, 2026.
+              Switch to the new analytics export API before then.{" "}
+              <Hoverable
+                variant="highlight"
+                href={ANALYTICS_EXPORT_DOCS_URL}
+                target="_blank"
+              >
+                View documentation
+              </Hoverable>
+              .
+            </ContentMessage>
+            <DialogDescription>
+              Do you want to continue and download the report for{" "}
+              {pendingMonth ? toPrettyDate(pendingMonth).trim() : ""}?
+            </DialogDescription>
+          </DialogContainer>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              onClick: () => setPendingMonth(null),
+            }}
+            rightButtonProps={{
+              label: "Download anyway",
+              variant: "warning",
+              onClick: () => {
+                const month = pendingMonth;
+                setPendingMonth(null);
+                handleDownload(month);
+              },
+            }}
+          />
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/front/components/workspace/ActivityReport.tsx
+++ b/front/components/workspace/ActivityReport.tsx
@@ -1,0 +1,116 @@
+import {
+  Button,
+  Checkbox,
+  ContextItem,
+  GoogleSpreadsheetLogo,
+  Icon,
+  Pagination,
+} from "@dust-tt/sparkle";
+import { DownloadIcon } from "lucide-react";
+import { useState } from "react";
+
+interface ActivityReportProps {
+  monthOptions: string[];
+  downloadingMonth: string | null;
+  handleDownload: (selectedMonth: string | null) => void;
+  includeInactive: boolean;
+  onIncludeInactiveChange: (value: boolean) => void;
+}
+
+const maxItemsPerPage = 4;
+
+export function ActivityReport({
+  monthOptions,
+  downloadingMonth,
+  handleDownload,
+  includeInactive,
+  onIncludeInactiveChange,
+}: ActivityReportProps) {
+  const [pagination, setPagination] = useState({
+    pageIndex: 0,
+    pageSize: maxItemsPerPage,
+  });
+
+  const toPrettyDate = (date: string) => {
+    const months = [
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December",
+    ];
+    const [year, monthIndex] = date.split("-");
+    return `${months.at(Number(monthIndex) - 1)} ${year} `;
+  };
+  const { pageIndex, pageSize } = pagination;
+  const startIndex = pageIndex * pageSize;
+  const endIndex = startIndex + pageSize;
+  const currentItems = monthOptions.slice(startIndex, endIndex);
+  return (
+    <>
+      {!!monthOptions.length && (
+        <div className="flex-grow rounded-lg border border-border bg-card p-4 dark:border-border-night">
+          <div className="flex flex-col gap-3">
+            <h3 className="text-base font-medium text-foreground dark:text-foreground-night">
+              Detailed activity report
+            </h3>
+            <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              Download workspace activity details.
+            </p>
+            <div className="flex flex-row items-center gap-2">
+              <Checkbox
+                aria-label="Include inactive users and assistants"
+                checked={includeInactive}
+                onCheckedChange={() => {
+                  onIncludeInactiveChange(!includeInactive);
+                }}
+              />
+              <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                Include members and agents without messages.
+              </div>
+            </div>
+          </div>
+          <div className="flex h-full flex-col">
+            <ContextItem.List>
+              {currentItems.map((item, index) => (
+                <ContextItem
+                  key={index}
+                  title={toPrettyDate(item)}
+                  visual={<Icon visual={GoogleSpreadsheetLogo} size="sm" />}
+                  action={
+                    <Button
+                      icon={DownloadIcon}
+                      variant="ghost"
+                      size="xs"
+                      tooltip="Download"
+                      onClick={() => {
+                        handleDownload(item);
+                      }}
+                      disabled={downloadingMonth !== null}
+                      isLoading={downloadingMonth === item}
+                    />
+                  }
+                ></ContextItem>
+              ))}
+            </ContextItem.List>
+            <div className="mt-2">
+              <Pagination
+                rowCount={monthOptions.length}
+                pagination={pagination}
+                setPagination={setPagination}
+                size="xs"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Description

This PR restores the detailed monthly activity report download functionality in the Analytics page. The ActivityReport component was removed in #23889 during the analytics CSV export GA rollout, but customers still need the ability to download monthly workspace activity reports through the UI (see #7627). 

This PR re-adds the ActivityReport component with a deprecation warning dialog that informs users the feature will be removed on June 1st, 2026, and directs them to transition to the new `/api/v1/w/{wId}/analytics/export` endpoint. 

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front