### PR TITLE
[coding_rules] add exception to GEN9 for `createdAt`/`updatedAt`

### DIFF
--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -208,6 +208,9 @@ Common suffixes:
 - Money: `Cents`, `Dollars` (e.g., `priceCents`, `amountDollars`)
 - Time: `Ms`, `Seconds`, `Minutes`, `Hours` (e.g., `timeoutMs`, `durationSeconds`)
 
+This rule does not apply to common Sequelize date/timestamp fields that follow the framework
+convention, such as `createdAt` and `updatedAt`.
+
 Reviewer: If you detect a variable representing money or time without a unit suffix, require the
 author to rename it with the appropriate suffix.
 


### PR DESCRIPTION
## Description

- This PR refines the coding rule GEN9 relative to adding unit suffixes to variable names to mention that adding a unit is not needed for `createdAt`/`updatedAt`.

## Tests

- N/A

## Risk

- N/A

## Deploy Plan

- No deploy.
