### PR TITLE
Bump hot-shots to v12 to avoid dns.lookup on StatsD sends

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -147,7 +147,7 @@
     "framer-motion": "^12.7.3",
     "fs-extra": "^11.1.1",
     "googleapis": "^118.0.0",
-    "hot-shots": "^10.0.0",
+    "hot-shots": "^12.1.0",
     "html-escaper": "^3.0.3",
     "htmlparser2": "^9.1.0",
     "image-size": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -599,7 +599,7 @@
         "framer-motion": "^12.7.3",
         "fs-extra": "^11.1.1",
         "googleapis": "^118.0.0",
-        "hot-shots": "^10.0.0",
+        "hot-shots": "^12.1.0",
         "html-escaper": "^3.0.3",
         "htmlparser2": "^9.1.0",
         "image-size": "^2.0.2",
@@ -985,6 +985,18 @@
       },
       "engines": {
         "node": ">= 20.0.0"
+      }
+    },
+    "front/node_modules/hot-shots": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-12.1.0.tgz",
+      "integrity": "sha512-Wu5rNjuBZy826Umns60bB47gF8b4rPIa0QDMXNKNMmQUqIWVlizmTgomHUS64zLChVytbieO7KDnT2M4E3/njw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "2.x"
       }
     },
     "front/node_modules/lru-cache": {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
`hot-shots` v10 calls `dns.lookup()` on every `dgram.send()` even when the target is already an IP address (`DD_AGENT_HOST = status.hostIP`). This could saturates the libuv thread pool. v12.0.0 fixes this.

See https://github.com/bdeitte/hot-shots/issues/198.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
