### PR TITLE
[front] handle cancel message when no workflow is running

### DIFF
--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -117,7 +117,9 @@ const runAgent = async (
   );
 
   const abortSignal = signal ?? null;
-  let childCancellationPromise: Promise<string[] | void> | null = null;
+  let childCancellationPromise: Promise<{
+    failedMessageIds: string[];
+  } | void> | null = null;
   const finalizeAndReturn = async <T>(
     result: Result<T, MCPError>
   ): Promise<Result<T, MCPError>> => {

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -117,7 +117,7 @@ const runAgent = async (
   );
 
   const abortSignal = signal ?? null;
-  let childCancellationPromise: Promise<void> | null = null;
+  let childCancellationPromise: Promise<string[] | void> | null = null;
   const finalizeAndReturn = async <T>(
     result: Result<T, MCPError>
   ): Promise<Result<T, MCPError>> => {

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -1,5 +1,4 @@
 import { signalAgentUsage } from "@app/lib/api/assistant/agent_usage";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import {
   canAgentBeUsedInProjectConversation,
   updateConversationRequirements,
@@ -685,101 +684,5 @@ export async function createCompactionMessage(
     branchId: conversation.branchId,
     status: "created",
     content: null,
-  };
-}
-
-export async function fetchAgentMessageBySId(
-  auth: Authenticator,
-  {
-    conversation,
-    messageId,
-  }: {
-    conversation: ConversationWithoutContentType;
-    messageId: string;
-  }
-): Promise<AgentMessageType | null> {
-  const workspace = auth.getNonNullableWorkspace();
-
-  const messageRow = await MessageModel.findOne({
-    where: {
-      sId: messageId,
-      conversationId: conversation.id,
-      workspaceId: workspace.id,
-    },
-    include: [
-      {
-        model: AgentMessageModel,
-        as: "agentMessage",
-        required: true,
-      },
-    ],
-  });
-
-  if (!messageRow || !messageRow.agentMessage) {
-    return null;
-  }
-
-  const agentMessage = messageRow.agentMessage;
-
-  const [agentConfigurations, parentMessageRow] = await Promise.all([
-    getAgentConfigurations(auth, {
-      agentIds: [agentMessage.agentConfigurationId],
-      variant: "extra_light",
-    }),
-    messageRow.parentId
-      ? MessageModel.findOne({
-          where: { id: messageRow.parentId, workspaceId: workspace.id },
-          attributes: ["sId"],
-          include: [
-            {
-              model: UserMessageModel,
-              as: "userMessage",
-              required: true,
-              attributes: ["agenticMessageType", "agenticOriginMessageId"],
-            },
-          ],
-        })
-      : null,
-  ]);
-
-  const configuration = agentConfigurations[0];
-  if (!configuration || !parentMessageRow) {
-    return null;
-  }
-
-  const parentAgentMessageId =
-    parentMessageRow.userMessage?.agenticMessageType === "agent_handover"
-      ? (parentMessageRow.userMessage.agenticOriginMessageId ?? null)
-      : null;
-
-  return {
-    id: messageRow.id,
-    agentMessageId: agentMessage.id,
-    created: agentMessage.createdAt.getTime(),
-    completedTs: agentMessage.completedAt?.getTime() ?? null,
-    sId: messageRow.sId,
-    type: "agent_message",
-    visibility: messageRow.visibility,
-    version: messageRow.version,
-    parentMessageId: parentMessageRow.sId,
-    parentAgentMessageId,
-    status: agentMessage.status,
-    actions: [],
-    content: null,
-    chainOfThought: null,
-    error: null,
-    configuration,
-    rank: messageRow.rank,
-    branchId: conversation.branchId,
-    skipToolsValidation: agentMessage.skipToolsValidation,
-    contents: [],
-    modelInteractionDurationMs: agentMessage.modelInteractionDurationMs,
-    completionDurationMs: getCompletionDuration(
-      agentMessage.createdAt.getTime(),
-      agentMessage.completedAt?.getTime() ?? null,
-      []
-    ),
-    richMentions: [],
-    reactions: [],
   };
 }

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -1,4 +1,5 @@
 import { signalAgentUsage } from "@app/lib/api/assistant/agent_usage";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import {
   canAgentBeUsedInProjectConversation,
   updateConversationRequirements,
@@ -684,5 +685,101 @@ export async function createCompactionMessage(
     branchId: conversation.branchId,
     status: "created",
     content: null,
+  };
+}
+
+export async function fetchAgentMessageBySId(
+  auth: Authenticator,
+  {
+    conversation,
+    messageId,
+  }: {
+    conversation: ConversationWithoutContentType;
+    messageId: string;
+  }
+): Promise<AgentMessageType | null> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const messageRow = await MessageModel.findOne({
+    where: {
+      sId: messageId,
+      conversationId: conversation.id,
+      workspaceId: workspace.id,
+    },
+    include: [
+      {
+        model: AgentMessageModel,
+        as: "agentMessage",
+        required: true,
+      },
+    ],
+  });
+
+  if (!messageRow || !messageRow.agentMessage) {
+    return null;
+  }
+
+  const agentMessage = messageRow.agentMessage;
+
+  const [agentConfigurations, parentMessageRow] = await Promise.all([
+    getAgentConfigurations(auth, {
+      agentIds: [agentMessage.agentConfigurationId],
+      variant: "extra_light",
+    }),
+    messageRow.parentId
+      ? MessageModel.findOne({
+          where: { id: messageRow.parentId, workspaceId: workspace.id },
+          attributes: ["sId"],
+          include: [
+            {
+              model: UserMessageModel,
+              as: "userMessage",
+              required: true,
+              attributes: ["agenticMessageType", "agenticOriginMessageId"],
+            },
+          ],
+        })
+      : null,
+  ]);
+
+  const configuration = agentConfigurations[0];
+  if (!configuration || !parentMessageRow) {
+    return null;
+  }
+
+  const parentAgentMessageId =
+    parentMessageRow.userMessage?.agenticMessageType === "agent_handover"
+      ? (parentMessageRow.userMessage.agenticOriginMessageId ?? null)
+      : null;
+
+  return {
+    id: messageRow.id,
+    agentMessageId: agentMessage.id,
+    created: agentMessage.createdAt.getTime(),
+    completedTs: agentMessage.completedAt?.getTime() ?? null,
+    sId: messageRow.sId,
+    type: "agent_message",
+    visibility: messageRow.visibility,
+    version: messageRow.version,
+    parentMessageId: parentMessageRow.sId,
+    parentAgentMessageId,
+    status: agentMessage.status,
+    actions: [],
+    content: null,
+    chainOfThought: null,
+    error: null,
+    configuration,
+    rank: messageRow.rank,
+    branchId: conversation.branchId,
+    skipToolsValidation: agentMessage.skipToolsValidation,
+    contents: [],
+    modelInteractionDurationMs: agentMessage.modelInteractionDurationMs,
+    completionDurationMs: getCompletionDuration(
+      agentMessage.createdAt.getTime(),
+      agentMessage.completedAt?.getTime() ?? null,
+      []
+    ),
+    richMentions: [],
+    reactions: [],
   };
 }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -365,7 +365,7 @@ export async function batchRenderUserMessagesWithoutMentions(
   );
 }
 
-async function batchRenderAgentMessages<V extends RenderMessageVariant>(
+export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
   auth: Authenticator,
   messages: MessageModel[],
   viewType: V,

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -132,7 +132,7 @@ export async function cancelMessageGenerationEvent(
         const signalError = normalizeError(err);
         // Swallow errors from signaling (workflow might not exist anymore)
         logger.warn(
-          { error: signalError, messageId },
+          { error: signalError, conversationId, messageId },
           "Failed to signal agent loop workflow for cancellation"
         );
         failedIds.push(messageId);
@@ -170,7 +170,7 @@ export async function gracefullyStopAgentLoop(
         const signalError = normalizeError(err);
         // Swallow errors from signaling (workflow might not exist anymore)
         logger.warn(
-          { error: signalError, messageId },
+          { error: signalError, conversationId, messageId },
           "Failed to signal agent loop workflow for graceful stop"
         );
       }

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -109,9 +109,10 @@ export async function cancelMessageGenerationEvent(
     messageIds,
     conversationId,
   }: { messageIds: string[]; conversationId: string }
-): Promise<void> {
+): Promise<string[]> {
   const client = await getTemporalClientForAgentNamespace();
   const workspaceId = auth.getNonNullableWorkspace().sId;
+  const failedIds: string[] = [];
 
   await concurrentExecutor(
     messageIds,
@@ -134,10 +135,13 @@ export async function cancelMessageGenerationEvent(
           { error: signalError, messageId },
           "Failed to signal agent loop workflow for cancellation"
         );
+        failedIds.push(messageId);
       }
     },
     { concurrency: 8 }
   );
+
+  return failedIds;
 }
 
 export async function gracefullyStopAgentLoop(

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -109,10 +109,10 @@ export async function cancelMessageGenerationEvent(
     messageIds,
     conversationId,
   }: { messageIds: string[]; conversationId: string }
-): Promise<string[]> {
+): Promise<{ failedMessageIds: string[] }> {
   const client = await getTemporalClientForAgentNamespace();
   const workspaceId = auth.getNonNullableWorkspace().sId;
-  const failedIds: string[] = [];
+  const failedMessageIds: string[] = [];
 
   await concurrentExecutor(
     messageIds,
@@ -135,13 +135,13 @@ export async function cancelMessageGenerationEvent(
           { error: signalError, conversationId, messageId },
           "Failed to signal agent loop workflow for cancellation"
         );
-        failedIds.push(messageId);
+        failedMessageIds.push(messageId);
       }
     },
     { concurrency: 8 }
   );
 
-  return failedIds;
+  return { failedMessageIds };
 }
 
 export async function gracefullyStopAgentLoop(

--- a/front/lib/api/cancel.ts
+++ b/front/lib/api/cancel.ts
@@ -1,6 +1,7 @@
 import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
 import { fetchAgentMessageBySId } from "@app/lib/api/assistant/conversation/messages";
 import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
+import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -65,6 +66,17 @@ export async function cancelMessageGeneration(
         conversation,
         agentMessage,
         status: "cancelled",
+      });
+
+      await publishConversationRelatedEvent({
+        event: {
+          type: "agent_generation_cancelled",
+          created: Date.now(),
+          configurationId: agentMessage.configuration.sId,
+          messageId: agentMessage.sId,
+        },
+        conversationId: conversation.sId,
+        step: 0,
       });
     },
     { concurrency: 8 }

--- a/front/lib/api/cancel.ts
+++ b/front/lib/api/cancel.ts
@@ -90,7 +90,7 @@ export async function cancelMessageGeneration(
         messageId: agentMessage.sId,
       },
       conversationId: conversation.sId,
-      step: 0,
+      step: agentMessage.contents.reduce((max, c) => Math.max(max, c.step), 0),
     });
   }
 }

--- a/front/lib/api/cancel.ts
+++ b/front/lib/api/cancel.ts
@@ -1,0 +1,72 @@
+import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
+import { fetchAgentMessageBySId } from "@app/lib/api/assistant/conversation/messages";
+import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+
+export async function cancelMessageGeneration(
+  auth: Authenticator,
+  {
+    messageIds,
+    conversationId,
+  }: {
+    messageIds: string[];
+    conversationId: string;
+  }
+): Promise<void> {
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+
+  if (conversationRes.isErr()) {
+    logger.warn(
+      { conversationId, error: conversationRes.error },
+      "cancelMessageGeneration: conversation not found, skipping fallback"
+    );
+    return;
+  }
+
+  const conversation = conversationRes.value;
+
+  const failedIds = await cancelMessageGenerationEvent(auth, {
+    messageIds,
+    conversationId,
+  });
+
+  if (failedIds.length === 0) {
+    return;
+  }
+
+  await concurrentExecutor(
+    failedIds,
+    async (messageId) => {
+      const agentMessage = await fetchAgentMessageBySId(auth, {
+        conversation,
+        messageId,
+      });
+
+      if (!agentMessage) {
+        logger.warn(
+          { messageId, conversationId },
+          "cancelMessageGeneration: agent message not found for failed signal, skipping fallback"
+        );
+        return;
+      }
+
+      if (agentMessage.status !== "created") {
+        return;
+      }
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "cancelled",
+      });
+    },
+    { concurrency: 8 }
+  );
+}

--- a/front/lib/api/cancel.ts
+++ b/front/lib/api/cancel.ts
@@ -1,10 +1,9 @@
 import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
-import { fetchAgentMessageBySId } from "@app/lib/api/assistant/conversation/messages";
+import { batchRenderAgentMessages } from "@app/lib/api/assistant/messages";
 import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 
 export async function cancelMessageGeneration(
@@ -33,52 +32,65 @@ export async function cancelMessageGeneration(
 
   const conversation = conversationRes.value;
 
-  const failedIds = await cancelMessageGenerationEvent(auth, {
+  const { failedMessageIds } = await cancelMessageGenerationEvent(auth, {
     messageIds,
     conversationId,
   });
 
-  if (failedIds.length === 0) {
+  if (failedMessageIds.length === 0) {
     return;
   }
 
-  await concurrentExecutor(
-    failedIds,
-    async (messageId) => {
-      const agentMessage = await fetchAgentMessageBySId(auth, {
-        conversation,
-        messageId,
-      });
-
-      if (!agentMessage) {
-        logger.warn(
-          { messageId, conversationId },
-          "cancelMessageGeneration: agent message not found for failed signal, skipping fallback"
-        );
-        return;
-      }
-
-      if (agentMessage.status !== "created") {
-        return;
-      }
-
-      await updateAgentMessageWithFinalStatus(auth, {
-        conversation,
-        agentMessage,
-        status: "cancelled",
-      });
-
-      await publishConversationRelatedEvent({
-        event: {
-          type: "agent_generation_cancelled",
-          created: Date.now(),
-          configurationId: agentMessage.configuration.sId,
-          messageId: agentMessage.sId,
-        },
-        conversationId: conversation.sId,
-        step: 0,
-      });
-    },
-    { concurrency: 8 }
+  const messageRows = await ConversationResource.getMessageByIds(
+    auth,
+    conversation,
+    failedMessageIds
   );
+
+  const foundMessageIds = new Set(messageRows.map((m) => m.sId));
+  for (const messageId of failedMessageIds) {
+    if (!foundMessageIds.has(messageId)) {
+      logger.warn(
+        { messageId, conversationId },
+        "cancelMessageGeneration: agent message not found for failed signal, skipping fallback"
+      );
+    }
+  }
+
+  const agentMessagesRes = await batchRenderAgentMessages(
+    auth,
+    messageRows,
+    "full"
+  );
+
+  if (agentMessagesRes.isErr()) {
+    logger.error(
+      { conversationId, error: agentMessagesRes.error },
+      "cancelMessageGeneration: failed to render agent messages"
+    );
+    return;
+  }
+
+  for (const agentMessage of agentMessagesRes.value) {
+    if (agentMessage.status !== "created") {
+      continue;
+    }
+
+    await updateAgentMessageWithFinalStatus(auth, {
+      conversation,
+      agentMessage,
+      status: "cancelled",
+    });
+
+    await publishConversationRelatedEvent({
+      event: {
+        type: "agent_generation_cancelled",
+        created: Date.now(),
+        configurationId: agentMessage.configuration.sId,
+        messageId: agentMessage.sId,
+      },
+      conversationId: conversation.sId,
+      step: 0,
+    });
+  }
 }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2508,6 +2508,32 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return new Ok(message);
   }
 
+  static async getMessageByIds(
+    auth: Authenticator,
+    conversation: ConversationWithoutContentType,
+    messageIds: string[]
+  ): Promise<MessageModel[]> {
+    return MessageModel.findAll({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        sId: { [Op.in]: messageIds },
+      },
+      include: [
+        {
+          model: UserMessageModel,
+          as: "userMessage",
+          required: false,
+        },
+        {
+          model: AgentMessageModel,
+          as: "agentMessage",
+          required: false,
+        },
+      ],
+    });
+  }
+
   /**
    * This function retrieves the latest version of each message for the current page,
    * because there's no easy way to fetch only the latest version of a message.

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -1,6 +1,6 @@
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
-import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { cancelMessageGeneration } from "@app/lib/api/cancel";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -103,7 +103,7 @@ async function handler(
         });
       }
 
-      await cancelMessageGenerationEvent(auth, {
+      await cancelMessageGeneration(auth, {
         messageIds: r.data.messageIds,
         conversationId,
       });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -52,11 +52,9 @@
  *         description: Unauthorized
  */
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
-import {
-  cancelMessageGenerationEvent,
-  gracefullyStopAgentLoop,
-} from "@app/lib/api/assistant/pubsub";
+import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { cancelMessageGeneration } from "@app/lib/api/cancel";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -118,7 +116,7 @@ async function handler(
 
       switch (action) {
         case "cancel":
-          await cancelMessageGenerationEvent(auth, {
+          await cancelMessageGeneration(auth, {
             messageIds,
             conversationId,
           });


### PR DESCRIPTION
## Description

2nd part of https://github.com/dust-tt/tasks/issues/7657

We can have messages with status stuck to 'created' with no corresponding workflow running
Current implementation of cancel only works if there is a running workflow

=> when there is no running workflow, force cancellation of the agent message by calling updateAgentMessageWithFinalStatus and publishConversationRelatedEvent
 

## Tests

- tested locally by setting agent message to "created" in DB, posting new messages that are set as "pending"
=> clicking on Stop button sets the stuck message to cancelled + promoted pending message to visible and conversation can continue on user input

## Risk

Low, the forced cancellation of messages is only called when no workflow is running which is already a corner case that should not happen

## Deploy Plan

Deploy front