### PR TITLE
[front] - devops: skip unmatched files in biome lefthook hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "knip": "knip",
     "format": "biome check --write --error-on-warnings .",
     "format:ci": "biome ci --error-on-warnings .",
-    "format:lefthook": "biome check --write --error-on-warnings",
+    "format:lefthook": "biome check --write --error-on-warnings --no-errors-on-unmatched",
     "format:changed": "biome check --write --error-on-warnings --changed",
     "test:grit": "command -v grit >/dev/null 2>&1 || { echo 'Error: grit CLI not found. Install it with: brew install getgrit/tap/grit (or: curl -fsSL https://docs.grit.io/install | bash)'; exit 1; } && grit patterns test"
   },


### PR DESCRIPTION
## Description

Fixes a pre-commit hook failure when staging CSS/SCSS files. The `biome` task in lefthook's configuration globs `*.{js,jsx,ts,tsx,css,scss}` files, but biome.json only includes JavaScript/TypeScript files. This caused biome to fail with "paths provided but ignored" errors when attempting to commit CSS/SCSS changes. The fix adds the `--no-errors-on-unmatched` flag to silently skip file types not configured in biome.json.

## Tests

Manually tested by staging CSS files and running pre-commit hooks.

## Risk

Low

## Deploy Plan

None