### PR TITLE
[front] chore: remove type casts in `SkillResource`

### DIFF
--- a/front/lib/models/agent/agent_skill.ts
+++ b/front/lib/models/agent/agent_skill.ts
@@ -3,7 +3,6 @@ import {
   eitherGlobalOrCustomSkillValidation,
   SkillConfigurationModel,
 } from "@app/lib/models/skill";
-import type { GlobalSkillId } from "@app/lib/resources/skill/global/registry";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
@@ -14,7 +13,7 @@ export class AgentSkillModel extends WorkspaceAwareModel<AgentSkillModel> {
   declare updatedAt: CreationOptional<Date>;
 
   declare customSkillId: ForeignKey<SkillConfigurationModel["id"]> | null;
-  declare globalSkillId: GlobalSkillId | null;
+  declare globalSkillId: string | null;
 
   declare agentConfigurationId: ForeignKey<AgentConfigurationModel["id"]>;
 }

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -6,7 +6,6 @@ import {
   eitherGlobalOrCustomSkillValidation,
   SkillConfigurationModel,
 } from "@app/lib/models/skill";
-import type { GlobalSkillId } from "@app/lib/resources/skill/global/registry";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -75,7 +74,7 @@ export class ConversationSkillModel extends WorkspaceAwareModel<ConversationSkil
   declare agentConfigurationId: string | null;
 
   declare customSkillId: ForeignKey<SkillConfigurationModel["id"]> | null;
-  declare globalSkillId: GlobalSkillId | null;
+  declare globalSkillId: string | null;
 
   declare conversationId: ForeignKey<ConversationModel["id"]>;
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -28,10 +28,7 @@ import {
   createResourcePermissionsFromSpacesWithMap,
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
-import type {
-  GlobalSkillDefinition,
-  GlobalSkillId,
-} from "@app/lib/resources/skill/global/registry";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/global/registry";
 import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -97,7 +94,7 @@ type SkillResourceConstructorOptions =
       dataSourceConfigurations: SkillDataSourceConfigurationModel[];
       editorGroup?: undefined;
       fileAttachments: FileResource[];
-      globalSId: GlobalSkillId;
+      globalSId: string;
       mcpServerConfigurations: SkillMCPServerConfiguration[];
       version?: number;
     }
@@ -200,7 +197,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   readonly editorGroup: GroupResource | null = null;
   readonly version: number | null = null;
 
-  private readonly globalSId: GlobalSkillId | null;
+  private readonly globalSId: string | null;
 
   private _mcpServerConfigurations: SkillMCPServerConfiguration[];
 
@@ -835,7 +832,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     auth: Authenticator,
     refs: {
       customSkillId: ModelId | null;
-      globalSkillId: GlobalSkillId | null;
+      globalSkillId: string | null;
     }[],
     {
       agentLoopData,
@@ -867,7 +864,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    * Returns the fields to identify this skill in related tables (e.g., AgentSkillModel).
    */
   private get skillReference():
-    | { globalSkillId: GlobalSkillId }
+    | { globalSkillId: string }
     | { customSkillId: ModelId } {
     return this.globalSId
       ? { globalSkillId: this.globalSId }
@@ -977,7 +974,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<
     {
       customSkillId: ModelId | null;
-      globalSkillId: GlobalSkillId | null;
+      globalSkillId: string | null;
     }[]
   > {
     // For global agents, skills are defined in the config, not in the database.
@@ -985,12 +982,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       isGlobalAgentId(agentConfiguration.sId) &&
       "skills" in agentConfiguration
     ) {
-      return ((agentConfiguration.skills ?? []) as GlobalSkillId[]).map(
-        (globalSkillId) => ({
-          customSkillId: null,
-          globalSkillId,
-        })
-      );
+      return (agentConfiguration.skills ?? []).map((globalSkillId) => ({
+        customSkillId: null,
+        globalSkillId,
+      }));
     }
 
     const workspace = auth.getNonNullableWorkspace();
@@ -1479,7 +1474,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       {
         // Global skills do not have data source configurations.
         dataSourceConfigurations: [],
-        globalSId: def.sId as GlobalSkillId,
+        globalSId: def.sId,
         mcpServerConfigurations,
         fileAttachments: [],
       }

--- a/front/migrations/20260217_backfill_skills_analytics.ts
+++ b/front/migrations/20260217_backfill_skills_analytics.ts
@@ -10,10 +10,7 @@ import {
 } from "@app/lib/models/agent/conversation";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill";
-import type {
-  GlobalSkillDefinition,
-  GlobalSkillId,
-} from "@app/lib/resources/skill/global/registry";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/global/registry";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -136,9 +133,11 @@ async function backfillSkillsAnalyticsForWorkspace(
     }
 
     // Fetch global skill definitions for referenced global skills.
-    const globalSkillIds: GlobalSkillId[] = [
+    const globalSkillIds: string[] = [
       ...new Set(
-        skillRecords.map((r) => r.globalSkillId).filter((id) => id !== null)
+        skillRecords
+          .map((r) => r.globalSkillId)
+          .filter((id): id is string => id !== null)
       ),
     ];
 


### PR DESCRIPTION
## Description

- This PR removes a few type casts that were added in `SkillResource`.
- The typing of the global skill ID as strings rather than `GlobalSkillId` is unavoidable without checking on every fetch from the db. Having a somewhat loose type that is checked only when necessary compared to typecasting and potentially causing runtime errors downstream was intentional.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
- No migration (only a type change).
