### PR TITLE
Add separate section for skill suggestions

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1067,9 +1067,9 @@ export function AgentSidebarMenu({
   );
 }
 
-interface InboxConversationListProps {
-  inboxConversations: ConversationWithoutContentType[];
-  dateLabel: string;
+interface UnreadConversationsSectionProps {
+  label: string;
+  conversations: ConversationWithoutContentType[];
   isMultiSelect: boolean;
   isMarkingAllAsRead: boolean;
   onMarkAllAsRead: (conversationIds: string[]) => void;
@@ -1091,11 +1091,9 @@ const ConversationListContainer = ({
   return <div className="sm:flex sm:flex-col sm:gap-0.5">{children}</div>;
 };
 
-interface InboxSectionProps
-  extends Omit<InboxConversationListProps, "dateLabel"> {}
-
-function InboxSection({
-  inboxConversations,
+function UnreadConversationsSection({
+  label,
+  conversations,
   isMultiSelect,
   isMarkingAllAsRead,
   titleFilter,
@@ -1105,15 +1103,15 @@ function InboxSection({
   toggleConversationSelection,
   activeConversationId,
   owner,
-}: InboxSectionProps) {
-  const totalCount = inboxConversations.length;
+}: UnreadConversationsSectionProps) {
+  const totalCount = conversations.length;
 
   const shouldShowMarkAllAsReadButton =
     totalCount > 0 && titleFilter.length === 0 && !isMultiSelect;
 
   return (
     <NavigationListCollapsibleSection
-      label={`Inbox (${totalCount})`}
+      label={`${label} (${totalCount})`}
       className="border-b border-t border-border bg-background/50 px-2 pb-2 dark:border-border-night dark:bg-background-night/50"
       defaultOpen
       actionOnHover={false}
@@ -1124,15 +1122,13 @@ function InboxSection({
             variant="ghost"
             icon={CheckDoubleIcon}
             tooltip="Mark all as read"
-            onClick={() =>
-              onMarkAllAsRead(inboxConversations.map((c) => c.sId))
-            }
+            onClick={() => onMarkAllAsRead(conversations.map((c) => c.sId))}
             isLoading={isMarkingAllAsRead}
           />
         ) : null
       }
     >
-      {inboxConversations.map((conversation) => (
+      {conversations.map((conversation) => (
         <ConversationListItem
           key={conversation.sId}
           conversation={conversation}
@@ -1357,7 +1353,11 @@ function NavigationListWithInbox({
   isLoadingMore,
 }: NavigationListWithInboxProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const { readConversations, inboxConversations } = useMemo(() => {
+  const {
+    readConversations,
+    inboxConversations,
+    skillSuggestionConversations,
+  } = useMemo(() => {
     return getGroupConversationsByUnreadAndActionRequired(
       conversations,
       titleFilter
@@ -1409,9 +1409,25 @@ function NavigationListWithInbox({
       ref={scrollContainerRef}
       className="dd-privacy-mask h-full w-full overflow-y-auto"
     >
+      {skillSuggestionConversations.length > 0 && (
+        <UnreadConversationsSection
+          label="Skill suggestions"
+          conversations={skillSuggestionConversations}
+          isMultiSelect={isMultiSelect}
+          isMarkingAllAsRead={isMarkingAllAsRead}
+          titleFilter={titleFilter}
+          onMarkAllAsRead={markAllAsRead}
+          onConversationBranched={onConversationBranched}
+          selectedConversations={selectedConversations}
+          toggleConversationSelection={toggleConversationSelection}
+          activeConversationId={activeConversationId}
+          owner={owner}
+        />
+      )}
       {inboxConversations.length > 0 && (
-        <InboxSection
-          inboxConversations={inboxConversations}
+        <UnreadConversationsSection
+          label="Inbox"
+          conversations={inboxConversations}
           isMultiSelect={isMultiSelect}
           isMarkingAllAsRead={isMarkingAllAsRead}
           titleFilter={titleFilter}

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -7,10 +7,19 @@ import type {
   UserMessageType,
   UserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
+import { isReinforcedSkillNotificationMetadata } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import moment from "moment";
 
 import type { VirtuosoMessage } from "./types";
+
+function isReinforcedSkillConversation(
+  conversation: ConversationWithoutContentType
+): boolean {
+  return isReinforcedSkillNotificationMetadata(
+    conversation.metadata?.reinforcedSkillNotification
+  );
+}
 
 type GroupLabel =
   | "Today"
@@ -22,6 +31,9 @@ type GroupLabel =
 
 // We treat the conversations as unread if they are unread or have an action required
 // (note that action required conversations are never marked as unread).
+// Unread reinforced-skill-notification conversations are split out into their own bucket so
+// the sidebar can show them in a dedicated "Skill suggestions" section above the Inbox; once
+// read they fall back into the date-grouped Conversations list like any other read conversation.
 export function getGroupConversationsByUnreadAndActionRequired(
   conversations: ConversationWithoutContentType[],
   titleFilter: string
@@ -43,7 +55,11 @@ export function getGroupConversationsByUnreadAndActionRequired(
           }
 
           if (conversation.unread || conversation.actionRequired) {
-            acc.inboxConversations.push(conversation);
+            if (isReinforcedSkillConversation(conversation)) {
+              acc.skillSuggestionConversations.push(conversation);
+            } else {
+              acc.inboxConversations.push(conversation);
+            }
             return acc;
           }
 
@@ -53,9 +69,11 @@ export function getGroupConversationsByUnreadAndActionRequired(
         {
           readConversations: [],
           inboxConversations: [],
+          skillSuggestionConversations: [],
         } as {
           readConversations: ConversationWithoutContentType[];
           inboxConversations: ConversationWithoutContentType[];
+          skillSuggestionConversations: ConversationWithoutContentType[];
         }
       )
   );

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -21,6 +21,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import {
   isAgentMessageType,
+  isReinforcedSkillNotificationMetadata,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
 import type { Result } from "../shared/result";
@@ -39,20 +40,6 @@ function isReinforcedAgentNotificationMetadata(
     typeof value.agentName === "string" &&
     "agentConfigurationId" in value &&
     typeof value.agentConfigurationId === "string"
-  );
-}
-
-function isReinforcedSkillNotificationMetadata(
-  value: unknown
-): value is { skillName: string; skillId: string } {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-  return (
-    "skillName" in value &&
-    typeof value.skillName === "string" &&
-    "skillId" in value &&
-    typeof value.skillId === "string"
   );
 }
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -400,6 +400,20 @@ export function getConversationUrlAccessMode(
   return isConversationUrlAccessMode(accessMode) ? accessMode : null;
 }
 
+export function isReinforcedSkillNotificationMetadata(
+  value: unknown
+): value is { skillName: string; skillId: string } {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  return (
+    "skillName" in value &&
+    typeof value.skillName === "string" &&
+    "skillId" in value &&
+    typeof value.skillId === "string"
+  );
+}
+
 export type ConversationForkedFromType = {
   parentConversationId: string;
   sourceMessageId: string;


### PR DESCRIPTION
## Description

- Split unread reinforced-skill-notification conversations into a new "Skill suggestions" section rendered above Inbox in the conversation sidebar.
- Once a suggestion is read, it falls into the regular date-grouped Conversations list — same flow as Inbox.
- Extracted `isReinforcedSkillNotificationMetadata` into `types/assistant/conversation.ts` so both `agent_run.ts` and the sidebar grouping util can reuse it. Renamed `InboxSection` to `UnreadConversationsSection` (label + conversations props) and reused it for both sections, including a scoped "Mark all as read".

<img width="305" height="470" alt="Screenshot 2026-04-20 at 17 10 07" src="https://github.com/user-attachments/assets/bce91c71-f26d-468e-b01d-8df31cdeb3ae" />

## Tests

Manual

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
