### PR TITLE
[sessions] add Skip to Google Drive file authorization dialog

### DIFF
--- a/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
+++ b/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
@@ -1,6 +1,7 @@
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import type { GooglePickerFile } from "@app/hooks/useGooglePicker";
 import { useGooglePicker } from "@app/hooks/useGooglePicker";
+import { useResolveAuthentication } from "@app/hooks/useResolveAuthentication";
 import type {
   BlockedToolExecution,
   FileAuthorizationInfo,
@@ -17,6 +18,7 @@ import {
   ContentMessage,
   DocumentTextIcon,
   ExternalLinkIcon,
+  XMarkIcon,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -51,6 +53,10 @@ export function GoogleDriveFileAuthorizationRequired({
   const [credentialsError, setCredentialsError] = useState<string | null>(null);
 
   const { removeCompletedAction } = useBlockedActionsContext();
+  const { resolveAuthentication, isResolving } = useResolveAuthentication({
+    owner,
+    kind: "file_authorization",
+  });
   const isExtension = clientType === "extension";
 
   const isTriggeredByCurrentUser = useMemo(
@@ -148,6 +154,27 @@ export function GoogleDriveFileAuthorizationRequired({
     setIsOpeningPicker(true);
   };
 
+  const handleSkip = useCallback(async () => {
+    const denyRes = await resolveAuthentication({
+      outcome: "denied",
+      actionId: blockedAction.actionId,
+      conversationId: blockedAction.conversationId,
+      messageId: blockedAction.messageId,
+    });
+
+    if (!denyRes.success) {
+      return;
+    }
+
+    removeCompletedAction(blockedAction.actionId);
+  }, [
+    resolveAuthentication,
+    removeCompletedAction,
+    blockedAction.actionId,
+    blockedAction.conversationId,
+    blockedAction.messageId,
+  ]);
+
   const webAppConversationUrl = `${regionInfo.url}/w/${owner.sId}/conversation/${blockedAction.conversationId}`;
 
   const handleOpenInWebApp = () => {
@@ -179,7 +206,15 @@ export function GoogleDriveFileAuthorizationRequired({
             )}
           </div>
           {!isAuthorized && (
-            <div className="mt-3 flex flex-col justify-end sm:flex-row">
+            <div className="mt-3 flex flex-col justify-end gap-3 sm:flex-row">
+              <Button
+                variant="outline"
+                size="xs"
+                label="Skip"
+                icon={XMarkIcon}
+                disabled={isResolving || isOpeningPicker}
+                onClick={() => void handleSkip()}
+              />
               {isExtension ? (
                 <Button
                   label="Open in Web App"
@@ -194,7 +229,12 @@ export function GoogleDriveFileAuthorizationRequired({
                   variant="highlight"
                   size="xs"
                   icon={DocumentTextIcon}
-                  disabled={isButtonLoading || !!error || !!credentialsError}
+                  disabled={
+                    isButtonLoading ||
+                    isResolving ||
+                    !!error ||
+                    !!credentialsError
+                  }
                   onClick={handleOpenPicker}
                 />
               )}

--- a/front/hooks/useResolveAuthentication.ts
+++ b/front/hooks/useResolveAuthentication.ts
@@ -1,4 +1,5 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { ResolveAuthenticationKind } from "@app/lib/api/assistant/conversation/resolve_authentication";
 import { useFetcher } from "@app/lib/swr/swr";
 import { isAPIErrorResponse } from "@app/types/error";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -6,12 +7,24 @@ import { useCallback, useState } from "react";
 
 type ResolveAuthenticationOutcome = "completed" | "denied";
 
+const ROUTE_FOR_KIND: Record<ResolveAuthenticationKind, string> = {
+  authentication: "resolve-authentication",
+  file_authorization: "resolve-file-authorization",
+};
+
+const LABEL_FOR_KIND: Record<ResolveAuthenticationKind, string> = {
+  authentication: "authentication",
+  file_authorization: "file authorization",
+};
+
 interface UseResolveAuthenticationParams {
   owner: LightWorkspaceType;
+  kind?: ResolveAuthenticationKind;
 }
 
 export function useResolveAuthentication({
   owner,
+  kind = "authentication",
 }: UseResolveAuthenticationParams) {
   const sendNotification = useSendNotification();
   const { fetcher } = useFetcher();
@@ -33,7 +46,7 @@ export function useResolveAuthentication({
 
       try {
         await fetcher(
-          `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}/resolve-authentication`,
+          `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}/${ROUTE_FOR_KIND[kind]}`,
           {
             method: "POST",
             headers: {
@@ -51,16 +64,15 @@ export function useResolveAuthentication({
 
         sendNotification({
           type: "error",
-          title: "Failed to resolve authentication",
-          description:
-            "Failed to resume the authenticated tool. Please try again.",
+          title: `Failed to resolve ${LABEL_FOR_KIND[kind]}`,
+          description: `Failed to resume the ${LABEL_FOR_KIND[kind]} tool. Please try again.`,
         });
         return { success: false };
       } finally {
         setIsCompleting(false);
       }
     },
-    [owner.sId, sendNotification, fetcher]
+    [owner.sId, sendNotification, fetcher, kind]
   );
 
   return { resolveAuthentication, isResolving: isCompleting };

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -294,7 +294,7 @@ export function isToolPersonalAuthRequiredEvent(
   );
 }
 
-function isToolFileAuthRequiredEvent(
+export function isToolFileAuthRequiredEvent(
   event: unknown
 ): event is ToolFileAuthRequiredEvent {
   return (

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -1,17 +1,49 @@
-import { isToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp";
+import {
+  isToolFileAuthRequiredEvent,
+  isToolPersonalAuthRequiredEvent,
+} from "@app/lib/actions/mcp";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import type { WithAPIErrorResponse } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 export type ResolveAuthenticationOutcome = "completed" | "denied";
+export type ResolveAuthenticationKind = "authentication" | "file_authorization";
+
+const KIND_CONFIG: Record<
+  ResolveAuthenticationKind,
+  {
+    blockedStatus:
+      | "blocked_authentication_required"
+      | "blocked_file_authorization_required";
+    isMatchingEvent: (event: unknown) => boolean;
+    label: string;
+  }
+> = {
+  authentication: {
+    blockedStatus: "blocked_authentication_required",
+    isMatchingEvent: isToolPersonalAuthRequiredEvent,
+    label: "authentication",
+  },
+  file_authorization: {
+    blockedStatus: "blocked_file_authorization_required",
+    isMatchingEvent: isToolFileAuthRequiredEvent,
+    label: "file authorization",
+  },
+};
 
 export async function resolveAuthentication(
   auth: Authenticator,
@@ -20,12 +52,15 @@ export async function resolveAuthentication(
     actionId,
     messageId,
     outcome,
+    kind = "authentication",
   }: {
     actionId: string;
     messageId: string;
     outcome: ResolveAuthenticationOutcome;
+    kind?: ResolveAuthenticationKind;
   }
 ): Promise<Result<void, DustError>> {
+  const { blockedStatus, isMatchingEvent, label } = KIND_CONFIG[kind];
   const owner = auth.getNonNullableWorkspace();
   const user = auth.user();
   const { sId: conversationId, title: conversationTitle } = conversation;
@@ -39,7 +74,7 @@ export async function resolveAuthentication(
       workspaceId: owner.sId,
       userId: user?.sId,
     },
-    "Resolve authentication request"
+    `Resolve ${label} request`
   );
 
   const {
@@ -58,7 +93,7 @@ export async function resolveAuthentication(
     return new Err(
       new DustError(
         "unauthorized",
-        "User is not authorized to resolve authentication for this action"
+        `User is not authorized to resolve ${label} for this action`
       )
     );
   }
@@ -70,11 +105,11 @@ export async function resolveAuthentication(
     );
   }
 
-  if (action.status !== "blocked_authentication_required") {
+  if (action.status !== blockedStatus) {
     return new Err(
       new DustError(
         "action_not_blocked",
-        `Action is not blocked for authentication: ${action.status}`
+        `Action is not blocked for ${label}: ${action.status}`
       )
     );
   }
@@ -91,7 +126,7 @@ export async function resolveAuthentication(
         workspaceId: owner.sId,
         userId: user?.sId,
       },
-      "Authentication action already resolved"
+      `${label} action already resolved`
     );
 
     return new Ok(undefined);
@@ -100,7 +135,8 @@ export async function resolveAuthentication(
   await getRedisHybridManager().removeEvent((event) => {
     const payload = JSON.parse(event.message["payload"]);
     return (
-      isToolPersonalAuthRequiredEvent(payload) && payload.actionId === actionId
+      isMatchingEvent(payload) &&
+      (payload as { actionId: string }).actionId === actionId
     );
   }, getMessageChannelId(messageId));
 
@@ -142,8 +178,118 @@ export async function resolveAuthentication(
       actionId,
       outcome,
     },
-    `Authentication ${outcome}, agent loop resumed`
+    `${label} ${outcome}, agent loop resumed`
   );
 
   return new Ok(undefined);
+}
+
+const ResolveAuthenticationSchema = z.object({
+  actionId: z.string(),
+  outcome: z.enum(["completed", "denied"]),
+});
+
+export type ResolveAuthenticationResponse = {
+  success: boolean;
+};
+
+export function makeResolveAuthenticationHandler(
+  kind: ResolveAuthenticationKind
+): NextApiHandler<WithAPIErrorResponse<ResolveAuthenticationResponse>> {
+  async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<WithAPIErrorResponse<ResolveAuthenticationResponse>>,
+    auth: Authenticator
+  ): Promise<void> {
+    const { cId, mId } = req.query;
+    if (!isString(cId) || !isString(mId)) {
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation, message, or workspace not found.",
+        },
+      });
+    }
+
+    if (req.method !== "POST") {
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+    }
+
+    const parseResult = ResolveAuthenticationSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Invalid request body: ${parseResult.error.message}`,
+        },
+      });
+    }
+
+    const conversation = await ConversationResource.fetchById(auth, cId);
+
+    if (!conversation) {
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found.",
+        },
+      });
+    }
+
+    const { actionId, outcome } = parseResult.data;
+
+    const result = await resolveAuthentication(auth, conversation, {
+      actionId,
+      messageId: mId,
+      outcome,
+      kind,
+    });
+
+    if (result.isErr()) {
+      switch (result.error.code) {
+        case "action_not_blocked":
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "action_not_blocked",
+              message: result.error.message,
+            },
+          });
+        case "action_not_found":
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "action_not_found",
+              message: result.error.message,
+            },
+          });
+        default:
+          return apiError(
+            req,
+            res,
+            {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: `Failed to resolve ${KIND_CONFIG[kind].label}`,
+              },
+            },
+            result.error
+          );
+      }
+    }
+
+    res.status(200).json({ success: true });
+  }
+
+  return withSessionAuthenticationForWorkspace(handler);
 }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/resolve-file-authorization.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/resolve-file-authorization.ts
@@ -1,4 +1,4 @@
 /** @ignoreswagger */
 import { makeResolveAuthenticationHandler } from "@app/lib/api/assistant/conversation/resolve_authentication";
 
-export default makeResolveAuthenticationHandler("authentication");
+export default makeResolveAuthenticationHandler("file_authorization");


### PR DESCRIPTION
## Description
- Adds a **Skip** button to the Google Drive file authorization dialog, matching the Skip pattern used for MCP personal auth (#24520). This was the only blocking-action type still missing a skip/deny path — since steering, any unresolvable blocking action permanently stalls the conversation.
- Parameterizes `resolveAuthentication` and `useResolveAuthentication` with a `kind` discriminator (`"authentication" | "file_authorization"`, defaults to `"authentication"`) so the file-auth path reuses the existing resolver's blocked-status check, Redis event cleanup, remaining-blocked-actions check, and agent-loop relaunch. Exports `isToolFileAuthRequiredEvent` for the event predicate.
- Extracts `makeResolveAuthenticationHandler(kind)` so both `resolve-authentication` and `resolve-file-authorization` API routes are 4-line factory calls with no duplicated parsing/error-mapping boilerplate.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

1. Verified oauth path still works as expected
2. File picker dialogue now has skip button as well
<img width="754" height="374" alt="Screenshot 2026-04-21 at 3 07 33 PM" src="https://github.com/user-attachments/assets/02ae355a-28a9-4af8-a6d5-6c62bf203acc" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
