### PR TITLE
Implement wake-up Temporal activities

### DIFF
--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -4,7 +4,7 @@ import type { ConversationResource } from "@app/lib/resources/conversation_resou
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { makeSId } from "@app/lib/resources/string_ids";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
@@ -123,6 +123,24 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     return new Ok(wakeUp);
   }
 
+  static async fetchById(
+    auth: Authenticator,
+    wakeUpId: string
+  ): Promise<WakeUpResource | null> {
+    const modelId = getResourceIdFromSId(wakeUpId);
+    if (!modelId) {
+      return null;
+    }
+
+    const [wakeUp] = await this.baseFetch(auth, {
+      where: {
+        id: modelId,
+      },
+    });
+
+    return wakeUp ?? null;
+  }
+
   static async listByConversation(
     auth: Authenticator,
     conversation: ConversationWithoutContentType
@@ -196,22 +214,49 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       return temporalResult;
     }
 
+    await this.markCancelled(auth, { transaction });
+
+    return new Ok(undefined);
+  }
+
+  async markCancelled(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    if (this.status === "cancelled") {
+      return;
+    }
+
     await this.update(
       {
         status: "cancelled",
       },
       transaction
     );
+  }
 
-    return new Ok(undefined);
+  async markExpired(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    if (this.status === "expired") {
+      return;
+    }
+
+    await this.update(
+      {
+        status: "expired",
+      },
+      transaction
+    );
   }
 
   async markFired(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
-  ): Promise<Result<void, Error>> {
+  ): Promise<void> {
     if (this.status !== "scheduled") {
-      return new Ok(undefined);
+      return;
     }
 
     const nextStatus: WakeUpStatus =
@@ -224,8 +269,6 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       },
       transaction
     );
-
-    return new Ok(undefined);
   }
 
   async delete(

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -98,8 +98,6 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     const { scheduleType, fireAt, cronExpression, cronTimezone, reason } = blob;
     const user = auth.getNonNullableUser();
 
-    const user = auth.getNonNullableUser();
-
     const row = await this.model.create(
       {
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -183,10 +181,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
   }: {
     workspaceId: string;
     wakeUpId: string;
-  }): Promise<Result<
-    { auth: Authenticator; wakeUp: WakeUpResource },
-    Error
-  >> {
+  }): Promise<Result<{ auth: Authenticator; wakeUp: WakeUpResource }, Error>> {
     let auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
     const wakeUp = await WakeUpResource.fetchById(auth, wakeUpId);
 

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -189,9 +189,6 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       return new Err(new Error("WakeUp not found"));
     }
 
-    if (!wakeUp.userId) {
-      return new Err(new Error("WakeUp has no associated user"));
-    }
     const [user] = await UserResource.fetchByModelIds([wakeUp.userId]);
     if (!user) {
       return new Err(new Error("WakeUp user not found"));

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -1,4 +1,4 @@
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
@@ -6,6 +6,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
   cancelWakeUpTemporalWorkflow,
@@ -20,7 +21,7 @@ import type {
 } from "@app/types/assistant/wakeups";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Attributes, Transaction, WhereOptions } from "sequelize";
 
@@ -97,6 +98,8 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     const { scheduleType, fireAt, cronExpression, cronTimezone, reason } = blob;
     const user = auth.getNonNullableUser();
 
+    const user = auth.getNonNullableUser();
+
     const row = await this.model.create(
       {
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -168,6 +171,44 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
         ["id", "ASC"],
       ],
     });
+  }
+
+  /**
+   * This is used by the wake-up temporal activities to recover the wake-up resource and its
+   * associated user's authenticator.
+   */
+  static async fetchWakeUpAndAuthenticatorById({
+    workspaceId,
+    wakeUpId,
+  }: {
+    workspaceId: string;
+    wakeUpId: string;
+  }): Promise<Result<
+    { auth: Authenticator; wakeUp: WakeUpResource },
+    Error
+  >> {
+    let auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+    const wakeUp = await WakeUpResource.fetchById(auth, wakeUpId);
+
+    if (!wakeUp) {
+      return new Err(new Error("WakeUp not found"));
+    }
+
+    if (!wakeUp.userId) {
+      return new Err(new Error("WakeUp has no associated user"));
+    }
+    const [user] = await UserResource.fetchByModelIds([wakeUp.userId]);
+    if (!user) {
+      return new Err(new Error("WakeUp user not found"));
+    }
+
+    auth = await Authenticator.fromUserIdAndWorkspaceId(user.sId, workspaceId);
+
+    if (!auth.workspace() || !auth.user()) {
+      return new Err(new Error("Invalid Authenticator for WakeUp"));
+    }
+
+    return new Ok({ auth, wakeUp });
   }
 
   static async deleteByConversation(

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -32,7 +32,6 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 class TriggerNonRetryableError extends Error {}
 
 export class WakeUpNonRetryableError extends Error {}
-export class WakeUpRetryableError extends Error {}
 
 async function createConversationForAgentConfiguration({
   auth,

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -4,13 +4,16 @@ import {
   postNewContentFragment,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
@@ -19,15 +22,17 @@ import type { ContentFragmentInputWithFileIdType } from "@app/types/api/internal
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { TriggerType } from "@app/types/assistant/triggers";
+import type { WakeUpType } from "@app/types/assistant/wakeups";
 import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 class TriggerNonRetryableError extends Error {}
 
-// biome-ignore lint/correctness/noUnusedVariables: not implemented yet.
-class WakeUpNonRetryableError extends Error {}
+export class WakeUpNonRetryableError extends Error {}
+export class WakeUpRetryableError extends Error {}
 
 async function createConversationForAgentConfiguration({
   auth,
@@ -265,6 +270,14 @@ export async function runTriggeredAgentsActivity({
   }
 }
 
+function buildWakeUpMessageContent(wakeUp: WakeUpType): string {
+  return `<dust_system>
+This is an automatic wake-up message for a previously scheduled follow-up using the wake-up tool.
+- Wake-up ID: ${wakeUp.sId}
+</dust_system>
+Wake-up reason: ${wakeUp.reason}`;
+}
+
 export async function runWakeUpActivity({
   workspaceId,
   wakeUpId,
@@ -272,8 +285,107 @@ export async function runWakeUpActivity({
   workspaceId: string;
   wakeUpId: string;
 }): Promise<void> {
-  logger.info(
-    { wakeUpId, workspaceId },
-    "Wake-up activity is not implemented yet."
+  const wakeUpAndAuthRes = await WakeUpResource.fetchWakeUpAndAuthenticatorById(
+    {
+      workspaceId,
+      wakeUpId,
+    }
   );
+  if (wakeUpAndAuthRes.isErr()) {
+    logger.error(
+      { wakeUpId, workspaceId, error: normalizeError(wakeUpAndAuthRes.error) },
+      "Skipping wake-up: workspace or wake-up not found."
+    );
+    throw new WakeUpNonRetryableError("Workspace or wake-up not found.");
+  }
+
+  const { auth, wakeUp } = wakeUpAndAuthRes.value;
+
+  if (wakeUp.status !== "scheduled") {
+    logger.info(
+      { status: wakeUp.status, wakeUpId, workspaceId },
+      "Skipping wake-up: wake-up is not scheduled."
+    );
+    throw new WakeUpNonRetryableError("Wake-up is not scheduled.");
+  }
+
+  const [c] = await ConversationResource.fetchByModelIds(auth, [
+    wakeUp.conversationId,
+  ]);
+  if (!c) {
+    logger.info(
+      { status: wakeUp.status, wakeUpId, workspaceId },
+      "Cancelling wake-up: conversation not found."
+    );
+    await wakeUp.markCancelled(auth);
+    throw new WakeUpNonRetryableError("Conversation not found.");
+  }
+
+  const conversationRes = await getConversation(auth, c.sId);
+  if (conversationRes.isErr()) {
+    logger.info(
+      {
+        status: wakeUp.status,
+        wakeUpId,
+        workspaceId,
+        error: normalizeError(conversationRes.error),
+      },
+      "Cancelling wake-up: conversation not accessible."
+    );
+    await wakeUp.markCancelled(auth);
+    throw new WakeUpNonRetryableError("Conversation not accessible.");
+  }
+
+  const conversation = conversationRes.value;
+
+  const postMessageResult = await postUserMessage(auth, {
+    conversation,
+    content: buildWakeUpMessageContent(wakeUp.toJSON()),
+    mentions: [{ configurationId: wakeUp.agentConfigurationId }],
+    context: {
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
+      username: "Dust",
+      fullName: "Dust",
+      email: null,
+      profilePictureUrl: null,
+      origin: "wakeup",
+    },
+    skipToolsValidation: false,
+    doNotAssociateUser: true,
+  });
+
+  if (postMessageResult.isErr()) {
+    const {
+      api_error: { message, type },
+    } = postMessageResult.error;
+
+    throw new Error(`Error posting wake-up message: [${type}] ${message}`);
+  }
+
+  await wakeUp.markFired(auth);
+}
+
+export async function expireWakeUpActivity({
+  workspaceId,
+  wakeUpId,
+}: {
+  workspaceId: string;
+  wakeUpId: string;
+}): Promise<void> {
+  const wakeUpAndAuthRes = await WakeUpResource.fetchWakeUpAndAuthenticatorById(
+    {
+      workspaceId,
+      wakeUpId,
+    }
+  );
+  if (wakeUpAndAuthRes.isErr()) {
+    logger.error(
+      { wakeUpId, workspaceId, error: normalizeError(wakeUpAndAuthRes.error) },
+      "Expire wake-up: workspace or wake-up not found."
+    );
+    throw new WakeUpNonRetryableError("Workspace or wake-up not found.");
+  }
+  const { auth, wakeUp } = wakeUpAndAuthRes.value;
+
+  await wakeUp.markExpired(auth);
 }

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -30,8 +30,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 class TriggerNonRetryableError extends Error {}
-
-export class WakeUpNonRetryableError extends Error {}
+class WakeUpNonRetryableError extends Error {}
 
 async function createConversationForAgentConfiguration({
   auth,

--- a/front/temporal/triggers/workflows.ts
+++ b/front/temporal/triggers/workflows.ts
@@ -1,4 +1,5 @@
 import type { ContentFragmentInputWithFileIdType } from "@app/types/api/internal/assistant";
+import { ActivityFailure, RetryState } from "@temporalio/common";
 import { proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "./activities";
@@ -10,9 +11,15 @@ const { runTriggeredAgentsActivity } = proxyActivities<typeof activities>({
   },
 });
 
-const { runWakeUpActivity } = proxyActivities<typeof activities>({
+const { expireWakeUpActivity, runWakeUpActivity } = proxyActivities<
+  typeof activities
+>({
   startToCloseTimeout: "5 minutes",
   retry: {
+    initialInterval: "30 seconds",
+    backoffCoefficient: 2,
+    maximumAttempts: 6,
+    maximumInterval: "5 minutes",
     nonRetryableErrorTypes: ["WakeUpNonRetryableError"],
   },
 });
@@ -39,6 +46,23 @@ export async function agentTriggerWorkflow({
   });
 }
 
+function isWakeUpActivityRetryExhausted(
+  error: unknown
+): error is ActivityFailure {
+  if (!(error instanceof ActivityFailure)) {
+    return false;
+  }
+
+  if (error.activityType !== "runWakeUpActivity") {
+    return false;
+  }
+
+  return (
+    error.retryState === RetryState.MAXIMUM_ATTEMPTS_REACHED ||
+    error.retryState === RetryState.TIMEOUT
+  );
+}
+
 export async function wakeUpWorkflow({
   workspaceId,
   wakeUpId,
@@ -46,5 +70,14 @@ export async function wakeUpWorkflow({
   workspaceId: string;
   wakeUpId: string;
 }): Promise<void> {
-  await runWakeUpActivity({ workspaceId, wakeUpId });
+  try {
+    await runWakeUpActivity({ workspaceId, wakeUpId });
+  } catch (error) {
+    if (isWakeUpActivityRetryExhausted(error)) {
+      await expireWakeUpActivity({ workspaceId, wakeUpId });
+      return;
+    }
+
+    throw error;
+  }
 }

--- a/front/temporal/triggers/workflows.ts
+++ b/front/temporal/triggers/workflows.ts
@@ -18,7 +18,7 @@ const { expireWakeUpActivity, runWakeUpActivity } = proxyActivities<
   retry: {
     initialInterval: "30 seconds",
     backoffCoefficient: 2,
-    maximumAttempts: 6,
+    maximumAttempts: 3,
     maximumInterval: "5 minutes",
     nonRetryableErrorTypes: ["WakeUpNonRetryableError"],
   },

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -27,10 +27,10 @@ reuse the same serialized shape.
 Add `wakeUpWorkflow` and `runWakeUpActivity` to the `agent-schedule-v1` queue. Wire up the
 one-shot path: `startDelay` on `client.workflow.start()`. Activity posts a user message into the
 conversation with `origin: "wakeup"`, `doNotAssociateUser: true`, `username: "Dust"`,
-`<dust_system>` context block, and agent mention. Use an atomic claim / duplicate-fire protection
-when firing, and treat missing/deleted conversation, user, workspace, or agent as terminal
-cancelled/expired states. Back-off + retry only when a different agent is running (retryable
-error, 10min max window).
+`<dust_system>` context block, and agent mention. Use duplicate-fire protection when firing, and
+treat missing/deleted conversation, user, workspace, or agent as terminal cancelled/expired
+states. Back-off + retry only when a different agent is running (retryable error, 10min max
+window).
 
 Status: Temporal scaffolding for one-shot wake-ups is in place (`front/temporal/triggers/wakeup/*`,
 worker wiring, and `WakeUpResource` integration). Remaining work is implementing the activity

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -22,25 +22,33 @@ reuse the same serialized shape.
 
 ## Milestone 2: Temporal execution (one-shot only)
 
-### PR 3 — wakeUpWorkflow + runWakeUpActivity
+### [x] PR 3 — wakeUpWorkflow + runWakeUpActivity
 
-Add `wakeUpWorkflow` and `runWakeUpActivity` to the `agent-schedule-v1` queue. Wire up the
-one-shot path: `startDelay` on `client.workflow.start()`. Activity posts a user message into the
-conversation with `origin: "wakeup"`, `doNotAssociateUser: true`, `username: "Dust"`,
-`<dust_system>` context block, and agent mention. Use duplicate-fire protection when firing, and
-treat missing/deleted conversation, user, workspace, or agent as terminal cancelled/expired
-states. Back-off + retry only when a different agent is running (retryable error, 10min max
-window).
+Add `wakeUpWorkflow`, `runWakeUpActivity`, and `expireWakeUpActivity` to the shared
+`agent-schedule-v1` queue in `front/temporal/triggers/{workflows,activities}.ts`. Wire up the
+one-shot path with `startDelay` on `client.workflow.start()`. The activity resolves the wake-up
+and acting user via `WakeUpResource.fetchWakeUpAndAuthenticatorById(...)`, fetches the
+conversation with `getConversation(...)`, posts a user message with `origin: "wakeup"`,
+`doNotAssociateUser: true`, `username: "Dust"`, and a `<dust_system>` context block, then marks
+the wake-up as fired.
 
-Status: Temporal scaffolding for one-shot wake-ups is in place (`front/temporal/triggers/wakeup/*`,
-worker wiring, and `WakeUpResource` integration). Remaining work is implementing the activity
-logic and retry/terminal-state behavior.
+Current terminal / retry behavior:
+- Missing workspace or wake-up: non-retryable failure.
+- Missing or inaccessible conversation: mark `cancelled` and stop.
+- Posting failure: retry via Temporal backoff.
+- Retry exhaustion or timeout: mark `expired` via `expireWakeUpActivity(...)`.
 
-### PR 4 — Wire WakeUpResource to Temporal
+Current retry policy: 3 attempts, exponential backoff starting at 30 seconds, max interval
+5 minutes. Cron wake-ups still return an unsupported error for now.
 
-Connect `WakeUpResource.makeNew` and `cancel` to actual Temporal workflow start/terminate. Remove
-stubs from PR 2. One-shot wake-ups are now fully functional end-to-end at the backend level.
-Emit the corresponding audit events.
+### [x] PR 4 — Wire WakeUpResource to Temporal
+
+Connect `WakeUpResource.makeNew` and `cancel` to actual Temporal workflow start / cancellation via
+`front/temporal/triggers/wakeup_client.ts`. One-shot wake-ups are now functional end-to-end at the
+backend level.
+
+Follow-up work remains for explicit duplicate-fire / cancel-vs-fire race handling, tighter retry
+classification, audit events, and the cron path.
 
 ## Milestone 3: Agent action
 

--- a/x/spolu/wakeup/wakeup.md
+++ b/x/spolu/wakeup/wakeup.md
@@ -10,9 +10,12 @@ user must come back and manually poke the agent.
 ## Goal
 
 Provide a skill (always enabled) that lets agents schedule wake-ups within a conversation. When the
-wake-up fires, the agent resumes in the same conversation with full context. Supports one-shot
-Delays ("in 2 hours"), absolute times ("at 2026-04-16T16:00Z"), and cron patterns
-("0 9 * * MON-FRI").
+wake-up fires, the agent resumes in the same conversation with full context. The overall design
+supports one-shot delays ("in 2 hours"), absolute times ("at 2026-04-16T16:00Z"), and cron
+patterns ("0 9 * * MON-FRI").
+
+Current implementation status: the backend Temporal path is implemented for one-shot wake-ups only.
+Cron scheduling, the tool surface, API endpoints, and UI are still follow-up work.
 
 ## Design Overview
 
@@ -41,8 +44,9 @@ Delays ("in 2 hours"), absolute times ("at 2026-04-16T16:00Z"), and cron pattern
 ┌─────────────────────────────────────────────────────────────┐
 │  Temporal (agent-schedule-v1 queue, reused)                 │
 │                                                             │
-│  One-shot: wakeUpWorkflow { sleep(duration) → activity }    │
-│  Cron:     client.schedule.create() → wakeUpWorkflow        │
+│  One-shot: client.workflow.start(..., startDelay)           │
+│            → wakeUpWorkflow → runWakeUpActivity             │
+│  Cron:     not implemented yet                              │
 │                                                             │
 │  Workflow ID: wakeup-{workspaceId}-{wakeUpId}               │
 └──────────────────────┬──────────────────────────────────────┘
@@ -50,21 +54,18 @@ Delays ("in 2 hours"), absolute times ("at 2026-04-16T16:00Z"), and cron pattern
                        ▼
 ┌─────────────────────────────────────────────────────────────┐
 │  runWakeUpActivity                                          │
-│  1. Fetch WakeUpResource, verify status = scheduled         │
-│  2. Fetch conversation                                      │
-│  3. postUserMessage into the conversation:                  │
+│  1. Resolve WakeUpResource + wake-up owner auth             │
+│  2. Verify status = scheduled                               │
+│  3. Fetch conversation and call getConversation(...)        │
+│  4. postUserMessage into the conversation:                  │
 │     - origin: "wakeup"                                      │
-│     - username: "Dust" (not the human user)                 │
+│     - username: "Dust"                                      │
 │     - doNotAssociateUser: true                              │
-│     - content: "Wake-up: {reason}"                          │
-│     - mention the agent                                     │
-│  4. Update WakeUpResource:                                  │
-│     - fireCount++                                           │
-│     - one_shot → status = fired                             │
-│     - cron + fireCount >= MAX_FIRES → status = expired,     │
-│       delete Temporal schedule (MAX_FIRES is a code const)  │
-│  5. Steering handles the busy-agent case automatically      │
-│     (pending user message path).                            │
+│     - content: <dust_system> + "Wake-up reason: ..."        │
+│     - mentions: [{ configurationId: agentConfigurationId }] │
+│  5. fireCount++ and one_shot → status = fired               │
+│  6. Missing / inaccessible conversation → cancelled         │
+│     Retry exhaustion / timeout → expired                    │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -100,65 +101,66 @@ CREATE INDEX idx_wake_ups_workspace_status ON wake_ups("workspaceId", "status");
 
 Wraps `WakeUpModel`. Key methods:
 
-- `makeNew(auth, { conversationId, agentConfigurationId, scheduleType, ... })` — creates row +
-  starts Temporal workflow/schedule.
-- `cancel(auth)` — sets status to `cancelled`, terminates Temporal workflow/schedule.
+- `makeNew(auth, { conversationId, agentConfigurationId, scheduleType, ... })` — creates the row
+  and starts the Temporal workflow.
+- `cancel(auth)` — cancels the Temporal workflow and sets status to `cancelled`.
 - `markFired()` — increments `fireCount`, updates status for one-shot.
+- `markExpired()` — sets status to `expired`.
 - `listByConversation(auth, conversationId)` — for UI display.
 - `listActiveByWorkspace(auth)` — for guardrail checks.
+- `fetchWakeUpAndAuthenticatorById({ workspaceId, wakeUpId })` — resolves the wake-up and the
+  wake-up owner's authenticator for Temporal activities.
 - `toJSON()` — serializes to the shared `WakeUpType` shape.
-+
-+Also define shared Zod-backed types in `front/types/assistant/wakeups.ts`:
-+
-+- `WakeUpScheduleConfig`
-+- `WakeUpOneShotScheduleConfig`
-+- `WakeUpCronScheduleConfig`
-+- `WakeUpType`
-+
-+These types should be the source of truth for endpoint and UI serialization.
+
+Also define shared Zod-backed types in `front/types/assistant/wakeups.ts`:
+
+- `WakeUpScheduleConfig`
+- `WakeUpOneShotScheduleConfig`
+- `WakeUpCronScheduleConfig`
+- `WakeUpType`
+
+These types should be the source of truth for endpoint and UI serialization.
 
 ## Temporal Workflows
 
-Reuse the `agent-schedule-v1` queue (currently used by `agentTriggerWorkflow`). Add a new workflow
-alongside it.
+Reuse the `agent-schedule-v1` queue (currently used by `agentTriggerWorkflow`). The current
+implementation adds wake-up handling alongside the existing trigger workflow in the shared files:
+`front/temporal/triggers/workflows.ts`, `front/temporal/triggers/activities.ts`, and
+`front/temporal/triggers/wakeup_client.ts`.
 
-### `wakeUpWorkflow` (new, in `front/temporal/triggers/common/workflows.ts`)
+### `wakeUpWorkflow` (current, in `front/temporal/triggers/workflows.ts`)
 
-```typescript
-export async function wakeUpWorkflow({
-  workspaceId,
-  wakeUpId,
-}: {
-  workspaceId: string;
-  wakeUpId: string;
-}): Promise<void> {
-  await runWakeUpActivity({ workspaceId, wakeUpId });
-}
-```
+`wakeUpWorkflow` wraps `runWakeUpActivity(...)` with Temporal retry handling. For one-shot wake-ups,
+the workflow is started with a `startDelay` computed from `fireAt`. On retry exhaustion or timeout,
+the workflow calls `expireWakeUpActivity(...)` to mark the wake-up as `expired`.
 
-For **one-shot** wake-ups, the workflow is started with a `startDelay` computed from the `fireAt`
-timestamp. The workflow body is just the activity call — Temporal handles the delay natively via
-`startDelay` on `client.workflow.start()`.
+Current retry policy:
+- initial interval: 30 seconds
+- backoff coefficient: 2
+- maximum interval: 5 minutes
+- maximum attempts: 3
+- non-retryable error type: `WakeUpNonRetryableError`
 
-For **cron** wake-ups, a Temporal Schedule is created (via `client.schedule.create()`) pointing at
-`wakeUpWorkflow`, reusing the same `buildScheduleSpec()` helper from the trigger infrastructure.
+Cron wake-ups are not implemented yet. `launchOrScheduleWakeUpTemporalWorkflow(...)` returns an
+error for `scheduleType: "cron"`.
 
-### `runWakeUpActivity` (new, in `front/temporal/triggers/common/activities.ts`)
+### `runWakeUpActivity` (current, in `front/temporal/triggers/activities.ts`)
 
-1. Fetch `WakeUpResource` by sId, verify `status === "scheduled"`.
-2. Fetch conversation via `ConversationResource`.
-3. Authenticate as the wake-up's userId via `Authenticator.fromUserIdAndWorkspaceId()` (the agent
-   runs under that user's credentials).
-4. Call `postUserMessage` with:
-   - `content`: `@agent Wake-up: {reason}`
-   - `context.origin`: `"wakeup"` (new origin value)
-   - `context.username`: `"Dust"`
-   - `context.profilePictureUrl`: Dust logo URL or null
+1. Resolve the wake-up and acting user with
+   `WakeUpResource.fetchWakeUpAndAuthenticatorById({ workspaceId, wakeUpId })`.
+2. Verify `status === "scheduled"`.
+3. Fetch the conversation resource and then the full conversation with `getConversation(...)`.
+4. Call `postUserMessage(...)` with:
+   - a `<dust_system>` block containing the wake-up sId
+   - `Wake-up reason: {reason}`
+   - `context.origin: "wakeup"`
+   - `context.username: "Dust"`
    - `doNotAssociateUser: true`
-   - `steeringEnabled: true` (follows steering path if agent is busy)
-5. Update `WakeUpResource`: increment `fireCount`, update status.
-6. For one-shot: done (workflow completes). For cron where `fireCount >= MAX_FIRES` (code
-   constant): cancel the Temporal schedule and set status to `expired`.
+   - `mentions: [{ configurationId: wakeUp.agentConfigurationId }]`
+5. Mark the wake-up as fired on success.
+6. Mark the wake-up as cancelled when the conversation is missing or inaccessible.
+7. Let Temporal retry posting failures. If retries are exhausted, `expireWakeUpActivity(...)`
+   marks the wake-up as expired.
 
 ## Agent Skill Interface
 
@@ -219,18 +221,15 @@ access, or allow messages that don't mention agents) once we better understand t
 
 ## Steering Integration
 
-When the wake-up fires:
+When the wake-up fires, it is posted through the normal `postUserMessage(...)` path with
+`origin: "wakeup"` and `doNotAssociateUser: true`.
 
-- **Agent idle**: message is posted with `visibility: "visible"`, agent starts normally.
-- **Agent running, same agent**: message is posted with `visibility: "pending"`. The steering code
-  path gracefully stops the current run, then promotes the pending message and the agent processes
-  it.
-- **Agent running, different agent**: steering rejects mentions to a different agent than the one
-  currently running. In this case `runWakeUpActivity` backs off and retries after a delay (e.g.,
-  30s exponential backoff, capped at a few minutes). The Temporal activity retry policy handles
-  this naturally — the activity throws a retryable error and Temporal re-schedules it. A maximum
-  retry window (e.g., 10 minutes) prevents the wake-up from retrying indefinitely; after that the
-  wake-up is marked as `expired` and the user is notified.
+Current behavior is intentionally simple:
+- missing or inaccessible conversations are treated as terminal cancellation
+- posting failures bubble up to Temporal and are retried according to the workflow retry policy
+- retry exhaustion marks the wake-up as `expired`
+
+A follow-up can make retry classification more specific for steering-related failures.
 
 ## Guardrails
 
@@ -269,11 +268,10 @@ When a conversation has active wake-ups (`status = scheduled`):
 
 ### Wake-up message rendering
 
-The wake-up message appears in the conversation thread as a system-style message:
-- Sender: "Dust" (with Dust logo)
-- Content: "Wake-up: {reason}"
-- Visual treatment: slightly distinct from regular user messages (similar to how trigger messages
-  are shown today possibly).
+The wake-up message appears in the conversation thread as a Dust-authored wake-up message:
+- Sender: "Dust"
+- Content: a `<dust_system>` block including the wake-up sId, followed by `Wake-up reason: {reason}`
+- Visual treatment: can be refined later in the dedicated UI work
 
 ### Notifications
 
@@ -302,25 +300,24 @@ When a wake-up fires:
 | File | Change |
 |------|--------|
 | `front/types/assistant/conversation.ts` | Add `"wakeup"` to `UserMessageOrigin` |
-| `front/temporal/triggers/common/workflows.ts` | Add `wakeUpWorkflow` |
-| `front/temporal/triggers/common/activities.ts` | Add `runWakeUpActivity` |
-| `front/temporal/triggers/common/worker.ts` | Activities auto-registered (no change needed) |
-| `front/lib/api/assistant/agent_action.ts` | Register `schedule_wakeup` action |
-| `front/components/assistant/conversation/` | Render wake-up messages + banner |
+| `front/temporal/triggers/workflows.ts` | Add `wakeUpWorkflow` + retry / expiry handling |
+| `front/temporal/triggers/activities.ts` | Add `runWakeUpActivity` and `expireWakeUpActivity` |
+| `front/temporal/triggers/wakeup_client.ts` | Start / cancel one-shot wake-up workflows |
+| `front/lib/resources/wakeup_resource.ts` | Temporal integration + activity helpers |
+| `front/types/assistant/wakeups.ts` | Shared wake-up schemas and types |
 
 ## Resolved Decisions
 
-1. **Authentication**: The activity authenticates as the wake-up's `userId` (the user whose agent
-   loop created it). See Security section for interaction restrictions that prevent privilege
-   escalation.
+1. **Authentication**: The activity resolves the wake-up owner through
+   `WakeUpResource.fetchWakeUpAndAuthenticatorById(...)` and posts using that user's workspace
+   authenticator.
 
 2. **Conversation cleanup**: Handled in code, not via DB cascade. When a conversation is deleted,
-   the deletion logic cancels all active wake-ups (Temporal workflows/schedules) and deletes the
+   the deletion logic cancels all active wake-ups (Temporal workflows / schedules) and deletes the
    `WakeUpModel` rows explicitly.
 
-3. **Wake-up message content**: Exact format to be figured out during implementation. The message
-   should include a `<dust_system>` contextual block explaining that this is a wake-up, followed
-   by the reason provided by the agent when scheduling it.
+3. **Wake-up message content**: The current implementation posts a `<dust_system>` block that
+   includes the wake-up sId, followed by `Wake-up reason: {reason}`.
 
 4. **Billing**: Wake-up fires count as programmatic usage, same treatment as trigger-fired
    messages.
@@ -333,11 +330,11 @@ When a wake-up fires:
 
 - In the current codebase, `schedule_wakeup` should be wired through the internal MCP tool
   architecture rather than a legacy `front/lib/api/assistant/agent_action.ts` registry.
-- The firing path should define idempotency explicitly so retries cannot post duplicate wake-up
-  messages.
-- Cancel-vs-fire races should be handled explicitly by `WakeUpResource`, not left to best effort.
-- Missing/deleted conversation, user, workspace, or inaccessible agent at fire time should be
-  terminal `cancelled` / `expired` states, not infinite retries.
+- The current PR does not add explicit duplicate-fire protection yet. A follow-up should define the
+  idempotency story clearly.
+- Cancel-vs-fire races are still best-effort today and should be tightened in `WakeUpResource`.
+- The current implementation retries generic posting failures and expires after retry exhaustion.
+  A follow-up can narrow retry behavior to the intended steering-related cases.
 - The new private API endpoint should keep Swagger annotations/schemas in sync.
 - Emit audit events for create / cancel / fire / expire.
 - Add focused tests for resource invariants, Temporal behavior, permissions, API, and UI.

--- a/x/spolu/wakeup/wakeup.md
+++ b/x/spolu/wakeup/wakeup.md
@@ -333,8 +333,8 @@ When a wake-up fires:
 
 - In the current codebase, `schedule_wakeup` should be wired through the internal MCP tool
   architecture rather than a legacy `front/lib/api/assistant/agent_action.ts` registry.
-- The firing path should define idempotency explicitly, e.g. an atomic claim / fire transition and
-  a persisted fired message identifier, so retries cannot post duplicate wake-up messages.
+- The firing path should define idempotency explicitly so retries cannot post duplicate wake-up
+  messages.
 - Cancel-vs-fire races should be handled explicitly by `WakeUpResource`, not left to best effort.
 - Missing/deleted conversation, user, workspace, or inaccessible agent at fire time should be
   terminal `cancelled` / `expired` states, not infinite retries.


### PR DESCRIPTION
## Summary
- implement the one-shot wake-up Temporal activity flow in `front/temporal/triggers`
- add wake-up resource helpers used by the activity and retry/expiry handling in the workflow
- update the wake-up docs to reflect the current one-shot behavior

## Testing
- cd front && npx tsgo --noEmit