### PR TITLE
[front] enh: Chunk ids arrays in fetch agent content step

### DIFF
--- a/front/lib/resources/agent_step_content_resource.test.ts
+++ b/front/lib/resources/agent_step_content_resource.test.ts
@@ -1,0 +1,169 @@
+import { Authenticator } from "@app/lib/auth";
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import {
+  AgentStepContentResource,
+  FETCH_BY_AGENT_MESSAGES_CHUNK_SIZE,
+} from "@app/lib/resources/agent_step_content_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { AgentTextContentType } from "@app/types/assistant/agent_message_content";
+import assert from "assert";
+import { describe, expect, it } from "vitest";
+
+function makeTextContent(value: string): AgentTextContentType {
+  return {
+    type: "text_content",
+    value,
+  };
+}
+
+async function createAgentMessages(
+  auth: Authenticator,
+  {
+    count,
+    agentConfigurationId,
+    agentConfigurationVersion,
+  }: {
+    count: number;
+    agentConfigurationId: string;
+    agentConfigurationVersion: number;
+  }
+): Promise<AgentMessageModel[]> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  return AgentMessageModel.bulkCreate(
+    Array.from({ length: count }, () => ({
+      workspaceId: workspace.id,
+      status: "succeeded",
+      agentConfigurationId,
+      agentConfigurationVersion,
+      skipToolsValidation: true,
+      completedAt: new Date(),
+    })),
+    { returning: true }
+  );
+}
+
+describe("AgentStepContentResource.fetchByAgentMessages", () => {
+  it("returns latest versions for every agent message when the input exceeds the chunk size", async () => {
+    const { authenticator, workspace } = await createResourceTest({});
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Chunk Fetch Test Agent",
+      }
+    );
+    const agentMessages = await createAgentMessages(authenticator, {
+      count: FETCH_BY_AGENT_MESSAGES_CHUNK_SIZE + 1,
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: agent.version,
+    });
+
+    const [versionedAgentMessage, ...remainingAgentMessages] = agentMessages;
+
+    await AgentStepContentModel.bulkCreate([
+      {
+        workspaceId: workspace.id,
+        agentMessageId: versionedAgentMessage.id,
+        step: 0,
+        index: 0,
+        version: 0,
+        type: "text_content",
+        value: makeTextContent("old version"),
+      },
+      {
+        workspaceId: workspace.id,
+        agentMessageId: versionedAgentMessage.id,
+        step: 0,
+        index: 0,
+        version: 1,
+        type: "text_content",
+        value: makeTextContent("new version"),
+      },
+      ...remainingAgentMessages.map((agentMessage, index) => ({
+        workspaceId: workspace.id,
+        agentMessageId: agentMessage.id,
+        step: 0,
+        index: 0,
+        version: 0,
+        type: "text_content" as const,
+        value: makeTextContent(`message-${index}`),
+      })),
+    ]);
+
+    const stepContents = await AgentStepContentResource.fetchByAgentMessages(
+      authenticator,
+      {
+        agentMessageIds: agentMessages.map((message) => message.id),
+        latestVersionsOnly: true,
+      }
+    );
+
+    expect(stepContents).toHaveLength(agentMessages.length);
+    expect(
+      stepContents.map((c) => c.agentMessageId).toSorted((a, b) => a - b)
+    ).toEqual(agentMessages.map((m) => m.id).toSorted((a, b) => a - b));
+
+    const latestVersion = stepContents.find(
+      (content) => content.agentMessageId === versionedAgentMessage.id
+    );
+    expect(latestVersion?.version).toBe(1);
+    expect(latestVersion?.value).toEqual(makeTextContent("new version"));
+  });
+
+  it("returns an empty result when the caller has no access to the agent", async () => {
+    const { authenticator, user, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const addMembersRes = await restrictedSpace.addMembers(authenticator, {
+      userIds: [user.sId],
+    });
+    assert(addMembersRes.isOk(), "Failed to add author to restricted space");
+
+    const restrictedAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const restrictedAgent = await AgentConfigurationFactory.createTestAgent(
+      restrictedAuth,
+      {
+        name: "Restricted Chunk Fetch Test Agent",
+        requestedSpaceIds: [restrictedSpace.id],
+      }
+    );
+    const [restrictedAgentMessage] = await createAgentMessages(restrictedAuth, {
+      count: 1,
+      agentConfigurationId: restrictedAgent.sId,
+      agentConfigurationVersion: restrictedAgent.version,
+    });
+
+    await AgentStepContentModel.create({
+      workspaceId: workspace.id,
+      agentMessageId: restrictedAgentMessage.id,
+      step: 0,
+      index: 0,
+      version: 0,
+      type: "text_content",
+      value: makeTextContent("secret"),
+    });
+
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+
+    const stepContents = await AgentStepContentResource.fetchByAgentMessages(
+      otherAuth,
+      { agentMessageIds: [restrictedAgentMessage.id] }
+    );
+
+    expect(stepContents).toEqual([]);
+  });
+});

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -11,6 +11,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -33,6 +34,13 @@ import type {
   WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
+
+export const FETCH_BY_AGENT_MESSAGES_CHUNK_SIZE = 512;
+
+// DO NOT INCREASE THIS BLINDLY, instead you can first try
+// to bump up FETCH_BY_AGENT_MESSAGES_CHUNK_SIZE
+// value = max peak concurrency - 1
+const FETCH_BY_AGENT_MESSAGES_CONCURRENCY = 4;
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -172,20 +180,38 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       agentMessageIds
     );
 
-    let contents = await this.model.findAll({
-      where: {
-        workspaceId: owner.id,
-        agentMessageId: {
-          [Op.in]: allowedAgentMessageIds,
-        },
-      },
-      order: [
-        ["step", "ASC"],
-        ["index", "ASC"],
-        ["version", "DESC"],
-      ],
-      transaction,
-    });
+    if (allowedAgentMessageIds.length === 0) {
+      return [];
+    }
+
+    const chunks = _.chunk(
+      allowedAgentMessageIds,
+      FETCH_BY_AGENT_MESSAGES_CHUNK_SIZE
+    );
+
+    const batchResults = await concurrentExecutor(
+      chunks,
+      async (chunk) =>
+        this.model.findAll({
+          where: {
+            workspaceId: owner.id,
+            agentMessageId: {
+              [Op.in]: chunk,
+            },
+          },
+          order: [
+            ["step", "ASC"],
+            ["index", "ASC"],
+            ["version", "DESC"],
+          ],
+          transaction,
+        }),
+      {
+        concurrency: transaction ? 1 : FETCH_BY_AGENT_MESSAGES_CONCURRENCY,
+      }
+    );
+
+    let contents = batchResults.flat();
 
     if (latestVersionsOnly) {
       contents = this.filterLatestVersions(contents, [


### PR DESCRIPTION
## Description

PG among other things looks at the number of rows a particular node might return to choose a given plan.

In the case of an any(array) = ($0::bigint[]), pg will lookup the most common values (MCV) table for this column, which has [100 entries](https://www.postgresql.org/docs/14/runtime-config-query.html#GUC-DEFAULT-STATISTICS-TARGET). 

This query (which can be considered high QPS) has an unbounded size for $0, which can lead PG to grossly overestimate/underestimate the number of rows it will return, on top of quadratic complexity when comparing $0 with MCV.

All in all it's better to make it finite, put 500 with 4 concurrency, can be tweaked.


## Tests

Unit tests

## Risk

Low

## Deploy Plan

- [ ] Deploy front