### PR TITLE
[front] chore: fix biome formatting in jira_api_helper

### DIFF
--- a/front/lib/api/actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/api/actions/servers/jira/jira_api_helper.ts
@@ -891,7 +891,6 @@ export async function updateIssue(
   return new Ok(responseData);
 }
 
-
 export async function createIssueLink(
   baseUrl: string,
   accessToken: string,


### PR DESCRIPTION
## Description

Small fix for biome check (seems to have appeared when merging a previous PR)

## Tests

None (formatting only)

## Risk

None (formatting only)

## Deploy Plan

None (formatting only)