### PR TITLE
Upgrade anthropic SDK to version 0.90.0

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -156,18 +156,18 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
   protected buildStreamRequestPayload(
     streamParameters: LLMStreamParameters
   ): BetaMessageStreamParams {
-    // Merge betas, always include structured-outputs, add custom betas if specified.
-    // TODO(fabien): Remove beta tag and beta client when structured outputs are generally available.
-    const betas = [
-      "structured-outputs-2025-11-13",
-      ...(this.modelConfig.customBetas ?? []),
-    ];
+    const basePayload = this.buildBaseRequestPayload(streamParameters);
+    const outputFormat = toOutputFormatParam(this.responseFormat);
+
+    const customBetas = this.modelConfig.customBetas;
 
     return {
-      ...this.buildBaseRequestPayload(streamParameters),
+      ...basePayload,
       stream: true,
-      betas,
-      output_format: toOutputFormatParam(this.responseFormat),
+      ...(customBetas && customBetas.length > 0 ? { betas: customBetas } : {}),
+      output_config: outputFormat
+        ? { ...basePayload.output_config, format: outputFormat }
+        : basePayload.output_config,
       cache_control: { type: "ephemeral" },
     };
   }

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -206,6 +206,7 @@ function* handleContentBlockStart(
     case "mcp_tool_result":
     case "container_upload":
     case "compaction":
+    case "advisor_tool_result":
       // We don't use these Anthropic tools
       return;
     default:

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/empty_tool_call.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/empty_tool_call.ts
@@ -12,6 +12,7 @@ export const emptyToolCallModelEvents: BetaRawMessageStreamEvent[] = [
       role: "assistant",
       content: [],
       stop_reason: "tool_use",
+      stop_details: null,
       stop_sequence: null,
       usage: {
         input_tokens: 0,
@@ -58,6 +59,7 @@ export const emptyToolCallModelEvents: BetaRawMessageStreamEvent[] = [
     type: "message_delta",
     delta: {
       stop_reason: "tool_use",
+      stop_details: null,
       stop_sequence: null,
       container: null,
     },

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/reasoning.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/reasoning.ts
@@ -12,6 +12,7 @@ export const reasoningModelEvents: BetaRawMessageStreamEvent[] = [
       role: "assistant",
       content: [],
       stop_reason: "end_turn",
+      stop_details: null,
       stop_sequence: null,
       usage: {
         input_tokens: 0,
@@ -94,6 +95,7 @@ export const reasoningModelEvents: BetaRawMessageStreamEvent[] = [
     type: "message_delta",
     delta: {
       stop_reason: "end_turn",
+      stop_details: null,
       stop_sequence: null,
       container: null,
     },

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/tool_use.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/tool_use.ts
@@ -12,6 +12,7 @@ export const toolUseModelEvents: BetaRawMessageStreamEvent[] = [
       role: "assistant",
       content: [],
       stop_reason: "tool_use",
+      stop_details: null,
       stop_sequence: null,
       usage: {
         input_tokens: 0,
@@ -87,6 +88,7 @@ export const toolUseModelEvents: BetaRawMessageStreamEvent[] = [
     type: "message_delta",
     delta: {
       stop_reason: "tool_use",
+      stop_details: null,
       stop_sequence: null,
       container: null,
     },

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -452,7 +452,7 @@ export const runConversation = async (
       }
     }
 
-    expect(fullResponse, "Full response should match deltas").toBe(
+    expect(fullResponse.trim(), "Full response should match deltas").toBe(
       responseFromDeltas.trim()
     );
     if (reasoningFromDeltas.length > 0) {

--- a/front/package.json
+++ b/front/package.json
@@ -37,7 +37,7 @@
     "generate:hubspot-forms": "tsx scripts/generate-hubspot-forms.ts"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.79.0",
+    "@anthropic-ai/sdk": "^0.90.0",
     "@contentful/rich-text-react-renderer": "^16.1.6",
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -217,11 +217,7 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
     enterprise: true,
     featureFlag: "claude_4_5_opus_feature",
   },
-  customBetas: [
-    "auto-thinking-2026-01-12",
-    "effort-2025-11-24",
-    "max-effort-2026-01-24",
-  ],
+  customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],
   disablePrefill: true,
 };
 export const CLAUDE_OPUS_4_7_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
@@ -254,11 +250,7 @@ export const CLAUDE_OPUS_4_7_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
     enterprise: true,
     featureFlag: "claude_4_5_opus_feature",
   },
-  customBetas: [
-    "auto-thinking-2026-01-12",
-    "effort-2025-11-24",
-    "max-effort-2026-01-24",
-  ],
+  customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],
   disablePrefill: true,
 };
 export const CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
@@ -288,11 +280,7 @@ export const CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
-  customBetas: [
-    "auto-thinking-2026-01-12",
-    "effort-2025-11-24",
-    "max-effort-2026-01-24",
-  ],
+  customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],
   disablePrefill: true,
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -489,7 +489,7 @@
       "name": "@dust-tt/front",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.79.0",
+        "@anthropic-ai/sdk": "^0.90.0",
         "@contentful/rich-text-react-renderer": "^16.1.6",
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
@@ -1133,9 +1133,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.79.0.tgz",
-      "integrity": "sha512-ietmtM6glcnnrWq26H+BZm8J07iay9Cob6hRzDTr/A9QWF1m2T//TQhFO4MTKcZht2/7LS8bG9wUYEhcizKRnA==",
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"


### PR DESCRIPTION
## Description

Upgradingfrom 0.79 to latest 0.90 and removing these betas:

`"structured-outputs-2025-11-13"`
https://platform.claude.com/docs/en/build-with-claude/structured-outputs
> Migrating from beta? The output_format parameter has moved to output_config.format, and beta headers are no longer required. The old beta header (structured-outputs-2025-11-13) and output_format parameter will continue working for a transition period. See code examples below for the updated API shape.

`"effort-2025-11-24"`
https://platform.claude.com/docs/en/about-claude/models/migration-guide
> Remove effort beta header: The effort parameter is now GA. Remove betas=["effort-2025-11-24"] from your requests.


## Tests

tsted locally the unit tests on Opus 4.6, Sonnet 4.6 and Haiku 4.5

## Risk
may break something not covered by unit tests

## Deploy Plan
deploy front 