### PR TITLE
[Sessions] Support compaction from a source conversation

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2579,10 +2579,21 @@ export async function compactConversation(
   {
     conversation,
     model,
+    sourceConversationId,
+    sourceMessageRank,
   }: {
     conversation: ConversationType;
     model: SupportedModel;
-  }
+  } & (
+    | {
+        sourceConversationId?: undefined;
+        sourceMessageRank?: undefined;
+      }
+    | {
+        sourceConversationId: string;
+        sourceMessageRank: number;
+      }
+  )
 ): Promise<
   Result<{ compactionMessage: CompactionMessageType }, APIErrorWithStatusCode>
 > {
@@ -2696,12 +2707,18 @@ export async function compactConversation(
     { conversationId: conversation.sId }
   );
 
+  const sourceOverride =
+    sourceConversationId === undefined || sourceMessageRank === undefined
+      ? {}
+      : { sourceConversationId, sourceMessageRank };
+
   void launchCompactionWorkflow({
     auth,
     conversationId: conversation.sId,
     compactionMessageId: compactionMessage.sId,
     compactionMessageVersion: compactionMessage.version,
     model,
+    ...sourceOverride,
   });
 
   return new Ok({ compactionMessage });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2579,21 +2579,15 @@ export async function compactConversation(
   {
     conversation,
     model,
-    sourceConversationId,
-    sourceMessageRank,
+    sourceConversation,
   }: {
     conversation: ConversationType;
     model: SupportedModel;
-  } & (
-    | {
-        sourceConversationId?: undefined;
-        sourceMessageRank?: undefined;
-      }
-    | {
-        sourceConversationId: string;
-        sourceMessageRank: number;
-      }
-  )
+    sourceConversation?: {
+      conversationId: string;
+      messageRank: number;
+    };
+  }
 ): Promise<
   Result<{ compactionMessage: CompactionMessageType }, APIErrorWithStatusCode>
 > {
@@ -2707,18 +2701,13 @@ export async function compactConversation(
     { conversationId: conversation.sId }
   );
 
-  const sourceOverride =
-    sourceConversationId === undefined || sourceMessageRank === undefined
-      ? {}
-      : { sourceConversationId, sourceMessageRank };
-
   void launchCompactionWorkflow({
     auth,
     conversationId: conversation.sId,
     compactionMessageId: compactionMessage.sId,
     compactionMessageVersion: compactionMessage.version,
     model,
-    ...sourceOverride,
+    sourceConversation,
   });
 
   return new Ok({ compactionMessage });

--- a/front/temporal/agent_loop/activities/compaction.ts
+++ b/front/temporal/agent_loop/activities/compaction.ts
@@ -9,23 +9,17 @@ export async function compactionActivity(
     compactionMessageId,
     compactionMessageVersion,
     model,
-    sourceConversationId,
-    sourceMessageRank,
+    sourceConversation,
   }: {
     conversationId: string;
     compactionMessageId: string;
     compactionMessageVersion: number;
     model: SupportedModel;
-  } & (
-    | {
-        sourceConversationId?: undefined;
-        sourceMessageRank?: undefined;
-      }
-    | {
-        sourceConversationId: string;
-        sourceMessageRank: number;
-      }
-  )
+    sourceConversation?: {
+      conversationId: string;
+      messageRank: number;
+    };
+  }
 ): Promise<void> {
   const authResult = await Authenticator.fromJSON(authType);
   if (authResult.isErr()) {
@@ -34,17 +28,12 @@ export async function compactionActivity(
     );
   }
   const auth = authResult.value;
-  const sourceOverride =
-    sourceConversationId === undefined || sourceMessageRank === undefined
-      ? {}
-      : { sourceConversationId, sourceMessageRank };
-
   const compactionRes = await runCompaction(auth, {
     conversationId,
     compactionMessageId,
     compactionMessageVersion,
     model,
-    ...sourceOverride,
+    sourceConversation,
   });
 
   if (compactionRes.isErr()) {

--- a/front/temporal/agent_loop/activities/compaction.ts
+++ b/front/temporal/agent_loop/activities/compaction.ts
@@ -9,12 +9,23 @@ export async function compactionActivity(
     compactionMessageId,
     compactionMessageVersion,
     model,
+    sourceConversationId,
+    sourceMessageRank,
   }: {
     conversationId: string;
     compactionMessageId: string;
     compactionMessageVersion: number;
     model: SupportedModel;
-  }
+  } & (
+    | {
+        sourceConversationId?: undefined;
+        sourceMessageRank?: undefined;
+      }
+    | {
+        sourceConversationId: string;
+        sourceMessageRank: number;
+      }
+  )
 ): Promise<void> {
   const authResult = await Authenticator.fromJSON(authType);
   if (authResult.isErr()) {
@@ -23,12 +34,17 @@ export async function compactionActivity(
     );
   }
   const auth = authResult.value;
+  const sourceOverride =
+    sourceConversationId === undefined || sourceMessageRank === undefined
+      ? {}
+      : { sourceConversationId, sourceMessageRank };
 
   const compactionRes = await runCompaction(auth, {
     conversationId,
     compactionMessageId,
     compactionMessageVersion,
     model,
+    ...sourceOverride,
   });
 
   if (compactionRes.isErr()) {

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -119,24 +119,18 @@ export async function launchCompactionWorkflow({
   compactionMessageId,
   compactionMessageVersion,
   model,
-  sourceConversationId,
-  sourceMessageRank,
+  sourceConversation,
 }: {
   auth: Authenticator;
   conversationId: string;
   compactionMessageId: string;
   compactionMessageVersion: number;
   model: SupportedModel;
-} & (
-  | {
-      sourceConversationId?: undefined;
-      sourceMessageRank?: undefined;
-    }
-  | {
-      sourceConversationId: string;
-      sourceMessageRank: number;
-    }
-)): Promise<
+  sourceConversation?: {
+    conversationId: string;
+    messageRank: number;
+  };
+}): Promise<
   Result<undefined, Error | DustError<"compaction_already_running">>
 > {
   const authType = auth.toJSON();
@@ -147,11 +141,6 @@ export async function launchCompactionWorkflow({
     workspaceId,
     conversationId,
   });
-  const sourceOverride =
-    sourceConversationId === undefined || sourceMessageRank === undefined
-      ? {}
-      : { sourceConversationId, sourceMessageRank };
-
   try {
     await client.workflow.start(compactionWorkflow, {
       args: [
@@ -161,7 +150,7 @@ export async function launchCompactionWorkflow({
           compactionMessageId,
           compactionMessageVersion,
           model,
-          ...sourceOverride,
+          sourceConversation,
         },
       ],
       taskQueue: QUEUE_NAME,

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -119,13 +119,24 @@ export async function launchCompactionWorkflow({
   compactionMessageId,
   compactionMessageVersion,
   model,
+  sourceConversationId,
+  sourceMessageRank,
 }: {
   auth: Authenticator;
   conversationId: string;
   compactionMessageId: string;
   compactionMessageVersion: number;
   model: SupportedModel;
-}): Promise<
+} & (
+  | {
+      sourceConversationId?: undefined;
+      sourceMessageRank?: undefined;
+    }
+  | {
+      sourceConversationId: string;
+      sourceMessageRank: number;
+    }
+)): Promise<
   Result<undefined, Error | DustError<"compaction_already_running">>
 > {
   const authType = auth.toJSON();
@@ -136,6 +147,10 @@ export async function launchCompactionWorkflow({
     workspaceId,
     conversationId,
   });
+  const sourceOverride =
+    sourceConversationId === undefined || sourceMessageRank === undefined
+      ? {}
+      : { sourceConversationId, sourceMessageRank };
 
   try {
     await client.workflow.start(compactionWorkflow, {
@@ -146,6 +161,7 @@ export async function launchCompactionWorkflow({
           compactionMessageId,
           compactionMessageVersion,
           model,
+          ...sourceOverride,
         },
       ],
       taskQueue: QUEUE_NAME,

--- a/front/temporal/agent_loop/lib/compaction.test.ts
+++ b/front/temporal/agent_loop/lib/compaction.test.ts
@@ -91,8 +91,10 @@ describe("runCompaction", () => {
     const result = await compactConversation(auth, {
       conversation,
       model: MODEL,
-      sourceConversationId: "conv_source",
-      sourceMessageRank: 3,
+      sourceConversation: {
+        conversationId: "conv_source",
+        messageRank: 3,
+      },
     });
 
     expect(result.isOk()).toBe(true);
@@ -107,8 +109,10 @@ describe("runCompaction", () => {
           ? result.value.compactionMessage.version
           : undefined,
         model: MODEL,
-        sourceConversationId: "conv_source",
-        sourceMessageRank: 3,
+        sourceConversation: {
+          conversationId: "conv_source",
+          messageRank: 3,
+        },
       })
     );
   });
@@ -277,8 +281,10 @@ describe("runCompaction", () => {
       compactionMessageId: compactionMessage.sId,
       compactionMessageVersion: compactionMessage.version,
       model: MODEL,
-      sourceConversationId: sourceConversationWithoutContent.sId,
-      sourceMessageRank: 1,
+      sourceConversation: {
+        conversationId: sourceConversationWithoutContent.sId,
+        messageRank: 1,
+      },
     });
 
     expect(result.isOk()).toBe(true);

--- a/front/temporal/agent_loop/lib/compaction.test.ts
+++ b/front/temporal/agent_loop/lib/compaction.test.ts
@@ -3,6 +3,7 @@ import { compactConversation } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { Authenticator } from "@app/lib/auth";
 import { CompactionMessageModel } from "@app/lib/models/agent/conversation";
+import { launchCompactionWorkflow } from "@app/temporal/agent_loop/client";
 import { runCompaction } from "@app/temporal/agent_loop/lib/compaction";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -12,6 +13,7 @@ import type {
   CompactionMessageType,
   ConversationType,
 } from "@app/types/assistant/conversation";
+import { isCompactionMessageType } from "@app/types/assistant/conversation";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -69,9 +71,11 @@ describe("runCompaction", () => {
     vi.clearAllMocks();
   });
 
-  async function createCompactionMessage(): Promise<CompactionMessageType> {
+  async function createCompactionMessage(
+    targetConversation: ConversationType = conversation
+  ): Promise<CompactionMessageType> {
     const result = await compactConversation(auth, {
-      conversation,
+      conversation: targetConversation,
       model: MODEL,
     });
 
@@ -82,6 +86,32 @@ describe("runCompaction", () => {
 
     return result.value.compactionMessage;
   }
+
+  it("forwards source overrides when launching compaction", async () => {
+    const result = await compactConversation(auth, {
+      conversation,
+      model: MODEL,
+      sourceConversationId: "conv_source",
+      sourceMessageRank: 3,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(vi.mocked(launchCompactionWorkflow)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth,
+        conversationId: conversation.sId,
+        compactionMessageId: result.isOk()
+          ? result.value.compactionMessage.sId
+          : undefined,
+        compactionMessageVersion: result.isOk()
+          ? result.value.compactionMessage.version
+          : undefined,
+        model: MODEL,
+        sourceConversationId: "conv_source",
+        sourceMessageRank: 3,
+      })
+    );
+  });
 
   it("stores the run id before marking compaction as succeeded", async () => {
     const compactionMessage = await createCompactionMessage();
@@ -183,5 +213,101 @@ describe("runCompaction", () => {
     });
 
     expect(compactionMessageRow?.runIds).toEqual(["llm_trace_run_'quoted'"]);
+  });
+
+  it("summarizes a source snapshot into the target compaction message", async () => {
+    const sourceConversationWithoutContent = await ConversationFactory.create(
+      auth,
+      {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      }
+    );
+
+    await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: sourceConversationWithoutContent.id,
+      rank: 0,
+      content: "source before cutoff",
+    });
+    await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: sourceConversationWithoutContent.id,
+      rank: 1,
+      content: "source at cutoff",
+    });
+    await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: sourceConversationWithoutContent.id,
+      rank: 2,
+      content: "source after cutoff",
+    });
+
+    const compactionMessage = await createCompactionMessage();
+    let summarizedText: string | null = null;
+
+    vi.mocked(runMultiActionsAgent).mockImplementationOnce(
+      async (_auth, _config, input) => {
+        const firstMessage = input.conversation.messages[0];
+        const firstContent = firstMessage?.content?.[0];
+
+        if (
+          !firstContent ||
+          typeof firstContent === "string" ||
+          firstContent.type !== "text"
+        ) {
+          throw new Error("Expected compaction prompt text input");
+        }
+
+        summarizedText = firstContent.text;
+
+        return new Ok({
+          actions: [],
+          generation:
+            "<analysis>Scratchpad.</analysis><summary>Summary from source.</summary>",
+        });
+      }
+    );
+
+    const result = await runCompaction(auth, {
+      conversationId: conversation.sId,
+      compactionMessageId: compactionMessage.sId,
+      compactionMessageVersion: compactionMessage.version,
+      model: MODEL,
+      sourceConversationId: sourceConversationWithoutContent.sId,
+      sourceMessageRank: 1,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(summarizedText).toContain("source before cutoff");
+    expect(summarizedText).toContain("source at cutoff");
+    expect(summarizedText).not.toContain("source after cutoff");
+
+    const updatedCompactionMessageRow = await CompactionMessageModel.findOne({
+      where: {
+        id: compactionMessage.compactionMessageId,
+        workspaceId: workspace.id,
+      },
+    });
+    expect(updatedCompactionMessageRow?.status).toBe("succeeded");
+    expect(updatedCompactionMessageRow?.content).toBe("Summary from source.");
+
+    const sourceConversation = await getConversation(
+      auth,
+      sourceConversationWithoutContent.sId
+    );
+    expect(sourceConversation.isOk()).toBe(true);
+    if (sourceConversation.isErr()) {
+      return;
+    }
+
+    expect(
+      sourceConversation.value.content
+        .flat()
+        .some((message) => isCompactionMessageType(message))
+    ).toBe(false);
   });
 });

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -172,15 +172,9 @@ export async function runCompaction(
     conversationToSummarize = sourceConversationRes.value;
   }
 
-  if (sourceConversation) {
-    conversationToSummarize = filterConversationContentUpToRank(
-      conversationToSummarize,
-      sourceConversation.messageRank
-    );
-  }
-
   const summaryRes = await generateCompactionSummary(auth, {
     sourceConversation: conversationToSummarize,
+    sourceMessageRank: sourceConversation?.messageRank,
     targetConversationId: targetConversation.sId,
     compactionMessage,
     model,
@@ -246,11 +240,13 @@ async function generateCompactionSummary(
   auth: Authenticator,
   {
     sourceConversation,
+    sourceMessageRank,
     targetConversationId,
     compactionMessage,
     model,
   }: {
     sourceConversation: ConversationType;
+    sourceMessageRank?: number;
     targetConversationId: string;
     compactionMessage: CompactionMessageType;
     model: SupportedModel;
@@ -258,9 +254,17 @@ async function generateCompactionSummary(
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
+  const conversationToSummarize =
+    sourceMessageRank === undefined
+      ? sourceConversation
+      : filterConversationContentUpToRank(
+          sourceConversation,
+          sourceMessageRank
+        );
+
   // renderConversationAsText stops at the last succeeded compaction boundary by default and skips
   // running agent messages, producing exactly the messages that need to be summarized.
-  const renderedMessages = renderConversationAsText(sourceConversation, {
+  const renderedMessages = renderConversationAsText(conversationToSummarize, {
     includeTimestamps: true,
     includeActions: true,
     includeActionDetails: true,

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -68,41 +68,25 @@ function extractSummary(generation: string): string {
   return generation.replace(/<analysis>[\s\S]*?<\/analysis>/g, "").trim();
 }
 
-export async function runCompaction(
-  auth: Authenticator,
-  {
-    conversationId,
-    compactionMessageId,
-    compactionMessageVersion,
-    model,
-  }: {
-    conversationId: string;
-    compactionMessageId: string;
-    compactionMessageVersion: number;
-    model: SupportedModel;
-  }
-): Promise<Result<void, Error>> {
-  const owner = auth.getNonNullableWorkspace();
+function filterConversationContentUpToRank(
+  conversation: ConversationType,
+  maxRank: number
+): ConversationType {
+  return {
+    ...conversation,
+    content: conversation.content.filter((versions) => {
+      const latestVersion = versions[versions.length - 1];
+      return latestVersion ? latestVersion.rank <= maxRank : false;
+    }),
+  };
+}
 
-  const conversationRes = await getConversation(
-    auth,
-    conversationId,
-    false,
-    null,
-    PREVIOUS_INTERACTIONS_TO_PRESERVE + 1 // X previous + the last one
-  );
-  if (conversationRes.isErr()) {
-    return conversationRes;
-  }
-  const conversation = conversationRes.value;
-
-  let compactionMessage: CompactionMessageType | undefined;
-
-  for (
-    let i = conversation.content.length - 1;
-    i >= 0 && !compactionMessage;
-    i--
-  ) {
+function findCompactionMessage(
+  conversation: ConversationType,
+  compactionMessageId: string,
+  compactionMessageVersion: number
+): CompactionMessageType | undefined {
+  for (let i = conversation.content.length - 1; i >= 0; i--) {
     const messageGroup = conversation.content[i];
     for (const msg of messageGroup) {
       if (
@@ -110,11 +94,58 @@ export async function runCompaction(
         msg.sId === compactionMessageId &&
         msg.version === compactionMessageVersion
       ) {
-        compactionMessage = msg;
-        break;
+        return msg;
       }
     }
   }
+
+  return undefined;
+}
+
+export async function runCompaction(
+  auth: Authenticator,
+  {
+    conversationId,
+    compactionMessageId,
+    compactionMessageVersion,
+    model,
+    sourceConversationId,
+    sourceMessageRank,
+  }: {
+    conversationId: string;
+    compactionMessageId: string;
+    compactionMessageVersion: number;
+    model: SupportedModel;
+  } & (
+    | {
+        sourceConversationId?: undefined;
+        sourceMessageRank?: undefined;
+      }
+    | {
+        sourceConversationId: string;
+        sourceMessageRank: number;
+      }
+  )
+): Promise<Result<void, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const targetConversationRes = await getConversation(
+    auth,
+    conversationId,
+    false,
+    null,
+    PREVIOUS_INTERACTIONS_TO_PRESERVE + 1 // X previous + the last one
+  );
+  if (targetConversationRes.isErr()) {
+    return targetConversationRes;
+  }
+  const targetConversation = targetConversationRes.value;
+
+  const compactionMessage = findCompactionMessage(
+    targetConversation,
+    compactionMessageId,
+    compactionMessageVersion
+  );
 
   if (!compactionMessage) {
     return new Err(new Error("Compaction message not found"));
@@ -128,8 +159,32 @@ export async function runCompaction(
     );
   }
 
+  let sourceConversation = targetConversation;
+  if (sourceConversationId && sourceConversationId !== conversationId) {
+    const sourceConversationRes = await getConversation(
+      auth,
+      sourceConversationId,
+      false,
+      null,
+      PREVIOUS_INTERACTIONS_TO_PRESERVE + 1
+    );
+    if (sourceConversationRes.isErr()) {
+      return sourceConversationRes;
+    }
+
+    sourceConversation = sourceConversationRes.value;
+  }
+
+  if (sourceMessageRank !== undefined) {
+    sourceConversation = filterConversationContentUpToRank(
+      sourceConversation,
+      sourceMessageRank
+    );
+  }
+
   const summaryRes = await generateCompactionSummary(auth, {
-    conversation,
+    sourceConversation,
+    targetConversationId: targetConversation.sId,
     compactionMessage,
     model,
   });
@@ -142,7 +197,13 @@ export async function runCompaction(
     status = "succeeded";
 
     logger.info(
-      { workspaceId: owner.sId, conversationId, compactionMessageId, status },
+      {
+        workspaceId: owner.sId,
+        conversationId,
+        sourceConversationId,
+        compactionMessageId,
+        status,
+      },
       "Compaction generation succeeded"
     );
   } else {
@@ -153,6 +214,7 @@ export async function runCompaction(
       {
         workspaceId: owner.sId,
         conversationId,
+        sourceConversationId,
         compactionMessageId,
         error: summaryRes.error,
       },
@@ -161,7 +223,7 @@ export async function runCompaction(
   }
 
   const result = await updateCompactionMessageWithContentAndFinalStatus(auth, {
-    conversation,
+    conversation: targetConversation,
     compactionMessage,
     status,
     content,
@@ -177,7 +239,7 @@ export async function runCompaction(
       messageId: compactionMessage.sId,
       message: compactionMessage,
     },
-    { conversationId }
+    { conversationId: targetConversation.sId }
   );
 
   return new Ok(undefined);
@@ -186,11 +248,13 @@ export async function runCompaction(
 async function generateCompactionSummary(
   auth: Authenticator,
   {
-    conversation,
+    sourceConversation,
+    targetConversationId,
     compactionMessage,
     model,
   }: {
-    conversation: ConversationType;
+    sourceConversation: ConversationType;
+    targetConversationId: string;
     compactionMessage: CompactionMessageType;
     model: SupportedModel;
   }
@@ -199,7 +263,7 @@ async function generateCompactionSummary(
 
   // renderConversationAsText stops at the last succeeded compaction boundary by default and skips
   // running agent messages, producing exactly the messages that need to be summarized.
-  const renderedMessages = renderConversationAsText(conversation, {
+  const renderedMessages = renderConversationAsText(sourceConversation, {
     includeTimestamps: true,
     includeActions: true,
     includeActionDetails: true,
@@ -244,7 +308,7 @@ async function generateCompactionSummary(
     {
       context: {
         operationType: "compaction",
-        conversationId: conversation.sId,
+        conversationId: targetConversationId,
         userId: auth.user()?.sId,
         workspaceId: owner.sId,
       },

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -109,23 +109,17 @@ export async function runCompaction(
     compactionMessageId,
     compactionMessageVersion,
     model,
-    sourceConversationId,
-    sourceMessageRank,
+    sourceConversation,
   }: {
     conversationId: string;
     compactionMessageId: string;
     compactionMessageVersion: number;
     model: SupportedModel;
-  } & (
-    | {
-        sourceConversationId?: undefined;
-        sourceMessageRank?: undefined;
-      }
-    | {
-        sourceConversationId: string;
-        sourceMessageRank: number;
-      }
-  )
+    sourceConversation?: {
+      conversationId: string;
+      messageRank: number;
+    };
+  }
 ): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
@@ -159,11 +153,14 @@ export async function runCompaction(
     );
   }
 
-  let sourceConversation = targetConversation;
-  if (sourceConversationId && sourceConversationId !== conversationId) {
+  let conversationToSummarize = targetConversation;
+  if (
+    sourceConversation &&
+    sourceConversation.conversationId !== conversationId
+  ) {
     const sourceConversationRes = await getConversation(
       auth,
-      sourceConversationId,
+      sourceConversation.conversationId,
       false,
       null,
       PREVIOUS_INTERACTIONS_TO_PRESERVE + 1
@@ -172,18 +169,18 @@ export async function runCompaction(
       return sourceConversationRes;
     }
 
-    sourceConversation = sourceConversationRes.value;
+    conversationToSummarize = sourceConversationRes.value;
   }
 
-  if (sourceMessageRank !== undefined) {
-    sourceConversation = filterConversationContentUpToRank(
-      sourceConversation,
-      sourceMessageRank
+  if (sourceConversation) {
+    conversationToSummarize = filterConversationContentUpToRank(
+      conversationToSummarize,
+      sourceConversation.messageRank
     );
   }
 
   const summaryRes = await generateCompactionSummary(auth, {
-    sourceConversation,
+    sourceConversation: conversationToSummarize,
     targetConversationId: targetConversation.sId,
     compactionMessage,
     model,
@@ -200,7 +197,7 @@ export async function runCompaction(
       {
         workspaceId: owner.sId,
         conversationId,
-        sourceConversationId,
+        sourceConversationId: sourceConversation?.conversationId,
         compactionMessageId,
         status,
       },
@@ -214,7 +211,7 @@ export async function runCompaction(
       {
         workspaceId: owner.sId,
         conversationId,
-        sourceConversationId,
+        sourceConversationId: sourceConversation?.conversationId,
         compactionMessageId,
         error: summaryRes.error,
       },

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -141,18 +141,35 @@ export async function compactionWorkflow({
   compactionMessageId,
   compactionMessageVersion,
   model,
+  sourceConversationId,
+  sourceMessageRank,
 }: {
   authType: AuthenticatorType;
   conversationId: string;
   compactionMessageId: string;
   compactionMessageVersion: number;
   model: SupportedModel;
-}) {
+} & (
+  | {
+      sourceConversationId?: undefined;
+      sourceMessageRank?: undefined;
+    }
+  | {
+      sourceConversationId: string;
+      sourceMessageRank: number;
+    }
+)) {
+  const sourceOverride =
+    sourceConversationId === undefined || sourceMessageRank === undefined
+      ? {}
+      : { sourceConversationId, sourceMessageRank };
+
   await compactionActivity(authType, {
     conversationId,
     compactionMessageId,
     compactionMessageVersion,
     model,
+    ...sourceOverride,
   });
 }
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -141,35 +141,24 @@ export async function compactionWorkflow({
   compactionMessageId,
   compactionMessageVersion,
   model,
-  sourceConversationId,
-  sourceMessageRank,
+  sourceConversation,
 }: {
   authType: AuthenticatorType;
   conversationId: string;
   compactionMessageId: string;
   compactionMessageVersion: number;
   model: SupportedModel;
-} & (
-  | {
-      sourceConversationId?: undefined;
-      sourceMessageRank?: undefined;
-    }
-  | {
-      sourceConversationId: string;
-      sourceMessageRank: number;
-    }
-)) {
-  const sourceOverride =
-    sourceConversationId === undefined || sourceMessageRank === undefined
-      ? {}
-      : { sourceConversationId, sourceMessageRank };
-
+  sourceConversation?: {
+    conversationId: string;
+    messageRank: number;
+  };
+}) {
   await compactionActivity(authType, {
     conversationId,
     compactionMessageId,
     compactionMessageVersion,
     model,
-    ...sourceOverride,
+    sourceConversation,
   });
 }
 

--- a/x/pr/branching.md
+++ b/x/pr/branching.md
@@ -85,18 +85,21 @@ The target design uses the compaction flow from the parallel compaction proposal
 - the child remains blocked for posting while the initial compaction is in the
   `created` state
 
-Until compaction ships, the fork flow can use an artificial compaction
-placeholder internally. That placeholder reuses the rendered
-conversation-for-model view at the resolved source message of the parent
-conversation and stores it as the initial message in the child, explicitly
-stating that it is a forked starting point.
+This now lands in 3 steps:
+
+1. refactor compaction so the existing workflow can keep the compaction message
+   and SSE on a target conversation while summarizing a separate source
+   conversation snapshot
+2. switch fork creation from the placeholder message to a real child-side
+   compaction that targets the parent conversation at the resolved source rank
+3. refine model selection so fork compaction uses the source agent message
+   model instead of the default fallback
 
 Compaction happens after the fork is created. We never compact the
 parent conversation as part of the fork action.
 
-This placeholder path exists only to unblock internal development and
-integration work while compaction is still in flight. Before release, fork
-initialization switches to the shipped compaction flow.
+Until step 2 lands, the fork flow continues to use the temporary placeholder
+message that states the conversation was forked.
 
 #### 3. Filesystem and File Seeding
 
@@ -279,20 +282,26 @@ Scope:
 - add the lightweight "XXX branched this conversation: " UI in the parent conversation
 - wire the UI to the backend endpoint
 
-#### 5: Switch Fork Initialization to Shipped Compaction
+#### 5: Replace the Placeholder with Child-Side Compaction
 
 Scope:
 
-- switch the fork initialization seam from the artificial placeholder to the
-  shipped compaction flow
-- keep the same fork API and lineage model
+- PR 1: refactor `compactConversation` so the existing workflow can summarize
+  a source conversation snapshot into a compaction message owned by another
+  target conversation
+- PR 2: create that compaction message in the child during fork creation and
+  summarize the parent conversation up to the resolved source message rank
+- PR 3: refine model selection so fork compaction uses the source agent
+  message model instead of the current default
 
 Why separate:
 
-- compaction is already being developed independently
-- this keeps the forking work moving internally without blocking on compaction
-  shipping
-- this is the release gate for broad exposure of the feature
+- the compaction refactor is independently useful and lower risk than changing
+  fork creation at the same time
+- the fork integration stays small once the workflow already supports separate
+  source and target conversations
+- model selection is not product-critical for the first internal rollout and
+  can follow after the functional child-side compaction path exists
 
 ### Non-Goals for the First Version
 


### PR DESCRIPTION
## Description
Follows the sessions branching work.

This refactors the existing compaction path so a compaction message can stay on a target conversation while summarizing a separate source conversation snapshot, optionally cut at a source rank. Normal compaction still uses the target conversation as its source; the public compaction API stays unchanged. It also updates [x/pr/branching.md](x/pr/branching.md) with the 3-step plan for replacing the temporary fork placeholder with child-side compaction.

## Risks
Blast radius: compaction workflow launch/execution and the upcoming fork initialization seam
Risk: standard

## Deploy Plan
- deploy front

## Tests
- [x] `NODE_ENV=test npm run test -- temporal/agent_loop/lib/compaction.test.ts`
