### PR TITLE
feat: first iteration of animation of the TODO diff

### DIFF
--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -2,6 +2,7 @@ import { useAppRouter } from "@app/lib/platform";
 import {
   useCleanDoneProjectTodos,
   useDeleteProjectTodo,
+  useMarkProjectTodosAsRead,
   useProjectTodos,
   useUpdateProjectTodo,
 } from "@app/lib/swr/projects";
@@ -30,11 +31,54 @@ import {
   SquareIcon,
   Tooltip,
   TrashIcon,
+  TypingAnimation,
   WindIcon,
 } from "@dust-tt/sparkle";
 import { AnimatePresence, motion } from "framer-motion";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
+
+// Total duration of the "what's new" diff animation when a user returns to a
+// project with unread changes. Matches the playground feel.
+const ANIMATION_MS = 600;
+
+// Delay between first paint (page fully loaded with the "before" state showing)
+// and the start of the diff animation. Gives the user a beat to register the
+// current state before changes animate in.
+const DIFF_ANIMATION_START_DELAY_MS = 1_000;
+
+type TodoDiffState = "added" | "text-changed" | "to-done" | "unchanged";
+
+function computeProjectTodoDiff(
+  previousTodos: ProjectTodoType[],
+  currentTodos: ProjectTodoType[]
+): Map<string, TodoDiffState> {
+  const previousBySId = new Map<string, ProjectTodoType>();
+  for (const todo of previousTodos) {
+    previousBySId.set(todo.sId, todo);
+  }
+
+  const diff = new Map<string, TodoDiffState>();
+  for (const todo of currentTodos) {
+    const previous = previousBySId.get(todo.sId);
+    if (!previous) {
+      diff.set(todo.sId, "added");
+      continue;
+    }
+    // Status → done takes priority over text changes so we animate the checkbox
+    // without competing with the typing animation on the same item.
+    if (previous.status !== "done" && todo.status === "done") {
+      diff.set(todo.sId, "to-done");
+      continue;
+    }
+    if (previous.text !== todo.text) {
+      diff.set(todo.sId, "text-changed");
+      continue;
+    }
+    diff.set(todo.sId, "unchanged");
+  }
+  return diff;
+}
 
 // ── Category display configuration ────────────────────────────────────────────
 
@@ -353,6 +397,9 @@ interface EditableTodoItemProps {
   onToggleDone: (todo: ProjectTodoType) => void;
   onDelete: (todo: ProjectTodoType) => void;
   owner: LightWorkspaceType;
+  isEntering?: boolean;
+  isTypingText?: boolean;
+  isAutoChecked?: boolean;
 }
 
 function EditableTodoItem({
@@ -360,8 +407,28 @@ function EditableTodoItem({
   onToggleDone,
   onDelete,
   owner,
+  isEntering = false,
+  isTypingText = false,
+  isAutoChecked = false,
 }: EditableTodoItemProps) {
-  const isDone = todo.status === "done";
+  const realIsDone = todo.status === "done";
+  // When an item is transitioning to "done" as part of the diff animation, we
+  // start unchecked and flip to checked after a short delay so the checkbox
+  // animates visibly. For all other items the value tracks the todo directly.
+  const [displayedChecked, setDisplayedChecked] = useState(
+    isAutoChecked ? false : realIsDone
+  );
+
+  useEffect(() => {
+    if (!isAutoChecked) {
+      setDisplayedChecked(realIsDone);
+      return;
+    }
+    const timer = window.setTimeout(() => setDisplayedChecked(true), 150);
+    return () => window.clearTimeout(timer);
+  }, [isAutoChecked, realIsDone]);
+
+  const isDone = isAutoChecked ? displayedChecked : realIsDone;
 
   const handleToggle = () => {
     onToggleDone(todo);
@@ -370,7 +437,9 @@ function EditableTodoItem({
   return (
     <motion.li
       layout
-      initial={{ opacity: 1, height: "auto" }}
+      initial={
+        isEntering ? { opacity: 0, height: 0 } : { opacity: 1, height: "auto" }
+      }
       animate={{ opacity: 1, height: "auto" }}
       exit={{
         opacity: 0,
@@ -404,7 +473,11 @@ function EditableTodoItem({
               : "text-foreground dark:text-foreground-night"
           )}
         >
-          {todo.text}
+          {isTypingText ? (
+            <TypingAnimation text={todo.text} duration={16} />
+          ) : (
+            todo.text
+          )}
         </span>
         <TodoSources sources={todo.sources} owner={owner} isDone={isDone} />
       </button>
@@ -428,13 +501,16 @@ function EditableProjectTodosPanel({
   owner: LightWorkspaceType;
   spaceId: string;
 }) {
-  const { todos, isTodosLoading, mutateTodos } = useProjectTodos({
-    owner,
-    spaceId,
-  });
+  const { todos, previousTodos, isTodosLoading, mutateTodos } = useProjectTodos(
+    {
+      owner,
+      spaceId,
+    }
+  );
   const doUpdate = useUpdateProjectTodo({ owner, spaceId });
   const doDelete = useDeleteProjectTodo({ owner, spaceId });
   const doCleanDone = useCleanDoneProjectTodos({ owner, spaceId });
+  const markAsRead = useMarkProjectTodosAsRead({ owner, spaceId });
 
   // Tracks todos being animated out during a clean operation.
   const [pendingRemovalIds, setPendingRemovalIds] = useState<Set<string>>(
@@ -442,18 +518,98 @@ function EditableProjectTodosPanel({
   );
   const [isCleaning, setIsCleaning] = useState(false);
 
+  // "What's new" diff animation state. Populated once on mount if the previous
+  // snapshot differs from the current one; cleared after ANIMATION_MS so later
+  // user interactions animate normally.
+  const [displayedTodos, setDisplayedTodos] = useState<
+    ProjectTodoType[] | null
+  >(null);
+  const [enteringKeys, setEnteringKeys] = useState<Set<string>>(new Set());
+  const [typingKeys, setTypingKeys] = useState<Set<string>>(new Set());
+  const [autoCheckedKeys, setAutoCheckedKeys] = useState<Set<string>>(
+    new Set()
+  );
+  const hasStartedDiffAnimationRef = useRef(false);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: diff animation must run once on mount only; re-running on todos/previousTodos/markAsRead changes would replay the animation after user interactions.
+  useEffect(() => {
+    if (hasStartedDiffAnimationRef.current) {
+      return;
+    }
+    if (isTodosLoading) {
+      return;
+    }
+    hasStartedDiffAnimationRef.current = true;
+
+    // Fire-and-forget mark-as-read: silent infrastructure, no notifications.
+    void markAsRead();
+
+    if (!previousTodos) {
+      return;
+    }
+
+    const diff = computeProjectTodoDiff(previousTodos, todos);
+    const hasChanges = Array.from(diff.values()).some((v) => v !== "unchanged");
+    if (!hasChanges) {
+      return;
+    }
+
+    // Render the "before" state first, then swap to the current state on the
+    // next frame so framer-motion picks up the transition.
+    setDisplayedTodos(previousTodos);
+
+    const added = new Set<string>();
+    const textChanged = new Set<string>();
+    const toDone = new Set<string>();
+    for (const [sId, state] of diff) {
+      if (state === "added") {
+        added.add(sId);
+      } else if (state === "text-changed") {
+        textChanged.add(sId);
+      } else if (state === "to-done") {
+        toDone.add(sId);
+      }
+    }
+
+    // Hold the "before" state for a moment so the page is visibly settled
+    // before the animation kicks in, then swap to the current state.
+    const startId = window.setTimeout(() => {
+      setDisplayedTodos(null);
+      setEnteringKeys(added);
+      setTypingKeys(textChanged);
+      setAutoCheckedKeys(toDone);
+    }, DIFF_ANIMATION_START_DELAY_MS);
+
+    const clearId = window.setTimeout(() => {
+      setEnteringKeys(new Set());
+      setTypingKeys(new Set());
+      setAutoCheckedKeys(new Set());
+    }, DIFF_ANIMATION_START_DELAY_MS + ANIMATION_MS);
+
+    return () => {
+      window.clearTimeout(startId);
+      window.clearTimeout(clearId);
+    };
+  }, [isTodosLoading]);
+
   const hasDoneItems = todos.some((t) => t.status === "done");
 
-  const { todosByCategory, activeSections } = groupTodosByCategory(todos);
+  const todosToRender = displayedTodos ?? todos;
+  const { todosByCategory, activeSections } =
+    groupTodosByCategory(todosToRender);
 
   // Optimistically update a todo's status in the SWR cache and send the PATCH.
   // On failure the cache is revalidated from the server.
   const handleSetStatus = useCallback(
     async (todo: ProjectTodoType, status: ProjectTodoStatus) => {
-      const optimistic = (prev: GetProjectTodosResponseBody | undefined) => ({
+      const optimistic = (
+        prev: GetProjectTodosResponseBody | undefined
+      ): GetProjectTodosResponseBody => ({
         todos: (prev?.todos ?? []).map((t) =>
           t.sId === todo.sId ? { ...t, status } : t
         ),
+        previousTodos: prev?.previousTodos ?? null,
+        previousLastReadAt: prev?.previousLastReadAt ?? null,
       });
 
       void mutateTodos(optimistic, { revalidate: false });
@@ -619,6 +775,9 @@ function EditableProjectTodosPanel({
                         onToggleDone={handleToggleDone}
                         onDelete={handleDelete}
                         owner={owner}
+                        isEntering={enteringKeys.has(todo.sId)}
+                        isTypingText={typingKeys.has(todo.sId)}
+                        isAutoChecked={autoCheckedKeys.has(todo.sId)}
                       />
                     ))}
                   </AnimatePresence>

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -234,6 +234,101 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
   }
 
+  // Reconstructs the list of todos as they existed at `timestamp` for a given
+  // (space, user) pair. For each main row created `<= timestamp`, we pick the
+  // earliest version row with `createdAt > timestamp` as the snapshot at that
+  // time; if no such version exists, the current row is itself the state at
+  // `timestamp`. Rows whose reconstructed state is already deleted or cleaned
+  // are filtered out. Results are not persisted — resources are built directly
+  // from the reconstructed attribute blobs.
+  static async fetchLatestBySpaceForUserAtTimestamp(
+    auth: Authenticator,
+    {
+      spaceId,
+      userId,
+      timestamp,
+    }: { spaceId: ModelId; userId: ModelId; timestamp: Date }
+  ): Promise<ProjectTodoResource[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    // Step 1: fetch candidate main rows — includes currently deleted / cleaned
+    // todos, because they may have been live at `timestamp`. Bypasses the
+    // baseFetch filters intentionally.
+    const mainRows = await ProjectTodoModel.findAll({
+      where: {
+        workspaceId,
+        spaceId,
+        userId,
+        createdAt: { [Op.lte]: timestamp },
+      },
+      order: [["createdAt", "DESC"]],
+    });
+
+    if (mainRows.length === 0) {
+      return [];
+    }
+
+    // Step 2: fetch all versions whose `createdAt > timestamp` for these todos.
+    // The earliest such version per todo holds the snapshot at `timestamp`.
+    const mainIds = mainRows.map((r) => r.id);
+    const versionWhere: WhereOptions<ProjectTodoVersionModel> = {
+      workspaceId,
+      projectTodoId: { [Op.in]: mainIds },
+      createdAt: { [Op.gt]: timestamp },
+    };
+    const laterVersions = await ProjectTodoVersionModel.findAll({
+      where: versionWhere,
+      order: [["createdAt", "ASC"]],
+    });
+
+    const earliestVersionByTodoId = new Map<ModelId, ProjectTodoVersionModel>();
+    for (const version of laterVersions) {
+      if (!earliestVersionByTodoId.has(version.projectTodoId)) {
+        earliestVersionByTodoId.set(version.projectTodoId, version);
+      }
+    }
+
+    // Step 3: build reconstructed attribute blobs.
+    const reconstructed: ProjectTodoResource[] = [];
+    for (const row of mainRows) {
+      const snapshot = earliestVersionByTodoId.get(row.id);
+
+      if (snapshot) {
+        // Use the version snapshot — but keep the main row's id and createdAt
+        // so the reconstructed resource is keyed by the logical todo identity.
+        const rowAttrs = row.get();
+        const snapshotAttrs = snapshot.get();
+        const blob: Attributes<ProjectTodoModel> = {
+          ...rowAttrs,
+          category: snapshotAttrs.category,
+          text: snapshotAttrs.text,
+          status: snapshotAttrs.status,
+          doneAt: snapshotAttrs.doneAt,
+          actorRationale: snapshotAttrs.actorRationale,
+          markedAsDoneByType: snapshotAttrs.markedAsDoneByType,
+          markedAsDoneByUserId: snapshotAttrs.markedAsDoneByUserId,
+          markedAsDoneByAgentConfigurationId:
+            snapshotAttrs.markedAsDoneByAgentConfigurationId,
+          deletedAt: snapshotAttrs.deletedAt,
+          cleanedAt: snapshotAttrs.cleanedAt,
+        };
+        if (blob.deletedAt !== null || blob.cleanedAt !== null) {
+          continue;
+        }
+        reconstructed.push(new this(ProjectTodoModel, blob));
+      } else {
+        // No version created after `timestamp` → the current row is the state
+        // at `timestamp`. Drop it if it is now deleted or cleaned.
+        if (row.deletedAt !== null || row.cleanedAt !== null) {
+          continue;
+        }
+        reconstructed.push(new this(ProjectTodoModel, row.get()));
+      }
+    }
+
+    return reconstructed;
+  }
+
   // Batch variant: fetches the current todo row for each sourceId in one pass.
   // Returns a map from `${sourceId}:${userId}` to the matching ProjectTodoResource.
   static async fetchBySourceIds(

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -13,6 +13,7 @@ import type {
 import type { PatchProjectTodoResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index";
 import type { PostCleanDoneTodosResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/clean";
 import type { GetProjectTodosResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index";
+import type { PostMarkProjectTodosReadResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/mark-read";
 import type { CheckNameResponseBody } from "@app/pages/api/w/[wId]/spaces/check-name";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
 import type {
@@ -336,9 +337,38 @@ export function useProjectTodos({
 
   return {
     todos: data?.todos ?? [],
+    previousTodos: data?.previousTodos ?? null,
+    previousLastReadAt: data?.previousLastReadAt ?? null,
     isTodosLoading: !disabled && !error && !data,
     isTodosError: !!error,
     mutateTodos: mutate,
+  };
+}
+
+export function useMarkProjectTodosAsRead({
+  owner,
+  spaceId,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+}) {
+  return async (): Promise<Result<{ lastReadAt: string }, Error>> => {
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/spaces/${spaceId}/project_todos/mark-read`,
+        { method: "POST" }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        return new Err(new Error(errorData.message));
+      }
+
+      const data: PostMarkProjectTodosReadResponseBody = await res.json();
+      return new Ok({ lastReadAt: data.lastReadAt });
+    } catch (e) {
+      return new Err(normalizeError(e));
+    }
   };
 }
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
@@ -3,14 +3,38 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { ProjectTodoStateResource } from "@app/lib/resources/project_todo_state_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { ProjectTodoType } from "@app/types/project_todo";
+import type {
+  ProjectTodoSourceInfo,
+  ProjectTodoType,
+} from "@app/types/project_todo";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export interface GetProjectTodosResponseBody {
   todos: ProjectTodoType[];
+  previousTodos: ProjectTodoType[] | null;
+  previousLastReadAt: string | null;
+}
+
+function enrichWithSources(
+  todos: ProjectTodoResource[],
+  sourcesByTodoId: Map<string, ProjectTodoSourceInfo[]>
+): ProjectTodoType[] {
+  return todos.map((t) => {
+    const sources = sourcesByTodoId.get(t.sId) ?? [];
+    return {
+      ...t.toJSON(),
+      sources: sources.map((s) => ({
+        sourceType: s.sourceType,
+        sourceId: s.sourceId,
+        sourceTitle: s.sourceTitle,
+        sourceUrl: s.sourceUrl,
+      })),
+    };
+  });
 }
 
 async function handler(
@@ -35,31 +59,43 @@ async function handler(
         spaceId: space.id,
       });
 
-      const todoIds = todos.map((t) => t.sId);
+      // Reconstruct the state as it was at the user's last visit.
+      const state = await ProjectTodoStateResource.fetchBySpace(auth, {
+        spaceId: space.id,
+      });
 
-      // Fetch sources for all todos (across all version rows).
+      const previous = state
+        ? await ProjectTodoResource.fetchLatestBySpaceForUserAtTimestamp(auth, {
+            spaceId: space.id,
+            userId: auth.getNonNullableUser().id,
+            timestamp: state.lastReadAt,
+          })
+        : null;
+
+      // Fetch sources for all todos, past and present, in one query.
+      const allSIds = [
+        ...new Set([
+          ...todos.map((t) => t.sId),
+          ...(previous?.map((t) => t.sId) ?? []),
+        ]),
+      ];
       const sourcesByTodoId = await ProjectTodoResource.fetchSourcesForTodoIds(
         auth,
         {
-          sIds: todoIds,
+          sIds: allSIds,
         }
       );
 
-      // Combine todo data with enriched sources.
-      const todosWithSources: ProjectTodoType[] = todos.map((t) => {
-        const sources = sourcesByTodoId.get(t.sId) ?? [];
-        return {
-          ...t.toJSON(),
-          sources: sources.map((s) => ({
-            sourceType: s.sourceType,
-            sourceId: s.sourceId,
-            sourceTitle: s.sourceTitle,
-            sourceUrl: s.sourceUrl,
-          })),
-        };
-      });
+      const todosWithSources = enrichWithSources(todos, sourcesByTodoId);
+      const previousTodos = previous
+        ? enrichWithSources(previous, sourcesByTodoId)
+        : null;
 
-      return res.status(200).json({ todos: todosWithSources });
+      return res.status(200).json({
+        todos: todosWithSources,
+        previousTodos,
+        previousLastReadAt: state ? state.lastReadAt.toISOString() : null,
+      });
     }
 
     default:

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/mark-read.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/mark-read.ts
@@ -1,0 +1,59 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectTodoStateResource } from "@app/lib/resources/project_todo_state_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export interface PostMarkProjectTodosReadResponseBody {
+  lastReadAt: string;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PostMarkProjectTodosReadResponseBody>
+  >,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  if (!space.isProject()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Todos are only available for project spaces.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const lastReadAt = new Date();
+      await ProjectTodoStateResource.upsertBySpace(auth, {
+        spaceId: space.id,
+        lastReadAt,
+      });
+
+      return res.status(200).json({ lastReadAt: lastReadAt.toISOString() });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanRead: true },
+  })
+);

--- a/front/scripts/dev/seed_project_todos.ts
+++ b/front/scripts/dev/seed_project_todos.ts
@@ -1,8 +1,18 @@
 import { Authenticator } from "@app/lib/auth";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { ProjectTodoStateResource } from "@app/lib/resources/project_todo_state_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { makeScript } from "@app/scripts/helpers";
+
+// Matches the backend reconstruction precision: `createdAt > lastReadAt`. Sleep
+// at least this long before applying diff-wave changes so their versions land
+// strictly after the recorded lastReadAt timestamp.
+const LAST_READ_BUFFER_MS = 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 const SEED_TODOS = [
   // Current version, in progress.
@@ -72,8 +82,15 @@ makeScript(
       demandOption: true,
       description: "User sId.",
     },
+    withUnreadDiff: {
+      alias: "u",
+      type: "boolean" as const,
+      default: false,
+      description:
+        "After the base seed, mark todos as read then apply a second wave of changes to produce a visible diff on next open.",
+    },
   },
-  async ({ execute, workspaceId, spaceId, userId }, logger) => {
+  async ({ execute, workspaceId, spaceId, userId, withUnreadDiff }, logger) => {
     const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
     const space = await SpaceResource.fetchById(auth, spaceId);
@@ -173,5 +190,108 @@ makeScript(
     }
 
     logger.info({ count: SEED_TODOS.length }, "Done seeding project todos.");
+
+    if (!withUnreadDiff) {
+      return;
+    }
+
+    // ── Second wave: simulate an "unread diff" the user will see animated. ──
+
+    // upsertBySpace needs a user-scoped authenticator since it keys state per
+    // (workspace, space, user).
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      userId,
+      workspaceId
+    );
+
+    await ProjectTodoStateResource.upsertBySpace(userAuth, {
+      spaceId: space.id,
+      lastReadAt: new Date(),
+    });
+    logger.info(
+      { lastReadAt: new Date().toISOString() },
+      "Marked project todos as read."
+    );
+
+    // Sleep so every subsequent version lands with `createdAt > lastReadAt`.
+    await sleep(LAST_READ_BUFFER_MS);
+
+    // (a) Create brand-new todos → will animate as "added". One of them starts
+    // in "done" state so we can see a freshly-added, already-checked item.
+    const newTodoSeeds = [
+      { text: "Schedule Q4 planning kickoff", status: "todo" as const },
+      {
+        text: "Collect feedback on the new onboarding flow",
+        status: "todo" as const,
+      },
+      {
+        text: "Archive the retired beta landing page",
+        status: "done" as const,
+      },
+    ];
+    const newTodoTexts = newTodoSeeds.map((s) => s.text);
+    for (const seed of newTodoSeeds) {
+      const isDone = seed.status === "done";
+      await ProjectTodoResource.makeNew(auth, {
+        spaceId: space.id,
+        userId: user.id,
+        createdByType: "user",
+        createdByUserId: user.id,
+        createdByAgentConfigurationId: null,
+        markedAsDoneByType: isDone ? "user" : null,
+        markedAsDoneByUserId: isDone ? user.id : null,
+        markedAsDoneByAgentConfigurationId: null,
+        category: "to_do",
+        text: seed.text,
+        status: seed.status,
+        doneAt: isDone ? new Date() : null,
+        actorRationale: null,
+      });
+      logger.info(
+        { text: seed.text, status: seed.status },
+        "Diff wave: created new todo."
+      );
+    }
+
+    // Reload the current state so we can pick live todos for the other cases.
+    const current = await ProjectTodoResource.fetchLatestBySpaceForUser(auth, {
+      spaceId: space.id,
+      userId: user.id,
+    });
+
+    // (b) Text changes: pick two todo / in_progress entries and rewrite them.
+    const editableCandidates = current.filter(
+      (t) =>
+        (t.status === "todo" || t.status === "in_progress") &&
+        !newTodoTexts.includes(t.text)
+    );
+    const textEdits = editableCandidates.slice(0, 2);
+    for (const todo of textEdits) {
+      const nextText = `${todo.text} (updated)`;
+      await todo.updateWithVersion(auth, { text: nextText });
+      logger.info(
+        { previous: todo.text, next: nextText },
+        "Diff wave: updated todo text."
+      );
+    }
+
+    // (c) Status → done: pick up to two in_progress entries untouched by the
+    // edit pass and mark them as done to animate the checkbox.
+    const editedIds = new Set(textEdits.map((t) => t.id));
+    const toDoneCandidates = current
+      .filter((t) => t.status === "in_progress" && !editedIds.has(t.id))
+      .slice(0, 2);
+    for (const todo of toDoneCandidates) {
+      await todo.updateWithVersion(auth, {
+        status: "done",
+        doneAt: new Date(),
+        markedAsDoneByType: "user",
+        markedAsDoneByUserId: user.id,
+        markedAsDoneByAgentConfigurationId: null,
+      });
+      logger.info({ text: todo.text }, "Diff wave: marked todo as done.");
+    }
+
+    logger.info("Done seeding unread diff.");
   }
 );


### PR DESCRIPTION
## Description

Adds a "what's new" diff animation to the Project TODO panel. When a user
opens a project with unread changes, the panel first renders the state as it
was at their last visit, then animates the transition to the current state:
newly-added todos fade in, text-changed todos type out their new text, and
todos that transitioned to done animate the checkbox flip. The panel then
marks the todos as read.

Backend additions:
- `ProjectTodoResource.fetchLatestBySpaceForUserAtTimestamp` reconstructs the
  list of todos as they existed at an arbitrary timestamp using the version
  history.
- `GET /api/w/[wId]/spaces/[spaceId]/project_todos` now returns
  `previousTodos` and `previousLastReadAt` in addition to the current list.
- New `POST /api/w/[wId]/spaces/[spaceId]/project_todos/mark-read` endpoint
  upserts the user's `lastReadAt` on the project.

Frontend additions:
- `useProjectTodos` exposes the previous snapshot; new
  `useMarkProjectTodosAsRead` hook (silent, no notifications).
- `EditableProjectTodosPanel` computes the diff once on mount, renders the
  "before" state, waits ~1s, then swaps to the current state and plays the
  animation.

Dev tooling:
- `scripts/dev/seed_project_todos.ts` gets a `--withUnreadDiff` flag that
  seeds a baseline, marks it as read, then applies a second wave of changes
  (new todos including one created in `done` state, text edits, multiple
  in-progress → done transitions) so the full animation can be exercised
  locally.

## Tests

Tested manually via the seed script with `--withUnreadDiff` to verify each
diff branch (added, text-changed, to-done) renders with the expected
animation. No automated tests added.
