### PR TITLE
fix(sbx): add egress proxy LB IPs to sandbox network allowlist

### DIFF
--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -94,8 +94,11 @@ export const ALLOWLIST_NETWORK_POLICY: NetworkPolicy = {
     // Datadog EU — sandbox telemetry
     "http-intake.logs.datadoghq.eu",
     "api.datadoghq.eu",
-    // Regional egress proxy (eu.sandbox-egress.dust.tt, us.sandbox-egress.dust.tt, ...)
+    // Regional egress proxy — the forwarder connects by IP (resolved by front),
+    // so E2B's domain-based allowOut doesn't cover it. These are reserved GCP LB IPs.
     "*.sandbox-egress.dust.tt",
+    "104.199.4.80/32", // eu.sandbox-egress.dust.tt
+    "104.154.146.142/32", // us.sandbox-egress.dust.tt
   ],
 };
 


### PR DESCRIPTION
## Description

E2B's `deny_all` network policy was blocking the egress forwarder's TLS connection to the proxy. The forwarder connects by **IP** (resolved by front via DNS), but E2B's `allowOut` only matches **hostnames**. So `*.sandbox-egress.dust.tt` in the allowlist didn't cover the raw IP connection from the forwarder to the proxy.

This adds the reserved GCP Load Balancer IPs for both regional egress proxies:
- `104.199.4.80/32` — eu.sandbox-egress.dust.tt
- `104.154.146.142/32` — us.sandbox-egress.dust.tt

## Tests

Tested by creating E2B sandboxes with various `deny_all` + allowlist configurations:

| Scenario | Root TLS to proxy | curl as agent-proxied |
|---|---|---|
| Domains only (current prod) | Connection reset | Exit 35 (TLS fail) |
| Domains + proxy IPs (this fix) | CONNECTION ESTABLISHED | **HTTP 200** |
| Allow all (no deny) | CONNECTION ESTABLISHED | HTTP 200 |

Full e2e pipeline verified: `curl https://dust.tt` as `agent-proxied` → nftables redirect → forwarder:9990 → TLS to proxy:4443 → proxy validates JWT + allowlist → upstream → HTTP 200.

## Risk

**Low.** Adds two static IPs to an existing allowlist constant. These are reserved GCP LB IPs attached to DNS records we control. Only affects new sandbox creation (existing sandboxes keep their network policy from creation time).

## Deploy Plan

Standard deploy. New sandboxes created after deploy will have the proxy IPs in their network policy. Existing sandboxes will need to be recycled (next conversation or sleep/wake cycle) to pick up the change.