### PR TITLE
feat(google_drive): add upload_file tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -228,6 +228,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "update_file_permission": "medium",
     "update_presentation": "medium",
     "update_spreadsheet": "medium",
+    "upload_file": "low",
   },
   "google_sheets": {
     "add_worksheet": "low",

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -597,6 +597,34 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       done: "Remove file access",
     },
   },
+  upload_file: {
+    description:
+      "Upload a file from the Dust conversation to Google Drive. Optionally specify a folder to upload into.",
+    schema: {
+      fileId: z
+        .string()
+        .describe(
+          "The Dust fileId from the conversation attachments to upload."
+        ),
+      parentId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the folder to upload the file into. If not provided, uploads to the user's root Drive. Use the search_files tool with `mimeType = 'application/vnd.google-apps.folder'` to find folder IDs."
+        ),
+      fileName: z
+        .string()
+        .optional()
+        .describe(
+          "Optional custom filename for the uploaded file. If not provided, uses the original filename from the conversation attachment."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Uploading file to Google Drive",
+      done: "Upload file to Google Drive",
+    },
+  },
 });
 
 const ALL_TOOLS_METADATA = {

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -9,6 +9,10 @@ import {
   makeFileAuthorizationError,
   makePersonalAuthenticationError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import {
+  getFileFromConversationAttachment,
+  sanitizeFilename,
+} from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import { formatDocumentStructure } from "@app/lib/api/actions/servers/google_drive/format_document";
 import { formatPresentationStructure } from "@app/lib/api/actions/servers/google_drive/format_presentation";
 import {
@@ -27,6 +31,7 @@ import {
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Common } from "googleapis";
+import { Readable } from "stream";
 
 /**
  * Normalizes GaxiosError code to string for comparison.
@@ -1273,6 +1278,70 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         ),
       },
     ]);
+  },
+
+  upload_file: async (
+    { fileId, parentId, fileName },
+    { auth, authInfo, agentLoopContext }
+  ) => {
+    const drive = await getDriveClient(authInfo);
+    if (!drive) {
+      return new Err(new MCPError("Failed to authenticate with Google Drive"));
+    }
+
+    if (!agentLoopContext) {
+      return new Err(
+        new MCPError("No conversation context available for file access")
+      );
+    }
+
+    try {
+      const fileResult = await getFileFromConversationAttachment(
+        auth,
+        fileId,
+        agentLoopContext
+      );
+
+      if (fileResult.isErr()) {
+        return new Err(new MCPError(fileResult.error));
+      }
+
+      const { buffer, filename, contentType } = fileResult.value;
+
+      const uploadFileName = sanitizeFilename(fileName ?? filename);
+
+      const res = await drive.files.create({
+        requestBody: {
+          name: uploadFileName,
+          ...(parentId ? { parents: [parentId] } : {}),
+        },
+        media: {
+          mimeType: contentType,
+          body: Readable.from(buffer),
+        },
+        fields: "id, name, mimeType, size, webViewLink",
+        supportsAllDrives: true,
+      });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              fileId: res.data.id,
+              name: res.data.name,
+              mimeType: res.data.mimeType,
+              size: res.data.size,
+              url: res.data.webViewLink,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (err) {
+      return handleDriveAccessError(err, authInfo);
+    }
   },
 };
 


### PR DESCRIPTION
Fix https://github.com/issues/mentioned?issue=dust-tt%7Ctasks%7C7415

## Description
Adds an upload_file MCP tool to the Google Drive server that uploads a Dust conversation attachment to Drive, with an optional parent folder. Uses drive.files.create with a Readable media body under the existing drive.file scope.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually. Had dust create a file and then upload it to gdrive, also tested uploading a file to dust and asking it to push to gdrive
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
