### PR TITLE
[front] fix: revert Jira and MCP changes for multiple instances

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -71,7 +71,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "confluence": {
     "create_page": "low",
-    "get_connection_info": "never_ask",
     "get_current_user": "never_ask",
     "get_page": "never_ask",
     "get_pages": "never_ask",

--- a/front/lib/api/actions/servers/confluence/helpers.ts
+++ b/front/lib/api/actions/servers/confluence/helpers.ts
@@ -89,7 +89,6 @@ async function confluenceApiCall<T extends z.ZodTypeAny>(
 
 export async function withAuth<T>(
   accessToken: string | undefined,
-  cloudId: string | undefined,
   action: (baseUrl: string, accessToken: string) => Promise<T>
 ): Promise<
   | { success: true; result: T }
@@ -102,44 +101,20 @@ export async function withAuth<T>(
     };
   }
 
-  let baseUrl: string;
-
-  if (cloudId) {
-    // cloud_id explicitly provided — use directly, no API call.
-    baseUrl = `https://api.atlassian.com/ex/confluence/${cloudId}`;
-  } else {
-    const resources = await getAllConfluenceResources(accessToken);
-    if (!resources || resources.length === 0) {
-      return {
-        success: false,
-        error: [
-          {
-            type: "text" as const,
-            text: "No Confluence instance found. Please reconnect.",
-          },
-        ],
-      };
-    }
-    if (resources.length > 1) {
-      return {
-        success: false,
-        error: [
-          {
-            type: "text" as const,
-            text:
-              "Multiple Confluence instances are accessible with this connection. " +
-              "A cloud_id parameter is required to identify which instance to use. " +
-              "Please call the get_connection_info tool to retrieve the list of available " +
-              "instances (with their cloud IDs, names, and URLs), present the options to the " +
-              "user, ask which instance they want to use, then retry with the chosen cloud_id.",
-          },
-        ],
-      };
-    }
-    baseUrl = `https://api.atlassian.com/ex/confluence/${resources[0].id}`;
-  }
-
   try {
+    const baseUrl = await getConfluenceBaseUrl(accessToken);
+    if (!baseUrl) {
+      return {
+        success: false,
+        error: [
+          {
+            type: "text" as const,
+            text: "Failed to determine Confluence instance URL. Please check your connection.",
+          },
+        ],
+      };
+    }
+
     const result = await action(baseUrl, accessToken);
     return { success: true, result };
   } catch (error) {
@@ -156,9 +131,19 @@ export async function withAuth<T>(
   }
 }
 
-export async function getAllConfluenceResources(
+async function getConfluenceBaseUrl(
   accessToken: string
-): Promise<{ id: string; name: string; url: string }[] | null> {
+): Promise<string | null> {
+  const resourceInfo = await getConfluenceResourceInfo(accessToken);
+  if (resourceInfo?.id) {
+    return `https://api.atlassian.com/ex/confluence/${resourceInfo.id}`;
+  }
+  return null;
+}
+
+async function getConfluenceResourceInfo(
+  accessToken: string
+): Promise<{ id: string; name: string; url: string } | null> {
   const result = await confluenceApiCall(
     {
       endpoint: "/oauth/token/accessible-resources",
@@ -175,7 +160,17 @@ export async function getAllConfluenceResources(
     return null;
   }
 
-  return result.value ?? null;
+  const resources = result.value;
+  if (!resources || resources.length === 0) {
+    logger.error("No accessible resources found");
+    return null;
+  }
+  const resource = resources[0];
+  return {
+    id: resource.id,
+    name: resource.name,
+    url: resource.url,
+  };
 }
 
 export async function getCurrentUser(

--- a/front/lib/api/actions/servers/confluence/metadata.ts
+++ b/front/lib/api/actions/servers/confluence/metadata.ts
@@ -6,30 +6,11 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const CONFLUENCE_TOOL_NAME = "confluence" as const;
 
-const CLOUD_ID_FIELD = z
-  .string()
-  .optional()
-  .describe(
-    "Atlassian cloud instance ID. Required when multiple Confluence instances are accessible. Use get_connection_info to list available instances."
-  );
-
 export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
-  get_connection_info: {
-    description:
-      "Lists all Confluence instances accessible through the current OAuth connection (cloud IDs, names, URLs). Call this tool when multiple Confluence instances are accessible to find the cloud_id required by other tools, then present the list to the user and ask which instance they want to use.",
-    schema: {},
-    stake: "never_ask",
-    displayLabels: {
-      running: "Getting Confluence connection info",
-      done: "Get Confluence connection info",
-    },
-  },
   get_current_user: {
     description:
       "Get information about the currently authenticated Confluence user including account ID, display name, and email.",
-    schema: {
-      cloud_id: CLOUD_ID_FIELD,
-    },
+    schema: {},
     stake: "never_ask",
     displayLabels: {
       running: "Getting current Confluence user",
@@ -39,9 +20,7 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
   get_spaces: {
     description:
       "Get a list of Confluence spaces. Returns a list of spaces with their IDs, keys, names, types, and statuses.",
-    schema: {
-      cloud_id: CLOUD_ID_FIELD,
-    },
+    schema: {},
     stake: "never_ask",
     displayLabels: {
       running: "Listing Confluence spaces",
@@ -68,7 +47,6 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
         .number()
         .optional()
         .describe("Number of results per page (default 25)"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -88,7 +66,6 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Whether to include the page body content (default: false). When true, returns body in storage format."
         ),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -124,7 +101,6 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
         })
         .optional()
         .describe("Page body content"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "low",
     displayLabels: {
@@ -174,7 +150,6 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe("New parent page ID to move the page under"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "low",
     displayLabels: {

--- a/front/lib/api/actions/servers/confluence/tools/index.ts
+++ b/front/lib/api/actions/servers/confluence/tools/index.ts
@@ -7,7 +7,6 @@ import type {
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   createPage,
-  getAllConfluenceResources,
   getCurrentUser,
   getPage,
   listPages,
@@ -25,35 +24,9 @@ import { Ok } from "@app/types/shared/result";
 
 export function createConfluenceTools(): ToolDefinition[] {
   const handlers: ToolHandlers<typeof CONFLUENCE_TOOLS_METADATA> = {
-    get_connection_info: async (_params, { authInfo }: ToolHandlerExtra) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return new Ok([
-          { type: "text" as const, text: "No access token found." },
-        ]);
-      }
-      const resources = await getAllConfluenceResources(accessToken);
-      if (!resources) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: "Failed to retrieve connection information.",
-          },
-        ]);
-      }
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "Connection information retrieved successfully",
-        },
-        { type: "text" as const, text: JSON.stringify(resources, null, 2) },
-      ]);
-    },
-
-    get_current_user: async ({ cloud_id }, { authInfo }: ToolHandlerExtra) => {
+    get_current_user: async (_params, { authInfo }: ToolHandlerExtra) => {
       const authResult = await withAuth(
         authInfo?.token,
-        cloud_id,
         async (baseUrl, accessToken) => {
           const result = await getCurrentUser(baseUrl, accessToken);
           if (result.isErr()) {
@@ -79,10 +52,9 @@ export function createConfluenceTools(): ToolDefinition[] {
       ]);
     },
 
-    get_spaces: async ({ cloud_id }, { authInfo }: ToolHandlerExtra) => {
+    get_spaces: async (_params, { authInfo }: ToolHandlerExtra) => {
       const authResult = await withAuth(
         authInfo?.token,
-        cloud_id,
         async (baseUrl, accessToken) => {
           const result = await listSpaces(baseUrl, accessToken);
           if (result.isErr()) {
@@ -110,15 +82,11 @@ export function createConfluenceTools(): ToolDefinition[] {
       ]);
     },
 
-    get_pages: async (
-      { cloud_id, ...pageParams },
-      { authInfo }: ToolHandlerExtra
-    ) => {
+    get_pages: async (params, { authInfo }: ToolHandlerExtra) => {
       const authResult = await withAuth(
         authInfo?.token,
-        cloud_id,
         async (baseUrl, accessToken) => {
-          const result = await listPages(baseUrl, accessToken, pageParams);
+          const result = await listPages(baseUrl, accessToken, params);
           if (result.isErr()) {
             throw new MCPError(`Error listing pages: ${result.error}`);
           }
@@ -147,7 +115,6 @@ export function createConfluenceTools(): ToolDefinition[] {
     get_page: async (params, { authInfo }: ToolHandlerExtra) => {
       const authResult = await withAuth(
         authInfo?.token,
-        params.cloud_id,
         async (baseUrl, accessToken) => {
           const result = await getPage(
             baseUrl,
@@ -186,15 +153,11 @@ export function createConfluenceTools(): ToolDefinition[] {
       ]);
     },
 
-    create_page: async (
-      { cloud_id, ...pageParams },
-      { authInfo }: ToolHandlerExtra
-    ) => {
+    create_page: async (params, { authInfo }: ToolHandlerExtra) => {
       const authResult = await withAuth(
         authInfo?.token,
-        cloud_id,
         async (baseUrl, accessToken) => {
-          const result = await createPage(baseUrl, accessToken, pageParams);
+          const result = await createPage(baseUrl, accessToken, params);
           if (result.isErr()) {
             throw new MCPError(`Error creating page: ${result.error}`);
           }
@@ -215,15 +178,11 @@ export function createConfluenceTools(): ToolDefinition[] {
       ]);
     },
 
-    update_page: async (
-      { cloud_id, ...pageParams },
-      { authInfo }: ToolHandlerExtra
-    ) => {
+    update_page: async (params, { authInfo }: ToolHandlerExtra) => {
       const authResult = await withAuth(
         authInfo?.token,
-        cloud_id,
         async (baseUrl, accessToken) => {
-          const result = await updatePage(baseUrl, accessToken, pageParams);
+          const result = await updatePage(baseUrl, accessToken, params);
           if (result.isErr()) {
             throw new MCPError(`Error updating page: ${result.error}`);
           }

--- a/front/lib/api/actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/api/actions/servers/jira/jira_api_helper.ts
@@ -891,6 +891,7 @@ export async function updateIssue(
   return new Ok(responseData);
 }
 
+
 export async function createIssueLink(
   baseUrl: string,
   accessToken: string,

--- a/front/lib/api/actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/api/actions/servers/jira/jira_api_helper.ts
@@ -246,7 +246,7 @@ export async function getIssue({
     return new Ok(null);
   }
 
-  const resourceInfo = (await getAllJiraResources(accessToken))?.[0] ?? null;
+  const resourceInfo = await getJiraResourceInfo(accessToken);
   if (resourceInfo) {
     handledResult.value = {
       ...handledResult.value,
@@ -332,9 +332,11 @@ export async function getTransitions(
 }
 
 // Jira resource and URL utilities
-async function getAllJiraResources(
-  accessToken: string
-): Promise<{ id: string; url: string; name: string }[] | null> {
+async function getJiraResourceInfo(accessToken: string): Promise<{
+  id: string;
+  url: string;
+  name: string;
+} | null> {
   const result = await jiraApiCall(
     {
       endpoint: "/oauth/token/accessible-resources",
@@ -350,14 +352,25 @@ async function getAllJiraResources(
     return null;
   }
 
-  return result.value ?? null;
+  const resources = result.value;
+  if (resources && resources.length > 0) {
+    const resource = resources[0];
+    return {
+      id: resource.id,
+      url: resource.url,
+      name: resource.name,
+    };
+  }
+
+  return null;
 }
 
 export async function getJiraBaseUrl(
   accessToken: string
 ): Promise<string | null> {
-  const resources = await getAllJiraResources(accessToken);
-  const cloudId = resources?.[0]?.id ?? null;
+  const resourceInfo = await getJiraResourceInfo(accessToken);
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const cloudId = resourceInfo?.id || null;
   if (cloudId) {
     return `https://api.atlassian.com/ex/jira/${cloudId}`;
   }
@@ -507,7 +520,7 @@ export async function searchIssues(
     return result;
   }
 
-  const resourceInfo = (await getAllJiraResources(accessToken))?.[0] ?? null;
+  const resourceInfo = await getJiraResourceInfo(accessToken);
   if (resourceInfo && result.value.issues) {
     result.value.issues = result.value.issues.map((issue) => ({
       ...issue,
@@ -568,7 +581,7 @@ export async function searchJiraIssuesUsingJql(
     return result;
   }
 
-  const resourceInfo = (await getAllJiraResources(accessToken))?.[0] ?? null;
+  const resourceInfo = await getJiraResourceInfo(accessToken);
   if (resourceInfo && result.value.issues) {
     result.value.issues = result.value.issues.map((issue) => ({
       ...issue,
@@ -646,31 +659,31 @@ async function getUserInfo(
 export async function getConnectionInfo(
   accessToken: string
 ): Promise<Result<z.infer<typeof JiraConnectionInfoSchema>, JiraErrorResult>> {
-  const resources = await getAllJiraResources(accessToken);
-  if (!resources || resources.length === 0) {
+  const resourceInfo = await getJiraResourceInfo(accessToken);
+  if (!resourceInfo) {
     return new Err("Failed to retrieve JIRA resource information");
   }
 
-  // Fetch user info using the first instance (arbitrary but consistent).
-  const primaryBaseUrl = `https://api.atlassian.com/ex/jira/${resources[0].id}`;
-  const userResult = await getUserInfo(primaryBaseUrl, accessToken);
+  const baseUrl = `https://api.atlassian.com/ex/jira/${resourceInfo.id}`;
+  const userResult = await getUserInfo(baseUrl, accessToken);
   if (userResult.isErr()) {
     return userResult;
   }
 
-  return new Ok({
+  const connectionInfo = {
     user: {
       account_id: userResult.value.accountId,
       name: userResult.value.displayName,
       nickname: userResult.value.displayName,
     },
-    instances: resources.map((r) => ({
-      cloud_id: r.id,
-      site_url: r.url,
-      site_name: r.name,
-      api_base_url: `https://api.atlassian.com/ex/jira/${r.id}`,
-    })),
-  });
+    instance: {
+      cloud_id: resourceInfo.id,
+      site_url: resourceInfo.url,
+      site_name: resourceInfo.name,
+      api_base_url: baseUrl,
+    },
+  };
+  return new Ok(connectionInfo);
 }
 
 export async function transitionIssue(
@@ -838,7 +851,7 @@ export async function createIssue(
     return result;
   }
 
-  const resourceInfo = (await getAllJiraResources(accessToken))?.[0] ?? null;
+  const resourceInfo = await getJiraResourceInfo(accessToken);
   if (resourceInfo && result.value) {
     result.value.browseUrl = `${resourceInfo.url}/browse/${result.value.key}`;
   }
@@ -880,7 +893,7 @@ export async function updateIssue(
 
   const responseData = { issueKey };
 
-  const resourceInfo = (await getAllJiraResources(accessToken))?.[0] ?? null;
+  const resourceInfo = await getJiraResourceInfo(accessToken);
   if (resourceInfo) {
     return new Ok({
       ...responseData,
@@ -891,6 +904,13 @@ export async function updateIssue(
   return new Ok(responseData);
 }
 
+type WithAuthParams = {
+  authInfo?: AuthInfo;
+  action: (
+    baseUrl: string,
+    accessToken: string
+  ) => Promise<Result<CallToolResult["content"], MCPError>>;
+};
 
 export async function createIssueLink(
   baseUrl: string,
@@ -1028,45 +1048,23 @@ export async function searchUsersByEmailExact(
   return new Ok({ users: matches, nextStartAt: cursor });
 }
 
-export async function withAuth(
-  authInfo: AuthInfo | undefined,
-  cloudId: string | undefined,
-  action: (
-    baseUrl: string,
-    accessToken: string
-  ) => Promise<Result<CallToolResult["content"], MCPError>>
-): Promise<Result<CallToolResult["content"], MCPError>> {
+export const withAuth = async ({
+  authInfo,
+  action,
+}: WithAuthParams): Promise<Result<CallToolResult["content"], MCPError>> => {
   const accessToken = authInfo?.token;
 
   if (!accessToken) {
     return new Err(new MCPError("No access token found"));
   }
 
-  let baseUrl: string;
-
-  if (cloudId) {
-    // cloud_id explicitly provided — use directly, no API call.
-    baseUrl = `https://api.atlassian.com/ex/jira/${cloudId}`;
-  } else {
-    const resources = await getAllJiraResources(accessToken);
-    if (!resources || resources.length === 0) {
-      return new Err(new MCPError("No Jira instance found. Please reconnect."));
-    }
-    if (resources.length > 1) {
-      return new Err(
-        new MCPError(
-          "Multiple Jira instances are accessible with this connection. " +
-            "A cloud_id parameter is required to identify which instance to use. " +
-            "Please call the get_connection_info tool to retrieve the list of available " +
-            "instances (with their cloud IDs, names, and URLs), present the options to the " +
-            "user, ask which instance they want to use, then retry with the chosen cloud_id."
-        )
-      );
-    }
-    baseUrl = `https://api.atlassian.com/ex/jira/${resources[0].id}`;
-  }
-
   try {
+    // Get the base URL from accessible resources
+    const baseUrl = await getJiraBaseUrl(accessToken);
+    if (!baseUrl) {
+      return new Err(new MCPError("No base url found"));
+    }
+
     return await action(baseUrl, accessToken);
   } catch (error: unknown) {
     return logAndReturnError({
@@ -1074,7 +1072,7 @@ export async function withAuth(
       message: "Operation failed",
     });
   }
-}
+};
 
 function logAndReturnError({
   error,

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -13,21 +13,12 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-const CLOUD_ID_FIELD = z
-  .string()
-  .optional()
-  .describe(
-    "Atlassian cloud instance ID. Required when multiple Jira instances are accessible. Use get_connection_info to list available instances."
-  );
-
 export const JIRA_TOOLS_METADATA = createToolsRecord({
   // Read operations
   get_issue_read_fields: {
     description:
       "Lists available Jira field keys/ids and names for use in the get_issue.fields parameter (read-time).",
-    schema: {
-      cloud_id: CLOUD_ID_FIELD,
-    },
+    schema: {},
     stake: "never_ask",
     displayLabels: {
       running: "Listing Jira issue fields",
@@ -44,7 +35,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Optional list of fields to include. Defaults to a minimal set for performance."
         ),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -54,9 +44,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_projects: {
     description: "Retrieves a list of JIRA projects.",
-    schema: {
-      cloud_id: CLOUD_ID_FIELD,
-    },
+    schema: {},
     stake: "never_ask",
     displayLabels: {
       running: "Listing Jira projects",
@@ -67,7 +55,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     description: "Retrieves a single JIRA project by its key (e.g., 'PROJ').",
     schema: {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -80,7 +67,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       "Retrieves all versions (releases) for a JIRA project. Useful for getting release reports and understanding which versions are available for filtering issues.",
     schema: {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -93,7 +79,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       "Gets available transitions for a JIRA issue based on its current status and workflow.",
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -116,7 +101,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe("Token for next page of results (for pagination)"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -147,7 +131,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe("Token for next page of results (for pagination)"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -159,7 +142,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     description: "Retrieves available issue types for a JIRA project.",
     schema: {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -175,7 +157,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       issueTypeId: z
         .string()
         .describe("The issue type ID to get fields for (required)"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -185,7 +166,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   },
   get_connection_info: {
     description:
-      "Lists all Jira instances accessible through the current OAuth connection (cloud IDs, names, URLs) along with the authenticated user's details. Call this tool when multiple Jira instances are accessible to find the cloud_id required by other tools, then present the list to the user and ask which instance they want to use. Also use this tool when the user is referring about themselves.",
+      "Gets comprehensive connection information including user details, cloud ID, and site URL for the currently authenticated JIRA instance. This tool is used when the user is referring about themselves",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -196,9 +177,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
   get_issue_link_types: {
     description:
       "Retrieves all available issue link types that can be used when creating issue links.",
-    schema: {
-      cloud_id: CLOUD_ID_FIELD,
-    },
+    schema: {},
     stake: "never_ask",
     displayLabels: {
       running: "Retrieving Jira link types",
@@ -238,7 +217,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Pagination offset. Pass the previous response's nextStartAt to fetch the next page."
         ),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -251,7 +229,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       "Retrieve all attachments for a Jira issue, including metadata like filename, size, MIME type, and download URLs.",
     schema: {
       issueKey: z.string().describe("The Jira issue key (e.g., 'PROJ-123')"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -265,7 +242,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     schema: {
       issueKey: z.string().describe("The Jira issue key (e.g., 'PROJ-123')"),
       attachmentId: z.string().describe("The ID of the attachment to read"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "never_ask",
     displayLabels: {
@@ -293,7 +269,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe("Group or role name for visibility restriction"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "low",
     displayLabels: {
@@ -307,7 +282,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     schema: {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       transitionId: z.string().describe("The ID of the transition to perform"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "low",
     displayLabels: {
@@ -322,7 +296,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       issueData: JiraCreateIssueRequestSchema.describe(
         "The description of the issue"
       ),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "low",
     displayLabels: {
@@ -338,7 +311,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       updateData: JiraCreateIssueRequestSchema.partial().describe(
         "The partial data to update the issue with - description field supports both plain text and ADF format"
       ),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "low",
     displayLabels: {
@@ -353,7 +325,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
       linkData: JiraCreateIssueLinkRequestSchema.describe(
         "Link configuration including type and issues to link"
       ),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "low",
     displayLabels: {
@@ -365,7 +336,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     description: "Deletes an existing link between JIRA issues.",
     schema: {
       linkId: z.string().describe("The ID of the issue link to delete"),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "low",
     displayLabels: {
@@ -406,7 +376,6 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
           base64Data: z.string().describe("Base64 encoded file data"),
         }),
       ]),
-      cloud_id: CLOUD_ID_FIELD,
     },
     stake: "low",
     displayLabels: {

--- a/front/lib/api/actions/servers/jira/tools/index.ts
+++ b/front/lib/api/actions/servers/jira/tools/index.ts
@@ -38,286 +38,328 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
-  get_issue_read_fields: async ({ cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await listFieldSummaries(baseUrl, accessToken);
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(`Error retrieving fields: ${result.error}`)
-        );
-      }
-      return new Ok([
-        { type: "text" as const, text: "Fields retrieved successfully" },
-        {
-          type: "text" as const,
-          text: JSON.stringify(result.value, null, 2),
-        },
-      ]);
+  get_issue_read_fields: async (_params, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await listFieldSummaries(baseUrl, accessToken);
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Error retrieving fields: ${result.error}`)
+          );
+        }
+        return new Ok([
+          { type: "text" as const, text: "Fields retrieved successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(result.value, null, 2),
+          },
+        ]);
+      },
+      authInfo,
     });
   },
 
-  get_issue: async ({ issueKey, fields, cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const issue = await getIssue({
-        baseUrl,
-        accessToken,
-        issueKey,
-        fields,
-      });
-      if (issue.isOk() && issue.value === null) {
+  get_issue: async ({ issueKey, fields }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const issue = await getIssue({
+          baseUrl,
+          accessToken,
+          issueKey,
+          fields,
+        });
+        if (issue.isOk() && issue.value === null) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: "No issue found with the specified key",
+            },
+            {
+              type: "text" as const,
+              text: JSON.stringify({ found: false, issueKey }, null, 2),
+            },
+          ]);
+        }
+        if (issue.isErr()) {
+          return new Err(
+            new MCPError(`Error retrieving issue: ${issue.error}`)
+          );
+        }
+
+        const issueText = issue.value
+          ? renderIssueWithEmbeddedComments(issue.value)
+          : "";
+
+        return new Ok([
+          { type: "text" as const, text: "Issue retrieved successfully" },
+          {
+            type: "text" as const,
+            text: issueText,
+          },
+        ]);
+      },
+      authInfo,
+    });
+  },
+
+  get_projects: async (_params, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await getProjects(baseUrl, accessToken);
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Error retrieving projects: ${result.error}`)
+          );
+        }
         return new Ok([
           {
             type: "text" as const,
-            text: "No issue found with the specified key",
+            text: "Projects retrieved successfully",
+          },
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ]);
+      },
+      authInfo,
+    });
+  },
+
+  get_project: async ({ projectKey }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await getProject(baseUrl, accessToken, projectKey);
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Error retrieving project: ${result.error}`)
+          );
+        }
+        if (result.value === null) {
+          return new Err(
+            new MCPError(
+              `No project found with the specified key: ${projectKey}`
+            )
+          );
+        }
+        return new Ok([
+          { type: "text" as const, text: "Project retrieved successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(result.value, null, 2),
+          },
+        ]);
+      },
+      authInfo,
+    });
+  },
+
+  get_project_versions: async ({ projectKey }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await getProjectVersions(
+          baseUrl,
+          accessToken,
+          projectKey
+        );
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Error retrieving project versions: ${result.error}`)
+          );
+        }
+        return new Ok([
+          {
+            type: "text" as const,
+            text: "Project versions retrieved successfully",
           },
           {
             type: "text" as const,
-            text: JSON.stringify({ found: false, issueKey }, null, 2),
+            text: JSON.stringify(result.value, null, 2),
           },
         ]);
-      }
-      if (issue.isErr()) {
-        return new Err(new MCPError(`Error retrieving issue: ${issue.error}`));
-      }
-
-      const issueText = issue.value
-        ? renderIssueWithEmbeddedComments(issue.value)
-        : "";
-
-      return new Ok([
-        { type: "text" as const, text: "Issue retrieved successfully" },
-        {
-          type: "text" as const,
-          text: issueText,
-        },
-      ]);
+      },
+      authInfo,
     });
   },
 
-  get_projects: async ({ cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await getProjects(baseUrl, accessToken);
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(`Error retrieving projects: ${result.error}`)
-        );
-      }
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "Projects retrieved successfully",
-        },
-        { type: "text" as const, text: JSON.stringify(result, null, 2) },
-      ]);
+  get_transitions: async ({ issueKey }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await getTransitions(baseUrl, accessToken, issueKey);
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Error retrieving transitions: ${result.error}`)
+          );
+        }
+        return new Ok([
+          {
+            type: "text" as const,
+            text: "Transitions retrieved successfully",
+          },
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ]);
+      },
+      authInfo,
     });
   },
 
-  get_project: async ({ projectKey, cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await getProject(baseUrl, accessToken, projectKey);
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(`Error retrieving project: ${result.error}`)
-        );
-      }
-      if (result.value === null) {
-        return new Err(
-          new MCPError(`No project found with the specified key: ${projectKey}`)
-        );
-      }
-      return new Ok([
-        { type: "text" as const, text: "Project retrieved successfully" },
-        {
-          type: "text" as const,
-          text: JSON.stringify(result.value, null, 2),
-        },
-      ]);
-    });
-  },
+  get_issues: async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await searchIssues(baseUrl, accessToken, filters, {
+          nextPageToken,
+          sortBy,
+        });
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Error searching issues: ${result.error}`)
+          );
+        }
+        const message =
+          result.value.issues.length === 0
+            ? "No issues found matching the search criteria"
+            : `Found ${result.value.issues.length} issue(s)`;
 
-  get_project_versions: async ({ projectKey, cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await getProjectVersions(baseUrl, accessToken, projectKey);
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(`Error retrieving project versions: ${result.error}`)
-        );
-      }
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "Project versions retrieved successfully",
-        },
-        {
-          type: "text" as const,
-          text: JSON.stringify(result.value, null, 2),
-        },
-      ]);
-    });
-  },
+        const issueTexts = result.value.issues.map((issue, index) => {
+          const formatted = renderIssueWithEmbeddedComments(issue);
+          return index > 0 ? `\n${"-".repeat(80)}\n\n${formatted}` : formatted;
+        });
 
-  get_transitions: async ({ issueKey, cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await getTransitions(baseUrl, accessToken, issueKey);
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(`Error retrieving transitions: ${result.error}`)
-        );
-      }
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "Transitions retrieved successfully",
-        },
-        { type: "text" as const, text: JSON.stringify(result, null, 2) },
-      ]);
-    });
-  },
+        let outputText = message + "\n\n";
+        outputText += issueTexts.join("\n");
 
-  get_issues: async (
-    { filters, sortBy, nextPageToken, cloud_id },
-    { authInfo }
-  ) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await searchIssues(baseUrl, accessToken, filters, {
-        nextPageToken,
-        sortBy,
-      });
-      if (result.isErr()) {
-        return new Err(new MCPError(`Error searching issues: ${result.error}`));
-      }
-      const message =
-        result.value.issues.length === 0
-          ? "No issues found matching the search criteria"
-          : `Found ${result.value.issues.length} issue(s)`;
+        if (result.value.nextPageToken) {
+          outputText += `\n\nNote: More results available. Use nextPageToken: ${result.value.nextPageToken} to fetch the next page.`;
+        }
 
-      const issueTexts = result.value.issues.map((issue, index) => {
-        const formatted = renderIssueWithEmbeddedComments(issue);
-        return index > 0 ? `\n${"-".repeat(80)}\n\n${formatted}` : formatted;
-      });
-
-      let outputText = message + "\n\n";
-      outputText += issueTexts.join("\n");
-
-      if (result.value.nextPageToken) {
-        outputText += `\n\nNote: More results available. Use nextPageToken: ${result.value.nextPageToken} to fetch the next page.`;
-      }
-
-      return new Ok([
-        { type: "text" as const, text: message },
-        {
-          type: "text" as const,
-          text: outputText,
-        },
-      ]);
+        return new Ok([
+          { type: "text" as const, text: message },
+          {
+            type: "text" as const,
+            text: outputText,
+          },
+        ]);
+      },
+      authInfo,
     });
   },
 
   get_issues_using_jql: async (
-    { jql, maxResults, fields, nextPageToken, cloud_id },
+    { jql, maxResults, fields, nextPageToken },
     { authInfo }
   ) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await searchJiraIssuesUsingJql(baseUrl, accessToken, jql, {
-        maxResults,
-        fields,
-        nextPageToken,
-      });
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(`Error executing JQL search: ${result.error}`)
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await searchJiraIssuesUsingJql(
+          baseUrl,
+          accessToken,
+          jql,
+          {
+            maxResults,
+            fields,
+            nextPageToken,
+          }
         );
-      }
-      const message =
-        result.value.issues.length === 0
-          ? "No issues found matching the JQL query"
-          : `Found ${result.value.issues.length} issue(s) using JQL`;
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Error executing JQL search: ${result.error}`)
+          );
+        }
+        const message =
+          result.value.issues.length === 0
+            ? "No issues found matching the JQL query"
+            : `Found ${result.value.issues.length} issue(s) using JQL`;
 
-      const issueTexts = result.value.issues.map((issue, index) => {
-        const formatted = renderIssueWithEmbeddedComments(issue);
-        return index > 0 ? `\n${"-".repeat(80)}\n\n${formatted}` : formatted;
-      });
+        const issueTexts = result.value.issues.map((issue, index) => {
+          const formatted = renderIssueWithEmbeddedComments(issue);
+          return index > 0 ? `\n${"-".repeat(80)}\n\n${formatted}` : formatted;
+        });
 
-      let outputText = message + "\n\n";
-      outputText += issueTexts.join("\n");
+        let outputText = message + "\n\n";
+        outputText += issueTexts.join("\n");
 
-      if (result.value.nextPageToken) {
-        outputText += `\n\nNote: More results available. Use nextPageToken: ${result.value.nextPageToken} to fetch the next page.`;
-      }
+        if (result.value.nextPageToken) {
+          outputText += `\n\nNote: More results available. Use nextPageToken: ${result.value.nextPageToken} to fetch the next page.`;
+        }
 
-      return new Ok([
-        { type: "text" as const, text: message },
-        {
-          type: "text" as const,
-          text: outputText,
-        },
-      ]);
+        return new Ok([
+          { type: "text" as const, text: message },
+          {
+            type: "text" as const,
+            text: outputText,
+          },
+        ]);
+      },
+      authInfo,
     });
   },
 
-  get_issue_types: async ({ projectKey, cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      try {
-        const result = await getIssueTypes(baseUrl, accessToken, projectKey);
-        if (result.isErr()) {
+  get_issue_types: async ({ projectKey }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        try {
+          const result = await getIssueTypes(baseUrl, accessToken, projectKey);
+          if (result.isErr()) {
+            return new Err(
+              new MCPError(`Error retrieving issue types: ${result.error}`)
+            );
+          }
+          return new Ok([
+            {
+              type: "text" as const,
+              text: "Issue types retrieved successfully",
+            },
+            {
+              type: "text" as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ]);
+        } catch (error) {
           return new Err(
-            new MCPError(`Error retrieving issue types: ${result.error}`)
+            new MCPError(
+              `Error retrieving issue types: ${normalizeError(error).message}`
+            )
           );
         }
-        return new Ok([
-          {
-            type: "text" as const,
-            text: "Issue types retrieved successfully",
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ]);
-      } catch (error) {
-        return new Err(
-          new MCPError(
-            `Error retrieving issue types: ${normalizeError(error).message}`
-          )
-        );
-      }
+      },
+      authInfo,
     });
   },
 
   get_issue_create_fields: async (
-    { projectKey, issueTypeId, cloud_id },
+    { projectKey, issueTypeId },
     { authInfo }
   ) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      try {
-        const result = await getIssueFields(
-          baseUrl,
-          accessToken,
-          projectKey,
-          issueTypeId
-        );
-        if (result.isErr()) {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        try {
+          const result = await getIssueFields(
+            baseUrl,
+            accessToken,
+            projectKey,
+            issueTypeId
+          );
+          if (result.isErr()) {
+            return new Err(
+              new MCPError(`Error retrieving issue fields: ${result.error}`)
+            );
+          }
+          return new Ok([
+            {
+              type: "text" as const,
+              text: "Issue fields retrieved successfully",
+            },
+            {
+              type: "text" as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ]);
+        } catch (error) {
           return new Err(
-            new MCPError(`Error retrieving issue fields: ${result.error}`)
+            new MCPError(
+              `Error retrieving issue fields: ${normalizeError(error).message}`
+            )
           );
         }
-        return new Ok([
-          {
-            type: "text" as const,
-            text: "Issue fields retrieved successfully",
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ]);
-      } catch (error) {
-        return new Err(
-          new MCPError(
-            `Error retrieving issue fields: ${normalizeError(error).message}`
-          )
-        );
-      }
+      },
+      authInfo,
     });
   },
 
@@ -343,50 +385,79 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
       },
       {
         type: "text" as const,
-        text: JSON.stringify(connectionInfo.value, null, 2),
+        text: JSON.stringify(connectionInfo, null, 2),
       },
     ]);
   },
 
-  get_issue_link_types: async ({ cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await getIssueLinkTypes(baseUrl, accessToken);
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(`Error retrieving issue link types: ${result.error}`)
-        );
-      }
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "Issue link types retrieved successfully",
-        },
-        {
-          type: "text" as const,
-          text: JSON.stringify(result.value, null, 2),
-        },
-      ]);
+  get_issue_link_types: async (_params, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await getIssueLinkTypes(baseUrl, accessToken);
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Error retrieving issue link types: ${result.error}`)
+          );
+        }
+        return new Ok([
+          {
+            type: "text" as const,
+            text: "Issue link types retrieved successfully",
+          },
+          {
+            type: "text" as const,
+            text: JSON.stringify(result.value, null, 2),
+          },
+        ]);
+      },
+      authInfo,
     });
   },
 
   get_users: async (
-    {
-      emailAddress,
-      name,
-      maxResults = SEARCH_USERS_MAX_RESULTS,
-      startAt,
-      cloud_id,
-    },
+    { emailAddress, name, maxResults = SEARCH_USERS_MAX_RESULTS, startAt },
     { authInfo }
   ) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      if (emailAddress) {
-        const result = await searchUsersByEmailExact(
-          baseUrl,
-          accessToken,
-          emailAddress,
-          { maxResults, startAt }
-        );
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        if (emailAddress) {
+          const result = await searchUsersByEmailExact(
+            baseUrl,
+            accessToken,
+            emailAddress,
+            { maxResults, startAt }
+          );
+          if (result.isErr()) {
+            return new Err(
+              new MCPError(`Error searching users: ${result.error}`)
+            );
+          }
+
+          const message =
+            result.value.users.length === 0
+              ? "No users found with the specified email address"
+              : `Found ${result.value.users.length} exact match(es) for the specified email address`;
+          return new Ok([
+            { type: "text" as const, text: message },
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  users: result.value.users,
+                  nextStartAt: result.value.nextStartAt,
+                },
+                null,
+                2
+              ),
+            },
+          ]);
+        }
+
+        const result = await listUsers(baseUrl, accessToken, {
+          name,
+          maxResults,
+          startAt,
+        });
         if (result.isErr()) {
           return new Err(
             new MCPError(`Error searching users: ${result.error}`)
@@ -395,8 +466,12 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
         const message =
           result.value.users.length === 0
-            ? "No users found with the specified email address"
-            : `Found ${result.value.users.length} exact match(es) for the specified email address`;
+            ? name
+              ? "No users found matching the name"
+              : "No users found"
+            : name
+              ? `Found ${result.value.users.length} user(s) matching the name`
+              : `Listed ${result.value.users.length} user(s)`;
         return new Ok([
           { type: "text" as const, text: message },
           {
@@ -411,97 +486,14 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
             ),
           },
         ]);
-      }
-
-      const result = await listUsers(baseUrl, accessToken, {
-        name,
-        maxResults,
-        startAt,
-      });
-      if (result.isErr()) {
-        return new Err(new MCPError(`Error searching users: ${result.error}`));
-      }
-
-      const message =
-        result.value.users.length === 0
-          ? name
-            ? "No users found matching the name"
-            : "No users found"
-          : name
-            ? `Found ${result.value.users.length} user(s) matching the name`
-            : `Listed ${result.value.users.length} user(s)`;
-      return new Ok([
-        { type: "text" as const, text: message },
-        {
-          type: "text" as const,
-          text: JSON.stringify(
-            {
-              users: result.value.users,
-              nextStartAt: result.value.nextStartAt,
-            },
-            null,
-            2
-          ),
-        },
-      ]);
+      },
+      authInfo,
     });
   },
 
-  get_attachments: async ({ issueKey, cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const attachmentsResult = await getIssueAttachments({
-        baseUrl,
-        accessToken,
-        issueKey,
-      });
-
-      if (attachmentsResult.isErr()) {
-        return new Err(new MCPError(attachmentsResult.error));
-      }
-
-      const attachments = attachmentsResult.value;
-      const attachmentSummary = attachments.map((att) => ({
-        id: att.id,
-        filename: att.filename,
-        size: att.size,
-        mimeType: att.mimeType,
-        created: att.created,
-        author: att.author?.displayName ?? att.author?.accountId,
-        content: att.content,
-        thumbnail: att.thumbnail,
-      }));
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `Found ${attachments.length} attachment(s) for issue ${issueKey}`,
-        },
-        {
-          type: "text" as const,
-          text: JSON.stringify(
-            {
-              issueKey,
-              attachments: attachmentSummary,
-              totalAttachments: attachments.length,
-              totalSize: attachments.reduce(
-                (sum, att) => sum + (att.size || 0),
-                0
-              ),
-            },
-            null,
-            2
-          ),
-        },
-      ]);
-    });
-  },
-
-  read_attachment: async (
-    { issueKey, attachmentId, cloud_id },
-    { authInfo }
-  ) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      try {
+  get_attachments: async ({ issueKey }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
         const attachmentsResult = await getIssueAttachments({
           baseUrl,
           accessToken,
@@ -513,379 +505,452 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
         }
 
         const attachments = attachmentsResult.value;
-        const targetAttachment = attachments.find(
-          (att) => att.id === attachmentId
-        );
-        if (!targetAttachment) {
+        const attachmentSummary = attachments.map((att) => ({
+          id: att.id,
+          filename: att.filename,
+          size: att.size,
+          mimeType: att.mimeType,
+          created: att.created,
+          author: att.author?.displayName ?? att.author?.accountId,
+          content: att.content,
+          thumbnail: att.thumbnail,
+        }));
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Found ${attachments.length} attachment(s) for issue ${issueKey}`,
+          },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                issueKey,
+                attachments: attachmentSummary,
+                totalAttachments: attachments.length,
+                totalSize: attachments.reduce(
+                  (sum, att) => sum + (att.size || 0),
+                  0
+                ),
+              },
+              null,
+              2
+            ),
+          },
+        ]);
+      },
+      authInfo,
+    });
+  },
+
+  read_attachment: async ({ issueKey, attachmentId }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        try {
+          const attachmentsResult = await getIssueAttachments({
+            baseUrl,
+            accessToken,
+            issueKey,
+          });
+
+          if (attachmentsResult.isErr()) {
+            return new Err(new MCPError(attachmentsResult.error));
+          }
+
+          const attachments = attachmentsResult.value;
+          const targetAttachment = attachments.find(
+            (att) => att.id === attachmentId
+          );
+          if (!targetAttachment) {
+            return new Err(
+              new MCPError(
+                `Attachment with ID ${attachmentId} not found on issue ${issueKey}`
+              )
+            );
+          }
+          return await processAttachment({
+            mimeType: targetAttachment.mimeType,
+            filename: targetAttachment.filename,
+            extractText: async () =>
+              extractTextFromAttachment({
+                baseUrl,
+                accessToken,
+                attachmentId,
+                mimeType: targetAttachment.mimeType,
+              }),
+            downloadContent: async () => {
+              const result = await getAttachmentContent({
+                baseUrl,
+                accessToken,
+                attachmentId,
+                mimeType: targetAttachment.mimeType,
+              });
+              if (result.isErr()) {
+                return result;
+              }
+              return new Ok(Buffer.from(result.value.content, "base64"));
+            },
+          });
+        } catch (error) {
+          logger.error(`Error in read_attachment:`, {
+            error: error,
+            issueKey,
+            attachmentId,
+          });
           return new Err(
             new MCPError(
-              `Attachment with ID ${attachmentId} not found on issue ${issueKey}`
+              `Error in read_attachment: ${normalizeError(error).message}`
             )
           );
         }
-        return await processAttachment({
-          mimeType: targetAttachment.mimeType,
-          filename: targetAttachment.filename,
-          extractText: async () =>
-            extractTextFromAttachment({
-              baseUrl,
-              accessToken,
-              attachmentId,
-              mimeType: targetAttachment.mimeType,
-            }),
-          downloadContent: async () => {
-            const result = await getAttachmentContent({
-              baseUrl,
-              accessToken,
-              attachmentId,
-              mimeType: targetAttachment.mimeType,
-            });
-            if (result.isErr()) {
-              return result;
-            }
-            return new Ok(Buffer.from(result.value.content, "base64"));
-          },
-        });
-      } catch (error) {
-        logger.error(`Error in read_attachment:`, {
-          error: error,
-          issueKey,
-          attachmentId,
-        });
-        return new Err(
-          new MCPError(
-            `Error in read_attachment: ${normalizeError(error).message}`
-          )
-        );
-      }
+      },
+      authInfo,
     });
   },
 
   // Write operations
   create_comment: async (
-    { issueKey, comment, visibilityType, visibilityValue, cloud_id },
+    { issueKey, comment, visibilityType, visibilityValue },
     { authInfo }
   ) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const visibility =
-        visibilityType && visibilityValue
-          ? { type: visibilityType, value: visibilityValue }
-          : undefined;
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const visibility =
+          visibilityType && visibilityValue
+            ? { type: visibilityType, value: visibilityValue }
+            : undefined;
 
-      const result = await createComment(
-        baseUrl,
-        accessToken,
-        issueKey,
-        comment,
-        visibility
-      );
-      if (result.isErr()) {
-        return new Err(new MCPError(`Error adding comment: ${result.error}`));
-      }
-      if (result.value === null) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: "Issue not found or no permission to add comment",
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify({ found: false, issueKey }, null, 2),
-          },
-        ]);
-      }
-      return new Ok([
-        { type: "text" as const, text: "Comment added successfully" },
-        {
-          type: "text" as const,
-          text: JSON.stringify(
-            {
-              issueKey,
-              comment:
-                typeof comment === "string" ? comment : "[Rich ADF Content]",
-              commentId: result.value.id,
-            },
-            null,
-            2
-          ),
-        },
-      ]);
-    });
-  },
-
-  transition_issue: async (
-    { issueKey, transitionId, cloud_id },
-    { authInfo }
-  ) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await transitionIssue(
-        baseUrl,
-        accessToken,
-        issueKey,
-        transitionId
-      );
-      if (result.isErr()) {
-        let errorMessage = `Error transitioning issue: ${result.error}`;
-        if (
-          result.error.includes("transition") &&
-          (result.error.includes("not valid") ||
-            result.error.includes("not allowed"))
-        ) {
-          errorMessage = `Transition failed: ${result.error}. This transition may not be available from the current status, or you may lack permission to perform it.`;
-        } else if (result.error.includes("workflow")) {
-          errorMessage = `Workflow error: ${result.error}. The issue's workflow may have conditions or validators preventing this transition.`;
-        }
-        return new Err(new MCPError(errorMessage));
-      }
-      if (result.value === null) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: "Issue not found or no permission to transition it",
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify({ found: false, issueKey }, null, 2),
-          },
-        ]);
-      }
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "Issue transitioned successfully",
-        },
-        {
-          type: "text" as const,
-          text: JSON.stringify(
-            {
-              issueKey,
-              transitionId,
-            },
-            null,
-            2
-          ),
-        },
-      ]);
-    });
-  },
-
-  create_issue: async ({ issueData, cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await createIssue(baseUrl, accessToken, issueData);
-      if (result.isErr()) {
-        let errorMessage = `Error creating issue: ${result.error}`;
-        if (
-          result.error.includes("cannot be set") ||
-          result.error.includes("not on the appropriate screen")
-        ) {
-          errorMessage = `Field configuration error: ${result.error}. Some fields are not available for this project/issue type. Use get_issue_create_fields to check which fields are required and available before creating issues.`;
-        }
-        return new Err(new MCPError(errorMessage));
-      }
-      return new Ok([
-        { type: "text" as const, text: "Issue created successfully" },
-        {
-          type: "text" as const,
-          text: JSON.stringify(result.value, null, 2),
-        },
-      ]);
-    });
-  },
-
-  update_issue: async ({ issueKey, updateData, cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await updateIssue(
-        baseUrl,
-        accessToken,
-        issueKey,
-        updateData
-      );
-      if (result.isErr()) {
-        return new Err(new MCPError(`Error updating issue: ${result.error}`));
-      }
-      if (result.value === null) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: "Issue not found or no permission to update it",
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify({ found: false, issueKey }, null, 2),
-          },
-        ]);
-      }
-      return new Ok([
-        { type: "text" as const, text: "Issue updated successfully" },
-        {
-          type: "text" as const,
-          text: JSON.stringify(
-            {
-              ...result.value,
-              updatedFields: Object.keys(updateData),
-            },
-            null,
-            2
-          ),
-        },
-      ]);
-    });
-  },
-
-  create_issue_link: async ({ linkData, cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await createIssueLink(baseUrl, accessToken, linkData);
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(`Error creating issue link: ${result.error}`)
+        const result = await createComment(
+          baseUrl,
+          accessToken,
+          issueKey,
+          comment,
+          visibility
         );
-      }
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "Issue link created successfully",
-        },
-        {
-          type: "text" as const,
-          text: JSON.stringify(
+        if (result.isErr()) {
+          return new Err(new MCPError(`Error adding comment: ${result.error}`));
+        }
+        if (result.value === null) {
+          return new Ok([
             {
-              ...linkData,
+              type: "text" as const,
+              text: "Issue not found or no permission to add comment",
             },
-            null,
-            2
-          ),
-        },
-      ]);
+            {
+              type: "text" as const,
+              text: JSON.stringify({ found: false, issueKey }, null, 2),
+            },
+          ]);
+        }
+        return new Ok([
+          { type: "text" as const, text: "Comment added successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                issueKey,
+                comment:
+                  typeof comment === "string" ? comment : "[Rich ADF Content]",
+                commentId: result.value.id,
+              },
+              null,
+              2
+            ),
+          },
+        ]);
+      },
+      authInfo,
     });
   },
 
-  delete_issue_link: async ({ linkId, cloud_id }, { authInfo }) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      const result = await deleteIssueLink(baseUrl, accessToken, linkId);
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(`Error deleting issue link: ${result.error}`)
+  transition_issue: async ({ issueKey, transitionId }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await transitionIssue(
+          baseUrl,
+          accessToken,
+          issueKey,
+          transitionId
         );
-      }
-      return new Ok([
-        {
-          type: "text" as const,
-          text: "Issue link deleted successfully",
-        },
-        {
-          type: "text" as const,
-          text: JSON.stringify({ linkId }, null, 2),
-        },
-      ]);
+        if (result.isErr()) {
+          let errorMessage = `Error transitioning issue: ${result.error}`;
+          if (
+            result.error.includes("transition") &&
+            (result.error.includes("not valid") ||
+              result.error.includes("not allowed"))
+          ) {
+            errorMessage = `Transition failed: ${result.error}. This transition may not be available from the current status, or you may lack permission to perform it.`;
+          } else if (result.error.includes("workflow")) {
+            errorMessage = `Workflow error: ${result.error}. The issue's workflow may have conditions or validators preventing this transition.`;
+          }
+          return new Err(new MCPError(errorMessage));
+        }
+        if (result.value === null) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: "Issue not found or no permission to transition it",
+            },
+            {
+              type: "text" as const,
+              text: JSON.stringify({ found: false, issueKey }, null, 2),
+            },
+          ]);
+        }
+        return new Ok([
+          {
+            type: "text" as const,
+            text: "Issue transitioned successfully",
+          },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                issueKey,
+                transitionId,
+              },
+              null,
+              2
+            ),
+          },
+        ]);
+      },
+      authInfo,
+    });
+  },
+
+  create_issue: async ({ issueData }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await createIssue(baseUrl, accessToken, issueData);
+        if (result.isErr()) {
+          let errorMessage = `Error creating issue: ${result.error}`;
+          if (
+            result.error.includes("cannot be set") ||
+            result.error.includes("not on the appropriate screen")
+          ) {
+            errorMessage = `Field configuration error: ${result.error}. Some fields are not available for this project/issue type. Use get_issue_create_fields to check which fields are required and available before creating issues.`;
+          }
+          return new Err(new MCPError(errorMessage));
+        }
+        return new Ok([
+          { type: "text" as const, text: "Issue created successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(result.value, null, 2),
+          },
+        ]);
+      },
+      authInfo,
+    });
+  },
+
+  update_issue: async ({ issueKey, updateData }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await updateIssue(
+          baseUrl,
+          accessToken,
+          issueKey,
+          updateData
+        );
+        if (result.isErr()) {
+          return new Err(new MCPError(`Error updating issue: ${result.error}`));
+        }
+        if (result.value === null) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: "Issue not found or no permission to update it",
+            },
+            {
+              type: "text" as const,
+              text: JSON.stringify({ found: false, issueKey }, null, 2),
+            },
+          ]);
+        }
+        return new Ok([
+          { type: "text" as const, text: "Issue updated successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                ...result.value,
+                updatedFields: Object.keys(updateData),
+              },
+              null,
+              2
+            ),
+          },
+        ]);
+      },
+      authInfo,
+    });
+  },
+
+  create_issue_link: async ({ linkData }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await createIssueLink(baseUrl, accessToken, linkData);
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Error creating issue link: ${result.error}`)
+          );
+        }
+        return new Ok([
+          {
+            type: "text" as const,
+            text: "Issue link created successfully",
+          },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                ...linkData,
+              },
+              null,
+              2
+            ),
+          },
+        ]);
+      },
+      authInfo,
+    });
+  },
+
+  delete_issue_link: async ({ linkId }, { authInfo }) => {
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        const result = await deleteIssueLink(baseUrl, accessToken, linkId);
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Error deleting issue link: ${result.error}`)
+          );
+        }
+        return new Ok([
+          {
+            type: "text" as const,
+            text: "Issue link deleted successfully",
+          },
+          {
+            type: "text" as const,
+            text: JSON.stringify({ linkId }, null, 2),
+          },
+        ]);
+      },
+      authInfo,
     });
   },
 
   upload_attachment: async (
-    { issueKey, attachment, cloud_id },
+    { issueKey, attachment },
     { auth, authInfo, agentLoopContext }
   ) => {
-    return withAuth(authInfo, cloud_id, async (baseUrl, accessToken) => {
-      let fileToUpload: {
-        buffer: Buffer;
-        filename: string;
-        contentType: string;
-      };
+    return withAuth({
+      action: async (baseUrl, accessToken) => {
+        let fileToUpload: {
+          buffer: Buffer;
+          filename: string;
+          contentType: string;
+        };
 
-      if (attachment.type === "conversation_file") {
-        if (!agentLoopContext) {
-          return new Err(
-            new MCPError(
-              "Conversation context required for conversation file attachments"
-            )
+        if (attachment.type === "conversation_file") {
+          if (!agentLoopContext) {
+            return new Err(
+              new MCPError(
+                "Conversation context required for conversation file attachments"
+              )
+            );
+          }
+
+          const fileResult = await getFileFromConversationAttachment(
+            auth,
+            attachment.fileId,
+            agentLoopContext
           );
+
+          if (fileResult.isErr()) {
+            return new Err(
+              new MCPError(
+                `Failed to get conversation file ${attachment.fileId}: ${fileResult.error}`
+              )
+            );
+          }
+
+          fileToUpload = fileResult.value;
+        } else if (attachment.type === "external_file") {
+          const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+          const estimatedSize = (attachment.base64Data.length * 3) / 4;
+
+          if (estimatedSize > MAX_FILE_SIZE_BYTES) {
+            return new Err(
+              new MCPError(
+                `File ${attachment.filename} is too large. Maximum size allowed is ${MAX_FILE_SIZE_BYTES / (1024 * 1024)}MB`
+              )
+            );
+          }
+
+          try {
+            const buffer = Buffer.from(attachment.base64Data, "base64");
+            fileToUpload = {
+              buffer,
+              filename: attachment.filename,
+              contentType: attachment.contentType,
+            };
+          } catch (error) {
+            return new Err(
+              new MCPError(
+                `Failed to decode base64 data for ${attachment.filename}: ${normalizeError(error).message}`
+              )
+            );
+          }
+        } else {
+          return new Err(new MCPError("Invalid attachment type"));
         }
 
-        const fileResult = await getFileFromConversationAttachment(
-          auth,
-          attachment.fileId,
-          agentLoopContext
+        const uploadResult = await uploadAttachmentsToJira(
+          baseUrl,
+          accessToken,
+          issueKey,
+          [fileToUpload]
         );
 
-        if (fileResult.isErr()) {
+        if (uploadResult.isErr()) {
           return new Err(
-            new MCPError(
-              `Failed to get conversation file ${attachment.fileId}: ${fileResult.error}`
-            )
+            new MCPError(`Failed to upload attachment: ${uploadResult.error}`)
           );
         }
 
-        fileToUpload = fileResult.value;
-      } else if (attachment.type === "external_file") {
-        const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
-        const estimatedSize = (attachment.base64Data.length * 3) / 4;
+        const uploadedAttachment = uploadResult.value[0];
 
-        if (estimatedSize > MAX_FILE_SIZE_BYTES) {
-          return new Err(
-            new MCPError(
-              `File ${attachment.filename} is too large. Maximum size allowed is ${MAX_FILE_SIZE_BYTES / (1024 * 1024)}MB`
-            )
-          );
-        }
-
-        try {
-          const buffer = Buffer.from(attachment.base64Data, "base64");
-          fileToUpload = {
-            buffer,
-            filename: attachment.filename,
-            contentType: attachment.contentType,
-          };
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Failed to decode base64 data for ${attachment.filename}: ${normalizeError(error).message}`
-            )
-          );
-        }
-      } else {
-        return new Err(new MCPError("Invalid attachment type"));
-      }
-
-      const uploadResult = await uploadAttachmentsToJira(
-        baseUrl,
-        accessToken,
-        issueKey,
-        [fileToUpload]
-      );
-
-      if (uploadResult.isErr()) {
-        return new Err(
-          new MCPError(`Failed to upload attachment: ${uploadResult.error}`)
-        );
-      }
-
-      const uploadedAttachment = uploadResult.value[0];
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `Successfully uploaded attachment to issue ${issueKey}`,
-        },
-        {
-          type: "text" as const,
-          text: JSON.stringify(
-            {
-              issueKey,
-              attachment: {
-                id: uploadedAttachment.id,
-                filename: uploadedAttachment.filename,
-                size: uploadedAttachment.size,
-                mimeType: uploadedAttachment.mimeType,
-                created: uploadedAttachment.created,
-                author:
-                  uploadedAttachment.author.displayName ??
-                  uploadedAttachment.author.accountId,
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Successfully uploaded attachment to issue ${issueKey}`,
+          },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                issueKey,
+                attachment: {
+                  id: uploadedAttachment.id,
+                  filename: uploadedAttachment.filename,
+                  size: uploadedAttachment.size,
+                  mimeType: uploadedAttachment.mimeType,
+                  created: uploadedAttachment.created,
+                  author:
+                    uploadedAttachment.author.displayName ??
+                    uploadedAttachment.author.accountId,
+                },
               },
-            },
-            null,
-            2
-          ),
-        },
-      ]);
+              null,
+              2
+            ),
+          },
+        ]);
+      },
+      authInfo,
     });
   },
 };

--- a/front/lib/api/actions/servers/jira/types.ts
+++ b/front/lib/api/actions/servers/jira/types.ts
@@ -172,14 +172,12 @@ export const JiraConnectionInfoSchema = z.object({
     name: z.string(),
     nickname: z.string(),
   }),
-  instances: z.array(
-    z.object({
-      cloud_id: z.string(),
-      site_url: z.string(),
-      site_name: z.string(),
-      api_base_url: z.string(),
-    })
-  ),
+  instance: z.object({
+    cloud_id: z.string(),
+    site_url: z.string(),
+    site_name: z.string(),
+    api_base_url: z.string(),
+  }),
 });
 
 export const JiraTransitionIssueSchema = z.void();


### PR DESCRIPTION
## Description

PR https://github.com/dust-tt/dust/pull/24211 was merged to fix https://github.com/dust-tt/tasks/issues/4500
It introduced updates on the Jira MCP tools to enable users to choose their instance when multiples instances were associated via the OAuth

But the changes introduced break some workflows for some customer, where they did not expect to provide the Jira instance.
=> reverting the changes to get back to previous behavior and will work on a better solution for multiple instances management

Fixes https://github.com/dust-tt/tasks/issues/7704

## Tests

None (revert)

## Risk

Limited as reverting to previous behavior

## Deploy Plan

Deploy front