### PR TITLE
feat: skip notification for slack conversations

### DIFF
--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -1032,6 +1032,95 @@ describe("conversation-unread workflow business logic", () => {
       expect(result.isOk()).toBe(true);
       expect(vi.mocked(getNovuClient)).not.toHaveBeenCalled();
     });
+
+    it("should skip notifications for slack-origin user messages", async () => {
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Slack Agent",
+        description: "Test",
+      });
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+      });
+
+      const { userMessage } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Posted from slack",
+        origin: "slack",
+      });
+
+      await ConversationResource.upsertParticipation(auth, {
+        conversation,
+        action: "posted",
+        user: user1.toJSON(),
+        lastReadAt: null,
+      });
+      await ConversationResource.upsertParticipation(auth, {
+        conversation,
+        action: "posted",
+        user: user2.toJSON(),
+        lastReadAt: null,
+      });
+
+      const result = await triggerConversationUnreadNotifications(auth, {
+        conversationId: conversation.sId,
+        messageId: userMessage.sId,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(vi.mocked(getNovuClient)).not.toHaveBeenCalled();
+    });
+
+    it("should skip notifications for agent replies to slack-origin user messages", async () => {
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Slack Agent",
+        description: "Test",
+      });
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+      });
+
+      const { userMessage } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Posted from slack",
+        origin: "slack",
+      });
+      const agentMessage = await ConversationFactory.createAgentMessageWithRank(
+        {
+          workspace,
+          conversationId: conversation.id,
+          rank: 1,
+          agentConfigurationId: agent.sId,
+          parentId: userMessage.id,
+        }
+      );
+
+      await ConversationResource.upsertParticipation(auth, {
+        conversation,
+        action: "posted",
+        user: user1.toJSON(),
+        lastReadAt: null,
+      });
+      await ConversationResource.upsertParticipation(auth, {
+        conversation,
+        action: "posted",
+        user: user2.toJSON(),
+        lastReadAt: null,
+      });
+
+      const result = await triggerConversationUnreadNotifications(auth, {
+        conversationId: conversation.sId,
+        messageId: agentMessage.sId,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(vi.mocked(getNovuClient)).not.toHaveBeenCalled();
+    });
   });
 });
 
@@ -1052,6 +1141,7 @@ describe("getMessagePreviewText", () => {
     isNewProjectConversation: true,
     mentionedUserIds: [],
     isFromEmailAgentConversation: false,
+    isFromSlackAgentConversation: false,
   };
   it("should return retention policy message for conversation retention", () => {
     const details: ConversationDetailsType = {
@@ -1146,6 +1236,7 @@ describe("getMessagePreviewSlack", () => {
     avatarUrl: "https://example.com/avatar.jpg",
     isFromTrigger: false,
     isFromEmailAgentConversation: false,
+    isFromSlackAgentConversation: false,
     workspaceName: "Test Workspace",
     mentionedUserIds: [],
     hasUnreadMessages: true,
@@ -1280,6 +1371,7 @@ describe("getEmailSummary", () => {
     authorIsAgent: false,
     isFromTrigger: false,
     isFromEmailAgentConversation: false,
+    isFromSlackAgentConversation: false,
     workspaceName: "Test Workspace",
     mentionedUserIds: [],
     hasUnreadMessages: true,

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -120,6 +120,7 @@ const ConversationDetailsSchema = z.object({
   authorUserId: z.string().optional(),
   isFromTrigger: z.boolean(),
   isFromEmailAgentConversation: z.boolean(),
+  isFromSlackAgentConversation: z.boolean(),
   workspaceName: z.string(),
   mentionedUserIds: z.array(z.string()),
   hasUnreadMessages: z.boolean(),
@@ -176,6 +177,7 @@ const getConversationDetails = async ({
         authorIsAgent: false,
         isFromTrigger: false,
         isFromEmailAgentConversation: false,
+        isFromSlackAgentConversation: false,
         workspaceName: "Deleted conversation",
         mentionedUserIds: [],
         avatarUrl: undefined,
@@ -251,6 +253,12 @@ const getConversationDetails = async ({
       isUserMessageType(parentUserMessage) &&
       parentUserMessage.context.origin === "email");
 
+  const isFromSlackAgentConversation =
+    (isUserMessageType(message) && message.context.origin === "slack") ||
+    (parentUserMessage !== undefined &&
+      isUserMessageType(parentUserMessage) &&
+      parentUserMessage.context.origin === "slack");
+
   if (isCompactionMessageType(message)) {
     // Compaction messages don't trigger notifications.
     return new Err(new ConversationError("message_not_found"));
@@ -322,6 +330,7 @@ const getConversationDetails = async ({
     authorUserId,
     isFromTrigger,
     isFromEmailAgentConversation,
+    isFromSlackAgentConversation,
     workspaceName,
     mentionedUserIds,
     hasUnreadMessages,
@@ -1174,7 +1183,10 @@ export const triggerConversationUnreadNotifications = async (
     // Conversation or message was deleted - no notification needed.
     return new Ok(undefined);
   }
-  if (detailsResult.value.isFromEmailAgentConversation) {
+  if (
+    detailsResult.value.isFromEmailAgentConversation ||
+    detailsResult.value.isFromSlackAgentConversation
+  ) {
     return new Ok(undefined);
   }
   const { authorUserId } = detailsResult.value;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7618

This PR adds logic to skip notification triggers for Slack-origin conversations, preventing duplicate notifications when messages come from Slack.

- Introduces `isFromSlackAgentConversation` field to track whether a message or its parent message originated from Slack
- Updates the notification trigger logic to skip Slack-origin conversations
- Follows the same pattern as the existing email-origin conversation handling

## Tests

- Added unit tests for Slack-origin user messages
- Added unit tests for agent replies to Slack-origin user messages

## Risk

Low - This follows the same pattern as the existing email notification handling and is covered by tests.

## Deploy Plan

Standard deployment - no special steps required.
