### PR TITLE
Add cron wake-up Temporal schedules

### DIFF
--- a/front/temporal/triggers/schedule_client.ts
+++ b/front/temporal/triggers/schedule_client.ts
@@ -64,12 +64,19 @@ function computeIntervalOffsetMs(config: IntervalScheduleConfig): number {
   return utcTimeMs;
 }
 
+export function buildCronScheduleSpec(config: {
+  cron: string;
+  timezone: string;
+}): ScheduleSpec {
+  return {
+    cronExpressions: [config.cron],
+    timezone: config.timezone,
+  };
+}
+
 function buildScheduleSpec(config: ScheduleConfig): ScheduleSpec {
   if (isCronScheduleConfig(config)) {
-    return {
-      cronExpressions: [config.cron],
-      timezone: config.timezone,
-    };
+    return buildCronScheduleSpec(config);
   }
 
   // Interval-based (N-day, N-week).

--- a/front/temporal/triggers/wakeup_client.ts
+++ b/front/temporal/triggers/wakeup_client.ts
@@ -66,6 +66,15 @@ export async function launchOrScheduleWakeUpTemporalWorkflow(
             wakeUpId: wakeUp.sId,
           },
         });
+        logger.info(
+          {
+            workspaceId: owner.sId,
+            wakeUpId: wakeUp.sId,
+            workflowId,
+            wakeUp,
+          },
+          "Created new wake-up workflow (one_shot)."
+        );
       } catch (error) {
         // We log and error even if this is a WorkflowExecutionAlreadyStartedError, because it means
         // that the existing workflow is still running, which is unexpected (since this is a
@@ -77,12 +86,11 @@ export async function launchOrScheduleWakeUpTemporalWorkflow(
             workflowId,
             error,
           },
-          "Failed starting wake-up workflow."
+          "Failed starting wake-up workflow (one_shot)."
         );
 
         return new Err(normalizeError(error));
       }
-
       return new Ok(undefined);
     }
 
@@ -90,13 +98,6 @@ export async function launchOrScheduleWakeUpTemporalWorkflow(
       const scheduleId = makeWakeUpScheduleId({
         workspaceId: owner.sId,
         wakeUpId: wakeUp.sId,
-      });
-
-      const childLogger = logger.child({
-        workspaceId: owner.sId,
-        wakeUpId: wakeUp.sId,
-        scheduleId,
-        wakeUp,
       });
 
       const scheduleOptions: ScheduleOptions = {
@@ -113,35 +114,31 @@ export async function launchOrScheduleWakeUpTemporalWorkflow(
         spec: buildCronScheduleSpec(wakeUp.scheduleConfig),
       };
 
-      const existingSchedule = client.schedule.getHandle(scheduleId);
-      try {
-        await existingSchedule.update((previous) => {
-          return {
-            ...scheduleOptions,
-            state: previous.state,
-          };
-        });
-
-        childLogger.info("Updated existing wake-up schedule.");
-        return new Ok(undefined);
-      } catch (error) {
-        if (!(error instanceof ScheduleNotFoundError)) {
-          childLogger.error(
-            { error },
-            "Failed to update existing wake-up schedule."
-          );
-          return new Err(normalizeError(error));
-        }
-      }
-
       try {
         await client.schedule.create(scheduleOptions);
-        childLogger.info("Created new wake-up schedule.");
-        return new Ok(undefined);
+        logger.info(
+          {
+            workspaceId: owner.sId,
+            wakeUpId: wakeUp.sId,
+            scheduleId,
+            wakeUp,
+          },
+          "Created new wake-up schedule (cron)."
+        );
       } catch (error) {
-        childLogger.error({ error }, "Failed to create wake-up schedule.");
+        logger.error(
+          {
+            workspaceId: owner.sId,
+            wakeUpId: wakeUp.sId,
+            scheduleId,
+            wakeUp,
+            error,
+          },
+          "Failed to create wake-up schedule (cron)."
+        );
         return new Err(normalizeError(error));
       }
+      return new Ok(undefined);
     }
 
     default:

--- a/front/temporal/triggers/wakeup_client.ts
+++ b/front/temporal/triggers/wakeup_client.ts
@@ -2,12 +2,18 @@ import type { Authenticator } from "@app/lib/auth";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/triggers/config";
+import { buildCronScheduleSpec } from "@app/temporal/triggers/schedule_client";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { WorkflowNotFoundError } from "@temporalio/client";
+import type { ScheduleOptions } from "@temporalio/client";
+import {
+  ScheduleNotFoundError,
+  ScheduleOverlapPolicy,
+  WorkflowNotFoundError,
+} from "@temporalio/client";
 
 import { wakeUpWorkflow } from "./workflows";
 
@@ -19,6 +25,16 @@ export function makeWakeUpWorkflowId({
   wakeUpId: string;
 }): string {
   return `wakeup-${workspaceId}-${wakeUpId}`;
+}
+
+export function makeWakeUpScheduleId({
+  workspaceId,
+  wakeUpId,
+}: {
+  workspaceId: string;
+  wakeUpId: string;
+}): string {
+  return `wakeup-schedule-${workspaceId}-${wakeUpId}`;
 }
 
 export async function launchOrScheduleWakeUpTemporalWorkflow(
@@ -71,9 +87,61 @@ export async function launchOrScheduleWakeUpTemporalWorkflow(
     }
 
     case "cron": {
-      //TODO(wakeup): Implement schedule creation
+      const scheduleId = makeWakeUpScheduleId({
+        workspaceId: owner.sId,
+        wakeUpId: wakeUp.sId,
+      });
 
-      return new Err(new Error("Cron wake-ups are not supported yet."));
+      const childLogger = logger.child({
+        workspaceId: owner.sId,
+        wakeUpId: wakeUp.sId,
+        scheduleId,
+        wakeUp,
+      });
+
+      const scheduleOptions: ScheduleOptions = {
+        action: {
+          type: "startWorkflow" as const,
+          workflowType: wakeUpWorkflow,
+          args: [{ workspaceId: owner.sId, wakeUpId: wakeUp.sId }] as const,
+          taskQueue: QUEUE_NAME,
+        },
+        scheduleId,
+        policies: {
+          overlap: ScheduleOverlapPolicy.SKIP,
+        },
+        spec: buildCronScheduleSpec(wakeUp.scheduleConfig),
+      };
+
+      const existingSchedule = client.schedule.getHandle(scheduleId);
+      try {
+        await existingSchedule.update((previous) => {
+          return {
+            ...scheduleOptions,
+            state: previous.state,
+          };
+        });
+
+        childLogger.info("Updated existing wake-up schedule.");
+        return new Ok(undefined);
+      } catch (error) {
+        if (!(error instanceof ScheduleNotFoundError)) {
+          childLogger.error(
+            { error },
+            "Failed to update existing wake-up schedule."
+          );
+          return new Err(normalizeError(error));
+        }
+      }
+
+      try {
+        await client.schedule.create(scheduleOptions);
+        childLogger.info("Created new wake-up schedule.");
+        return new Ok(undefined);
+      } catch (error) {
+        childLogger.error({ error }, "Failed to create wake-up schedule.");
+        return new Err(normalizeError(error));
+      }
     }
 
     default:
@@ -116,9 +184,29 @@ export async function cancelWakeUpTemporalWorkflow(
     }
 
     case "cron": {
-      //TODO(wakeup): Implement schedule deletion
+      const scheduleId = makeWakeUpScheduleId({
+        workspaceId: owner.sId,
+        wakeUpId: wakeUp.sId,
+      });
 
-      return new Err(new Error("Cron wake-ups are not supported yet."));
+      try {
+        await client.schedule.getHandle(scheduleId).delete();
+      } catch (error) {
+        if (!(error instanceof ScheduleNotFoundError)) {
+          logger.warn(
+            {
+              workspaceId: owner.sId,
+              wakeUpId: wakeUp.sId,
+              scheduleId,
+              error,
+            },
+            "Failed deleting wake-up schedule."
+          );
+          return new Err(normalizeError(error));
+        }
+      }
+
+      return new Ok(undefined);
     }
 
     default:

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -50,43 +50,44 @@ backend level.
 Follow-up work remains for explicit duplicate-fire / cancel-vs-fire race handling, tighter retry
 classification, audit events, and the cron path.
 
-## Milestone 3: Agent action
+## Milestone 3: Cron wake-ups
 
-### PR 5 — schedule_wakeup tool (one-shot)
+### PR 5 — Cron scheduling path
+
+Create the cron Temporal path for wake-ups. Replace the current unsupported-error branch with
+Temporal Schedule creation / deletion. Reuse the existing trigger schedule patterns where helpful,
+track `fireCount`, expire recurring wake-ups after the chosen max-fire policy, and add
+cron-specific guardrails.
+
+## Milestone 4: Agent action
+
+### PR 6 — schedule_wakeup tool (one-shot + cron)
 
 Agent tool definition for `schedule_wakeup`. Deterministic `when` parsing (relative durations, ISO
-timestamps). Guardrail enforcement (max 1 active per conversation, min interval, max delay,
-workspace limits). Returns confirmation with scheduled time and wake-up sId. Gate behind feature
-flag. In the current codebase, wire this through the internal MCP tool architecture rather than a
-legacy `agent_action.ts` registry.
+timestamps, cron expressions). Guardrail enforcement (max 1 active per conversation, min interval,
+max delay, workspace limits). Returns confirmation with scheduled time and wake-up sId. Gate
+behind feature flag. In the current codebase, wire this through the internal MCP tool
+architecture rather than a legacy `agent_action.ts` registry.
 
-## Milestone 4: Security
+## Milestone 5: Security
 
-### PR 6 — Conversation interaction restrictions
+### PR 7 — Conversation interaction restrictions
 
 Enforce that only the wake-up owner can post in a conversation with an active wake-up.
 Cancellation permissions are owner + workspace admins.
 
-## Milestone 5: API + UI
+## Milestone 6: API + UI
 
-### PR 7 — Wake-up API endpoints
+### PR 8 — Wake-up API endpoints
 
 `GET/DELETE /api/w/[wId]/assistant/conversations/[cId]/wakeups`. List active wake-ups, cancel by
 sId. SWR hooks. Keep private Swagger docs/annotations in sync.
 
-### PR 8 — Conversation UI
+### PR 9 — Conversation UI
 
 Wake-up banner ("Waiting until {time} — {reason}" + cancel button). Wake-up message rendering
 (system-style message from "Dust"). Conversation moves to active in sidebar when wake-up fires.
 For V1, the UI can assume max 1 active wake-up per conversation.
-
-## Milestone 6: Cron wake-ups
-
-### PR 9 — Cron scheduling path
-
-Extend `schedule_wakeup` to accept cron expressions. Create Temporal Schedules via
-`client.schedule.create()` reusing `buildScheduleSpec()`. `fireCount` tracking + `MAX_FIRES`
-expiration. Cron-specific guardrails.
 
 ## Milestone 7: Cleanup + GA
 

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -39,7 +39,8 @@ Current terminal / retry behavior:
 - Retry exhaustion or timeout: mark `expired` via `expireWakeUpActivity(...)`.
 
 Current retry policy: 3 attempts, exponential backoff starting at 30 seconds, max interval
-5 minutes. Cron wake-ups still return an unsupported error for now.
+5 minutes. Cron firing semantics are still follow-up work, but the Temporal schedule create /
+delete path now exists in `front/temporal/triggers/wakeup_client.ts`.
 
 ### [x] PR 4 — Wire WakeUpResource to Temporal
 
@@ -54,10 +55,12 @@ classification, audit events, and the cron path.
 
 ### PR 5 — Cron scheduling path
 
-Create the cron Temporal path for wake-ups. Replace the current unsupported-error branch with
-Temporal Schedule creation / deletion. Reuse the existing trigger schedule patterns where helpful,
-track `fireCount`, expire recurring wake-ups after the chosen max-fire policy, and add
-cron-specific guardrails.
+Create the cron Temporal path for wake-ups. Reuse the existing trigger schedule patterns where
+helpful.
+
+Status: in progress. This PR now implements Temporal Schedule creation / deletion in
+`front/temporal/triggers/wakeup_client.ts`. Remaining work is cron validation, recurring fire
+semantics (`fireCount`, expiry / max-fire policy), and cron-specific guardrails.
 
 ## Milestone 4: Agent action
 

--- a/x/spolu/wakeup/wakeup.md
+++ b/x/spolu/wakeup/wakeup.md
@@ -46,7 +46,8 @@ Cron scheduling, the tool surface, API endpoints, and UI are still follow-up wor
 │                                                             │
 │  One-shot: client.workflow.start(..., startDelay)           │
 │            → wakeUpWorkflow → runWakeUpActivity             │
-│  Cron:     not implemented yet                              │
+│  Cron:     client.schedule.create() / delete()              │
+│            → wakeUpWorkflow → runWakeUpActivity             │
 │                                                             │
 │  Workflow ID: wakeup-{workspaceId}-{wakeUpId}               │
 └──────────────────────┬──────────────────────────────────────┘
@@ -141,8 +142,9 @@ Current retry policy:
 - maximum attempts: 3
 - non-retryable error type: `WakeUpNonRetryableError`
 
-Cron wake-ups are not implemented yet. `launchOrScheduleWakeUpTemporalWorkflow(...)` returns an
-error for `scheduleType: "cron"`.
+Cron wake-ups are partially implemented. `launchOrScheduleWakeUpTemporalWorkflow(...)` can now
+create a Temporal Schedule for `scheduleType: "cron"`, and
+`cancelWakeUpTemporalWorkflow(...)` can delete it. Recurring fire semantics remain follow-up work.
 
 ### `runWakeUpActivity` (current, in `front/temporal/triggers/activities.ts`)
 
@@ -302,7 +304,7 @@ When a wake-up fires:
 | `front/types/assistant/conversation.ts` | Add `"wakeup"` to `UserMessageOrigin` |
 | `front/temporal/triggers/workflows.ts` | Add `wakeUpWorkflow` + retry / expiry handling |
 | `front/temporal/triggers/activities.ts` | Add `runWakeUpActivity` and `expireWakeUpActivity` |
-| `front/temporal/triggers/wakeup_client.ts` | Start / cancel one-shot wake-up workflows |
+| `front/temporal/triggers/wakeup_client.ts` | Start / cancel one-shot workflows and create / delete cron schedules |
 | `front/lib/resources/wakeup_resource.ts` | Temporal integration + activity helpers |
 | `front/types/assistant/wakeups.ts` | Shared wake-up schemas and types |
 
@@ -330,6 +332,9 @@ When a wake-up fires:
 
 - In the current codebase, `schedule_wakeup` should be wired through the internal MCP tool
   architecture rather than a legacy `front/lib/api/assistant/agent_action.ts` registry.
+- The current implementation can create / delete cron schedules, but recurring fire semantics are
+  still incomplete. A follow-up should define cron validation, `fireCount`, and expiry / max-fire
+  behavior clearly.
 - The current PR does not add explicit duplicate-fire protection yet. A follow-up should define the
   idempotency story clearly.
 - Cancel-vs-fire races are still best-effort today and should be tightened in `WakeUpResource`.


### PR DESCRIPTION
## Summary

Add Temporal schedule creation and deletion for cron wake-ups.

Next step: cron validation, fireCount logic

## Testing

N/A

## Deploy

- deploy `front`