### PR TITLE
Skip indexing websearch / section files in conversation data source Qdrant

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -59,6 +59,10 @@ path = "bin/qdrant/qdrant_shard_rebalance_suggestions.rs"
 name = "qdrant_delete_orphaned_points"
 path = "bin/qdrant/delete_orphaned_points.rs"
 
+[[bin]]
+name = "qdrant_count_points_per_data_source"
+path = "bin/qdrant/count_points_per_data_source.rs"
+
 # [[bin]]
 # name = "oauth_generate_key"
 # path = "bin/oauth_generate_key.rs"

--- a/core/bin/qdrant/count_points_per_data_source.rs
+++ b/core/bin/qdrant/count_points_per_data_source.rs
@@ -14,8 +14,7 @@ use std::env;
 #[tokio::main]
 async fn main() -> Result<()> {
     let store = PostgresStore::new(
-        &env::var("CORE_DATABASE_URI")
-            .map_err(|_| anyhow!("CORE_DATABASE_URI is required"))?,
+        &env::var("CORE_DATABASE_URI").map_err(|_| anyhow!("CORE_DATABASE_URI is required"))?,
     )
     .await?;
 
@@ -94,7 +93,12 @@ async fn main() -> Result<()> {
         let qdrant_client = ds.main_qdrant_client(&qdrant_clients);
 
         let (point_count_str, error_str) = match qdrant_client
-            .count_points(&ds.embedder_config(), &ds.internal_id().to_string(), None, false)
+            .count_points(
+                &ds.embedder_config(),
+                &ds.internal_id().to_string(),
+                None,
+                false,
+            )
             .await
         {
             Ok(response) => {

--- a/core/bin/qdrant/count_points_per_data_source.rs
+++ b/core/bin/qdrant/count_points_per_data_source.rs
@@ -1,0 +1,140 @@
+use anyhow::{anyhow, Result};
+use chrono::{Duration, Utc};
+use csv::Writer;
+use dust::{
+    data_sources::{
+        data_source::{DataSource, DataSourceConfig},
+        qdrant::QdrantClients,
+    },
+    project::Project,
+    stores::{postgres::PostgresStore, store::Store},
+};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let store = PostgresStore::new(
+        &env::var("CORE_DATABASE_URI")
+            .map_err(|_| anyhow!("CORE_DATABASE_URI is required"))?,
+    )
+    .await?;
+
+    let qdrant_clients = QdrantClients::build().await?;
+
+    let cutoff_secs = (Utc::now() - Duration::days(120)).timestamp();
+
+    let pool = store.raw_pool();
+    let conn = pool.get().await?;
+
+    let rows = conn
+        .query(
+            "SELECT project, data_source_id, internal_id, config_json, name, created \
+             FROM data_sources \
+             WHERE created > $1 \
+             ORDER BY created DESC",
+            &[&cutoff_secs],
+        )
+        .await?;
+
+    println!("Found {} data sources from the past 4 months", rows.len());
+
+    let output_path = "data_sources_qdrant_counts.csv";
+    let mut wtr = Writer::from_path(output_path)?;
+    wtr.write_record([
+        "project_id",
+        "data_source_id",
+        "internal_id",
+        "name",
+        "created",
+        "point_count",
+        "error",
+    ])?;
+
+    for (i, row) in rows.iter().enumerate() {
+        let project_id: i64 = row.get(0);
+        let data_source_id: String = row.get(1);
+        let internal_id: String = row.get(2);
+        let config_json: String = row.get(3);
+        let name: String = row.get(4);
+        let created: i64 = row.get(5);
+
+        let config: DataSourceConfig = match serde_json::from_str(&config_json) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "[{}/{}] failed to parse config for {}: {}",
+                    i + 1,
+                    rows.len(),
+                    internal_id,
+                    e
+                );
+                wtr.write_record([
+                    &project_id.to_string(),
+                    &data_source_id,
+                    &internal_id,
+                    &name,
+                    &created.to_string(),
+                    "",
+                    &e.to_string(),
+                ])?;
+                continue;
+            }
+        };
+
+        let project = Project::new_from_id(project_id);
+        let ds = DataSource::new_from_store(
+            &project,
+            created as u64,
+            &data_source_id,
+            &internal_id,
+            &config,
+            &name,
+        );
+
+        let qdrant_client = ds.main_qdrant_client(&qdrant_clients);
+
+        let (point_count_str, error_str) = match qdrant_client
+            .count_points(&ds.embedder_config(), &ds.internal_id().to_string(), None, false)
+            .await
+        {
+            Ok(response) => {
+                let count = response.result.map(|r| r.count).unwrap_or(0);
+                (count.to_string(), String::new())
+            }
+            Err(e) => {
+                eprintln!(
+                    "[{}/{}] qdrant error for {}: {}",
+                    i + 1,
+                    rows.len(),
+                    internal_id,
+                    e
+                );
+                (String::new(), e.to_string())
+            }
+        };
+
+        println!(
+            "[{}/{}] {} (project={}) => {} points",
+            i + 1,
+            rows.len(),
+            internal_id,
+            project_id,
+            point_count_str
+        );
+
+        wtr.write_record([
+            &project_id.to_string(),
+            &data_source_id,
+            &internal_id,
+            &name,
+            &created.to_string(),
+            &point_count_str,
+            &error_str,
+        ])?;
+    }
+
+    wtr.flush()?;
+    println!("Results saved to {}", output_path);
+
+    Ok(())
+}

--- a/front/lib/actions/action_file_helpers.ts
+++ b/front/lib/actions/action_file_helpers.ts
@@ -184,6 +184,7 @@ export async function generateSectionFile(
     useCase: "tool_output",
     useCaseMetadata: {
       conversationId,
+      skipDataSourceIndexing: true,
     },
   });
 

--- a/front/lib/api/actions/servers/query_tables_v2/helpers.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/helpers.ts
@@ -210,7 +210,7 @@ export async function executeQuery(
       content.push({
         type: "resource",
         resource: {
-          text: "Results are also available as a rich text file that can be searched.",
+          text: "Results are also available as a rich text file that can be viewed.",
           uri: sectionFile.getPublicUrl(auth),
           mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
           fileId: sectionFile.sId,

--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -199,6 +199,8 @@ async function handleWebbrowser(
           content: fileContent,
           snippet,
           hideFromUser: true,
+          // No need to index web page content in Qdrant.
+          skipDataSourceIndexing: true,
         });
 
         await uploadFileToConversationDataSource({ auth, file });

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -61,9 +61,11 @@ export async function toFileContentFragment(
   {
     contentFragment,
     fileName,
+    skipDataSourceIndexing,
   }: {
     contentFragment: ContentFragmentInputWithInlinedContent;
     fileName?: string;
+    skipDataSourceIndexing?: boolean;
   }
 ): Promise<
   Result<ContentFragmentInputWithFileIdType, ProcessAndStoreFileError>
@@ -77,7 +79,7 @@ export async function toFileContentFragment(
     userId: auth.user()?.id,
     workspaceId: auth.getNonNullableWorkspace().id,
     useCase: "conversation",
-    useCaseMetadata: null,
+    useCaseMetadata: skipDataSourceIndexing ? {skipDataSourceIndexing: true} : undefined,
   });
 
   const processRes = await processAndStoreFile(auth, {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1776778266648789?thread_ts=1776168536.889749&cid=C050SM8NSPK).

In the same path as https://github.com/dust-tt/dust/pull/24279, this PR ensures the most noisiest files in conversation data sources don't end up in Qdrant.

After analyzing 120k of the latest created data sources in core:
```
Type                 #DS    Total pts    %pts       Mean      p50      p90      p95       p99       Max  %empty
----------------------------------------------------------------------------------------------------------------------
Conversation     130,373    6,647,118  63.93%       51.0        0       80      202       904   105,604   53.6%
Github                26    1,222,526  11.76%   47,020.2       46  135,784  331,107   476,395   509,341   34.6%
Notion                54      630,801   6.07%   11,681.5      294   21,638   45,357   183,279   230,412    7.4%
Microsoft             23      601,764   5.79%   26,163.7        3   31,531  141,465   319,732   366,632   47.8%
Gong                   1      511,351   4.92%  511,351.0  511,351  511,351  511,351   511,351   511,351    0.0%
Folder / Other     1,231      263,614   2.54%      214.1       21      350      694     2,967    29,327   11.9%
Zendesk                4      252,638   2.43%   63,159.5    6,542  171,606  205,579   232,758   239,553   25.0%
Google Drive          95      237,953   2.29%    2,504.8       79    7,213   15,491    29,310    64,241   32.6%
Intercom               2       14,682   0.14%    7,341.0    7,341   13,214   13,948    14,535    14,682   50.0%
Slack                  1        7,349   0.07%    7,349.0    7,349    7,349    7,349     7,349     7,349    0.0%
Confluence             3        6,953   0.07%    2,317.7    2,501    3,331    3,435     3,518     3,539    0.0%
Microsoft Bot          8            0   0.00%        0.0        0        0        0         0         0  100.0%
Bigquery               4            0   0.00%        0.0        0        0        0         0         0  100.0%
Snowflake              2            0   0.00%        0.0        0        0        0         0         0  100.0%
Slack Bot             21            0   0.00%        0.0        0        0        0         0         0  100.0%

TOTAL: 131,848 data sources, 10,396,749 points
```  

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
