### PR TITLE
reuse GCS client singleton in upsert queue

### DIFF
--- a/front/lib/upsert_queue.ts
+++ b/front/lib/upsert_queue.ts
@@ -1,4 +1,4 @@
-import config from "@app/lib/file_storage/config";
+import { getUpsertQueueBucket } from "@app/lib/file_storage";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
@@ -10,7 +10,6 @@ import {
 } from "@app/types/api/public/data_sources";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { Storage } from "@google-cloud/storage";
 import * as t from "io-ts";
 import { v4 as uuidv4 } from "uuid";
 
@@ -135,10 +134,8 @@ async function enqueueUpsert({
       launchWorkflowFn: typeof launchUpsertTableWorkflow;
     }): Promise<Result<string, Error>> {
   try {
-    const storage = new Storage({ keyFilename: config.getServiceAccount() });
-    const bucket = storage.bucket(config.getGcsUpsertQueueBucket());
     const now = Date.now();
-    await bucket
+    await getUpsertQueueBucket()
       .file(`${upsertQueueId}.json`)
       .save(JSON.stringify(upsertItem), {
         contentType: "application/json",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
`enqueueUpsert` was instantiating a new Storage client on every call, triggering a service account file read and fresh connection setup each time. Switch to the existing `getUpsertQueueBucket()` singleton so the GCS client (and its HTTP/2connection pool) is initialized once per process.

Spotted while investigating libuv thread pool saturation. File system ops were 43% of thread time.

<img width="860" height="95" alt="image" src="https://github.com/user-attachments/assets/2c6cf4a8-e762-48ce-9610-b31c088b375d" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
