### PR TITLE
Make images visually available for agents

### DIFF
--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -19,6 +19,7 @@ import {
 } from "@app/lib/api/actions/servers/microsoft/utils";
 import { MICROSOFT_DRIVE_TOOLS_METADATA } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { untrustedFetch } from "@app/lib/egress/server";
+import { isSupportedImageContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type AdmZip from "adm-zip";
@@ -260,6 +261,17 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         );
       }
       const buffer = Buffer.from(await fileResponse.arrayBuffer());
+
+      // Images are passed as MCP image blocks so the model can see them via vision.
+      if (isSupportedImageContentType(mimeType)) {
+        return new Ok([
+          {
+            type: "image" as const,
+            data: buffer.toString("base64"),
+            mimeType,
+          },
+        ]);
+      }
 
       const result = await processAttachment({
         mimeType,

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -6,12 +6,14 @@
 import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { rewriteContentForModel } from "@app/lib/actions/mcp_utils";
 import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import {
   replaceMentionsWithAt,
   serializeMention,
 } from "@app/lib/mentions/format";
 import { renderLightContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
@@ -26,12 +28,14 @@ import type {
 } from "@app/types/assistant/conversation";
 import type {
   CompactionMessageTypeModel,
+  Content,
   FunctionCallType,
   FunctionMessageTypeModel,
   ModelMessageTypeMultiActions,
   UserMessageTypeModel,
 } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import { isLLMVisionSupportedImageContentType } from "@app/types/files";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 /**
@@ -48,9 +52,11 @@ export type Step = {
 /**
  * Renders an action result for multi-actions model
  */
-export function renderActionForMultiActionsModel(
+export async function renderActionForMultiActionsModel(
+  auth: Authenticator,
+  model: ModelConfigurationType,
   action: AgentMCPActionWithOutputType
-): FunctionMessageTypeModel {
+): Promise<FunctionMessageTypeModel> {
   if (action.status === "denied") {
     return {
       role: "function" as const,
@@ -88,27 +94,59 @@ export function renderActionForMultiActionsModel(
     action.output?.map(rewriteContentForModel) ?? []
   );
 
-  let output;
+  let textOutput: string;
   if (outputItems.length === 0) {
-    output = "Successfully executed action, no output.";
+    textOutput = "Successfully executed action, no output.";
   } else if (outputItems.every((item) => isTextContent(item))) {
-    output = outputItems.map((item) => item.text).join("\n");
+    textOutput = outputItems.map((item) => item.text).join("\n");
   } else {
-    output = JSON.stringify(outputItems);
+    textOutput = JSON.stringify(outputItems);
+  }
+
+  // For vision-capable models, include image files as vision blocks so the model can
+  // directly interpret them (e.g. reading a schema from a PNG).
+  if (model.supportsVision) {
+    const imageFiles = action.generatedFiles.filter(
+      (f) => !f.hidden && isLLMVisionSupportedImageContentType(f.contentType)
+    );
+
+    if (imageFiles.length > 0) {
+      const bucket = getPrivateUploadBucket();
+      const workspaceId = auth.getNonNullableWorkspace().sId;
+
+      const imageBlocks = await Promise.all(
+        imageFiles.map(async (imageFile): Promise<Content> => {
+          const filePath = FileResource.getCloudStoragePathForId({
+            fileId: imageFile.fileId,
+            workspaceId,
+            version: "processed",
+          });
+          const signedUrl = await bucket.getSignedUrl(filePath);
+          return { type: "image_url", image_url: { url: signedUrl } };
+        })
+      );
+
+      return {
+        role: "function" as const,
+        name: action.functionCallName,
+        function_call_id: action.functionCallId,
+        content: [{ type: "text", text: textOutput }, ...imageBlocks],
+      };
+    }
   }
 
   return {
     role: "function" as const,
     name: action.functionCallName,
     function_call_id: action.functionCallId,
-    content: output,
+    content: textOutput,
   };
 }
 
 /**
  * Processes agent message steps
  */
-export function getSteps(
+export async function getSteps(
   auth: Authenticator,
   {
     model,
@@ -123,7 +161,7 @@ export function getSteps(
     conversationId: string;
     onMissingAction: "inject-placeholder" | "skip";
   }
-): Step[] {
+): Promise<Step[]> {
   const supportedModel = getSupportedModelConfig(model);
   if (!supportedModel) {
     return [];
@@ -143,15 +181,13 @@ export function getSteps(
   for (const action of actions) {
     const stepIndex = action.step;
     stepByStepIndex[stepIndex] = stepByStepIndex[stepIndex] || emptyStep();
-    // All these calls are not async, so we're not doing a Promise.all for now but might need to
-    // be reconsidered in the future.
     stepByStepIndex[stepIndex].actions.push({
       call: {
         id: action.functionCallId,
         name: action.functionCallName,
         arguments: JSON.stringify(action.params),
       },
-      result: renderActionForMultiActionsModel(action),
+      result: await renderActionForMultiActionsModel(auth, model, action),
     });
   }
 

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -14,6 +14,7 @@ import {
 } from "@app/lib/mentions/format";
 import { renderLightContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
@@ -114,8 +115,9 @@ export async function renderActionForMultiActionsModel(
       const bucket = getPrivateUploadBucket();
       const workspaceId = auth.getNonNullableWorkspace().sId;
 
-      const imageBlocks = await Promise.all(
-        imageFiles.map(async (imageFile): Promise<Content> => {
+      const imageBlocks = await concurrentExecutor(
+        imageFiles,
+        async (imageFile): Promise<Content> => {
           const filePath = FileResource.getCloudStoragePathForId({
             fileId: imageFile.fileId,
             workspaceId,
@@ -123,7 +125,8 @@ export async function renderActionForMultiActionsModel(
           });
           const signedUrl = await bucket.getSignedUrl(filePath);
           return { type: "image_url", image_url: { url: signedUrl } };
-        })
+        },
+        { concurrency: 4 }
       );
 
       return {

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -47,7 +47,7 @@ describe("renderAllMessages", () => {
         }) as UserMessageTypeModel
     );
 
-    vi.mocked(getSteps).mockReturnValue([
+    vi.mocked(getSteps).mockResolvedValue([
       {
         contents: [{ type: "text_content", value: "Agent response" }],
         actions: [],
@@ -352,7 +352,7 @@ describe("renderAllMessages", () => {
       ]);
 
       // Mock getSteps to return a step with both text_content and function_call
-      vi.mocked(getSteps).mockReturnValue([
+      vi.mocked(getSteps).mockResolvedValue([
         {
           contents: [
             { type: "text_content", value: "Agent response" },
@@ -404,7 +404,7 @@ describe("renderAllMessages", () => {
       ]);
 
       // Mock getSteps to return a step with both text_content and function_call
-      vi.mocked(getSteps).mockReturnValue([
+      vi.mocked(getSteps).mockResolvedValue([
         {
           contents: [
             { type: "text_content", value: "Agent response" },

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -177,7 +177,7 @@ export async function renderAllMessages(
 
         if (isCurrentAgentMessage) {
           // Render the current agent's messages normally with full agentic loop.
-          const steps = getSteps(auth, {
+          const steps = await getSteps(auth, {
             model,
             message: m,
             workspaceId: conversation.owner.sId,


### PR DESCRIPTION
## Description

Enables vision-capable models to visually interpret image files generated by agent actions. When an action produces image files (e.g., a screenshot from Microsoft Drive), the model can now directly "see" these images via vision blocks, allowing it to extract information like schemas from PNGs or read visual content.

The Microsoft Drive tool now returns images as MCP image blocks, and the conversation rendering layer automatically converts visible image files from action outputs into `image_url` blocks for models that support vision (`supportsVision: true`).

## Tests

Tested manually with Microsoft Drive image retrieval and vision-capable models.

## Risk

- `getSteps` function is now async, which required updating all call sites and tests
- Image files are served via signed URLs from private storage bucket

## Deploy Plan

Deploy front