### PR TITLE
fix(project_todo): improve to_know takeaway quality and fix decided key decisions mapping

### DIFF
--- a/front/lib/project_todo/analyze_document/key_decisions.ts
+++ b/front/lib/project_todo/analyze_document/key_decisions.ts
@@ -34,8 +34,11 @@ export function buildPromptKeyDecisions(
     "(e.g., a technical approach chosen, a scope change agreed upon, a trade-off accepted).\n" +
     "- Set status to 'decided' if the decision is finalized, 'open' if it is still being deliberated.\n" +
     "- Do not include minor preferences or passing comments — only significant, consequential decisions.\n" +
-    "- In the description, mention users and agents by their name, NOT via their id or via a generic term like User, Agent or Bot.\n" +
-    "- In the description, refer to the assignee by Your pronouns (e.g., 'You', 'Your', 'Yours'), not by their name.\n" +
+    "- In the description, mention users and agents by their name, NOT via their id or " +
+    "via a generic term like User, Agent or Bot.\n" +
+    "- Write each description as an objective factual statement. Name people by their actual " +
+    "name when relevant. Do not use 'You' or 'Your' — these items are shown to all project " +
+    "members, not just one person.\n" +
     "- Include relevant_user_ids (from the project members list) for people involved in making this decision.\n\n";
   if (previousKeyDecisions.length > 0) {
     prompt +=

--- a/front/lib/project_todo/analyze_document/notable_facts.ts
+++ b/front/lib/project_todo/analyze_document/notable_facts.ts
@@ -28,13 +28,23 @@ export function buildPromptNotableFacts(
 ): string {
   let prompt =
     "Notable fact guidelines:\n" +
-    "- A notable fact is a significant piece of information shared in the document " +
-    "that is worth remembering (e.g., a decision made, a key constraint, an important context).\n" +
+    "- A notable fact is a piece of information that would change how a project member " +
+    "plans their work or makes decisions. Good examples: deadlines discovered, technical " +
+    "constraints found, dependency changes, risks identified, scope clarifications, " +
+    "important metrics or thresholds.\n" +
     "- Be concise and specific — one fact per distinct piece of information.\n" +
-    "- Do not include trivial or already widely known information.\n" +
-    "- In the description, mention users and agents by their name, NOT via their id or via a generic term like User, Agent or Bot.\n" +
-    "- In the description, refer to the assignee by Your pronouns (e.g., 'You', 'Your', 'Yours'), not by their name.\n" +
-    "- Include relevant_user_ids (from the project members list) for people this fact is relevant to or was stated by.\n\n";
+    "- Do NOT extract: casual remarks, greetings, scheduling small-talk ('I'll be 5 min late'), " +
+    "information obvious from the project description, facts already captured as action items " +
+    "or key decisions, questions that were already answered in the conversation, or " +
+    "time-sensitive facts that will be irrelevant within 24 hours (e.g., 'server is currently " +
+    "down', 'waiting for a reply').\n" +
+    "- In the description, mention users and agents by their name, NOT via their id or " +
+    "via a generic term like User, Agent or Bot.\n" +
+    "- Write each description as an objective factual statement. Name people by their actual " +
+    "name when relevant. Do not use 'You' or 'Your' — these items are shown to all project " +
+    "members, not just one person.\n" +
+    "- Include relevant_user_ids (from the project members list) for people this fact is " +
+    "relevant to or was stated by.\n\n";
   if (previousNotableFacts.length > 0) {
     prompt +=
       "The following notable facts were detected in a previous analysis of this document. " +

--- a/front/lib/project_todo/merge_into_project.test.ts
+++ b/front/lib/project_todo/merge_into_project.test.ts
@@ -99,7 +99,7 @@ describe("keyDecisionBlob", () => {
 
   it("maps decided status to done", () => {
     const blob = keyDecisionBlob(makeKeyDecision({ status: "decided" }));
-    expect(blob.status).toBe("done");
+    expect(blob.status).toBe("todo");
   });
 
   it("maps open status to todo", () => {

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -29,7 +29,7 @@
 //   actionItems  (open)    → "to_do",   status: "todo"
 //   actionItems  (done)    → "to_do",   status: "done"
 //   keyDecisions (open)    → "to_know", status: "todo"
-//   keyDecisions (decided) → "to_know", status: "done"
+//   keyDecisions (decided) → "to_know", status: "todo"
 //   notableFacts           → "to_know", status: "todo"
 
 import { getFastestWhitelistedModel } from "@app/lib/assistant";
@@ -456,7 +456,7 @@ export function keyDecisionBlob(item: TodoVersionedKeyDecision): TodoBlob {
   return {
     category: "to_know",
     text: item.shortDescription,
-    status: item.status === "decided" ? "done" : "todo",
+    status: "todo",
     doneAt: null,
   };
 }


### PR DESCRIPTION
## Description

Improves the quality of "to know" items generated by the project TODO feature:

- **Fix decided key decisions mapping**: Decided key decisions were mapped to `status: "done"`, causing them to be swept away by "Clean done". They now map to `status: "todo"` so users see them as items to acknowledge, just like notable facts.
- **Tighten notable facts prompt**: Replaced the vague "significant piece of information" guideline with concrete examples (deadlines, constraints, risks, scope clarifications) and an explicit exclusion list (casual remarks, small-talk, already-answered questions, ephemeral facts).
- **Fix pronoun instruction**: Notable facts and key decisions prompts incorrectly asked the LLM to use "You/Your" pronouns (copied from action items). Replaced with "write as an objective factual statement" since these items are shown to all project members.
- **Add temporal filtering**: Notable facts prompt now excludes time-sensitive facts that will be irrelevant within 24 hours.

## Tests


