### PR TITLE
[front] fix: handle concurrent user membership revoke/dsync add in WorkOS events

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1249,11 +1249,11 @@ export class GroupResource extends BaseResource<GroupModel> {
     {
       users,
       transaction,
-      allowProvisionnedGroups = false,
+      allowProvisionedGroups = false,
     }: {
       users: UserType[];
       transaction?: Transaction;
-      allowProvisionnedGroups?: boolean;
+      allowProvisionedGroups?: boolean;
     }
   ): Promise<
     Result<
@@ -1272,7 +1272,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         this.kind === "space_editors" ||
         this.kind === "agent_editors" ||
         this.kind === "skill_editors" ||
-        (allowProvisionnedGroups && this.kind === "provisioned"),
+        (allowProvisionedGroups && this.kind === "provisioned"),
       `You can't add members to ${this.kind} groups.`
     );
     const owner = auth.getNonNullableWorkspace();
@@ -1394,11 +1394,11 @@ export class GroupResource extends BaseResource<GroupModel> {
     {
       user,
       transaction,
-      allowProvisionnedGroups = false,
+      allowProvisionedGroups = false,
     }: {
       user: UserType;
       transaction?: Transaction;
-      allowProvisionnedGroups?: boolean;
+      allowProvisionedGroups?: boolean;
     }
   ): Promise<
     Result<
@@ -1415,7 +1415,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     return this.dangerouslyAddMembers(auth, {
       users: [user],
       transaction,
-      allowProvisionnedGroups,
+      allowProvisionedGroups,
     });
   }
 
@@ -1427,11 +1427,11 @@ export class GroupResource extends BaseResource<GroupModel> {
     {
       users,
       transaction,
-      allowProvisionnedGroups = false,
+      allowProvisionedGroups = false,
     }: {
       users: UserType[];
       transaction?: Transaction;
-      allowProvisionnedGroups?: boolean;
+      allowProvisionedGroups?: boolean;
     }
   ): Promise<
     Result<
@@ -1449,7 +1449,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         this.kind === "space_editors" ||
         this.kind === "agent_editors" ||
         this.kind === "skill_editors" ||
-        (allowProvisionnedGroups && this.kind === "provisioned"),
+        (allowProvisionedGroups && this.kind === "provisioned"),
       `You can't remove members from ${this.kind} groups.`
     );
     const owner = auth.getNonNullableWorkspace();
@@ -1554,11 +1554,11 @@ export class GroupResource extends BaseResource<GroupModel> {
     {
       user,
       transaction,
-      allowProvisionnedGroups = false,
+      allowProvisionedGroups = false,
     }: {
       user: UserType;
       transaction?: Transaction;
-      allowProvisionnedGroups?: boolean;
+      allowProvisionedGroups?: boolean;
     }
   ): Promise<
     Result<
@@ -1574,7 +1574,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     return this.dangerouslyRemoveMembers(auth, {
       users: [user],
       transaction,
-      allowProvisionnedGroups,
+      allowProvisionedGroups,
     });
   }
 

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -834,7 +834,7 @@ describe("SpaceResource", () => {
           // Add user as a simple member to the provisioned group
           await provisionedMemberGroup.dangerouslyAddMember(adminAuth, {
             user: memberUser.toJSON(),
-            allowProvisionnedGroups: true,
+            allowProvisionedGroups: true,
           });
 
           // Create an authenticator for the member user
@@ -897,7 +897,7 @@ describe("SpaceResource", () => {
           // Add editor to the provisioned editor group
           await provisionedEditorGroup.dangerouslyAddMember(adminAuth, {
             user: editorUser.toJSON(),
-            allowProvisionnedGroups: true,
+            allowProvisionedGroups: true,
           });
 
           // Create another provisioned group for the new members
@@ -910,7 +910,7 @@ describe("SpaceResource", () => {
           // Add members to the new provisioned group
           await newProvisionedMemberGroup.dangerouslyAddMembers(adminAuth, {
             users: [user1.toJSON(), user2.toJSON(), editorUser.toJSON()],
-            allowProvisionnedGroups: true,
+            allowProvisionedGroups: true,
           });
 
           // Create an authenticator for the editor user

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -763,8 +763,9 @@ async function handleUserAddedToGroup(
           });
         if (
           latestMembership?.endAt &&
-          latestMembership.endAt.getTime() >=
-            eventCreatedAt.getTime() - STALE_USER_ADDED_GRACE_MS
+          Math.abs(
+            latestMembership.endAt.getTime() - eventCreatedAt.getTime()
+          ) <= STALE_USER_ADDED_GRACE_MS
         ) {
           logger.info(
             {

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -722,7 +722,7 @@ async function handleUserAddedToGroup(
   if (!isMember) {
     const res = await group.dangerouslyAddMember(auth, {
       user: user.toJSON(),
-      allowProvisionnedGroups: true,
+      allowProvisionedGroups: true,
     });
     if (res.isErr()) {
       throw new Error(res.error.message);
@@ -875,7 +875,7 @@ async function handleUserRemovedFromGroup(
   }
   const res = await group.dangerouslyRemoveMember(auth, {
     user: user.toJSON(),
-    allowProvisionnedGroups: true,
+    allowProvisionedGroups: true,
   });
   if (res.isErr() && res.error.code !== "user_not_member") {
     throw new Error(res.error.message);
@@ -1123,7 +1123,7 @@ async function handleDeleteWorkOSUser(
     }
     const removeResult = await group.dangerouslyRemoveMember(auth, {
       user: user.toJSON(),
-      allowProvisionnedGroups: true,
+      allowProvisionedGroups: true,
     });
     if (removeResult.isErr()) {
       logger.warn(

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -71,6 +71,11 @@ const logger = mainLogger.child(
 const ADMIN_GROUP_NAME = "dust-admins";
 const BUILDER_GROUP_NAME = "dust-builders";
 
+// Grace window for treating a user_added event as stale when the user was
+// revoked around the same time. Covers races where WorkOS emits both events
+// together but the revoke is processed a moment before the add is emitted.
+const STALE_USER_ADDED_GRACE_MS = 1_000;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -740,6 +745,33 @@ async function handleUserAddedToGroup(
       allowProvisionedGroups: true,
     });
     if (res.isErr()) {
+      // Races can occur when WorkOS delivers a user_added event together with a
+      // membership revocation and the revoke is processed first. In that case
+      // we want to drop the event.
+      if (res.error.code === "user_not_found") {
+        const latestMembership =
+          await MembershipResource.getLatestMembershipOfUserInWorkspace({
+            user,
+            workspace,
+          });
+        if (
+          latestMembership?.endAt &&
+          latestMembership.endAt.getTime() >=
+            eventCreatedAt.getTime() - STALE_USER_ADDED_GRACE_MS
+        ) {
+          logger.info(
+            {
+              userId: user.sId,
+              groupId: group.sId,
+              workspaceId: workspace.sId,
+              eventCreatedAt,
+              membershipEndAt: latestMembership.endAt,
+            },
+            "Dropping stale dsync.group.user_added: user revoked after event"
+          );
+          return;
+        }
+      }
       throw new Error(res.error.message);
     }
   } else {

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -42,16 +42,24 @@ import { GROUP_KINDS } from "@app/types/groups";
 import type { Result } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import type {
-  DirectoryGroup,
   DirectoryUser,
+  DsyncGroupCreatedEvent,
+  DsyncGroupDeletedEvent,
+  DsyncGroupUpdatedEvent,
   DsyncGroupUserAddedEvent,
   DsyncGroupUserRemovedEvent,
+  DsyncUserCreatedEvent,
+  DsyncUserDeletedEvent,
+  DsyncUserUpdatedEvent,
   Event,
-  Organization,
   OrganizationDomain,
+  OrganizationDomainVerificationFailedEvent,
+  OrganizationDomainVerifiedEvent,
+  OrganizationUpdatedEvent,
 } from "@workos-inc/node";
 import { NotFoundException } from "@workos-inc/node";
 import assert from "assert";
+import {isString} from "@app/types/shared/utils/general";
 
 const logger = mainLogger.child(
   {},
@@ -71,10 +79,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * Verify if workspace exist, if it does will call the callback with the found workspace.
  * Otherwise will return undefined
  */
-async function verifyWorkOSWorkspace<E extends object, R>(
+async function verifyWorkOSWorkspace<E extends Event, R>(
   organizationId: string | null,
   event: E,
-  handler: (workspace: LightWorkspaceType, eventData: E) => R
+  handler: (workspace: LightWorkspaceType, event: E) => R
 ) {
   if (!organizationId) {
     return;
@@ -101,7 +109,8 @@ async function verifyWorkOSWorkspace<E extends object, R>(
 
   // For dsync events, verify the plan allows SCIM and the directoryId matches
   // the current organization's active directory.
-  if (isRecord(event) && typeof event.directoryId === "string") {
+  const { data: eventData } = event;
+  if (isRecord(eventData) && "directoryId" in eventData && isString(eventData.directoryId)) {
     const subscription =
       await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
     if (!subscription?.getPlan().limits.users.isSCIMAllowed) {
@@ -125,9 +134,9 @@ async function verifyWorkOSWorkspace<E extends object, R>(
     const activeDirectoryIds = new Set(
       directoriesResult.value.map((d) => d.id)
     );
-    if (!activeDirectoryIds.has(event.directoryId)) {
+    if (!activeDirectoryIds.has(eventData.directoryId)) {
       logger.info(
-        { workspaceId: workspace.sId, directoryId: event.directoryId },
+        { workspaceId: workspace.sId, directoryId: eventData.directoryId },
         "Event from disconnected directory, skipping"
       );
       return;
@@ -267,7 +276,7 @@ export async function processWorkOSEventActivity({
     case "organization_domain.verified":
       await verifyWorkOSWorkspace(
         eventPayload.data.organizationId,
-        eventPayload.data,
+        eventPayload,
         handleOrganizationDomainVerified
       );
       break;
@@ -275,7 +284,7 @@ export async function processWorkOSEventActivity({
     case "organization_domain.verification_failed":
       await verifyWorkOSWorkspace(
         eventPayload.data.organizationId,
-        eventPayload.data,
+        eventPayload,
         handleOrganizationDomainVerificationFailed
       );
       break;
@@ -283,7 +292,7 @@ export async function processWorkOSEventActivity({
     case "organization.updated":
       await verifyWorkOSWorkspace(
         eventPayload.data.id,
-        eventPayload.data,
+        eventPayload,
         handleOrganizationUpdated
       );
       break;
@@ -292,7 +301,7 @@ export async function processWorkOSEventActivity({
     case "dsync.group.updated":
       await verifyWorkOSWorkspace(
         eventPayload.data.organizationId,
-        eventPayload.data,
+        eventPayload,
         handleGroupUpsert
       );
       break;
@@ -300,7 +309,7 @@ export async function processWorkOSEventActivity({
     case "dsync.group.deleted":
       await verifyWorkOSWorkspace(
         eventPayload.data.organizationId,
-        eventPayload.data,
+        eventPayload,
         handleGroupDelete
       );
       break;
@@ -308,7 +317,7 @@ export async function processWorkOSEventActivity({
     case "dsync.group.user_added":
       await verifyWorkOSWorkspace(
         eventPayload.data.user.organizationId,
-        eventPayload.data,
+        eventPayload,
         handleUserAddedToGroup
       );
       break;
@@ -316,7 +325,7 @@ export async function processWorkOSEventActivity({
     case "dsync.group.user_removed":
       await verifyWorkOSWorkspace(
         eventPayload.data.user.organizationId,
-        eventPayload.data,
+        eventPayload,
         handleUserRemovedFromGroup
       );
       break;
@@ -325,7 +334,7 @@ export async function processWorkOSEventActivity({
     case "dsync.user.updated":
       await verifyWorkOSWorkspace(
         eventPayload.data.organizationId,
-        eventPayload.data,
+        eventPayload,
         handleCreateOrUpdateWorkOSUser
       );
       break;
@@ -333,7 +342,7 @@ export async function processWorkOSEventActivity({
     case "dsync.user.deleted":
       await verifyWorkOSWorkspace(
         eventPayload.data.organizationId,
-        eventPayload.data,
+        eventPayload,
         handleDeleteWorkOSUser
       );
       break;
@@ -394,8 +403,9 @@ async function handleOrganizationDomainEvent(
 
 async function handleOrganizationDomainVerified(
   workspace: LightWorkspaceType,
-  eventData: OrganizationDomain
+  event: OrganizationDomainVerifiedEvent
 ) {
+  const { data: eventData } = event;
   await handleOrganizationDomainEvent(workspace, eventData, "verified");
 
   void emitAuditLogEventDirect({
@@ -410,8 +420,9 @@ async function handleOrganizationDomainVerified(
 
 async function handleOrganizationDomainVerificationFailed(
   workspace: LightWorkspaceType,
-  eventData: OrganizationDomain
+  event: OrganizationDomainVerificationFailedEvent
 ) {
+  const { data: eventData } = event;
   await handleOrganizationDomainEvent(workspace, eventData, "failed");
 
   void emitAuditLogEventDirect({
@@ -426,9 +437,9 @@ async function handleOrganizationDomainVerificationFailed(
 
 async function handleOrganizationUpdated(
   workspace: LightWorkspaceType,
-  eventData: Organization
+  event: OrganizationUpdatedEvent
 ) {
-  const { domains } = eventData;
+  const { domains } = event.data;
 
   const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
   if (!workspaceResource) {
@@ -565,17 +576,18 @@ async function autoCreateSpaceForProvisionedGroup(
 
 async function handleGroupUpsert(
   workspace: LightWorkspaceType,
-  event: DirectoryGroup
+  event: DsyncGroupCreatedEvent | DsyncGroupUpdatedEvent
 ) {
+  const { data: eventData } = event;
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-  const groupByName = await GroupResource.fetchByName(auth, event.name);
-  if (groupByName && groupByName.workOSGroupId !== event.id) {
+  const groupByName = await GroupResource.fetchByName(auth, eventData.name);
+  if (groupByName && groupByName.workOSGroupId !== eventData.id) {
     // Conflict - another group with the same name already exists.
 
     // First check if this group still exists in workos.
     try {
-      await getWorkOS().directorySync.getGroup(event.id);
+      await getWorkOS().directorySync.getGroup(eventData.id);
     } catch (error) {
       if (error instanceof NotFoundException) {
         // Group doesn't exist, just ignore the event.
@@ -638,8 +650,8 @@ async function handleGroupUpsert(
         {
           oldWorkOsGroupId: groupByName.workOSGroupId,
           oldDirectoryId: oldGroup.directoryId,
-          newWorkOsGroupId: event.id,
-          newDirectoryId: event.directoryId,
+          newWorkOsGroupId: eventData.id,
+          newDirectoryId: eventData.directoryId,
           groupName: groupByName.name,
           workspaceId: workspace.sId,
         },
@@ -649,7 +661,7 @@ async function handleGroupUpsert(
     }
   }
 
-  const group = await GroupResource.upsertByWorkOSGroupId(auth, event);
+  const group = await GroupResource.upsertByWorkOSGroupId(auth, eventData);
 
   // Auto-create space if workspace setting is enabled
   let spaceCreated = false;
@@ -668,7 +680,7 @@ async function handleGroupUpsert(
     action: "scim.group_created",
     actor: {
       type: "system",
-      id: String(event.directoryId ?? "directory_sync"),
+      id: String(eventData.directoryId ?? "directory_sync"),
       name: "Directory Sync",
     },
     targets: [
@@ -678,7 +690,7 @@ async function handleGroupUpsert(
     context: { location: "system" },
     metadata: {
       groupName: group.name,
-      directoryId: String(event.directoryId ?? "unknown"),
+      directoryId: String(eventData.directoryId ?? "unknown"),
       spaceCreated: String(spaceCreated),
     },
   });
@@ -686,11 +698,14 @@ async function handleGroupUpsert(
 
 async function handleUserAddedToGroup(
   workspace: LightWorkspaceType,
-  event: DsyncGroupUserAddedEvent["data"]
+  event: DsyncGroupUserAddedEvent
 ) {
-  if (!event.user.email) {
+  const { data: eventData, createdAt } = event;
+  const eventCreatedAt = new Date(createdAt);
+
+  if (!eventData.user.email) {
     logger.warn(
-      { workspaceId: workspace.sId, userId: event.user.id },
+      { workspaceId: workspace.sId, userId: eventData.user.id },
       "Try to 'dsync.group.user_added' without an email"
     );
     return;
@@ -698,7 +713,7 @@ async function handleUserAddedToGroup(
 
   const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail({
     workspace,
-    workOSUser: event.user,
+    workOSUser: eventData.user,
   });
   if (workOSUserRes.isErr()) {
     throw workOSUserRes.error;
@@ -711,10 +726,10 @@ async function handleUserAddedToGroup(
   }
 
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const group = await GroupResource.fetchByWorkOSGroupId(auth, event.group.id);
+  const group = await GroupResource.fetchByWorkOSGroupId(auth, eventData.group.id);
   if (!group) {
     throw new Error(
-      `Group not found for workOSId "${event.group.id}" in workspace "${workspace.sId}"`
+      `Group not found for workOSId "${eventData.group.id}" in workspace "${workspace.sId}"`
     );
   }
 
@@ -777,7 +792,7 @@ async function handleUserAddedToGroup(
       action: "membership.origin_updated",
       actor: {
         type: "system",
-        id: String(event.directoryId ?? "directory_sync"),
+        id: String(eventData.directoryId ?? "directory_sync"),
         name: "Directory Sync",
       },
       targets: [
@@ -800,7 +815,7 @@ async function handleUserAddedToGroup(
     action: "scim.group_user_added",
     actor: {
       type: "system",
-      id: String(event.directoryId ?? "directory_sync"),
+      id: String(eventData.directoryId ?? "directory_sync"),
       name: "Directory Sync",
     },
     targets: [
@@ -815,7 +830,7 @@ async function handleUserAddedToGroup(
     metadata: {
       groupName: group.name,
       userEmail: user.email,
-      directoryId: String(event.user.directoryId ?? "unknown"),
+      directoryId: String(eventData.user.directoryId ?? "unknown"),
       roleGranted: "member",
     },
   });
@@ -823,16 +838,18 @@ async function handleUserAddedToGroup(
 
 async function handleUserRemovedFromGroup(
   workspace: LightWorkspaceType,
-  event: DsyncGroupUserRemovedEvent["data"]
+  event: DsyncGroupUserRemovedEvent
 ) {
-  if (!event.user.email) {
+  const { data: eventData } = event;
+
+  if (!eventData.user.email) {
     logger.warn("Try to 'dsync.group.user_removed' without an email");
     return;
   }
 
   const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail({
     workspace,
-    workOSUser: event.user,
+    workOSUser: eventData.user,
   });
   if (workOSUserRes.isErr()) {
     throw workOSUserRes.error;
@@ -845,10 +862,10 @@ async function handleUserRemovedFromGroup(
   }
 
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const group = await GroupResource.fetchByWorkOSGroupId(auth, event.group.id);
+  const group = await GroupResource.fetchByWorkOSGroupId(auth, eventData.group.id);
   if (!group) {
     throw new Error(
-      `Group not found for workOSId "${event.group.id}" in workspace "${workspace.sId}"`
+      `Group not found for workOSId "${eventData.group.id}" in workspace "${workspace.sId}"`
     );
   }
 
@@ -894,7 +911,7 @@ async function handleUserRemovedFromGroup(
     action: "scim.group_user_removed",
     actor: {
       type: "system",
-      id: String(event.directoryId ?? "directory_sync"),
+      id: String(eventData.directoryId ?? "directory_sync"),
       name: "Directory Sync",
     },
     targets: [
@@ -909,7 +926,7 @@ async function handleUserRemovedFromGroup(
     metadata: {
       groupName: group.name,
       userEmail: user.email,
-      directoryId: String(event.user.directoryId ?? "unknown"),
+      directoryId: String(eventData.user.directoryId ?? "unknown"),
       roleChange: "removed",
     },
   });
@@ -957,11 +974,13 @@ async function clearCustomAttributesFromUserMetadata(
 
 async function handleCreateOrUpdateWorkOSUser(
   workspace: LightWorkspaceType,
-  event: DirectoryUser
+  event: DsyncUserCreatedEvent | DsyncUserUpdatedEvent
 ) {
+  const { data: eventData} = event;
+
   const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail({
     workspace,
-    workOSUser: event,
+    workOSUser: eventData,
   });
   if (workOSUserRes.isErr()) {
     throw workOSUserRes.error;
@@ -978,7 +997,7 @@ async function handleCreateOrUpdateWorkOSUser(
     given_name: workOSUser.firstName ?? undefined,
     family_name: workOSUser.lastName ?? undefined,
     picture: workOSUser.profilePictureUrl ?? undefined,
-    customAttributes: extractCustomAttributes(event),
+    customAttributes: extractCustomAttributes(eventData),
   };
 
   const { user: createdOrUpdatedUser } = await createOrUpdateUser({
@@ -1013,7 +1032,7 @@ async function handleCreateOrUpdateWorkOSUser(
       action: "membership.origin_updated",
       actor: {
         type: "system",
-        id: String(event.directoryId ?? "directory_sync"),
+        id: String(eventData.directoryId ?? "directory_sync"),
         name: "Directory Sync",
       },
       targets: [
@@ -1035,7 +1054,7 @@ async function handleCreateOrUpdateWorkOSUser(
       action: "scim.user_updated",
       actor: {
         type: "system",
-        id: String(event.directoryId ?? "directory_sync"),
+        id: String(eventData.directoryId ?? "directory_sync"),
         name: "Directory Sync",
       },
       targets: [
@@ -1047,9 +1066,9 @@ async function handleCreateOrUpdateWorkOSUser(
       ],
       context: { location: "system" },
       metadata: {
-        directoryId: String(event.directoryId ?? "unknown"),
+        directoryId: String(eventData.directoryId ?? "unknown"),
         updatedAttributes: JSON.stringify(
-          Object.keys(event.rawAttributes ?? {})
+          Object.keys(eventData.rawAttributes ?? {})
         ),
       },
     });
@@ -1069,7 +1088,7 @@ async function handleCreateOrUpdateWorkOSUser(
     action: "scim.user_provisioned",
     actor: {
       type: "system",
-      id: String(event.directoryId ?? "directory_sync"),
+      id: String(eventData.directoryId ?? "directory_sync"),
       name: "Directory Sync",
     },
     targets: [
@@ -1082,18 +1101,19 @@ async function handleCreateOrUpdateWorkOSUser(
     context: { location: "system" },
     metadata: {
       email: createdOrUpdatedUser.email,
-      directoryId: String(event.directoryId ?? "unknown"),
+      directoryId: String(eventData.directoryId ?? "unknown"),
     },
   });
 }
 
 async function handleDeleteWorkOSUser(
   workspace: LightWorkspaceType,
-  event: DirectoryUser
+  event: DsyncUserDeletedEvent
 ) {
+  const {data:eventData} = event;
   const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail({
     workspace,
-    workOSUser: event,
+    workOSUser: eventData,
   });
   if (workOSUserRes.isErr()) {
     throw workOSUserRes.error;
@@ -1161,7 +1181,7 @@ async function handleDeleteWorkOSUser(
     action: "scim.user_deprovisioned",
     actor: {
       type: "system",
-      id: String(event.directoryId ?? "directory_sync"),
+      id: String(eventData.directoryId ?? "directory_sync"),
       name: "Directory Sync",
     },
     targets: [
@@ -1174,7 +1194,7 @@ async function handleDeleteWorkOSUser(
     context: { location: "system" },
     metadata: {
       email: user.email,
-      directoryId: String(event.directoryId ?? "unknown"),
+      directoryId: String(eventData.directoryId ?? "unknown"),
       triggersDeleted: "true",
     },
   });
@@ -1182,18 +1202,19 @@ async function handleDeleteWorkOSUser(
 
 async function handleGroupDelete(
   workspace: LightWorkspaceType,
-  event: DirectoryGroup
+  event: DsyncGroupDeletedEvent
 ) {
+  const {data:eventData} = event;
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const group = await GroupResource.fetchByWorkOSGroupId(auth, event.id);
+  const group = await GroupResource.fetchByWorkOSGroupId(auth, eventData.id);
 
   if (!group) {
     // Group already deleted, log and return success to avoid blocking the workflow
     logger.info(
       {
         workspaceId: workspace.sId,
-        directoryId: event.directoryId,
-        groupId: event.id,
+        directoryId: eventData.directoryId,
+        groupId: eventData.id,
       },
       "Group to delete not found, likely already deleted"
     );
@@ -1213,7 +1234,7 @@ async function handleGroupDelete(
     action: "scim.group_deleted",
     actor: {
       type: "system",
-      id: String(event.directoryId ?? "directory_sync"),
+      id: String(eventData.directoryId ?? "directory_sync"),
       name: "Directory Sync",
     },
     targets: [
@@ -1223,7 +1244,7 @@ async function handleGroupDelete(
     context: { location: "system" },
     metadata: {
       groupName,
-      directoryId: String(event.directoryId ?? "unknown"),
+      directoryId: String(eventData.directoryId ?? "unknown"),
     },
   });
 }

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -40,6 +40,7 @@ import { ServerSideTracking } from "@app/lib/tracking/server";
 import mainLogger from "@app/logger/logger";
 import { GROUP_KINDS } from "@app/types/groups";
 import type { Result } from "@app/types/shared/result";
+import { isString } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import type {
   DirectoryUser,
@@ -59,7 +60,6 @@ import type {
 } from "@workos-inc/node";
 import { NotFoundException } from "@workos-inc/node";
 import assert from "assert";
-import {isString} from "@app/types/shared/utils/general";
 
 const logger = mainLogger.child(
   {},
@@ -115,7 +115,11 @@ async function verifyWorkOSWorkspace<E extends Event, R>(
   // For dsync events, verify the plan allows SCIM and the directoryId matches
   // the current organization's active directory.
   const { data: eventData } = event;
-  if (isRecord(eventData) && "directoryId" in eventData && isString(eventData.directoryId)) {
+  if (
+    isRecord(eventData) &&
+    "directoryId" in eventData &&
+    isString(eventData.directoryId)
+  ) {
     const subscription =
       await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
     if (!subscription?.getPlan().limits.users.isSCIMAllowed) {
@@ -731,7 +735,10 @@ async function handleUserAddedToGroup(
   }
 
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const group = await GroupResource.fetchByWorkOSGroupId(auth, eventData.group.id);
+  const group = await GroupResource.fetchByWorkOSGroupId(
+    auth,
+    eventData.group.id
+  );
   if (!group) {
     throw new Error(
       `Group not found for workOSId "${eventData.group.id}" in workspace "${workspace.sId}"`
@@ -894,7 +901,10 @@ async function handleUserRemovedFromGroup(
   }
 
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const group = await GroupResource.fetchByWorkOSGroupId(auth, eventData.group.id);
+  const group = await GroupResource.fetchByWorkOSGroupId(
+    auth,
+    eventData.group.id
+  );
   if (!group) {
     throw new Error(
       `Group not found for workOSId "${eventData.group.id}" in workspace "${workspace.sId}"`
@@ -1008,7 +1018,7 @@ async function handleCreateOrUpdateWorkOSUser(
   workspace: LightWorkspaceType,
   event: DsyncUserCreatedEvent | DsyncUserUpdatedEvent
 ) {
-  const { data: eventData} = event;
+  const { data: eventData } = event;
 
   const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail({
     workspace,
@@ -1142,7 +1152,7 @@ async function handleDeleteWorkOSUser(
   workspace: LightWorkspaceType,
   event: DsyncUserDeletedEvent
 ) {
-  const {data:eventData} = event;
+  const { data: eventData } = event;
   const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail({
     workspace,
     workOSUser: eventData,
@@ -1236,7 +1246,7 @@ async function handleGroupDelete(
   workspace: LightWorkspaceType,
   event: DsyncGroupDeletedEvent
 ) {
-  const {data:eventData} = event;
+  const { data: eventData } = event;
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   const group = await GroupResource.fetchByWorkOSGroupId(auth, eventData.id);
 


### PR DESCRIPTION
## Description

- Context in [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1776690662815539).
- This PR adds graceful handling on a possible race condition in the directory sync: if we receive in the same push an event to revoke a user + an event to add the same user to a group the latter can churn and retry endlessly if processed last.
- This PR checks the end date of the latest membership to single out this case and prevent the workflow from churning in this case.
- Most of the change comes from the need to expose the timestamp of the event, only the data was exposed
- Also fixes a typo on provisionned -> provisioned

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy front.
