### PR TITLE
[front] chore: remove metrics `mcp_actions_success.count` and `mcp_actions_error.count`

### DIFF
--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -22,7 +22,6 @@ import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
@@ -76,11 +75,6 @@ export async function* runToolWithStreaming(
     workspaceId: conversation.owner.sId,
   });
 
-  const tags = [
-    `action:${toolConfiguration.name}`,
-    `mcp_server:${toolConfiguration.mcpServerName}`,
-  ];
-
   const agentLoopRunContext: AgentLoopRunContextType = {
     agentConfiguration,
     agentMessage,
@@ -113,8 +107,6 @@ export async function* runToolWithStreaming(
   // validation error, or any other kind of error from MCP, but not a tool error, which are returned
   // as content.
   if (toolCallResult.isError) {
-    getStatsDClient().increment("mcp_actions_error.count", 1, tags);
-
     const endDate = performance.now();
     yield await handleMCPActionError(auth, {
       action,
@@ -150,22 +142,20 @@ export async function* runToolWithStreaming(
       yield event;
     }
     return;
-  } else {
-    getStatsDClient().increment("mcp_actions_success.count", 1, tags);
-
-    const endDate = performance.now();
-    await action.markAsSucceeded({ executionDurationMs: endDate - startDate });
-
-    yield {
-      type: "tool_success",
-      created: Date.now(),
-      configurationId: agentConfiguration.sId,
-      messageId: agentMessage.sId,
-      action: {
-        ...action.toJSON(),
-        output: removeNulls(outputItems.map(hideFileFromActionOutput)),
-        generatedFiles,
-      },
-    };
   }
+
+  const endDate = performance.now();
+  await action.markAsSucceeded({ executionDurationMs: endDate - startDate });
+
+  yield {
+    type: "tool_success",
+    created: Date.now(),
+    configurationId: agentConfiguration.sId,
+    messageId: agentMessage.sId,
+    action: {
+      ...action.toJSON(),
+      output: removeNulls(outputItems.map(hideFileFromActionOutput)),
+      generatedFiles,
+    },
+  };
 }


### PR DESCRIPTION
## Description

- This PR removes the two metrics `mcp_actions_error.count` and `mcp_actions_success.count`.
- These metrics have a high cardinality due to being relative to the MCP tool x MCP server.
- We don't rely on any of them in any dashboard nor monitor: these are the legacy metrics from when we had separate metrics `retrieval_actions_error`, `websearch_actions_error`, etc... They are not superseded by `use_tools.count`, `use_tools_error.count` and `run_tool.duration.distribution`.
- Also contains an early return.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
