### PR TITLE
Add workspace_sensitivity_label_configs table

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -64,6 +64,7 @@ import {
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
 import { TagModel } from "@app/lib/models/tags";
+import { WorkspaceSensitivityLabelConfigModel } from "@app/lib/models/workspace_sensitivity_label_config";
 import { AcademyChapterVisitModel } from "@app/lib/resources/storage/models/academy_chapter_visit";
 import { AcademyQuizAttemptModel } from "@app/lib/resources/storage/models/academy_quiz_attempt";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
@@ -243,6 +244,7 @@ export function loadAllModels() {
     TakeawaysVersionModel,
     ProjectTodoTakeawaySourcesModel,
     UserProjectNotificationPreferenceModel,
+    WorkspaceSensitivityLabelConfigModel,
   ];
 }
 

--- a/front/lib/models/workspace_sensitivity_label_config.ts
+++ b/front/lib/models/workspace_sensitivity_label_config.ts
@@ -1,0 +1,61 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional } from "sequelize";
+import { DataTypes } from "sequelize";
+
+export type SensitivityLabelSourceType = "connector" | "mcp_connection";
+
+// Allowed label shapes:
+// - Microsoft: string (sensitivityLabelId GUID)
+export type MicrosoftAllowedLabel = string;
+
+export type AllowedLabel = MicrosoftAllowedLabel; // We'll add Google in the future
+
+export class WorkspaceSensitivityLabelConfigModel extends WorkspaceAwareModel<WorkspaceSensitivityLabelConfigModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  // "connector" → sourceId is the data source sId
+  // "mcp_connection" → sourceId is the internalMCPServerId
+  declare sourceType: SensitivityLabelSourceType;
+  declare sourceId: string;
+  declare allowedLabels: AllowedLabel[];
+}
+
+WorkspaceSensitivityLabelConfigModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    sourceType: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    sourceId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    allowedLabels: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+    },
+  },
+  {
+    sequelize: frontSequelize,
+    modelName: "workspace_sensitivity_label_config",
+    indexes: [
+      {
+        fields: ["workspaceId", "sourceType", "sourceId"],
+        name: "workspace_sensitivity_label_configs_workspace_id_source_type_source_id",
+      },
+    ],
+  }
+);

--- a/front/lib/models/workspace_sensitivity_label_config.ts
+++ b/front/lib/models/workspace_sensitivity_label_config.ts
@@ -54,7 +54,8 @@ WorkspaceSensitivityLabelConfigModel.init(
     indexes: [
       {
         fields: ["workspaceId", "sourceType", "sourceId"],
-        name: "workspace_sensitivity_label_configs_workspace_id_source_type_source_id",
+        name: "workspace_sensitivity_label_configs_workspace_source_idx",
+        concurrently: true,
       },
     ],
   }

--- a/front/lib/resources/workspace_sensitivity_label_config_resource.ts
+++ b/front/lib/resources/workspace_sensitivity_label_config_resource.ts
@@ -1,0 +1,100 @@
+import type { Authenticator } from "@app/lib/auth";
+import type {
+  AllowedLabel,
+  SensitivityLabelSourceType,
+} from "@app/lib/models/workspace_sensitivity_label_config";
+import { WorkspaceSensitivityLabelConfigModel } from "@app/lib/models/workspace_sensitivity_label_config";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface WorkspaceSensitivityLabelConfigResource
+  extends ReadonlyAttributesType<WorkspaceSensitivityLabelConfigModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class WorkspaceSensitivityLabelConfigResource extends BaseResource<WorkspaceSensitivityLabelConfigModel> {
+  static model: ModelStatic<WorkspaceSensitivityLabelConfigModel> =
+    WorkspaceSensitivityLabelConfigModel;
+
+  constructor(
+    model: ModelStatic<WorkspaceSensitivityLabelConfigModel>,
+    blob: Attributes<WorkspaceSensitivityLabelConfigModel>
+  ) {
+    super(WorkspaceSensitivityLabelConfigModel, blob);
+  }
+
+  static async fetchBySource(
+    auth: Authenticator,
+    {
+      sourceType,
+      sourceId,
+    }: { sourceType: SensitivityLabelSourceType; sourceId: string }
+  ): Promise<WorkspaceSensitivityLabelConfigResource | null> {
+    const workspace = auth.getNonNullableWorkspace();
+    const blob = await WorkspaceSensitivityLabelConfigModel.findOne({
+      where: { workspaceId: workspace.id, sourceType, sourceId },
+    });
+    if (!blob) {
+      return null;
+    }
+    return new WorkspaceSensitivityLabelConfigResource(
+      WorkspaceSensitivityLabelConfigModel,
+      blob.get()
+    );
+  }
+
+  static async upsert(
+    auth: Authenticator,
+    {
+      sourceType,
+      sourceId,
+      allowedLabels,
+    }: {
+      sourceType: SensitivityLabelSourceType;
+      sourceId: string;
+      allowedLabels: AllowedLabel[];
+    }
+  ): Promise<WorkspaceSensitivityLabelConfigResource> {
+    const workspace = auth.getNonNullableWorkspace();
+    await WorkspaceSensitivityLabelConfigModel.upsert({
+      workspaceId: workspace.id,
+      sourceType,
+      sourceId,
+      allowedLabels,
+    });
+    const blob = await WorkspaceSensitivityLabelConfigModel.findOne({
+      where: { workspaceId: workspace.id, sourceType, sourceId },
+    });
+    if (!blob) {
+      throw new Error("Failed to upsert WorkspaceSensitivityLabelConfig");
+    }
+    return new WorkspaceSensitivityLabelConfigResource(
+      WorkspaceSensitivityLabelConfigModel,
+      blob.get()
+    );
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<number | undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+    return new Ok(this.id);
+  }
+
+  toLogJSON() {
+    return {
+      id: this.id,
+      sourceType: this.sourceType,
+      sourceId: this.sourceId,
+    };
+  }
+}

--- a/front/migrations/db/migration_594.sql
+++ b/front/migrations/db/migration_594.sql
@@ -1,3 +1,3 @@
 -- Migration created on Apr 20, 2026
 CREATE TABLE IF NOT EXISTS "workspace_sensitivity_label_configs" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "sourceType" VARCHAR(255) NOT NULL, "sourceId" VARCHAR(255) NOT NULL, "allowedLabels" JSONB NOT NULL DEFAULT '[]', "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , PRIMARY KEY ("id"));
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "workspace_sensitivity_label_configs_workspace_id_source_type_source_id" ON "workspace_sensitivity_label_configs" ("workspaceId", "sourceType", "sourceId");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "workspace_sensitivity_label_configs_workspace_source_idx" ON "workspace_sensitivity_label_configs" ("workspaceId", "sourceType", "sourceId");

--- a/front/migrations/db/migration_594.sql
+++ b/front/migrations/db/migration_594.sql
@@ -1,0 +1,3 @@
+-- Migration created on Apr 20, 2026
+CREATE TABLE IF NOT EXISTS "workspace_sensitivity_label_configs" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "sourceType" VARCHAR(255) NOT NULL, "sourceId" VARCHAR(255) NOT NULL, "allowedLabels" JSONB NOT NULL DEFAULT '[]', "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , PRIMARY KEY ("id"));
+CREATE INDEX CONCURRENTLY "workspace_sensitivity_label_configs_workspace_id_source_type_source_id" ON "workspace_sensitivity_label_configs" ("workspaceId", "sourceType", "sourceId");

--- a/front/migrations/db/migration_594.sql
+++ b/front/migrations/db/migration_594.sql
@@ -1,3 +1,3 @@
 -- Migration created on Apr 20, 2026
 CREATE TABLE IF NOT EXISTS "workspace_sensitivity_label_configs" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "sourceType" VARCHAR(255) NOT NULL, "sourceId" VARCHAR(255) NOT NULL, "allowedLabels" JSONB NOT NULL DEFAULT '[]', "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , PRIMARY KEY ("id"));
-CREATE INDEX CONCURRENTLY "workspace_sensitivity_label_configs_workspace_id_source_type_source_id" ON "workspace_sensitivity_label_configs" ("workspaceId", "sourceType", "sourceId");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "workspace_sensitivity_label_configs_workspace_id_source_type_source_id" ON "workspace_sensitivity_label_configs" ("workspaceId", "sourceType", "sourceId");


### PR DESCRIPTION
## Description

Adds database infrastructure to store workspace-level sensitivity label filtering configurations. This table supports the broader initiative to allow admins to whitelist allowed Microsoft/Google sensitivity labels (GUIDs) for connectors and MCP connections, preventing high-sensitivity documents from being synced to Dust. The configuration is stored per workspace and per source (identified by `sourceType` and `sourceId`), where `sourceType` can be either `connector` (for data sources) or `mcp_connection` (for MCP server connections), and `sourceId` is the corresponding data source sId or internal MCP server ID.

## Tests

Manual testing of migration and model creation. No functional changes yet as this only adds the table structure.

## Risk

New database table and model. The danger bot warns that this model should be included in workspace/space deletion workflow to avoid crashing temporal.

## Deploy Plan

1. Apply migration first to create the `workspace_sensitivity_label_configs` table
2. Deploy front