### PR TITLE
[front] - chore(analytics): tweak source chart

### DIFF
--- a/front/components/workspace/analytics/WorkspaceSourceChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSourceChart.tsx
@@ -1,5 +1,4 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
-import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
 import {
   buildSourceChartData,
   getSourceColor,
@@ -10,11 +9,108 @@ import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownlo
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import { useWorkspaceContextOrigin } from "@app/lib/swr/workspaces";
 import { isString } from "@app/types/shared/utils/general";
-import { Cell, Pie, PieChart, Tooltip } from "recharts";
+import { Bar, BarChart, LabelList, Tooltip, XAxis, YAxis } from "recharts";
 
 interface WorkspaceSourceChartProps {
   workspaceId: string;
   period: ObservabilityTimeRangeType;
+}
+
+const CARD_CHART_HEIGHT = 56;
+const BAR_MAX_SIZE = 40;
+const CORNER_RADIUS = 4;
+const SEGMENT_GAP = 2;
+const MIN_LABEL_SEGMENT_WIDTH = 32;
+
+// Recharts injects geometry props as `number | string`, so each field is
+// narrowed to `number` at render time.
+interface PercentLabelProps {
+  x?: number | string;
+  y?: number | string;
+  width?: number | string;
+  height?: number | string;
+  value?: number | string;
+  total: number;
+}
+
+function PercentLabel({
+  x,
+  y,
+  width,
+  height,
+  value,
+  total,
+}: PercentLabelProps) {
+  if (
+    typeof x !== "number" ||
+    typeof y !== "number" ||
+    typeof width !== "number" ||
+    typeof height !== "number" ||
+    typeof value !== "number" ||
+    total === 0 ||
+    width < MIN_LABEL_SEGMENT_WIDTH
+  ) {
+    return null;
+  }
+  return (
+    <text
+      x={x + width / 2}
+      y={y + height / 2}
+      textAnchor="middle"
+      dominantBaseline="central"
+      className="fill-white text-xs font-medium"
+    >
+      {Math.round((value / total) * 100)}%
+    </text>
+  );
+}
+
+interface SegmentShapeProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  fill?: string;
+  isFirst?: boolean;
+  isLast?: boolean;
+}
+
+function SegmentShape({
+  x,
+  y,
+  width,
+  height,
+  fill,
+  isFirst,
+  isLast,
+}: SegmentShapeProps) {
+  if (
+    typeof x !== "number" ||
+    typeof y !== "number" ||
+    typeof width !== "number" ||
+    typeof height !== "number"
+  ) {
+    return null;
+  }
+  const gap = isLast ? 0 : SEGMENT_GAP;
+  if (width - gap <= 0) {
+    return null;
+  }
+  const leftRadius = isFirst ? CORNER_RADIUS : 0;
+  const rightRadius = isLast ? CORNER_RADIUS : 0;
+  const right = x + width - gap;
+  const bottom = y + height;
+  const d =
+    `M ${x + leftRadius} ${y} ` +
+    `L ${right - rightRadius} ${y} ` +
+    `A ${rightRadius} ${rightRadius} 0 0 1 ${right} ${y + rightRadius} ` +
+    `L ${right} ${bottom - rightRadius} ` +
+    `A ${rightRadius} ${rightRadius} 0 0 1 ${right - rightRadius} ${bottom} ` +
+    `L ${x + leftRadius} ${bottom} ` +
+    `A ${leftRadius} ${leftRadius} 0 0 1 ${x} ${bottom - leftRadius} ` +
+    `L ${x} ${y + leftRadius} ` +
+    `A ${leftRadius} ${leftRadius} 0 0 1 ${x + leftRadius} ${y} Z`;
+  return <path d={d} fill={fill} />;
 }
 
 export function WorkspaceSourceChart({
@@ -31,6 +127,13 @@ export function WorkspaceSourceChart({
   const total = contextOrigin.total;
   const data = buildSourceChartData(contextOrigin.buckets, total);
 
+  // Pivot the breakdown into a single-row dataset so recharts renders a
+  // horizontal stacked bar (one segment per origin).
+  const chartData =
+    data.length > 0
+      ? [Object.fromEntries(data.map((d) => [d.origin, d.count]))]
+      : [];
+
   const legendItems = data.map((d) => ({
     key: d.label,
     label: d.label,
@@ -46,6 +149,13 @@ export function WorkspaceSourceChart({
 
   const controls = <CsvDownloadButton {...csvDownload} />;
 
+  const statusChip =
+    total > 0 ? (
+      <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        {total.toLocaleString()} messages
+      </span>
+    ) : null;
+
   return (
     <ChartContainer
       title="Source"
@@ -57,20 +167,28 @@ export function WorkspaceSourceChart({
       emptyMessage={
         data.length === 0 ? "No messages for this selection." : undefined
       }
-      height={CHART_HEIGHT}
+      height={CARD_CHART_HEIGHT}
       legendItems={legendItems}
+      statusChip={statusChip}
       additionalControls={controls}
     >
-      <PieChart>
+      <BarChart
+        data={chartData}
+        layout="vertical"
+        margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
+      >
+        <XAxis type="number" hide domain={[0, total]} />
+        <YAxis type="category" hide />
         <Tooltip
           isAnimationActive={false}
+          shared={false}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
           content={({ active, payload }) => {
             if (!active || data.length === 0) {
               return null;
             }
-            const rawOrigin = payload?.[0]?.payload?.origin;
+            const rawOrigin = payload?.[0]?.dataKey;
             const activeOrigin = isString(rawOrigin) ? rawOrigin : undefined;
             const rows = data.map((d) => ({
               key: d.origin,
@@ -94,41 +212,30 @@ export function WorkspaceSourceChart({
             boxShadow: "none",
           }}
         />
-        <Pie
-          data={data}
-          dataKey="count"
-          nameKey="origin"
-          innerRadius="60%"
-          outerRadius="80%"
-          minAngle={4}
-          paddingAngle={3}
-          strokeWidth={0}
-        >
-          {data.map((entry) => (
-            <Cell
-              key={entry.origin}
-              className={getSourceColor(entry.origin)}
-              fill="currentColor"
-            />
-          ))}
-        </Pie>
-        {total > 0 && (
-          <text
-            x="50%"
-            y="50%"
-            textAnchor="middle"
-            dominantBaseline="middle"
-            className="fill-foreground dark:fill-foreground-night"
+        {data.map((entry, idx) => (
+          <Bar
+            key={entry.origin}
+            dataKey={entry.origin}
+            stackId="source"
+            name={entry.label}
+            className={getSourceColor(entry.origin)}
+            fill="currentColor"
+            isAnimationActive={false}
+            maxBarSize={BAR_MAX_SIZE}
+            shape={
+              <SegmentShape
+                isFirst={idx === 0}
+                isLast={idx === data.length - 1}
+              />
+            }
           >
-            <tspan className="text-2xl font-semibold">
-              {total.toLocaleString()}
-            </tspan>
-            <tspan x="50%" dy="1.2em" className="text-sm">
-              Messages
-            </tspan>
-          </text>
-        )}
-      </PieChart>
+            <LabelList
+              dataKey={entry.origin}
+              content={<PercentLabel total={total} />}
+            />
+          </Bar>
+        ))}
+      </BarChart>
     </ChartContainer>
   );
 }

--- a/front/components/workspace/analytics/WorkspaceSourceChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSourceChart.tsx
@@ -16,11 +16,20 @@ interface WorkspaceSourceChartProps {
   period: ObservabilityTimeRangeType;
 }
 
-const CARD_CHART_HEIGHT = 56;
+const CARD_CHART_HEIGHT = 72;
 const BAR_MAX_SIZE = 40;
 const CORNER_RADIUS = 4;
-const SEGMENT_GAP = 2;
+const MIN_SEGMENT_WIDTH = 6;
 const MIN_LABEL_SEGMENT_WIDTH = 32;
+
+function getSegmentRadius(
+  index: number,
+  count: number
+): [number, number, number, number] {
+  const left = index === 0 ? CORNER_RADIUS : 0;
+  const right = index === count - 1 ? CORNER_RADIUS : 0;
+  return [left, right, right, left];
+}
 
 // Picks black or white text based on the Tailwind shade in `sourceColor`
 // (e.g. `text-emerald-300`). Dust's bar colors render at the same luminance in
@@ -78,54 +87,6 @@ function PercentLabel({
   );
 }
 
-interface SegmentShapeProps {
-  x?: number;
-  y?: number;
-  width?: number;
-  height?: number;
-  fill?: string;
-  isFirst?: boolean;
-  isLast?: boolean;
-}
-
-function SegmentShape({
-  x,
-  y,
-  width,
-  height,
-  fill,
-  isFirst,
-  isLast,
-}: SegmentShapeProps) {
-  if (
-    typeof x !== "number" ||
-    typeof y !== "number" ||
-    typeof width !== "number" ||
-    typeof height !== "number"
-  ) {
-    return null;
-  }
-  const gap = isLast ? 0 : SEGMENT_GAP;
-  if (width - gap <= 0) {
-    return null;
-  }
-  const leftRadius = isFirst ? CORNER_RADIUS : 0;
-  const rightRadius = isLast ? CORNER_RADIUS : 0;
-  const right = x + width - gap;
-  const bottom = y + height;
-  const d =
-    `M ${x + leftRadius} ${y} ` +
-    `L ${right - rightRadius} ${y} ` +
-    `A ${rightRadius} ${rightRadius} 0 0 1 ${right} ${y + rightRadius} ` +
-    `L ${right} ${bottom - rightRadius} ` +
-    `A ${rightRadius} ${rightRadius} 0 0 1 ${right - rightRadius} ${bottom} ` +
-    `L ${x + leftRadius} ${bottom} ` +
-    `A ${leftRadius} ${leftRadius} 0 0 1 ${x} ${bottom - leftRadius} ` +
-    `L ${x} ${y + leftRadius} ` +
-    `A ${leftRadius} ${leftRadius} 0 0 1 ${x + leftRadius} ${y} Z`;
-  return <path d={d} fill={fill} />;
-}
-
 export function WorkspaceSourceChart({
   workspaceId,
   period,
@@ -162,13 +123,6 @@ export function WorkspaceSourceChart({
 
   const controls = <CsvDownloadButton {...csvDownload} />;
 
-  const statusChip =
-    total > 0 ? (
-      <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        {total.toLocaleString()} messages
-      </span>
-    ) : null;
-
   return (
     <ChartContainer
       title="Source"
@@ -182,7 +136,6 @@ export function WorkspaceSourceChart({
       }
       height={CARD_CHART_HEIGHT}
       legendItems={legendItems}
-      statusChip={statusChip}
       additionalControls={controls}
     >
       <BarChart
@@ -235,12 +188,8 @@ export function WorkspaceSourceChart({
             fill="currentColor"
             isAnimationActive={false}
             maxBarSize={BAR_MAX_SIZE}
-            shape={
-              <SegmentShape
-                isFirst={idx === 0}
-                isLast={idx === data.length - 1}
-              />
-            }
+            minPointSize={MIN_SEGMENT_WIDTH}
+            radius={getSegmentRadius(idx, data.length)}
           >
             <LabelList
               dataKey={entry.origin}

--- a/front/components/workspace/analytics/WorkspaceSourceChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSourceChart.tsx
@@ -22,6 +22,17 @@ const CORNER_RADIUS = 4;
 const SEGMENT_GAP = 2;
 const MIN_LABEL_SEGMENT_WIDTH = 32;
 
+// Picks black or white text based on the Tailwind shade in `sourceColor`
+// (e.g. `text-emerald-300`). Dust's bar colors render at the same luminance in
+// light and dark mode, so a single class suffices.
+function getLabelFillClass(sourceColor: string): string {
+  const match = sourceColor.match(/text-[a-z]+-(\d+)/);
+  if (!match) {
+    return "fill-white";
+  }
+  return Number(match[1]) >= 500 ? "fill-white" : "fill-gray-950";
+}
+
 // Recharts injects geometry props as `number | string`, so each field is
 // narrowed to `number` at render time.
 interface PercentLabelProps {
@@ -31,6 +42,7 @@ interface PercentLabelProps {
   height?: number | string;
   value?: number | string;
   total: number;
+  fillClassName: string;
 }
 
 function PercentLabel({
@@ -40,6 +52,7 @@ function PercentLabel({
   height,
   value,
   total,
+  fillClassName,
 }: PercentLabelProps) {
   if (
     typeof x !== "number" ||
@@ -58,7 +71,7 @@ function PercentLabel({
       y={y + height / 2}
       textAnchor="middle"
       dominantBaseline="central"
-      className="fill-white text-xs font-medium"
+      className={`${fillClassName} text-xs font-medium`}
     >
       {Math.round((value / total) * 100)}%
     </text>
@@ -231,7 +244,14 @@ export function WorkspaceSourceChart({
           >
             <LabelList
               dataKey={entry.origin}
-              content={<PercentLabel total={total} />}
+              content={
+                <PercentLabel
+                  total={total}
+                  fillClassName={getLabelFillClass(
+                    getSourceColor(entry.origin)
+                  )}
+                />
+              }
             />
           </Bar>
         ))}


### PR DESCRIPTION
## Description

This PR refactors `WorkspaceSourceChart` to replace the pie chart with a horizontal stacked bar chart for improved readability. The new implementation displays source breakdown as a single-row stacked bar where each segment represents a different origin (web, Slack, API, etc.). Segment labels show percentages when the segment is wide enough, with automatic contrast adjustment (black or white text) based on the source color

<img width="1137" height="439" alt="Screenshot 2026-04-21 at 14 26 35" src="https://github.com/user-attachments/assets/7b5fb3d2-9ca3-46f2-b01d-671e305100d8" />

## Tests

- [x] Locally
- [x] front-edge

## Risk

Low risk. Visual change only, no data processing or API changes.

## Deploy Plan

Deploy front
