### PR TITLE
[front] Reduce peak concurrent SQL on reaction endpoint

### DIFF
--- a/front/lib/api/assistant/reaction_update.ts
+++ b/front/lib/api/assistant/reaction_update.ts
@@ -1,0 +1,234 @@
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
+import {
+  publishAgentMessagesEvents,
+  publishMessageEventsOnMessagePostOrEdit,
+} from "@app/lib/api/assistant/streaming/events";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  CompactionMessageModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import {
+  isAgentMessageType,
+  isUserMessageType,
+} from "@app/types/assistant/conversation";
+import type { ContentFragmentType } from "@app/types/content_fragment";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { Op } from "sequelize";
+
+export type ReactionTargetMessageType =
+  | "user"
+  | "agent"
+  | "content_fragment"
+  | "compaction";
+
+/**
+ * Lightweight validation for a reaction target. Returns the kind of message
+ * behind `messageId` in the given conversation (main branch only), or `null`
+ * if the message does not exist.
+ */
+export async function getReactionTargetMessageType(
+  auth: Authenticator,
+  {
+    conversation,
+    messageId,
+  }: {
+    conversation: ConversationResource;
+    messageId: string;
+  }
+): Promise<ReactionTargetMessageType | null> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const message = await MessageModel.findOne({
+    attributes: ["id"],
+    where: {
+      sId: messageId,
+      conversationId: conversation.id,
+      workspaceId: owner.id,
+      branchId: null,
+    },
+    include: [
+      {
+        model: UserMessageModel,
+        as: "userMessage",
+        required: false,
+        attributes: ["id"],
+      },
+      {
+        model: AgentMessageModel,
+        as: "agentMessage",
+        required: false,
+        attributes: ["id"],
+      },
+      {
+        model: ContentFragmentModel,
+        as: "contentFragment",
+        required: false,
+        attributes: ["id"],
+      },
+      {
+        model: CompactionMessageModel,
+        as: "compactionMessage",
+        required: false,
+        attributes: ["id"],
+      },
+    ],
+  });
+
+  if (!message) {
+    return null;
+  }
+  if (message.compactionMessage) {
+    return "compaction";
+  }
+  if (message.agentMessage) {
+    return "agent";
+  }
+  if (message.userMessage) {
+    return "user";
+  }
+  if (message.contentFragment) {
+    return "content_fragment";
+  }
+  return null;
+}
+
+/**
+ * Render `messageId` and publish a post/edit event so listeners observe the
+ * updated reactions. Used after createMessageReaction / deleteMessageReaction
+ * to avoid loading the full conversation just to republish a single message.
+ */
+export async function publishReactionUpdate(
+  auth: Authenticator,
+  {
+    conversation,
+    messageId,
+  }: {
+    conversation: ConversationResource;
+    messageId: string;
+  }
+): Promise<Result<undefined, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const messageModel = await MessageModel.findOne({
+    where: {
+      sId: messageId,
+      conversationId: conversation.id,
+      workspaceId: owner.id,
+      branchId: null,
+    },
+    include: [
+      { model: UserMessageModel, as: "userMessage", required: false },
+      { model: AgentMessageModel, as: "agentMessage", required: false },
+      { model: ContentFragmentModel, as: "contentFragment", required: false },
+      {
+        model: CompactionMessageModel,
+        as: "compactionMessage",
+        required: false,
+      },
+    ],
+  });
+  if (!messageModel) {
+    return new Err(new Error("Message not found for reaction update."));
+  }
+
+  const renderRes = await batchRenderMessages(
+    auth,
+    conversation,
+    [messageModel],
+    "full"
+  );
+  if (renderRes.isErr()) {
+    return new Err(new Error("Failed to render message for reaction update."));
+  }
+
+  const [message] = renderRes.value;
+  if (!message) {
+    return new Err(new Error("Rendered message missing."));
+  }
+
+  const conversationJSON = conversation.toJSON();
+
+  if (isUserMessageType(message)) {
+    const contentFragments = await fetchPrecedingContentFragments(auth, {
+      conversation,
+      targetRank: message.rank,
+    });
+    await publishMessageEventsOnMessagePostOrEdit(
+      conversationJSON,
+      { ...message, contentFragments },
+      []
+    );
+    return new Ok(undefined);
+  }
+
+  if (isAgentMessageType(message)) {
+    await publishAgentMessagesEvents(conversationJSON, [message]);
+    return new Ok(undefined);
+  }
+
+  return new Err(new Error("Unexpected message type for reaction update."));
+}
+
+// Fetch the contiguous content fragments that immediately precede the given
+// rank in the conversation (main branch). Mirrors the behavior of
+// getRelatedContentFragments but avoids loading the full conversation content.
+async function fetchPrecedingContentFragments(
+  auth: Authenticator,
+  {
+    conversation,
+    targetRank,
+  }: { conversation: ConversationResource; targetRank: number }
+): Promise<ContentFragmentType[]> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const messages = await MessageModel.findAll({
+    where: {
+      conversationId: conversation.id,
+      workspaceId: owner.id,
+      branchId: null,
+      rank: { [Op.lt]: targetRank },
+    },
+    include: [
+      { model: ContentFragmentModel, as: "contentFragment", required: true },
+    ],
+    order: [
+      ["rank", "DESC"],
+      ["version", "DESC"],
+    ],
+  });
+
+  // Keep only the latest version per rank.
+  const latestPerRank = new Map<number, MessageModel>();
+  for (const m of messages) {
+    if (!latestPerRank.has(m.rank)) {
+      latestPerRank.set(m.rank, m);
+    }
+  }
+
+  const fragments = await ContentFragmentResource.batchRenderFromMessages(
+    auth,
+    {
+      conversationId: conversation.sId,
+      messages: [...latestPerRank.values()],
+    }
+  );
+
+  const related: ContentFragmentType[] = [];
+  let lastRank = targetRank;
+  for (const cf of fragments) {
+    if (cf.rank === lastRank - 1) {
+      related.push(cf);
+      lastRank = cf.rank;
+    } else {
+      break;
+    }
+  }
+  return related;
+}

--- a/front/lib/api/assistant/reaction_update.ts
+++ b/front/lib/api/assistant/reaction_update.ts
@@ -156,6 +156,11 @@ export async function publishReactionUpdate(
   const conversationJSON = conversation.toJSON();
 
   if (isUserMessageType(message)) {
+    // We reuse the post/edit event shape, whose payload is a full user message
+    // including its attached content fragments. Subscribers replace the whole
+    // message on this event, so omitting contentFragments would wipe the
+    // attachments from the UI. A dedicated `reactions_updated` event carrying
+    // just { messageId, reactions } would remove the need for this fetch.
     const contentFragments = await fetchPrecedingContentFragments(auth, {
       conversation,
       targetRank: message.rank,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.test.ts
@@ -1,0 +1,242 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  CompactionMessageModel,
+  MessageModel,
+  MessageReactionModel,
+} from "@app/lib/models/agent/conversation";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { ModelId } from "@app/types/shared/model_id";
+import { describe, expect, it } from "vitest";
+
+import handler from "./index";
+
+async function getMessageByRank(
+  auth: Authenticator,
+  conversationId: ModelId,
+  rank: number
+): Promise<MessageModel> {
+  const message = await MessageModel.findOne({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      conversationId,
+      rank,
+    },
+  });
+  if (!message) {
+    throw new Error(`No message found at rank ${rank}`);
+  }
+  return message;
+}
+
+describe("POST /api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions", () => {
+  it("creates a reaction on a user message", async () => {
+    const { req, res, auth, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+    const userMsg = await getMessageByRank(auth, conversation.id, 0);
+
+    req.query.cId = conversation.sId;
+    req.query.mId = userMsg.sId;
+    req.body = { reaction: "👍" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+
+    const reactions = await MessageReactionModel.findAll({
+      where: { workspaceId: workspace.id, messageId: userMsg.id },
+    });
+    expect(reactions).toHaveLength(1);
+    expect(reactions[0].reaction).toBe("👍");
+  });
+
+  it("creates a reaction on an agent message", async () => {
+    const { req, res, auth, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+    const agentMsg = await getMessageByRank(auth, conversation.id, 1);
+
+    req.query.cId = conversation.sId;
+    req.query.mId = agentMsg.sId;
+    req.body = { reaction: "🎉" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const reactions = await MessageReactionModel.findAll({
+      where: { workspaceId: workspace.id, messageId: agentMsg.id },
+    });
+    expect(reactions).toHaveLength(1);
+    expect(reactions[0].reaction).toBe("🎉");
+  });
+
+  it("returns 400 when the message does not exist", async () => {
+    const { req, res, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    req.query.cId = conversation.sId;
+    req.query.mId = "msg_does_not_exist";
+    req.body = { reaction: "👍" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 when reacting to a compaction message", async () => {
+    const { req, res, auth, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const compactionRow = await CompactionMessageModel.create({
+      status: "created",
+      content: null,
+      workspaceId: workspace.id,
+    });
+    const compactionMsg = await MessageModel.create({
+      sId: generateRandomModelSId(),
+      rank: 2,
+      conversationId: conversation.id,
+      compactionMessageId: compactionRow.id,
+      workspaceId: workspace.id,
+    });
+
+    req.query.cId = conversation.sId;
+    req.query.mId = compactionMsg.sId;
+    req.body = { reaction: "👍" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain("compaction");
+  });
+
+  it("returns 404 when the conversation does not exist", async () => {
+    const { req, res } = await createPrivateApiMockRequest({ method: "POST" });
+
+    req.query.cId = "conv_does_not_exist";
+    req.query.mId = "msg_whatever";
+    req.body = { reaction: "👍" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("conversation_not_found");
+  });
+
+  it("returns 400 when the reaction body is missing", async () => {
+    const { req, res, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+    const userMsg = await getMessageByRank(auth, conversation.id, 0);
+
+    req.query.cId = conversation.sId;
+    req.query.mId = userMsg.sId;
+    req.body = {};
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 405 for unsupported methods", async () => {
+    const { req, res, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+    const userMsg = await getMessageByRank(auth, conversation.id, 0);
+
+    req.query.cId = conversation.sId;
+    req.query.mId = userMsg.sId;
+    req.body = { reaction: "👍" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+});
+
+describe("DELETE /api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions", () => {
+  it("deletes an existing reaction", async () => {
+    const { req, res, auth, user, workspace } =
+      await createPrivateApiMockRequest({ method: "DELETE" });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+    const userMsg = await getMessageByRank(auth, conversation.id, 0);
+
+    await MessageReactionModel.create({
+      messageId: userMsg.id,
+      userId: user.id,
+      userContextUsername: user.username,
+      userContextFullName: user.fullName(),
+      reaction: "👍",
+      workspaceId: workspace.id,
+    });
+
+    req.query.cId = conversation.sId;
+    req.query.mId = userMsg.sId;
+    req.body = { reaction: "👍" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+
+    const reactions = await MessageReactionModel.findAll({
+      where: { workspaceId: workspace.id, messageId: userMsg.id },
+    });
+    expect(reactions).toHaveLength(0);
+  });
+
+  it("returns 400 when no matching reaction exists", async () => {
+    const { req, res, auth } = await createPrivateApiMockRequest({
+      method: "DELETE",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+    const userMsg = await getMessageByRank(auth, conversation.id, 0);
+
+    req.query.cId = conversation.sId;
+    req.query.mId = userMsg.sId;
+    req.body = { reaction: "🤷" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.test.ts
@@ -102,6 +102,39 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactio
     expect(res._getJSONData().error.type).toBe("invalid_request_error");
   });
 
+  it("returns 400 when reacting to a content fragment", async () => {
+    const { req, res, auth, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+    const contentFragmentMsg =
+      await ConversationFactory.createContentFragmentMessage({
+        auth,
+        workspace,
+        conversationId: conversation.id,
+        rank: 2,
+        title: "attachment.txt",
+      });
+
+    req.query.cId = conversation.sId;
+    req.query.mId = contentFragmentMsg.sId;
+    req.body = { reaction: "👍" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain("content fragment");
+
+    // Ensure the mutation was not persisted.
+    const reactions = await MessageReactionModel.findAll({
+      where: { workspaceId: workspace.id, messageId: contentFragmentMsg.id },
+    });
+    expect(reactions).toHaveLength(0);
+  });
+
   it("returns 400 when reacting to a compaction message", async () => {
     const { req, res, auth, workspace } = await createPrivateApiMockRequest({
       method: "POST",

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -1,33 +1,18 @@
 /** @ignoreswagger */
-import { getRelatedContentFragments } from "@app/lib/api/assistant/content_fragments";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import {
   createMessageReaction,
   deleteMessageReaction,
-  getMessagesReactions,
 } from "@app/lib/api/assistant/reaction";
 import {
-  publishAgentMessagesEvents,
-  publishMessageEventsOnMessagePostOrEdit,
-} from "@app/lib/api/assistant/streaming/events";
+  getReactionTargetMessageType,
+  publishReactionUpdate,
+} from "@app/lib/api/assistant/reaction_update";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type {
-  AgentMessageType,
-  ConversationType,
-  MessageReactionType,
-  UserMessageType,
-} from "@app/types/assistant/conversation";
-import {
-  isAgentMessageType,
-  isCompactionMessageType,
-  isProjectConversation,
-  isUserMessageType,
-} from "@app/types/assistant/conversation";
-import type { ContentFragmentType } from "@app/types/content_fragment";
+import type { MessageReactionType } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -60,31 +45,29 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const conversationRes = await getConversation(auth, conversationId);
 
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
   }
 
-  const conversation = conversationRes.value;
-
-  if (isProjectConversation(conversation)) {
-    const space = await SpaceResource.fetchById(auth, conversation.spaceId);
-    if (!space) {
-      return apiError(req, res, {
-        status_code: 404,
-        api_error: { type: "space_not_found", message: "Space not found." },
-      });
-    }
-    if (!space.isMember(auth)) {
-      return apiError(req, res, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: "You are not a member of the project.",
-        },
-      });
-    }
+  if (conversation.space && !conversation.space.isMember(auth)) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "You are not a member of the project.",
+      },
+    });
   }
 
   if (!(typeof req.query.mId === "string")) {
@@ -110,8 +93,11 @@ async function handler(
     });
   }
 
-  const message = conversation.content.flat().find((m) => m.sId === messageId);
-  if (!message) {
+  const targetKind = await getReactionTargetMessageType(auth, {
+    conversation,
+    messageId,
+  });
+  if (targetKind === null) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -120,7 +106,7 @@ async function handler(
       },
     });
   }
-  if (isCompactionMessageType(message)) {
+  if (targetKind === "compaction") {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -130,11 +116,13 @@ async function handler(
     });
   }
 
+  const conversationJSON = conversation.toJSON();
+
   switch (req.method) {
     case "POST":
       const created = await createMessageReaction(auth, {
         messageId,
-        conversation,
+        conversation: conversationJSON,
         user: user.toJSON(),
         context: {
           username: user.username,
@@ -144,7 +132,16 @@ async function handler(
       });
 
       if (created) {
-        await publishMessageUpdate(req, res, auth, { conversation, message });
+        const pubRes = await publishReactionUpdate(auth, {
+          conversation,
+          messageId,
+        });
+        if (pubRes.isErr()) {
+          logger.error(
+            { err: pubRes.error, conversationId, messageId },
+            "Failed to publish reaction update."
+          );
+        }
         res.status(200).json({ success: true });
         return;
       }
@@ -159,7 +156,7 @@ async function handler(
     case "DELETE":
       const deleted = await deleteMessageReaction(auth, {
         messageId,
-        conversation,
+        conversation: conversationJSON,
         user: user.toJSON(),
         context: {
           username: user.username,
@@ -169,7 +166,16 @@ async function handler(
       });
 
       if (deleted) {
-        await publishMessageUpdate(req, res, auth, { conversation, message });
+        const pubRes = await publishReactionUpdate(auth, {
+          conversation,
+          messageId,
+        });
+        if (pubRes.isErr()) {
+          logger.error(
+            { err: pubRes.error, conversationId, messageId },
+            "Failed to publish reaction update."
+          );
+        }
         res.status(200).json({ success: true });
         return;
       }
@@ -192,55 +198,5 @@ async function handler(
       });
   }
 }
-
-const publishMessageUpdate = async (
-  req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<
-      { reactions: MessageReactionType[] } | { success: boolean }
-    >
-  >,
-  auth: Authenticator,
-  {
-    conversation,
-    message,
-  }: {
-    conversation: ConversationType;
-    message: UserMessageType | ContentFragmentType | AgentMessageType;
-  }
-) => {
-  const reactions = await getMessagesReactions(auth, {
-    messageIds: [message.id],
-  });
-
-  if (isUserMessageType(message)) {
-    return publishMessageEventsOnMessagePostOrEdit(
-      conversation,
-      {
-        ...message,
-        contentFragments: getRelatedContentFragments(conversation, message),
-        reactions: reactions[message.id] ?? [],
-      },
-      []
-    );
-  }
-
-  if (isAgentMessageType(message)) {
-    return publishAgentMessagesEvents(conversation, [
-      {
-        ...message,
-        reactions: reactions[message.id] ?? [],
-      },
-    ]);
-  }
-
-  return apiError(req, res, {
-    status_code: 500,
-    api_error: {
-      type: "internal_server_error",
-      message: "Unexpected message type",
-    },
-  });
-};
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -115,6 +115,15 @@ async function handler(
       },
     });
   }
+  if (targetKind === "content_fragment") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Reactions are not allowed on content fragments.",
+      },
+    });
+  }
 
   const conversationJSON = conversation.toJSON();
 


### PR DESCRIPTION
## Description

The reactions endpoint was calling `getConversation`, which fully renders every message in the conversation just to find the target message and republish an event. That fans out ~15–20 concurrent SQL queries for a single reaction toggle.

Replaced with:
- `ConversationResource.fetchById` for access checks (drops a redundant `SpaceResource.fetchById`).
- `MessageModel.findOne` by `sId` for target validation.
- Post-mutation: render only the target message, and for user messages fetch only the preceding content fragments.

Peak concurrent queries drop to ~5–6.

Two behavior changes worth flagging:
- Content fragments are now explicitly rejected with 400 at the validation step. The old path accepted them, persisted the reaction, and returned 500 on publish (because the publish path doesn't handle them). No real callers in the UI.
- If the target agent message's configuration is deleted, we now persist the reaction and log a publish failure instead of 500'ing before the mutation. Endpoint returns `success: true`.

The handover parent-linkage fix this PR depended on landed as #24544.

## Tests

New endpoint tests in `index.test.ts`: POST/DELETE happy paths on user + agent messages, unknown message, compaction rejection, content-fragment rejection, unknown conversation, missing body, unsupported method, deleting a non-existent reaction. `npm run test -- reaction` passes.

## Risk

Hot path, rollback is a clean revert.

## Deploy Plan

Standard front deploy. Watch peak-concurrent SQL on this route and errors for `Failed to publish reaction update.`.