### PR TITLE
[front] - feature(charts): add interactive legend selection to chart components

### DIFF
--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -12,12 +12,13 @@ import {
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { legendFromConstant } from "@app/components/charts/ChartLegend";
-import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
+import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import {
   useAgentFeedbackDistribution,
   useAgentVersionMarkers,
 } from "@app/lib/swr/assistants";
 import { formatShortDate } from "@app/lib/utils/timestamps";
+import { cn } from "@dust-tt/sparkle";
 import {
   CartesianGrid,
   Line,
@@ -66,16 +67,20 @@ export function FeedbackDistributionChart({
     disabled: !workspaceId || !agentConfigurationId || !isCustomAgent,
   });
 
-  const legendItems = legendFromConstant(
-    FEEDBACK_DISTRIBUTION_LEGEND,
-    FEEDBACK_DISTRIBUTION_PALETTE,
-    {
-      includeVersionMarker:
-        isCustomAgent && mode === "timeRange" && versionMarkers.length > 0,
-    }
-  );
+  const { activeKey, isDimmed, decorate, hoverHandlers } =
+    useSelectableSeries();
 
-  const { hoveredKey, hoverHandlers } = useHoveredSeries();
+  const legendItems = decorate(
+    legendFromConstant(
+      FEEDBACK_DISTRIBUTION_LEGEND,
+      FEEDBACK_DISTRIBUTION_PALETTE,
+      {
+        includeVersionMarker:
+          isCustomAgent && mode === "timeRange" && versionMarkers.length > 0,
+      }
+    ),
+    { skip: (item) => item.key === "versionMarkers" }
+  );
 
   const filteredData = filterTimeSeriesByVersionWindow(
     feedbackDistribution,
@@ -129,7 +134,7 @@ export function FeedbackDistributionChart({
         />
         <Tooltip
           content={(props: TooltipContentProps<number, string>) => (
-            <FeedbackDistributionTooltip {...props} activeKey={hoveredKey} />
+            <FeedbackDistributionTooltip {...props} activeKey={activeKey} />
           )}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
@@ -144,7 +149,11 @@ export function FeedbackDistributionChart({
           type="monotone"
           dataKey="positive"
           name="Positive"
-          className={FEEDBACK_DISTRIBUTION_PALETTE.positive}
+          className={cn(
+            FEEDBACK_DISTRIBUTION_PALETTE.positive,
+            "transition-opacity",
+            isDimmed("positive") && "opacity-25"
+          )}
           stroke="currentColor"
           strokeWidth={2}
           dot={false}
@@ -154,7 +163,11 @@ export function FeedbackDistributionChart({
           type="monotone"
           dataKey="negative"
           name="Negative"
-          className={FEEDBACK_DISTRIBUTION_PALETTE.negative}
+          className={cn(
+            FEEDBACK_DISTRIBUTION_PALETTE.negative,
+            "transition-opacity",
+            isDimmed("negative") && "opacity-25"
+          )}
           stroke="currentColor"
           strokeWidth={2}
           dot={false}

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -12,11 +12,12 @@ import { padSeriesToTimeRange } from "@app/components/agent_builder/observabilit
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { legendFromConstant } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
-import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
+import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
 import { useAgentVersionMarkers } from "@app/lib/swr/assistants";
 import { BROWSER_TIMEZONE } from "@app/lib/swr/workspaces";
 import { formatShortDate } from "@app/lib/utils/timestamps";
+import { cn } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 import {
   CartesianGrid,
@@ -137,12 +138,16 @@ export function LatencyChart({
     }));
   }, [rawData, mode, period]);
 
-  const legendItems = legendFromConstant(LATENCY_LEGEND, LATENCY_PALETTE, {
-    includeVersionMarker:
-      isCustomAgent && mode === "timeRange" && versionMarkers.length > 0,
-  });
+  const { activeKey, isDimmed, decorate, hoverHandlers } =
+    useSelectableSeries();
 
-  const { hoveredKey, hoverHandlers } = useHoveredSeries();
+  const legendItems = decorate(
+    legendFromConstant(LATENCY_LEGEND, LATENCY_PALETTE, {
+      includeVersionMarker:
+        isCustomAgent && mode === "timeRange" && versionMarkers.length > 0,
+    }),
+    { skip: (item) => item.key === "versionMarkers" }
+  );
 
   return (
     <ChartContainer
@@ -199,7 +204,7 @@ export function LatencyChart({
             <LatencyTooltip
               {...props}
               versionMarkers={versionMarkers}
-              activeKey={hoveredKey}
+              activeKey={activeKey}
             />
           )}
           cursor={false}
@@ -216,7 +221,11 @@ export function LatencyChart({
           strokeWidth={2}
           dataKey="avgLatencyMs"
           name="Average time to complete output"
-          className={LATENCY_PALETTE.average}
+          className={cn(
+            LATENCY_PALETTE.average,
+            "transition-opacity",
+            isDimmed("average") && "opacity-25"
+          )}
           fill="url(#fillAverage)"
           stroke="currentColor"
           dot={false}
@@ -227,7 +236,11 @@ export function LatencyChart({
           strokeWidth={2}
           dataKey="percentilesLatencyMs"
           name="Median time to complete output"
-          className={LATENCY_PALETTE.median}
+          className={cn(
+            LATENCY_PALETTE.median,
+            "transition-opacity",
+            isDimmed("median") && "opacity-25"
+          )}
           stroke="currentColor"
           dot={false}
           {...hoverHandlers("median")}

--- a/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
@@ -14,10 +14,12 @@ import { getIndexedColor } from "@app/components/agent_builder/observability/uti
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { RoundedBarShape } from "@app/components/charts/ChartShapes";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import {
   Button,
   ButtonsSwitch,
   ButtonsSwitchList,
+  cn,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -128,20 +130,26 @@ export function SkillUsageChart({
       ? versionData.chartData.length === 0
       : filteredSourceItems.length === 0;
 
+  const { isDimmed, decorate } = useSelectableSeries();
+
   const legendItems = useMemo(() => {
     if (skillMode === "version") {
-      return versionData.topTools.map((t) => ({
-        key: t,
-        label: t,
-        colorClassName: getIndexedColor(t, versionData.topTools),
-      }));
+      return decorate(
+        versionData.topTools.map((t) => ({
+          key: t,
+          label: t,
+          colorClassName: getIndexedColor(t, versionData.topTools),
+        }))
+      );
     }
-    return filteredSkillNames.map((name) => ({
-      key: name,
-      label: name,
-      colorClassName: getIndexedColor(name, filteredSkillNames),
-    }));
-  }, [skillMode, versionData.topTools, filteredSkillNames]);
+    return decorate(
+      filteredSkillNames.map((name) => ({
+        key: name,
+        label: name,
+        colorClassName: getIndexedColor(name, filteredSkillNames),
+      }))
+    );
+  }, [skillMode, versionData.topTools, filteredSkillNames, decorate]);
 
   const renderVersionTooltip = useCallback(
     (props: TooltipContentProps<number, string>) => (
@@ -317,7 +325,11 @@ export function SkillUsageChart({
               dataKey={(row: ChartDatum) => row.values[toolName]?.count ?? 0}
               stackId="a"
               fill="currentColor"
-              className={getIndexedColor(toolName, versionData.topTools)}
+              className={cn(
+                getIndexedColor(toolName, versionData.topTools),
+                "transition-opacity",
+                isDimmed(toolName) && "opacity-25"
+              )}
               name={toolName}
               shape={
                 <RoundedBarShape
@@ -362,7 +374,11 @@ export function SkillUsageChart({
               <Cell
                 key={item.skillName}
                 fill="currentColor"
-                className={getIndexedColor(item.skillName, filteredSkillNames)}
+                className={cn(
+                  getIndexedColor(item.skillName, filteredSkillNames),
+                  "transition-opacity",
+                  isDimmed(item.skillName) && "opacity-25"
+                )}
               />
             ))}
           </Bar>

--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -6,8 +6,10 @@ import {
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import { useAgentContextOrigin } from "@app/lib/swr/assistants";
 import { isString } from "@app/types/shared/utils/general";
+import { cn } from "@dust-tt/sparkle";
 import { Cell, Pie, PieChart, Tooltip } from "recharts";
 
 interface SourceChartProps {
@@ -42,11 +44,15 @@ export function SourceChart({
 
   const data = buildSourceChartData(contextOrigin.buckets, total);
 
-  const legendItems = data.map((d) => ({
-    key: d.label,
-    label: d.label,
-    colorClassName: getSourceColor(d.origin),
-  }));
+  const { selectedKey, isDimmed, decorate } = useSelectableSeries();
+
+  const legendItems = decorate(
+    data.map((d) => ({
+      key: d.origin,
+      label: d.label,
+      colorClassName: getSourceColor(d.origin),
+    }))
+  );
 
   return (
     <ChartContainer
@@ -71,7 +77,7 @@ export function SourceChart({
               return null;
             }
             const rawOrigin = payload?.[0]?.payload?.origin;
-            const activeOrigin = isString(rawOrigin) ? rawOrigin : undefined;
+            const hoveredOrigin = isString(rawOrigin) ? rawOrigin : undefined;
             const rows = data.map((d) => ({
               key: d.origin,
               label: d.label,
@@ -83,7 +89,7 @@ export function SourceChart({
               <ChartTooltipCard
                 title="Source breakdown"
                 rows={rows}
-                activeKey={activeOrigin}
+                activeKey={hoveredOrigin ?? selectedKey}
               />
             );
           }}
@@ -107,7 +113,11 @@ export function SourceChart({
           {data.map((entry) => (
             <Cell
               key={entry.origin}
-              className={getSourceColor(entry.origin)}
+              className={cn(
+                getSourceColor(entry.origin),
+                "transition-opacity",
+                isDimmed(entry.origin) && "opacity-25"
+              )}
               fill="currentColor"
             />
           ))}

--- a/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
@@ -11,12 +11,13 @@ import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { legendFromConstant } from "@app/components/charts/ChartLegend";
 import { RoundedBarShape } from "@app/components/charts/ChartShapes";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
-import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
+import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import type { ToolLatencyView } from "@app/lib/api/assistant/observability/tool_latency";
 import {
   Button,
   ButtonsSwitch,
   ButtonsSwitchList,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -192,12 +193,12 @@ export function ToolExecutionTimeChart({
     emptyMessage = "No successful tool executions for this server.";
   }
 
-  const legendItems = legendFromConstant(
-    TOOL_EXECUTION_TIME_LEGEND,
-    TOOL_EXECUTION_TIME_PALETTE
-  );
+  const { activeKey, isDimmed, decorate, hoverHandlers } =
+    useSelectableSeries();
 
-  const { hoveredKey, hoverHandlers } = useHoveredSeries();
+  const legendItems = decorate(
+    legendFromConstant(TOOL_EXECUTION_TIME_LEGEND, TOOL_EXECUTION_TIME_PALETTE)
+  );
 
   const selectedServerLabel =
     serverOptions.find((server) => server.name === selectedServerName)?.label ??
@@ -285,7 +286,7 @@ export function ToolExecutionTimeChart({
         />
         <Tooltip
           content={(props: TooltipContentProps<number, string>) => (
-            <ToolExecutionTimeTooltip {...props} activeKey={hoveredKey} />
+            <ToolExecutionTimeTooltip {...props} activeKey={activeKey} />
           )}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
@@ -300,7 +301,11 @@ export function ToolExecutionTimeChart({
           dataKey="p50LatencyMs"
           name="P50"
           fill="currentColor"
-          className={TOOL_EXECUTION_TIME_PALETTE.p50LatencyMs}
+          className={cn(
+            TOOL_EXECUTION_TIME_PALETTE.p50LatencyMs,
+            "transition-opacity",
+            isDimmed("p50LatencyMs") && "opacity-25"
+          )}
           shape={<RoundedBarShape />}
           {...hoverHandlers("p50LatencyMs")}
         />
@@ -308,7 +313,11 @@ export function ToolExecutionTimeChart({
           dataKey="avgLatencyMs"
           name="Average"
           fill="currentColor"
-          className={TOOL_EXECUTION_TIME_PALETTE.avgLatencyMs}
+          className={cn(
+            TOOL_EXECUTION_TIME_PALETTE.avgLatencyMs,
+            "transition-opacity",
+            isDimmed("avgLatencyMs") && "opacity-25"
+          )}
           shape={<RoundedBarShape />}
           {...hoverHandlers("avgLatencyMs")}
         />
@@ -316,7 +325,11 @@ export function ToolExecutionTimeChart({
           dataKey="p95LatencyMs"
           name="P95"
           fill="currentColor"
-          className={TOOL_EXECUTION_TIME_PALETTE.p95LatencyMs}
+          className={cn(
+            TOOL_EXECUTION_TIME_PALETTE.p95LatencyMs,
+            "transition-opacity",
+            isDimmed("p95LatencyMs") && "opacity-25"
+          )}
           shape={<RoundedBarShape />}
           {...hoverHandlers("p95LatencyMs")}
         />

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -9,8 +9,9 @@ import type {
 import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { RoundedBarShape } from "@app/components/charts/ChartShapes";
+import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import { useAgentMcpConfigurations } from "@app/lib/swr/assistants";
-import { ButtonsSwitch, ButtonsSwitchList } from "@dust-tt/sparkle";
+import { ButtonsSwitch, ButtonsSwitchList, cn } from "@dust-tt/sparkle";
 import { useCallback, useMemo, useState } from "react";
 import {
   Bar,
@@ -75,14 +76,18 @@ export function ToolUsageChart({
     configurationNames,
   });
 
+  const { isDimmed, decorate } = useSelectableSeries();
+
   const legendItems = useMemo(
     () =>
-      topTools.map((t) => ({
-        key: t,
-        label: t,
-        colorClassName: getIndexedColor(t, topTools),
-      })),
-    [topTools]
+      decorate(
+        topTools.map((t) => ({
+          key: t,
+          label: t,
+          colorClassName: getIndexedColor(t, topTools),
+        }))
+      ),
+    [topTools, decorate]
   );
 
   const renderToolUsageTooltip = useCallback(
@@ -179,7 +184,11 @@ export function ToolUsageChart({
             dataKey={(row: ChartDatum) => row.values[toolName]?.count ?? 0}
             stackId="a"
             fill="currentColor"
-            className={getIndexedColor(toolName, topTools)}
+            className={cn(
+              getIndexedColor(toolName, topTools),
+              "transition-opacity",
+              isDimmed(toolName) && "opacity-25"
+            )}
             name={toolName}
             shape={
               <RoundedBarShape seriesKey={toolName} stackOrderKeys={topTools} />

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -13,13 +13,14 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { legendFromConstant } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
-import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
+import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
 import {
   useAgentUsageMetrics,
   useAgentVersionMarkers,
 } from "@app/lib/swr/assistants";
 import { BROWSER_TIMEZONE } from "@app/lib/swr/workspaces";
+import { cn } from "@dust-tt/sparkle";
 import {
   CartesianGrid,
   Line,
@@ -129,16 +130,16 @@ export function UsageMetricsChart({
     disabled: !workspaceId || !agentConfigurationId || !isCustomAgent,
   });
 
-  const legendItems = legendFromConstant(
-    USAGE_METRICS_LEGEND,
-    USAGE_METRICS_PALETTE,
-    {
+  const { activeKey, isDimmed, decorate, hoverHandlers } =
+    useSelectableSeries();
+
+  const legendItems = decorate(
+    legendFromConstant(USAGE_METRICS_LEGEND, USAGE_METRICS_PALETTE, {
       includeVersionMarker:
         isCustomAgent && mode === "timeRange" && versionMarkers.length > 0,
-    }
+    }),
+    { skip: (item) => item.key === "versionMarkers" }
   );
-
-  const { hoveredKey, hoverHandlers } = useHoveredSeries();
 
   const filteredData = filterTimeSeriesByVersionWindow(
     usageMetrics,
@@ -235,7 +236,7 @@ export function UsageMetricsChart({
             <UsageMetricsTooltip
               {...props}
               versionMarkers={versionMarkers}
-              activeKey={hoveredKey}
+              activeKey={activeKey}
             />
           )}
           cursor={false}
@@ -257,7 +258,11 @@ export function UsageMetricsChart({
           strokeWidth={2}
           dataKey="count"
           name="Messages"
-          className={USAGE_METRICS_PALETTE.messages}
+          className={cn(
+            USAGE_METRICS_PALETTE.messages,
+            "transition-opacity",
+            isDimmed("messages") && "opacity-25"
+          )}
           stroke="currentColor"
           dot={false}
           {...hoverHandlers("messages")}
@@ -271,7 +276,11 @@ export function UsageMetricsChart({
           strokeWidth={2}
           dataKey="conversations"
           name="Conversations"
-          className={USAGE_METRICS_PALETTE.conversations}
+          className={cn(
+            USAGE_METRICS_PALETTE.conversations,
+            "transition-opacity",
+            isDimmed("conversations") && "opacity-25"
+          )}
           stroke="currentColor"
           dot={false}
           {...hoverHandlers("conversations")}
@@ -285,7 +294,11 @@ export function UsageMetricsChart({
           strokeWidth={2}
           dataKey="activeUsers"
           name="Active users"
-          className={USAGE_METRICS_PALETTE.activeUsers}
+          className={cn(
+            USAGE_METRICS_PALETTE.activeUsers,
+            "transition-opacity",
+            isDimmed("activeUsers") && "opacity-25"
+          )}
           stroke="currentColor"
           dot={false}
           {...hoverHandlers("activeUsers")}

--- a/front/components/charts/useSelectableSeries.ts
+++ b/front/components/charts/useSelectableSeries.ts
@@ -11,10 +11,6 @@ export function useSelectableSeries() {
 
   const activeKey = hoveredKey ?? selectedKey;
 
-  const toggle = useCallback((key: string) => {
-    setSelectedKey((prev) => (prev === key ? undefined : key));
-  }, []);
-
   const isDimmed = useCallback(
     (key: string) => selectedKey !== undefined && selectedKey !== key,
     [selectedKey]
@@ -31,12 +27,15 @@ export function useSelectableSeries() {
         }
         return {
           ...item,
-          onClick: () => toggle(item.key),
+          onClick: () =>
+            setSelectedKey((prev) =>
+              prev === item.key ? undefined : item.key
+            ),
           isActive:
             selectedKey === undefined ? undefined : selectedKey === item.key,
         };
       }),
-    [selectedKey, toggle]
+    [selectedKey]
   );
 
   return { selectedKey, activeKey, isDimmed, decorate, hoverHandlers };

--- a/front/components/charts/useSelectableSeries.ts
+++ b/front/components/charts/useSelectableSeries.ts
@@ -1,0 +1,43 @@
+import type {
+  LegendEntry,
+  LegendItem,
+} from "@app/components/charts/ChartLegend";
+import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
+import { useCallback, useState } from "react";
+
+export function useSelectableSeries() {
+  const { hoveredKey, hoverHandlers } = useHoveredSeries();
+  const [selectedKey, setSelectedKey] = useState<string | undefined>(undefined);
+
+  const activeKey = hoveredKey ?? selectedKey;
+
+  const toggle = useCallback((key: string) => {
+    setSelectedKey((prev) => (prev === key ? undefined : key));
+  }, []);
+
+  const isDimmed = useCallback(
+    (key: string) => selectedKey !== undefined && selectedKey !== key,
+    [selectedKey]
+  );
+
+  const decorate = useCallback(
+    (
+      items: readonly LegendEntry[],
+      options?: { skip?: (item: LegendEntry) => boolean }
+    ): LegendItem[] =>
+      items.map((item) => {
+        if (options?.skip?.(item)) {
+          return item;
+        }
+        return {
+          ...item,
+          onClick: () => toggle(item.key),
+          isActive:
+            selectedKey === undefined ? undefined : selectedKey === item.key,
+        };
+      }),
+    [selectedKey, toggle]
+  );
+
+  return { selectedKey, activeKey, isDimmed, decorate, hoverHandlers };
+}

--- a/front/components/workspace/analytics/WorkspaceSourceChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSourceChart.tsx
@@ -206,7 +206,9 @@ export function WorkspaceSourceChart({
               content={
                 <PercentLabel
                   total={total}
-                  fillClassName={getLabelFillClass(getSourceColor(entry.origin))}
+                  fillClassName={getLabelFillClass(
+                    getSourceColor(entry.origin)
+                  )}
                 />
               }
             />

--- a/front/components/workspace/analytics/WorkspaceSourceChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSourceChart.tsx
@@ -5,10 +5,12 @@ import {
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import { useWorkspaceContextOrigin } from "@app/lib/swr/workspaces";
 import { isString } from "@app/types/shared/utils/general";
+import { cn } from "@dust-tt/sparkle";
 import { Bar, BarChart, LabelList, Tooltip, XAxis, YAxis } from "recharts";
 
 interface WorkspaceSourceChartProps {
@@ -101,6 +103,8 @@ export function WorkspaceSourceChart({
   const total = contextOrigin.total;
   const data = buildSourceChartData(contextOrigin.buckets, total);
 
+  const { selectedKey, isDimmed, decorate } = useSelectableSeries();
+
   // Pivot the breakdown into a single-row dataset so recharts renders a
   // horizontal stacked bar (one segment per origin).
   const chartData =
@@ -108,11 +112,13 @@ export function WorkspaceSourceChart({
       ? [Object.fromEntries(data.map((d) => [d.origin, d.count]))]
       : [];
 
-  const legendItems = data.map((d) => ({
-    key: d.label,
-    label: d.label,
-    colorClassName: getSourceColor(d.origin),
-  }));
+  const legendItems = decorate(
+    data.map((d) => ({
+      key: d.origin,
+      label: d.label,
+      colorClassName: getSourceColor(d.origin),
+    }))
+  );
 
   const csvDownload = useDownloadCsv({
     url: `/api/w/${workspaceId}/analytics/source-export?days=${period}`,
@@ -155,7 +161,7 @@ export function WorkspaceSourceChart({
               return null;
             }
             const rawOrigin = payload?.[0]?.dataKey;
-            const activeOrigin = isString(rawOrigin) ? rawOrigin : undefined;
+            const hoveredOrigin = isString(rawOrigin) ? rawOrigin : undefined;
             const rows = data.map((d) => ({
               key: d.origin,
               label: d.label,
@@ -167,7 +173,7 @@ export function WorkspaceSourceChart({
               <ChartTooltipCard
                 title="Source breakdown"
                 rows={rows}
-                activeKey={activeOrigin}
+                activeKey={hoveredOrigin ?? selectedKey}
               />
             );
           }}
@@ -184,7 +190,11 @@ export function WorkspaceSourceChart({
             dataKey={entry.origin}
             stackId="source"
             name={entry.label}
-            className={getSourceColor(entry.origin)}
+            className={cn(
+              getSourceColor(entry.origin),
+              "transition-opacity",
+              isDimmed(entry.origin) && "opacity-25"
+            )}
             fill="currentColor"
             isAnimationActive={false}
             maxBarSize={BAR_MAX_SIZE}
@@ -196,9 +206,7 @@ export function WorkspaceSourceChart({
               content={
                 <PercentLabel
                   total={total}
-                  fillClassName={getLabelFillClass(
-                    getSourceColor(entry.origin)
-                  )}
+                  fillClassName={getLabelFillClass(getSourceColor(entry.origin))}
                 />
               }
             />

--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -5,9 +5,8 @@ import {
   getIndexedColor,
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
-import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
-import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
+import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import type { AvailableTool } from "@app/lib/api/assistant/observability/tool_usage";
@@ -20,6 +19,7 @@ import {
   Button,
   ButtonsSwitch,
   ButtonsSwitchList,
+  cn,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -240,13 +240,16 @@ export function WorkspaceToolUsageChart({
     }
   };
 
-  const legendItems: LegendItem[] = toolsWithData.map((tool) => ({
-    key: tool,
-    label: displayNameMap.get(tool) ?? tool,
-    colorClassName: getIndexedColor(tool, toolsWithData),
-  }));
+  const { activeKey, isDimmed, decorate, hoverHandlers } =
+    useSelectableSeries();
 
-  const { hoveredKey, hoverHandlers } = useHoveredSeries();
+  const legendItems = decorate(
+    toolsWithData.map((tool) => ({
+      key: tool,
+      label: displayNameMap.get(tool) ?? tool,
+      colorClassName: getIndexedColor(tool, toolsWithData),
+    }))
+  );
 
   const toolSelector = (
     <DropdownMenu modal={false}>
@@ -360,7 +363,7 @@ export function WorkspaceToolUsageChart({
               displayMode={displayMode}
               toolsWithData={toolsWithData}
               displayNameMap={displayNameMap}
-              activeKey={hoveredKey}
+              activeKey={activeKey}
             />
           )}
           cursor={false}
@@ -379,7 +382,11 @@ export function WorkspaceToolUsageChart({
             strokeWidth={2}
             dataKey={(point: ToolUsageChartPoint) => point.values[tool] ?? 0}
             name={displayNameMap.get(tool) ?? tool}
-            className={getIndexedColor(tool, toolsWithData)}
+            className={cn(
+              getIndexedColor(tool, toolsWithData),
+              "transition-opacity",
+              isDimmed(tool) && "opacity-25"
+            )}
             stroke="currentColor"
             dot={false}
             {...hoverHandlers(tool)}

--- a/front/components/workspace/analytics/WorkspaceUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceUsageChart.tsx
@@ -8,7 +8,7 @@ import { padSeriesToTimeRange } from "@app/components/agent_builder/observabilit
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
-import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
+import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import {
@@ -17,7 +17,7 @@ import {
   useWorkspaceUsageMetrics,
 } from "@app/lib/swr/workspaces";
 import { formatShortDate } from "@app/lib/utils/timestamps";
-import { ButtonsSwitch, ButtonsSwitchList } from "@dust-tt/sparkle";
+import { ButtonsSwitch, ButtonsSwitchList, cn } from "@dust-tt/sparkle";
 import { useState } from "react";
 import {
   CartesianGrid,
@@ -258,9 +258,10 @@ export function WorkspaceUsageChart({
     disabled: !workspaceId || displayMode !== "users",
   });
 
-  const legendItems = getLegendItemsForMode(displayMode);
+  const { activeKey, isDimmed, decorate, hoverHandlers } =
+    useSelectableSeries();
 
-  const { hoveredKey, hoverHandlers } = useHoveredSeries();
+  const legendItems = decorate(getLegendItemsForMode(displayMode));
 
   const usageData = padSeriesToTimeRange<WorkspaceUsageMetricsDatum>(
     usageMetrics,
@@ -372,7 +373,7 @@ export function WorkspaceUsageChart({
             <UsageMetricsTooltip
               {...props}
               displayMode={displayMode}
-              activeKey={hoveredKey}
+              activeKey={activeKey}
             />
           )}
           cursor={false}
@@ -391,7 +392,11 @@ export function WorkspaceUsageChart({
               strokeWidth={2}
               dataKey="count"
               name="Messages"
-              className={USAGE_METRICS_PALETTE.messages}
+              className={cn(
+                USAGE_METRICS_PALETTE.messages,
+                "transition-opacity",
+                isDimmed("messages") && "opacity-25"
+              )}
               stroke="currentColor"
               dot={false}
               {...hoverHandlers("messages")}
@@ -401,7 +406,11 @@ export function WorkspaceUsageChart({
               strokeWidth={2}
               dataKey="conversations"
               name="Conversations"
-              className={USAGE_METRICS_PALETTE.conversations}
+              className={cn(
+                USAGE_METRICS_PALETTE.conversations,
+                "transition-opacity",
+                isDimmed("conversations") && "opacity-25"
+              )}
               stroke="currentColor"
               dot={false}
               {...hoverHandlers("conversations")}
@@ -414,7 +423,11 @@ export function WorkspaceUsageChart({
               strokeWidth={2}
               dataKey="dau"
               name="DAU"
-              className={ACTIVE_USERS_PALETTE.dau}
+              className={cn(
+                ACTIVE_USERS_PALETTE.dau,
+                "transition-opacity",
+                isDimmed("dau") && "opacity-25"
+              )}
               stroke="currentColor"
               dot={false}
               {...hoverHandlers("dau")}
@@ -424,7 +437,11 @@ export function WorkspaceUsageChart({
               strokeWidth={2}
               dataKey="wau"
               name="WAU"
-              className={ACTIVE_USERS_PALETTE.wau}
+              className={cn(
+                ACTIVE_USERS_PALETTE.wau,
+                "transition-opacity",
+                isDimmed("wau") && "opacity-25"
+              )}
               stroke="currentColor"
               dot={false}
               {...hoverHandlers("wau")}
@@ -434,7 +451,11 @@ export function WorkspaceUsageChart({
               strokeWidth={2}
               dataKey="mau"
               name="MAU"
-              className={ACTIVE_USERS_PALETTE.mau}
+              className={cn(
+                ACTIVE_USERS_PALETTE.mau,
+                "transition-opacity",
+                isDimmed("mau") && "opacity-25"
+              )}
               stroke="currentColor"
               dot={false}
               {...hoverHandlers("mau")}


### PR DESCRIPTION
## Description

This PR enhances chart interactivity by adding clickable legend selection. Builds on #24554's hover functionality by introducing a new `useSelectableSeries` hook that manages both hover and persistent selection state. 

Users can now click legend items to focus on specific chart series -> the selected series remains highlighted while others are dimmed with opacity transitions. The hook provides a `decorate` function to wrap legend items with `onClick` handlers and `isActive` states, and an `isDimmed` function to determine which chart elements should be visually de-emphasized.

## Tests

- [x] Locally
- [x] Front-edge

## Risk

Low risk. The changes are purely visual enhancements that don't affect data processing or rendering logic. The selection state is local to each chart component and can be cleared by clicking the selected legend item again.

## Deploy Plan

Deploy front