### PR TITLE
[front] Fix parentAgentMessageId fallback in batchRenderMessages

### DIFF
--- a/front/lib/api/assistant/messages.test.ts
+++ b/front/lib/api/assistant/messages.test.ts
@@ -187,6 +187,92 @@ describe("batchRenderMessages", () => {
       }
     });
 
+    it("falls back to the DB for parentAgentMessageId when the handover origin is not in the batch", async () => {
+      // Simulates an agent_handover in a single conversation:
+      //   rank 0: initial user message
+      //   rank 1: origin agent message (the handover source)
+      //   rank 2: handover user message pointing back to rank 1 by sId
+      //   rank 3: child agent message produced by the sub-agent
+      // A single-message render of rank 3 doesn't include rank 1, so the
+      // fallback has to resolve the origin from the DB.
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const originAgentMessage = await MessageModel.findOne({
+        where: {
+          conversationId: conversation.id,
+          rank: 1,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(originAgentMessage).not.toBeNull();
+
+      const handoverUserMessageRow = await UserMessageModel.create({
+        userId: auth.getNonNullableUser().id,
+        workspaceId: workspace.id,
+        content: "continue on another agent",
+        userContextUsername: "testuser",
+        userContextTimezone: "UTC",
+        userContextFullName: "Test User",
+        userContextEmail: "test@example.com",
+        userContextProfilePictureUrl: null,
+        userContextOrigin: "web",
+        clientSideMCPServerIds: [],
+        agenticMessageType: "agent_handover",
+        agenticOriginMessageId: originAgentMessage!.sId,
+      });
+      const handoverUserRow = await MessageModel.create({
+        sId: `mes_handover_user_${Date.now()}`,
+        rank: 2,
+        conversationId: conversation.id,
+        parentId: null,
+        userMessageId: handoverUserMessageRow.id,
+        workspaceId: workspace.id,
+      });
+
+      const childAgentRow =
+        await ConversationFactory.createAgentMessageWithRank({
+          workspace,
+          conversationId: conversation.id,
+          rank: 3,
+          agentConfigurationId: agentConfig.sId,
+          parentId: handoverUserRow.id,
+        });
+
+      const childAgentFull = await MessageModel.findOne({
+        where: { id: childAgentRow.id, workspaceId: workspace.id },
+        include: [
+          { model: UserMessageModel, as: "userMessage", required: false },
+          { model: AgentMessageModel, as: "agentMessage", required: false },
+        ],
+      });
+      expect(childAgentFull).not.toBeNull();
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      const result = await batchRenderMessages(
+        auth,
+        conversationResource!,
+        [childAgentFull!],
+        "full"
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const rendered = result.value.find((m) => m.type === "agent_message") as
+          | AgentMessageType
+          | undefined;
+        expect(rendered).toBeDefined();
+        expect(rendered?.parentAgentMessageId).toBe(originAgentMessage!.sId);
+      }
+    });
+
     it("should work with light view type", async () => {
       // Create a conversation with a user message and agent message
       const conversation = await ConversationFactory.create(auth, {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -655,7 +655,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       const userMessage = parentMessage.userMessage;
       assert(!!userMessage, "Parent message must be a userMessage.");
 
-      let parentAgentMessage: MessageModel | null = null;
+      let parentAgentMessage: Pick<MessageModel, "sId"> | null = null;
 
       if (
         userMessage.agenticMessageType === "agent_handover" &&
@@ -663,6 +663,19 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       ) {
         parentAgentMessage =
           messagesBySId.get(userMessage.agenticOriginMessageId) ?? null;
+
+        // Fallback to the DB when the origin message isn't in the current batch
+        // (e.g. single-message renders). For `agent_handover`, the origin
+        // always lives in the same conversation as the child, so scope by
+        // conversationId too. Only sId is needed downstream.
+        parentAgentMessage ??= await MessageModel.findOne({
+          attributes: ["sId"],
+          where: {
+            sId: userMessage.agenticOriginMessageId,
+            workspaceId: auth.getNonNullableWorkspace().id,
+            conversationId: message.conversationId,
+          },
+        });
       }
 
       const richMentions = getRichMentionsWithStatusForMessage(


### PR DESCRIPTION
## Description

`parentAgentMessage` in `batchRenderAgentMessages` is resolved only via `messagesBySId` (the in-batch map). So any caller that renders a subset of a conversation — paginated fetches, single-message renders — silently drops the handover origin linkage on `agent_handover` children, nulling `parentAgentMessageId` even when the origin exists in the DB.

Adds a DB fallback that looks up the origin by `sId`. Scoped to the workspace only, since handover origins commonly live in another conversation (`sId` is globally unique on the `message` table, so that's sufficient).

Found while splitting the reaction endpoint refactor (#24542) — that PR triggers the single-message render path. Splitting this out because the fix is independent of the reactions change and belongs in `messages.ts`, not the endpoint.

## Tests

New test in `messages.test.ts` that creates a handover agent message in one conversation pointing to an origin agent message in another conversation, renders just the child via `batchRenderMessages`, and asserts `parentAgentMessageId` is populated.

## Risk

Low. Adds one DB query per handover message when rendering a subset where the origin isn't already in the batch. Full-conversation renders are unaffected (origin is typically in the map, fallback short-circuits).

## Deploy Plan

Standard front deploy.