### PR TITLE
[front] enh: batch fetch MCP server views in global skills fetch

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1456,8 +1456,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       def.mcpServers ?? []
     ).flatMap(({ name, childAgentId, serverNameOverride }) => {
       const views =
-        viewsByServerId[autoInternalMCPServerNameToSId({ name, workspaceId })] ??
-        [];
+        viewsByServerId[
+          autoInternalMCPServerNameToSId({ name, workspaceId })
+        ] ?? [];
       return views.map((view) => ({ view, childAgentId, serverNameOverride }));
     });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -713,19 +713,22 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     let mcpServerViews: MCPServerViewResource[] = [];
     if (withTools) {
       const mcpServerIds = uniq(
-            enabledGlobalSkillDefinitions.flatMap(
-              (def) => def.mcpServers?.map((s) => s.name) ?? []
-            )
-          ).map((name) =>
-            autoInternalMCPServerNameToSId({ name, workspaceId: workspace.id })
-          );
+        enabledGlobalSkillDefinitions.flatMap(
+          (def) => def.mcpServers?.map((s) => s.name) ?? []
+        )
+      ).map((name) =>
+        autoInternalMCPServerNameToSId({ name, workspaceId: workspace.id })
+      );
       const allMCPServerViews = await MCPServerViewResource.listByMCPServers(
         auth,
         mcpServerIds,
         transaction
       );
-      mcpServerViews = allMCPServerViews.filter(view => requestedSpaceModelIds.includes(view.vaultId) ||
-        view.space.kind === "global");
+      mcpServerViews = allMCPServerViews.filter(
+        (view) =>
+          requestedSpaceModelIds.includes(view.vaultId) ||
+          view.space.kind === "global"
+      );
     }
 
     const globalSkills = await concurrentExecutor(
@@ -1444,13 +1447,18 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const mcpServerConfigurations: SkillMCPServerConfiguration[] = (
       def.mcpServers ?? []
-    ).flatMap(({ name, childAgentId, serverNameOverride }) => mcpServerViews
-        .filter((view) => view.internalMCPServerId === autoInternalMCPServerNameToSId({
-          name,
-          workspaceId: auth.getNonNullableWorkspace().id,
-        }))
-        .map((view) => ({ view, childAgentId, serverNameOverride })
-    ));
+    ).flatMap(({ name, childAgentId, serverNameOverride }) =>
+      mcpServerViews
+        .filter(
+          (view) =>
+            view.internalMCPServerId ===
+            autoInternalMCPServerNameToSId({
+              name,
+              workspaceId: auth.getNonNullableWorkspace().id,
+            })
+        )
+        .map((view) => ({ view, childAgentId, serverNameOverride }))
+    );
 
     const instructions = def.fetchInstructions
       ? await def.fetchInstructions(auth, {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1454,13 +1454,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const mcpServerConfigurations: SkillMCPServerConfiguration[] = (
       def.mcpServers ?? []
-    ).flatMap(({ name, childAgentId, serverNameOverride }) => {
-      const views =
+    ).flatMap(({ name, childAgentId, serverNameOverride }) =>
+      (
         viewsByServerId[
           autoInternalMCPServerNameToSId({ name, workspaceId })
-        ] ?? [];
-      return views.map((view) => ({ view, childAgentId, serverNameOverride }));
-    });
+        ] ?? []
+      ).map((view) => ({ view, childAgentId, serverNameOverride }))
+    );
 
     const instructions = def.fetchInstructions
       ? await def.fetchInstructions(auth, {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1439,26 +1439,27 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       mcpServerViews: MCPServerViewResource[];
     }
   ): Promise<SkillResource> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
     const { agentConfiguration } = agentLoopData ?? {};
     const requestedSpaceIds = agentConfiguration?.requestedSpaceIds ?? [];
     const requestedSpaceModelIds = removeNulls(
       requestedSpaceIds.map(getResourceIdFromSId)
     );
 
+    const viewsByServerId = groupBy(
+      mcpServerViews.filter((v) => v.internalMCPServerId !== null),
+      "internalMCPServerId"
+    );
+
     const mcpServerConfigurations: SkillMCPServerConfiguration[] = (
       def.mcpServers ?? []
-    ).flatMap(({ name, childAgentId, serverNameOverride }) =>
-      mcpServerViews
-        .filter(
-          (view) =>
-            view.internalMCPServerId ===
-            autoInternalMCPServerNameToSId({
-              name,
-              workspaceId: auth.getNonNullableWorkspace().id,
-            })
-        )
-        .map((view) => ({ view, childAgentId, serverNameOverride }))
-    );
+    ).flatMap(({ name, childAgentId, serverNameOverride }) => {
+      const views =
+        viewsByServerId[autoInternalMCPServerNameToSId({ name, workspaceId })] ??
+        [];
+      return views.map((view) => ({ view, childAgentId, serverNameOverride }));
+    });
 
     const instructions = def.fetchInstructions
       ? await def.fetchInstructions(auth, {
@@ -1482,7 +1483,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         requestedSpaceIds: requestedSpaceModelIds,
         status: "active",
         updatedAt: new Date(),
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId,
         icon: def.icon,
         extendedSkillId: null,
         source: null,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1,4 +1,5 @@
 import { fetchMCPServerActionConfigurations } from "@app/lib/actions/configuration/mcp";
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent_requirements";
 import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
 import { hasSharedMembership } from "@app/lib/api/user";
@@ -698,18 +699,43 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       where
     );
 
-    // Fetch global skills with their MCP server configurations.
-    const globalSkills = removeNulls(
-      await concurrentExecutor(
-        globalSkillDefinitions,
-        async (def) => {
-          if (agentLoopData && def.isDisabledForAgentLoop?.(agentLoopData)) {
-            return null;
-          }
-          return this.fromGlobalSkill(auth, def, context, { withTools });
-        },
-        { concurrency: 5 }
+    const enabledGlobalSkillDefinitions = globalSkillDefinitions.filter(
+      (def) => !agentLoopData || !def.isDisabledForAgentLoop?.(agentLoopData)
+    );
+
+    const requestedSpaceModelIds = removeNulls(
+      (agentLoopData?.agentConfiguration?.requestedSpaceIds ?? []).map(
+        getResourceIdFromSId
       )
+    );
+
+    // Batch-fetch MCP server views for all enabled global skills in a single query.
+    let mcpServerViews: MCPServerViewResource[] = [];
+    if (withTools) {
+      const mcpServerIds = uniq(
+            enabledGlobalSkillDefinitions.flatMap(
+              (def) => def.mcpServers?.map((s) => s.name) ?? []
+            )
+          ).map((name) =>
+            autoInternalMCPServerNameToSId({ name, workspaceId: workspace.id })
+          );
+      const allMCPServerViews = await MCPServerViewResource.listByMCPServers(
+        auth,
+        mcpServerIds,
+        transaction
+      );
+      mcpServerViews = allMCPServerViews.filter(view => requestedSpaceModelIds.includes(view.vaultId) ||
+        view.space.kind === "global");
+    }
+
+    const globalSkills = await concurrentExecutor(
+      enabledGlobalSkillDefinitions,
+      (def) =>
+        this.fromGlobalSkill(auth, def, {
+          agentLoopData,
+          mcpServerViews,
+        }),
+      { concurrency: 5 }
     );
 
     return [...allowedCustomSkillsRes, ...globalSkills];
@@ -1404,16 +1430,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     def: GlobalSkillDefinition,
     {
       agentLoopData,
-      transaction,
+      mcpServerViews,
     }: {
       agentLoopData?: AgentLoopExecutionData;
-      transaction?: Transaction;
-    } = {},
-    {
-      withTools = true,
-    }: {
-      withTools?: boolean;
-    } = {}
+      mcpServerViews: MCPServerViewResource[];
+    }
   ): Promise<SkillResource> {
     const { agentConfiguration } = agentLoopData ?? {};
     const requestedSpaceIds = agentConfiguration?.requestedSpaceIds ?? [];
@@ -1421,29 +1442,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       requestedSpaceIds.map(getResourceIdFromSId)
     );
 
-    let mcpServerConfigurations: SkillMCPServerConfiguration[] = [];
-
-    if (withTools && def.mcpServers) {
-      const mcpServerConfigurationsByName = await concurrentExecutor(
-        def.mcpServers,
-        async ({ name, childAgentId, serverNameOverride }) => {
-          const views =
-            await MCPServerViewResource.listMCPServerViewsAutoInternalForSpaces(
-              auth,
-              name,
-              requestedSpaceModelIds,
-              transaction
-            );
-          return views.map((view) => ({
-            view,
-            childAgentId,
-            serverNameOverride,
-          }));
-        },
-        { concurrency: 5 }
-      );
-      mcpServerConfigurations = mcpServerConfigurationsByName.flat();
-    }
+    const mcpServerConfigurations: SkillMCPServerConfiguration[] = (
+      def.mcpServers ?? []
+    ).flatMap(({ name, childAgentId, serverNameOverride }) => mcpServerViews
+        .filter((view) => view.internalMCPServerId === autoInternalMCPServerNameToSId({
+          name,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        }))
+        .map((view) => ({ view, childAgentId, serverNameOverride })
+    ));
 
     const instructions = def.fetchInstructions
       ? await def.fetchInstructions(auth, {


### PR DESCRIPTION
## Description

- This PR batch fetches the MCP server views when fetching global skills instead of fetching them concurrently.
- Prevents connection pool exhaustion: the global skills were fetched concurrently, and the MCP server views were also fetched concurrently, leading to > 10 connections acquired in parallel peak.

## Tests

- Tested locally.

## Risk

- Medium. Affects all global skills fetchs

## Deploy Plan

- Deploy front.
