### PR TITLE
[front] fix MCP static credential submit race

### DIFF
--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -218,11 +218,21 @@ export function CreateMCPServerDialog({
     connectionType: "workspace",
   });
 
+  // Only reset on the closed→open transition. Resetting whenever
+  // `defaultValues` changes is unsafe: SWR mutations triggered during submit
+  // (e.g. `createInternalMCPServer` invalidating the servers list) bubble up
+  // to `existingViewNames`, which recomputes `defaultValues` here and would
+  // clobber in-flight user state — most visibly, it resets `useCase` to null
+  // and unmounts the static credential form mid-submit.
+  const prevIsOpenRef = useRef(false);
+  const defaultValuesRef = useRef(defaultValues);
+  defaultValuesRef.current = defaultValues;
   useEffect(() => {
-    if (isOpen) {
-      form.reset(defaultValues);
+    if (isOpen && !prevIsOpenRef.current) {
+      form.reset(defaultValuesRef.current);
     }
-  }, [defaultValues, form, isOpen]);
+    prevIsOpenRef.current = isOpen;
+  }, [isOpen, form]);
 
   // Initialize authorization from internalMCPServer when dialog opens.
   useEffect(() => {
@@ -401,6 +411,29 @@ export function CreateMCPServerDialog({
       return;
     }
 
+    // Capture the form handle before any async work. SWR mutations that fire
+    // during submit (e.g. `createInternalMCPServer` invalidating the servers
+    // list) can re-render the dialog and unmount the static credential form,
+    // which nulls `staticFormRef.current`. Grabbing it up front avoids that
+    // race.
+    const formHandle = staticFormRef.current;
+    if (!formHandle) {
+      sendNotification({
+        type: "error",
+        title: "Cannot submit credentials",
+        description: "The credentials form is not ready. Please retry.",
+      });
+      datadogLogger.error(
+        {
+          workspaceId: owner.sId,
+          hasAuthorization: !!authorization,
+          useCase,
+        },
+        "Static credential form ref is null at submit time"
+      );
+      return;
+    }
+
     setIsLoading(true);
     setExternalIsLoading(true);
 
@@ -423,26 +456,6 @@ export function CreateMCPServerDialog({
       }
 
       const createdServer = createRes.value.server;
-
-      // Submit the static credential form — returns credentialId or null.
-      const formHandle = staticFormRef.current;
-      if (!formHandle) {
-        sendNotification({
-          type: "error",
-          title: "Cannot submit credentials",
-          description: "The credentials form is not ready. Please retry.",
-        });
-        datadogLogger.error(
-          {
-            workspaceId: owner.sId,
-            mcpServerId: createdServer.sId,
-            hasAuthorization: !!authorization,
-            useCase,
-          },
-          "Static credential form ref is null at submit time"
-        );
-        return;
-      }
 
       const credentialId = await formHandle.submit();
       if (!credentialId) {


### PR DESCRIPTION
## Description

The Snowflake MCP connection flow (and any future static-credential flow) was silently stalling on submit with a "The credentials form is not ready. Please retry." toast. Root cause is a race between two pre-existing pieces of code that interact badly:

1. `CreateMCPServerDialog` has a `useEffect` that runs `form.reset(defaultValues)` whenever `defaultValues` changes while the dialog is open (PR #19783).
2. `defaultValues` depends on `existingViewNames`, which is derived from the SWR `useMCPServers` list (PR #22795). `createInternalMCPServer` invalidates that list on success via `mutate()`.

So on a successful `POST /mcp`:
- SWR invalidates → parent re-renders with a new `existingViewNames`.
- `suggestedViewName` → `defaultValues` change in the dialog.
- The effect fires `form.reset(defaultValues)`, which resets `useCase` (zod default: `null`).
- `staticFormComponent` computed from `authorization && useCase` becomes `null`.
- The `<StaticFormComp>` branch in `MCPServerAuthConnection` unmounts, React clears `staticFormRef.current`.
- The submit handler, which is still `await`ing `createInternalMCPServer`, resumes and reads `staticFormRef.current` — now `null` — and bails with the toast.

Two fixes, both minimal:

- Capture `staticFormRef.current` **before** any `await`. No re-render triggered during submit can null it after the fact.
- Only run `form.reset(defaultValues)` on the closed→open edge, not on every `defaultValues` change. SWR mutations during submit no longer clobber in-flight form state.

No other behavior change — the open-time reset still happens, and the form handle null-check + log still guards against truly unmounted forms.

## Tests

Manual repro: opening the Snowflake MCP connect dialog, filling the keypair form, and clicking Connect now completes successfully instead of showing the "form is not ready" toast.
## Risk

Low.

- `useEffect` change is equivalent behavior on first open; only removes spurious resets mid-session. The stale-closure shape (`defaultValuesRef`) is idiomatic; `defaultValues` is only read at reset time.
- Capturing `formHandle` earlier just hoists the read — no logic change.
- Rollback: revert the single commit.

## Deploy Plan

`front`