### PR TITLE
Poke gdrive error display

### DIFF
--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -146,6 +146,13 @@ function ContentNodeTreeInfiniteScroll({
   );
 }
 
+const PERMISSIONS_ERROR_MESSAGES: Record<string, string> = {
+  rate_limit_error:
+    "Connected service's API limit reached. Please retry shortly.",
+  data_source_auth_error:
+    "Failed to retrieve permissions due to a revoked authorization. Please re-authorize the connection.",
+};
+
 interface ContentNodeTreeChildrenProps {
   depth: number;
   isRoundedBackground?: boolean;
@@ -226,12 +233,6 @@ function ContentNodeTreeChildren({
   );
 
   if (isResourcesError) {
-    const PERMISSIONS_ERROR_MESSAGES: Record<string, string> = {
-      rate_limit_error:
-        "Connected service's API limit reached. Please retry shortly.",
-      data_source_auth_error:
-        "Failed to retrieve permissions due to a revoked authorization. Please re-authorize the connection.",
-    };
     const errorMessage =
       (resourcesError?.type &&
         PERMISSIONS_ERROR_MESSAGES[resourcesError.type]) ||

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -226,18 +226,18 @@ function ContentNodeTreeChildren({
   );
 
   if (isResourcesError) {
-    return (
-      <div className="text-sm text-warning">
-        {resourcesError?.type === "rate_limit_error" ? (
-          <>Connected service's API limit reached. Please retry shortly.</>
-        ) : (
-          <>
-            Failed to retrieve permissions likely due to a revoked
-            authorization.
-          </>
-        )}
-      </div>
-    );
+    const errorMessage = (() => {
+      switch (resourcesError?.type) {
+        case "rate_limit_error":
+          return "Connected service's API limit reached. Please retry shortly.";
+        case "data_source_auth_error":
+          return "Failed to retrieve permissions due to a revoked authorization. Please re-authorize the connection.";
+        default:
+          return "Failed to retrieve permissions due to an unexpected error. The resource may have been deleted, moved, or its sharing permissions changed.";
+      }
+    })();
+
+    return <div className="text-sm text-warning">{errorMessage}</div>;
   }
 
   const tree = (

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -226,16 +226,16 @@ function ContentNodeTreeChildren({
   );
 
   if (isResourcesError) {
-    const errorMessage = (() => {
-      switch (resourcesError?.type) {
-        case "rate_limit_error":
-          return "Connected service's API limit reached. Please retry shortly.";
-        case "data_source_auth_error":
-          return "Failed to retrieve permissions due to a revoked authorization. Please re-authorize the connection.";
-        default:
-          return "Failed to retrieve permissions due to an unexpected error. The resource may have been deleted, moved, or its sharing permissions changed.";
-      }
-    })();
+    const PERMISSIONS_ERROR_MESSAGES: Record<string, string> = {
+      rate_limit_error:
+        "Connected service's API limit reached. Please retry shortly.",
+      data_source_auth_error:
+        "Failed to retrieve permissions due to a revoked authorization. Please re-authorize the connection.",
+    };
+    const errorMessage =
+      (resourcesError?.type &&
+        PERMISSIONS_ERROR_MESSAGES[resourcesError.type]) ||
+      "Failed to retrieve permissions due to an unexpected error. The resource may have been deleted, moved, or its sharing permissions changed.";
 
     return <div className="text-sm text-warning">{errorMessage}</div>;
   }

--- a/front/lib/actions/mcp_transport_errors.ts
+++ b/front/lib/actions/mcp_transport_errors.ts
@@ -1,0 +1,36 @@
+import { MCPOAuthProviderError } from "@app/lib/actions/mcp_oauth_provider";
+
+/**
+ * Detects authentication errors from the MCP SDK, whether they come from
+ * MCPOAuthProvider (when an authProvider is supplied) or from the transport
+ * layer (when the token is injected directly as a header and no authProvider
+ * is present).
+ *
+ * Transport-level 401 errors surface as:
+ *  - StreamableHTTPError (code 401) from the Streamable HTTP transport
+ *  - SseError            (code 401) from the SSE transport during GET
+ *  - plain Error with "(HTTP 401)" in the message from SSE POST
+ */
+export function isOAuthOrTransportAuthError(e: unknown): boolean {
+  if (e instanceof MCPOAuthProviderError) {
+    return true;
+  }
+
+  if (e instanceof Error) {
+    // StreamableHTTPError and SseError both carry a numeric `code` property.
+    if ("code" in e) {
+      const coded = e as Error & { code: unknown };
+      if (coded.code === 401 || coded.code === 403) {
+        return true;
+      }
+    }
+
+    // SSE transport POST path throws a plain Error whose message contains
+    // the HTTP status, e.g. "Error POSTing to endpoint (HTTP 401): …".
+    if (/\(HTTP 40[13]\)/.test(e.message)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -10,7 +10,11 @@ import type { GetPokeFeaturesResponseBody } from "@app/pages/api/poke/workspaces
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
 import type { ConnectorPermission } from "@app/types/connectors/connectors_api";
 import type { DataSourceType } from "@app/types/data_source";
-import type { APIErrorResponse, RegionRedirectError } from "@app/types/error";
+import type {
+  APIError,
+  APIErrorResponse,
+  RegionRedirectError,
+} from "@app/types/error";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useEffect } from "react";
 import type { Fetcher } from "swr";
@@ -61,6 +65,7 @@ export function usePokeConnectorPermissions({
     resources: data?.resources ?? emptyArray(),
     isResourcesLoading: !error && !data,
     isResourcesError: error,
+    resourcesError: error ? (error.error as APIError) : null,
   };
 }
 

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -10,10 +10,11 @@ import type { GetPokeFeaturesResponseBody } from "@app/pages/api/poke/workspaces
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
 import type { ConnectorPermission } from "@app/types/connectors/connectors_api";
 import type { DataSourceType } from "@app/types/data_source";
-import type {
-  APIError,
-  APIErrorResponse,
-  RegionRedirectError,
+import {
+  isAPIErrorResponse,
+  type APIError,
+  type APIErrorResponse,
+  type RegionRedirectError,
 } from "@app/types/error";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useEffect } from "react";
@@ -65,7 +66,7 @@ export function usePokeConnectorPermissions({
     resources: data?.resources ?? emptyArray(),
     isResourcesLoading: !error && !data,
     isResourcesError: error,
-    resourcesError: error ? (error.error as APIError) : null,
+    resourcesError: isAPIErrorResponse(error) ? error.error : null,
   };
 }
 

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -11,9 +11,8 @@ import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId
 import type { ConnectorPermission } from "@app/types/connectors/connectors_api";
 import type { DataSourceType } from "@app/types/data_source";
 import {
-  isAPIErrorResponse,
-  type APIError,
   type APIErrorResponse,
+  isAPIErrorResponse,
   type RegionRedirectError,
 } from "@app/types/error";
 import type { LightWorkspaceType } from "@app/types/user";


### PR DESCRIPTION
## Description
This PR is to display the error message in content node tree. For this workspace (https://github.com/dust-tt/tasks/issues/7601), the connector is running, oauth token seems to be valid, but we show generic error message: `Failed to retrieve permissions likely due to a revoked authorization.`

IIUC the flow is:
- Poke calls the front api: `workspaces/[wId]/data_sources/[dsId]/managed/permissions?viewType=document&parentId=XXX&filterPermission=read`
- we call Google Drive `files.get` API and then throw either ExternalOAuthTokenError , RATE_LIMIT_ERROR, or generic 500 errors https://github.com/dust-tt/dust/blob/c048e1f9cf2186308876c0a49fc258628cb74a1d/connectors/src/connectors/google_drive/index.ts#L535-L555

For this connector I see the endpoint returns 500, and judging from temporal is still running and I can retrieve OAuth token, token is still valid but the user who authorized the access seems to lose the access to the folder? 

before:
<img width="1304" height="216" alt="CleanShot 2026-04-21 at 09 24 27@2x" src="https://github.com/user-attachments/assets/7d916d31-dd6e-43c3-ab7b-c8fd9c39860d" />

after:
<img width="1846" height="196" alt="CleanShot 2026-04-21 at 09 24 24@2x" src="https://github.com/user-attachments/assets/fdc3e7d5-aef4-43a2-9620-e1439f8825db" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
