### PR TITLE
chore: fix n+1 query on skill detection endpoint

### DIFF
--- a/front/pages/api/w/[wId]/skills/detect/index.ts
+++ b/front/pages/api/w/[wId]/skills/detect/index.ts
@@ -132,13 +132,17 @@ async function handler(
         });
       }
 
+      const existingSkills = await SkillResource.fetchByNames(
+        auth,
+        detectedSkills.map((s) => s.name)
+      );
+
+      const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
+
       const skillSummaries = await concurrentExecutor(
         detectedSkills,
         async (skill): Promise<DetectedSkillSummary> => {
-          const existing = await SkillResource.fetchActiveByName(
-            auth,
-            skill.name
-          );
+          const existing = existingSkillsMap.get(skill.name);
 
           if (!existing) {
             return {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Batch fetch existing skill before the concurrent executor instead of fetching skills 1 by 1 on the skill detection endpoint.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front