### PR TITLE
fix(sbx): compat probe fails because nft requires root

### DIFF
--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -97,7 +97,7 @@ describe("sandbox egress helpers", () => {
     );
     expect(sandbox.exec).toHaveBeenCalledWith(
       {},
-      expect.stringContaining("grep -q 'skuid 1003'")
+      expect.stringContaining("systemctl is-active --quiet dust-egress-nftables.service")
     );
   });
 

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -97,7 +97,9 @@ describe("sandbox egress helpers", () => {
     );
     expect(sandbox.exec).toHaveBeenCalledWith(
       {},
-      expect.stringContaining("systemctl is-active --quiet dust-egress-nftables.service")
+      expect.stringContaining(
+        "systemctl is-active --quiet dust-egress-nftables.service"
+      )
     );
   });
 

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -90,7 +90,7 @@ export async function sandboxSupportsEgressForwarding(
 ): Promise<Result<boolean, Error>> {
   const probeResult = await sandbox.exec(
     auth,
-    "test -d /etc/dust && id agent-proxied >/dev/null 2>&1 && id dust-fwd >/dev/null 2>&1 && test -x /opt/bin/dsbx && nft list ruleset 2>/dev/null | grep -q 'skuid 1003'"
+    "test -d /etc/dust && id agent-proxied >/dev/null 2>&1 && id dust-fwd >/dev/null 2>&1 && test -x /opt/bin/dsbx && systemctl is-active --quiet dust-egress-nftables.service"
   );
 
   if (probeResult.isErr()) {


### PR DESCRIPTION
## Description

`nft list ruleset` requires root but the compat probe runs as `agent`. Every sandbox hits compat_skip, egress proxy never activates.

Fix: use `systemctl is-active --quiet dust-egress-nftables.service` instead.

## Tests

Updated `egress.test.ts`. Verified on live 0.7.9 sandbox: `systemctl is-active` returns 0 as agent, `nft list ruleset` returns "Operation not permitted".

## Risk

Low. Fixes broken probe. No change for pre-PR1 sandboxes (no service = probe fails as expected).

## Deploy Plan

Merge and deploy.