### PR TITLE
[front] - chore(charts): tooltip active row

### DIFF
--- a/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
+++ b/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
@@ -182,9 +182,9 @@ function isFeedbackDistributionData(
 }
 
 export function FeedbackDistributionTooltip(
-  props: TooltipContentProps<number, string>
+  props: TooltipContentProps<number, string> & { activeKey?: string }
 ) {
-  const { active, payload } = props;
+  const { active, payload, activeKey } = props;
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -198,10 +198,12 @@ export function FeedbackDistributionTooltip(
     <ChartTooltipCard
       title={row.date}
       rows={FEEDBACK_DISTRIBUTION_LEGEND.map(({ key, label: itemLabel }) => ({
+        key,
         label: itemLabel,
         value: row[key],
         colorClassName: FEEDBACK_DISTRIBUTION_PALETTE[key],
       }))}
+      activeKey={activeKey}
     />
   );
 }

--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -12,6 +12,7 @@ import {
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { legendFromConstant } from "@app/components/charts/ChartLegend";
+import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
 import {
   useAgentFeedbackDistribution,
   useAgentVersionMarkers,
@@ -25,6 +26,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 
 interface FeedbackDistributionChartProps {
   workspaceId: string;
@@ -72,6 +74,8 @@ export function FeedbackDistributionChart({
         isCustomAgent && mode === "timeRange" && versionMarkers.length > 0,
     }
   );
+
+  const { hoveredKey, hoverHandlers } = useHoveredSeries();
 
   const filteredData = filterTimeSeriesByVersionWindow(
     feedbackDistribution,
@@ -124,7 +128,9 @@ export function FeedbackDistributionChart({
           tickMargin={8}
         />
         <Tooltip
-          content={FeedbackDistributionTooltip}
+          content={(props: TooltipContentProps<number, string>) => (
+            <FeedbackDistributionTooltip {...props} activeKey={hoveredKey} />
+          )}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
           contentStyle={{
@@ -142,6 +148,7 @@ export function FeedbackDistributionChart({
           stroke="currentColor"
           strokeWidth={2}
           dot={false}
+          {...hoverHandlers("positive")}
         />
         <Line
           type="monotone"
@@ -151,6 +158,7 @@ export function FeedbackDistributionChart({
           stroke="currentColor"
           strokeWidth={2}
           dot={false}
+          {...hoverHandlers("negative")}
         />
         {isCustomAgent && (
           <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -12,6 +12,7 @@ import { padSeriesToTimeRange } from "@app/components/agent_builder/observabilit
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { legendFromConstant } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
 import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
 import { useAgentVersionMarkers } from "@app/lib/swr/assistants";
 import { BROWSER_TIMEZONE } from "@app/lib/swr/workspaces";
@@ -52,9 +53,10 @@ function zeroFactory(timestamp: number) {
 function LatencyTooltip(
   props: TooltipContentProps<number, string> & {
     versionMarkers: AgentVersionMarker[];
+    activeKey?: string;
   }
 ) {
-  const { active, payload, versionMarkers } = props;
+  const { active, payload, versionMarkers, activeKey } = props;
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -69,16 +71,19 @@ function LatencyTooltip(
       title={formatTimeSeriesTitle(row.date, row.timestamp, versionMarkers)}
       rows={[
         {
+          key: "average",
           label: "Average time",
           value: `${row.avgLatencyMs}s`,
           colorClassName: LATENCY_PALETTE.average,
         },
         {
+          key: "median",
           label: "Median time",
           value: `${row.percentilesLatencyMs}s`,
           colorClassName: LATENCY_PALETTE.median,
         },
       ]}
+      activeKey={activeKey}
     />
   );
 }
@@ -137,6 +142,8 @@ export function LatencyChart({
       isCustomAgent && mode === "timeRange" && versionMarkers.length > 0,
   });
 
+  const { hoveredKey, hoverHandlers } = useHoveredSeries();
+
   return (
     <ChartContainer
       title="Latency"
@@ -189,7 +196,11 @@ export function LatencyChart({
         />
         <Tooltip
           content={(props: TooltipContentProps<number, string>) => (
-            <LatencyTooltip {...props} versionMarkers={versionMarkers} />
+            <LatencyTooltip
+              {...props}
+              versionMarkers={versionMarkers}
+              activeKey={hoveredKey}
+            />
           )}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
@@ -209,6 +220,7 @@ export function LatencyChart({
           fill="url(#fillAverage)"
           stroke="currentColor"
           dot={false}
+          {...hoverHandlers("average")}
         />
         <Line
           type="monotone"
@@ -218,6 +230,7 @@ export function LatencyChart({
           className={LATENCY_PALETTE.median}
           stroke="currentColor"
           dot={false}
+          {...hoverHandlers("median")}
         />
         {isCustomAgent && (
           <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />

--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -65,17 +65,27 @@ export function SourceChart({
         <Tooltip
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
-          content={({ active }) => {
+          content={({ active, payload }) => {
             if (!active || data.length === 0) {
               return null;
             }
+            const rawOrigin = payload?.[0]?.payload?.origin;
+            const activeOrigin =
+              typeof rawOrigin === "string" ? rawOrigin : undefined;
             const rows = data.map((d) => ({
+              key: d.origin,
               label: d.label,
               value: d.count,
               percent: d.percent,
               colorClassName: getSourceColor(d.origin),
             }));
-            return <ChartTooltipCard title="Source breakdown" rows={rows} />;
+            return (
+              <ChartTooltipCard
+                title="Source breakdown"
+                rows={rows}
+                activeKey={activeOrigin}
+              />
+            );
           }}
           contentStyle={{
             background: "transparent",

--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -7,6 +7,7 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import { useAgentContextOrigin } from "@app/lib/swr/assistants";
+import { isString } from "@app/types/shared/utils/general";
 import { Cell, Pie, PieChart, Tooltip } from "recharts";
 
 interface SourceChartProps {
@@ -70,8 +71,7 @@ export function SourceChart({
               return null;
             }
             const rawOrigin = payload?.[0]?.payload?.origin;
-            const activeOrigin =
-              typeof rawOrigin === "string" ? rawOrigin : undefined;
+            const activeOrigin = isString(rawOrigin) ? rawOrigin : undefined;
             const rows = data.map((d) => ({
               key: d.origin,
               label: d.label,

--- a/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
@@ -11,6 +11,7 @@ import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { legendFromConstant } from "@app/components/charts/ChartLegend";
 import { RoundedBarShape } from "@app/components/charts/ChartShapes";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
 import type { ToolLatencyView } from "@app/lib/api/assistant/observability/tool_latency";
 import {
   Button,
@@ -54,9 +55,9 @@ function isToolLatencyDatum(data: unknown): data is ToolLatencyDatum {
 }
 
 function ToolExecutionTimeTooltip(
-  props: TooltipContentProps<number, string>
+  props: TooltipContentProps<number, string> & { activeKey?: string }
 ): JSX.Element | null {
-  const { active, payload } = props;
+  const { active, payload, activeKey } = props;
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -73,22 +74,26 @@ function ToolExecutionTimeTooltip(
       title={row.label}
       rows={[
         {
+          key: "avgLatencyMs",
           label: "Average",
           value: formatDurationMs(row.avgLatencyMs),
           colorClassName: TOOL_EXECUTION_TIME_PALETTE.avgLatencyMs,
         },
         {
+          key: "p50LatencyMs",
           label: "P50",
           value: formatDurationMs(row.p50LatencyMs),
           colorClassName: TOOL_EXECUTION_TIME_PALETTE.p50LatencyMs,
         },
         {
+          key: "p95LatencyMs",
           label: "P95",
           value: formatDurationMs(row.p95LatencyMs),
           colorClassName: TOOL_EXECUTION_TIME_PALETTE.p95LatencyMs,
         },
       ]}
       footer={`Executions: ${row.count}`}
+      activeKey={activeKey}
     />
   );
 }
@@ -192,6 +197,8 @@ export function ToolExecutionTimeChart({
     TOOL_EXECUTION_TIME_PALETTE
   );
 
+  const { hoveredKey, hoverHandlers } = useHoveredSeries();
+
   const selectedServerLabel =
     serverOptions.find((server) => server.name === selectedServerName)?.label ??
     (serverLatency.isLoading ? "Loading" : "Select server");
@@ -277,7 +284,9 @@ export function ToolExecutionTimeChart({
           tickFormatter={formatDurationMs}
         />
         <Tooltip
-          content={ToolExecutionTimeTooltip}
+          content={(props: TooltipContentProps<number, string>) => (
+            <ToolExecutionTimeTooltip {...props} activeKey={hoveredKey} />
+          )}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
           contentStyle={{
@@ -293,6 +302,7 @@ export function ToolExecutionTimeChart({
           fill="currentColor"
           className={TOOL_EXECUTION_TIME_PALETTE.p50LatencyMs}
           shape={<RoundedBarShape />}
+          {...hoverHandlers("p50LatencyMs")}
         />
         <Bar
           dataKey="avgLatencyMs"
@@ -300,6 +310,7 @@ export function ToolExecutionTimeChart({
           fill="currentColor"
           className={TOOL_EXECUTION_TIME_PALETTE.avgLatencyMs}
           shape={<RoundedBarShape />}
+          {...hoverHandlers("avgLatencyMs")}
         />
         <Bar
           dataKey="p95LatencyMs"
@@ -307,6 +318,7 @@ export function ToolExecutionTimeChart({
           fill="currentColor"
           className={TOOL_EXECUTION_TIME_PALETTE.p95LatencyMs}
           shape={<RoundedBarShape />}
+          {...hoverHandlers("p95LatencyMs")}
         />
       </BarChart>
     </ChartContainer>

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -13,6 +13,7 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { legendFromConstant } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
 import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
 import {
   useAgentUsageMetrics,
@@ -58,9 +59,10 @@ function zeroFactory(timestamp: number) {
 function UsageMetricsTooltip(
   props: TooltipContentProps<number, string> & {
     versionMarkers: AgentVersionMarker[];
+    activeKey?: string;
   }
 ) {
-  const { active, payload, versionMarkers } = props;
+  const { active, payload, versionMarkers, activeKey } = props;
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -77,21 +79,25 @@ function UsageMetricsTooltip(
       title={formatTimeSeriesTitle(row.date, row.timestamp, versionMarkers)}
       rows={[
         {
+          key: "messages",
           label: "Messages",
           value: row.count,
           colorClassName: USAGE_METRICS_PALETTE.messages,
         },
         {
+          key: "conversations",
           label: "Conversations",
           value: row.conversations,
           colorClassName: USAGE_METRICS_PALETTE.conversations,
         },
         {
+          key: "activeUsers",
           label: "Active users",
           value: row.activeUsers,
           colorClassName: USAGE_METRICS_PALETTE.activeUsers,
         },
       ]}
+      activeKey={activeKey}
     />
   );
 }
@@ -131,6 +137,8 @@ export function UsageMetricsChart({
         isCustomAgent && mode === "timeRange" && versionMarkers.length > 0,
     }
   );
+
+  const { hoveredKey, hoverHandlers } = useHoveredSeries();
 
   const filteredData = filterTimeSeriesByVersionWindow(
     usageMetrics,
@@ -224,7 +232,11 @@ export function UsageMetricsChart({
         />
         <Tooltip
           content={(props: TooltipContentProps<number, string>) => (
-            <UsageMetricsTooltip {...props} versionMarkers={versionMarkers} />
+            <UsageMetricsTooltip
+              {...props}
+              versionMarkers={versionMarkers}
+              activeKey={hoveredKey}
+            />
           )}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
@@ -248,6 +260,7 @@ export function UsageMetricsChart({
           className={USAGE_METRICS_PALETTE.messages}
           stroke="currentColor"
           dot={false}
+          {...hoverHandlers("messages")}
         />
         <Line
           type={
@@ -261,6 +274,7 @@ export function UsageMetricsChart({
           className={USAGE_METRICS_PALETTE.conversations}
           stroke="currentColor"
           dot={false}
+          {...hoverHandlers("conversations")}
         />
         <Line
           type={
@@ -274,6 +288,7 @@ export function UsageMetricsChart({
           className={USAGE_METRICS_PALETTE.activeUsers}
           stroke="currentColor"
           dot={false}
+          {...hoverHandlers("activeUsers")}
         />
         {isCustomAgent && (
           <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />

--- a/front/components/charts/ChartTooltip.tsx
+++ b/front/components/charts/ChartTooltip.tsx
@@ -20,6 +20,7 @@ export function LegendDot({ className, rounded = "sm" }: LegendDotProps) {
 }
 
 interface TooltipRow {
+  key?: string;
   label: string;
   value: string | number;
   colorClassName?: string;
@@ -30,9 +31,15 @@ interface ChartTooltipProps {
   title?: string;
   rows: TooltipRow[];
   footer?: string;
+  activeKey?: string;
 }
 
-export function ChartTooltipCard({ title, rows, footer }: ChartTooltipProps) {
+export function ChartTooltipCard({
+  title,
+  rows,
+  footer,
+  activeKey,
+}: ChartTooltipProps) {
   return (
     <div
       role="tooltip"
@@ -44,22 +51,39 @@ export function ChartTooltipCard({ title, rows, footer }: ChartTooltipProps) {
         </div>
       )}
       <ul className="space-y-1.5">
-        {rows.map((r) => (
-          <li key={r.label} className="flex items-center gap-2">
-            {r.colorClassName && <LegendDot className={r.colorClassName} />}
-            <span className="text-muted-foreground dark:text-muted-foreground-night">
-              {r.label}
-            </span>
-            <span className="ml-auto font-mono font-medium tabular-nums text-foreground dark:text-foreground-night">
-              {r.value.toLocaleString()}
-            </span>
-            {typeof r.percent === "number" && (
-              <span className="text-muted-foreground dark:text-muted-foreground-night">
-                ({r.percent}%)
+        {rows.map((r) => {
+          const rowKey = r.key ?? r.label;
+          const isActive = rowKey === activeKey;
+          return (
+            <li
+              key={rowKey}
+              className={cn(
+                "flex items-center gap-2 rounded",
+                isActive &&
+                  "-mx-1.5 bg-muted-background/60 px-1.5 dark:bg-muted-background-night/60"
+              )}
+            >
+              {r.colorClassName && <LegendDot className={r.colorClassName} />}
+              <span
+                className={cn(
+                  isActive
+                    ? "font-medium text-foreground dark:text-foreground-night"
+                    : "text-muted-foreground dark:text-muted-foreground-night"
+                )}
+              >
+                {r.label}
               </span>
-            )}
-          </li>
-        ))}
+              <span className="ml-auto font-mono font-medium tabular-nums text-foreground dark:text-foreground-night">
+                {r.value.toLocaleString()}
+              </span>
+              {typeof r.percent === "number" && (
+                <span className="text-muted-foreground dark:text-muted-foreground-night">
+                  ({r.percent}%)
+                </span>
+              )}
+            </li>
+          );
+        })}
       </ul>
       {footer && (
         <div className="mt-1 border-t border-border/50 pt-1 text-muted-foreground dark:border-border-night/50 dark:text-muted-foreground-night">

--- a/front/components/charts/useHoveredSeries.ts
+++ b/front/components/charts/useHoveredSeries.ts
@@ -1,0 +1,15 @@
+import { useCallback, useState } from "react";
+
+export function useHoveredSeries() {
+  const [hoveredKey, setHoveredKey] = useState<string | undefined>(undefined);
+
+  const hoverHandlers = useCallback(
+    (key: string) => ({
+      onMouseEnter: () => setHoveredKey(key),
+      onMouseLeave: () => setHoveredKey(undefined),
+    }),
+    []
+  );
+
+  return { hoveredKey, hoverHandlers };
+}

--- a/front/components/workspace/analytics/WorkspaceSourceChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSourceChart.tsx
@@ -9,6 +9,7 @@ import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import { useWorkspaceContextOrigin } from "@app/lib/swr/workspaces";
+import { isString } from "@app/types/shared/utils/general";
 import { Cell, Pie, PieChart, Tooltip } from "recharts";
 
 interface WorkspaceSourceChartProps {
@@ -70,8 +71,7 @@ export function WorkspaceSourceChart({
               return null;
             }
             const rawOrigin = payload?.[0]?.payload?.origin;
-            const activeOrigin =
-              typeof rawOrigin === "string" ? rawOrigin : undefined;
+            const activeOrigin = isString(rawOrigin) ? rawOrigin : undefined;
             const rows = data.map((d) => ({
               key: d.origin,
               label: d.label,

--- a/front/components/workspace/analytics/WorkspaceSourceChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSourceChart.tsx
@@ -65,17 +65,27 @@ export function WorkspaceSourceChart({
           isAnimationActive={false}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
-          content={({ active }) => {
+          content={({ active, payload }) => {
             if (!active || data.length === 0) {
               return null;
             }
+            const rawOrigin = payload?.[0]?.payload?.origin;
+            const activeOrigin =
+              typeof rawOrigin === "string" ? rawOrigin : undefined;
             const rows = data.map((d) => ({
+              key: d.origin,
               label: d.label,
               value: d.count.toLocaleString(),
               percent: d.percent,
               colorClassName: getSourceColor(d.origin),
             }));
-            return <ChartTooltipCard title="Source breakdown" rows={rows} />;
+            return (
+              <ChartTooltipCard
+                title="Source breakdown"
+                rows={rows}
+                activeKey={activeOrigin}
+              />
+            );
           }}
           contentStyle={{
             background: "transparent",

--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -7,6 +7,7 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import type { AvailableTool } from "@app/lib/api/assistant/observability/tool_usage";
@@ -67,6 +68,7 @@ interface ToolUsageTooltipProps extends TooltipContentProps<number, string> {
   displayMode: ToolUsageDisplayMode;
   toolsWithData: string[];
   displayNameMap: Map<string, string>;
+  activeKey?: string;
 }
 
 function ToolUsageTooltip({
@@ -75,6 +77,7 @@ function ToolUsageTooltip({
   displayNameMap,
   active,
   payload,
+  activeKey,
 }: ToolUsageTooltipProps) {
   if (!active || !payload || payload.length === 0) {
     return null;
@@ -91,6 +94,7 @@ function ToolUsageTooltip({
 
   const values = toolsWithData.map((tool) => point.values[tool] ?? 0);
   const rows = toolsWithData.map((tool, idx) => ({
+    key: tool,
     label: displayNameMap.get(tool) ?? tool,
     value: values[idx].toLocaleString(),
     colorClassName: getIndexedColor(tool, toolsWithData),
@@ -99,13 +103,14 @@ function ToolUsageTooltip({
   if (toolsWithData.length > 1) {
     const total = values.reduce((sum, v) => sum + v, 0);
     rows.push({
+      key: "__total__",
       label: `Total ${label}`,
       value: total.toLocaleString(),
       colorClassName: "",
     });
   }
 
-  return <ChartTooltipCard title={title} rows={rows} />;
+  return <ChartTooltipCard title={title} rows={rows} activeKey={activeKey} />;
 }
 
 interface WorkspaceToolUsageChartProps {
@@ -241,6 +246,8 @@ export function WorkspaceToolUsageChart({
     colorClassName: getIndexedColor(tool, toolsWithData),
   }));
 
+  const { hoveredKey, hoverHandlers } = useHoveredSeries();
+
   const toolSelector = (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
@@ -353,6 +360,7 @@ export function WorkspaceToolUsageChart({
               displayMode={displayMode}
               toolsWithData={toolsWithData}
               displayNameMap={displayNameMap}
+              activeKey={hoveredKey}
             />
           )}
           cursor={false}
@@ -374,6 +382,7 @@ export function WorkspaceToolUsageChart({
             className={getIndexedColor(tool, toolsWithData)}
             stroke="currentColor"
             dot={false}
+            {...hoverHandlers(tool)}
           />
         ))}
       </LineChart>

--- a/front/components/workspace/analytics/WorkspaceUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceUsageChart.tsx
@@ -8,6 +8,7 @@ import { padSeriesToTimeRange } from "@app/components/agent_builder/observabilit
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import {
@@ -156,12 +157,14 @@ function activeUsersZeroFactory(timestamp: number): ActiveUsersMetricsDatum {
 
 interface UsageMetricsTooltipProps extends TooltipContentProps<number, string> {
   displayMode: UsageDisplayMode;
+  activeKey?: string;
 }
 
 function UsageMetricsTooltip({
   active,
   payload,
   displayMode,
+  activeKey,
 }: UsageMetricsTooltipProps) {
   if (!active || !payload || payload.length === 0) {
     return null;
@@ -180,22 +183,25 @@ function UsageMetricsTooltip({
     const title = row.date ?? formatShortDate(row.timestamp);
     const rows = [
       {
+        key: "dau",
         label: "DAU (Daily)",
         value: `${row.dau}%`,
         colorClassName: ACTIVE_USERS_PALETTE.dau,
       },
       {
+        key: "wau",
         label: "WAU (7-day)",
         value: `${row.wau}%`,
         colorClassName: ACTIVE_USERS_PALETTE.wau,
       },
       {
+        key: "mau",
         label: "MAU (28-day)",
         value: `${row.mau}%`,
         colorClassName: ACTIVE_USERS_PALETTE.mau,
       },
     ];
-    return <ChartTooltipCard title={title} rows={rows} />;
+    return <ChartTooltipCard title={title} rows={rows} activeKey={activeKey} />;
   }
 
   if (!isWorkspaceUsageMetricsDatum(first.payload)) {
@@ -207,18 +213,20 @@ function UsageMetricsTooltip({
 
   const rows = [
     {
+      key: "messages",
       label: "Messages",
       value: row.count.toLocaleString(),
       colorClassName: USAGE_METRICS_PALETTE.messages,
     },
     {
+      key: "conversations",
       label: "Conversations",
       value: row.conversations.toLocaleString(),
       colorClassName: USAGE_METRICS_PALETTE.conversations,
     },
   ];
 
-  return <ChartTooltipCard title={title} rows={rows} />;
+  return <ChartTooltipCard title={title} rows={rows} activeKey={activeKey} />;
 }
 
 interface WorkspaceUsageChartProps {
@@ -251,6 +259,8 @@ export function WorkspaceUsageChart({
   });
 
   const legendItems = getLegendItemsForMode(displayMode);
+
+  const { hoveredKey, hoverHandlers } = useHoveredSeries();
 
   const usageData = padSeriesToTimeRange<WorkspaceUsageMetricsDatum>(
     usageMetrics,
@@ -359,7 +369,11 @@ export function WorkspaceUsageChart({
         <Tooltip
           isAnimationActive={false}
           content={(props: TooltipContentProps<number, string>) => (
-            <UsageMetricsTooltip {...props} displayMode={displayMode} />
+            <UsageMetricsTooltip
+              {...props}
+              displayMode={displayMode}
+              activeKey={hoveredKey}
+            />
           )}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
@@ -380,6 +394,7 @@ export function WorkspaceUsageChart({
               className={USAGE_METRICS_PALETTE.messages}
               stroke="currentColor"
               dot={false}
+              {...hoverHandlers("messages")}
             />
             <Line
               type={getLineType(period)}
@@ -389,6 +404,7 @@ export function WorkspaceUsageChart({
               className={USAGE_METRICS_PALETTE.conversations}
               stroke="currentColor"
               dot={false}
+              {...hoverHandlers("conversations")}
             />
           </>
         ) : (
@@ -401,6 +417,7 @@ export function WorkspaceUsageChart({
               className={ACTIVE_USERS_PALETTE.dau}
               stroke="currentColor"
               dot={false}
+              {...hoverHandlers("dau")}
             />
             <Line
               type={getLineType(period)}
@@ -410,6 +427,7 @@ export function WorkspaceUsageChart({
               className={ACTIVE_USERS_PALETTE.wau}
               stroke="currentColor"
               dot={false}
+              {...hoverHandlers("wau")}
             />
             <Line
               type={getLineType(period)}
@@ -419,6 +437,7 @@ export function WorkspaceUsageChart({
               className={ACTIVE_USERS_PALETTE.mau}
               stroke="currentColor"
               dot={false}
+              {...hoverHandlers("mau")}
             />
           </>
         )}

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -198,9 +198,7 @@ body {
 
 /* Avoid the native focus outline border on Recharts surfaces when clicking charts. */
 .observability-chart-container svg:focus,
-.observability-chart-container svg :focus,
-.observability-chart-container svg:focus-visible,
-.observability-chart-container svg :focus-visible {
+.observability-chart-container svg:focus-visible {
   outline: none;
 }
 

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -198,7 +198,9 @@ body {
 
 /* Avoid the native focus outline border on Recharts surfaces when clicking charts. */
 .observability-chart-container svg:focus,
-.observability-chart-container svg:focus-visible {
+.observability-chart-container svg :focus,
+.observability-chart-container svg:focus-visible,
+.observability-chart-container svg :focus-visible {
   outline: none;
 }
 


### PR DESCRIPTION
## Description

This PR improves chart interactivity by visually highlighting the hovered series in tooltips. Introduces a new `useHoveredSeries` hook that tracks which chart element (line, bar, or pie slice) is currently being hovered. The `ChartTooltipCard` component now accepts an `activeKey` prop to apply visual emphasis (bold text) to the corresponding tooltip row. 

## Tests

Locally tested across various chart types (line charts, bar charts, pie charts) in observability and analytics pages.

## Risk

Low risk

## Deploy Plan

Deploy front