### PR TITLE
[front] add alerting on `ask_user_question` tool

### DIFF
--- a/front/lib/api/actions/servers/ask_user_question/metadata.ts
+++ b/front/lib/api/actions/servers/ask_user_question/metadata.ts
@@ -32,6 +32,7 @@ export const ASK_USER_QUESTION_TOOLS_METADATA = createToolsRecord({
     schema: {
       ...UserQuestionSchema.shape,
     },
+    enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
       running: "Asking user...",


### PR DESCRIPTION
## Description

- This PR adds alerting on the `ask_user_question` tool (datadog monitor if it fails).
- This tool should never fail (and [has not](https://app.datadoghq.eu/logs?query=%40toolName%3Aask_user_question%20-status%3Ainfo&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1776757799600&to_ts=1776758699600&live=true)), we want to be alerted fast if it does.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
