### PR TITLE
fix(conversation): cascade soft-delete to orphan agent replies

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -422,8 +422,14 @@ export function AgentMessage({
     [agentMessage.citations]
   );
 
-  // GenerationContext: to know if we are generating or not.
-  const generationContext = useGenerationContext();
+  // GenerationContext: to know if we are generating or not. Destructure the (stable) mutators
+  // so the effect below doesn't re-run on every context value change — which happens on every
+  // add/remove since the context value ref is tied to the generatingMessages state.
+  const {
+    addGeneratingMessage,
+    removeGeneratingMessage,
+    getConversationGeneratingMessages,
+  } = useGenerationContext();
 
   // Once a handoff user message exists for this agent message, the agent has
   // effectively handed over: the child agent owns the generation from here.
@@ -440,18 +446,24 @@ export function AgentMessage({
 
   useEffect(() => {
     if (shouldStream && !isAgentMessageHandingOver) {
-      generationContext.addGeneratingMessage({
+      addGeneratingMessage({
         messageId: sId,
         conversationId,
         agentId: agentMessage.configuration.sId,
       });
     } else {
-      generationContext.removeGeneratingMessage({ messageId: sId });
+      removeGeneratingMessage({ messageId: sId });
     }
+    // Clean up on unmount so we don't leak a generating entry (e.g. when the message is replaced
+    // by a v+1 deletion placeholder mid-stream).
+    return () => {
+      removeGeneratingMessage({ messageId: sId });
+    };
   }, [
     shouldStream,
     isAgentMessageHandingOver,
-    generationContext,
+    addGeneratingMessage,
+    removeGeneratingMessage,
     sId,
     conversationId,
     agentMessage.configuration.sId,
@@ -546,8 +558,7 @@ export function AgentMessage({
   const hoverButtons: ReactElement[] = [];
 
   const hasMultiAgents =
-    generationContext.getConversationGeneratingMessages(conversationId).length >
-    1;
+    getConversationGeneratingMessages(conversationId).length > 1;
 
   // Show stop agent button only when streaming with multiple agents
   if (hasMultiAgents && shouldStream) {

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -238,11 +238,17 @@ export function UserMessage({
       return;
     }
 
+    // Only mention the agent reply when the message actually triggered one.
+    const hasAgentReply = message.richMentions.some(isRichAgentMention);
+    const replyNote = hasAgentReply
+      ? " The agent's reply will also be removed."
+      : "";
+
     const confirmed = await confirm({
       title: isCurrentUser ? "Delete your message" : "Delete user message",
       message: isCurrentUser
-        ? "Are you sure you want to delete this message? This action cannot be undone."
-        : "Are you sure you want to delete this user's message? This the message will be deleted for all participants.",
+        ? `Are you sure you want to delete this message?${replyNote} This action cannot be undone.`
+        : `Are you sure you want to delete this user's message?${replyNote} This will be reflected for all participants.`,
       validateLabel: "Delete",
       validateVariant: "warning",
     });
@@ -267,6 +273,7 @@ export function UserMessage({
     deleteMessage,
     isCurrentUser,
     message.sId,
+    message.richMentions,
     methods,
   ]);
 

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -7,12 +7,14 @@ import {
   postUserMessage,
   retryAgentMessage,
   softDeleteAgentMessage,
+  softDeleteUserMessageAndReplies,
 } from "@app/lib/api/assistant/conversation";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import {
   getConversation,
   getLightConversation,
 } from "@app/lib/api/assistant/conversation/fetch";
+import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import { publishAgentMessagesEvents } from "@app/lib/api/assistant/streaming/events";
 import * as attachmentsModule from "@app/lib/api/files/attachments";
 import { fetchLatestProjectContextFileContentFragment } from "@app/lib/api/projects/context";
@@ -72,6 +74,10 @@ vi.mock("@app/lib/api/assistant/streaming/events", () => ({
   publishAgentMessagesEvents: vi.fn(),
   publishConversationEvent: vi.fn(),
   publishMessageEventsOnMessagePostOrEdit: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/assistant/pubsub", () => ({
+  gracefullyStopAgentLoop: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/assistant/conversation/content_fragment", () => ({
@@ -1180,6 +1186,213 @@ describe("softDeleteAgentMessage", () => {
       expect(result.error).toBeInstanceOf(ConversationError);
       expect(result.error.type).toBe("message_deletion_not_authorized");
     }
+  });
+});
+
+describe("softDeleteUserMessageAndReplies", () => {
+  let auth: Authenticator;
+  let conversation: ConversationType;
+  let agentConfig: LightAgentConfigurationType;
+
+  beforeEach(async () => {
+    vi.mocked(gracefullyStopAgentLoop).mockClear();
+
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+
+    agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent Description",
+    });
+
+    // Two user/agent pairs so we can exercise the mid-conversation cascade.
+    const conversationWithoutContent = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date(), new Date()],
+    });
+
+    const fetchedConversationResult = await getConversation(
+      auth,
+      conversationWithoutContent.sId
+    );
+    if (fetchedConversationResult.isErr()) {
+      throw new Error("Failed to fetch conversation");
+    }
+    conversation = fetchedConversationResult.value;
+  });
+
+  it("cascade-deletes the agent message that replied to the deleted user message", async () => {
+    const firstUserMessage = conversation.content
+      .flat()
+      .find((m): m is UserMessageType => isUserMessageType(m));
+    if (!firstUserMessage) {
+      throw new Error("No user message found in conversation");
+    }
+
+    const result = await softDeleteUserMessageAndReplies(auth, {
+      message: firstUserMessage,
+      conversation,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const updated = await getConversation(auth, conversation.sId);
+    if (updated.isErr()) {
+      throw new Error("Failed to refetch conversation");
+    }
+
+    // Rank 0: user v1 ("deleted" placeholder).
+    const rank0Latest =
+      updated.value.content[0][updated.value.content[0].length - 1];
+    expect(rank0Latest.type).toBe("user_message");
+    expect(rank0Latest.visibility).toBe("deleted");
+
+    // Rank 1: agent v1 (cascade-deleted placeholder).
+    const rank1Latest =
+      updated.value.content[1][updated.value.content[1].length - 1];
+    expect(rank1Latest.type).toBe("agent_message");
+    expect(rank1Latest.visibility).toBe("deleted");
+    expect(rank1Latest.version).toBe(1);
+
+    // Rank 2 (next turn's user) remains untouched.
+    const rank2Latest =
+      updated.value.content[2][updated.value.content[2].length - 1];
+    expect(rank2Latest.type).toBe("user_message");
+    expect(rank2Latest.visibility).toBe("visible");
+
+    // Rank 3 (next turn's agent) remains untouched.
+    const rank3Latest =
+      updated.value.content[3][updated.value.content[3].length - 1];
+    expect(rank3Latest.type).toBe("agent_message");
+    expect(rank3Latest.visibility).toBe("visible");
+  });
+
+  it("cascades to the trailing agent when the last user message is deleted", async () => {
+    const userMessages = conversation.content
+      .flat()
+      .filter((m): m is UserMessageType => isUserMessageType(m));
+    const lastUser = userMessages[userMessages.length - 1];
+
+    const result = await softDeleteUserMessageAndReplies(auth, {
+      message: lastUser,
+      conversation,
+    });
+    expect(result.isOk()).toBe(true);
+
+    const updated = await getConversation(auth, conversation.sId);
+    if (updated.isErr()) {
+      throw new Error("Failed to refetch conversation");
+    }
+
+    const rank3Latest =
+      updated.value.content[3][updated.value.content[3].length - 1];
+    expect(rank3Latest.visibility).toBe("deleted");
+  });
+
+  it("does not create a duplicate placeholder when the following agent is already deleted", async () => {
+    const agentMessages = conversation.content
+      .flat()
+      .filter((m): m is AgentMessageType => m.type === "agent_message");
+    const firstAgent = agentMessages[0];
+
+    // Pre-delete the agent directly.
+    const preDelete = await softDeleteAgentMessage(auth, {
+      message: firstAgent,
+      conversation,
+    });
+    expect(preDelete.isOk()).toBe(true);
+
+    // Refetch so we have the updated conversation with the existing v1 placeholder.
+    const refetched = await getConversation(auth, conversation.sId);
+    if (refetched.isErr()) {
+      throw new Error("Failed to refetch conversation");
+    }
+    const refetchedConversation = refetched.value;
+    const firstUser = refetchedConversation.content
+      .flat()
+      .find((m): m is UserMessageType => isUserMessageType(m));
+    if (!firstUser) {
+      throw new Error("No user message found");
+    }
+
+    // content[1] is the agent rank; pre-delete has given it v0 + v1 placeholder (2 versions).
+    const agentRankVersionsBefore = refetchedConversation.content[1].length;
+
+    const result = await softDeleteUserMessageAndReplies(auth, {
+      message: firstUser,
+      conversation: refetchedConversation,
+    });
+    expect(result.isOk()).toBe(true);
+
+    const updated = await getConversation(auth, conversation.sId);
+    if (updated.isErr()) {
+      throw new Error("Failed to refetch conversation");
+    }
+
+    // Cascade should not add a v2 placeholder when the orphan is already deleted.
+    expect(updated.value.content[1].length).toBe(agentRankVersionsBefore);
+  });
+
+  it("signals gracefullyStopAgentLoop when the cascaded agent reply is still running", async () => {
+    // ConversationFactory creates agent messages with status "created" by default, which
+    // simulates a mid-stream reply being orphaned by the user-message delete.
+    const firstUserMessage = conversation.content
+      .flat()
+      .find((m): m is UserMessageType => isUserMessageType(m));
+    if (!firstUserMessage) {
+      throw new Error("No user message found in conversation");
+    }
+    const firstAgentMessage = conversation.content
+      .flat()
+      .find((m): m is AgentMessageType => m.type === "agent_message");
+    if (!firstAgentMessage) {
+      throw new Error("No agent message found in conversation");
+    }
+
+    const result = await softDeleteUserMessageAndReplies(auth, {
+      message: firstUserMessage,
+      conversation,
+    });
+    expect(result.isOk()).toBe(true);
+
+    expect(gracefullyStopAgentLoop).toHaveBeenCalledWith(expect.anything(), {
+      messageIds: [firstAgentMessage.sId],
+      conversationId: conversation.sId,
+    });
+  });
+
+  it("does not signal gracefullyStopAgentLoop when the cascaded agent reply already finished", async () => {
+    const firstUserMessage = conversation.content
+      .flat()
+      .find((m): m is UserMessageType => isUserMessageType(m));
+    if (!firstUserMessage) {
+      throw new Error("No user message found in conversation");
+    }
+
+    // Flip the first agent's status away from "created" before cascading.
+    await AgentMessageModel.update(
+      { status: "succeeded" },
+      {
+        where: {
+          id: conversation.content
+            .flat()
+            .filter((m): m is AgentMessageType => m.type === "agent_message")
+            .map((m) => m.agentMessageId),
+        },
+      }
+    );
+    const refetched = await getConversation(auth, conversation.sId);
+    if (refetched.isErr()) {
+      throw new Error("Failed to refetch conversation");
+    }
+
+    const result = await softDeleteUserMessageAndReplies(auth, {
+      message: firstUserMessage,
+      conversation: refetched.value,
+    });
+    expect(result.isOk()).toBe(true);
+
+    expect(gracefullyStopAgentLoop).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2064,7 +2064,56 @@ export async function postNewContentFragment(
   return new Ok(render);
 }
 
-export async function softDeleteUserMessage(
+/**
+ * Returns the agent replies that follow `userMessage` in the conversation and would be orphaned
+ * by soft-deleting it. These are agent messages at subsequent ranks up to (but not including) the
+ * next non-agent rank. Already-deleted agent messages are skipped.
+ *
+ * Invariant: agent replies are immediately contiguous to the user message they respond to (no
+ * compaction, content fragment, or another user message inserted in between). If that ever
+ * changes, this walk will stop short and leave orphans that re-introduce the trailing-assistant
+ * bug this cascade is meant to fix.
+ *
+ * New conversations are capped at one mention per user message (enforced in postUserMessage) so
+ * in practice there's at most one, but legacy conversations can have multiple agent replies in a
+ * single turn, which is why the return type is an array.
+ */
+function getAgentRepliesToCascadeOnUserDelete(
+  conversation: ConversationType,
+  userMessage: UserMessageType
+): AgentMessageType[] {
+  const orphans: AgentMessageType[] = [];
+  let sawUserMessage = false;
+  for (const versions of conversation.content) {
+    const latest = versions[versions.length - 1];
+    if (!sawUserMessage) {
+      sawUserMessage = latest.sId === userMessage.sId;
+      continue;
+    }
+    if (!isAgentMessageType(latest)) {
+      break;
+    }
+    if (latest.visibility !== "deleted") {
+      orphans.push(latest);
+    }
+  }
+  return orphans;
+}
+
+/**
+ * Soft-delete a user message and the agent replies that followed it.
+ *
+ * Both deletions are represented as new v+1 `messages` rows with `visibility: "deleted"` rather
+ * than UPDATEs on the v0 rows. This is required so other clients viewing the conversation see the
+ * deletion in realtime: the message event stream fires on new rows (publishAgentMessagesEvents /
+ * publishMessageEventsOnMessagePostOrEdit), not on UPDATEs. As a side benefit, v0 stays intact as
+ * immutable history.
+ *
+ * The cascade to the following agent replies is necessary because otherwise the orphaned agent
+ * messages would be rendered for the model with no preceding user turn, producing a trailing
+ * assistant turn that providers like Anthropic reject (400 invalid_request_error).
+ */
+export async function softDeleteUserMessageAndReplies(
   auth: Authenticator,
   {
     message,
@@ -2086,6 +2135,15 @@ export async function softDeleteUserMessage(
     return new Err(new ConversationError("message_deletion_not_authorized"));
   }
 
+  // Known small race: this snapshot of `conversation.content` is taken before the rank lock
+  // below. A concurrent retry/edit that takes the lock first and writes a v+1 at the same rank
+  // could cause the cascade insert to hit the (rank, version) unique constraint.
+  const orphanAgentMessages = getAgentRepliesToCascadeOnUserDelete(
+    conversation,
+    message
+  );
+
+  const cascadedAgentMessages: AgentMessageType[] = [];
   const userMessage = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
@@ -2121,6 +2179,19 @@ export async function softDeleteUserMessage(
       );
     }
 
+    for (const orphan of orphanAgentMessages) {
+      const { agentMessages } = await createAgentMessages(auth, {
+        conversation,
+        metadata: {
+          type: "delete",
+          agentMessage: orphan,
+          parentId: message.id,
+        },
+        transaction: t,
+      });
+      cascadedAgentMessages.push(...agentMessages);
+    }
+
     await ConversationResource.markAsUpdated(auth, { conversation, t });
 
     return userMessage;
@@ -2131,6 +2202,23 @@ export async function softDeleteUserMessage(
     { ...userMessage, contentFragments: [], mentions: [], richMentions: [] },
     []
   );
+
+  if (cascadedAgentMessages.length > 0) {
+    await publishAgentMessagesEvents(conversation, cascadedAgentMessages);
+  }
+
+  // Signal any still-running agent loops to stop. Orphans with status "created" have a live
+  // Temporal workflow that would otherwise keep streaming to a deleted message. The gracefully-
+  // stopped event also lets the client flip the message status and hide the Stop button.
+  const runningOrphans = orphanAgentMessages.filter(
+    (m) => m.status === "created"
+  );
+  if (runningOrphans.length > 0) {
+    await gracefullyStopAgentLoop(auth, {
+      messageIds: runningOrphans.map((m) => m.sId),
+      conversationId: conversation.sId,
+    });
+  }
 
   auditLog(
     {
@@ -2147,6 +2235,12 @@ export async function softDeleteUserMessage(
   return new Ok({ success: true });
 }
 
+/**
+ * Soft-delete a single agent message.
+ *
+ * See {@link softDeleteUserMessageAndReplies} for the rationale of the v+1 placeholder pattern
+ * (realtime sync + immutable history).
+ */
 export async function softDeleteAgentMessage(
   auth: Authenticator,
   {
@@ -2202,6 +2296,15 @@ export async function softDeleteAgentMessage(
   });
 
   await publishAgentMessagesEvents(conversation, agentMessages);
+
+  // Stop the underlying agent loop if it's still running so the Temporal workflow doesn't keep
+  // streaming to a deleted message and the client sees the Stop button disappear.
+  if (message.status === "created") {
+    await gracefullyStopAgentLoop(auth, {
+      messageIds: [message.sId],
+      conversationId: conversation.sId,
+    });
+  }
 
   auditLog(
     {

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -118,7 +118,7 @@ export async function createUserMessage(
       agenticMessageData = metadata.message.agenticMessageData;
       break;
     case "delete":
-      // In case of delete, we use the message metadata to delete the user message.
+      // See softDeleteUserMessageAndReplies for why a v+1 placeholder is used instead of an UPDATE.
       rank = metadata.message.rank;
       version = metadata.message.version + 1;
       parentId = metadata.message.id;
@@ -335,6 +335,9 @@ export const createAgentMessages = async (
 
     case "delete":
       {
+        // See softDeleteUserMessageAndReplies / softDeleteAgentMessage for why a v+1 placeholder is used
+        // instead of an UPDATE. MessageModel's exclusivity constraint forces us to anchor the v+1
+        // row with a new AgentMessageModel (status "cancelled", it never ran).
         const agentConfiguration = metadata.agentMessage.configuration;
         const agentMessageRow = await AgentMessageModel.create({
           status: "cancelled",

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -87,7 +87,7 @@
  */
 import {
   softDeleteAgentMessage,
-  softDeleteUserMessage,
+  softDeleteUserMessageAndReplies,
 } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
@@ -266,7 +266,7 @@ async function handler(
       const renderedMessage = renderRes.value[0];
 
       if (isUserMessageType(renderedMessage)) {
-        const deleteResult = await softDeleteUserMessage(auth, {
+        const deleteResult = await softDeleteUserMessageAndReplies(auth, {
           message: renderedMessage,
           conversation: fullConversation,
         });


### PR DESCRIPTION
## Description

Anthropic returns 400 invalid_request_error ("conversation must end with a user message") when a user soft-deletes a message mid-conversation and then retries the agent response. The deleted user rank is skipped at render time but the agent reply at the following rank is still visible, so when the retry builds the conversation for the model it ends on an assistant turn, which newer Claude models reject. Older models silently tolerated this as a prefill. Reproduced locally.

Fix: **when a user soft-deletes their message, cascade the delete to the agent reply that followed it**, in the same transaction. Rendering then skips both ranks so a subsequent retry produces a conversation ending on a user turn. If the reply is still streaming when the user deletes, the cascade also signals gracefullyStopAgentLoop so the Temporal workflow does not keep streaming to a deleted message and the client can hide its Stop button. softDeleteAgentMessage gets the same stop signal for symmetry.

softDeleteUserMessage is renamed to softDeleteUserMessageAndReplies to reflect the new scope. The helper stays array-returning so the rare case of multiple replies per user turn in legacy conversations still works.

## Tests

Bug to reproduce on prod: 
- Post "coucou"
- Wait for the agent to answer. 
- Delete your message. 
- Retry the agent message. 🙃 


With this code: 
- Post "coucou"
- Wait for the agent to answer. 
- Delete your message. -> the dialog message explain that it would remove both messages. 

<kbd>
<img width="870" height="358" alt="Screenshot 2026-04-21 at 22 09 04" src="https://github.com/user-attachments/assets/d6cead84-30a7-4423-a6b9-9a97a5408b62" />
</kbd>
<kbd>
<img width="895" height="595" alt="Screenshot 2026-04-21 at 22 09 11" src="https://github.com/user-attachments/assets/6babd8d2-1b24-4763-ab43-3a12da2851e2" />
</kbd>
<kbd>
<img width="881" height="361" alt="Screenshot 2026-04-21 at 22 09 18" src="https://github.com/user-attachments/assets/2065b5b2-f525-4149-8e35-2df80897011e" />
</kbd>


## Risk

Moderate. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
