### PR TITLE
Poke button to help generate eval tests

### DIFF
--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -1,13 +1,12 @@
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
-import { useSendNotification } from "@app/hooks/useNotification";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { classNames } from "@app/lib/utils";
-import type { GetReinforcementTestCaseResponseBody } from "@app/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case";
 import { usePokeConversation } from "@app/poke/swr";
 import { usePokeAgentConfigurations } from "@app/poke/swr/agent_configurations";
 import { usePokeConversationConfig } from "@app/poke/swr/conversation_config";
+import { useCopyReinforcementTestCase } from "@app/poke/swr/reinforcement_test_case";
 import type {
   CompactionMessageType,
   UserMessageType,
@@ -387,37 +386,8 @@ export function ConversationPage() {
   const [showRenderControls, setShowRenderControls] = useState(false);
   const [isCopiedJSON, copyJSON] = useCopyToClipboard();
 
-  const [isTestCaseLoading, setIsTestCaseLoading] = useState(false);
-  const sendNotification = useSendNotification();
-
-  async function handleCopyReinforcementTestCase() {
-    setIsTestCaseLoading(true);
-    try {
-      const response = await clientFetch(
-        `/api/poke/workspaces/${owner.sId}/conversations/${conversationId}/reinforcement_test_case`
-      );
-      const data = await response.json();
-      if (!response.ok) {
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        throw new Error(data.error?.message || "Failed to generate test case");
-      }
-      const { testCase } = data as GetReinforcementTestCaseResponseBody;
-      await navigator.clipboard.writeText(JSON.stringify(testCase, null, 2));
-      sendNotification({
-        title: "Copied",
-        description: "Reinforcement test case copied to clipboard.",
-        type: "success",
-      });
-    } catch (e) {
-      sendNotification({
-        title: "Error",
-        description: e instanceof Error ? e.message : "Unknown error",
-        type: "error",
-      });
-    } finally {
-      setIsTestCaseLoading(false);
-    }
-  }
+  const { copyTestCase, isLoading: isTestCaseLoading } =
+    useCopyReinforcementTestCase({ owner, conversationId });
 
   useEffect(() => {
     if (!selectedAgentId) {
@@ -563,7 +533,7 @@ export function ConversationPage() {
               label="Reinforcement test"
               variant="primary"
               size="xs"
-              onClick={() => void handleCopyReinforcementTestCase()}
+              onClick={() => void copyTestCase()}
               disabled={isTestCaseLoading}
             />
             {isRendering && <Spinner size="xs" />}

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -1,8 +1,10 @@
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
+import { useSendNotification } from "@app/hooks/useNotification";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { classNames } from "@app/lib/utils";
+import type { GetReinforcementTestCaseResponseBody } from "@app/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case";
 import { usePokeConversation } from "@app/poke/swr";
 import { usePokeAgentConfigurations } from "@app/poke/swr/agent_configurations";
 import { usePokeConversationConfig } from "@app/poke/swr/conversation_config";
@@ -385,6 +387,38 @@ export function ConversationPage() {
   const [showRenderControls, setShowRenderControls] = useState(false);
   const [isCopiedJSON, copyJSON] = useCopyToClipboard();
 
+  const [isTestCaseLoading, setIsTestCaseLoading] = useState(false);
+  const sendNotification = useSendNotification();
+
+  async function handleCopyReinforcementTestCase() {
+    setIsTestCaseLoading(true);
+    try {
+      const response = await clientFetch(
+        `/api/poke/workspaces/${owner.sId}/conversations/${conversationId}/reinforcement_test_case`
+      );
+      const data = await response.json();
+      if (!response.ok) {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        throw new Error(data.error?.message || "Failed to generate test case");
+      }
+      const { testCase } = data as GetReinforcementTestCaseResponseBody;
+      await navigator.clipboard.writeText(JSON.stringify(testCase, null, 2));
+      sendNotification({
+        title: "Copied",
+        description: "Reinforcement test case copied to clipboard.",
+        type: "success",
+      });
+    } catch (e) {
+      sendNotification({
+        title: "Error",
+        description: e instanceof Error ? e.message : "Unknown error",
+        type: "error",
+      });
+    } finally {
+      setIsTestCaseLoading(false);
+    }
+  }
+
   useEffect(() => {
     if (!selectedAgentId) {
       if (defaultAgentId) {
@@ -524,6 +558,13 @@ export function ConversationPage() {
                 void handleRenderConversation();
               }}
               disabled={isRendering}
+            />
+            <Button
+              label="Reinforcement test"
+              variant="primary"
+              size="xs"
+              onClick={() => void handleCopyReinforcementTestCase()}
+              disabled={isTestCaseLoading}
             />
             {isRendering && <Spinner size="xs" />}
             {showRenderControls && (

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2415,6 +2415,25 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
+  static async listByConversationModelId(
+    auth: Authenticator,
+    conversationModelId: ModelId
+  ): Promise<SkillResource[]> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const agentMessageSkills = await AgentMessageSkillModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        conversationId: conversationModelId,
+      },
+    });
+
+    // Include all statuses for historical accuracy.
+    return this.fetchBySkillReferences(auth, agentMessageSkills, {
+      status: ["active", "archived", "suggested"],
+    });
+  }
+
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
@@ -6,10 +6,8 @@ import { listAvailableTools } from "@app/lib/api/assistant/workspace_capabilitie
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { makeSId } from "@app/lib/resources/string_ids";
 import { apiError } from "@app/logger/withlogging";
 import {
   isAgentMessageType,
@@ -135,27 +133,11 @@ async function handler(
     });
   }
   const conversation = conversationRes.value;
-  const workspace = auth.getNonNullableWorkspace();
 
-  // Discover custom skills used in this conversation via AgentMessageSkillModel.
-  const skillRecords = await AgentMessageSkillModel.findAll({
-    attributes: ["customSkillId"],
-    where: {
-      workspaceId: workspace.id,
-      conversationId: conversation.id,
-    },
-  });
-  const customSkillModelIds: ModelId[] = [
-    ...new Set(
-      skillRecords
-        .map((r) => r.customSkillId)
-        .filter((id): id is number => id !== null)
-    ),
-  ];
-  const skillIds = customSkillModelIds.map((id) =>
-    makeSId("skill", { id, workspaceId: workspace.id })
+  const skills = await SkillResource.listByConversationModelId(
+    auth,
+    conversation.id
   );
-  const skills = await SkillResource.fetchByIds(auth, skillIds);
 
   const skillConfigs: ReinforcementTestCaseMockSkillConfig[] = skills.map(
     (skill) => {

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
@@ -152,10 +152,10 @@ async function handler(
         .filter((id): id is number => id !== null)
     ),
   ];
-  const skillSIds = customSkillModelIds.map((id) =>
+  const skillIds = customSkillModelIds.map((id) =>
     makeSId("skill", { id, workspaceId: workspace.id })
   );
-  const skills = await SkillResource.fetchByIds(auth, skillSIds);
+  const skills = await SkillResource.fetchByIds(auth, skillIds);
 
   const skillConfigs: ReinforcementTestCaseMockSkillConfig[] = skills.map(
     (skill) => {

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
@@ -1,0 +1,275 @@
+/** @ignoreswagger */
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import type { AvailableTool } from "@app/lib/api/assistant/workspace_capabilities";
+import { listAvailableTools } from "@app/lib/api/assistant/workspace_capabilities";
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { apiError } from "@app/logger/withlogging";
+import {
+  isAgentMessageType,
+  isUserMessageType,
+} from "@app/types/assistant/conversation";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { ModelId } from "@app/types/shared/model_id";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+interface ReinforcementTestCaseMockAction {
+  functionCallName: string;
+  status: "succeeded" | "failed";
+  params?: Record<string, unknown>;
+  output?: string | null;
+}
+
+interface ReinforcementTestCaseMockFeedback {
+  direction: "up" | "down";
+  comment?: string;
+}
+
+interface ReinforcementTestCaseMockMessage {
+  role: "user" | "agent";
+  content: string;
+  feedback?: ReinforcementTestCaseMockFeedback;
+  actions?: ReinforcementTestCaseMockAction[];
+}
+
+interface ReinforcementTestCaseMockSkillTool {
+  name: string;
+  sId: string;
+}
+
+interface ReinforcementTestCaseMockSkillConfig {
+  name: string;
+  sId: string;
+  description?: string;
+  instructions?: string;
+  tools?: ReinforcementTestCaseMockSkillTool[];
+}
+
+interface ReinforcementTestCaseWorkspaceContext {
+  tools: AvailableTool[];
+}
+
+export interface ReinforcementTestCaseType {
+  scenarioId: string;
+  type: "analysis";
+  skillConfigs: ReinforcementTestCaseMockSkillConfig[];
+  conversation: ReinforcementTestCaseMockMessage[];
+  workspaceContext: ReinforcementTestCaseWorkspaceContext;
+  expectedToolCalls: [];
+  judgeCriteria: string;
+}
+
+export type GetReinforcementTestCaseResponseBody = {
+  testCase: ReinforcementTestCaseType;
+};
+
+function serializeActionOutput(
+  output: Array<{ type: string; text?: string }> | null | undefined
+): string | null {
+  if (!output) {
+    return null;
+  }
+  const texts = output
+    .filter(
+      (block): block is { type: "text"; text: string } =>
+        block.type === "text" && typeof block.text === "string"
+    )
+    .map((block) => block.text);
+  return texts.length > 0 ? texts.join("\n") : null;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetReinforcementTestCaseResponseBody>
+  >,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, cId } = req.query;
+  if (!isString(wId) || !isString(cId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or conversation ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const conversationRes = await getConversation(auth, cId, true);
+  if (conversationRes.isErr()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: conversationRes.error.message,
+      },
+    });
+  }
+  const conversation = conversationRes.value;
+  const workspace = auth.getNonNullableWorkspace();
+
+  // Discover custom skills used in this conversation via AgentMessageSkillModel.
+  const skillRecords = await AgentMessageSkillModel.findAll({
+    attributes: ["customSkillId"],
+    where: {
+      workspaceId: workspace.id,
+      conversationId: conversation.id,
+    },
+  });
+  const customSkillModelIds: ModelId[] = [
+    ...new Set(
+      skillRecords
+        .map((r) => r.customSkillId)
+        .filter((id): id is number => id !== null)
+    ),
+  ];
+  const skillSIds = customSkillModelIds.map((id) =>
+    makeSId("skill", { id, workspaceId: workspace.id })
+  );
+  const skills = await SkillResource.fetchByIds(auth, skillSIds);
+
+  const skillConfigs: ReinforcementTestCaseMockSkillConfig[] = skills.map(
+    (skill) => {
+      const tools: ReinforcementTestCaseMockSkillTool[] = skill.mcpServerViews
+        .map((view) => {
+          const viewJson = view.toJSON();
+          if (!viewJson) {
+            return null;
+          }
+          return {
+            name: getMcpServerViewDisplayName(viewJson),
+            sId: viewJson.sId,
+          };
+        })
+        .filter((t): t is ReinforcementTestCaseMockSkillTool => t !== null);
+
+      const config: ReinforcementTestCaseMockSkillConfig = {
+        name: skill.name,
+        sId: skill.sId,
+        description: skill.agentFacingDescription,
+      };
+      if (skill.instructions) {
+        config.instructions = skill.instructions;
+      }
+      if (tools.length > 0) {
+        config.tools = tools;
+      }
+      return config;
+    }
+  );
+
+  // Fetch feedbacks and index by agent message model id.
+  const feedbacks =
+    await AgentMessageFeedbackResource.listByConversationModelId(
+      auth,
+      conversation.id
+    );
+  const feedbackByAgentMessageModelId = new Map<
+    ModelId,
+    ReinforcementTestCaseMockFeedback
+  >();
+  for (const f of feedbacks) {
+    if (feedbackByAgentMessageModelId.has(f.agentMessageId)) {
+      continue;
+    }
+    const feedback: ReinforcementTestCaseMockFeedback = {
+      direction: f.thumbDirection,
+    };
+    if (f.content) {
+      feedback.comment = f.content;
+    }
+    feedbackByAgentMessageModelId.set(f.agentMessageId, feedback);
+  }
+
+  // Build mock conversation messages (last version of each, only user and agent).
+  const mockMessages: ReinforcementTestCaseMockMessage[] = [];
+  for (const messageVersions of conversation.content) {
+    if (messageVersions.length === 0) {
+      continue;
+    }
+    const last = messageVersions[messageVersions.length - 1];
+    if (isUserMessageType(last)) {
+      mockMessages.push({
+        role: "user",
+        content: last.content,
+      });
+    } else if (isAgentMessageType(last)) {
+      const actions: ReinforcementTestCaseMockAction[] = last.actions.map(
+        (a) => {
+          const action: ReinforcementTestCaseMockAction = {
+            functionCallName: a.functionCallName,
+            status: a.status === "succeeded" ? "succeeded" : "failed",
+          };
+          if (a.params && Object.keys(a.params).length > 0) {
+            action.params = a.params;
+          }
+          const output = serializeActionOutput(a.output);
+          if (output !== null) {
+            action.output = output;
+          }
+          return action;
+        }
+      );
+      const feedback = feedbackByAgentMessageModelId.get(last.agentMessageId);
+      const message: ReinforcementTestCaseMockMessage = {
+        role: "agent",
+        content: last.content ?? "",
+      };
+      if (actions.length > 0) {
+        message.actions = actions;
+      }
+      if (feedback) {
+        message.feedback = feedback;
+      }
+      mockMessages.push(message);
+    }
+  }
+
+  const availableTools = await listAvailableTools(auth);
+
+  const testCase: ReinforcementTestCaseType = {
+    scenarioId: conversation.sId,
+    type: "analysis",
+    skillConfigs,
+    conversation: mockMessages,
+    workspaceContext: {
+      tools: availableTools,
+    },
+    expectedToolCalls: [],
+    judgeCriteria:
+      "TODO: describe expected analyst behavior and scoring rubric.",
+  };
+
+  return res.status(200).json({ testCase });
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/poke/swr/reinforcement_test_case.ts
+++ b/front/poke/swr/reinforcement_test_case.ts
@@ -1,0 +1,47 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import type { GetReinforcementTestCaseResponseBody } from "@app/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useState } from "react";
+
+export function useCopyReinforcementTestCase({
+  owner,
+  conversationId,
+}: {
+  owner: LightWorkspaceType;
+  conversationId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const copyTestCase = async () => {
+    setIsLoading(true);
+    try {
+      const response = await clientFetch(
+        `/api/poke/workspaces/${owner.sId}/conversations/${conversationId}/reinforcement_test_case`
+      );
+      const data = await response.json();
+      if (!response.ok) {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        throw new Error(data.error?.message || "Failed to generate test case");
+      }
+      const { testCase } = data as GetReinforcementTestCaseResponseBody;
+      await navigator.clipboard.writeText(JSON.stringify(testCase, null, 2));
+      sendNotification({
+        title: "Copied",
+        description: "Reinforcement test case copied to clipboard.",
+        type: "success",
+      });
+    } catch (e) {
+      sendNotification({
+        title: "Error",
+        description: e instanceof Error ? e.message : "Unknown error",
+        type: "error",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { copyTestCase, isLoading };
+}


### PR DESCRIPTION
## Description

- Adds a "Reinforcement test" button on the poke conversation page that generates a scaffolded TestCase for tests/reinforcement-evals/test-suites/ from the current conversation and copies it to the clipboard.
- New GET /api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case endpoint builds the test case: custom skills used in the conversation (via AgentMessageSkillModel), messages mapped to MockConversationMessage (with actions, outputs, and feedback), and the workspace's available tools. expectedToolCalls and judgeCriteria are left as placeholders for the author to fill in.

Fixes https://github.com/dust-tt/tasks/issues/7679

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Poke only

## Deploy Plan

Front