### PR TITLE
[google drive]: Fix Google picker for shared credentials

### DIFF
--- a/front/pages/api/w/[wId]/google_drive/picker_token.ts
+++ b/front/pages/api/w/[wId]/google_drive/picker_token.ts
@@ -50,7 +50,9 @@ async function handler(
         mcpServerId
       );
       const connectionType =
-        views[0]?.oAuthUseCase === "platform_actions" ? "workspace" : "personal";
+        views[0]?.oAuthUseCase === "platform_actions"
+          ? "workspace"
+          : "personal";
 
       const connectionResult =
         await MCPServerConnectionResource.findByMCPServer(auth, {

--- a/front/pages/api/w/[wId]/google_drive/picker_token.ts
+++ b/front/pages/api/w/[wId]/google_drive/picker_token.ts
@@ -4,6 +4,7 @@ import config from "@app/lib/api/config";
 import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -43,11 +44,18 @@ async function handler(
 
       const { mcpServerId } = parseResult.data;
 
-      // Look up the user's personal OAuth connection for this MCP server
+      // Use whichever connection type the tool is configured for.
+      const views = await MCPServerViewResource.listByMCPServer(
+        auth,
+        mcpServerId
+      );
+      const connectionType =
+        views[0]?.oAuthUseCase === "platform_actions" ? "workspace" : "personal";
+
       const connectionResult =
         await MCPServerConnectionResource.findByMCPServer(auth, {
           mcpServerId,
-          connectionType: "personal",
+          connectionType,
         });
 
       if (connectionResult.isErr()) {


### PR DESCRIPTION
## Description
Last week we added the ability for admins to set up google drive tools with shared credentials, but missed checking which credentials to use in the google picker
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Set up google drive tool with workspace credentials, attempt to edit a document and see that the picker works correctly
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
