### PR TITLE
Add wake-up message origin

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -149,6 +149,10 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
     label: "Trigger",
     color: buildColorClass("orange", 300),
   },
+  wakeup: {
+    label: "Wake-up",
+    color: buildColorClass("violet", 700),
+  },
   onboarding_conversation: {
     label: "Onboarding",
     color: buildColorClass("rose", 300),

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -543,6 +543,7 @@ export function isUserMessageContextValid(
     case "transcript":
     case "triggered":
     case "triggered_programmatic":
+    case "wakeup":
     case "onboarding_conversation":
     case "agent_sidekick":
     case "project_kickoff":

--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -29,6 +29,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   transcript: "user",
   triggered_programmatic: "programmatic",
   triggered: "user",
+  wakeup: "programmatic",
   web: "user",
   zapier: "programmatic",
   zendesk: "user",

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -90,6 +90,7 @@ describe("conversation-unread workflow business logic", () => {
     transcript: false,
     triggered: false,
     triggered_programmatic: false,
+    wakeup: false,
     zendesk: false,
     reinforced_agent_notification: false,
     reinforced_skill_notification: false,

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -90,7 +90,7 @@ describe("conversation-unread workflow business logic", () => {
     transcript: false,
     triggered: false,
     triggered_programmatic: false,
-    wakeup: false,
+    wakeup: true,
     zendesk: false,
     reinforced_agent_notification: false,
     reinforced_skill_notification: false,

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -80,6 +80,7 @@ export const shouldSendNotificationForAgentAnswer = (
     case "extension":
     case "cli":
     case "cli_programmatic":
+    case "wakeup":
       return true;
     case "onboarding_conversation":
     case "agent_sidekick":
@@ -102,7 +103,6 @@ export const shouldSendNotificationForAgentAnswer = (
     case "transcript":
     case "triggered_programmatic":
     case "triggered":
-    case "wakeup":
     case "zapier":
     case "zendesk":
     case "project_kickoff":

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -102,6 +102,7 @@ export const shouldSendNotificationForAgentAnswer = (
     case "transcript":
     case "triggered_programmatic":
     case "triggered":
+    case "wakeup":
     case "zapier":
     case "zendesk":
     case "project_kickoff":

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -1089,7 +1089,7 @@
  *           type: string
  *         origin:
  *           type: string
- *           enum: [web, project_kickoff, extension, agent_sidekick, api, cli, cli_programmatic, email, excel, gsheet, make, n8n, powerpoint, raycast, slack, slack_workflow, teams, transcript, triggered_programmatic, triggered, zapier, zendesk, onboarding_conversation]
+ *           enum: [web, project_kickoff, extension, agent_sidekick, api, cli, cli_programmatic, email, excel, gsheet, make, n8n, powerpoint, raycast, slack, slack_workflow, teams, transcript, triggered_programmatic, triggered, wakeup, zapier, zendesk, onboarding_conversation]
  *     PrivateReaction:
  *       type: object
  *       description: A reaction on a message.

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -11063,6 +11063,7 @@
               "transcript",
               "triggered_programmatic",
               "triggered",
+              "wakeup",
               "zapier",
               "zendesk",
               "onboarding_conversation"

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -104,6 +104,7 @@ export type UserMessageOrigin =
   | "transcript"
   | "triggered_programmatic"
   | "triggered"
+  | "wakeup"
   | "zapier"
   | "zendesk"
   // TODO onboarding_conversation, agent_sidekick, and project_kickoff aren't message origins. They

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -337,6 +337,7 @@ const USER_MESSAGE_ORIGINS = [
   "transcript",
   "triggered_programmatic",
   "triggered",
+  "wakeup",
   "web",
   "zapier",
   "zendesk",

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -8,6 +8,9 @@ Add the `wake_ups` table (migration), `WakeUpModel` Sequelize model, indexes on 
 `userId`, and `(workspaceId, status)`. Add `"wakeup"` to `UserMessageOrigin` union type and usage
 classification.
 
+Status: merged, including SDK / Swagger / observability updates for the new origin. Agent
+replies to wake-up messages are treated like regular unread replies for notifications.
+
 ### [x] PR 2 — WakeUpResource
 
 `WakeUpResource` wrapping the model: `makeNew`, `cancel`, `markFired`, `listByConversation`,


### PR DESCRIPTION
## Description

Add the new `"wakeup"` user message origin across `front` and the JS SDK.

This PR:
- adds `"wakeup"` to `UserMessageOrigin`
- classifies it as programmatic usage
- updates Swagger and SDK types
- adds observability labeling for the new origin
- keeps unread agent-reply notifications enabled for wake-up-origin conversations

## Tests

- Covered by some tests

## Risk

None. Additive sdk.

## Deploy Plan

- deploy `front`
