### PR TITLE
fix(sbx): run egress forwarder via runuser to bypass nologin shell

### DIFF
--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -136,14 +136,14 @@ describe("sandbox egress helpers", () => {
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       2,
       {},
-      expect.stringContaining("--proxy-addr '203.0.113.10:4443'"),
-      { user: "dust-fwd" }
+      expect.stringContaining("runuser -u dust-fwd"),
+      { user: "root" }
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       2,
       {},
-      expect.stringContaining("--proxy-tls-name 'eu.sandbox-egress.dust.tt'"),
-      { user: "dust-fwd" }
+      expect.stringContaining("203.0.113.10:4443"),
+      { user: "root" }
     );
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -152,7 +152,10 @@ export async function setupEgressForwarder(
     return chmodResult;
   }
 
-  const startForwarderCommand =
+  // Run as root with runuser to drop to dust-fwd. E2B exec requires the
+  // target user to have a real login shell; dust-fwd is created with
+  // nologin in bedrock, so exec-as-dust-fwd fails with EACCES.
+  const forwarderBin =
     "nohup /opt/bin/dsbx forward " +
     `--token-file ${shellEscape(EGRESS_TOKEN_PATH)} ` +
     `--proxy-addr ${shellEscape(`${proxyAddr}:${config.getEgressProxyPort()}`)} ` +
@@ -161,11 +164,13 @@ export async function setupEgressForwarder(
     `--deny-log ${shellEscape(EGRESS_DENY_LOG_PATH)} ` +
     `>${shellEscape(EGRESS_FORWARDER_LOG_PATH)} 2>&1 &`;
 
+  const startForwarderCommand = `runuser -u dust-fwd -- bash -c ${shellEscape(forwarderBin)}`;
+
   const startResult = await runSuccessfulSandboxCommand(
     auth,
     sandbox,
     startForwarderCommand,
-    "dust-fwd"
+    "root"
   );
   if (startResult.isErr()) {
     return startResult;


### PR DESCRIPTION
## Description

E2B exec requires the target user to have a real login shell. dust-fwd is created with /usr/sbin/nologin in bedrock, causing forwarder startup to fail with "fork/exec /bin/sh: permission denied".

Template rebuilds are blocked by E2B infra issues, so this works around it at runtime: exec as root with `runuser -u dust-fwd --` to drop privileges without needing a login shell.

## Tests

Egress and registry unit tests updated and passing.

## Risk

Low. Same process, same user (dust-fwd), just started via runuser instead of E2B's user switching. Safe to rollback.

## Deploy Plan

Standard deploy, no template rebuild needed. Works on all existing templates.