### PR TITLE
[front] enh: optimize fetching of poke workspace list

### DIFF
--- a/front/components/poke/pages/DashboardPage.tsx
+++ b/front/components/poke/pages/DashboardPage.tsx
@@ -19,6 +19,7 @@ import { usePokeRegion } from "@app/lib/swr/poke";
 import { classNames } from "@app/lib/utils";
 import type { PokeWorkspaceWithRegion } from "@app/poke/swr/search";
 import { usePokeWorkspacesAllRegions } from "@app/poke/swr/search";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import { Chip, Icon, Input, LinkWrapper, Spinner } from "@dust-tt/sparkle";
 import { UsersIcon } from "lucide-react";
 import moment from "moment";
@@ -72,9 +73,13 @@ function WorkspaceList({
                     </PokeTableRow>
                     <PokeTableRow>
                       <PokeTableCell className="space-x-2" colSpan={3}>
-                        <label>
-                          <Icon visual={UsersIcon} /> {ws.membersCount}
-                        </label>
+                        <div className="flex items-center gap-1.5">
+                          <Icon visual={UsersIcon} size="xs" />
+                          <span>
+                            {ws.membersCount}&nbsp;
+                            member{pluralize(ws.membersCount)}
+                          </span>
+                        </div>
                       </PokeTableCell>
                     </PokeTableRow>
                     <PokeTableRow>

--- a/front/components/poke/pages/DashboardPage.tsx
+++ b/front/components/poke/pages/DashboardPage.tsx
@@ -19,7 +19,8 @@ import { usePokeRegion } from "@app/lib/swr/poke";
 import { classNames } from "@app/lib/utils";
 import type { PokeWorkspaceWithRegion } from "@app/poke/swr/search";
 import { usePokeWorkspacesAllRegions } from "@app/poke/swr/search";
-import { Chip, Input, LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import { Chip, Icon, Input, LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import { UsersIcon } from "lucide-react";
 import moment from "moment";
 import type { ChangeEvent } from "react";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
@@ -66,6 +67,13 @@ function WorkspaceList({
                       <PokeTableCell className="space-x-2" colSpan={3}>
                         <label>
                           Created: {moment(ws.createdAt).format("DD-MM-YYYY")}
+                        </label>
+                      </PokeTableCell>
+                    </PokeTableRow>
+                    <PokeTableRow>
+                      <PokeTableCell className="space-x-2" colSpan={3}>
+                        <label>
+                          <Icon visual={UsersIcon} /> {ws.membersCount}
                         </label>
                       </PokeTableCell>
                     </PokeTableRow>

--- a/front/components/poke/pages/DashboardPage.tsx
+++ b/front/components/poke/pages/DashboardPage.tsx
@@ -19,15 +19,7 @@ import { usePokeRegion } from "@app/lib/swr/poke";
 import { classNames } from "@app/lib/utils";
 import type { PokeWorkspaceWithRegion } from "@app/poke/swr/search";
 import { usePokeWorkspacesAllRegions } from "@app/poke/swr/search";
-import {
-  BookOpenIcon,
-  Chip,
-  Icon,
-  Input,
-  LinkWrapper,
-  Spinner,
-} from "@dust-tt/sparkle";
-import { UsersIcon } from "lucide-react";
+import { Chip, Input, LinkWrapper, Spinner } from "@dust-tt/sparkle";
 import moment from "moment";
 import type { ChangeEvent } from "react";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
@@ -74,30 +66,6 @@ function WorkspaceList({
                       <PokeTableCell className="space-x-2" colSpan={3}>
                         <label>
                           Created: {moment(ws.createdAt).format("DD-MM-YYYY")}
-                        </label>
-                      </PokeTableCell>
-                    </PokeTableRow>
-                    <PokeTableRow>
-                      <PokeTableCell className="max-w-[200px] overflow-hidden text-ellipsis">
-                        {ws.adminEmail}{" "}
-                        {ws.workspaceDomains && (
-                          <label>
-                            (
-                            {ws.workspaceDomains
-                              .map((d) => d.domain)
-                              .join(", ")}
-                            )
-                          </label>
-                        )}
-                      </PokeTableCell>
-                      <PokeTableCell align="center">
-                        <label>
-                          <Icon visual={UsersIcon} /> {ws.membersCount}
-                        </label>
-                      </PokeTableCell>
-                      <PokeTableCell align="center">
-                        <label>
-                          <Icon visual={BookOpenIcon} /> {ws.dataSourcesCount}
                         </label>
                       </PokeTableCell>
                     </PokeTableRow>

--- a/front/components/poke/pages/DashboardPage.tsx
+++ b/front/components/poke/pages/DashboardPage.tsx
@@ -76,8 +76,8 @@ function WorkspaceList({
                         <div className="flex items-center gap-1.5">
                           <Icon visual={UsersIcon} size="xs" />
                           <span>
-                            {ws.membersCount}&nbsp;
-                            member{pluralize(ws.membersCount)}
+                            {ws.membersCount}&nbsp; member
+                            {pluralize(ws.membersCount)}
                           </span>
                         </div>
                       </PokeTableCell>

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -27,6 +27,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import type { RequireAtLeastOne } from "@app/types/shared/typescipt_utils";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
+import assert from "assert";
 import type {
   Attributes,
   FindOptions,
@@ -517,13 +518,21 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
   }
 
-  static async getMembersCountsForWorkspaces({
-    workspaces,
-    activeOnly,
-  }: {
-    workspaces: LightWorkspaceType[];
-    activeOnly: boolean;
-  }): Promise<Record<string, number>> {
+  static async getMembersCountsForWorkspaces(
+    auth: Authenticator,
+    {
+      workspaces,
+      activeOnly,
+    }: {
+      workspaces: LightWorkspaceType[];
+      activeOnly: boolean;
+    }
+  ): Promise<Record<string, number>> {
+    assert(
+      auth.isDustSuperUser(),
+      "Counting members across different workspaces is only allowed for super users."
+    );
+
     const countByWorkspaceId: Record<string, number> = {};
     for (const w of workspaces) {
       countByWorkspaceId[w.sId] = 0;

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -534,15 +534,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     );
 
     const countByWorkspaceId: Record<string, number> = {};
-    for (const w of workspaces) {
-      countByWorkspaceId[w.sId] = 0;
-    }
     if (workspaces.length === 0) {
       return countByWorkspaceId;
     }
 
     const workspaceIdByModelId = new Map<ModelId, string>();
     for (const w of workspaces) {
+      countByWorkspaceId[w.sId] = 0;
       workspaceIdByModelId.set(w.id, w.sId);
     }
 
@@ -556,20 +554,29 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       where.firstUsedAt = { [Op.ne]: null };
     }
 
-    const rows = await this.model.count({
+    const rows = await this.model.findAll({
+      attributes: ["workspaceId", "userId"],
       where,
-      distinct: true,
-      col: "userId",
-      group: "workspaceId",
+      // WORKSPACE_ISOLATION_BYPASS: this is a Poke only query where we batch count members across different workspaces
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
 
+    // Dedupe userIds per workspace in memory (faster than a COUNT(DISTINCT ...) in SQL).
+    const userModelIdsByWorkspaceModelId = new Map<ModelId, Set<ModelId>>();
     for (const row of rows) {
-      const workspaceModelId = row.workspaceId;
-      if (typeof workspaceModelId === "number") {
-        const workspaceId = workspaceIdByModelId.get(workspaceModelId);
-        if (workspaceId !== undefined) {
-          countByWorkspaceId[workspaceId] = row.count;
-        }
+      let userIds = userModelIdsByWorkspaceModelId.get(row.workspaceId);
+      if (!userIds) {
+        userIds = new Set();
+        userModelIdsByWorkspaceModelId.set(row.workspaceId, userIds);
+      }
+      userIds.add(row.userId);
+    }
+
+    for (const [workspaceModelId, userIds] of userModelIdsByWorkspaceModelId) {
+      const workspaceId = workspaceIdByModelId.get(workspaceModelId);
+      if (workspaceId) {
+        countByWorkspaceId[workspaceId] = userIds.size;
       }
     }
     return countByWorkspaceId;

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -545,13 +545,16 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     }
 
     const now = new Date();
-    const where: WhereOptions<InferAttributes<MembershipModel>> = {
+    let where: WhereOptions<InferAttributes<MembershipModel>> = {
       workspaceId: { [Op.in]: workspaces.map((w) => w.id) },
     };
     if (activeOnly) {
-      where.endAt = { [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: now }] };
-      where.startAt = { [Op.lte]: now };
-      where.firstUsedAt = { [Op.ne]: null };
+      where = {
+        ...where,
+        endAt: { [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: now }] },
+        startAt: { [Op.lte]: now },
+        firstUsedAt: { [Op.ne]: null },
+      };
     }
 
     const rows = await this.model.count({

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -554,29 +554,20 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       where.firstUsedAt = { [Op.ne]: null };
     }
 
-    const rows = await this.model.findAll({
-      attributes: ["workspaceId", "userId"],
+    const rows = await this.model.count({
       where,
-      // WORKSPACE_ISOLATION_BYPASS: this is a Poke only query where we batch count members across different workspaces
-      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
-      dangerouslyBypassWorkspaceIsolationSecurity: true,
+      distinct: true,
+      col: "userId",
+      group: ["workspaceId"],
     });
 
-    // Dedupe userIds per workspace.
-    const userModelIdsByWorkspaceModelId = new Map<ModelId, Set<ModelId>>();
     for (const row of rows) {
-      let userIds = userModelIdsByWorkspaceModelId.get(row.workspaceId);
-      if (!userIds) {
-        userIds = new Set();
-        userModelIdsByWorkspaceModelId.set(row.workspaceId, userIds);
-      }
-      userIds.add(row.userId);
-    }
-
-    for (const [workspaceModelId, userIds] of userModelIdsByWorkspaceModelId) {
-      const workspaceId = workspaceIdByModelId.get(workspaceModelId);
-      if (workspaceId) {
-        countByWorkspaceId[workspaceId] = userIds.size;
+      const workspaceModelId = row.workspaceId;
+      if (typeof workspaceModelId === "number") {
+        const workspaceId = workspaceIdByModelId.get(workspaceModelId);
+        if (workspaceId) {
+          countByWorkspaceId[workspaceId] = row.count;
+        }
       }
     }
     return countByWorkspaceId;

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -517,6 +517,55 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
   }
 
+  static async getMembersCountsForWorkspaces({
+    workspaces,
+    activeOnly,
+  }: {
+    workspaces: LightWorkspaceType[];
+    activeOnly: boolean;
+  }): Promise<Record<string, number>> {
+    const countByWorkspaceId: Record<string, number> = {};
+    for (const w of workspaces) {
+      countByWorkspaceId[w.sId] = 0;
+    }
+    if (workspaces.length === 0) {
+      return countByWorkspaceId;
+    }
+
+    const workspaceIdByModelId = new Map<ModelId, string>();
+    for (const w of workspaces) {
+      workspaceIdByModelId.set(w.id, w.sId);
+    }
+
+    const now = new Date();
+    const where: WhereOptions<InferAttributes<MembershipModel>> = {
+      workspaceId: { [Op.in]: workspaces.map((w) => w.id) },
+    };
+    if (activeOnly) {
+      where.endAt = { [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: now }] };
+      where.startAt = { [Op.lte]: now };
+      where.firstUsedAt = { [Op.ne]: null };
+    }
+
+    const rows = await this.model.count({
+      where,
+      distinct: true,
+      col: "userId",
+      group: "workspaceId",
+    });
+
+    for (const row of rows) {
+      const workspaceModelId = row.workspaceId;
+      if (typeof workspaceModelId === "number") {
+        const workspaceId = workspaceIdByModelId.get(workspaceModelId);
+        if (workspaceId !== undefined) {
+          countByWorkspaceId[workspaceId] = row.count;
+        }
+      }
+    }
+    return countByWorkspaceId;
+  }
+
   static async countActiveMembersForWorkspace({
     workspace,
   }: {

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -562,7 +562,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
 
-    // Dedupe userIds per workspace in memory (faster than a COUNT(DISTINCT ...) in SQL).
+    // Dedupe userIds per workspace.
     const userModelIdsByWorkspaceModelId = new Map<ModelId, Set<ModelId>>();
     for (const row of rows) {
       let userIds = userModelIdsByWorkspaceModelId.get(row.workspaceId);

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -296,7 +296,7 @@ async function handler(
         renderLightWorkspaceType({ workspace, role: "admin" })
       );
       const membersCountByWorkspaceId =
-        await MembershipResource.getMembersCountsForWorkspaces({
+        await MembershipResource.getMembersCountsForWorkspaces(auth, {
           workspaces: lightWorkspaces,
           activeOnly: true,
         });

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -32,6 +32,7 @@ import { Op } from "sequelize";
 export type PokeWorkspaceType = LightWorkspaceType & {
   createdAt: string;
   subscription: SubscriptionType;
+  membersCount: number;
 };
 
 export type GetPokeWorkspacesResponseBody = {
@@ -291,24 +292,31 @@ async function handler(
         workspaces.splice(originalLimit);
       }
 
+      const lightWorkspaces = workspaces.map((workspace) =>
+        renderLightWorkspaceType({ workspace, role: "admin" })
+      );
+      const membersCountByWorkspaceId =
+        await MembershipResource.getMembersCountsForWorkspaces({
+          workspaces: lightWorkspaces,
+          activeOnly: true,
+        });
+
       return res.status(200).json({
         workspaces: workspaces.map((workspace) => ({
-            ...renderLightWorkspaceType({
-              workspace,
-              role: "admin",
-            }),
-            createdAt: workspace.createdAt.toISOString(),
-            subscription: renderSubscriptionFromModels(
-              {
-                plan: workspace.subscriptions[0]
-                  ? workspace.subscriptions[0].plan
-                  : // If there is no active subscription, we use the free plan data.
-                  FREE_NO_PLAN_DATA,
-                activeSubscription: workspace.subscriptions[0],
-              }
-            ),
-          })
-        ),
+          ...renderLightWorkspaceType({
+            workspace,
+            role: "admin",
+          }),
+          createdAt: workspace.createdAt.toISOString(),
+          subscription: renderSubscriptionFromModels({
+            plan: workspace.subscriptions[0]
+              ? workspace.subscriptions[0].plan
+              : // If there is no active subscription, we use the free plan data.
+                FREE_NO_PLAN_DATA,
+            activeSubscription: workspace.subscriptions[0],
+          }),
+          membersCount: membersCountByWorkspaceId[workspace.sId] ?? 0,
+        })),
       });
 
     default:

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -13,7 +13,6 @@ import {
 } from "@app/lib/plans/plan_codes";
 import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
 import { tryParsePhoneNumber } from "@app/lib/plans/trial/phone";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -24,10 +23,8 @@ import { isDomain, isEmailValid } from "@app/lib/utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { MembershipRoleType } from "@app/types/memberships";
 import type { SubscriptionType } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
-import type { WorkspaceDomain } from "@app/types/workspace";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { FindOptions, Order, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
@@ -35,10 +32,6 @@ import { Op } from "sequelize";
 export type PokeWorkspaceType = LightWorkspaceType & {
   createdAt: string;
   subscription: SubscriptionType;
-  adminEmail: string | null;
-  membersCount: number;
-  dataSourcesCount: number;
-  workspaceDomains: WorkspaceDomain[];
 };
 
 export type GetPokeWorkspacesResponseBody = {
@@ -299,67 +292,21 @@ async function handler(
       }
 
       return res.status(200).json({
-        workspaces: await Promise.all(
-          workspaces.map(async (ws): Promise<PokeWorkspaceType> => {
-            // Note: TypeScript may incorrectly assume that `subscriptions` is always defined.
-            const [activeSubscription] = ws.subscriptions;
-
-            const subscription: SubscriptionType = renderSubscriptionFromModels(
-              {
-                plan: activeSubscription
-                  ? activeSubscription.plan
-                  : // If there is no active subscription, we use the free plan data.
-                    FREE_NO_PLAN_DATA,
-                activeSubscription: activeSubscription,
-              }
-            );
-
-            const lightWorkspace = renderLightWorkspaceType({
-              workspace: ws,
+        workspaces: workspaces.map((workspace) => ({
+            ...renderLightWorkspaceType({
+              workspace,
               role: "admin",
-            });
-
-            const auth = await Authenticator.internalAdminForWorkspace(ws.sId);
-            const dataSources = await DataSourceResource.listByWorkspace(auth);
-            const dataSourcesCount = dataSources.length;
-
-            const { memberships: admins, total } =
-              await MembershipResource.getActiveMemberships({
-                workspace: lightWorkspace,
-                roles: ["admin" as MembershipRoleType],
-              });
-
-            const firstAdmin = total
-              ? await UserResource.fetchByModelId(
-                  admins.sort(
-                    (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
-                  )[0].userId
-                )
-              : null;
-
-            const membersCount =
-              await MembershipResource.getMembersCountForWorkspace({
-                workspace: lightWorkspace,
-                activeOnly: true,
-              });
-
-            const workspaceResource = await WorkspaceResource.fetchById(ws.sId);
-            if (!workspaceResource) {
-              throw new Error(`Workspace not found: ${ws.sId}`);
-            }
-
-            const verifiedDomains =
-              await workspaceResource.getVerifiedDomains();
-
-            return {
-              ...lightWorkspace,
-              createdAt: ws.createdAt.toISOString(),
-              subscription,
-              adminEmail: firstAdmin?.email ?? null,
-              membersCount,
-              dataSourcesCount,
-              workspaceDomains: verifiedDomains,
-            };
+            }),
+            createdAt: workspace.createdAt.toISOString(),
+            subscription: renderSubscriptionFromModels(
+              {
+                plan: workspace.subscriptions[0]
+                  ? workspace.subscriptions[0].plan
+                  : // If there is no active subscription, we use the free plan data.
+                  FREE_NO_PLAN_DATA,
+                activeSubscription: workspace.subscriptions[0],
+              }
+            ),
           })
         ),
       });


### PR DESCRIPTION
## Description

- This PR improves the performances of the main poke page, where we display a list of workspaces that are all fetched in parallel + run several queries for each workspace. This Promise.all can hold several SQL connections at once, causing risks of pool exhaustion.
- This PR removes the parallel fetching with a batch fetch and removes some of the queries that were not actually useful (cc [thread](https://dust4ai.slack.com/archives/C0A42UMFUM6/p1776437425963719))
- A follow up PR will change what we see on the main page, turns out the "Last 20 upgraded workspaces" list is not really used all that much.

<img width="542" height="171" alt="Screenshot 2026-04-20 at 2 43 18 PM" src="https://github.com/user-attachments/assets/b4bffc04-d21f-429c-a1b7-afa19a11ac12" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
