### PR TITLE
[front] log silent failures in MCP connect/create dialogs

### DIFF
--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -29,10 +29,12 @@ import {
   useDiscoverOAuthMetadata,
   useUpdateMCPServerView,
 } from "@app/lib/swr/mcp_servers";
+import datadogLogger from "@app/logger/datadogLogger";
 import {
   OAUTH_PROVIDER_NAMES,
   validateOAuthCredentials,
 } from "@app/types/oauth/lib";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Dialog,
@@ -268,8 +270,36 @@ export function ConnectMCPServerDialog({
     setExternalIsLoading(true);
 
     try {
-      const credentialId = await staticFormRef.current?.submit();
+      const formHandle = staticFormRef.current;
+      if (!formHandle) {
+        sendNotification({
+          type: "error",
+          title: "Cannot submit credentials",
+          description: "The credentials form is not ready. Please retry.",
+        });
+        datadogLogger.error(
+          {
+            workspaceId: owner.sId,
+            mcpServerSId: mcpServerView.server.sId,
+            hasAuthorization: !!authorization,
+            useCase,
+          },
+          "Static credential form ref is null at submit time"
+        );
+        return;
+      }
+
+      const credentialId = await formHandle.submit();
       if (!credentialId) {
+        // The form surfaced its own notification for the specific failure;
+        // log here so we also have a parent-side breadcrumb.
+        datadogLogger.warn(
+          {
+            workspaceId: owner.sId,
+            mcpServerSId: mcpServerView.server.sId,
+          },
+          "Static credential form submit returned null"
+        );
         return;
       }
 
@@ -280,6 +310,14 @@ export function ConnectMCPServerDialog({
         provider: authorization.provider,
       });
       if (!connectionCreationRes) {
+        datadogLogger.error(
+          {
+            workspaceId: owner.sId,
+            mcpServerSId: mcpServerView.server.sId,
+            credentialId,
+          },
+          "createMCPServerConnection returned falsy result"
+        );
         return;
       }
 
@@ -287,11 +325,29 @@ export function ConnectMCPServerDialog({
         oAuthUseCase: useCase,
       });
       if (!updateServerViewRes) {
+        datadogLogger.error(
+          {
+            workspaceId: owner.sId,
+            mcpServerSId: mcpServerView.server.sId,
+          },
+          "updateServerView returned falsy result"
+        );
         return;
       }
 
       setIsOpen(false);
       resetState();
+    } catch (err) {
+      const e = normalizeError(err);
+      sendNotification({
+        type: "error",
+        title: "Failed to connect the tool",
+        description: e.message,
+      });
+      datadogLogger.error(
+        { workspaceId: owner.sId, err: e },
+        "Unexpected error in handleStaticCredentialSave"
+      );
     } finally {
       setIsLoading(false);
       setExternalIsLoading(false);

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -36,7 +36,9 @@ import {
   useCreateRemoteMCPServer,
   useDiscoverOAuthMetadata,
 } from "@app/lib/swr/mcp_servers";
+import datadogLogger from "@app/logger/datadogLogger";
 import { validateOAuthCredentials } from "@app/types/oauth/lib";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkspaceType } from "@app/types/user";
 import {
   ContentMessage,
@@ -423,8 +425,36 @@ export function CreateMCPServerDialog({
       const createdServer = createRes.value.server;
 
       // Submit the static credential form — returns credentialId or null.
-      const credentialId = await staticFormRef.current?.submit();
+      const formHandle = staticFormRef.current;
+      if (!formHandle) {
+        sendNotification({
+          type: "error",
+          title: "Cannot submit credentials",
+          description: "The credentials form is not ready. Please retry.",
+        });
+        datadogLogger.error(
+          {
+            workspaceId: owner.sId,
+            mcpServerSId: createdServer.sId,
+            hasAuthorization: !!authorization,
+            useCase,
+          },
+          "Static credential form ref is null at submit time"
+        );
+        return;
+      }
+
+      const credentialId = await formHandle.submit();
       if (!credentialId) {
+        // The form surfaced its own notification for the specific failure;
+        // log here so we also have a parent-side breadcrumb.
+        datadogLogger.warn(
+          {
+            workspaceId: owner.sId,
+            mcpServerSId: createdServer.sId,
+          },
+          "Static credential form submit returned null"
+        );
         return;
       }
 
@@ -435,6 +465,14 @@ export function CreateMCPServerDialog({
         provider: authorization.provider,
       });
       if (!connectionCreationRes) {
+        datadogLogger.error(
+          {
+            workspaceId: owner.sId,
+            mcpServerSId: createdServer.sId,
+            credentialId,
+          },
+          "createMCPServerConnection returned falsy result"
+        );
         return;
       }
 
@@ -446,6 +484,17 @@ export function CreateMCPServerDialog({
       setMCPServerToShow(createdServer);
       setIsOpen(false);
       resetState();
+    } catch (err) {
+      const e = normalizeError(err);
+      sendNotification({
+        type: "error",
+        title: "Failed to add the tool",
+        description: e.message,
+      });
+      datadogLogger.error(
+        { workspaceId: owner.sId, err: e },
+        "Unexpected error in handleCreateServerAndSubmitStaticCredentials"
+      );
     } finally {
       setIsLoading(false);
       setExternalIsLoading(false);


### PR DESCRIPTION
## Description

Follow-up to #24543.

That PR added toasts and Datadog logs inside the credential form (`SnowflakeKeypairCredentialForm`), but the parent dialogs (`CreateMCPServerDialog`, `ConnectMCPServerDialog`) still had several silent bail-outs where the form never runs and therefore can't log anything itself:

- `staticFormRef.current` is `null` (form not mounted or ref not attached yet) → `?.submit()` returns `undefined`, no form code runs, no toast fires, user sees nothing.
- `submit()` returns `null` → dialog silently `return`s.
- `createMCPServerConnection` / `updateServerView` return a falsy result → dialog silently `return`s.
- Anything inside the handler throws (json parsing, network, schema mismatch) → unhandled promise rejection, no toast.

We just observed this in prod: the customer tried to connect after #24543 deployed, saw no toast and no browser log, but Datadog confirmed the handler did run and created the MCP server view — so `submit()` was being called (or skipped) without any of our new form branches firing. That points to one of the parent-level silent paths above.

This PR:

- Shows a toast + `datadogLogger.error` when `staticFormRef.current` is `null` (the only failure mode the form itself can't report).
- Adds a parent-side `datadogLogger.warn` breadcrumb when `submit()` returns `null` (form has already toasted; this just gives us a paired log on the parent side).
- Adds `datadogLogger.error` on the remaining falsy-result branches (`createMCPServerConnection`, `updateServerView`).
- Wraps each handler in a top-level `catch` that surfaces a toast + error log, so unexpected throws no longer disappear.

## Tests

- `npx tsc --noEmit` in `front/` — clean.
- `biome check` — clean.
- Manual verification pending: reproduce the connect flow and confirm we now get a log/toast for every failure mode.

## Risk

Low. All additions are on error / silent-return branches; happy path is unchanged. Rollback is a single revert.

## Deploy Plan

Standard front deploy. No migrations, no feature flag needed.