### PR TITLE
feat(project): animate new and newly-done todos on panel open

### DIFF
--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -3,6 +3,7 @@ import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import {
   useCleanDoneProjectTodos,
   useDeleteProjectTodo,
+  useMarkProjectTodosRead,
   useProjectTodos,
   useUpdateProjectTodo,
 } from "@app/lib/swr/projects";
@@ -36,6 +37,7 @@ import {
   Tooltip,
   TrashIcon,
   TriangleIcon,
+  TypingAnimation,
   WindIcon,
 } from "@dust-tt/sparkle";
 import type React from "react";
@@ -463,6 +465,10 @@ interface EditableTodoItemProps {
   owner: LightWorkspaceType;
   agentNameById: Map<string, string>;
   isExiting: boolean;
+  isAdded: boolean;
+  isEntering: boolean;
+  isTyping: boolean;
+  isNewlyDone: boolean;
 }
 
 function EditableTodoItem({
@@ -472,8 +478,21 @@ function EditableTodoItem({
   owner,
   agentNameById,
   isExiting,
+  isAdded,
+  isEntering,
+  isTyping,
+  isNewlyDone,
 }: EditableTodoItemProps) {
   const isDone = todo.status === "done";
+  const [isFlashing, setIsFlashing] = useState(isNewlyDone);
+
+  useEffect(() => {
+    if (!isNewlyDone) {
+      return;
+    }
+    const timeout = setTimeout(() => setIsFlashing(false), 1000);
+    return () => clearTimeout(timeout);
+  }, [isNewlyDone]);
 
   const handleToggle = () => {
     onToggleDone(todo);
@@ -484,7 +503,11 @@ function EditableTodoItem({
       className={cn(
         "group/todo flex items-start gap-3 overflow-hidden",
         "transition-all duration-200",
-        isExiting ? "max-h-0 opacity-0" : "max-h-32 opacity-100"
+        isExiting
+          ? "max-h-0 opacity-0"
+          : isAdded && !isEntering
+            ? "max-h-0 opacity-0"
+            : "max-h-32 opacity-100"
       )}
     >
       <div className="mt-1 shrink-0">
@@ -506,10 +529,16 @@ function EditableTodoItem({
               "text-base min-h-6 transition-all duration-300",
               isDone
                 ? "text-faint dark:text-faint-night line-through"
-                : "text-foreground dark:text-foreground-night"
+                : "text-foreground dark:text-foreground-night",
+              isFlashing &&
+                "rounded bg-warning-100/40 dark:bg-warning-100-night/30"
             )}
           >
-            {todo.text}
+            {isTyping ? (
+              <TypingAnimation text={todo.text} duration={16} />
+            ) : (
+              todo.text
+            )}
           </span>
           <TodoSources sources={todo.sources} owner={owner} isDone={isDone} />
         </button>
@@ -534,7 +563,7 @@ function EditableProjectTodosPanel({
   owner: LightWorkspaceType;
   spaceId: string;
 }) {
-  const { todos, isTodosLoading, mutateTodos } = useProjectTodos({
+  const { todos, lastReadAt, isTodosLoading, mutateTodos } = useProjectTodos({
     owner,
     spaceId,
   });
@@ -542,12 +571,105 @@ function EditableProjectTodosPanel({
   const doUpdate = useUpdateProjectTodo({ owner, spaceId });
   const doDelete = useDeleteProjectTodo({ owner, spaceId });
   const doCleanDone = useCleanDoneProjectTodos({ owner, spaceId });
+  const markRead = useMarkProjectTodosRead({ owner, spaceId });
+  const markReadRef = useRef(markRead);
+  markReadRef.current = markRead;
 
   // Tracks todos being animated out during a clean operation.
   const [pendingRemovalIds, setPendingRemovalIds] = useState<Set<string>>(
     new Set()
   );
   const [isCleaning, setIsCleaning] = useState(false);
+
+  // ── Diff animation state ────────────────────────────────────────────────────
+
+  // Frozen snapshot of lastReadAt taken on first successful load. undefined =
+  // not yet captured; null = first-ever visit; string = ISO timestamp.
+  // Initialized synchronously so new items start hidden from the very first
+  // render with data — prevents a layout shift on unchanged items caused by
+  // transitioning new items from visible→hidden after the first paint.
+  const [frozenLastReadAt, setFrozenLastReadAt] = useState<
+    string | null | undefined
+  >(() => (!isTodosLoading ? lastReadAt : undefined));
+
+  useEffect(() => {
+    if (!isTodosLoading && frozenLastReadAt === undefined) {
+      setFrozenLastReadAt(lastReadAt);
+    }
+  }, [isTodosLoading, frozenLastReadAt, lastReadAt]);
+
+  const diffKeys = useMemo(() => {
+    if (frozenLastReadAt === undefined || frozenLastReadAt === null) {
+      return { added: new Set<string>(), newlyDone: new Set<string>() };
+    }
+    const cutoff = new Date(frozenLastReadAt).getTime();
+    const added = new Set<string>();
+    const newlyDone = new Set<string>();
+    for (const t of todos) {
+      if (new Date(t.createdAt).getTime() > cutoff) {
+        added.add(t.sId);
+      } else if (
+        t.status === "done" &&
+        t.doneAt &&
+        new Date(t.doneAt).getTime() > cutoff
+      ) {
+        newlyDone.add(t.sId);
+      }
+    }
+    return { added, newlyDone };
+  }, [frozenLastReadAt, todos]);
+
+  const [enteringKeys, setEnteringKeys] = useState<Set<string>>(new Set());
+  const [enteredKeys, setEnteredKeys] = useState<Set<string>>(new Set());
+  const [typingKeys, setTypingKeys] = useState<Set<string>>(new Set());
+  const [doneFlashKeys, setDoneFlashKeys] = useState<Set<string>>(new Set());
+  const startTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cleanupTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasRunRef = useRef(false);
+
+  // diffKeys is intentionally excluded: it is memoized and stable during
+  // animation (no SWR updates occur while animation state updates fire).
+  // markReadRef is a ref — .current is updated synchronously every render so
+  // it never needs to be a dep. Including either would cause the cleanup to
+  // fire on every animation state update and cancel the in-flight timeouts.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional one-shot effect, see comment above
+  useEffect(() => {
+    if (isTodosLoading || frozenLastReadAt === undefined || hasRunRef.current) {
+      return;
+    }
+    hasRunRef.current = true;
+
+    const { added, newlyDone } = diffKeys;
+
+    if (added.size === 0 && newlyDone.size === 0) {
+      void markReadRef.current();
+      return;
+    }
+
+    setTypingKeys(new Set(added));
+    setDoneFlashKeys(new Set(newlyDone));
+
+    startTimeoutRef.current = setTimeout(() => {
+      setEnteringKeys(new Set(added));
+      startTimeoutRef.current = null;
+    }, 0);
+
+    cleanupTimeoutRef.current = setTimeout(() => {
+      void markReadRef.current();
+      setEnteringKeys(new Set());
+      setEnteredKeys(new Set(added));
+      cleanupTimeoutRef.current = null;
+    }, SUMMARY_ITEM_TRANSITION_MS);
+
+    return () => {
+      if (startTimeoutRef.current !== null) {
+        clearTimeout(startTimeoutRef.current);
+      }
+      if (cleanupTimeoutRef.current !== null) {
+        clearTimeout(cleanupTimeoutRef.current);
+      }
+    };
+  }, [isTodosLoading, frozenLastReadAt]);
 
   const hasDoneItems = todos.some((t) => t.status === "done");
 
@@ -558,6 +680,7 @@ function EditableProjectTodosPanel({
   const handleSetStatus = useCallback(
     async (todo: ProjectTodoType, status: ProjectTodoStatus) => {
       const optimistic = (prev: GetProjectTodosResponseBody | undefined) => ({
+        lastReadAt: prev?.lastReadAt ?? null,
         todos: (prev?.todos ?? []).map((t) =>
           t.sId === todo.sId ? { ...t, status } : t
         ),
@@ -657,7 +780,7 @@ function EditableProjectTodosPanel({
       </div>
 
       {/* Body */}
-      {isTodosLoading ? (
+      {isTodosLoading || frozenLastReadAt === undefined ? (
         <div className="flex justify-center py-4">
           <Spinner size="sm" />
         </div>
@@ -710,6 +833,13 @@ function EditableProjectTodosPanel({
                       owner={owner}
                       agentNameById={agentNameById}
                       isExiting={pendingRemovalIds.has(todo.sId)}
+                      isAdded={
+                        diffKeys.added.has(todo.sId) &&
+                        !enteredKeys.has(todo.sId)
+                      }
+                      isEntering={enteringKeys.has(todo.sId)}
+                      isTyping={typingKeys.has(todo.sId)}
+                      isNewlyDone={doneFlashKeys.has(todo.sId)}
                     />
                   ))}
                 </div>

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -336,9 +336,29 @@ export function useProjectTodos({
 
   return {
     todos: data?.todos ?? [],
+    lastReadAt: data?.lastReadAt ?? null,
     isTodosLoading: !disabled && !error && !data,
     isTodosError: !!error,
     mutateTodos: mutate,
+  };
+}
+
+export function useMarkProjectTodosRead({
+  owner,
+  spaceId,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+}) {
+  return async (): Promise<void> => {
+    try {
+      await clientFetch(
+        `/api/w/${owner.sId}/spaces/${spaceId}/project_todos/mark_read`,
+        { method: "POST" }
+      );
+    } catch {
+      // Silent — mark_read is best-effort.
+    }
   };
 }
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.test.ts
@@ -30,7 +30,9 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_todos", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(res._getJSONData().todos).toEqual([]);
+    const data = res._getJSONData();
+    expect(data.todos).toEqual([]);
+    expect(data.lastReadAt).toBeNull();
   });
 
   it("should return latest versions of todos for the space", async () => {
@@ -49,11 +51,12 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_todos", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    const { todos } = res._getJSONData();
+    const { todos, lastReadAt } = res._getJSONData();
     // Only the latest version should appear.
     expect(todos).toHaveLength(1);
     expect(todos[0].text).toBe("Updated todo");
     expect(todos[0].sId).toBe(todo.sId);
+    expect(lastReadAt).toBeNull();
   });
 
   it("should return 400 for non-project spaces", async () => {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
@@ -3,6 +3,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { ProjectTodoStateResource } from "@app/lib/resources/project_todo_state_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -11,6 +12,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 export interface GetProjectTodosResponseBody {
   todos: ProjectTodoType[];
+  lastReadAt: string | null;
 }
 
 async function handler(
@@ -31,9 +33,10 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const todos = await ProjectTodoResource.fetchLatestBySpace(auth, {
-        spaceId: space.id,
-      });
+      const [todos, state] = await Promise.all([
+        ProjectTodoResource.fetchLatestBySpace(auth, { spaceId: space.id }),
+        ProjectTodoStateResource.fetchBySpace(auth, { spaceId: space.id }),
+      ]);
 
       const todoIds = todos.map((t) => t.sId);
 
@@ -59,7 +62,10 @@ async function handler(
         };
       });
 
-      return res.status(200).json({ todos: todosWithSources });
+      return res.status(200).json({
+        todos: todosWithSources,
+        lastReadAt: state ? state.lastReadAt.toISOString() : null,
+      });
     }
 
     default:

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/mark_read.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/mark_read.test.ts
@@ -1,0 +1,103 @@
+import { Authenticator } from "@app/lib/auth";
+import { ProjectTodoStateResource } from "@app/lib/resources/project_todo_state_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { WorkspaceType } from "@app/types/user";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { describe, expect, it } from "vitest";
+
+import handler from "./mark_read";
+
+describe("POST /api/w/[wId]/spaces/[spaceId]/project_todos/mark_read", () => {
+  let workspace: WorkspaceType;
+
+  async function setup(method = "POST") {
+    const result = await createPrivateApiMockRequest({ method: method as any });
+    workspace = result.workspace;
+    return result;
+  }
+
+  it("should create a state row on first call and return success", async () => {
+    const { req, res, user, auth } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    req.query.spaceId = project.sId;
+
+    const before = Date.now();
+    await handler(req, res);
+    const after = Date.now();
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().success).toBe(true);
+
+    const state = await ProjectTodoStateResource.fetchBySpace(auth, {
+      spaceId: project.id,
+    });
+    expect(state).not.toBeNull();
+    expect(state!.lastReadAt.getTime()).toBeGreaterThanOrEqual(before);
+    expect(state!.lastReadAt.getTime()).toBeLessThanOrEqual(after);
+  });
+
+  it("should upsert lastReadAt on subsequent calls without error", async () => {
+    const { req, res, user, auth } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    req.query.spaceId = project.sId;
+
+    // First call.
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+
+    const firstState = await ProjectTodoStateResource.fetchBySpace(auth, {
+      spaceId: project.id,
+    });
+    const firstReadAt = firstState!.lastReadAt;
+
+    // Second call — reuse the same workspace/spaceId; session mock is still set
+    // to the same user from setup().
+    const { req: req2, res: res2 } = createMocks<
+      NextApiRequest,
+      NextApiResponse
+    >({ method: "POST", query: { wId: workspace.sId, spaceId: project.sId } });
+    await handler(req2, res2);
+
+    expect(res2._getStatusCode()).toBe(200);
+
+    const updatedState = await ProjectTodoStateResource.fetchBySpace(auth, {
+      spaceId: project.id,
+    });
+    expect(updatedState!.lastReadAt.getTime()).toBeGreaterThanOrEqual(
+      firstReadAt.getTime()
+    );
+  });
+
+  it("should return 400 for non-project spaces", async () => {
+    const { req, res, user } = await setup();
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const regularSpace = await SpaceFactory.regular(workspace);
+
+    const memberGroup = regularSpace.groups.find((g) => g.kind === "regular");
+    if (memberGroup) {
+      await memberGroup.dangerouslyAddMembers(adminAuth, {
+        users: [user.toJSON()],
+      });
+    }
+
+    req.query.spaceId = regularSpace.sId;
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("should return 405 for unsupported methods", async () => {
+    const { req, res, user } = await setup("GET");
+    const project = await SpaceFactory.project(workspace, user.id);
+    req.query.spaceId = project.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/mark_read.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/mark_read.ts
@@ -1,0 +1,56 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectTodoStateResource } from "@app/lib/resources/project_todo_state_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export interface PostMarkReadResponseBody {
+  success: true;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostMarkReadResponseBody>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  if (!space.isProject()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Todos are only available for project spaces.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      await ProjectTodoStateResource.upsertBySpace(auth, {
+        spaceId: space.id,
+        lastReadAt: new Date(),
+      });
+
+      return res.status(200).json({ success: true });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanRead: true },
+  })
+);


### PR DESCRIPTION
## Description

When a user reopens a project's "What's new?" panel, new todos and recently-completed todos added since their last visit now animate in rather than popping in as a static block.


https://github.com/user-attachments/assets/a651d4e1-6688-4d17-acd4-0ad1b2e906f0



**How it works:**
- `GET /project_todos` now returns `lastReadAt` (the user's last read timestamp from `ProjectTodoStateResource`, or `null` for first-ever visit).
- A new `POST /project_todos/mark_read` endpoint upserts the read receipt to `now`.
- On panel mount, `lastReadAt` is frozen in state on the first successful load so SWR revalidations don't wipe out the diff mid-animation.
- Todos with `createdAt > lastReadAt` are classified as **added** — they start hidden (`max-h-0 opacity-0`) and slide in over 200 ms, with their text rendered via `TypingAnimation` at 16 ms/char.
- Todos with `status === "done"` and `doneAt > lastReadAt` are **newly done** — they briefly show a yellow highlight that fades over 300 ms.
- `markRead()` is called exactly once per mount, ~240 ms after the enter animation starts. A `hasRunRef` guard prevents re-triggering on SWR revalidations or optimistic updates.
- The archived (`ReadOnlyProjectTodosPanel`) variant is untouched and never calls `mark_read`.

## Tests


## Risk
