### PR TITLE
[front] enh: improve performances of agent scope batch update

### DIFF
--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -4,6 +4,7 @@ import {
   createPendingAgentConfiguration,
   getAgentConfiguration,
   restoreAgentConfiguration,
+  updateAgentConfigurationsScope,
 } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -11,6 +12,7 @@ import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_res
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -328,5 +330,175 @@ describe("archiveAgentConfiguration and restoreAgentConfiguration", () => {
         "Agent configuration is not archived"
       );
     }
+  });
+});
+
+describe("updateAgentConfigurationsScope", () => {
+  it("updates the scope of a single agent", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { scope: "hidden" }
+    );
+
+    const result = await updateAgentConfigurationsScope(
+      authenticator,
+      [agent.sId],
+      "visible"
+    );
+    expect(result.isOk()).toBe(true);
+
+    const row = await AgentConfigurationModel.findOne({
+      where: { sId: agent.sId, workspaceId: workspace.id },
+    });
+    expect(row!.scope).toBe("visible");
+  });
+
+  it("updates the scope of multiple agents in a single call", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const agents = await Promise.all([
+      AgentConfigurationFactory.createTestAgent(authenticator, {
+        name: "A1",
+        scope: "hidden",
+      }),
+      AgentConfigurationFactory.createTestAgent(authenticator, {
+        name: "A2",
+        scope: "hidden",
+      }),
+      AgentConfigurationFactory.createTestAgent(authenticator, {
+        name: "A3",
+        scope: "hidden",
+      }),
+    ]);
+
+    const result = await updateAgentConfigurationsScope(
+      authenticator,
+      agents.map((a) => a.sId),
+      "visible"
+    );
+    expect(result.isOk()).toBe(true);
+
+    for (const a of agents) {
+      const row = await AgentConfigurationModel.findOne({
+        where: { sId: a.sId, workspaceId: workspace.id },
+      });
+      expect(row!.scope).toBe("visible");
+    }
+  });
+
+  it("returns Ok without changes when agentIds is empty", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const result = await updateAgentConfigurationsScope(
+      authenticator,
+      [],
+      "visible"
+    );
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("skips agents the caller cannot edit and is not admin of", async () => {
+    const { authenticator: ownerAuth, workspace } = await createResourceTest({
+      role: "builder",
+    });
+    const ownedAgent = await AgentConfigurationFactory.createTestAgent(
+      ownerAuth,
+      { name: "Owned", scope: "hidden" }
+    );
+
+    // Another builder who has no editing rights on the agent.
+    const outsider = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, outsider, { role: "builder" });
+    const outsiderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      outsider.sId,
+      workspace.sId
+    );
+
+    const result = await updateAgentConfigurationsScope(
+      outsiderAuth,
+      [ownedAgent.sId],
+      "visible"
+    );
+    expect(result.isOk()).toBe(true);
+
+    const row = await AgentConfigurationModel.findOne({
+      where: { sId: ownedAgent.sId, workspaceId: workspace.id },
+    });
+    expect(row!.scope).toBe("hidden");
+  });
+
+  it("disables triggers of non-editors when transitioning visible → hidden", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { scope: "visible" }
+    );
+
+    // A workspace member who is not in the agent's editor group.
+    const nonEditor = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, nonEditor, {
+      role: "builder",
+    });
+
+    // Trigger owned by the admin (member of the editor group).
+    const editorTriggerRes = await TriggerResource.makeNew(authenticator, {
+      workspaceId: workspace.id,
+      name: "editor-trigger",
+      kind: "webhook",
+      agentConfigurationId: agent.sId,
+      editor: user.id,
+      customPrompt: null,
+      status: "enabled",
+      configuration: { includePayload: true },
+      webhookSourceViewId: null,
+      origin: "user",
+    });
+    expect(editorTriggerRes.isOk()).toBe(true);
+    const editorTrigger = editorTriggerRes.isOk()
+      ? editorTriggerRes.value
+      : null;
+
+    // Trigger owned by the non-editor user.
+    const nonEditorTriggerRes = await TriggerResource.makeNew(authenticator, {
+      workspaceId: workspace.id,
+      name: "non-editor-trigger",
+      kind: "webhook",
+      agentConfigurationId: agent.sId,
+      editor: nonEditor.id,
+      customPrompt: null,
+      status: "enabled",
+      configuration: { includePayload: true },
+      webhookSourceViewId: null,
+      origin: "user",
+    });
+    expect(nonEditorTriggerRes.isOk()).toBe(true);
+    const nonEditorTrigger = nonEditorTriggerRes.isOk()
+      ? nonEditorTriggerRes.value
+      : null;
+
+    const result = await updateAgentConfigurationsScope(
+      authenticator,
+      [agent.sId],
+      "hidden"
+    );
+    expect(result.isOk()).toBe(true);
+
+    const refreshedEditorTrigger = await TriggerResource.fetchById(
+      authenticator,
+      editorTrigger!.sId
+    );
+    const refreshedNonEditorTrigger = await TriggerResource.fetchById(
+      authenticator,
+      nonEditorTrigger!.sId
+    );
+
+    expect(refreshedEditorTrigger!.status).toBe("enabled");
+    expect(refreshedNonEditorTrigger!.status).toBe("disabled");
   });
 });

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1792,7 +1792,6 @@ async function disableTriggersForNonEditors(
     const editorModelIds = group
       ? editorModelIdsByGroupModelId.get(group.id)
       : undefined;
-    // No editor group resolved → disable all triggers for that agent (matches prior behavior).
     return !editorModelIds || !editorModelIds.has(trigger.editor);
   });
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1679,95 +1679,141 @@ async function canPublishAgent(auth: Authenticator): Promise<{
 
 export async function updateAgentConfigurationScope(
   auth: Authenticator,
-  agentConfigurationId: string,
+  agentIds: string[],
   scope: Exclude<AgentConfigurationScope, "global">
 ): Promise<Result<void, Error>> {
-  const agentConfig = await getAgentConfiguration(auth, {
-    agentId: agentConfigurationId,
+  if (agentIds.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const agentConfigs = await getAgentConfigurations(auth, {
+    agentIds,
     variant: "light",
   });
 
-  if (!agentConfig) {
-    return new Err(new Error(`Could not find agent ${agentConfigurationId}`));
+  const editableAgents = agentConfigs.filter(
+    (a) => a.canEdit || auth.isAdmin()
+  );
+  if (editableAgents.length === 0) {
+    return new Ok(undefined);
   }
 
   const { canPublish, message } = await canPublishAgent(auth);
-  if (
-    !canPublish &&
-    agentConfig.scope !== "visible" &&
-    scope === "visible" &&
-    agentConfig.status === "active"
-  ) {
-    return new Err(new Error(message ?? "Publishing agents is restricted."));
+  if (scope === "visible" && !canPublish) {
+    if (editableAgents.some(
+      (a) => a.scope !== "visible" && a.status === "active"
+    )) {
+      return new Err(new Error(message ?? "Publishing agents is restricted."));
+    }
   }
 
-  const previousScope = agentConfig.scope;
+  // Snapshot previous scopes before the bulk UPDATE so downstream logic doesn't depend on
+  // the in-memory agent objects being untouched by the static Sequelize update.
+  const previousScopeByAgentId = new Map(
+    editableAgents.map((a) => [a.sId, a.scope])
+  );
+
   await AgentConfigurationModel.update(
     { scope },
     {
       where: {
-        id: agentConfig.id,
+        id: { [Op.in]: editableAgents.map((a) => a.id) },
       },
     }
   );
 
-  void emitAuditLogEvent({
-    auth,
-    action: "agent.scope_changed",
-    targets: [
-      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-      buildAuditLogTarget("agent", agentConfig),
-    ],
-    context: getAuditLogContext(auth),
-    metadata: {
-      agentName: agentConfig.name,
-      previousScope: previousScope,
-      newScope: scope,
-    },
-  });
+  for (const agentConfig of editableAgents) {
+    void emitAuditLogEvent({
+      auth,
+      action: "agent.scope_changed",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("agent", agentConfig),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        agentName: agentConfig.name,
+        previousScope:
+          previousScopeByAgentId.get(agentConfig.sId) ?? agentConfig.scope,
+        newScope: scope,
+      },
+    });
+  }
 
   // When scope changes from visible to hidden, disable triggers for non-editors.
   // Non-editors will no longer have access to the hidden agent.
-  if (previousScope === "visible" && scope === "hidden") {
-    const triggers = await TriggerResource.listByAgentConfigurationId(
-      auth,
-      agentConfigurationId
+  if (scope === "hidden") {
+    const transitioningAgents = editableAgents.filter(
+      (a) => previousScopeByAgentId.get(a.sId) === "visible"
     );
-
-    if (triggers.length > 0) {
-      // Get the editor group to find who can still access the agent
-      const editorGroupRes = await GroupResource.findEditorGroupForAgent(
-        auth,
-        agentConfig
-      );
-
-      let editorIds: Set<ModelId> = new Set();
-      if (editorGroupRes.isOk()) {
-        const members = await editorGroupRes.value.getActiveMembers(auth);
-        editorIds = new Set(members.map((m) => m.id));
-      }
-
-      // Disable triggers for users who are not editors
-      for (const trigger of triggers) {
-        if (!editorIds.has(trigger.editor)) {
-          const disableResult = await trigger.disable(auth);
-          if (disableResult.isErr()) {
-            logger.error(
-              {
-                workspaceId: auth.getNonNullableWorkspace().sId,
-                agentConfigurationId,
-                triggerId: trigger.sId,
-                error: disableResult.error,
-              },
-              `Failed to disable trigger ${trigger.sId} when changing agent ${agentConfigurationId} scope to hidden`
-            );
-          }
-        }
-      }
+    if (transitioningAgents.length > 0) {
+      await disableTriggersForNonEditors(auth, transitioningAgents);
     }
   }
 
   return new Ok(undefined);
+}
+
+async function disableTriggersForNonEditors(
+  auth: Authenticator,
+  agents: LightAgentConfigurationType[]
+): Promise<void> {
+  const triggers = await TriggerResource.listByAgentConfigurationIds(
+    auth,
+    agents.map((a) => a.sId)
+  );
+  if (triggers.length === 0) {
+    return;
+  }
+
+  const editorGroupsRes = await GroupResource.findEditorGroupsForAgents(
+    auth,
+    agents
+  );
+  const editorGroupsByAgentId = editorGroupsRes.isOk()
+    ? editorGroupsRes.value
+    : {};
+
+  // Dedupe editor groups so we fetch members once per unique group.
+  const uniqueGroupsByGroupModelId = new Map<ModelId, GroupResource>();
+  for (const group of Object.values(editorGroupsByAgentId)) {
+    uniqueGroupsByGroupModelId.set(group.id, group);
+  }
+
+  const editorIdsByGroupModelId = new Map<ModelId, Set<ModelId>>();
+  for (const group of uniqueGroupsByGroupModelId.values()) {
+    const members = await group.getActiveMembers(auth);
+    editorIdsByGroupModelId.set(group.id, new Set(members.map((m) => m.id)));
+  }
+
+  const editorIdsByAgentId = new Map<string, Set<ModelId>>();
+  for (const agent of agents) {
+    const group = editorGroupsByAgentId[agent.sId];
+    const editorIds = group
+      ? (editorIdsByGroupModelId.get(group.id) ?? new Set<ModelId>())
+      : new Set<ModelId>();
+    editorIdsByAgentId.set(agent.sId, editorIds);
+  }
+
+  const triggersToDisable = triggers.filter((trigger) => {
+    const editorIds = editorIdsByAgentId.get(trigger.agentConfigurationId);
+    return editorIds !== undefined && !editorIds.has(trigger.editor);
+  });
+
+  if (triggersToDisable.length === 0) {
+    return;
+  }
+
+  const res = await TriggerResource.disableMany(auth, triggersToDisable);
+  if (res.isErr()) {
+    logger.error(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        error: res.error,
+      },
+      "Failed to disable triggers when changing agent scope to hidden"
+    );
+  }
 }
 
 export { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent_requirements";

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1774,30 +1774,26 @@ async function disableTriggersForNonEditors(
     ? editorGroupsRes.value
     : {};
 
-  // Dedupe editor groups so we fetch members once per unique group.
-  const uniqueGroupsByGroupModelId = new Map<ModelId, GroupResource>();
+  // Fetch members once per unique editor group.
+  const editorModelIdsByGroupModelId = new Map<ModelId, Set<ModelId>>();
   for (const group of Object.values(editorGroupsByAgentId)) {
-    uniqueGroupsByGroupModelId.set(group.id, group);
-  }
-
-  const editorIdsByGroupModelId = new Map<ModelId, Set<ModelId>>();
-  for (const group of uniqueGroupsByGroupModelId.values()) {
+    if (editorModelIdsByGroupModelId.has(group.id)) {
+      continue;
+    }
     const members = await group.getActiveMembers(auth);
-    editorIdsByGroupModelId.set(group.id, new Set(members.map((m) => m.id)));
-  }
-
-  const editorIdsByAgentId = new Map<string, Set<ModelId>>();
-  for (const agent of agents) {
-    const group = editorGroupsByAgentId[agent.sId];
-    const editorIds = group
-      ? (editorIdsByGroupModelId.get(group.id) ?? new Set<ModelId>())
-      : new Set<ModelId>();
-    editorIdsByAgentId.set(agent.sId, editorIds);
+    editorModelIdsByGroupModelId.set(
+      group.id,
+      new Set(members.map((m) => m.id))
+    );
   }
 
   const triggersToDisable = triggers.filter((trigger) => {
-    const editorIds = editorIdsByAgentId.get(trigger.agentConfigurationId);
-    return editorIds !== undefined && !editorIds.has(trigger.editor);
+    const group = editorGroupsByAgentId[trigger.agentConfigurationId];
+    const editorModelIds = group
+      ? editorModelIdsByGroupModelId.get(group.id)
+      : undefined;
+    // No editor group resolved → disable all triggers for that agent (matches prior behavior).
+    return !editorModelIds || !editorModelIds.has(trigger.editor);
   });
 
   if (triggersToDisable.length === 0) {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1791,7 +1791,7 @@ async function disableTriggersForNonEditors(
     const group = editorGroupsByAgentId[trigger.agentConfigurationId];
     const editorModelIds = group
       ? editorModelIdsByGroupModelId.get(group.id)
-      : undefined;
+      : null;
     return !editorModelIds || !editorModelIds.has(trigger.editor);
   });
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1816,8 +1816,6 @@ async function disableTriggersForNonEditors(
   }
 }
 
-export { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent_requirements";
-
 export async function filterAgentsByRequestedSpaces(
   auth: Authenticator,
   agents: AgentConfigurationModel[]

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1677,7 +1677,7 @@ async function canPublishAgent(auth: Authenticator): Promise<{
   return { canPublish: false, message: PUBLISHING_RESTRICTIONS[level].message };
 }
 
-export async function updateAgentConfigurationScope(
+export async function updateAgentConfigurationsScope(
   auth: Authenticator,
   agentIds: string[],
   scope: Exclude<AgentConfigurationScope, "global">
@@ -1700,9 +1700,9 @@ export async function updateAgentConfigurationScope(
 
   const { canPublish, message } = await canPublishAgent(auth);
   if (scope === "visible" && !canPublish) {
-    if (editableAgents.some(
-      (a) => a.scope !== "visible" && a.status === "active"
-    )) {
+    if (
+      editableAgents.some((a) => a.scope !== "visible" && a.status === "active")
+    ) {
       return new Err(new Error(message ?? "Publishing agents is restricted."));
     }
   }

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -130,6 +130,21 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     });
   }
 
+  static async listByAgentConfigurationIds(
+    auth: Authenticator,
+    agentConfigurationIds: string[]
+  ): Promise<TriggerResource[]> {
+    if (agentConfigurationIds.length === 0) {
+      return [];
+    }
+
+    return this.baseFetch(auth, {
+      where: {
+        agentConfigurationId: agentConfigurationIds,
+      },
+    });
+  }
+
   static async listByAgentConfigurationIdAndEditors(
     auth: Authenticator,
     {
@@ -657,6 +672,46 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     const r = await this.removeTemporalWorkflow(auth);
     if (r.isErr()) {
       return r;
+    }
+
+    return new Ok(undefined);
+  }
+
+  static async disableMany(
+    auth: Authenticator,
+    triggers: TriggerResource[],
+    targetStatus: Exclude<TriggerStatus, "enabled"> = "disabled"
+  ): Promise<Result<undefined, Error>> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const toUpdate = triggers.filter((t) => t.status !== targetStatus);
+    if (toUpdate.length === 0) {
+      return new Ok(undefined);
+    }
+
+    await this.model.update(
+      { status: targetStatus },
+      {
+        where: {
+          id: { [Op.in]: toUpdate.map((t) => t.id) },
+          workspaceId: workspace.id,
+        },
+      }
+    );
+
+    for (const trigger of toUpdate) {
+      const r = await trigger.removeTemporalWorkflow(auth);
+      if (r.isErr()) {
+        logger.error(
+          {
+            triggerId: trigger.sId,
+            workspaceId: workspace.sId,
+            agentConfigurationId: trigger.agentConfigurationId,
+            error: r.error,
+          },
+          `Failed to remove temporal workflow while disabling trigger ${trigger.sId}`
+        );
+      }
     }
 
     return new Ok(undefined);

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -709,7 +709,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
             agentConfigurationId: trigger.agentConfigurationId,
             error: r.error,
           },
-          `Failed to remove temporal workflow while disabling trigger ${trigger.sId}`
+          "Failed to remove Temporal workflow while disabling trigger"
         );
       }
     }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
@@ -1,5 +1,5 @@
 /** @ignoreswagger */
-import { updateAgentConfigurationScope } from "@app/lib/api/assistant/configuration/agent";
+import { updateAgentConfigurationsScope } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -59,7 +59,7 @@ async function handler(
 
   const { agentIds, scope } = bodyValidation.data;
 
-  const result = await updateAgentConfigurationScope(auth, agentIds, scope);
+  const result = await updateAgentConfigurationsScope(auth, agentIds, scope);
   if (result.isErr()) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
@@ -1,8 +1,5 @@
 /** @ignoreswagger */
-import {
-  getAgentConfiguration,
-  updateAgentConfigurationScope,
-} from "@app/lib/api/assistant/configuration/agent";
+import { updateAgentConfigurationScope } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -62,23 +59,15 @@ async function handler(
 
   const { agentIds, scope } = bodyValidation.data;
 
-  // We specifically don't want to use concurrentExecutor here to avoid
-  // too much DB concurrency
-
-  for (const agentId of agentIds) {
-    const agent = await getAgentConfiguration(auth, {
-      agentId,
-      variant: "light",
+  const result = await updateAgentConfigurationScope(auth, agentIds, scope);
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: result.error.message,
+      },
     });
-    if (!agent) {
-      continue; // Skip if agent not found
-    }
-
-    if (!agent.canEdit && !auth.isAdmin()) {
-      continue; // Skip if user doesn't have permission
-    }
-
-    await updateAgentConfigurationScope(auth, agentId, scope);
   }
 
   return res.status(200).json({


### PR DESCRIPTION
## Description

- This PR batches the query for updating the scopes of agents in batch (from Manage agents, then batch publish/unpublish).
- The current implementation loops over the agents.
- This PR batches the fetch of agents, editors, triggers + their updates.
- Relatively niche path.

## Tests

- Tested locally.

## Risk

- Low. Only one code path affected (update of scopes for an agent).

## Deploy Plan

- Deploy front.
