### PR TITLE
fix(sbx): dust-fwd has nologin shell, E2B exec needs bash

### DIFF
--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -77,7 +77,7 @@ describe("sandbox image registry", () => {
       });
       expect(imageResult.value.imageId).toEqual({
         imageName: "dust-base",
-        tag: "0.7.9",
+        tag: "0.7.10",
       });
     }
   });

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -11,7 +11,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.6.0";
-const DUST_BASE_IMAGE_VERSION = "0.7.9";
+const DUST_BASE_IMAGE_VERSION = "0.7.10";
 const DSBX_CLI_VERSION = "0.1.4";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
@@ -113,6 +113,8 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
     user: "root",
   })
   .runCmd(getAgentProxiedSetupCommand(), { user: "root" })
+  // dust-fwd is created with nologin in bedrock; E2B exec needs a real shell.
+  .runCmd("usermod -s /bin/bash dust-fwd", { user: "root" })
   // Create simple netcat-based token server script.
   .runCmd("mkdir -p /home/agent/.bin", { user: "root" })
   // TODO(2026-03-06 SANDBOX): .copy is broken, use file once fixed.


### PR DESCRIPTION
## Description

E2B wraps exec in `/bin/bash -l -c` which requires the user to have a real shell. `dust-fwd` was created with `--shell /usr/sbin/nologin` in bedrock, so starting the forwarder as `dust-fwd` fails with "permission denied".

Fix: `usermod -s /bin/bash dust-fwd` at template build time. Bump to 0.7.10.

## Tests

Version bump in `registry.test.ts`.

## Risk

Low. Only affects `dust-fwd` user's shell. Requires template rebuild after merge.

## Deploy Plan

1. Merge
2. Trigger Sandbox Image Registry workflow with `rebuild=true` to build dust-base:0.7.10
3. New sandboxes will use the fixed template