### PR TITLE
Disable history when showing suggestions

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -189,7 +189,7 @@ export default function SkillBuilder({
         className="mx-4"
         title={skill ? `Edit skill ${skill.name}` : "Create new skill"}
         centerActions={
-          skill && skillHistory ? (
+          skill && skillHistory && !hasPendingSuggestions ? (
             <SkillVersionHistoryPicker
               skill={skill}
               skillHistory={skillHistory}

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -290,14 +290,14 @@ export function SkillBuilderInstructionsEditor({
           class: cn(
             editorVariants({
               error: displayError,
-              disabled: isDiffMode,
+              disabled: isDiffMode || hasSuggestions,
             }),
             INSTRUCTIONS_EDITOR_SIZE
           ),
         },
       },
     });
-  }, [editor, displayError, isDiffMode]);
+  }, [editor, displayError, isDiffMode, hasSuggestions]);
 
   // Sync external changes to the editor content
   useEffect(() => {


### PR DESCRIPTION
## Description

When the skill builder is showing pending suggestions, interacting with
version history doesn't make sense — you can't compare versions while the
editor is also being hijacked by a pending diff. This PR hardens that mode:

- **Hide the version history picker** in `BarHeader` when there are pending
  suggestions (`hasPendingSuggestions`).
- **Apply the disabled editor styling** (`cursor-not-allowed`, dimmed
  background) to the instructions editor when suggestions are shown, matching
  the existing behavior when a history item is selected (`isDiffMode`). The
  editor was already made non-editable via `editor.setEditable(!hasSuggestions)`;
  this just makes the readonly state visually consistent with the history-diff
  state.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front