### PR TITLE
Add wake-up Temporal scaffolding

### DIFF
--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -288,8 +288,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
   private async startTemporalWorkflow(
     auth: Authenticator
   ): Promise<Result<void, Error>> {
-    return launchOrScheduleWakeUpTemporalWorkflow({
-      auth,
+    return launchOrScheduleWakeUpTemporalWorkflow(auth, {
       wakeUp: this.toJSON(),
     });
   }
@@ -297,9 +296,6 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
   private async cancelTemporalWorkflow(
     auth: Authenticator
   ): Promise<Result<void, Error>> {
-    return cancelWakeUpTemporalWorkflow({
-      auth,
-      wakeUp: this.toJSON(),
-    });
+    return cancelWakeUpTemporalWorkflow(auth, { wakeUp: this.toJSON() });
   }
 }

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -7,6 +7,10 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import {
+  cancelWakeUpTemporalWorkflow,
+  launchOrScheduleWakeUpTemporalWorkflow,
+} from "@app/temporal/triggers/wakeup/client";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type {
@@ -282,16 +286,20 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
   }
 
   private async startTemporalWorkflow(
-    _auth: Authenticator
+    auth: Authenticator
   ): Promise<Result<void, Error>> {
-    // Temporal wiring will be added in a follow-up PR.
-    return new Ok(undefined);
+    return launchOrScheduleWakeUpTemporalWorkflow({
+      auth,
+      wakeUp: this.toJSON(),
+    });
   }
 
   private async cancelTemporalWorkflow(
-    _auth: Authenticator
+    auth: Authenticator
   ): Promise<Result<void, Error>> {
-    // Temporal wiring will be added in a follow-up PR.
-    return new Ok(undefined);
+    return cancelWakeUpTemporalWorkflow({
+      auth,
+      wakeUp: this.toJSON(),
+    });
   }
 }

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -1,0 +1,2 @@
+export * from "./common/activities";
+export * from "./wakeup/activities";

--- a/front/temporal/triggers/common/worker.ts
+++ b/front/temporal/triggers/common/worker.ts
@@ -8,7 +8,7 @@ import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 
-import * as activities from "./activities";
+import * as activities from "../activities";
 import { QUEUE_NAME } from "./config";
 
 export async function runAgentTriggerWorker() {
@@ -17,7 +17,7 @@ export async function runAgentTriggerWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "agent_schedule",
-      getWorkflowsPath: () => require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("../workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,

--- a/front/temporal/triggers/wakeup/activities.ts
+++ b/front/temporal/triggers/wakeup/activities.ts
@@ -1,0 +1,16 @@
+import logger from "@app/logger/logger";
+
+export class WakeUpNonRetryableError extends Error {}
+
+export async function runWakeUpActivity({
+  workspaceId,
+  wakeUpId,
+}: {
+  workspaceId: string;
+  wakeUpId: string;
+}): Promise<void> {
+  logger.info(
+    { wakeUpId, workspaceId },
+    "Wake-up activity is not implemented yet."
+  );
+}

--- a/front/temporal/triggers/wakeup/client.ts
+++ b/front/temporal/triggers/wakeup/client.ts
@@ -7,6 +7,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { WorkflowNotFoundError } from "@temporalio/client";
 
 import { wakeUpWorkflow } from "./workflows";
 
@@ -20,7 +21,7 @@ export function makeWakeUpWorkflowId({
   return `wakeup-${workspaceId}-${wakeUpId}`;
 }
 
-export async function createWakeUpTemporal({
+export async function launchOrScheduleWakeUpTemporalWorkflow({
   auth,
   wakeUp,
 }: {
@@ -73,6 +74,56 @@ export async function createWakeUpTemporal({
     }
 
     case "cron": {
+      //TODO(wakeup): Implement schedule creation
+
+      return new Err(new Error("Cron wake-ups are not supported yet."));
+    }
+
+    default:
+      return assertNever(wakeUp.scheduleConfig);
+  }
+}
+
+export async function cancelWakeUpTemporalWorkflow({
+  auth,
+  wakeUp,
+}: {
+  auth: Authenticator;
+  wakeUp: WakeUpType;
+}): Promise<Result<void, Error>> {
+  const client = await getTemporalClientForAgentNamespace();
+  const owner = auth.getNonNullableWorkspace();
+
+  switch (wakeUp.scheduleConfig.type) {
+    case "one_shot": {
+      const workflowId = makeWakeUpWorkflowId({
+        workspaceId: owner.sId,
+        wakeUpId: wakeUp.sId,
+      });
+
+      try {
+        await client.workflow.getHandle(workflowId).cancel();
+      } catch (error) {
+        if (!(error instanceof WorkflowNotFoundError)) {
+          logger.warn(
+            {
+              workspaceId: owner.sId,
+              wakeUpId: wakeUp.sId,
+              workflowId,
+              error,
+            },
+            "Failed cancelling wake-up workflow."
+          );
+          return new Err(normalizeError(error));
+        }
+      }
+
+      return new Ok(undefined);
+    }
+
+    case "cron": {
+      //TODO(wakeup): Implement schedule deletion
+
       return new Err(new Error("Cron wake-ups are not supported yet."));
     }
 

--- a/front/temporal/triggers/wakeup/client.ts
+++ b/front/temporal/triggers/wakeup/client.ts
@@ -1,0 +1,82 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { QUEUE_NAME } from "@app/temporal/triggers/common/config";
+import type { WakeUpType } from "@app/types/assistant/wakeups";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+import { wakeUpWorkflow } from "./workflows";
+
+export function makeWakeUpWorkflowId({
+  workspaceId,
+  wakeUpId,
+}: {
+  workspaceId: string;
+  wakeUpId: string;
+}): string {
+  return `wakeup-${workspaceId}-${wakeUpId}`;
+}
+
+export async function createWakeUpTemporal({
+  auth,
+  wakeUp,
+}: {
+  auth: Authenticator;
+  wakeUp: WakeUpType;
+}): Promise<Result<void, Error>> {
+  const client = await getTemporalClientForAgentNamespace();
+  const owner = auth.getNonNullableWorkspace();
+  const workflowId = makeWakeUpWorkflowId({
+    workspaceId: owner.sId,
+    wakeUpId: wakeUp.sId,
+  });
+
+  switch (wakeUp.scheduleConfig.type) {
+    case "one_shot": {
+      const startDelayMs = Math.max(
+        0,
+        wakeUp.scheduleConfig.fireAt - Date.now()
+      );
+
+      try {
+        await client.workflow.start(wakeUpWorkflow, {
+          args: [{ workspaceId: owner.sId, wakeUpId: wakeUp.sId }],
+          taskQueue: QUEUE_NAME,
+          workflowId,
+          startDelay: startDelayMs,
+          memo: {
+            workspaceId: owner.sId,
+            wakeUpId: wakeUp.sId,
+          },
+        });
+      } catch (error) {
+        // We log and error even if this is a WorkflowExecutionAlreadyStartedError, because it means
+        // that the existing workflow is still running, which is unexpected (since this is a
+        // one-shot wake-up).
+        logger.error(
+          {
+            workspaceId: owner.sId,
+            wakeUpId: wakeUp.sId,
+            workflowId,
+            error,
+          },
+          "Failed starting wake-up workflow."
+        );
+
+        return new Err(normalizeError(error));
+      }
+
+      return new Ok(undefined);
+    }
+
+    case "cron": {
+      return new Err(new Error("Cron wake-ups are not supported yet."));
+    }
+
+    default:
+      return assertNever(wakeUp.scheduleConfig);
+  }
+}

--- a/front/temporal/triggers/wakeup/client.ts
+++ b/front/temporal/triggers/wakeup/client.ts
@@ -21,13 +21,10 @@ export function makeWakeUpWorkflowId({
   return `wakeup-${workspaceId}-${wakeUpId}`;
 }
 
-export async function launchOrScheduleWakeUpTemporalWorkflow({
-  auth,
-  wakeUp,
-}: {
-  auth: Authenticator;
-  wakeUp: WakeUpType;
-}): Promise<Result<void, Error>> {
+export async function launchOrScheduleWakeUpTemporalWorkflow(
+  auth: Authenticator,
+  { wakeUp }: { wakeUp: WakeUpType }
+): Promise<Result<void, Error>> {
   const client = await getTemporalClientForAgentNamespace();
   const owner = auth.getNonNullableWorkspace();
   const workflowId = makeWakeUpWorkflowId({
@@ -84,13 +81,10 @@ export async function launchOrScheduleWakeUpTemporalWorkflow({
   }
 }
 
-export async function cancelWakeUpTemporalWorkflow({
-  auth,
-  wakeUp,
-}: {
-  auth: Authenticator;
-  wakeUp: WakeUpType;
-}): Promise<Result<void, Error>> {
+export async function cancelWakeUpTemporalWorkflow(
+  auth: Authenticator,
+  { wakeUp }: { wakeUp: WakeUpType }
+): Promise<Result<void, Error>> {
   const client = await getTemporalClientForAgentNamespace();
   const owner = auth.getNonNullableWorkspace();
 

--- a/front/temporal/triggers/wakeup/workflows.ts
+++ b/front/temporal/triggers/wakeup/workflows.ts
@@ -1,0 +1,20 @@
+import { proxyActivities } from "@temporalio/workflow";
+
+import type * as activities from "./activities";
+
+const { runWakeUpActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+  retry: {
+    nonRetryableErrorTypes: ["WakeUpNonRetryableError"],
+  },
+});
+
+export async function wakeUpWorkflow({
+  workspaceId,
+  wakeUpId,
+}: {
+  workspaceId: string;
+  wakeUpId: string;
+}): Promise<void> {
+  await runWakeUpActivity({ workspaceId, wakeUpId });
+}

--- a/front/temporal/triggers/workflows.ts
+++ b/front/temporal/triggers/workflows.ts
@@ -1,0 +1,2 @@
+export * from "./common/workflows";
+export * from "./wakeup/workflows";

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -28,6 +28,10 @@ when firing, and treat missing/deleted conversation, user, workspace, or agent a
 cancelled/expired states. Back-off + retry only when a different agent is running (retryable
 error, 10min max window).
 
+Status: Temporal scaffolding for one-shot wake-ups is in place (`front/temporal/triggers/wakeup/*`,
+worker wiring, and `WakeUpResource` integration). Remaining work is implementing the activity
+logic and retry/terminal-state behavior.
+
 ### PR 4 — Wire WakeUpResource to Temporal
 
 Connect `WakeUpResource.makeNew` and `cancel` to actual Temporal workflow start/terminate. Remove


### PR DESCRIPTION
## Description

Add Temporal scaffolding for one-off wake-ups under `front/temporal/triggers/wakeup/`.

This PR introduces:
- the wake-up Temporal client
- the wake-up workflow
- a stub wake-up activity
- worker wiring so the shared agent-schedule worker bundles the new wake-up Temporal code
- `WakeUpResource` integration with the new Temporal client helpers

For now, this is one-off scaffolding only:
- one-shot launch/cancel is wired at the client/resource level
- cron returns a not-supported error
- the activity is still a stub

## Tests

N/A

## Risk

None. Please double check the import logic change.

## Deploy Plan

- deploy `front`
