### PR TITLE
[front] rename mcpServerSId to mcpServerId in DD logs

### DIFF
--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -280,7 +280,7 @@ export function ConnectMCPServerDialog({
         datadogLogger.error(
           {
             workspaceId: owner.sId,
-            mcpServerSId: mcpServerView.server.sId,
+            mcpServerId: mcpServerView.server.sId,
             hasAuthorization: !!authorization,
             useCase,
           },
@@ -296,7 +296,7 @@ export function ConnectMCPServerDialog({
         datadogLogger.warn(
           {
             workspaceId: owner.sId,
-            mcpServerSId: mcpServerView.server.sId,
+            mcpServerId: mcpServerView.server.sId,
           },
           "Static credential form submit returned null"
         );
@@ -313,7 +313,7 @@ export function ConnectMCPServerDialog({
         datadogLogger.error(
           {
             workspaceId: owner.sId,
-            mcpServerSId: mcpServerView.server.sId,
+            mcpServerId: mcpServerView.server.sId,
             credentialId,
           },
           "createMCPServerConnection returned falsy result"
@@ -328,7 +328,7 @@ export function ConnectMCPServerDialog({
         datadogLogger.error(
           {
             workspaceId: owner.sId,
-            mcpServerSId: mcpServerView.server.sId,
+            mcpServerId: mcpServerView.server.sId,
           },
           "updateServerView returned falsy result"
         );

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -435,7 +435,7 @@ export function CreateMCPServerDialog({
         datadogLogger.error(
           {
             workspaceId: owner.sId,
-            mcpServerSId: createdServer.sId,
+            mcpServerId: createdServer.sId,
             hasAuthorization: !!authorization,
             useCase,
           },
@@ -451,7 +451,7 @@ export function CreateMCPServerDialog({
         datadogLogger.warn(
           {
             workspaceId: owner.sId,
-            mcpServerSId: createdServer.sId,
+            mcpServerId: createdServer.sId,
           },
           "Static credential form submit returned null"
         );
@@ -468,7 +468,7 @@ export function CreateMCPServerDialog({
         datadogLogger.error(
           {
             workspaceId: owner.sId,
-            mcpServerSId: createdServer.sId,
+            mcpServerId: createdServer.sId,
             credentialId,
           },
           "createMCPServerConnection returned falsy result"


### PR DESCRIPTION
## Description

Follow-up consistency nit on top of #24552. The repo convention is to key Datadog logs with `workspaceId` / `mcpServerId` even when the value is actually an sId — rename the remaining `mcpServerSId` occurrences accordingly.

## Tests

Typecheck only — this is a log-attribute rename with no behavior change.

## Risk

None. Log attribute name change only; no code paths touched.

## Deploy Plan

Standard.