### PR TITLE
[Sessions] Seed child conversation datasource in forks

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -10,6 +10,8 @@ import * as contentFragmentModule from "@app/lib/api/assistant/conversation/cont
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { createConversationFork } from "@app/lib/api/assistant/conversation/forks";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+import * as dataSourcesModule from "@app/lib/api/data_sources";
+import * as fileUpsertModule from "@app/lib/api/files/upsert";
 import { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPActionModel,
@@ -232,11 +234,13 @@ async function createToolOutputFile(
     fileName,
     snippet = null,
     hideFromUser = false,
+    skipDataSourceIndexing = false,
   }: {
     conversationId: string;
     fileName: string;
     snippet?: string | null;
     hideFromUser?: boolean;
+    skipDataSourceIndexing?: boolean;
   }
 ): Promise<FileResource> {
   return FileFactory.create(auth, auth.getNonNullableUser(), {
@@ -248,6 +252,7 @@ async function createToolOutputFile(
     useCaseMetadata: {
       conversationId,
       ...(hideFromUser ? { hideFromUser: true } : {}),
+      ...(skipDataSourceIndexing ? { skipDataSourceIndexing: true } : {}),
     },
     snippet,
   });
@@ -289,6 +294,24 @@ function mockCopyToConversation() {
 
       return new Ok(copiedFile);
     });
+}
+
+function mockDatasourceSeeding(
+  dataSource: Awaited<
+    ReturnType<typeof DataSourceViewFactory.folder>
+  >["dataSource"]
+) {
+  const getOrCreateConversationDataSourceFromFileSpy = vi
+    .spyOn(dataSourcesModule, "getOrCreateConversationDataSourceFromFile")
+    .mockResolvedValue(new Ok(dataSource));
+  const processAndUpsertToDataSourceSpy = vi
+    .spyOn(fileUpsertModule, "processAndUpsertToDataSource")
+    .mockImplementation(async (_auth, _dataSource, { file }) => new Ok(file));
+
+  return {
+    getOrCreateConversationDataSourceFromFileSpy,
+    processAndUpsertToDataSourceSpy,
+  };
 }
 
 function mockContentNodeAttachments(nodeDataSourceViewId: number) {
@@ -634,8 +657,18 @@ describe("createConversationFork", () => {
   });
 
   it("copies direct conversation file attachments into the child conversation", async () => {
-    const { auth } = await createPrivateApiMockRequest();
+    const { auth, workspace, globalSpace } =
+      await createPrivateApiMockRequest();
     const copyToConversationSpy = mockCopyToConversation();
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      globalSpace,
+      auth.user() ?? null
+    );
+    const {
+      getOrCreateConversationDataSourceFromFileSpy,
+      processAndUpsertToDataSourceSpy,
+    } = mockDatasourceSeeding(dataSourceView.dataSource);
 
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
@@ -712,13 +745,32 @@ describe("createConversationFork", () => {
       childConversation.sId
     );
     expect(copiedFiles[0]?.snippet).toBe(sourceFile.snippet);
+    expect(getOrCreateConversationDataSourceFromFileSpy).toHaveBeenCalledTimes(
+      1
+    );
+    expect(processAndUpsertToDataSourceSpy).toHaveBeenCalledTimes(1);
+    expect(processAndUpsertToDataSourceSpy.mock.calls[0]?.[2].file.sId).toBe(
+      copiedFiles[0]?.sId
+    );
 
     copyToConversationSpy.mockRestore();
+    getOrCreateConversationDataSourceFromFileSpy.mockRestore();
+    processAndUpsertToDataSourceSpy.mockRestore();
   }, 15_000);
 
   it("only copies attachments that existed at the selected source message", async () => {
-    const { auth } = await createPrivateApiMockRequest();
+    const { auth, workspace, globalSpace } =
+      await createPrivateApiMockRequest();
     const copyToConversationSpy = mockCopyToConversation();
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      globalSpace,
+      auth.user() ?? null
+    );
+    const {
+      getOrCreateConversationDataSourceFromFileSpy,
+      processAndUpsertToDataSourceSpy,
+    } = mockDatasourceSeeding(dataSourceView.dataSource);
 
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
@@ -807,11 +859,23 @@ describe("createConversationFork", () => {
     expect(childFileAttachments[0]?.title).toBe("First attachment");
 
     copyToConversationSpy.mockRestore();
+    getOrCreateConversationDataSourceFromFileSpy.mockRestore();
+    processAndUpsertToDataSourceSpy.mockRestore();
   }, 15_000);
 
   it("carries over tool output attachments from the selected source message", async () => {
-    const { auth } = await createPrivateApiMockRequest();
+    const { auth, workspace, globalSpace } =
+      await createPrivateApiMockRequest();
     const copyToConversationSpy = mockCopyToConversation();
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      globalSpace,
+      auth.user() ?? null
+    );
+    const {
+      getOrCreateConversationDataSourceFromFileSpy,
+      processAndUpsertToDataSourceSpy,
+    } = mockDatasourceSeeding(dataSourceView.dataSource);
 
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
@@ -888,13 +952,100 @@ describe("createConversationFork", () => {
       childConversation.sId
     );
     expect(copiedFiles[0]?.snippet).toBe(sourceToolOutput.snippet);
+    expect(getOrCreateConversationDataSourceFromFileSpy).toHaveBeenCalledTimes(
+      1
+    );
+    expect(processAndUpsertToDataSourceSpy).toHaveBeenCalledTimes(1);
+    expect(processAndUpsertToDataSourceSpy.mock.calls[0]?.[2].file.sId).toBe(
+      copiedFiles[0]?.sId
+    );
 
     copyToConversationSpy.mockRestore();
+    getOrCreateConversationDataSourceFromFileSpy.mockRestore();
+    processAndUpsertToDataSourceSpy.mockRestore();
+  }, 15_000);
+
+  it("does not seed the child conversation datasource for skipped tool outputs", async () => {
+    const { auth, workspace, globalSpace } =
+      await createPrivateApiMockRequest();
+    const copyToConversationSpy = mockCopyToConversation();
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      globalSpace,
+      auth.user() ?? null
+    );
+    const {
+      getOrCreateConversationDataSourceFromFileSpy,
+      processAndUpsertToDataSourceSpy,
+    } = mockDatasourceSeeding(dataSourceView.dataSource);
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const skippedToolOutput = await createToolOutputFile(auth, {
+      conversationId: parentConversation.sId,
+      fileName: "offloaded-output.txt",
+      skipDataSourceIndexing: true,
+    });
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      content: "Fork from the next answer.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 2,
+      parentId: userMessage.id,
+      status: "succeeded",
+      generatedFileId: skippedToolOutput.id,
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
+
+    const childAttachments = await listAttachments(auth, {
+      conversation: childConversation,
+    });
+    const childFileAttachments = childAttachments.filter(isFileAttachmentType);
+
+    expect(childFileAttachments).toHaveLength(1);
+    expect(getOrCreateConversationDataSourceFromFileSpy).not.toHaveBeenCalled();
+    expect(processAndUpsertToDataSourceSpy).not.toHaveBeenCalled();
+
+    copyToConversationSpy.mockRestore();
+    getOrCreateConversationDataSourceFromFileSpy.mockRestore();
+    processAndUpsertToDataSourceSpy.mockRestore();
   }, 15_000);
 
   it("preserves hidden tool output attachments in the forked conversation", async () => {
-    const { auth } = await createPrivateApiMockRequest();
+    const { auth, workspace, globalSpace } =
+      await createPrivateApiMockRequest();
     const copyToConversationSpy = mockCopyToConversation();
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      globalSpace,
+      auth.user() ?? null
+    );
+    const {
+      getOrCreateConversationDataSourceFromFileSpy,
+      processAndUpsertToDataSourceSpy,
+    } = mockDatasourceSeeding(dataSourceView.dataSource);
 
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
@@ -951,6 +1102,8 @@ describe("createConversationFork", () => {
     expect(copiedFiles[0]?.useCaseMetadata?.hideFromUser).toBe(true);
 
     copyToConversationSpy.mockRestore();
+    getOrCreateConversationDataSourceFromFileSpy.mockRestore();
+    processAndUpsertToDataSourceSpy.mockRestore();
   }, 15_000);
 
   it("reattaches content node attachments that existed at the selected source message", async () => {

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -1,5 +1,7 @@
 import { postNewContentFragment } from "@app/lib/api/assistant/conversation";
 import {
+  type ContentNodeAttachmentType,
+  type FileAttachmentType,
   isContentNodeAttachmentType,
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
@@ -33,6 +35,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Transaction } from "sequelize";
 
 export type CreateConversationForkErrorCode =
@@ -43,6 +46,15 @@ export type CreateConversationForkErrorCode =
 const FORKED_CONVERSATION_TITLE_SUFFIX = " (forked)";
 const FORK_INITIALIZATION_MESSAGE_RANK = 0;
 const UNTITLED_CONVERSATION_TITLE = "Untitled conversation";
+
+type CarriedAttachment = {
+  carriedAttachment:
+    | ContentFragmentInputWithFileIdType
+    | ContentFragmentInputWithContentNode;
+  carriedFile: FileResource | null;
+  attachErrorMessage: string;
+  attachLogMetadata: Record<string, string>;
+};
 
 function getForkedConversationTitle(title: string | null): string | null {
   if (title === null) {
@@ -226,6 +238,143 @@ async function createForkInitializationMessage(
   });
 }
 
+async function carryOverFile(
+  auth: Authenticator,
+  {
+    attachment,
+    parentConversationId,
+    childConversationId,
+  }: {
+    attachment: FileAttachmentType;
+    parentConversationId: string;
+    childConversationId: string;
+  }
+): Promise<CarriedAttachment | null> {
+  const copiedFile = await FileResource.copyToConversation(auth, {
+    sourceId: attachment.fileId,
+    conversationId: childConversationId,
+  });
+
+  if (copiedFile.isErr()) {
+    logger.error(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        parentConversationId,
+        childConversationId,
+        sourceFileId: attachment.fileId,
+        error: copiedFile.error,
+      },
+      "Failed to copy file attachment into forked conversation."
+    );
+
+    return null;
+  }
+
+  return {
+    carriedAttachment: {
+      title: attachment.title,
+      fileId: copiedFile.value.sId,
+    },
+    carriedFile: copiedFile.value,
+    attachErrorMessage:
+      "Failed to attach copied file into forked conversation.",
+    attachLogMetadata: {
+      sourceFileId: attachment.fileId,
+      copiedFileId: copiedFile.value.sId,
+    },
+  };
+}
+
+function carryOverContentNode(
+  attachment: ContentNodeAttachmentType
+): CarriedAttachment {
+  return {
+    carriedAttachment: {
+      title: attachment.title,
+      nodeId: attachment.nodeId,
+      nodeDataSourceViewId: attachment.nodeDataSourceViewId,
+    },
+    carriedFile: null,
+    attachErrorMessage:
+      "Failed to reattach content node into forked conversation.",
+    attachLogMetadata: {
+      contentFragmentId: attachment.contentFragmentId,
+      nodeId: attachment.nodeId,
+      nodeDataSourceViewId: attachment.nodeDataSourceViewId,
+    },
+  };
+}
+
+async function addFileToConversationDatasource(
+  auth: Authenticator,
+  {
+    parentConversationId,
+    childConversationId,
+    carriedFile,
+    childConversationDataSource,
+  }: {
+    parentConversationId: string;
+    childConversationId: string;
+    carriedFile: FileResource | null;
+    childConversationDataSource: DataSourceResource | null;
+  }
+): Promise<DataSourceResource | null> {
+  if (
+    !carriedFile ||
+    carriedFile.useCaseMetadata?.skipDataSourceIndexing ||
+    !isFileTypeUpsertableForUseCase(carriedFile)
+  ) {
+    return childConversationDataSource;
+  }
+
+  let nextChildConversationDataSource = childConversationDataSource;
+
+  if (!nextChildConversationDataSource) {
+    const childDataSourceRes = await getOrCreateConversationDataSourceFromFile(
+      auth,
+      carriedFile
+    );
+
+    if (childDataSourceRes.isErr()) {
+      logger.error(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          parentConversationId,
+          childConversationId,
+          copiedFileId: carriedFile.sId,
+          error: childDataSourceRes.error,
+        },
+        "Failed to get or create child conversation datasource for forked file."
+      );
+
+      return childConversationDataSource;
+    }
+
+    nextChildConversationDataSource = childDataSourceRes.value;
+  }
+
+  const upsertRes = await processAndUpsertToDataSource(
+    auth,
+    nextChildConversationDataSource,
+    { file: carriedFile }
+  );
+
+  if (upsertRes.isErr()) {
+    logger.error(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        parentConversationId,
+        childConversationId,
+        copiedFileId: carriedFile.sId,
+        error: upsertRes.error,
+      },
+      "Failed to seed child conversation datasource for forked file."
+    );
+  }
+
+  return nextChildConversationDataSource;
+}
+
 async function carryOverConversationAttachments(
   auth: Authenticator,
   {
@@ -261,58 +410,30 @@ async function carryOverConversationAttachments(
   let childConversationDataSource: DataSourceResource | null = null;
 
   for (const attachment of directConversationAttachments) {
-    let carriedAttachment:
-      | ContentFragmentInputWithFileIdType
-      | ContentFragmentInputWithContentNode;
-    let carriedFile: FileResource | null = null;
-    let attachErrorMessage: string;
-    let attachLogMetadata: Record<string, string>;
+    let carriedResult: CarriedAttachment | null;
 
     if (isFileAttachmentType(attachment)) {
-      const copiedFile = await FileResource.copyToConversation(auth, {
-        sourceId: attachment.fileId,
-        conversationId: childConversation.sId,
+      carriedResult = await carryOverFile(auth, {
+        attachment,
+        parentConversationId: parentConversation.sId,
+        childConversationId: childConversation.sId,
       });
-
-      if (copiedFile.isErr()) {
-        logger.error(
-          {
-            workspaceId: auth.getNonNullableWorkspace().sId,
-            parentConversationId: parentConversation.sId,
-            childConversationId: childConversation.sId,
-            sourceFileId: attachment.fileId,
-            error: copiedFile.error,
-          },
-          "Failed to copy file attachment into forked conversation."
-        );
-        continue;
-      }
-
-      carriedAttachment = {
-        title: attachment.title,
-        fileId: copiedFile.value.sId,
-      };
-      carriedFile = copiedFile.value;
-      attachErrorMessage =
-        "Failed to attach copied file into forked conversation.";
-      attachLogMetadata = {
-        sourceFileId: attachment.fileId,
-        copiedFileId: copiedFile.value.sId,
-      };
+    } else if (isContentNodeAttachmentType(attachment)) {
+      carriedResult = carryOverContentNode(attachment);
     } else {
-      carriedAttachment = {
-        title: attachment.title,
-        nodeId: attachment.nodeId,
-        nodeDataSourceViewId: attachment.nodeDataSourceViewId,
-      };
-      attachErrorMessage =
-        "Failed to reattach content node into forked conversation.";
-      attachLogMetadata = {
-        contentFragmentId: attachment.contentFragmentId,
-        nodeId: attachment.nodeId,
-        nodeDataSourceViewId: attachment.nodeDataSourceViewId,
-      };
+      assertNever(attachment);
     }
+
+    if (!carriedResult) {
+      continue;
+    }
+
+    const {
+      carriedAttachment,
+      carriedFile,
+      attachErrorMessage,
+      attachLogMetadata,
+    } = carriedResult;
 
     const attachmentResult = await postNewContentFragment(
       auth,
@@ -336,52 +457,12 @@ async function carryOverConversationAttachments(
       continue;
     }
 
-    if (
-      carriedFile &&
-      !carriedFile.useCaseMetadata?.skipDataSourceIndexing &&
-      isFileTypeUpsertableForUseCase(carriedFile)
-    ) {
-      if (!childConversationDataSource) {
-        const childDataSourceRes =
-          await getOrCreateConversationDataSourceFromFile(auth, carriedFile);
-
-        if (childDataSourceRes.isErr()) {
-          logger.error(
-            {
-              workspaceId: auth.getNonNullableWorkspace().sId,
-              parentConversationId: parentConversation.sId,
-              childConversationId: childConversation.sId,
-              copiedFileId: carriedFile.sId,
-              error: childDataSourceRes.error,
-            },
-            "Failed to get or create child conversation datasource for forked file."
-          );
-
-          continue;
-        }
-
-        childConversationDataSource = childDataSourceRes.value;
-      }
-
-      const upsertRes = await processAndUpsertToDataSource(
-        auth,
-        childConversationDataSource,
-        { file: carriedFile }
-      );
-
-      if (upsertRes.isErr()) {
-        logger.error(
-          {
-            workspaceId: auth.getNonNullableWorkspace().sId,
-            parentConversationId: parentConversation.sId,
-            childConversationId: childConversation.sId,
-            copiedFileId: carriedFile.sId,
-            error: upsertRes.error,
-          },
-          "Failed to seed child conversation datasource for forked file."
-        );
-      }
-    }
+    childConversationDataSource = await addFileToConversationDatasource(auth, {
+      parentConversationId: parentConversation.sId,
+      childConversationId: childConversation.sId,
+      carriedFile,
+      childConversationDataSource,
+    });
   }
 }
 

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -319,11 +319,12 @@ async function addFileToConversationDatasource(
     childConversationDataSource: DataSourceResource | null;
   }
 ): Promise<DataSourceResource | null> {
-  if (
-    !carriedFile ||
-    carriedFile.useCaseMetadata?.skipDataSourceIndexing ||
-    !isFileTypeUpsertableForUseCase(carriedFile)
-  ) {
+  const shouldCopyFileToDatasource =
+    !!carriedFile &&
+    !carriedFile.useCaseMetadata?.skipDataSourceIndexing &&
+    isFileTypeUpsertableForUseCase(carriedFile);
+
+  if (!shouldCopyFileToDatasource) {
     return childConversationDataSource;
   }
 

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -315,19 +315,10 @@ async function addFileToConversationDatasource(
   }: {
     parentConversationId: string;
     childConversationId: string;
-    carriedFile: FileResource | null;
+    carriedFile: FileResource;
     childConversationDataSource: DataSourceResource | null;
   }
 ): Promise<DataSourceResource | null> {
-  const shouldCopyFileToDatasource =
-    !!carriedFile &&
-    !carriedFile.useCaseMetadata?.skipDataSourceIndexing &&
-    isFileTypeUpsertableForUseCase(carriedFile);
-
-  if (!shouldCopyFileToDatasource) {
-    return childConversationDataSource;
-  }
-
   let nextChildConversationDataSource = childConversationDataSource;
 
   if (!nextChildConversationDataSource) {
@@ -458,12 +449,22 @@ async function carryOverConversationAttachments(
       continue;
     }
 
-    childConversationDataSource = await addFileToConversationDatasource(auth, {
-      parentConversationId: parentConversation.sId,
-      childConversationId: childConversation.sId,
-      carriedFile,
-      childConversationDataSource,
-    });
+    const shouldCopyFileToDatasource =
+      carriedFile !== null &&
+      !carriedFile.useCaseMetadata?.skipDataSourceIndexing &&
+      isFileTypeUpsertableForUseCase(carriedFile);
+
+    if (shouldCopyFileToDatasource) {
+      childConversationDataSource = await addFileToConversationDatasource(
+        auth,
+        {
+          parentConversationId: parentConversation.sId,
+          childConversationId: childConversation.sId,
+          carriedFile,
+          childConversationDataSource,
+        }
+      );
+    }
   }
 }
 

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -6,10 +6,16 @@ import {
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { createUserMessage } from "@app/lib/api/assistant/conversation/messages";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
+import {
+  isFileTypeUpsertableForUseCase,
+  processAndUpsertToDataSource,
+} from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -252,11 +258,13 @@ async function carryOverConversationAttachments(
 
     return isContentNodeAttachmentType(attachment);
   });
+  let childConversationDataSource: DataSourceResource | null = null;
 
   for (const attachment of directConversationAttachments) {
     let carriedAttachment:
       | ContentFragmentInputWithFileIdType
       | ContentFragmentInputWithContentNode;
+    let carriedFile: FileResource | null = null;
     let attachErrorMessage: string;
     let attachLogMetadata: Record<string, string>;
 
@@ -284,6 +292,7 @@ async function carryOverConversationAttachments(
         title: attachment.title,
         fileId: copiedFile.value.sId,
       };
+      carriedFile = copiedFile.value;
       attachErrorMessage =
         "Failed to attach copied file into forked conversation.";
       attachLogMetadata = {
@@ -323,6 +332,55 @@ async function carryOverConversationAttachments(
         },
         attachErrorMessage
       );
+
+      continue;
+    }
+
+    if (
+      carriedFile &&
+      !carriedFile.useCaseMetadata?.skipDataSourceIndexing &&
+      isFileTypeUpsertableForUseCase(carriedFile)
+    ) {
+      if (!childConversationDataSource) {
+        const childDataSourceRes =
+          await getOrCreateConversationDataSourceFromFile(auth, carriedFile);
+
+        if (childDataSourceRes.isErr()) {
+          logger.error(
+            {
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              parentConversationId: parentConversation.sId,
+              childConversationId: childConversation.sId,
+              copiedFileId: carriedFile.sId,
+              error: childDataSourceRes.error,
+            },
+            "Failed to get or create child conversation datasource for forked file."
+          );
+
+          continue;
+        }
+
+        childConversationDataSource = childDataSourceRes.value;
+      }
+
+      const upsertRes = await processAndUpsertToDataSource(
+        auth,
+        childConversationDataSource,
+        { file: carriedFile }
+      );
+
+      if (upsertRes.isErr()) {
+        logger.error(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            parentConversationId: parentConversation.sId,
+            childConversationId: childConversation.sId,
+            copiedFileId: carriedFile.sId,
+            error: upsertRes.error,
+          },
+          "Failed to seed child conversation datasource for forked file."
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24505
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

This seeds the child conversation datasource for copied fork files after they are successfully re-attached. The datasource is created lazily once per fork, reused across copied files, and skipped for files marked `skipDataSourceIndexing`.

## Risks
Blast radius: conversation branching carryover for searchable/queryable copied files
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/api/assistant/conversation/forks.test.ts pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts`