### PR TITLE
feat(project_todo): add confluence, github, microsoft source types

### DIFF
--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -20,10 +20,13 @@ import {
   ChatBubbleLeftRightIcon,
   Checkbox,
   CircleIcon,
+  ConfluenceLogo,
   cn,
   DriveLogo,
+  GithubLogo,
   Icon,
   IconButton,
+  MicrosoftLogo,
   NotionLogo,
   SlackLogo,
   Spinner,
@@ -72,6 +75,9 @@ function getSourceDisplay(source: ProjectTodoType["sources"][number]) {
     slack: SlackLogo,
     notion: NotionLogo,
     gdrive: DriveLogo,
+    confluence: ConfluenceLogo,
+    github: GithubLogo,
+    microsoft: MicrosoftLogo,
   };
 
   const originalLabel = source.sourceTitle ?? source.sourceId;

--- a/front/lib/project_todo/analyze_document/prompts.ts
+++ b/front/lib/project_todo/analyze_document/prompts.ts
@@ -41,6 +41,21 @@ export function buildPromptForSourceType(
         "IMPORTANT CONTEXT: This is a gdrive document.\n" +
         "It has been added to the project knowledge base explicitly\n\n"
       );
+    case "confluence":
+      return (
+        "IMPORTANT CONTEXT: This is a confluence document.\n" +
+        "It has been added to the project knowledge base explicitly\n\n"
+      );
+    case "github":
+      return (
+        "IMPORTANT CONTEXT: This is a github document (issue, pull request, discussion, or code file).\n" +
+        "It has been added to the project knowledge base explicitly\n\n"
+      );
+    case "microsoft":
+      return (
+        "IMPORTANT CONTEXT: This is a Microsoft document (SharePoint, OneDrive, or Teams file).\n" +
+        "It has been added to the project knowledge base explicitly\n\n"
+      );
     default:
       assertNever(sourceType);
   }

--- a/front/temporal/project_todo/activities.ts
+++ b/front/temporal/project_todo/activities.ts
@@ -39,6 +39,15 @@ function resultToTakeawaySourceDocument(
       case "notion":
         sourceType = "notion";
         break;
+      case "confluence":
+        sourceType = "confluence";
+        break;
+      case "github":
+        sourceType = "github";
+        break;
+      case "microsoft":
+        sourceType = "microsoft";
+        break;
       default:
         logger.info(
           {

--- a/front/types/project_todo.ts
+++ b/front/types/project_todo.ts
@@ -18,6 +18,9 @@ export const PROJECT_TODO_SOURCE_TYPES = [
   "slack",
   "notion",
   "gdrive",
+  "confluence",
+  "github",
+  "microsoft",
 ] as const;
 
 export type ProjectTodoSourceType = (typeof PROJECT_TODO_SOURCE_TYPES)[number];


### PR DESCRIPTION
## Description

Extends `ProjectTodoSourceType` with `confluence`, `github`, and `microsoft` so project todos can be extracted from a broader set of connected data sources. Adds matching prompts in the analyze-document pipeline, maps the corresponding `ConnectorProvider` values in the temporal activity, and wires up Sparkle logos in the project todos panel.

## Tests

## Risk

## Deploy Plan
