### PR TITLE
feat: make it clearer that project is archived

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -48,12 +48,12 @@ import {
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
 import { formatWakeUpSidebarLabel } from "@app/lib/utils/wakeup_description";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import {
   type ConversationListItemType,
-  type ConversationWithoutContentType,
   getConversationDisplayTitle,
 } from "@app/types/assistant/conversation";
-import type { ProjectType, SpaceType } from "@app/types/space";
+import type { ProjectType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import { isBuilder } from "@app/types/user";
 import {
@@ -66,6 +66,7 @@ import {
   ChatBubbleBottomCenterPlusIcon,
   Checkbox,
   CheckDoubleIcon,
+  Chip,
   cn,
   DocumentIcon,
   DropdownMenu,
@@ -123,7 +124,7 @@ type GroupLabel =
   | "Older";
 
 interface SearchProjectItemProps {
-  space: SpaceType;
+  space: ProjectType;
   owner: WorkspaceType;
   isMember: boolean;
   activeSpaceId: string | null;
@@ -138,6 +139,8 @@ function SearchProjectItem({
   const router = useAppRouter();
   const { setSidebarOpen } = useContext(SidebarContext);
 
+  const isArchived = !!space.archivedAt;
+
   return (
     <NavigationListItem
       selected={activeSpaceId === space.sId}
@@ -148,6 +151,11 @@ function SearchProjectItem({
         setSidebarOpen(false);
         await router.push(getProjectRoute(owner.sId, space.sId));
       }}
+      suffix={
+        isArchived ? (
+          <Chip size="mini" color="white" label="Archived" />
+        ) : undefined
+      }
     />
   );
 }

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -141,8 +141,14 @@ export function SpaceConversationsTab({
           )}
         >
           <div className="flex w-full flex-col gap-3">
-            <h2 className="heading-2xl text-foreground dark:text-foreground-night">
-              {spaceInfo.name}
+            <h2
+              className={cn(
+                "heading-2xl text-foreground dark:text-foreground-night items-center",
+                spaceInfo.archivedAt &&
+                  "text-muted-foreground dark:text-muted-foreground-night"
+              )}
+            >
+              {`${spaceInfo.name}${spaceInfo.archivedAt ? " (Archived)" : ""}`}
             </h2>
             {isEmpty && (
               <h3 className="heading-lg text-foreground dark:text-foreground-night">
@@ -152,7 +158,7 @@ export function SpaceConversationsTab({
             {spaceInfo.archivedAt ? (
               <div className="mx-auto flex flex-col w-full py-4 sm:max-w-conversation">
                 <EmptyCTA
-                  message="This project is archived. You can view past conversations, but you cannot start new ones."
+                  message="This project is archived and no longer appears in your sidebar. You can still search for it and view past conversations, but you cannot start new ones."
                   action={null}
                 />
               </div>

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -25,6 +25,7 @@ import type { Result } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import {
   Button,
+  Chip,
   cn,
   EmptyCTA,
   ListGroup,
@@ -141,15 +142,20 @@ export function SpaceConversationsTab({
           )}
         >
           <div className="flex w-full flex-col gap-3">
-            <h2
-              className={cn(
-                "heading-2xl text-foreground dark:text-foreground-night items-center",
-                spaceInfo.archivedAt &&
-                  "text-muted-foreground dark:text-muted-foreground-night"
+            <div className="flex items-center gap-2">
+              <h2
+                className={cn(
+                  "heading-2xl text-foreground dark:text-foreground-night",
+                  spaceInfo.archivedAt &&
+                    "text-muted-foreground dark:text-muted-foreground-night"
+                )}
+              >
+                {spaceInfo.name}
+              </h2>
+              {spaceInfo.archivedAt && (
+                <Chip size="xs" color="rose" label="Archived" />
               )}
-            >
-              {`${spaceInfo.name}${spaceInfo.archivedAt ? " (Archived)" : ""}`}
-            </h2>
+            </div>
             {isEmpty && (
               <h3 className="heading-lg text-foreground dark:text-foreground-night">
                 Start a first conversation!

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -1,5 +1,6 @@
 import type * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 import { Button } from "@sparkle/components/Button";
+import { Chip } from "@sparkle/components/Chip";
 import {
   Collapsible,
   CollapsibleContent,

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -1,6 +1,5 @@
 import type * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 import { Button } from "@sparkle/components/Button";
-import { Chip } from "@sparkle/components/Chip";
 import {
   Collapsible,
   CollapsibleContent,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7696

This PR improves the UI for archived projects by making their archived status more visible.

- Added an "Archived" chip label to archived projects when searching for them
- Modified the project header to append "(Archived)" to the project name and dim the text color
- Enhanced the empty state message for archived projects to clarify that they no longer appear in the sidebar but can still be searched

<img width="317" height="174" alt="Capture d’écran 2026-04-21 à 10 32 02" src="https://github.com/user-attachments/assets/185b8615-e7e7-4cf2-8745-42223f72a8f2" />
<img width="1076" height="268" alt="Capture d’écran 2026-04-21 à 10 32 19" src="https://github.com/user-attachments/assets/11ff979a-d8b2-49e9-9f77-fc376f2e8531" />


## Tests

Manually

## Risks

Low - UI-only changes to improve clarity of archived project status.

## Deploy Plan

Standard deployment
