### PR TITLE
[Sessions] Render parent lineage chip in child conversation

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -10,19 +10,24 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
-import { getProjectRoute } from "@app/lib/utils/router";
+import { getConversationRoute, getProjectRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types/user";
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
 import {
+  ActionGitBranchIcon,
   ArrowLeftIcon,
   AttachmentIcon,
   Breadcrumbs,
   Button,
+  Chip,
   MoreIcon,
+  Tooltip,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 import { EditConversationTitleDialog } from "./EditConversationTitleDialog";
+
+const UNTITLED_CONVERSATION_TITLE = "Untitled conversation";
 
 export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const activeConversationId = useActiveConversationId();
@@ -57,6 +62,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const spaceId = conversation?.spaceId;
   const isProjectConversation = !!spaceId;
   const isLoading = isProjectConversation && !spaceInfo;
+  const forkedFrom = conversation?.forkedFrom;
 
   const breadcrumbItems: BreadcrumbItem[] = [];
 
@@ -79,19 +85,59 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     });
   }
 
+  const hasReadableParentConversation =
+    !!forkedFrom && "parentConversationTitle" in forkedFrom;
+  const parentConversationTitle = hasReadableParentConversation
+    ? (forkedFrom.parentConversationTitle ?? UNTITLED_CONVERSATION_TITLE)
+    : "Parent conversation";
+  const forkedFromTooltipLabel = hasReadableParentConversation
+    ? `Branched from ${parentConversationTitle}`
+    : "Branched from a parent conversation you can no longer access";
+
   return (
     <AppLayoutTitle>
       <div
         className="grid h-full min-w-0 max-w-full grid-cols-[1fr,auto] items-center gap-3"
         onContextMenu={handleRightClick}
       >
-        <div className="min-w-0 overflow-x-auto scrollbar-hide">
-          <Breadcrumbs
-            items={breadcrumbItems}
-            className="dd-privacy-mask"
-            truncateLengthMiddle={35}
-            truncateLengthEnd={120}
-          />
+        <div className="flex min-w-0 items-center gap-2 overflow-x-auto scrollbar-hide">
+          <div className="min-w-0">
+            <Breadcrumbs
+              items={breadcrumbItems}
+              className="dd-privacy-mask"
+              truncateLengthMiddle={35}
+              truncateLengthEnd={120}
+            />
+          </div>
+          {forkedFrom && (
+            <Tooltip
+              label={forkedFromTooltipLabel}
+              tooltipTriggerAsChild
+              trigger={
+                hasReadableParentConversation ? (
+                  <Chip
+                    className="max-w-44 shrink-0 dd-privacy-mask"
+                    color="primary"
+                    href={getConversationRoute(
+                      owner.sId,
+                      forkedFrom.parentConversationId
+                    )}
+                    icon={ActionGitBranchIcon}
+                    label={parentConversationTitle}
+                    size="mini"
+                  />
+                ) : (
+                  <Chip
+                    className="max-w-44 shrink-0"
+                    color="primary"
+                    icon={ActionGitBranchIcon}
+                    label={parentConversationTitle}
+                    size="mini"
+                  />
+                )
+              }
+            />
+          )}
         </div>
         <EditConversationTitleDialog
           isOpen={showRenameDialog}

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -147,6 +147,8 @@
  *           type: array
  *           items:
  *             type: string
+ *         forkedFrom:
+ *           $ref: '#/components/schemas/PrivateConversationForkedFrom'
  *         forkedChildren:
  *           type: array
  *           items:
@@ -181,6 +183,20 @@
  *         lastLoginAt:
  *           type: integer
  *           nullable: true
+ *     PrivateConversationForkedFrom:
+ *       type: object
+ *       properties:
+ *         parentConversationId:
+ *           type: string
+ *         parentConversationTitle:
+ *           type: string
+ *           nullable: true
+ *         sourceMessageId:
+ *           type: string
+ *         branchedAt:
+ *           type: integer
+ *         user:
+ *           $ref: '#/components/schemas/PrivateConversationForkUser'
  *     PrivateConversationForkedChild:
  *       type: object
  *       properties:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -1,6 +1,12 @@
 import { Authenticator } from "@app/lib/auth";
+import {
+  ConversationModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -91,6 +97,79 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]", () => {
     expect(res._getStatusCode()).toBe(200);
   });
 
+  it("includes the readable parent conversation title in forkedFrom", async () => {
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "GET",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Fork Fetch Agent",
+      description: "Fork fetch agent",
+    });
+
+    const parentConversationTitle = "Quarterly Review Data";
+    const parentConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date("2026-01-05T00:00:00.000Z")],
+    });
+    const childConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    await ConversationModel.update(
+      { title: parentConversationTitle },
+      {
+        where: {
+          id: parentConversation.id,
+          workspaceId: workspace.id,
+        },
+      }
+    );
+
+    const parentConversationResource = await ConversationResource.fetchById(
+      auth,
+      parentConversation.sId
+    );
+    const childConversationResource = await ConversationResource.fetchById(
+      auth,
+      childConversation.sId
+    );
+    assert(parentConversationResource, "Parent conversation not found");
+    assert(childConversationResource, "Child conversation not found");
+
+    const sourceMessage = await MessageModel.findOne({
+      where: {
+        conversationId: parentConversation.id,
+        workspaceId: workspace.id,
+        rank: 1,
+      },
+    });
+    assert(sourceMessage, "Source message not found");
+
+    const branchedAt = new Date("2026-01-06T00:00:00.000Z");
+    await ConversationForkResource.makeNew(auth, {
+      parentConversation: parentConversationResource,
+      childConversation: childConversationResource,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt,
+    });
+
+    req.query.wId = workspace.sId;
+    req.query.cId = childConversation.sId;
+    req.url = `/api/w/${workspace.sId}/assistant/conversations/${childConversation.sId}`;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().conversation.forkedFrom).toEqual({
+      parentConversationId: parentConversation.sId,
+      parentConversationTitle,
+      sourceMessageId: sourceMessage.sId,
+      branchedAt: branchedAt.getTime(),
+      user: auth.getNonNullableUser().toJSON(),
+    });
+  });
+
   it("returns 200 for project conversations for non-participants when private conversation URLs are enabled", async () => {
     const { req, res, workspace, user } = await createPrivateApiMockRequest({
       role: "user",
@@ -136,6 +215,107 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
+  });
+
+  it("omits the parent conversation title when the parent is unreadable", async () => {
+    const {
+      req,
+      res,
+      workspace,
+      auth: userAuth,
+    } = await createPrivateApiMockRequest({
+      role: "user",
+      method: "GET",
+    });
+
+    const adminUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const addMemberResult = await restrictedSpace.addMembers(adminAuth, {
+      userIds: [adminUser.sId],
+    });
+    assert(addMemberResult.isOk(), "Failed to add admin to restricted space");
+
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      name: "Restricted Fork Source Agent",
+      description: "Restricted fork source agent",
+    });
+    const parentConversationTitle = "Restricted parent";
+    const parentConversation = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date("2026-01-03T00:00:00.000Z")],
+      requestedSpaceIds: [restrictedSpace.id],
+      spaceId: restrictedSpace.id,
+    });
+    const childConversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    await ConversationModel.update(
+      { title: parentConversationTitle },
+      {
+        where: {
+          id: parentConversation.id,
+          workspaceId: workspace.id,
+        },
+      }
+    );
+
+    const parentConversationResource = await ConversationResource.fetchById(
+      adminAuth,
+      parentConversation.sId
+    );
+    const childConversationResource = await ConversationResource.fetchById(
+      adminAuth,
+      childConversation.sId
+    );
+    assert(parentConversationResource, "Parent conversation not found");
+    assert(childConversationResource, "Child conversation not found");
+
+    const sourceMessage = await MessageModel.findOne({
+      where: {
+        conversationId: parentConversation.id,
+        workspaceId: workspace.id,
+        rank: 1,
+      },
+    });
+    assert(sourceMessage, "Source message not found");
+
+    const branchedAt = new Date("2026-01-04T00:00:00.000Z");
+    await ConversationForkResource.makeNew(adminAuth, {
+      parentConversation: parentConversationResource,
+      childConversation: childConversationResource,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt,
+    });
+
+    expect(
+      await ConversationResource.fetchById(userAuth, parentConversation.sId)
+    ).toBeNull();
+
+    req.query.wId = workspace.sId;
+    req.query.cId = childConversation.sId;
+    req.url = `/api/w/${workspace.sId}/assistant/conversations/${childConversation.sId}`;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseConversation = res._getJSONData().conversation;
+    expect(responseConversation.forkedFrom).toEqual({
+      parentConversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+      branchedAt: branchedAt.getTime(),
+      user: adminAuth.getNonNullableUser().toJSON(),
+    });
+    expect(responseConversation.forkedFrom).not.toHaveProperty(
+      "parentConversationTitle"
+    );
   });
 
   it("returns 404 conversation_not_found for admins when private conversation URLs are enabled and they are not participants", async () => {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -183,6 +183,31 @@ export type PatchConversationResponseBody = {
   success: boolean;
 };
 
+async function enrichForkedFromParentConversationTitle(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType
+): Promise<ConversationWithoutContentType> {
+  if (!conversation.forkedFrom) {
+    return conversation;
+  }
+
+  const parentConversation = await ConversationResource.fetchById(
+    auth,
+    conversation.forkedFrom.parentConversationId
+  );
+  if (!parentConversation) {
+    return conversation;
+  }
+
+  return {
+    ...conversation,
+    forkedFrom: {
+      ...conversation.forkedFrom,
+      parentConversationTitle: parentConversation.title,
+    },
+  };
+}
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
@@ -220,7 +245,10 @@ async function handler(
         return apiErrorForConversation(req, res, error);
       }
 
-      const conversation = conversationRes.value;
+      const conversation = await enrichForkedFromParentConversationTitle(
+        auth,
+        conversationRes.value
+      );
 
       void emitAuditLogEvent({
         auth,

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -9582,6 +9582,9 @@
               "type": "string"
             }
           },
+          "forkedFrom": {
+            "$ref": "#/components/schemas/PrivateConversationForkedFrom"
+          },
           "forkedChildren": {
             "type": "array",
             "items": {
@@ -9637,6 +9640,27 @@
           "lastLoginAt": {
             "type": "integer",
             "nullable": true
+          }
+        }
+      },
+      "PrivateConversationForkedFrom": {
+        "type": "object",
+        "properties": {
+          "parentConversationId": {
+            "type": "string"
+          },
+          "parentConversationTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "sourceMessageId": {
+            "type": "string"
+          },
+          "branchedAt": {
+            "type": "integer"
+          },
+          "user": {
+            "$ref": "#/components/schemas/PrivateConversationForkUser"
           }
         }
       },

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -400,6 +400,9 @@ export function getConversationUrlAccessMode(
   return isConversationUrlAccessMode(accessMode) ? accessMode : null;
 }
 
+/**
+ * @swaggerschema PrivateConversationForkedFrom (swagger_private_schemas.ts)
+ */
 export type ConversationForkedFromType = {
   parentConversationId: string;
   parentConversationTitle?: string | null;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -402,6 +402,7 @@ export function getConversationUrlAccessMode(
 
 export type ConversationForkedFromType = {
   parentConversationId: string;
+  parentConversationTitle?: string | null;
   sourceMessageId: string;
   branchedAt: number;
   user: UserType;


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24418
Context: `x/pr/branching.md`
- renders a linked parent conversation chip in the child conversation header
- enriches the conversation detail route with `forkedFrom.parentConversationTitle` only when the parent conversation is readable, so restricted parents keep lineage without leaking the title

## Risks
Blast radius: forked child conversation header and the conversation detail payload for forked conversations
Risk: low

## Deploy Plan
- deploy front