### PR TITLE
fix: react error rendering frames

### DIFF
--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -429,7 +429,9 @@ export function FrameRenderer({
           onClose={conversation ? onClosePanel : undefined}
         />
         <CenteredState>
-          <p className="text-warning-500">Error loading file: {error}</p>
+          <p className="text-warning-500">
+            Error loading file: {error.message}
+          </p>
         </CenteredState>
       </div>
     );

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -20,6 +20,7 @@ import type {
   FileTypeWithMetadata,
   SharingGrantType,
 } from "@app/types/files";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher, SWRConfiguration } from "swr";
 
@@ -213,14 +214,21 @@ export function useFileContent({
     async (url: string) => {
       // Use custom fetcher to parse as text.
       const response = await clientFetch(url);
-
+      if (!response.ok) {
+        const errorData = await getErrorFromResponse(response);
+        throw new Error(errorData.message);
+      }
       return response.text();
     },
     { disabled: !fileId || config?.disabled, ...config }
   );
 
+  // SWR's error can be an Error object, which React cannot render as a child.
+  // Normalize it to so FrameRenderer can safely render it.
+  const normalizedError = error ? normalizeError(error) : null;
+
   return {
-    error,
+    error: normalizedError,
     fileContent: data,
     isFileContentLoading: !error && !data && !config?.disabled,
     mutateFileContent: mutate,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7692

This PR fixes a React error that occurred when attempting to render Error objects as children in the FrameRenderer component.

- Updated `useFileContent` hook to normalize SWR errors before returning them
- Modified `FrameRenderer.tsx` to render `error.message` instead of the raw error object

## Tests

Manually

## Risks

Low risk. This is a defensive fix to prevent React errors when displaying file loading errors. The change ensures errors are always in a renderable format.

## Deploy Plan

Standard deployment. No special considerations needed.
