### PR TITLE
[front] - refactor(ContextUsageIndicator): use Tooltip

### DIFF
--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -2,18 +2,14 @@ import {
   useCompactConversation,
   useConversationContextUsage,
 } from "@app/hooks/conversations";
-import {
-  COMPACTION_STARTED_EVENT,
-  CompactionStartedEvent,
-} from "@app/lib/notifications/events";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
+  TooltipContent,
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
 } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
 
 interface ContextUsageIndicatorProps {
   buttonSize: "xs" | "sm";
@@ -68,7 +64,6 @@ export function ContextUsageIndicator({
   owner,
   conversationId,
 }: ContextUsageIndicatorProps) {
-  const [isOpen, setIsOpen] = useState(false);
   const { contextUsage } = useConversationContextUsage({
     conversationId,
     workspaceId: owner.sId,
@@ -84,62 +79,40 @@ export function ContextUsageIndicator({
       ? Math.round((contextUsage.contextUsage / contextUsage.contextSize) * 100)
       : 0;
 
-  useEffect(() => {
-    const handleCompactionStarted = (event: Event) => {
-      if (
-        event instanceof CompactionStartedEvent &&
-        event.detail.conversationId === conversationId
-      ) {
-        setIsOpen(false);
-      }
-    };
-
-    window.addEventListener(COMPACTION_STARTED_EVENT, handleCompactionStarted);
-    return () => {
-      window.removeEventListener(
-        COMPACTION_STARTED_EVENT,
-        handleCompactionStarted
-      );
-    };
-  }, [conversationId]);
-
   return (
     <div className="hidden md:block">
-      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost-secondary"
-            size={buttonSize}
-            icon={() => <CircleProgress percentage={percentage} size={16} />}
-          />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent side="top" align="end" className="w-64">
-          <div className="flex flex-col items-start gap-3 p-3">
-            <div className="flex flex-col gap-1">
-              <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                Context
-              </span>
+      <TooltipProvider>
+        <TooltipRoot>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost-secondary"
+              size={buttonSize}
+              icon={() => <CircleProgress percentage={percentage} size={16} />}
+            />
+          </TooltipTrigger>
+          <TooltipContent side="top" className="p-3">
+            <div className="flex flex-col items-start gap-3">
               <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                 The current context usage is at {percentage}%
               </span>
+              {percentage > CONTEXT_USAGE_PERCENT_THRESHOLD && (
+                <Button
+                  variant="outline"
+                  size="xs"
+                  label={isCompacting ? "Compacting" : "Compact now"}
+                  onClick={() => {
+                    if (contextUsage?.model) {
+                      void compact(contextUsage.model);
+                    }
+                  }}
+                  disabled={isCompacting || !contextUsage?.model}
+                  isLoading={isCompacting}
+                />
+              )}
             </div>
-            {percentage > CONTEXT_USAGE_PERCENT_THRESHOLD && (
-              <Button
-                variant="outline"
-                size="xs"
-                label={isCompacting ? "Compacting" : "Compact now"}
-                onClick={() => {
-                  if (contextUsage?.model) {
-                    void compact(contextUsage.model);
-                  }
-                }}
-                disabled={isCompacting || !contextUsage?.model}
-                isLoading={isCompacting}
-              />
-            )}
-          </div>
-        </DropdownMenuContent>
-      </DropdownMenu>
+          </TooltipContent>
+        </TooltipRoot>
+      </TooltipProvider>
     </div>
   );
 }

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -79,7 +79,9 @@ export async function toFileContentFragment(
     userId: auth.user()?.id,
     workspaceId: auth.getNonNullableWorkspace().id,
     useCase: "conversation",
-    useCaseMetadata: skipDataSourceIndexing ? {skipDataSourceIndexing: true} : undefined,
+    useCaseMetadata: skipDataSourceIndexing
+      ? { skipDataSourceIndexing: true }
+      : undefined,
   });
 
   const processRes = await processAndStoreFile(auth, {


### PR DESCRIPTION
## Description

Refactors the `ContextUsageIndicator` component to use a `Tooltip` instead of a `DropdownMenu` for displaying context usage information. This simplifies the component by removing unnecessary state management (`isOpen`) and event handling logic for the compaction started event. The tooltip provides a cleaner UX for this read-mostly indicator with an optional action button.

## Tests

Manually tested locally.

## Risk

Low - visual and interaction change only, no backend logic affected.

## Deploy Plan

Deploy front