### PR TITLE
Fix Microsoft node name

### DIFF
--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -78,6 +78,7 @@ type ContextType = {
   useResourcesHook: UseResourcesHook;
   emptyComponent: ReactNode;
   defaultExpandedIds?: string[];
+  getLabel?: (node: ContentNode) => string;
 };
 
 const ContentNodeTreeContext = React.createContext<ContextType | undefined>(
@@ -165,8 +166,16 @@ function ContentNodeTreeChildren({
   parentIsSelected,
   additionalActions = undefined,
 }: ContentNodeTreeChildrenProps) {
-  const { onDocumentViewClick, selectedNodes, setSelectedNodes, showExpand } =
-    useContentNodeTreeContext();
+  const {
+    onDocumentViewClick,
+    selectedNodes,
+    setSelectedNodes,
+    showExpand,
+    useResourcesHook,
+    emptyComponent,
+    defaultExpandedIds,
+    getLabel,
+  } = useContentNodeTreeContext();
 
   const sendNotification = useSendNotification();
   const [filter, setFilter] = useState("");
@@ -174,9 +183,6 @@ function ContentNodeTreeChildren({
   // If the user pressed "select all", we want to display "unselect all" and vice versa.
   // But if the user types in the search bar, we want to reset the button to "select all".
   const [selectAllClicked, setSelectAllClicked] = useState(false);
-
-  const { useResourcesHook, emptyComponent, defaultExpandedIds } =
-    useContentNodeTreeContext();
 
   const {
     resources,
@@ -256,7 +262,7 @@ function ContentNodeTreeChildren({
             type={
               showExpand === false ? "item" : n.expandable ? "node" : "leaf"
             }
-            label={n.title}
+            label={getLabel ? getLabel(n) : n.title}
             labelClassName={
               n.providerVisibility === "private"
                 ? "after:content-['(private)'] after:text-warning after:ml-1"
@@ -447,6 +453,10 @@ interface ContentNodeTreeProps {
    * Additional actions to display on for each node.
    */
   additionalActionsForContentNode?: (contentNode: ContentNode) => ReactNode;
+  /**
+   * Optional function to compute the display label for a node. Defaults to node.title.
+   */
+  getLabel?: (node: ContentNode) => string;
 }
 
 export function ContentNodeTree({
@@ -461,6 +471,7 @@ export function ContentNodeTree({
   emptyComponent,
   defaultExpandedIds,
   additionalActionsForContentNode,
+  getLabel,
 }: ContentNodeTreeProps) {
   return (
     <ContentNodeTreeContextProvider
@@ -472,6 +483,7 @@ export function ContentNodeTree({
         useResourcesHook,
         emptyComponent,
         defaultExpandedIds,
+        getLabel,
       }}
     >
       <ContentNodeTreeChildren

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -28,6 +28,7 @@ import {
   isRemoteDatabase,
   isWebsite,
 } from "@app/lib/data_sources";
+import { getDisplayTitleForDataSourceViewContentNode } from "@app/lib/providers/content_nodes_display";
 import type { UseInfiniteContentNodes } from "@app/lib/swr/data_source_views";
 import { useInfiniteDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { useSpacesSearch } from "@app/lib/swr/spaces";
@@ -1025,6 +1026,11 @@ export function DataSourceViewSelector({
               )
             }
             defaultExpandedIds={defaultExpandedIds}
+            getLabel={(n) =>
+              getDisplayTitleForDataSourceViewContentNode(
+                n as DataSourceViewContentNode
+              )
+            }
             {...(selectionMode === "radio"
               ? { "data-selection-mode": "radio" }
               : {})}


### PR DESCRIPTION
## Description

Adds a `getLabel` prop to `ContentNodeTree` component to allow custom label formatting for content nodes. This enables `DataSourceViewSelector` to display SharePoint folder names with their site prefix (e.g., "Project Alpha → 01 Engagement") using `getDisplayTitleForDataSourceViewContentNode`. Previously, the tree component only used `node.title`, which made it impossible to identify which SharePoint site folders belonged to when they had identical names across multiple projects.

<img width="468" height="150" alt="image" src="https://github.com/user-attachments/assets/2ed5bff3-a53f-4bde-8283-505f26cc7875" />

## Tests

Manually tested with Microsoft SharePoint data sources to verify site names are properly prefixed for root-level folders.

## Risk

Low. This is a backward-compatible enhancement—existing usage without the `getLabel` prop continues to use `node.title` as before.

## Deploy Plan

Deploy front.