### PR TITLE
[slack] update slack personal tool description to pass correct slack id

### DIFF
--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -93,9 +93,9 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       to: z
         .union([z.string(), z.string().array().min(2)])
         .describe(
-          "Use a string to post to a channel (name or ID) or a single user (user ID for DM). " +
-            "Use an array of at least 2 user IDs to create a group DM (e.g. ['U123', 'U456']). " +
-            "Arrays only support user IDs, not channel names or IDs."
+          "Use a string to post to a channel (name or ID) or a single user (Slack user ID for DM). " +
+            "Use an array of at least 2 Slack user IDs to create a group DM (e.g. ['U123', 'U456']). " +
+            "Arrays only support Slack user IDs, not channel names or IDs."
         ),
       message: z
         .string()
@@ -157,19 +157,20 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     },
   },
   search_user: {
-    description: `Search for a Slack user by user ID or email address.
+    description: `Search for a Slack user by Slack user ID or email address.
 
 Query parameter accepts:
 - User ID (e.g., 'U01234ABCD') - instant lookup
 - Email address (e.g., 'user@company.com') - instant lookup
 
-If you only have a user's first name or partial information, ask the user to provide their email address or user ID instead of using search_all=true.
+This tool can be used to find the Slack user ID (starts with U, e.g. U01234ABCD) based on the user's email address.
+If you only have a user's first name or partial information, ask the user to provide their email address or Slack user ID instead of using search_all=true.
 
 The search_all parameter should only be set to true if the user explicitly requests to search all workspace users. This operation is slow on large workspaces and should be avoided unless specifically requested.`,
     schema: {
       query: z
         .string()
-        .describe("User ID (e.g., 'U01234ABCD'), email address, or user name"),
+        .describe("Slack user ID (e.g., 'U01234ABCD'), email address, or user name"),
       search_all: z
         .boolean()
         .optional()
@@ -230,7 +231,7 @@ Set search_all=true only if the user explicitly requests to search all public wo
       channel: z
         .string()
         .describe(
-          "The channel name, channel ID, or user ID to list threads for. Supports public channels, private channels, and DMs."
+          "The channel name, channel ID, or Slack user ID to list threads for. Supports public channels, private channels, and DMs."
         ),
       relativeTimeFrame: z
         .string()
@@ -255,7 +256,7 @@ Set search_all=true only if the user explicitly requests to search all public wo
       channel: z
         .string()
         .describe(
-          "Channel name, channel ID, or user ID where the thread is located. Supports public channels, private channels, and DMs."
+          "Channel name, channel ID, or Slack user ID where the thread is located. Supports public channels, private channels, and DMs."
         ),
       threadTs: z
         .string()
@@ -437,7 +438,7 @@ Set search_all=true only if the user explicitly requests to search all public wo
         .array()
         .min(1)
         .describe(
-          "Array of Slack user IDs to invite (e.g. ['U01234ABCD', 'U56789EFGH']). Use search_user to find user IDs."
+          "Array of Slack user IDs to invite (e.g. ['U01234ABCD', 'U56789EFGH']). Use search_user to find Slack user IDs."
         ),
     },
     stake: "high",
@@ -481,8 +482,8 @@ export const SLACK_PERSONAL_SERVER = {
     instructions:
       "When posting a message on Slack, you MUST use standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*, `code`). " +
       "Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
-      "IMPORTANT: All user-related parameters (usersFrom, usersTo, usersMentioned, user IDs in post_message, etc.) require Slack user IDs (e.g., 'U01234ABCD'), NOT Dust user IDs. Use the search_user tool to find Slack user IDs when needed.\n" +
-      "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the channel name, or <#CHANNEL_ID> where CHANNEL_ID is the channel ID."
+      "IMPORTANT: if you want to mention a user, you must use <@USER_ID> where USER_ID is the Slack ID (e.g., 'U01234ABCD') of the user you want to mention.\n" +
+      "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the channel name, or <#CHANNEL_ID> where CHANNEL_ID is the channel ID.",
   },
   tools: Object.values(SLACK_PERSONAL_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -18,21 +18,21 @@ const commonSearchParams = {
     .array()
     .optional()
     .describe(
-      "Narrow the search to messages wrote by specific users ids (optional)"
+      "Narrow the search to messages written by specific Slack user IDs (e.g., 'U01234ABCD'). Use the search_user tool to find Slack user IDs if needed (optional)"
     ),
   usersTo: z
     .string()
     .array()
     .optional()
     .describe(
-      "Narrow the search to direct messages sent to specific user IDs (optional)"
+      "Narrow the search to direct messages sent to specific Slack user IDs (e.g., 'U01234ABCD'). Use the search_user tool to find Slack user IDs if needed (optional)"
     ),
   usersMentioned: z
     .string()
     .array()
     .optional()
     .describe(
-      "Narrow the search to messages mentioning specific users ids (optional)"
+      "Narrow the search to messages mentioning specific Slack user IDs (e.g., 'U01234ABCD'). Use the search_user tool to find Slack user IDs if needed (optional)"
     ),
   relativeTimeFrame: z
     .string()

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -481,8 +481,8 @@ export const SLACK_PERSONAL_SERVER = {
     instructions:
       "When posting a message on Slack, you MUST use standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*, `code`). " +
       "Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
-      "IMPORTANT: if you want to mention a user, you must use <@USER_ID> where USER_ID is the id of the user you want to mention.\n" +
-      "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the channel name, or <#CHANNEL_ID> where CHANNEL_ID is the channel ID.",
+      "IMPORTANT: All user-related parameters (usersFrom, usersTo, usersMentioned, user IDs in post_message, etc.) require Slack user IDs (e.g., 'U01234ABCD'), NOT Dust user IDs. Use the search_user tool to find Slack user IDs when needed.\n" +
+      "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the channel name, or <#CHANNEL_ID> where CHANNEL_ID is the channel ID."
   },
   tools: Object.values(SLACK_PERSONAL_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -170,7 +170,9 @@ The search_all parameter should only be set to true if the user explicitly reque
     schema: {
       query: z
         .string()
-        .describe("Slack user ID (e.g., 'U01234ABCD'), email address, or user name"),
+        .describe(
+          "Slack user ID (e.g., 'U01234ABCD'), email address, or user name"
+        ),
       search_all: z
         .boolean()
         .optional()

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -315,13 +315,13 @@ function buildSlackSearchQuery(
       .join(" ")}`;
   }
   if (usersFrom && usersFrom.length > 0) {
-    query = `${query} ${usersFrom.map((user) => `from:${user}`).join(" ")}`;
+    query = `${query} ${usersFrom.map((user) => `from:<@${user}>`).join(" ")}`;
   }
   if (usersTo && usersTo.length > 0) {
-    query = `${query} ${usersTo.map((user) => `to:${user}`).join(" ")}`;
+    query = `${query} ${usersTo.map((user) => `to:<@${user}>`).join(" ")}`;
   }
   if (usersMentioned && usersMentioned.length > 0) {
-    query = `${query} ${usersMentioned.map((user) => `${user}`).join(" ")}`;
+    query = `${query} ${usersMentioned.map((user) => `<@${user}>`).join(" ")}`;
   }
   return query;
 }

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -284,6 +284,14 @@ function buildSearchResults<T>(
   );
 }
 
+// Best-effort detection of Slack user IDs (U* or W* for enterprise grid).
+// When matched, wraps as <@ID> which is the format Slack search expects.
+// Non-matching values (e.g. bot names like "slackbot") are passed through as-is.
+const SLACK_USER_ID_RE = /^[UW][A-Z0-9]+$/;
+function formatUserRef(user: string): string {
+  return SLACK_USER_ID_RE.test(user) ? `<@${user}>` : user;
+}
+
 function buildSlackSearchQuery(
   initial: string,
   {
@@ -315,13 +323,13 @@ function buildSlackSearchQuery(
       .join(" ")}`;
   }
   if (usersFrom && usersFrom.length > 0) {
-    query = `${query} ${usersFrom.map((user) => `from:<@${user}>`).join(" ")}`;
+    query = `${query} ${usersFrom.map((user) => `from:${formatUserRef(user)}`).join(" ")}`;
   }
   if (usersTo && usersTo.length > 0) {
-    query = `${query} ${usersTo.map((user) => `to:<@${user}>`).join(" ")}`;
+    query = `${query} ${usersTo.map((user) => `to:${formatUserRef(user)}`).join(" ")}`;
   }
   if (usersMentioned && usersMentioned.length > 0) {
-    query = `${query} ${usersMentioned.map((user) => `<@${user}>`).join(" ")}`;
+    query = `${query} ${usersMentioned.map((user) => formatUserRef(user)).join(" ")}`;
   }
   return query;
 }


### PR DESCRIPTION
## Description
This PR is aim to avoid using dust sId when the model uses Slack tool (e.g. search in usersFrom). We noticed that sometimes the model search users to find out slack id, and sometimes it doesn't, and we end up using Dust sId in a post message or search tool (example here, it's using my Dust sId: https://dust4ai.slack.com/archives/C050SM8NSPK/p1776242792097799?thread_ts=1776242758.921809&cid=C050SM8NSPK)    

We thought about rejecting a call if it has wrong user ID format, but it accepts slack username in usersFrom, so we only update the description. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
will test it on front edge
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
