### PR TITLE
feat: improve avatar stack display

### DIFF
--- a/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
+++ b/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
@@ -77,7 +77,7 @@ export function ProjectHeaderActions({
                 visual: member.image ?? undefined,
                 isRounded: true,
               }))}
-              nbVisibleItems={8}
+              nbVisibleItems={5}
               size="sm"
             />
           </div>

--- a/sparkle/src/components/Avatar.tsx
+++ b/sparkle/src/components/Avatar.tsx
@@ -443,10 +443,9 @@ Avatar.Stack = function ({
                     <Avatar
                       size={size}
                       name={
-                        "+" +
-                        String(
-                          Number(remainingCount) < 10 ? remainingCount : ""
-                        )
+                        Number(remainingCount) < 10
+                          ? `+${remainingCount}`
+                          : "9+"
                       }
                     />
                   </div>
@@ -454,8 +453,7 @@ Avatar.Stack = function ({
                   <Avatar
                     size={size}
                     name={
-                      "+" +
-                      String(Number(remainingCount) < 10 ? remainingCount : "")
+                      Number(remainingCount) < 10 ? `+${remainingCount}` : "9+"
                     }
                   />
                 )}

--- a/sparkle/src/stories/Avatar.stories.tsx
+++ b/sparkle/src/stories/Avatar.stories.tsx
@@ -312,6 +312,35 @@ export const AvatarStackExample: Story = {
 
         <Avatar.Stack
           size="xs"
+          nbVisibleItems={3}
+          avatars={[
+            {
+              name: "Isabelle Doe",
+              visual: "https://dust.tt/static/droidavatar/Droid_Lime_3.jpg",
+            },
+            {
+              name: "Rafael Doe",
+              visual: "https://dust.tt/static/droidavatar/Droid_Yellow_3.jpg",
+            },
+            {
+              name: "Aria Doe",
+              visual: "https://dust.tt/static/droidavatar/Droid_Red_3.jpg",
+            },
+            { name: "Omar Doe" },
+            { name: "Priya Doe" },
+            { name: "Leo Doe" },
+            { name: "Mia Doe" },
+            { name: "Kai Doe" },
+            { name: "Zara Doe" },
+            { name: "Finn Doe" },
+            { name: "Nova Doe" },
+            { name: "Quinn Doe" },
+            { name: "River Doe" },
+          ]}
+        />
+
+        <Avatar.Stack
+          size="xs"
           nbVisibleItems={1}
           avatars={[
             {
@@ -360,6 +389,35 @@ export const AvatarStackExample: Story = {
               visual: "https://dust.tt/static/droidavatar/Droid_Pink_3.jpg",
             },
             { name: "Eleanor Wright" },
+          ]}
+        />
+
+        <Avatar.Stack
+          size="sm"
+          nbVisibleItems={3}
+          avatars={[
+            {
+              name: "Isabelle Doe",
+              visual: "https://dust.tt/static/droidavatar/Droid_Lime_3.jpg",
+            },
+            {
+              name: "Rafael Doe",
+              visual: "https://dust.tt/static/droidavatar/Droid_Yellow_3.jpg",
+            },
+            {
+              name: "Aria Doe",
+              visual: "https://dust.tt/static/droidavatar/Droid_Red_3.jpg",
+            },
+            { name: "Omar Doe" },
+            { name: "Priya Doe" },
+            { name: "Leo Doe" },
+            { name: "Mia Doe" },
+            { name: "Kai Doe" },
+            { name: "Zara Doe" },
+            { name: "Finn Doe" },
+            { name: "Nova Doe" },
+            { name: "Quinn Doe" },
+            { name: "River Doe" },
           ]}
         />
 
@@ -417,6 +475,34 @@ export const AvatarStackExample: Story = {
               name: "Omar Doe",
               visual: "https://dust.tt/static/droidavatar/Droid_Pink_3.jpg",
             },
+          ]}
+        />
+        <Avatar.Stack
+          size="md"
+          nbVisibleItems={3}
+          avatars={[
+            {
+              name: "Isabelle Doe",
+              visual: "https://dust.tt/static/droidavatar/Droid_Lime_3.jpg",
+            },
+            {
+              name: "Rafael Doe",
+              visual: "https://dust.tt/static/droidavatar/Droid_Yellow_3.jpg",
+            },
+            {
+              name: "Aria Doe",
+              visual: "https://dust.tt/static/droidavatar/Droid_Red_3.jpg",
+            },
+            { name: "Omar Doe" },
+            { name: "Priya Doe" },
+            { name: "Leo Doe" },
+            { name: "Mia Doe" },
+            { name: "Kai Doe" },
+            { name: "Zara Doe" },
+            { name: "Finn Doe" },
+            { name: "Nova Doe" },
+            { name: "Quinn Doe" },
+            { name: "River Doe" },
           ]}
         />
         <Avatar.Stack


### PR DESCRIPTION
## Description

Improve display of stack avatars when more than 10 are hidden. It was just `+` before, and it was confusing. Users thought it was an "add button".

Changed to `9+` consistent with what we usually see online

<img width="350" height="188" alt="image" src="https://github.com/user-attachments/assets/50edfcd9-c1d1-4385-ad57-09913e31fa73" />


[We also reduced avatar count in projects to 5](https://dust4ai.slack.com/archives/C09T7N4S6GG/p1776759304326289?thread_ts=1776758009.764779&cid=C09T7N4S6GG)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
