### PR TITLE
[sessions]: surface pending message visibility and agent status in poke convos

### DIFF
--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -39,6 +39,23 @@ import {
 import { CodeBracketIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
 import { useEffect, useState } from "react";
 
+const USER_VISIBILITY: Record<string, { label: string; classes: string }> = {
+  visible: { label: "sent", classes: "bg-green-100 text-green-800" },
+  pending: { label: "queued", classes: "bg-amber-100 text-amber-800" },
+  deleted: { label: "deleted", classes: "bg-red-100 text-red-800" },
+};
+
+const AGENT_STATUS: Record<string, { label: string; classes: string }> = {
+  created: { label: "generating", classes: "bg-amber-100 text-amber-800" },
+  succeeded: { label: "succeeded", classes: "bg-green-100 text-green-800" },
+  failed: { label: "failed", classes: "bg-red-100 text-red-800" },
+  cancelled: { label: "cancelled", classes: "bg-gray-100 text-gray-700" },
+  gracefully_stopped: {
+    label: "stopped",
+    classes: "bg-gray-100 text-gray-700",
+  },
+};
+
 interface UserMessageViewProps {
   message: UserMessageType;
   useMarkdown: boolean;
@@ -82,8 +99,16 @@ const UserMessageView = ({ message, useMarkdown }: UserMessageViewProps) => {
               )}
             </>
           )}
-          <div className="mt-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
-            date: {new Date(message.created).toLocaleString()}
+          <div className="mt-2 flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+            <span>date: {new Date(message.created).toLocaleString()}</span>
+            <span
+              className={classNames(
+                "rounded-sm px-1 py-0.5 text-xs",
+                USER_VISIBILITY[message.visibility]?.classes
+              )}
+            >
+              {USER_VISIBILITY[message.visibility]?.label}
+            </span>
           </div>
         </ConversationMessage>
       </div>
@@ -149,6 +174,15 @@ const AgentMessageView = ({
           <div className="text-warning">{message.error.message}</div>
         )}
         <div className="mt-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+          <span
+            className={classNames(
+              "mr-1 rounded-sm px-1 py-0.5 text-xs",
+              AGENT_STATUS[message.status]?.classes ??
+                "bg-gray-100 text-gray-700"
+            )}
+          >
+            {AGENT_STATUS[message.status]?.label ?? message.status}
+          </span>
           date: {new Date(message.created).toLocaleString()} • message version :{" "}
           {message.version} • message sId : {message.sId} {" • "} agent sId :
           <LinkWrapper
@@ -453,6 +487,14 @@ export function ConversationPage() {
   const { conversationDataSourceId, langfuseUiBaseUrl, temporalWorkspace } =
     conversationConfig;
 
+  const allMessages = conversation?.content.flat() ?? [];
+  const pendingUserCount = allMessages.filter(
+    (m) => m.type === "user_message" && m.visibility === "pending"
+  ).length;
+  const createdAgentCount = allMessages.filter(
+    (m) => m.type === "agent_message" && m.status === "created"
+  ).length;
+
   return (
     conversation && (
       <div className="max-w-4xl">
@@ -624,10 +666,44 @@ export function ConversationPage() {
               )}
             </div>
           )}
+          {(pendingUserCount > 0 || createdAgentCount > 0) && (
+            <div className="flex flex-col gap-1 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+              {pendingUserCount > 0 && (
+                <div>
+                  ⏳ {pendingUserCount} user message
+                  {pendingUserCount > 1 ? "s" : ""} queued
+                </div>
+              )}
+              {createdAgentCount > 0 && (
+                <div>
+                  🔄 {createdAgentCount} agent message
+                  {createdAgentCount > 1 ? "s" : ""} generating
+                </div>
+              )}
+            </div>
+          )}
           <div className="flex w-full flex-1 flex-col justify-start gap-8 py-4">
             {conversation.content.map((messages, i) => {
+              const hasPending = messages.some(
+                (m) =>
+                  (m.type === "user_message" && m.visibility === "pending") ||
+                  (m.type === "agent_message" && m.status === "created")
+              );
+              const isUserGroup = messages.every(
+                (m) =>
+                  m.type === "user_message" || m.type === "content_fragment"
+              );
               return (
-                <div key={`messages-${i}`} className="flex flex-col gap-4">
+                <div
+                  key={`messages-${i}`}
+                  className={classNames(
+                    "flex flex-col gap-4",
+                    hasPending &&
+                      (isUserGroup
+                        ? "border-r-4 border-amber-400 pr-3"
+                        : "border-l-4 border-amber-400 pl-3")
+                  )}
+                >
                   {messages.map((m, j) => {
                     switch (m.type) {
                       case "agent_message": {

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -487,14 +487,6 @@ export function ConversationPage() {
   const { conversationDataSourceId, langfuseUiBaseUrl, temporalWorkspace } =
     conversationConfig;
 
-  const allMessages = conversation?.content.flat() ?? [];
-  const pendingUserCount = allMessages.filter(
-    (m) => m.type === "user_message" && m.visibility === "pending"
-  ).length;
-  const createdAgentCount = allMessages.filter(
-    (m) => m.type === "agent_message" && m.status === "created"
-  ).length;
-
   return (
     conversation && (
       <div className="max-w-4xl">
@@ -666,22 +658,7 @@ export function ConversationPage() {
               )}
             </div>
           )}
-          {(pendingUserCount > 0 || createdAgentCount > 0) && (
-            <div className="flex flex-col gap-1 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-              {pendingUserCount > 0 && (
-                <div>
-                  ⏳ {pendingUserCount} user message
-                  {pendingUserCount > 1 ? "s" : ""} queued
-                </div>
-              )}
-              {createdAgentCount > 0 && (
-                <div>
-                  🔄 {createdAgentCount} agent message
-                  {createdAgentCount > 1 ? "s" : ""} generating
-                </div>
-              )}
-            </div>
-          )}
+
           <div className="flex w-full flex-1 flex-col justify-start gap-8 py-4">
             {conversation.content.map((messages, i) => {
               const hasPending = messages.some(

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -487,6 +487,14 @@ export function ConversationPage() {
   const { conversationDataSourceId, langfuseUiBaseUrl, temporalWorkspace } =
     conversationConfig;
 
+  const allMessages = conversation?.content.flat() ?? [];
+  const pendingUserCount = allMessages.filter(
+    (m) => m.type === "user_message" && m.visibility === "pending"
+  ).length;
+  const createdAgentCount = allMessages.filter(
+    (m) => m.type === "agent_message" && m.status === "created"
+  ).length;
+
   return (
     conversation && (
       <div className="max-w-4xl">
@@ -658,29 +666,26 @@ export function ConversationPage() {
               )}
             </div>
           )}
-
+          {(pendingUserCount > 0 || createdAgentCount > 0) && (
+            <div className="flex flex-col gap-1 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+              {pendingUserCount > 0 && (
+                <div>
+                  ⏳ {pendingUserCount} user message
+                  {pendingUserCount > 1 ? "s" : ""} queued
+                </div>
+              )}
+              {createdAgentCount > 0 && (
+                <div>
+                  🔄 {createdAgentCount} agent message
+                  {createdAgentCount > 1 ? "s" : ""} generating
+                </div>
+              )}
+            </div>
+          )}
           <div className="flex w-full flex-1 flex-col justify-start gap-8 py-4">
             {conversation.content.map((messages, i) => {
-              const hasPending = messages.some(
-                (m) =>
-                  (m.type === "user_message" && m.visibility === "pending") ||
-                  (m.type === "agent_message" && m.status === "created")
-              );
-              const isUserGroup = messages.every(
-                (m) =>
-                  m.type === "user_message" || m.type === "content_fragment"
-              );
               return (
-                <div
-                  key={`messages-${i}`}
-                  className={classNames(
-                    "flex flex-col gap-4",
-                    hasPending &&
-                      (isUserGroup
-                        ? "border-r-4 border-amber-400 pr-3"
-                        : "border-l-4 border-amber-400 pl-3")
-                  )}
-                >
+                <div key={`messages-${i}`} className="flex flex-col gap-4">
                   {messages.map((m, j) => {
                     switch (m.type) {
                       case "agent_message": {


### PR DESCRIPTION
fix https://github.com/dust-tt/tasks/issues/7660
## Description
Adds a banner showing counts of pending/queued messages and status badges on both agent and user messages

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually:
<img width="948" height="856" alt="Screenshot 2026-04-20 at 2 10 45 PM" src="https://github.com/user-attachments/assets/8b72f620-be32-4155-beae-43977c695a71" />
<img width="959" height="738" alt="Screenshot 2026-04-20 at 2 10 25 PM" src="https://github.com/user-attachments/assets/16f46cfa-31f9-4945-9e1a-787c8cf7ef1e" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, poke only
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
