### PR TITLE
[front] feat: add `ask_user_question` to sidekick

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -317,8 +317,15 @@ export function _getSidekickGlobalAgent(
       })
     : null;
 
+  const askUserQuestionAction = sidekickContext?.mcpServerViews?.askUserQuestion
+    ? buildServerSideMCPServerConfiguration({
+        mcpServerView: sidekickContext.mcpServerViews.askUserQuestion,
+      })
+    : null;
+
   const actions = [
     ...(contextAction ? [contextAction] : []),
+    ...(askUserQuestionAction ? [askUserQuestionAction] : []),
     ...(companyDataAction ? [companyDataAction] : []),
   ];
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -179,7 +179,8 @@ Proactively make users aware that you can research internal data sources for ans
 If a question has a finite, small set of concrete choices, you MUST use the \`ask_user_question\` tool, it will display
 the options as clickable options so the user can answer in one click.
 A free text option is always included by default when using the tool, no need ot add one.
-For open-ended questions, you can still use the \`ask_user_question\` tool, by passing an empty array of \`options\` and 
+Yes/No questions MUST also go through the tool, with \`options: ["Yes", "No"]\`.
+For open-ended questions, you can still use the \`ask_user_question\` tool, by passing an empty array of \`options\` and
 letting the user reply in free text.
 
 </asking_questions>

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -49,7 +49,7 @@ Step 2: Understand the agent's workflow
 Reason about the agent based on the output of \`get_agent_config\`. Consider: goal, who interacts with it, how data flows in, what the output looks like.
 
 Step 3: Understand the user's intent for the sidekick interaction
-If it is not clear, ALWAYS ask the user for clarification.
+If it is not clear, ALWAYS ask the user for clarification. See <asking_questions> for how to ask.
 You should NEVER start building a plan until the user has clearly defined what their goal is for the interaction.
 
 Step 4: Build a plan
@@ -71,7 +71,7 @@ It is acceptable to change the plan mid-execution based on findings. Ensure to s
 
 Step 5: Execute research plan
 Do not make suggestions in this step. Those will be based on the information you have gathered.
-If you are running into ambiguity during execution, ask the user for clarification.
+If you are running into ambiguity during execution, ask the user for clarification. See <asking_questions> for how to ask.
 
 Step 6: Make suggestions (assuming this is the user's intent)
 Lead with the changes that will most affect agent behavior. Skip cosmetic fixes until fundamentals are solid.
@@ -174,12 +174,14 @@ GOOD: Jump straight to insights or suggestions based on what you found.
 
 <asking_questions>
 Only ask questions that are pinpointed to obtain the information needed to create a good suggestion.
-You should proactively make users aware that you can research internal data sources for answers.
+Proactively make users aware that you can research internal data sources for answers instead of asking.
 
-If a question has a finite, small set of concrete choices, you SHOULD use the \`ask_user_question\` tool, it will display
+If a question has a finite, small set of concrete choices, you MUST use the \`ask_user_question\` tool, it will display
 the options as clickable options so the user can answer in one click.
 A free text option is always included by default when using the tool, no need ot add one.
-For open-ended questions, omit \`options\` and let the user reply in free text.
+For open-ended questions, you can still use the \`ask_user_question\` tool, by passing an empty array of \`options\` and 
+letting the user reply in free text.
+
 </asking_questions>
 </response_style>`,
 
@@ -189,7 +191,7 @@ Each template will include a <sidekickInstructions> section which contains domai
 - <Capabilities_To_Suggest>: Tools and skills to suggest
 - <Knowledge_To_Suggest>: Knowledge to suggest
 
-First, try to answer <Business_Requirements> based on <context_guidance>. If you don't have the information, ask clarifying questions to the user ONLY on the ones that are critical to build the agent.
+First, try to answer <Business_Requirements> based on <context_guidance>. If you don't have the information, ask clarifying questions ONLY on the ones that are critical to build the agent. See <asking_questions> for how to ask.
 You may also be able to find business requirement information by following <company_data_guidance>. ALWAYS tell the user explicitly that you can research internal data sources for answers.
 
 <finding_templates>

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -178,7 +178,7 @@ Proactively make users aware that you can research internal data sources for ans
 
 If a question has a finite, small set of concrete choices, you MUST use the \`ask_user_question\` tool, it will display
 the options as clickable options so the user can answer in one click.
-A free text option is always included by default when using the tool, no need ot add one.
+A free text option is always included by default when using the tool, no need to add one.
 Yes/No questions MUST also go through the tool, with \`options: ["Yes", "No"]\`.
 For open-ended questions, you can still use the \`ask_user_question\` tool, by passing an empty array of \`options\` and
 letting the user reply in free text.

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -176,20 +176,10 @@ GOOD: Jump straight to insights or suggestions based on what you found.
 Only ask questions that are pinpointed to obtain the information needed to create a good suggestion.
 You should proactively make users aware that you can research internal data sources for answers.
 
-If a question has a finite, small set of concrete choices, you SHOULD offer them as clickable quickReply buttons so the user can answer in one click.
-NEVER mix quickReply buttons with open-ended questions in the same message. Expect users to always answer the question in one click.
-
-Format (all on one line, space-separated):
-:quickReply[Button label]{message="Exact message sent when clicked"}
-
-The \`message\` should be the exact text the user would send (so your next turn has clear intent).
-- Put quickReplies on a single line at the very end of your message.
-- NEVER add any prose, questions, or other text after the quickReply line. The quickReply line must be the last line.
-
-Examples:
-- Picking audience: :quickReply[Just me]{message="Just for me"} :quickReply[My team]{message="For my team"} :quickReply[Whole company]{message="For the whole company"}
-
-NEVER offer the quickReply button if the question is open-ended or requires multiple steps to answer. In this case, use bullet points to present the questions (3-4 max).
+If a question has a finite, small set of concrete choices, you SHOULD use the \`ask_user_question\` tool, it will display
+the options as clickable options so the user can answer in one click.
+A free text option is always included by default when using the tool, no need ot add one.
+For open-ended questions, omit \`options\` and let the user reply in free text.
 </asking_questions>
 </response_style>`,
 

--- a/front/lib/api/assistant/global_agents/sidekick_context.ts
+++ b/front/lib/api/assistant/global_agents/sidekick_context.ts
@@ -27,6 +27,7 @@ interface SidekickUserMetadata {
 export interface SidekickContext {
   mcpServerViews: {
     context: MCPServerViewResource;
+    askUserQuestion: MCPServerViewResource | null;
   } | null;
 }
 
@@ -261,13 +262,18 @@ export async function buildSidekickContext(
     return null;
   }
 
-  const context =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+  const [context, askUserQuestion] = await Promise.all([
+    MCPServerViewResource.getMCPServerViewForAutoInternalTool(
       auth,
       AGENT_SIDEKICK_CONTEXT_TOOL_NAME
-    );
+    ),
+    MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "ask_user_question"
+    ),
+  ]);
 
   return {
-    mcpServerViews: context ? { context } : null,
+    mcpServerViews: context ? { context, askUserQuestion } : null,
   };
 }

--- a/front/lib/api/assistant/global_agents/sidekick_context.ts
+++ b/front/lib/api/assistant/global_agents/sidekick_context.ts
@@ -262,16 +262,16 @@ export async function buildSidekickContext(
     return null;
   }
 
-  const [context, askUserQuestion] = await Promise.all([
-    MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+  const context =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
       auth,
       AGENT_SIDEKICK_CONTEXT_TOOL_NAME
-    ),
-    MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+    );
+  const askUserQuestion =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
       auth,
       "ask_user_question"
-    ),
-  ]);
+    );
 
   return {
     mcpServerViews: context ? { context, askUserQuestion } : null,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -287,6 +287,7 @@ export async function runModel(
   const ASK_USER_QUESTION_ALLOWED_ORIGINS: UserMessageOrigin[] = [
     "web",
     "slack",
+    "agent_sidekick",
   ];
   const filteredMcpActions = !ASK_USER_QUESTION_ALLOWED_ORIGINS.includes(
     userMessage.context.origin


### PR DESCRIPTION
## Description

- This PR replaces the use of the `quickReply` Markdown directive in favor of the `ask_user_question` tool in Sidekick.
- Goal is to deprecate `quickReply` once the onboarding conversation is also migrated.

<img width="664" height="664" alt="Screenshot 2026-04-20 at 1 43 53 PM" src="https://github.com/user-attachments/assets/ccd63417-d2f0-4d1e-8b89-08c5b108e1d7" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
