### PR TITLE
fix: agent loop crashes on workspaces with "private URLs by default" when triggered via API key

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1070,7 +1070,9 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
   let agents: LightAgentConfigurationType[];
   let globalSpace: SpaceResource;
   let restrictedSpace: SpaceResource;
-  let globalGroup: Awaited<ReturnType<typeof createResourceTest>>["globalGroup"];
+  let globalGroup: Awaited<
+    ReturnType<typeof createResourceTest>
+  >["globalGroup"];
   let conversations: {
     accessible: string[];
     restricted: string[];

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -29,6 +29,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -1069,6 +1070,7 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
   let agents: LightAgentConfigurationType[];
   let globalSpace: SpaceResource;
   let restrictedSpace: SpaceResource;
+  let globalGroup: Awaited<ReturnType<typeof createResourceTest>>["globalGroup"];
   let conversations: {
     accessible: string[];
     restricted: string[];
@@ -1078,11 +1080,13 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     const {
       authenticator,
       globalSpace: gs,
+      globalGroup: gg,
       user,
       workspace: w,
     } = await createResourceTest({
       role: "admin",
     });
+    globalGroup = gg;
 
     workspace = w;
     globalSpace = gs;
@@ -1447,6 +1451,33 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     expect(adminConversations.map((c) => c.sId)).not.toContain(
       participantRequiredConversation.sId
     );
+  });
+
+  it("should allow API key auth to fetch a conversation it created when private URLs are enabled by default", async () => {
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+    const apiKey = await KeyFactory.regular(globalGroup);
+    const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
+      apiKey,
+      workspace.sId
+    );
+
+    const conversation = await ConversationFactory.create(apiKeyAuth, {
+      agentConfigurationId: agents[0].sId,
+      messagesCreatedAt: [dateFromDaysAgo(2)],
+    });
+
+    // API key has no user so no participant record is created, but it should
+    // still be able to fetch the conversation it created via space permissions.
+    const fetched = await ConversationResource.fetchById(
+      apiKeyAuth,
+      conversation.sId
+    );
+    expect(fetched).not.toBeNull();
+    expect(fetched?.sId).toBe(conversation.sId);
   });
 });
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -509,7 +509,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     if (spaceBasedAccessible.length === 0) {
       const participantRestrictedConversationIds = new Set(
-        participantRestrictedConversations.map((conversation) => conversation.id)
+        participantRestrictedConversations.map(
+          (conversation) => conversation.id
+        )
       );
       return spaceBasedAccessible.filter(
         (conversation) =>

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -500,11 +500,16 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
 
     const user = auth.user();
-    if (!user || spaceBasedAccessible.length === 0) {
+    // API key auth has no user and never creates participant records, so the
+    // participant-restriction concept doesn't apply.
+    // TODO(2026-04-20 sebastien): Review implementation to support API Keys.
+    if (!user) {
+      return spaceBasedAccessible;
+    }
+
+    if (spaceBasedAccessible.length === 0) {
       const participantRestrictedConversationIds = new Set(
-        participantRestrictedConversations.map(
-          (conversation) => conversation.id
-        )
+        participantRestrictedConversations.map((conversation) => conversation.id)
       );
       return spaceBasedAccessible.filter(
         (conversation) =>

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -56,7 +56,8 @@ describe("GET /api/v1/w/[wId]/assistant/conversations/[cId]", () => {
     expect(res._getStatusCode()).toBe(200);
   });
 
-  it("returns 404 conversation_not_found when private conversation URLs are enabled", async () => {
+  // TODO(2026-04-20 sebastien): Re-enable this test once the API is updated to support API Keys and the concept of participant-restricted conversations is reviewed.
+  it.skip("returns 404 conversation_not_found when private conversation URLs are enabled", async () => {
     const { req, res, workspace } = await setupGetRequest();
 
     const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR is a follow up of https://github.com/dust-tt/dust/pull/24530, attempting to fix this error in the agent loop.

```
  "failure": {
    "message": "Activity task failed",
    "cause": {
      "message": "Cannot access conversation: conversation_not_found",
      "source": "TypeScriptSDK",
      "stackTrace": "Error: Cannot access conversation: conversation_not_found\n    at _getConversation (/app/front/dist/start_worker.js:96679:20)\n    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at async getAgentLoopDataWithAuth (/app/front/dist/start_worker.js:99668:29)\n    at async _runModelAndCreateActionsActivity (/app/front/dist/start_worker.js:156148:27)\n    at async wrapWithSpan (/app/front/node_modules/@temporalio/interceptors-opentelemetry/lib/instrumentation.js:77:21)\n    at async /app/front/node_modules/@temporalio/interceptors-opentelemetry/lib/instrumentation.js:120:75\n    at async /app/front/node_modules/@temporalio/interceptors-opentelemetry/lib/instrumentation.js:120:20\n    at async instrument (/app/front/node_modules/@temporalio/interceptors-opentelemetry/lib/instrumentation.js:119:16)\n    at async OpenTelemetryActivityInboundInterceptor.execute (/app/front/node_modules/@temporalio/interceptors-opentelemetry/lib/worker/index.js:48:16)\n    at async ActivityInboundLogInterceptor.execute (/app/front/dist/start_worker.js:231:14)",
      "applicationFailureInfo": {
        "type": "ConversationError"
      }
    },
    "activityFailureInfo": {
      "scheduledEventId": "5",
      "startedEventId": "6",
      "identity": "1@front-agent-loop-worker-deployment-55fd65f88-9bbsq",
      "activityType": {
        "name": "runModelAndCreateActionsActivity"
      },
      "activityId": "1",
      "retryState": "RETRY_STATE_MAXIMUM_ATTEMPTS_REACHED"
    }
  },
```
### What broke and why

Since Friday's "private conversation URLs by default" (PR https://github.com/dust-tt/dust/pull/24486), the agent loop would throw `Cannot access conversation: conversation_not_found` when triggered via an API key on a workspace with `privateConversationUrlsByDefault: true`.

API keys never create `ConversationParticipant` records (there's no user to record). The new participant-restriction check in
`baseFetchWithAuthorization` was filtering out all participant-restricted conversations when `auth.user()` is null. Making the
just-posted conversation invisible to the agent loop when it tried to fetch it.

The "participants only" URL restriction is a human-to-human concept: it prevents user A from opening a conversation URL they weren't involved in. Until current implementation is review to account for API Keys. This PR bypasses the participant-restrictions for API Keys.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
