### PR TITLE
fix(sbx): create dust-fwd with bash shell in bedrock

### DIFF
--- a/dockerfiles/sandbox-bedrock.Dockerfile
+++ b/dockerfiles/sandbox-bedrock.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates curl git unzip xz-utils gnupg lsb-release netcat-openbsd nftables acl \
   && rm -rf /var/lib/apt/lists/*
 
-RUN useradd --system --no-create-home --uid 9990 --shell /usr/sbin/nologin dust-fwd \
+RUN useradd --system --no-create-home --uid 9990 --shell /bin/bash dust-fwd \
   && mkdir -p /etc/dust \
   && chmod 755 /etc/dust
 

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -60,7 +60,7 @@ describe("sandbox image registry", () => {
 
     expect(dockerfile).toContain("netcat-openbsd nftables acl");
     expect(dockerfile).toContain(
-      "useradd --system --no-create-home --uid 9990 --shell /usr/sbin/nologin dust-fwd"
+      "useradd --system --no-create-home --uid 9990 --shell /bin/bash dust-fwd"
     );
     expect(dockerfile).toContain("mkdir -p /etc/dust");
     expect(dockerfile).toContain("command -v sudo >/dev/null 2>&1");
@@ -73,11 +73,11 @@ describe("sandbox image registry", () => {
     if (imageResult.isOk()) {
       expect(imageResult.value.baseImage).toEqual({
         type: "docker",
-        imageRef: "dust-sbx-bedrock:1.6.0",
+        imageRef: "dust-sbx-bedrock:1.7.0",
       });
       expect(imageResult.value.imageId).toEqual({
         imageName: "dust-base",
-        tag: "0.7.10",
+        tag: "0.7.11",
       });
     }
   });

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -10,8 +10,8 @@ import { Err, Ok } from "@app/types/shared/result";
 import fs from "fs";
 import path from "path";
 
-const DUST_BEDROCK_IMAGE_VERSION = "1.6.0";
-const DUST_BASE_IMAGE_VERSION = "0.7.10";
+const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
+const DUST_BASE_IMAGE_VERSION = "0.7.11";
 const DSBX_CLI_VERSION = "0.1.4";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
@@ -113,8 +113,6 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
     user: "root",
   })
   .runCmd(getAgentProxiedSetupCommand(), { user: "root" })
-  // dust-fwd is created with nologin in bedrock; E2B exec needs a real shell.
-  .runCmd("usermod -s /bin/bash dust-fwd", { user: "root" })
   // Create simple netcat-based token server script.
   .runCmd("mkdir -p /home/agent/.bin", { user: "root" })
   // TODO(2026-03-06 SANDBOX): .copy is broken, use file once fixed.


### PR DESCRIPTION
## Description

The `usermod` approach added in #24617 consistently fails on E2B's template build infra. Moving the fix to the bedrock Dockerfile instead: create `dust-fwd` with `/bin/bash` from the start.

Changes:
- Bedrock Dockerfile: `--shell /usr/sbin/nologin` -> `--shell /bin/bash`
- registry.ts: remove `usermod` step, bump bedrock to 1.7.0, template to 0.7.11

## Deploy plan

1. Build and push bedrock image `dust-sbx-bedrock:1.7.0` via Sandbox Bedrock Release workflow
2. Merge this PR
3. Run Sandbox Image Registry workflow with `rebuild=true`

## Tests

Registry and egress unit tests updated and passing.