### PR TITLE
[Sessions] Centralize conversation display titles

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -30,6 +30,7 @@ import type {
   ConversationError,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
+import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
 import { isString } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import { ResizablePanel, ResizablePanelGroup } from "@dust-tt/sparkle";
@@ -111,8 +112,8 @@ const ConversationLayoutContent = ({
     // Focus back on input bar
   };
 
-  const pageTitle = conversation?.title
-    ? `Dust - ${conversation.title}`
+  const pageTitle = conversation
+    ? `Dust - ${getConversationDisplayTitle(conversation)}`
     : "Dust - New Conversation";
 
   const navChildren = useMemo(

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -28,8 +28,9 @@ import {
   getProjectRoute,
   setQueryParam,
 } from "@app/lib/utils/router";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import {
+  type ConversationWithoutContentType,
+  getConversationDisplayTitle,
   getConversationUrlAccessMode,
   isProjectConversation,
 } from "@app/types/assistant/conversation";
@@ -357,8 +358,9 @@ export function ConversationMenu({
         onClose={() => setShowRenameDialog(false)}
         owner={owner}
         conversationId={activeConversationId}
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        currentTitle={conversation?.title || ""}
+        currentTitle={
+          conversation ? getConversationDisplayTitle(conversation) : ""
+        }
       />
       <DropdownMenu modal={false} open={isOpen} onOpenChange={onOpenChange}>
         {triggerPosition ? (

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -11,6 +11,7 @@ import { useAppRouter } from "@app/lib/platform";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getConversationRoute, getProjectRoute } from "@app/lib/utils/router";
+import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
 import {
@@ -53,7 +54,9 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     handleMenuOpenChange,
   } = useConversationMenu();
 
-  const currentTitle = conversation?.title ?? "";
+  const currentTitle = conversation
+    ? getConversationDisplayTitle(conversation)
+    : "";
 
   if (!activeConversationId) {
     return null;

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -47,7 +47,10 @@ import {
   getProjectRoute,
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import {
+  type ConversationWithoutContentType,
+  getConversationDisplayTitle,
+} from "@app/types/assistant/conversation";
 import type { ProjectType, SpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import { isBuilder } from "@app/types/user";
@@ -90,7 +93,6 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import moment from "moment";
 import {
   memo,
   useCallback,
@@ -1224,11 +1226,7 @@ const ConversationListItem = memo(
       handleMenuOpenChange,
     } = useConversationMenu();
 
-    const conversationLabel =
-      conversation.title ??
-      (moment(conversation.created).isSame(moment(), "day")
-        ? "New Conversation"
-        : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`);
+    const conversationLabel = getConversationDisplayTitle(conversation);
 
     const handleDragStart = useCallback(
       (e: React.DragEvent) => {

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -1,10 +1,11 @@
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { LightConversationType } from "@app/types/assistant/conversation";
 import {
+  getConversationDisplayTitle,
   isCompactionMessageType,
   isLightAgentMessageType,
   isUserMessageTypeWithContentFragments,
+  type LightConversationType,
 } from "@app/types/assistant/conversation";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { stripMarkdown } from "@app/types/shared/utils/string_utils";
@@ -93,11 +94,7 @@ export function SpaceConversationListItem({
     return null;
   }
 
-  const conversationLabel =
-    conversation.title ??
-    (moment(conversation.created).isSame(moment(), "day")
-      ? "New Conversation"
-      : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`);
+  const conversationLabel = getConversationDisplayTitle(conversation);
 
   const time = moment(conversation.updated).fromNow();
 

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -18,6 +18,7 @@ import type {
   ConversationWithoutContentType,
   LightConversationType,
 } from "@app/types/assistant/conversation";
+import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
@@ -213,10 +214,7 @@ export function SpaceConversationsTab({
                     displayItemCount={true}
                     renderItem={(conversation, selected) => {
                       const conversationLabel =
-                        conversation.title ??
-                        (moment(conversation.created).isSame(moment(), "day")
-                          ? "New Conversation"
-                          : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`);
+                        getConversationDisplayTitle(conversation);
                       const time = moment(conversation.updated).fromNow();
 
                       return (

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -7,7 +7,10 @@ import type {
   UserMessageType,
   UserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
-import { isReinforcedSkillNotificationMetadata } from "@app/types/assistant/conversation";
+import {
+  getConversationDisplayTitle,
+  isReinforcedSkillNotificationMetadata,
+} from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import moment from "moment";
 
@@ -48,7 +51,9 @@ export function getGroupConversationsByUnreadAndActionRequired(
             titleFilter &&
             !subFilter(
               removeDiacritics(titleFilter).toLowerCase(),
-              removeDiacritics(conversation.title ?? "").toLowerCase()
+              removeDiacritics(
+                getConversationDisplayTitle(conversation)
+              ).toLowerCase()
             )
           ) {
             return acc;
@@ -106,7 +111,9 @@ export function getGroupConversationsByDate({
       titleFilter &&
       !subFilter(
         removeDiacritics(titleFilter).toLowerCase(),
-        removeDiacritics(conversation.title ?? "").toLowerCase()
+        removeDiacritics(
+          getConversationDisplayTitle(conversation)
+        ).toLowerCase()
       )
     ) {
       return;

--- a/front/hooks/useMoveConversationOutOfProject.tsx
+++ b/front/hooks/useMoveConversationOutOfProject.tsx
@@ -7,7 +7,10 @@ import {
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import {
+  type ConversationWithoutContentType,
+  getConversationDisplayTitle,
+} from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useContext } from "react";
 
@@ -37,9 +40,9 @@ export function useMoveConversationOutOfProject(
         title: "Remove from project?",
         message: (
           <div>
-            <strong>{conversation.title}</strong> will be removed from the
-            project. Participants who no longer have access to the required
-            spaces will be removed from the conversation.
+            <strong>{getConversationDisplayTitle(conversation)}</strong> will be
+            removed from the project. Participants who no longer have access to
+            the required spaces will be removed from the conversation.
           </div>
         ),
         validateLabel: "Remove",

--- a/front/hooks/useMoveConversationToProject.tsx
+++ b/front/hooks/useMoveConversationToProject.tsx
@@ -6,7 +6,10 @@ import {
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import {
+  type ConversationWithoutContentType,
+  getConversationDisplayTitle,
+} from "@app/types/assistant/conversation";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useContext } from "react";
@@ -32,8 +35,9 @@ export function useMoveConversationToProject(owner: LightWorkspaceType) {
         message: (
           <div>
             The content of the conversation{" "}
-            <strong>{conversation.title}</strong> will be available to all
-            members of the project <strong>{space.name}</strong>.
+            <strong>{getConversationDisplayTitle(conversation)}</strong> will be
+            available to all members of the project{" "}
+            <strong>{space.name}</strong>.
           </div>
         ),
         validateLabel: "Move",

--- a/front/lib/notifications/workflows/agent-message-feedback.ts
+++ b/front/lib/notifications/workflows/agent-message-feedback.ts
@@ -12,6 +12,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
+import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
 import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -74,7 +75,7 @@ const getFeedbackDetails = async ({
 
     if (conversation) {
       workspaceName = auth.getNonNullableWorkspace().name;
-      conversationTitle = conversation.title ?? "Dust conversation";
+      conversationTitle = getConversationDisplayTitle(conversation.toJSON());
 
       const userWhoGaveFeedback = await UserResource.fetchById(
         payload.userWhoGaveFeedbackId

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -30,6 +30,7 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import {
   ConversationError,
+  getConversationDisplayTitle,
   isCompactionMessageType,
   isLightAgentMessageType,
   isProjectConversation,
@@ -217,7 +218,7 @@ const getConversationDetails = async ({
   const conversation = conversationRes.value;
 
   const workspaceName = auth.getNonNullableWorkspace().name;
-  const subject = conversation.title ?? "Dust conversation";
+  const subject = getConversationDisplayTitle(conversation);
   const isFromTrigger = !!conversation.triggerId;
 
   // Retrieve the message that triggered the notification.
@@ -613,7 +614,7 @@ const generateUnreadMessagesSummary = async ({
 
   const preamble = [
     `Conversation: ${conversation.sId}`,
-    `Title: ${conversation.title ?? "Untitled Conversation"}`,
+    `Title: ${getConversationDisplayTitle(conversation)}`,
     `Created: ${new Date(conversation.created).toISOString()}`,
     `Updated: ${new Date(conversation.updated).toISOString()}`,
     `Unread: ${conversation.unread}`,

--- a/front/types/assistant/conversation.test.ts
+++ b/front/types/assistant/conversation.test.ts
@@ -1,0 +1,44 @@
+import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
+import { describe, expect, it } from "vitest";
+
+describe("getConversationDisplayTitle", () => {
+  const now = new Date("2026-04-20T12:00:00Z");
+
+  it("returns the persisted title when present", () => {
+    expect(
+      getConversationDisplayTitle(
+        {
+          title: "Weekly planning",
+          created: now.getTime(),
+        },
+        now
+      )
+    ).toBe("Weekly planning");
+  });
+
+  it("returns the new conversation fallback on the same day", () => {
+    expect(
+      getConversationDisplayTitle(
+        {
+          title: null,
+          created: now.getTime(),
+        },
+        now
+      )
+    ).toBe("New Conversation");
+  });
+
+  it("keeps the existing fallback for untitled non-fork conversations", () => {
+    expect(
+      getConversationDisplayTitle(
+        {
+          title: null,
+          created: new Date("2026-04-19T12:00:00Z").getTime(),
+        },
+        now
+      )
+    ).toBe(
+      `Conversation from ${new Date("2026-04-19T12:00:00Z").toLocaleDateString()}`
+    );
+  });
+});

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -468,10 +468,6 @@ type ConversationDisplayTitleInput = Pick<
   "created" | "title"
 >;
 
-function isSameLocalDay(timestamp: number, now: Date): boolean {
-  return moment(timestamp).isSame(now, "day");
-}
-
 export function getConversationDisplayTitle(
   conversation: ConversationDisplayTitleInput,
   now = new Date()
@@ -480,7 +476,7 @@ export function getConversationDisplayTitle(
     return conversation.title;
   }
 
-  return isSameLocalDay(conversation.created, now)
+  return moment(conversation.created).isSame(now, "day")
     ? "New Conversation"
     : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`;
 }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -3,7 +3,7 @@ import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_act
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
-
+import moment from "moment";
 import type { ContentFragmentType } from "../content_fragment";
 import type { AllSupportedWithDustSpecificFileContentType } from "../files";
 import type { ModelId } from "../shared/model_id";
@@ -462,6 +462,28 @@ export type ConversationWithoutContentType = {
   // Ideally, this property should be moved to the ConversationType.
   requestedSpaceIds: string[];
 };
+
+type ConversationDisplayTitleInput = Pick<
+  ConversationWithoutContentType,
+  "created" | "title"
+>;
+
+function isSameLocalDay(timestamp: number, now: Date): boolean {
+  return moment(timestamp).isSame(now, "day");
+}
+
+export function getConversationDisplayTitle(
+  conversation: ConversationDisplayTitleInput,
+  now = new Date()
+): string {
+  if (conversation.title) {
+    return conversation.title;
+  }
+
+  return isSameLocalDay(conversation.created, now)
+    ? "New Conversation"
+    : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`;
+}
 
 /**
  * content [][] structure is intended to allow retries (of agent messages) or edits (of user


### PR DESCRIPTION
## Description
Centralizes the existing conversation title fallback logic in a shared helper and reusing it across the main UI and notification copy.

Prepares for follow-up PR for titling forked conversations

## Risks
Blast radius: conversation labels and subjects in front.
Risk: low

## Deploy Plan
- deploy front