### PR TITLE
fix(mcp): reduce peak concurrent DB connections in MCP API endpoints

### DIFF
--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -66,9 +66,13 @@ export class InternalMCPServerInMemoryResource {
     readonly availability: MCPServerAvailability
   ) {}
 
+  // When `preloadedCredential` is provided the per-server DB fetch is skipped.
+  // Pass it when calling in a loop so callers can batch-fetch all credentials
+  // upfront and avoid N concurrent queries.
   private static async init(
     auth: Authenticator,
-    id: string
+    id: string,
+    preloadedCredential?: InternalMCPServerCredentialModel | null
   ): Promise<InternalMCPServerInMemoryResource | null> {
     const r = getInternalMCPServerNameAndWorkspaceId(id);
     if (r.isErr()) {
@@ -100,8 +104,30 @@ export class InternalMCPServerInMemoryResource {
       ...serverMetadata.serverInfo,
       tools: serverMetadata.tools,
     };
-    server.internalServerCredential =
-      await server.fetchInternalServerCredential(auth);
+
+    if (preloadedCredential !== undefined) {
+      // Caller batch-fetched credentials — avoid the per-server DB round-trip.
+      if (
+        !doesInternalMCPServerRequireBearerToken(id) ||
+        !preloadedCredential
+      ) {
+        server.internalServerCredential = null;
+      } else {
+        server.internalServerCredential = {
+          sharedSecret: preloadedCredential.encryptedKey
+            ? decrypt({
+                encrypted: preloadedCredential.encryptedKey,
+                key: auth.getNonNullableWorkspace().sId,
+                useCase: "mcp_server_credentials",
+              })
+            : null,
+          customHeaders: preloadedCredential.customHeaders,
+        };
+      }
+    } else {
+      server.internalServerCredential =
+        await server.fetchInternalServerCredential(auth);
+    }
 
     return server;
   }
@@ -307,9 +333,30 @@ export class InternalMCPServerInMemoryResource {
     });
     validIds.push(...removeNulls(servers.map((s) => s.internalMCPServerId)));
 
+    if (validIds.length === 0) {
+      return [];
+    }
+
+    // Batch-fetch all credentials in one query instead of one per server in the executor.
+    const uniqueIds = [...new Set(validIds)];
+    const allCredentials = await InternalMCPServerCredentialModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        internalMCPServerId: { [Op.in]: uniqueIds },
+      },
+    });
+    const credentialsByServerId = new Map(
+      allCredentials.map((c) => [c.internalMCPServerId, c])
+    );
+
     const resources = await concurrentExecutor(
       validIds,
-      (id) => InternalMCPServerInMemoryResource.init(auth, id),
+      (id) =>
+        InternalMCPServerInMemoryResource.init(
+          auth,
+          id,
+          credentialsByServerId.get(id) ?? null
+        ),
       { concurrency: 10 }
     );
 
@@ -363,11 +410,34 @@ export class InternalMCPServerInMemoryResource {
       },
     });
 
+    const serverIds = removeNulls(
+      servers.map((server) => server.internalMCPServerId)
+    );
+
+    if (serverIds.length === 0) {
+      return [];
+    }
+
+    // Batch-fetch all credentials in one query instead of one per server in the executor.
+    const allCredentials = await InternalMCPServerCredentialModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        internalMCPServerId: { [Op.in]: serverIds },
+      },
+    });
+    const credentialsByServerId = new Map(
+      allCredentials.map((c) => [c.internalMCPServerId, c])
+    );
+
     const resources = await concurrentExecutor(
-      removeNulls(servers.map((server) => server.internalMCPServerId)),
+      serverIds,
       async (internalMCPServerId) =>
         // This does not create them in the workspace, only in memory, we need to call "makeNew" to create them in the workspace.
-        InternalMCPServerInMemoryResource.init(auth, internalMCPServerId),
+        InternalMCPServerInMemoryResource.init(
+          auth,
+          internalMCPServerId,
+          credentialsByServerId.get(internalMCPServerId) ?? null
+        ),
       {
         concurrency: 10,
       }

--- a/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
+++ b/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
@@ -62,6 +62,36 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
     return new this(RemoteMCPServerToolMetadataModel, toolMetadata.get());
   }
 
+  static async bulkCreate(
+    auth: Authenticator,
+    blobs: CreationAttributes<RemoteMCPServerToolMetadataModel>[],
+    transaction?: Transaction
+  ) {
+    if (blobs.length === 0) {
+      return [];
+    }
+
+    const canAdministrate =
+      await SpaceResource.canAdministrateSystemSpace(auth);
+
+    if (!canAdministrate) {
+      throw new DustError(
+        "unauthorized",
+        "The user is not authorized to create tool metadata"
+      );
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const records = await this.model.bulkCreate(
+      blobs.map((blob) => ({ ...blob, workspaceId })),
+      { transaction }
+    );
+
+    return records.map(
+      (r) => new this(RemoteMCPServerToolMetadataModel, r.get())
+    );
+  }
+
   // Fetch
 
   private static async baseFetch(

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -94,99 +94,51 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const { serverType, id } = getServerTypeAndIdFromSId(serverId);
-      switch (serverType) {
-        case "internal": {
-          const systemSpace =
-            await SpaceResource.fetchWorkspaceSystemSpace(auth);
-          const server = await InternalMCPServerInMemoryResource.fetchById(
-            auth,
-            serverId,
-            systemSpace
-          );
+      const { serverType } = getServerTypeAndIdFromSId(serverId);
 
-          if (!server) {
-            return apiError(req, res, {
-              status_code: 404,
-              api_error: {
-                type: "data_source_not_found",
-                message: "Internal MCP Server not found",
-              },
-            });
-          }
+      // Fetch all views for this server in one pass. baseFetch internally resolves
+      // the server resource, so we avoid a separate fetchById round-trip.
+      const allViews = await MCPServerViewResource.listByMCPServer(
+        auth,
+        serverId
+      );
 
-          const json = server.toJSON();
-
-          const views = (
-            await MCPServerViewResource.listByMCPServer(auth, json.sId)
-          ).map((v) => v.toJSON());
-
-          // Enrich authorization so the client can block the OAuth popup when the
-          // workspace-level connection is missing.
-          return res.status(200).json({
-            server: {
-              ...json,
-              views,
-              authorization: withWorkspaceConnectionRequirement(
-                json.authorization,
-                {
-                  isWorkspaceConnected: (
-                    await MCPServerConnectionResource.findByMCPServer(auth, {
-                      mcpServerId: json.sId,
-                      connectionType: "workspace",
-                    })
-                  ).isOk(),
-                }
-              ),
-            },
-          });
-        }
-        case "remote": {
-          const server = await RemoteMCPServerResource.fetchById(
-            auth,
-            serverId
-          );
-
-          if (!server || server.id !== id) {
-            return apiError(req, res, {
-              status_code: 404,
-              api_error: {
-                type: "data_source_not_found",
-                message: "Remote MCP Server not found",
-              },
-            });
-          }
-
-          const json = server.toJSON();
-
-          const views = (
-            await MCPServerViewResource.listByMCPServer(auth, json.sId)
-          ).map((v) => v.toJSON());
-
-          // Enrich authorization so the client can block the OAuth popup when the
-          // workspace-level connection is missing.
-          return res.status(200).json({
-            server: {
-              ...json,
-              views,
-              authorization: withWorkspaceConnectionRequirement(
-                json.authorization,
-                {
-                  isWorkspaceConnected: (
-                    await MCPServerConnectionResource.findByMCPServer(auth, {
-                      mcpServerId: json.sId,
-                      connectionType: "workspace",
-                    })
-                  ).isOk(),
-                }
-              ),
-            },
-          });
-        }
-        default:
-          assertNever(serverType);
+      if (allViews.length === 0) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "data_source_not_found",
+            message:
+              serverType === "internal"
+                ? "Internal MCP Server not found"
+                : "Remote MCP Server not found",
+          },
+        });
       }
-      break;
+
+      // Extract the server JSON from any view — all views point to the same server.
+      const json = allViews[0].toJSON().server;
+      const views = allViews.map((v) => v.toJSON());
+
+      // Enrich authorization so the client can block the OAuth popup when the
+      // workspace-level connection is missing.
+      return res.status(200).json({
+        server: {
+          ...json,
+          views,
+          authorization: withWorkspaceConnectionRequirement(
+            json.authorization,
+            {
+              isWorkspaceConnected: (
+                await MCPServerConnectionResource.findByMCPServer(auth, {
+                  mcpServerId: serverId,
+                  connectionType: "workspace",
+                })
+              ).isOk(),
+            }
+          ),
+        },
+      });
     }
     case "PATCH": {
       const r = PatchMCPServerBodySchema.safeParse(req.body);

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -247,11 +247,12 @@ async function handler(
             });
           }
 
-          // Check for name conflicts before creating the server.
-          if (body.includeGlobal) {
-            const globalSpace =
-              await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+          // Fetch once; reused for both the conflict check and the view creation below.
+          const globalSpace = body.includeGlobal
+            ? await SpaceResource.fetchWorkspaceGlobalSpace(auth)
+            : null;
 
+          if (globalSpace) {
             const { hasConflict } =
               await MCPServerViewResource.hasNameConflictInSpaceByName(
                 auth,
@@ -305,21 +306,22 @@ async function handler(
             });
           }
 
-          // Create default tool stakes if specified
+          // Create default tool stakes if specified — one bulk INSERT instead of N round-trips.
           if (defaultConfig?.toolStakes) {
-            for (const [toolName, stakeLevel] of Object.entries(
-              defaultConfig.toolStakes
-            )) {
-              await RemoteMCPServerToolMetadataResource.makeNew(auth, {
-                remoteMCPServerId: newRemoteMCPServer.id,
-                toolName,
-                permission: stakeLevel,
-                enabled: true,
-              });
-            }
+            await RemoteMCPServerToolMetadataResource.bulkCreate(
+              auth,
+              Object.entries(defaultConfig.toolStakes).map(
+                ([toolName, stakeLevel]) => ({
+                  remoteMCPServerId: newRemoteMCPServer.id,
+                  toolName,
+                  permission: stakeLevel,
+                  enabled: true,
+                })
+              )
+            );
           }
 
-          if (body.includeGlobal) {
+          if (globalSpace) {
             const systemView =
               await MCPServerViewResource.getMCPServerViewForSystemSpace(
                 auth,
@@ -339,7 +341,7 @@ async function handler(
 
             await MCPServerViewResource.create(auth, {
               systemView,
-              space: await SpaceResource.fetchWorkspaceGlobalSpace(auth),
+              space: globalSpace,
             });
           }
 
@@ -402,11 +404,12 @@ async function handler(
           // otherwise fall back to the internal server name.
           const nameForConflictCheck = viewName ?? name;
 
-          // Check for name conflicts before creating the server.
-          if (body.includeGlobal) {
-            const globalSpace =
-              await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+          // Fetch once; reused for both the conflict check and the view creation below.
+          const globalSpace = body.includeGlobal
+            ? await SpaceResource.fetchWorkspaceGlobalSpace(auth)
+            : null;
 
+          if (globalSpace) {
             const { hasConflict } =
               await MCPServerViewResource.hasNameConflictInSpaceByName(
                 auth,
@@ -483,10 +486,7 @@ async function handler(
             }
           }
 
-          if (body.includeGlobal) {
-            const globalSpace =
-              await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-
+          if (globalSpace) {
             const systemView =
               await MCPServerViewResource.getMCPServerViewForSystemSpace(
                 auth,


### PR DESCRIPTION
## Description
Reduce concurrent requests:
1. GET /api/w/[wId]/mcp: now 2 — credential fetch is a single batched query; inside concurrentExecutor (concurrency 10), each init() only calls isEnabledForWorkspace for restricted servers, and its two DB calls are lru-memoizer workspace-keyed with request coalescing
2. GET /api/w/[wId]/mcp/[serverId]: now 2-3 — listByMCPServer uses the same batched-credential + memoized-workspace path; MCPServerConnectionResource.findByMCPServer adds 1 parallel query
3. The concurrency: 10 executor parameter is now effectively decorative: coalesced memoization bounds actual fan-out to O(1) per workspace regardless of server count

Change summary:
- Batch-fetch internal server credentials in one WHERE-IN query instead of one per server inside concurrentExecutor; adds optional preloadedCredential param to init() so callers can opt in
- Add RemoteMCPServerToolMetadataResource.bulkCreate to replace the N+1 loop when persisting default tool stakes on server creation
- Cache fetchWorkspaceGlobalSpace result in POST handler to avoid a duplicate query per request
- Collapse the GET /mcp/[serverId] handler to call listByMCPServer once instead of fetchById + listByMCPServer (which re-fetched the same server internally)
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Smoke tested admin panel tool section
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low-mid
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
