### PR TITLE
Add wake-up shared types

### DIFF
--- a/front/lib/resources/storage/models/wakeup.ts
+++ b/front/lib/resources/storage/models/wakeup.ts
@@ -3,11 +3,12 @@ import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type {
+  WakeUpScheduleType,
+  WakeUpStatus,
+} from "@app/types/assistant/wakeups";
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
-
-export type WakeUpScheduleType = "one_shot" | "cron";
-export type WakeUpStatus = "scheduled" | "fired" | "cancelled" | "expired";
 
 export class WakeUpModel extends WorkspaceAwareModel<WakeUpModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -1,7 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
-import type { WakeUpStatus } from "@app/lib/resources/storage/models/wakeup";
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -9,8 +8,14 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type {
+  WakeUpScheduleConfig,
+  WakeUpStatus,
+  WakeUpType,
+} from "@app/types/assistant/wakeups";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Attributes, Transaction, WhereOptions } from "sequelize";
 
 const ACTIVE_WAKE_UP_STATUSES: WakeUpStatus[] = ["scheduled"];
@@ -212,6 +217,48 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     });
 
     return new Ok(undefined);
+  }
+
+  toJSON(): WakeUpType {
+    const scheduleConfig: WakeUpScheduleConfig = (() => {
+      switch (this.scheduleType) {
+        case "one_shot": {
+          if (!this.fireAt) {
+            throw new Error("Wake-up is missing fireAt for one-shot schedule.");
+          }
+
+          return {
+            type: "one_shot",
+            fireAt: this.fireAt.getTime(),
+          };
+        }
+        case "cron": {
+          if (!this.cronExpression || !this.cronTimezone) {
+            throw new Error(
+              "Wake-up is missing cron schedule fields for cron schedule."
+            );
+          }
+
+          return {
+            type: "cron",
+            cron: this.cronExpression,
+            timezone: this.cronTimezone,
+          };
+        }
+        default:
+          return assertNever(this.scheduleType);
+      }
+    })();
+
+    return {
+      id: this.id,
+      createdAt: this.createdAt.getTime(),
+      agentConfigurationId: this.agentConfigurationId,
+      scheduleConfig,
+      reason: this.reason,
+      status: this.status,
+      fireCount: this.fireCount,
+    };
   }
 
   private async startTemporalWorkflow(

--- a/front/types/assistant/wakeups.ts
+++ b/front/types/assistant/wakeups.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+export const WAKEUP_STATUSES = [
+  "scheduled",
+  "fired",
+  "cancelled",
+  "expired",
+] as const;
+
+export const WakeUpStatusSchema = z.enum(WAKEUP_STATUSES);
+export type WakeUpStatus = z.infer<typeof WakeUpStatusSchema>;
+
+export const WakeUpOneShotScheduleConfigSchema = z.object({
+  type: z.literal("one_shot"),
+  fireAt: z.number(),
+});
+export type WakeUpOneShotScheduleConfig = z.infer<
+  typeof WakeUpOneShotScheduleConfigSchema
+>;
+
+export const WakeUpCronScheduleConfigSchema = z.object({
+  type: z.literal("cron"),
+  cron: z.string(),
+  timezone: z.string(),
+});
+export type WakeUpCronScheduleConfig = z.infer<
+  typeof WakeUpCronScheduleConfigSchema
+>;
+
+export const WakeUpScheduleConfigSchema = z.discriminatedUnion("type", [
+  WakeUpOneShotScheduleConfigSchema,
+  WakeUpCronScheduleConfigSchema,
+]);
+export type WakeUpScheduleConfig = z.infer<typeof WakeUpScheduleConfigSchema>;
+export type WakeUpScheduleType = WakeUpScheduleConfig["type"];
+
+export const WakeUpSchema = z.object({
+  id: z.number(),
+  createdAt: z.number(),
+  agentConfigurationId: z.string(),
+  scheduleConfig: WakeUpScheduleConfigSchema,
+  reason: z.string(),
+  status: WakeUpStatusSchema,
+  fireCount: z.number(),
+});
+export type WakeUpType = z.infer<typeof WakeUpSchema>;

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -11,9 +11,10 @@ classification.
 ### [x] PR 2 — WakeUpResource
 
 `WakeUpResource` wrapping the model: `makeNew`, `cancel`, `markFired`, `listByConversation`,
-`listActiveByWorkspace`. Includes cleanup logic for conversation deletion (cancel Temporal
-workflows + delete rows). No Temporal calls yet — stub them behind a flag. Also define the
-idempotency / cancel-vs-fire behavior here so later wiring is deterministic.
+`listActiveByWorkspace`, `toJSON`. Includes cleanup logic for conversation deletion (cancel
+Temporal workflows + delete rows). No Temporal calls yet — stub them behind a flag. Also add
+shared `WakeUp` Zod schemas / types in `front/types/assistant/wakeups.ts` so API and UI code can
+reuse the same serialized shape.
 
 ## Milestone 2: Temporal execution (one-shot only)
 

--- a/x/spolu/wakeup/wakeup.md
+++ b/x/spolu/wakeup/wakeup.md
@@ -106,6 +106,16 @@ Wraps `WakeUpModel`. Key methods:
 - `markFired()` — increments `fireCount`, updates status for one-shot.
 - `listByConversation(auth, conversationId)` — for UI display.
 - `listActiveByWorkspace(auth)` — for guardrail checks.
+- `toJSON()` — serializes to the shared `WakeUpType` shape.
++
++Also define shared Zod-backed types in `front/types/assistant/wakeups.ts`:
++
++- `WakeUpScheduleConfig`
++- `WakeUpOneShotScheduleConfig`
++- `WakeUpCronScheduleConfig`
++- `WakeUpType`
++
++These types should be the source of truth for endpoint and UI serialization.
 
 ## Temporal Workflows
 
@@ -285,6 +295,7 @@ When a wake-up fires:
 |------|---------|
 | `front/lib/models/agent/wakeup.ts` | `WakeUpModel` Sequelize model |
 | `front/lib/resources/wakeup_resource.ts` | `WakeUpResource` wrapping the model |
+| `front/types/assistant/wakeups.ts` | Shared Zod schemas / serialized wake-up types |
 | `front/lib/api/assistant/wakeup.ts` | Business logic (create, cancel, list) |
 | `front/lib/actions/wakeup_action.ts` | Agent action definition for `schedule_wakeup` |
 | `front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/index.ts` | API: list/cancel |


### PR DESCRIPTION
## Description

Add shared wake-up types in `front/types/assistant/wakeups.ts` using Zod schemas, and update the
wake-up model/resource to reuse those shared types.

Also add `WakeUpResource.toJSON()` so the resource serializes to the new `WakeUpType` shape.

## Tests

N/A, tested locally

## Risk

Low. This is a small typing/serialization refactor for the new wake-up code path.

## Deploy Plan

(no migration needed)

- deploy `front`
