### PR TITLE
[Sessions] Recompute fork conversation permissions

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -1205,7 +1205,7 @@ describe("createConversationFork", () => {
     getContentFragmentBlobSpy.mockRestore();
   });
 
-  it("inherits the parent's requested spaces so the fork does not broaden visibility", async () => {
+  it("drops parent-only requested spaces that are not carried into the fork", async () => {
     const {
       auth: initialAuth,
       globalSpace,
@@ -1272,6 +1272,84 @@ describe("createConversationFork", () => {
       result.value
     );
 
+    expect(childConversation.requestedSpaceIds).toEqual([globalSpace.sId]);
+
+    const childConversationForOtherUser = await ConversationResource.fetchById(
+      otherAuth,
+      childConversation.sId
+    );
+    expect(childConversationForOtherUser?.sId).toBe(childConversation.sId);
+  });
+
+  it("includes copied skill permissions in the child conversation requirements", async () => {
+    const {
+      auth: initialAuth,
+      globalSpace,
+      user,
+      workspace,
+    } = await createPrivateApiMockRequest({ role: "admin" });
+
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const addMembersRes = await restrictedSpace.addMembers(initialAuth, {
+      userIds: [user.sId],
+    });
+    expect(addMembersRes.isOk()).toBe(true);
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: globalSpace.id,
+    });
+    const restrictedSkill = await SkillFactory.create(auth, {
+      name: "Restricted skill",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+
+    const upsertResult = await SkillResource.upsertConversationSkills(auth, {
+      conversationId: parentConversation.id,
+      skills: [restrictedSkill],
+      enabled: true,
+    });
+    expect(upsertResult.isOk()).toBe(true);
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "Continue with the same skills.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
+
     expect(childConversation.requestedSpaceIds).toEqual([
       globalSpace.sId,
       restrictedSpace.sId,
@@ -1282,5 +1360,101 @@ describe("createConversationFork", () => {
       childConversation.sId
     );
     expect(childConversationForOtherUser).toBeNull();
+  });
+
+  it("includes carried content node permissions in the child conversation requirements", async () => {
+    const {
+      auth: initialAuth,
+      user,
+      workspace,
+    } = await createPrivateApiMockRequest({ role: "admin" });
+
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const addMembersRes = await restrictedSpace.addMembers(initialAuth, {
+      userIds: [user.sId],
+    });
+    expect(addMembersRes.isOk()).toBe(true);
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+    const restrictedDataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      restrictedSpace,
+      auth.user() ?? null
+    );
+    const getContentFragmentBlobSpy = mockContentNodeAttachments(
+      restrictedDataSourceView.id
+    );
+
+    let parentConversationWithContent = await fetchConversationOrThrow(
+      auth,
+      parentConversation.sId
+    );
+    const contentNodeResult = await postNewContentFragment(
+      auth,
+      parentConversationWithContent,
+      {
+        title: "Restricted note",
+        nodeId: "node_before_fork",
+        nodeDataSourceViewId: restrictedDataSourceView.sId,
+      },
+      null
+    );
+    expect(contentNodeResult.isOk()).toBe(true);
+
+    parentConversationWithContent = await fetchConversationOrThrow(
+      auth,
+      parentConversation.sId
+    );
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversationWithContent,
+      rank: 1,
+      content: "Continue from the restricted note.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversationWithContent,
+      rank: 2,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
+
+    expect(childConversation.requestedSpaceIds).toEqual([restrictedSpace.sId]);
+
+    const childConversationForOtherUser = await ConversationResource.fetchById(
+      otherAuth,
+      childConversation.sId
+    );
+    expect(childConversationForOtherUser).toBeNull();
+
+    getContentFragmentBlobSpy.mockRestore();
   });
 });

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -18,6 +18,7 @@ import { DustError } from "@app/lib/error";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -104,37 +105,22 @@ function getForkInitializationMessageContent(
 async function copyConversationMCPServerViews(
   auth: Authenticator,
   {
-    parentConversation,
     childConversation,
+    mcpServerViews,
     transaction,
   }: {
-    parentConversation: ConversationWithoutContentType;
     childConversation: ConversationWithoutContentType;
+    mcpServerViews: MCPServerViewResource[];
     transaction: Transaction;
   }
 ): Promise<Result<undefined, DustError<CreateConversationForkErrorCode>>> {
-  const parentMCPServerViews = await ConversationResource.fetchMCPServerViews(
-    auth,
-    parentConversation,
-    { onlyEnabled: true }
-  );
-
-  if (parentMCPServerViews.length === 0) {
-    return new Ok(undefined);
-  }
-
-  const readableMCPServerViews = await MCPServerViewResource.fetchByModelIds(
-    auth,
-    parentMCPServerViews.map((view) => view.mcpServerViewId)
-  );
-
-  if (readableMCPServerViews.length === 0) {
+  if (mcpServerViews.length === 0) {
     return new Ok(undefined);
   }
 
   const upsertResult = await ConversationResource.upsertMCPServerViews(auth, {
     conversation: childConversation,
-    mcpServerViews: readableMCPServerViews,
+    mcpServerViews,
     enabled: true,
     source: "conversation",
     agentConfigurationId: null,
@@ -156,21 +142,16 @@ async function copyConversationMCPServerViews(
 async function copyConversationSkills(
   auth: Authenticator,
   {
-    parentConversation,
     childConversation,
+    skills,
     transaction,
   }: {
-    parentConversation: ConversationWithoutContentType;
     childConversation: ConversationWithoutContentType;
+    skills: SkillResource[];
     transaction: Transaction;
   }
 ): Promise<Result<undefined, DustError<CreateConversationForkErrorCode>>> {
-  const parentSkills = await SkillResource.listEnabledByConversation(auth, {
-    conversation: parentConversation,
-    transaction,
-  });
-
-  if (parentSkills.length === 0) {
+  if (skills.length === 0) {
     return new Ok(undefined);
   }
 
@@ -178,7 +159,7 @@ async function copyConversationSkills(
     auth,
     {
       conversationId: childConversation.id,
-      skills: parentSkills,
+      skills,
       enabled: true,
     },
     { transaction }
@@ -194,6 +175,111 @@ async function copyConversationSkills(
   }
 
   return new Ok(undefined);
+}
+
+async function getConversationMCPServerViewsToCopy(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType
+): Promise<MCPServerViewResource[]> {
+  const parentMCPServerViews = await ConversationResource.fetchMCPServerViews(
+    auth,
+    conversation,
+    { onlyEnabled: true }
+  );
+
+  if (parentMCPServerViews.length === 0) {
+    return [];
+  }
+
+  return MCPServerViewResource.fetchByModelIds(
+    auth,
+    parentMCPServerViews.map((view) => view.mcpServerViewId)
+  );
+}
+
+async function getConversationSkillsToCopy(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType
+): Promise<SkillResource[]> {
+  return SkillResource.listEnabledByConversation(auth, {
+    conversation,
+  });
+}
+
+async function getForkAttachmentSpaceIds(
+  auth: Authenticator,
+  {
+    parentConversation,
+    sourceMessageRank,
+  }: {
+    parentConversation: ConversationType;
+    sourceMessageRank: number;
+  }
+): Promise<number[]> {
+  const parentConversationAtSource = filterConversationContentUpToRank(
+    parentConversation,
+    sourceMessageRank
+  );
+  const attachments = await listAttachments(auth, {
+    conversation: parentConversationAtSource,
+  });
+  const contentNodeDataSourceViewIds = Array.from(
+    new Set(
+      attachments
+        .filter(isContentNodeAttachmentType)
+        .map((attachment) => attachment.nodeDataSourceViewId)
+    )
+  );
+
+  if (contentNodeDataSourceViewIds.length === 0) {
+    return [];
+  }
+
+  const dataSourceViews = await DataSourceViewResource.fetchByIds(
+    auth,
+    contentNodeDataSourceViewIds
+  );
+
+  return Array.from(new Set(dataSourceViews.map((view) => view.space.id)));
+}
+
+async function getForkRequestedSpaceIds(
+  auth: Authenticator,
+  {
+    parentConversation,
+    parentConversationWithContent,
+    sourceMessageRank,
+    mcpServerViews,
+    skills,
+  }: {
+    parentConversation: ConversationResource;
+    parentConversationWithContent: ConversationType;
+    sourceMessageRank: number;
+    mcpServerViews: MCPServerViewResource[];
+    skills: SkillResource[];
+  }
+): Promise<number[]> {
+  const parentSpace = parentConversation.space;
+
+  if (parentSpace?.isProject()) {
+    return [parentSpace.id];
+  }
+
+  // Conversation-owned files inherit the child conversation ACL. Only copied setup and content
+  // nodes contribute additional space requirements.
+  const contentNodeSpaceIds = await getForkAttachmentSpaceIds(auth, {
+    parentConversation: parentConversationWithContent,
+    sourceMessageRank,
+  });
+
+  return Array.from(
+    new Set([
+      ...(parentSpace ? [parentSpace.id] : []),
+      ...mcpServerViews.map((view) => view.space.id),
+      ...skills.flatMap((skill) => skill.requestedSpaceIds),
+      ...contentNodeSpaceIds,
+    ])
+  );
 }
 
 async function createForkInitializationMessage(
@@ -489,24 +575,57 @@ export async function createConversationFork(
     );
   }
 
+  const sourceMessage = await ConversationResource.resolveForkSourceMessage(
+    auth,
+    {
+      conversationId: parentConversation.id,
+      sourceMessageId,
+    }
+  );
+
+  if (sourceMessage.isErr()) {
+    return new Err(
+      new DustError("invalid_request_error", sourceMessage.error.message)
+    );
+  }
+
+  const parentConversationWithContent = await getConversation(
+    auth,
+    conversationId
+  );
+  if (parentConversationWithContent.isErr()) {
+    logger.error(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        parentConversationId: conversationId,
+        error: parentConversationWithContent.error,
+      },
+      "Failed to load parent conversation for fork preparation."
+    );
+
+    return new Err(
+      new DustError(
+        "internal_error",
+        "Failed to prepare the conversation fork."
+      )
+    );
+  }
+
+  const [mcpServerViewsToCopy, skillsToCopy] = await Promise.all([
+    getConversationMCPServerViewsToCopy(auth, parentConversation.toJSON()),
+    getConversationSkillsToCopy(auth, parentConversation.toJSON()),
+  ]);
+  const requestedSpaceIds = await getForkRequestedSpaceIds(auth, {
+    parentConversation,
+    parentConversationWithContent: parentConversationWithContent.value,
+    sourceMessageRank: sourceMessage.value.rank,
+    mcpServerViews: mcpServerViewsToCopy,
+    skills: skillsToCopy,
+  });
+
   const branchedAt = new Date();
 
   const childConversationId = await withTransaction(async (transaction) => {
-    const sourceMessage = await ConversationResource.resolveForkSourceMessage(
-      auth,
-      {
-        conversationId: parentConversation.id,
-        sourceMessageId,
-        transaction,
-      }
-    );
-
-    if (sourceMessage.isErr()) {
-      return new Err(
-        new DustError("invalid_request_error", sourceMessage.error.message)
-      );
-    }
-
     const childConversation = await ConversationResource.makeNew(
       auth,
       {
@@ -516,7 +635,7 @@ export async function createConversationFork(
         depth: parentConversation.depth + 1,
         triggerId: null,
         spaceId: parentConversation.space?.id ?? null,
-        requestedSpaceIds: [...parentConversation.requestedSpaceIds],
+        requestedSpaceIds,
         metadata: {},
       },
       parentConversation.space,
@@ -526,8 +645,8 @@ export async function createConversationFork(
     const copyMCPServerViewsResult = await copyConversationMCPServerViews(
       auth,
       {
-        parentConversation: parentConversation.toJSON(),
         childConversation: childConversation.toJSON(),
+        mcpServerViews: mcpServerViewsToCopy,
         transaction,
       }
     );
@@ -537,8 +656,8 @@ export async function createConversationFork(
     }
 
     const copySkillsResult = await copyConversationSkills(auth, {
-      parentConversation: parentConversation.toJSON(),
       childConversation: childConversation.toJSON(),
+      skills: skillsToCopy,
       transaction,
     });
 
@@ -598,23 +717,6 @@ export async function createConversationFork(
     );
 
     return new Ok(childConversationId.value.childConversationId);
-  }
-
-  const parentConversationWithContent = await getConversation(
-    auth,
-    conversationId
-  );
-  if (parentConversationWithContent.isErr()) {
-    logger.error(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        parentConversationId: conversationId,
-        childConversationId: childConversation.value.sId,
-        error: parentConversationWithContent.error,
-      },
-      "Failed to reload parent conversation for fork attachment carryover."
-    );
-    return new Ok(childConversation.value.sId);
   }
 
   await carryOverConversationAttachments(auth, {


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24537
Context: [slack thread](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1775655809989229)

This stops copying the parent conversation's full `requestedSpaceIds` into the child fork. The child now recomputes its requirements from the resources actually carried over into it: the base conversation space, copied conversation MCP views, copied skills, and pre-fork content node attachments.

## Risks
Blast radius: conversation branching access control for forked child conversations
Risk: standard

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm run test -- lib/api/assistant/conversation/forks.test.ts pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts`