### PR TITLE
Anthropic LLM: Catch invalid JSON input error to generate bad tool call

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import type { APIPromise } from "@anthropic-ai/sdk";
+import { APIError } from "@anthropic-ai/sdk";
 import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta.mjs";
 import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches.mjs";
 import type {
@@ -34,6 +35,7 @@ import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import cloneDeep from "lodash/cloneDeep";
 
 const MAX_EAGER_VALIDATION_INPUT_LENGTH = 5_000;
+const INVALID_JSON_MARKER = "JSON: ";
 
 export async function* streamLLMEvents(
   messageStreamEvents: AsyncIterable<BetaRawMessageStreamEvent>,
@@ -60,17 +62,40 @@ export async function* streamLLMEvents(
   // https://github.com/anthropics/anthropic-sdk-typescript/issues/777
   // They say it has been fixed in the version we are using but in practice we still see it happening.
   // To work around this, we clone each event before processing it.
-  for await (const mutableMessageStreamEvent of messageStreamEvents) {
-    const messageStreamEvent = cloneDeep(mutableMessageStreamEvent);
+  try {
+    for await (const mutableMessageStreamEvent of messageStreamEvents) {
+      const messageStreamEvent = cloneDeep(mutableMessageStreamEvent);
 
-    for (const ev of handleMessageStreamEvent(
-      messageStreamEvent,
-      stateContainer,
-      metadata,
-      tokenUsageAccumulator
-    )) {
+      for (const ev of handleMessageStreamEvent(
+        messageStreamEvent,
+        stateContainer,
+        metadata,
+        tokenUsageAccumulator
+      )) {
+        aggregate.add(ev);
+        yield ev;
+      }
+    }
+  } catch (err) {
+    // The Anthropic API sometimes aborts the stream with an error when the model
+    // produces invalid tool parameter JSON. When we have a tool in progress in our
+    // state, we recover by emitting a toolCallWithInvalidJson event so the agent
+    // loop can send it back as a tool result and let the model self-correct.
+    const invalidJson = extractInvalidJsonFromError(err);
+    if (
+      invalidJson !== null &&
+      stateContainer.state?.accumulatorType === "tool_use"
+    ) {
+      const ev = toolCallWithInvalidJson({
+        ...stateContainer.state.toolInfo,
+        invalidJson,
+        metadata,
+      });
       aggregate.add(ev);
       yield ev;
+      stateContainer.state = null;
+    } else {
+      throw err;
     }
   }
 
@@ -537,6 +562,40 @@ function toolCallWithInvalidJson({
     },
     metadata,
   };
+}
+
+/**
+ * Checks if an error is an Anthropic "Unable to parse tool parameter JSON" error
+ * and extracts the invalid JSON content from the error message.
+ * The Anthropic API error message format ends with `JSON: <raw invalid json>`.
+ * Returns the invalid JSON string, or null if the error doesn't match.
+ */
+function extractInvalidJsonFromError(err: unknown): string | null {
+  if (!(err instanceof APIError)) {
+    return null;
+  }
+  if (err.type !== "invalid_request_error") {
+    return null;
+  }
+  // The error body contains the original message from Anthropic.
+  // err.error is the parsed JSON body: { type: "error", error: { type, message } }.
+  const body = err.error;
+  const innerError =
+    isRecord(body) && typeof body.error === "object" && body.error !== null
+      ? body.error
+      : undefined;
+  const message =
+    innerError && isRecord(innerError) && typeof innerError.message === "string"
+      ? innerError.message
+      : err.message;
+  if (!message.includes("Unable to parse tool parameter JSON")) {
+    return null;
+  }
+  const jsonIndex = message.lastIndexOf(INVALID_JSON_MARKER);
+  if (jsonIndex === -1) {
+    return null;
+  }
+  return message.slice(jsonIndex + INVALID_JSON_MARKER.length);
 }
 
 /**

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -81,11 +81,14 @@ export async function* streamLLMEvents(
     // produces invalid tool parameter JSON. When we have a tool in progress in our
     // state, we recover by emitting a toolCallWithInvalidJson event so the agent
     // loop can send it back as a tool result and let the model self-correct.
-    const invalidJson = extractInvalidJsonFromError(err);
     if (
-      invalidJson !== null &&
+      isInvalidToolJsonError(err) &&
       stateContainer.state?.accumulatorType === "tool_use"
     ) {
+      const { message } = err.error.error;
+      const invalidJson = message.slice(
+        message.lastIndexOf(INVALID_JSON_MARKER) + INVALID_JSON_MARKER.length
+      );
       const ev = toolCallWithInvalidJson({
         ...stateContainer.state.toolInfo,
         invalidJson,
@@ -564,38 +567,43 @@ function toolCallWithInvalidJson({
   };
 }
 
+type InvalidToolJsonError = APIError & {
+  error: { error: { message: string } };
+};
+
 /**
- * Checks if an error is an Anthropic "Unable to parse tool parameter JSON" error
- * and extracts the invalid JSON content from the error message.
+ * Checks if an error is an Anthropic "Unable to parse tool parameter JSON" error.
  * The Anthropic API error message format ends with `JSON: <raw invalid json>`.
- * Returns the invalid JSON string, or null if the error doesn't match.
+ * The invalid JSON can be extracted from `err.error.error.message` at the call site.
  */
-function extractInvalidJsonFromError(err: unknown): string | null {
+function isInvalidToolJsonError(err: unknown): err is InvalidToolJsonError {
   if (!(err instanceof APIError)) {
-    return null;
+    return false;
   }
   if (err.type !== "invalid_request_error") {
-    return null;
+    return false;
   }
-  // The error body contains the original message from Anthropic.
   // err.error is the parsed JSON body: { type: "error", error: { type, message } }.
   const body = err.error;
-  const innerError =
-    isRecord(body) && typeof body.error === "object" && body.error !== null
-      ? body.error
-      : undefined;
-  const message =
-    innerError && isRecord(innerError) && typeof innerError.message === "string"
-      ? innerError.message
-      : err.message;
+  if (typeof body !== "object" || body === null || !isRecord(body)) {
+    return false;
+  }
+  const innerError = body.error;
+  if (
+    typeof innerError !== "object" ||
+    innerError === null ||
+    !isRecord(innerError)
+  ) {
+    return false;
+  }
+  const { message } = innerError;
+  if (typeof message !== "string") {
+    return false;
+  }
   if (!message.includes("Unable to parse tool parameter JSON")) {
-    return null;
+    return false;
   }
-  const jsonIndex = message.lastIndexOf(INVALID_JSON_MARKER);
-  if (jsonIndex === -1) {
-    return null;
-  }
-  return message.slice(jsonIndex + INVALID_JSON_MARKER.length);
+  return message.lastIndexOf(INVALID_JSON_MARKER) !== -1;
 }
 
 /**

--- a/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
@@ -1,3 +1,5 @@
+import { APIError } from "@anthropic-ai/sdk";
+import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta.mjs";
 import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches.mjs";
 import {
   batchResultToLLMEvents,
@@ -45,6 +47,106 @@ describe("streamLLMEvents", () => {
         metadata: { ...e.metadata, ...metadata },
       }))
     );
+  });
+
+  it("should recover from 'Unable to parse tool parameter JSON' error with tool state", async () => {
+    const errorMessage =
+      'Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: SyntaxError: Expected \',\' or \'}\' after property value in JSON at position 31 (line 1 column 32). JSON: {"keywords": urgent important action, "relativeTimeFrame": "2d"}';
+
+    const invalidJsonError = APIError.generate(
+      400,
+      {
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message: errorMessage,
+        },
+      },
+      errorMessage,
+      new Headers()
+    );
+
+    // Yield events up to tool_use content_block_start + some deltas, then throw.
+    const eventsBeforeError: BetaRawMessageStreamEvent[] = [
+      {
+        type: "message_start",
+        message: {
+          type: "message",
+          model: CLAUDE_4_SONNET_20250514_MODEL_ID,
+          id: "msg_invalid_json",
+          role: "assistant",
+          content: [],
+          stop_reason: null,
+          stop_details: null,
+          stop_sequence: null,
+          usage: {
+            input_tokens: 100,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: 0,
+            service_tier: "standard",
+            server_tool_use: null,
+            inference_geo: null,
+            iterations: null,
+            speed: null,
+            cache_creation: {
+              ephemeral_5m_input_tokens: 0,
+              ephemeral_1h_input_tokens: 0,
+            },
+          },
+          container: null,
+          context_management: null,
+        },
+      },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "tool_123",
+          name: "search_tool",
+          input: "",
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "input_json_delta",
+          partial_json: '{"keywords": urgent',
+        },
+      },
+    ];
+
+    async function* generateEventsWithError(): AsyncGenerator<BetaRawMessageStreamEvent> {
+      for (const event of eventsBeforeError) {
+        yield event;
+      }
+      throw invalidJsonError;
+    }
+
+    const result = [];
+    for await (const event of streamLLMEvents(
+      generateEventsWithError(),
+      metadata
+    )) {
+      result.push(event);
+    }
+
+    // Should have: interaction_id, tool_call_started, tool_call_delta, tool_call (invalid json), token_usage, success
+    const toolCallEvent = result.find((e) => e.type === "tool_call");
+    expect(toolCallEvent).toBeDefined();
+    expect(toolCallEvent).toMatchObject({
+      type: "tool_call",
+      content: {
+        id: "tool_123",
+        name: "search_tool",
+        arguments: {
+          INVALID_JSON:
+            '{"keywords": urgent important action, "relativeTimeFrame": "2d"}',
+        },
+      },
+    });
   });
 
   it("should handle empty tool call parameters", async () => {


### PR DESCRIPTION
## Description

Catch error thrown by Antrhopic when their generated tool input is invalid in eaget_streaming mode, so we can generate a bad tool call instead of throwing.
This will let the model know what the error is a and retry accordingly.

## Tests

Did not managed to reproduce the issue locally
Added a unit test

## Risk

low

## Deploy Plan

deploy front 
