### PR TITLE
Require user context for wake ups

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -774,9 +774,7 @@ async function batchRenderCompactionMessages(
         "Unreachable: batchRenderCompactionMessages has been filtered on compaction message"
       );
     }
-
     const compactionMessage = m.compactionMessage;
-
     return {
       type: "compaction_message" as const,
       id: m.id,

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -8,6 +8,7 @@ import {
   getCoTDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
 import {
+  CompactionMessageModel,
   MentionModel,
   MessageModel,
   UserMessageModel,
@@ -769,6 +770,7 @@ async function batchRenderCompactionMessages(
   const compactionMessages = messages.filter((m) => !!m.compactionMessage);
 
   return compactionMessages.map((m) => {
+<<<<<<< Updated upstream
     if (!m.compactionMessage) {
       throw new Error(
         "Unreachable: batchRenderCompactionMessages has been filtered on compaction message"
@@ -779,14 +781,26 @@ async function batchRenderCompactionMessages(
       type: "compaction_message" as const,
       id: m.id,
       compactionMessageId: compactionMessage.id,
+=======
+    const cm = m.compactionMessage!;
+    return {
+      type: "compaction_message" as const,
+      id: m.id,
+      compactionMessageId: cm.id,
+>>>>>>> Stashed changes
       sId: m.sId,
       created: m.createdAt.getTime(),
       visibility: m.visibility,
       version: m.version,
       rank: m.rank,
       branchId: m.getBranchId(),
+<<<<<<< Updated upstream
       status: compactionMessage.status,
       content: compactionMessage.content,
+=======
+      status: cm.status,
+      content: cm.content,
+>>>>>>> Stashed changes
     };
   });
 }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -8,7 +8,6 @@ import {
   getCoTDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
 import {
-  CompactionMessageModel,
   MentionModel,
   MessageModel,
   UserMessageModel,
@@ -770,37 +769,26 @@ async function batchRenderCompactionMessages(
   const compactionMessages = messages.filter((m) => !!m.compactionMessage);
 
   return compactionMessages.map((m) => {
-<<<<<<< Updated upstream
     if (!m.compactionMessage) {
       throw new Error(
         "Unreachable: batchRenderCompactionMessages has been filtered on compaction message"
       );
     }
+
     const compactionMessage = m.compactionMessage;
+
     return {
       type: "compaction_message" as const,
       id: m.id,
       compactionMessageId: compactionMessage.id,
-=======
-    const cm = m.compactionMessage!;
-    return {
-      type: "compaction_message" as const,
-      id: m.id,
-      compactionMessageId: cm.id,
->>>>>>> Stashed changes
       sId: m.sId,
       created: m.createdAt.getTime(),
       visibility: m.visibility,
       version: m.version,
       rank: m.rank,
       branchId: m.getBranchId(),
-<<<<<<< Updated upstream
       status: compactionMessage.status,
       content: compactionMessage.content,
-=======
-      status: cm.status,
-      content: cm.content,
->>>>>>> Stashed changes
     };
   });
 }

--- a/front/lib/resources/storage/models/wakeup.ts
+++ b/front/lib/resources/storage/models/wakeup.ts
@@ -15,7 +15,7 @@ export class WakeUpModel extends WorkspaceAwareModel<WakeUpModel> {
   declare updatedAt: CreationOptional<Date>;
 
   declare conversationId: ForeignKey<ConversationModel["id"]>;
-  declare userId: ForeignKey<UserModel["id"]> | null;
+  declare userId: ForeignKey<UserModel["id"]>;
   declare agentConfigurationId: ForeignKey<AgentConfigurationModel["sId"]>;
   declare scheduleType: WakeUpScheduleType;
   declare fireAt: Date | null;
@@ -48,7 +48,7 @@ WakeUpModel.init(
     },
     userId: {
       type: DataTypes.BIGINT,
-      allowNull: true,
+      allowNull: false,
       references: {
         model: UserModel,
         key: "id",
@@ -125,10 +125,10 @@ WakeUpModel.belongsTo(ConversationModel, {
 });
 
 UserModel.hasMany(WakeUpModel, {
-  foreignKey: { name: "userId", allowNull: true },
+  foreignKey: { name: "userId", allowNull: false },
   onDelete: "RESTRICT",
 });
 
 WakeUpModel.belongsTo(UserModel, {
-  foreignKey: { name: "userId", allowNull: true },
+  foreignKey: { name: "userId", allowNull: false },
 });

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -95,12 +95,13 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<WakeUpResource, Error>> {
     const { scheduleType, fireAt, cronExpression, cronTimezone, reason } = blob;
+    const user = auth.getNonNullableUser();
 
     const row = await this.model.create(
       {
         workspaceId: auth.getNonNullableWorkspace().id,
         conversationId: conversation.id,
-        userId: auth.user()?.id ?? null,
+        userId: user.id,
         agentConfigurationId: agentConfiguration.sId,
         status: "scheduled",
         fireCount: 0,

--- a/front/migrations/db/migration_595.sql
+++ b/front/migrations/db/migration_595.sql
@@ -1,0 +1,3 @@
+-- Migration created on Apr 21, 2026
+DELETE FROM "wake_ups" WHERE "userId" IS NULL;
+ALTER TABLE "wake_ups" ALTER COLUMN "userId" SET NOT NULL;

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -5,7 +5,8 @@
 ### [x] PR 1 — WakeUpModel + migration
 
 Add the `wake_ups` table (migration), `WakeUpModel` Sequelize model, indexes on `conversationId`,
-`userId`, and `(workspaceId, status)`. Add `"wakeup"` to `UserMessageOrigin` union type and usage
+`userId`, and `(workspaceId, status)`. Require `userId` to be non-null so wake-ups can only be
+created in a user context. Add `"wakeup"` to `UserMessageOrigin` union type and usage
 classification.
 
 ### [x] PR 2 — WakeUpResource
@@ -52,9 +53,8 @@ legacy `agent_action.ts` registry.
 
 ### PR 6 — Conversation interaction restrictions
 
-Enforce that only the wake-up owner can post in a conversation with an active user-owned wake-up.
-Cancellation permissions (owner + admins for user-owned, anyone for userless). Skip restrictions
-for API-created wake-ups with no userId.
+Enforce that only the wake-up owner can post in a conversation with an active wake-up.
+Cancellation permissions are owner + workspace admins.
 
 ## Milestone 5: API + UI
 

--- a/x/spolu/wakeup/wakeup.md
+++ b/x/spolu/wakeup/wakeup.md
@@ -28,7 +28,7 @@ Delays ("in 2 hours"), absolute times ("at 2026-04-16T16:00Z"), and cron pattern
 │  WakeUpResource (new model)                                 │
 │  - conversationId (FK → ConversationModel)                  │
 │  - workspaceId                                              │
-│  - userId (user associated with the agent loop, nullable)   │
+│  - userId (user associated with the agent loop, required)   │
 │  - agentConfigurationId                                     │
 │  - scheduleType: "one_shot" | "cron"                        │
 │  - scheduleConfig (fireAt timestamp | cron+tz)              │
@@ -79,7 +79,7 @@ CREATE TABLE wake_ups (
   "updatedAt"     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
   "workspaceId"   BIGINT NOT NULL REFERENCES workspaces(id),
   "conversationId" BIGINT NOT NULL REFERENCES conversations(id),
-  "userId"        BIGINT REFERENCES users(id),  -- null for API-created wake-ups
+  "userId"        BIGINT NOT NULL REFERENCES users(id),
   "agentConfigurationId" TEXT NOT NULL,
   "scheduleType"  TEXT NOT NULL,             -- "one_shot" | "cron"
   "fireAt"        TIMESTAMP WITH TIME ZONE,  -- for one_shot
@@ -148,8 +148,7 @@ For **cron** wake-ups, a Temporal Schedule is created (via `client.schedule.crea
 1. Fetch `WakeUpResource` by sId, verify `status === "scheduled"`.
 2. Fetch conversation via `ConversationResource`.
 3. Authenticate as the wake-up's userId via `Authenticator.fromUserIdAndWorkspaceId()` (the agent
-   runs under that user's credentials). If userId is null (API-created), use
-   `Authenticator.internalAdminForWorkspace()`.
+   runs under that user's credentials).
 4. Call `postUserMessage` with:
    - `content`: `@agent Wake-up: {reason}`
    - `context.origin`: `"wakeup"` (new origin value)
@@ -203,25 +202,20 @@ it executes under the original user's auth context.
 
 ### Conversation interaction restrictions
 
-To mitigate this, while a conversation has active wake-ups with an associated user (`userId` is
-set), only that user is allowed to post messages in the conversation. Other users attempting to
-post will receive an error explaining that the conversation has a pending wake-up owned by another
-user.
+To mitigate this, while a conversation has an active wake-up, only the wake-up owner is allowed to
+post messages in the conversation. Other users attempting to post will receive an error explaining
+that the conversation has a pending wake-up owned by another user.
 
-- Admins and the wake-up owner can cancel the wake-up (which lifts the restriction).
-- If the wake-up was created by an agent loop triggered via API with no associated user
-  (`userId` is null), the restriction does not apply — anyone with access to the conversation can
-  interact, and anyone with access can also cancel the wake-up.
+- Admins and the wake-up owner can cancel the wake-up, which lifts the restriction.
 
 This is a conservative starting point. We may relax restrictions later (e.g., allow read-only
 access, or allow messages that don't mention agents) once we better understand the threat model.
 
 ### Cancellation permissions
 
-| Wake-up has userId | Who can cancel                                  |
-|--------------------|-------------------------------------------------|
-| Yes                | The wake-up owner (userId) or workspace admins  |
-| No (API-created)   | Anyone with access to the conversation          |
+| Wake-up | Who can cancel                                 |
+|---------|------------------------------------------------|
+| Any     | The wake-up owner (userId) or workspace admins |
 
 ## Steering Integration
 
@@ -317,8 +311,8 @@ When a wake-up fires:
 ## Resolved Decisions
 
 1. **Authentication**: The activity authenticates as the wake-up's `userId` (the user whose agent
-   loop created it). For API-created wake-ups with no user, uses internal admin auth. See Security
-   section for interaction restrictions that prevent privilege escalation.
+   loop created it). See Security section for interaction restrictions that prevent privilege
+   escalation.
 
 2. **Conversation cleanup**: Handled in code, not via DB cascade. When a conversation is deleted,
    the deletion logic cancels all active wake-ups (Temporal workflows/schedules) and deletes the


### PR DESCRIPTION
## Description

Require wake-ups to always be created in a user context. This is a small limitation for now but will make the code much simpler. So we'd rather enforce it at first. The tool will simply fail if called from API.

- make `wake_ups.userId` non-nullable in the model
- use `auth.getNonNullableUser()` in `WakeUpResource.makeNew`
- add a migration that deletes any existing wake-ups without a user before setting `userId` to `NOT NULL`

## Tests

N/A

## Risk

Low. Not used in production

## Deploy Plan

- run migration `migration_595.sql`
- deploy `front`
