### PR TITLE
[Sessions] Unify conversation lineage loading

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -63,7 +63,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const spaceId = conversation?.spaceId;
   const isProjectConversation = !!spaceId;
   const isLoading = isProjectConversation && !spaceInfo;
-  const forkedFrom = conversation?.forkedFrom;
+  const forkedFrom = conversation?.forkingData?.forkedFrom;
 
   const breadcrumbItems: BreadcrumbItem[] = [];
 

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -359,7 +359,7 @@ export const ConversationViewer = ({
       const messagesToRender = convertLightMessageTypeToVirtuosoMessages(raw);
       const messagesAndNotices = addConversationForkNotices(
         messagesToRender,
-        conversation.forkedChildren
+        conversation.forkingData?.forkedChildren
       );
 
       setInitialListData(messagesAndNotices);
@@ -469,7 +469,7 @@ export const ConversationViewer = ({
       ref.current.data.prepend(
         addConversationForkNotices(
           renderedOlderMessages,
-          conversation?.forkedChildren
+          conversation?.forkingData?.forkedChildren
         )
       );
     }
@@ -487,11 +487,11 @@ export const ConversationViewer = ({
       ref.current.data.append(
         addConversationForkNotices(
           renderedRecentMessages,
-          conversation?.forkedChildren
+          conversation?.forkingData?.forkedChildren
         )
       );
     }
-  }, [conversation?.forkedChildren, messages]);
+  }, [conversation?.forkingData?.forkedChildren, messages]);
 
   useEffect(() => {
     if (!ref.current || !ref.current.data.get().length) {
@@ -501,7 +501,7 @@ export const ConversationViewer = ({
     const currentData = ref.current.data.get();
     const reconciledData = addConversationForkNotices(
       currentData,
-      conversation?.forkedChildren
+      conversation?.forkingData?.forkedChildren
     );
 
     if (
@@ -527,7 +527,7 @@ export const ConversationViewer = ({
       }
       index += 1;
     }
-  }, [conversation?.forkedChildren]);
+  }, [conversation?.forkingData?.forkedChildren]);
 
   const { feedbacks } = useConversationFeedbacks({
     conversationId: conversationId ?? "",

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -3863,7 +3863,7 @@ describe("isConversationEventAllowedForAuth", () => {
   });
 });
 
-describe("conversation fetch forkedFrom", () => {
+describe("conversation fetch forkingData", () => {
   it("includes forkedFrom in full and light conversation payloads", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({
       role: "admin",
@@ -3930,12 +3930,14 @@ describe("conversation fetch forkedFrom", () => {
     expect(fullConversationResult.isOk()).toBe(true);
 
     if (fullConversationResult.isOk()) {
-      expect(fullConversationResult.value.forkedFrom).toEqual({
-        parentConversationId: parentConversation.sId,
-        parentConversationTitle,
-        sourceMessageId: sourceMessage.sId,
-        branchedAt: branchedAt.getTime(),
-        user: auth.getNonNullableUser().toJSON(),
+      expect(fullConversationResult.value.forkingData).toEqual({
+        forkedFrom: {
+          parentConversationId: parentConversation.sId,
+          parentConversationTitle,
+          sourceMessageId: sourceMessage.sId,
+          branchedAt: branchedAt.getTime(),
+          user: auth.getNonNullableUser().toJSON(),
+        },
       });
     }
 
@@ -3946,12 +3948,14 @@ describe("conversation fetch forkedFrom", () => {
     expect(lightConversationResult.isOk()).toBe(true);
 
     if (lightConversationResult.isOk()) {
-      expect(lightConversationResult.value.forkedFrom).toEqual({
-        parentConversationId: parentConversation.sId,
-        parentConversationTitle,
-        sourceMessageId: sourceMessage.sId,
-        branchedAt: branchedAt.getTime(),
-        user: auth.getNonNullableUser().toJSON(),
+      expect(lightConversationResult.value.forkingData).toEqual({
+        forkedFrom: {
+          parentConversationId: parentConversation.sId,
+          parentConversationTitle,
+          sourceMessageId: sourceMessage.sId,
+          branchedAt: branchedAt.getTime(),
+          user: auth.getNonNullableUser().toJSON(),
+        },
       });
     }
   });
@@ -4059,14 +4063,14 @@ describe("conversation fetch forkedFrom", () => {
       await ConversationResource.fetchConversationWithoutContent(
         auth,
         parentConversation.sId,
-        { includeForkedChildrenInfo: true }
+        { includeForkingData: true }
       );
     expect(conversationResult.isOk()).toBe(true);
 
     if (conversationResult.isOk()) {
-      expect(conversationResult.value.forkedChildren).toEqual(
-        expectedForkedChildren
-      );
+      expect(conversationResult.value.forkingData).toEqual({
+        forkedChildren: expectedForkedChildren,
+      });
     }
   });
 });

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -243,10 +243,7 @@ async function _getConversation<V extends "light" | "full">(
 
   // TypeScript will now properly narrow based on viewType
   const messagesWithRank = renderRes.value as MessageTypeForView<V>[];
-  const forkingData = await ConversationResource.fetchForkingData(
-    auth,
-    conversation
-  );
+  const forkingData = await conversation.fetchForkingData(auth);
 
   // We pre-create an array that will hold
   // the versions of each User/Assistant/ContentFragment message. The length of that array is by definition the

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -92,7 +92,7 @@ async function _getConversation<V extends "light" | "full">(
   const conversation = await ConversationResource.fetchById(
     auth,
     conversationId,
-    { includeDeleted }
+    { includeDeleted, includeForkingData: true }
   );
 
   if (!conversation) {
@@ -243,6 +243,10 @@ async function _getConversation<V extends "light" | "full">(
 
   // TypeScript will now properly narrow based on viewType
   const messagesWithRank = renderRes.value as MessageTypeForView<V>[];
+  const forkingData = await ConversationResource.fetchForkingData(
+    auth,
+    conversation
+  );
 
   // We pre-create an array that will hold
   // the versions of each User/Assistant/ContentFragment message. The length of that array is by definition the
@@ -328,9 +332,7 @@ async function _getConversation<V extends "light" | "full">(
       spaceId: conversation.space?.sId ?? null,
       metadata: conversation.metadata,
       branchId,
-      ...(conversation.forkedFromInfo && {
-        forkedFrom: conversation.forkedFromInfo,
-      }),
+      ...(forkingData && { forkingData }),
     };
 
     if (paginationHasMore !== undefined) {
@@ -408,9 +410,7 @@ async function _getConversation<V extends "light" | "full">(
       spaceId: conversation.space?.sId ?? null,
       metadata: conversation.metadata,
       branchId,
-      ...(conversation.forkedFromInfo && {
-        forkedFrom: conversation.forkedFromInfo,
-      }),
+      ...(forkingData && { forkingData }),
     };
 
     if (paginationHasMore !== undefined) {

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -384,12 +384,14 @@ describe("createConversationFork", () => {
     expect(childConversation.title).toBeNull();
     expect(childConversation.spaceId).toBe(globalSpace.sId);
     expect(childConversation.depth).toBe(parentConversation.depth + 1);
-    expect(childConversation.forkedFrom).toEqual({
-      parentConversationId: parentConversation.sId,
-      parentConversationTitle: "Parent conversation",
-      sourceMessageId: sourceMessage.sId,
-      branchedAt: expect.any(Number),
-      user: user.toJSON(),
+    expect(childConversation.forkingData).toEqual({
+      forkedFrom: {
+        parentConversationId: parentConversation.sId,
+        parentConversationTitle: "Parent conversation",
+        sourceMessageId: sourceMessage.sId,
+        branchedAt: expect.any(Number),
+        user: user.toJSON(),
+      },
     });
     expect(childConversation.content).toHaveLength(1);
     expect(isCompactionMessageType(childConversation.content[0]![0]!)).toBe(
@@ -503,7 +505,7 @@ describe("createConversationFork", () => {
       result.value
     );
 
-    expect(childConversation.forkedFrom?.sourceMessageId).toBe(
+    expect(childConversation.forkingData?.forkedFrom?.sourceMessageId).toBe(
       firstAgentMessage.sId
     );
   });

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -137,7 +137,7 @@ describe("ConversationResource", () => {
       expect(fetched.length).toBe(0);
     });
 
-    it("should preload forkedFrom on forked child conversations", async () => {
+    it("should include forkingData on forked child conversations when requested", async () => {
       const { workspace, authenticator: auth } = await createResourceTest({
         role: "admin",
       });
@@ -194,16 +194,22 @@ describe("ConversationResource", () => {
       });
 
       const [fetchedChildConversation] =
-        await ConversationResource.fetchByModelIds(auth, [
-          childConversation.id,
-        ]);
+        await ConversationResource.fetchByModelIds(
+          auth,
+          [childConversation.id],
+          {
+            includeForkingData: true,
+          }
+        );
 
-      expect(fetchedChildConversation.toJSON().forkedFrom).toEqual({
-        parentConversationId: parentConversation.sId,
-        parentConversationTitle,
-        sourceMessageId: sourceMessage.sId,
-        branchedAt: branchedAt.getTime(),
-        user: auth.getNonNullableUser().toJSON(),
+      expect(fetchedChildConversation.toJSON().forkingData).toEqual({
+        forkedFrom: {
+          parentConversationId: parentConversation.sId,
+          parentConversationTitle,
+          sourceMessageId: sourceMessage.sId,
+          branchedAt: branchedAt.getTime(),
+          user: auth.getNonNullableUser().toJSON(),
+        },
       });
 
       const childConversationWithoutContent =
@@ -214,12 +220,28 @@ describe("ConversationResource", () => {
       expect(childConversationWithoutContent.isOk()).toBe(true);
 
       if (childConversationWithoutContent.isOk()) {
-        expect(childConversationWithoutContent.value.forkedFrom).toEqual({
-          parentConversationId: parentConversation.sId,
-          parentConversationTitle,
-          sourceMessageId: sourceMessage.sId,
-          branchedAt: branchedAt.getTime(),
-          user: auth.getNonNullableUser().toJSON(),
+        expect(
+          childConversationWithoutContent.value.forkingData
+        ).toBeUndefined();
+      }
+
+      const childConversationWithForkingData =
+        await ConversationResource.fetchConversationWithoutContent(
+          auth,
+          childConversation.sId,
+          { includeForkingData: true }
+        );
+      expect(childConversationWithForkingData.isOk()).toBe(true);
+
+      if (childConversationWithForkingData.isOk()) {
+        expect(childConversationWithForkingData.value.forkingData).toEqual({
+          forkedFrom: {
+            parentConversationId: parentConversation.sId,
+            parentConversationTitle,
+            sourceMessageId: sourceMessage.sId,
+            branchedAt: branchedAt.getTime(),
+            user: auth.getNonNullableUser().toJSON(),
+          },
         });
       }
     });
@@ -306,16 +328,19 @@ describe("ConversationResource", () => {
 
       const fetchedChildConversation = await ConversationResource.fetchById(
         userAuth,
-        childConversation.sId
+        childConversation.sId,
+        { includeForkingData: true }
       );
       assert(fetchedChildConversation, "Child conversation not found");
 
-      expect(fetchedChildConversation.toJSON().forkedFrom).toEqual({
-        parentConversationId: parentConversation.sId,
-        parentConversationTitle,
-        sourceMessageId: sourceMessage.sId,
-        branchedAt: branchedAt.getTime(),
-        user: adminAuth.getNonNullableUser().toJSON(),
+      expect(fetchedChildConversation.toJSON().forkingData).toEqual({
+        forkedFrom: {
+          parentConversationId: parentConversation.sId,
+          parentConversationTitle,
+          sourceMessageId: sourceMessage.sId,
+          branchedAt: branchedAt.getTime(),
+          user: adminAuth.getNonNullableUser().toJSON(),
+        },
       });
     });
   });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -356,22 +356,21 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
   }
 
-  static async fetchForkingData(
-    auth: Authenticator,
-    conversation: ConversationResource
+  async fetchForkingData(
+    auth: Authenticator
   ): Promise<ConversationForkingDataType | undefined> {
-    const forkedChildren = await this.listSerializedChildForks(
+    const forkedChildren = await ConversationResource.listSerializedChildForks(
       auth,
-      conversation
+      this
     );
 
-    if (!conversation.forkingData?.forkedFrom && forkedChildren.length === 0) {
+    if (!this.forkingData?.forkedFrom && forkedChildren.length === 0) {
       return undefined;
     }
 
     return {
-      ...(conversation.forkingData?.forkedFrom && {
-        forkedFrom: conversation.forkingData.forkedFrom,
+      ...(this.forkingData?.forkedFrom && {
+        forkedFrom: this.forkingData.forkedFrom,
       }),
       ...(forkedChildren.length > 0 && { forkedChildren }),
     };
@@ -1328,7 +1327,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         conversation.id
       );
     const forkingData = options?.includeForkingData
-      ? await ConversationResource.fetchForkingData(auth, conversation)
+      ? await conversation.fetchForkingData(auth)
       : undefined;
 
     return new Ok({

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -36,6 +36,7 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ConversationForkedChildType,
   ConversationForkedFromType,
+  ConversationForkingDataType,
   ConversationMCPServerViewType,
   ConversationMetadata,
   ConversationUrlAccessMode,
@@ -67,7 +68,7 @@ export type FetchConversationOptions = {
   includeDeleted?: boolean;
   excludeTest?: boolean; // Explicitly exclude test conversations
   dangerouslySkipPermissionFiltering?: boolean;
-  includeForkedChildrenInfo?: boolean;
+  includeForkingData?: boolean;
   updatedSince?: number; // Filter conversations updated after this timestamp (milliseconds)
 };
 
@@ -96,7 +97,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   // User-specific fields (populated when conversations are listed for a user).
   private userParticipation?: UserParticipation;
   private userLastReadAt: Date | null = null;
-  private forkedFromData?: ConversationForkedFromType;
+  private _forkingData?: ConversationForkingDataType;
 
   constructor(
     model: ModelStaticWorkspaceAware<ConversationModel>,
@@ -202,7 +203,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     space: SpaceResource | null
   ): ConversationResource {
     const resource = new this(this.model, conversation.get(), space);
-    resource.forkedFromData = this.getForkedFromData(conversation);
+    const forkedFrom = this.getForkedFromData(conversation);
+    if (forkedFrom) {
+      resource._forkingData = { forkedFrom };
+    }
 
     return resource;
   }
@@ -214,10 +218,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       transaction,
       excludeTest,
       updatedAfter,
+      includeForkingData,
     }: {
       transaction?: Transaction;
       excludeTest?: boolean;
       updatedAfter?: Date;
+      includeForkingData?: boolean;
     } = {}
   ): Promise<ConversationResource[]> {
     if (ids.length === 0) {
@@ -238,7 +244,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         visibility: { [Op.notIn]: excludedVisibilities },
         ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
       } as WhereOptions<ConversationModel>,
-      include: this.getForkedFromInclude(),
+      ...(includeForkingData ? { include: this.getForkedFromInclude() } : {}),
       transaction,
     });
 
@@ -246,8 +252,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return conversations.map((c) => this.fromModel(c, null));
   }
 
-  get forkedFromInfo(): ConversationForkedFromType | undefined {
-    return this.forkedFromData;
+  get forkingData(): ConversationForkingDataType | undefined {
+    return this._forkingData;
   }
 
   private static async listSerializedChildForks(
@@ -348,6 +354,27 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         },
       ];
     });
+  }
+
+  static async fetchForkingData(
+    auth: Authenticator,
+    conversation: ConversationResource
+  ): Promise<ConversationForkingDataType | undefined> {
+    const forkedChildren = await this.listSerializedChildForks(
+      auth,
+      conversation
+    );
+
+    if (!conversation.forkingData?.forkedFrom && forkedChildren.length === 0) {
+      return undefined;
+    }
+
+    return {
+      ...(conversation.forkingData?.forkedFrom && {
+        forkedFrom: conversation.forkingData.forkedFrom,
+      }),
+      ...(forkedChildren.length > 0 && { forkedChildren }),
+    };
   }
 
   get space(): SpaceResource | null {
@@ -534,7 +561,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         ...options.where,
         workspaceId: workspace.id,
       },
-      include: this.getForkedFromInclude(),
+      ...(fetchConversationOptions?.includeForkingData
+        ? { include: this.getForkedFromInclude() }
+        : {}),
       limit: options.limit,
       order: options.order,
     });
@@ -1286,6 +1315,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       includeDeleted: options?.includeDeleted,
       dangerouslySkipPermissionFiltering:
         options?.dangerouslySkipPermissionFiltering,
+      includeForkingData: options?.includeForkingData,
     });
 
     if (!conversation) {
@@ -1297,9 +1327,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         auth,
         conversation.id
       );
-    const forkedChildren = options?.includeForkedChildrenInfo
-      ? await ConversationResource.listSerializedChildForks(auth, conversation)
-      : [];
+    const forkingData = options?.includeForkingData
+      ? await ConversationResource.fetchForkingData(auth, conversation)
+      : undefined;
 
     return new Ok({
       id: conversation.id,
@@ -1318,10 +1348,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       depth: conversation.depth,
       metadata: conversation.metadata,
       branchId: null,
-      ...(conversation.forkedFromInfo && {
-        forkedFrom: conversation.forkedFromInfo,
-      }),
-      ...(forkedChildren.length > 0 && { forkedChildren }),
+      ...(forkingData && { forkingData }),
     });
   }
 
@@ -3332,7 +3359,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       depth: this.depth,
       metadata: this.metadata,
       branchId: null,
-      ...(this.forkedFromInfo && { forkedFrom: this.forkedFromInfo }),
+      ...(this.forkingData && { forkingData: this.forkingData }),
     };
   }
 }

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -147,12 +147,8 @@
  *           type: array
  *           items:
  *             type: string
- *         forkedFrom:
- *           $ref: '#/components/schemas/PrivateConversationForkedFrom'
- *         forkedChildren:
- *           type: array
- *           items:
- *             $ref: '#/components/schemas/PrivateConversationForkedChild'
+ *         forkingData:
+ *           $ref: '#/components/schemas/PrivateConversationForkingData'
  *     PrivateConversationForkUser:
  *       type: object
  *       properties:
@@ -217,6 +213,15 @@
  *           type: integer
  *         user:
  *           $ref: '#/components/schemas/PrivateConversationForkUser'
+ *     PrivateConversationForkingData:
+ *       type: object
+ *       properties:
+ *         forkedFrom:
+ *           $ref: '#/components/schemas/PrivateConversationForkedFrom'
+ *         forkedChildren:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/PrivateConversationForkedChild'
  *     PrivateFullConversation:
  *       type: object
  *       description: Full conversation including content, owner, and visibility.

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -166,12 +166,14 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
     const conversation = await fetchConversationOrThrow(auth, conversationId);
 
     expect(conversation.title).toBeNull();
-    expect(conversation.forkedFrom).toEqual({
-      parentConversationId: parentConversation.sId,
-      parentConversationTitle: "Parent conversation",
-      sourceMessageId: sourceMessage.sId,
-      branchedAt: expect.any(Number),
-      user: auth.getNonNullableUser().toJSON(),
+    expect(conversation.forkingData).toEqual({
+      forkedFrom: {
+        parentConversationId: parentConversation.sId,
+        parentConversationTitle: "Parent conversation",
+        sourceMessageId: sourceMessage.sId,
+        branchedAt: expect.any(Number),
+        user: auth.getNonNullableUser().toJSON(),
+      },
     });
     expect(conversation.depth).toBe(1);
     expect(conversation.spaceId).toBe(globalSpace.sId);
@@ -211,12 +213,14 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
     const { conversationId } = res._getJSONData();
     const conversation = await fetchConversationOrThrow(auth, conversationId);
 
-    expect(conversation.forkedFrom).toEqual({
-      parentConversationId: parentConversation.sId,
-      parentConversationTitle: "Parent conversation",
-      sourceMessageId: sourceMessage.sId,
-      branchedAt: expect.any(Number),
-      user: auth.getNonNullableUser().toJSON(),
+    expect(conversation.forkingData).toEqual({
+      forkedFrom: {
+        parentConversationId: parentConversation.sId,
+        parentConversationTitle: "Parent conversation",
+        sourceMessageId: sourceMessage.sId,
+        branchedAt: expect.any(Number),
+        user: auth.getNonNullableUser().toJSON(),
+      },
     });
   });
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -207,7 +207,7 @@ async function handler(
     case "GET": {
       const conversationRes =
         await ConversationResource.fetchConversationWithoutContent(auth, cId, {
-          includeForkedChildrenInfo: true,
+          includeForkingData: true,
         });
 
       if (conversationRes.isErr()) {

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -9582,14 +9582,8 @@
               "type": "string"
             }
           },
-          "forkedFrom": {
-            "$ref": "#/components/schemas/PrivateConversationForkedFrom"
-          },
-          "forkedChildren": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PrivateConversationForkedChild"
-            }
+          "forkingData": {
+            "$ref": "#/components/schemas/PrivateConversationForkingData"
           }
         }
       },
@@ -9689,6 +9683,20 @@
           },
           "user": {
             "$ref": "#/components/schemas/PrivateConversationForkUser"
+          }
+        }
+      },
+      "PrivateConversationForkingData": {
+        "type": "object",
+        "properties": {
+          "forkedFrom": {
+            "$ref": "#/components/schemas/PrivateConversationForkedFrom"
+          },
+          "forkedChildren": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateConversationForkedChild"
+            }
           }
         }
       },

--- a/front/types/assistant/conversation.test.ts
+++ b/front/types/assistant/conversation.test.ts
@@ -53,7 +53,7 @@ describe("getConversationDisplayTitle", () => {
         {
           title: null,
           created: now.getTime(),
-          forkedFrom,
+          forkingData: { forkedFrom },
         },
         now
       )
@@ -66,9 +66,11 @@ describe("getConversationDisplayTitle", () => {
         {
           title: null,
           created: now.getTime(),
-          forkedFrom: {
-            ...forkedFrom,
-            parentConversationTitle: null,
+          forkingData: {
+            forkedFrom: {
+              ...forkedFrom,
+              parentConversationTitle: null,
+            },
           },
         },
         now

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -438,6 +438,14 @@ export type ConversationForkedChildType = {
 };
 
 /**
+ * @swaggerschema PrivateConversationForkingData (swagger_private_schemas.ts)
+ */
+export type ConversationForkingDataType = {
+  forkedFrom?: ConversationForkedFromType;
+  forkedChildren?: ConversationForkedChildType[];
+};
+
+/**
  * A lighter version of Conversation without the content (for menu display).
  *
  * @swaggerschema PrivateConversation (swagger_private_schemas.ts)
@@ -457,8 +465,7 @@ export type ConversationWithoutContentType = {
   depth: number;
   metadata: ConversationMetadata;
   branchId: string | null;
-  forkedFrom?: ConversationForkedFromType;
-  forkedChildren?: ConversationForkedChildType[];
+  forkingData?: ConversationForkingDataType;
 
   // Ideally, this property should be moved to the ConversationType.
   requestedSpaceIds: string[];

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -473,7 +473,7 @@ export type ConversationWithoutContentType = {
 
 type ConversationDisplayTitleInput = Pick<
   ConversationWithoutContentType,
-  "created" | "title" | "forkedFrom"
+  "created" | "title" | "forkingData"
 >;
 export function getConversationDisplayTitle(
   conversation: ConversationDisplayTitleInput,
@@ -483,9 +483,10 @@ export function getConversationDisplayTitle(
     return conversation.title;
   }
 
-  if (conversation.forkedFrom) {
-    return conversation.forkedFrom.parentConversationTitle
-      ? `Branched from '${conversation.forkedFrom.parentConversationTitle}'`
+  const forkedFrom = conversation.forkingData?.forkedFrom;
+  if (forkedFrom) {
+    return forkedFrom.parentConversationTitle
+      ? `Branched from '${forkedFrom.parentConversationTitle}'`
       : "Branched conversation";
   }
 


### PR DESCRIPTION
## Description
This makes conversation lineage opt-in behind `includeForkingData` and nests it under `forkingData` in the private conversation payloads.

Detail-style fetches now request forking data explicitly, while list/search flows stop loading parent or child lineage by default.

## Risks
Blast radius: private conversation payloads and the conversation UI lineage consumers.
Risk: standard

## Deploy Plan
- deploy front