### PR TITLE
[front] enh(skills): optimize batch fetching by adding instructions-less type

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -366,7 +366,7 @@ export function CapabilitiesPicker({
     status: "active",
     globalSpaceOnly: true,
     disabled: !shouldFetchToolsData,
-    withTools: false,
+    viewType: "summary",
   });
 
   const isSkillsDataReady = !isSkillsLoading;

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -27,7 +27,7 @@ import {
   trackEvent,
 } from "@app/lib/tracking";
 import type {
-  SkillSummaryType,
+  SkillWithoutInstructionsAndToolsType,
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
@@ -50,7 +50,11 @@ import {
 import { useEffect, useMemo, useState } from "react";
 
 type MergedCapabilityItem =
-  | { kind: "skill"; skill: SkillSummaryType; sortName: string }
+  | {
+      kind: "skill";
+      skill: SkillWithoutInstructionsAndToolsType;
+      sortName: string;
+    }
   | { kind: "tool"; serverView: MCPServerViewType; sortName: string };
 
 function CapabilitiesPickerLoading({ count = 5 }: { count?: number }) {
@@ -72,8 +76,8 @@ function CapabilitiesPickerLoading({ count = 5 }: { count?: number }) {
 }
 
 interface SkillMenuItemProps {
-  skill: SkillSummaryType;
-  onSelect: (skill: SkillSummaryType) => void;
+  skill: SkillWithoutInstructionsAndToolsType;
+  onSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
   onDetails: (skillId: string) => void;
   closeDropdown: () => void;
 }
@@ -246,8 +250,8 @@ interface CapabilitiesPickerProps {
   user: UserType | null;
   selectedMCPServerViews: MCPServerViewType[];
   onSelect: (serverView: MCPServerViewType) => void;
-  selectedSkills: SkillSummaryType[];
-  onSkillSelect: (skill: SkillSummaryType) => void;
+  selectedSkills: SkillWithoutInstructionsAndToolsType[];
+  onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
   isLoading?: boolean;
   disabled?: boolean;
   buttonSize?: "xs" | "sm" | "md";

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -27,7 +27,7 @@ import {
   trackEvent,
 } from "@app/lib/tracking";
 import type {
-  SkillWithoutToolsType,
+  SkillSummaryType,
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
@@ -50,7 +50,7 @@ import {
 import { useEffect, useMemo, useState } from "react";
 
 type MergedCapabilityItem =
-  | { kind: "skill"; skill: SkillWithoutToolsType; sortName: string }
+  | { kind: "skill"; skill: SkillSummaryType; sortName: string }
   | { kind: "tool"; serverView: MCPServerViewType; sortName: string };
 
 function CapabilitiesPickerLoading({ count = 5 }: { count?: number }) {
@@ -72,8 +72,8 @@ function CapabilitiesPickerLoading({ count = 5 }: { count?: number }) {
 }
 
 interface SkillMenuItemProps {
-  skill: SkillWithoutToolsType;
-  onSelect: (skill: SkillWithoutToolsType) => void;
+  skill: SkillSummaryType;
+  onSelect: (skill: SkillSummaryType) => void;
   onDetails: (skillId: string) => void;
   closeDropdown: () => void;
 }
@@ -246,8 +246,8 @@ interface CapabilitiesPickerProps {
   user: UserType | null;
   selectedMCPServerViews: MCPServerViewType[];
   onSelect: (serverView: MCPServerViewType) => void;
-  selectedSkills: SkillWithoutToolsType[];
-  onSkillSelect: (skill: SkillWithoutToolsType) => void;
+  selectedSkills: SkillSummaryType[];
+  onSkillSelect: (skill: SkillSummaryType) => void;
   isLoading?: boolean;
   disabled?: boolean;
   buttonSize?: "xs" | "sm" | "md";

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -26,7 +26,7 @@ import {
 } from "@app/types/assistant/assistant";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
-import type { SkillSummaryType } from "@app/types/assistant/skill_configuration";
+import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { isEqualNode } from "@app/types/data_source_view";
@@ -188,7 +188,9 @@ export const InputBar = React.memo(function InputBar({
     MCPServerViewType[]
   >([]);
 
-  const [selectedSkills, setSelectedSkills] = useState<SkillSummaryType[]>([]);
+  const [selectedSkills, setSelectedSkills] = useState<
+    SkillWithoutInstructionsAndToolsType[]
+  >([]);
 
   const { conversationTools } = useConversationTools({
     conversationId: conversation?.sId,
@@ -235,12 +237,14 @@ export const InputBar = React.memo(function InputBar({
     void deleteTool(serverView.sId);
   };
 
-  const handleSkillSelect = (skill: SkillSummaryType) => {
+  const handleSkillSelect = (skill: SkillWithoutInstructionsAndToolsType) => {
     setSelectedSkills((prev) => [...prev, skill]);
     void addSkill(skill.sId);
   };
 
-  const handleSkillDeselect = (skill: SkillSummaryType) => {
+  const handleSkillDeselect = (
+    skill: SkillWithoutInstructionsAndToolsType
+  ) => {
     setSelectedSkills((prev) => prev.filter((s) => s.sId !== skill.sId));
     void deleteSkill(skill.sId);
   };

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -242,9 +242,7 @@ export const InputBar = React.memo(function InputBar({
     void addSkill(skill.sId);
   };
 
-  const handleSkillDeselect = (
-    skill: SkillWithoutInstructionsAndToolsType
-  ) => {
+  const handleSkillDeselect = (skill: SkillWithoutInstructionsAndToolsType) => {
     setSelectedSkills((prev) => prev.filter((s) => s.sId !== skill.sId));
     void deleteSkill(skill.sId);
   };

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -26,7 +26,7 @@ import {
 } from "@app/types/assistant/assistant";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
-import type { SkillWithoutToolsType } from "@app/types/assistant/skill_configuration";
+import type { SkillSummaryType } from "@app/types/assistant/skill_configuration";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { isEqualNode } from "@app/types/data_source_view";
@@ -188,9 +188,7 @@ export const InputBar = React.memo(function InputBar({
     MCPServerViewType[]
   >([]);
 
-  const [selectedSkills, setSelectedSkills] = useState<SkillWithoutToolsType[]>(
-    []
-  );
+  const [selectedSkills, setSelectedSkills] = useState<SkillSummaryType[]>([]);
 
   const { conversationTools } = useConversationTools({
     conversationId: conversation?.sId,
@@ -237,12 +235,12 @@ export const InputBar = React.memo(function InputBar({
     void deleteTool(serverView.sId);
   };
 
-  const handleSkillSelect = (skill: SkillWithoutToolsType) => {
+  const handleSkillSelect = (skill: SkillSummaryType) => {
     setSelectedSkills((prev) => [...prev, skill]);
     void addSkill(skill.sId);
   };
 
-  const handleSkillDeselect = (skill: SkillWithoutToolsType) => {
+  const handleSkillDeselect = (skill: SkillSummaryType) => {
     setSelectedSkills((prev) => prev.filter((s) => s.sId !== skill.sId));
     void deleteSkill(skill.sId);
   };

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -14,7 +14,7 @@ import type {
   RichMention,
 } from "@app/types/assistant/mentions";
 import { toRichAgentMentionType } from "@app/types/assistant/mentions";
-import type { SkillWithoutToolsType } from "@app/types/assistant/skill_configuration";
+import type { SkillSummaryType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { getSupportedFileExtensions } from "@app/types/files";
 import type { SpaceType } from "@app/types/space";
@@ -37,11 +37,11 @@ interface InputBarButtonsProps {
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
-  onSkillSelect: (skill: SkillWithoutToolsType) => void;
+  onSkillSelect: (skill: SkillSummaryType) => void;
   owner: WorkspaceType;
   selectedAgent: RichAgentMention | null;
   selectedMCPServerViews: MCPServerViewType[];
-  selectedSkills: SkillWithoutToolsType[];
+  selectedSkills: SkillSummaryType[];
   space: SpaceType | undefined;
   user: UserType | null;
 }

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -14,7 +14,7 @@ import type {
   RichMention,
 } from "@app/types/assistant/mentions";
 import { toRichAgentMentionType } from "@app/types/assistant/mentions";
-import type { SkillSummaryType } from "@app/types/assistant/skill_configuration";
+import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { getSupportedFileExtensions } from "@app/types/files";
 import type { SpaceType } from "@app/types/space";
@@ -37,11 +37,11 @@ interface InputBarButtonsProps {
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
-  onSkillSelect: (skill: SkillSummaryType) => void;
+  onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
   owner: WorkspaceType;
   selectedAgent: RichAgentMention | null;
   selectedMCPServerViews: MCPServerViewType[];
-  selectedSkills: SkillSummaryType[];
+  selectedSkills: SkillWithoutInstructionsAndToolsType[];
   space: SpaceType | undefined;
   user: UserType | null;
 }

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -35,7 +35,7 @@ import {
   isRichAgentMention,
   toRichAgentMentionType,
 } from "@app/types/assistant/mentions";
-import type { SkillSummaryType } from "@app/types/assistant/skill_configuration";
+import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -140,14 +140,14 @@ export interface InputBarContainerProps {
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
   onResetSelections: () => void;
-  onSkillDeselect: (skill: SkillSummaryType) => void;
-  onSkillSelect: (skill: SkillSummaryType) => void;
+  onSkillDeselect: (skill: SkillWithoutInstructionsAndToolsType) => void;
+  onSkillSelect: (skill: SkillWithoutInstructionsAndToolsType) => void;
   owner: WorkspaceType;
   saveDraft: (markdown: string, agentMention?: RichAgentMention | null) => void;
   pendingInputText: string | null;
   selectedAgent: RichAgentMention | null;
   selectedMCPServerViews: MCPServerViewType[];
-  selectedSkills: SkillSummaryType[];
+  selectedSkills: SkillWithoutInstructionsAndToolsType[];
   stickyMentions?: RichMention[];
   user: UserType | null;
 }

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -35,7 +35,7 @@ import {
   isRichAgentMention,
   toRichAgentMentionType,
 } from "@app/types/assistant/mentions";
-import type { SkillWithoutToolsType } from "@app/types/assistant/skill_configuration";
+import type { SkillSummaryType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -140,14 +140,14 @@ export interface InputBarContainerProps {
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
   onResetSelections: () => void;
-  onSkillDeselect: (skill: SkillWithoutToolsType) => void;
-  onSkillSelect: (skill: SkillWithoutToolsType) => void;
+  onSkillDeselect: (skill: SkillSummaryType) => void;
+  onSkillSelect: (skill: SkillSummaryType) => void;
   owner: WorkspaceType;
   saveDraft: (markdown: string, agentMention?: RichAgentMention | null) => void;
   pendingInputText: string | null;
   selectedAgent: RichAgentMention | null;
   selectedMCPServerViews: MCPServerViewType[];
-  selectedSkills: SkillWithoutToolsType[];
+  selectedSkills: SkillSummaryType[];
   stickyMentions?: RichMention[];
   user: UserType | null;
 }

--- a/front/components/assistant/conversation/input_bar/InputBarSkillChip.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarSkillChip.tsx
@@ -1,6 +1,6 @@
 import { getSkillIcon } from "@app/lib/skill";
 import { getManageSkillsRoute } from "@app/lib/utils/router";
-import type { SkillWithoutToolsType } from "@app/types/assistant/skill_configuration";
+import type { SkillSummaryType } from "@app/types/assistant/skill_configuration";
 import type { WorkspaceType } from "@app/types/user";
 import { isBuilder } from "@app/types/user";
 import { Chip } from "@dust-tt/sparkle";
@@ -9,7 +9,7 @@ interface InputBarSkillChipProps {
   className?: string;
   compact?: boolean;
   owner: WorkspaceType;
-  skill: SkillWithoutToolsType;
+  skill: SkillSummaryType;
   onRemove?: () => void;
 }
 

--- a/front/components/assistant/conversation/input_bar/InputBarSkillChip.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarSkillChip.tsx
@@ -1,6 +1,6 @@
 import { getSkillIcon } from "@app/lib/skill";
 import { getManageSkillsRoute } from "@app/lib/utils/router";
-import type { SkillSummaryType } from "@app/types/assistant/skill_configuration";
+import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { WorkspaceType } from "@app/types/user";
 import { isBuilder } from "@app/types/user";
 import { Chip } from "@dust-tt/sparkle";
@@ -9,7 +9,7 @@ interface InputBarSkillChipProps {
   className?: string;
   compact?: boolean;
   owner: WorkspaceType;
-  skill: SkillSummaryType;
+  skill: SkillWithoutInstructionsAndToolsType;
   onRemove?: () => void;
 }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -507,6 +507,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       where,
       includes,
       onlyCustom,
+      withInstructions = true,
       withTools = true,
       ...otherOptions
     } = options;
@@ -734,6 +735,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         this.fromGlobalSkill(auth, def, {
           agentLoopData,
           mcpServerViews,
+          withInstructions,
         }),
       { concurrency: 5 }
     );
@@ -1055,6 +1057,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       isDefault,
       updatedAfter,
       reinforcementNotOff,
+      withInstructions = true,
       withTools = true,
     }: {
       status?: SkillStatus | SkillStatus[];
@@ -1064,6 +1067,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       isDefault?: boolean;
       updatedAfter?: Date;
       reinforcementNotOff?: boolean;
+      withInstructions?: boolean;
       withTools?: boolean;
     } = {}
   ): Promise<SkillResource[]> {
@@ -1076,6 +1080,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       },
       ...(limit ? { limit } : {}),
       onlyCustom,
+      withInstructions,
       withTools,
     });
 
@@ -1429,9 +1434,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       agentLoopData,
       mcpServerViews,
+      withInstructions = true,
     }: {
       agentLoopData?: AgentLoopExecutionData;
       mcpServerViews: MCPServerViewResource[];
+      withInstructions?: boolean;
     }
   ): Promise<SkillResource> {
     const workspaceId = auth.getNonNullableWorkspace().id;
@@ -1457,12 +1464,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ).map((view) => ({ view, childAgentId, serverNameOverride }))
     );
 
-    const instructions = def.fetchInstructions
-      ? await def.fetchInstructions(auth, {
-          spaceIds: requestedSpaceIds,
-          agentLoopData,
-        })
-      : def.instructions;
+    const instructions = withInstructions
+      ? def.fetchInstructions
+        ? await def.fetchInstructions(auth, {
+            spaceIds: requestedSpaceIds,
+            agentLoopData,
+          })
+        : def.instructions
+      : "";
 
     return new SkillResource(
       this.model,

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -16,6 +16,7 @@ export type AllSkillConfigurationFindOptions = Omit<
   };
   onlyCustom?: false; // Default: include global skills.
   withTools?: boolean;
+  withInstructions?: boolean;
 };
 
 // Full find options only custom skills from database.
@@ -23,6 +24,7 @@ type CustomSkillConfigurationFindOptions =
   ResourceFindOptions<SkillConfigurationModel> & {
     onlyCustom: true; // Explicit: only custom skills.
     withTools?: boolean;
+    withInstructions?: boolean;
   };
 
 export type SkillConfigurationFindOptions =

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -4,8 +4,8 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import type { DetectedSkillSummary } from "@app/lib/skill_detection";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
-  GetSkillsWithoutInstructionsAndToolsResponseBody,
   GetSkillsResponseBody,
+  GetSkillsWithoutInstructionsAndToolsResponseBody,
   GetSkillsWithRelationsResponseBody,
 } from "@app/pages/api/w/[wId]/skills";
 import type {

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -4,7 +4,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import type { DetectedSkillSummary } from "@app/lib/skill_detection";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
-  GetSkillSummariesResponseBody,
+  GetSkillsWithoutInstructionsAndToolsResponseBody,
   GetSkillsResponseBody,
   GetSkillsWithRelationsResponseBody,
 } from "@app/pages/api/w/[wId]/skills";
@@ -35,7 +35,7 @@ const DETECT_SKILLS_DEBOUNCE_MS = 1_000;
 
 type SkillsResponseByViewType = {
   full: GetSkillsResponseBody;
-  summary: GetSkillSummariesResponseBody;
+  summary: GetSkillsWithoutInstructionsAndToolsResponseBody;
 };
 
 type SkillsByViewType<TViewType extends SkillViewType> =

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -4,8 +4,8 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import type { DetectedSkillSummary } from "@app/lib/skill_detection";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
+  GetSkillSummariesResponseBody,
   GetSkillsResponseBody,
-  GetSkillsWithoutToolsResponseBody,
   GetSkillsWithRelationsResponseBody,
 } from "@app/pages/api/w/[wId]/skills";
 import type {
@@ -19,7 +19,7 @@ import type { GetSimilarSkillsResponseBody } from "@app/pages/api/w/[wId]/skills
 import type {
   SkillStatus,
   SkillType,
-  SkillWithoutToolsType,
+  SkillViewType,
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import { isAPIErrorResponse } from "@app/types/error";
@@ -32,6 +32,21 @@ import type { SWRMutationConfiguration } from "swr/mutation";
 import useSWRMutation from "swr/mutation";
 
 const DETECT_SKILLS_DEBOUNCE_MS = 1_000;
+
+type SkillsResponseByViewType = {
+  full: GetSkillsResponseBody;
+  summary: GetSkillSummariesResponseBody;
+};
+
+type SkillsByViewType<TViewType extends SkillViewType> =
+  SkillsResponseByViewType[TViewType]["skills"];
+
+type UseSkillsResult<TViewType extends SkillViewType> = {
+  skills: SkillsByViewType<TViewType>;
+  isSkillsError: boolean;
+  isSkillsLoading: boolean;
+  mutateSkills: () => void;
+};
 
 export function useSkill(options: {
   workspaceId: string;
@@ -94,56 +109,23 @@ export function useSkill({
   };
 }
 
-export function useSkills(options: {
-  owner: LightWorkspaceType;
-  disabled?: boolean;
-  status?: SkillStatus;
-  globalSpaceOnly?: boolean;
-  isDefault?: boolean;
-  withTools: false;
-}): {
-  skills: SkillWithoutToolsType[];
-  isSkillsError: boolean;
-  isSkillsLoading: boolean;
-  mutateSkills: () => void;
-};
-export function useSkills(options: {
-  owner: LightWorkspaceType;
-  disabled?: boolean;
-  status?: SkillStatus;
-  globalSpaceOnly?: boolean;
-  isDefault?: boolean;
-  withTools?: true;
-}): {
-  skills: SkillType[];
-  isSkillsError: boolean;
-  isSkillsLoading: boolean;
-  mutateSkills: () => void;
-};
-export function useSkills({
+export function useSkills<TViewType extends SkillViewType = "full">({
   owner,
   disabled,
   status,
   globalSpaceOnly,
   isDefault,
-  withTools = true,
+  viewType,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
   status?: SkillStatus;
   globalSpaceOnly?: boolean;
   isDefault?: boolean;
-  withTools?: boolean;
-}): {
-  skills: SkillWithoutToolsType[] | SkillType[];
-  isSkillsError: boolean;
-  isSkillsLoading: boolean;
-  mutateSkills: () => void;
-} {
+  viewType?: TViewType;
+}): UseSkillsResult<TViewType> {
   const { fetcher } = useFetcher();
-  const skillsFetcher: Fetcher<
-    GetSkillsWithoutToolsResponseBody | GetSkillsResponseBody
-  > = fetcher;
+  const requestedViewType: SkillViewType = viewType ?? "full";
 
   const queryParams = new URLSearchParams();
   if (status) {
@@ -155,19 +137,19 @@ export function useSkills({
   if (isDefault) {
     queryParams.set("isDefault", "true");
   }
-  if (!withTools) {
-    queryParams.set("withTools", "false");
+  if (requestedViewType === "summary") {
+    queryParams.set("viewType", requestedViewType);
   }
   const queryString = queryParams.toString();
 
   const { data, error, isLoading, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/skills${queryString ? `?${queryString}` : ""}`,
-    skillsFetcher,
+    fetcher,
     { disabled }
   );
 
   return {
-    skills: data?.skills ?? emptyArray(),
+    skills: data?.skills ?? emptyArray<SkillsByViewType<TViewType>[number]>(),
     isSkillsError: !!error,
     isSkillsLoading: isLoading,
     mutateSkills: mutate,

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -16,7 +16,7 @@ import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory"
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type {
-  SkillSummaryType,
+  SkillWithoutInstructionsAndToolsType,
   SkillType,
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
@@ -227,11 +227,13 @@ describe("GET /api/w/[wId]/skills", () => {
 
     expect(res._getStatusCode()).toBe(200);
 
-    const skillSummary = res
+    const skillWithoutInstructionsAndTools = res
       ._getJSONData()
-      .skills.find((s: SkillSummaryType) => s.sId === skill.sId);
+      .skills.find(
+        (s: SkillWithoutInstructionsAndToolsType) => s.sId === skill.sId
+      );
 
-    expect(skillSummary).toMatchObject({
+    expect(skillWithoutInstructionsAndTools).toMatchObject({
       sId: skill.sId,
       name: "Picker Skill",
       userFacingDescription: "Shown in the capabilities picker",
@@ -243,13 +245,15 @@ describe("GET /api/w/[wId]/skills", () => {
       isDefault: false,
       extendedSkillId: null,
     });
-    expect(skillSummary).toHaveProperty("createdAt");
-    expect(skillSummary).toHaveProperty("updatedAt");
-    expect(skillSummary).toHaveProperty("source");
-    expect(skillSummary).toHaveProperty("sourceMetadata");
-    expect(skillSummary).not.toHaveProperty("instructions");
-    expect(skillSummary).not.toHaveProperty("instructionsHtml");
-    expect(skillSummary).not.toHaveProperty("tools");
+    expect(skillWithoutInstructionsAndTools).toHaveProperty("createdAt");
+    expect(skillWithoutInstructionsAndTools).toHaveProperty("updatedAt");
+    expect(skillWithoutInstructionsAndTools).toHaveProperty("source");
+    expect(skillWithoutInstructionsAndTools).toHaveProperty("sourceMetadata");
+    expect(skillWithoutInstructionsAndTools).not.toHaveProperty("instructions");
+    expect(skillWithoutInstructionsAndTools).not.toHaveProperty(
+      "instructionsHtml"
+    );
+    expect(skillWithoutInstructionsAndTools).not.toHaveProperty("tools");
   });
 
   it("should not fetch dynamic global instructions for viewType=summary", async () => {
@@ -274,7 +278,8 @@ describe("GET /api/w/[wId]/skills", () => {
         res
           ._getJSONData()
           .skills.some(
-            (s: SkillSummaryType) => s.sId === discoverToolsSkill.sId
+            (s: SkillWithoutInstructionsAndToolsType) =>
+              s.sId === discoverToolsSkill.sId
           )
       ).toBe(true);
       expect(fetchInstructionsSpy).not.toHaveBeenCalled();

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -4,6 +4,7 @@ import {
   SkillMCPServerConfigurationModel,
 } from "@app/lib/models/skill";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { discoverToolsSkill } from "@app/lib/resources/skill/global/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
@@ -15,12 +16,13 @@ import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory"
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type {
+  SkillSummaryType,
   SkillType,
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { MembershipRoleType } from "@app/types/memberships";
 import type { RequestMethod } from "node-mocks-http";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
 
@@ -209,6 +211,71 @@ describe("GET /api/w/[wId]/skills", () => {
     expect(res._getStatusCode()).toBe(200);
     const skillNames = res._getJSONData().skills.map((s: SkillType) => s.name);
     expect(skillNames).toContain("Skill In Restricted Space");
+  });
+
+  it("should return skill summaries for viewType=summary", async () => {
+    const { req, res, workspace, auth, user } = await setupTest();
+
+    const skill = await SkillFactory.create(auth, {
+      name: "Picker Skill",
+      userFacingDescription: "Shown in the capabilities picker",
+    });
+
+    req.query = { ...req.query, wId: workspace.sId, viewType: "summary" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const skillSummary = res
+      ._getJSONData()
+      .skills.find((s: SkillSummaryType) => s.sId === skill.sId);
+
+    expect(skillSummary).toMatchObject({
+      sId: skill.sId,
+      name: "Picker Skill",
+      userFacingDescription: "Shown in the capabilities picker",
+      agentFacingDescription: "Test skill agent facing description",
+      editedBy: user.id,
+      status: "active",
+      requestedSpaceIds: [],
+      fileAttachments: [],
+      isDefault: false,
+      extendedSkillId: null,
+    });
+    expect(skillSummary).toHaveProperty("createdAt");
+    expect(skillSummary).toHaveProperty("updatedAt");
+    expect(skillSummary).toHaveProperty("source");
+    expect(skillSummary).toHaveProperty("sourceMetadata");
+    expect(skillSummary).not.toHaveProperty("instructions");
+    expect(skillSummary).not.toHaveProperty("instructionsHtml");
+    expect(skillSummary).not.toHaveProperty("tools");
+  });
+
+  it("should not fetch dynamic global instructions for viewType=summary", async () => {
+    const { req, res, workspace } = await setupTest();
+
+    const fetchInstructionsSpy = vi.spyOn(discoverToolsSkill, "fetchInstructions");
+    try {
+      req.query = {
+        ...req.query,
+        wId: workspace.sId,
+        globalSpaceOnly: "true",
+        viewType: "summary",
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(
+        res
+          ._getJSONData()
+          .skills.some((s: SkillSummaryType) => s.sId === discoverToolsSkill.sId)
+      ).toBe(true);
+      expect(fetchInstructionsSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchInstructionsSpy.mockRestore();
+    }
   });
 });
 

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -255,7 +255,10 @@ describe("GET /api/w/[wId]/skills", () => {
   it("should not fetch dynamic global instructions for viewType=summary", async () => {
     const { req, res, workspace } = await setupTest();
 
-    const fetchInstructionsSpy = vi.spyOn(discoverToolsSkill, "fetchInstructions");
+    const fetchInstructionsSpy = vi.spyOn(
+      discoverToolsSkill,
+      "fetchInstructions"
+    );
     try {
       req.query = {
         ...req.query,
@@ -270,7 +273,9 @@ describe("GET /api/w/[wId]/skills", () => {
       expect(
         res
           ._getJSONData()
-          .skills.some((s: SkillSummaryType) => s.sId === discoverToolsSkill.sId)
+          .skills.some(
+            (s: SkillSummaryType) => s.sId === discoverToolsSkill.sId
+          )
       ).toBe(true);
       expect(fetchInstructionsSpy).not.toHaveBeenCalled();
     } finally {

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -16,8 +16,8 @@ import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory"
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type {
-  SkillWithoutInstructionsAndToolsType,
   SkillType,
+  SkillWithoutInstructionsAndToolsType,
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { MembershipRoleType } from "@app/types/memberships";

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -11,7 +11,7 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import {
   SKILL_VIEWS,
-  type SkillSummaryType,
+  type SkillWithoutInstructionsAndToolsType,
   type SkillType,
   type SkillViewType,
   type SkillWithRelationsType,
@@ -25,8 +25,8 @@ import * as reporter from "io-ts-reporters";
 import uniq from "lodash/uniq";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type GetSkillSummariesResponseBody = {
-  skills: SkillSummaryType[];
+export type GetSkillsWithoutInstructionsAndToolsResponseBody = {
+  skills: SkillWithoutInstructionsAndToolsType[];
 };
 
 export type GetSkillsResponseBody = {
@@ -103,7 +103,7 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<
-      | GetSkillSummariesResponseBody
+      | GetSkillsWithoutInstructionsAndToolsResponseBody
       | GetSkillsResponseBody
       | GetSkillsWithRelationsResponseBody
       | PostSkillResponseBody
@@ -202,10 +202,14 @@ async function handler(
       if (skillView === "summary") {
         return res.status(200).json({
           skills: skills.map((sc) => {
-            const { instructions, instructionsHtml, tools, ...skillSummary } =
-              sc.toJSON(auth);
+            const {
+              instructions,
+              instructionsHtml,
+              tools,
+              ...skillWithoutInstructionsAndTools
+            } = sc.toJSON(auth);
 
-            return skillSummary;
+            return skillWithoutInstructionsAndTools;
           }),
         });
       }

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -9,13 +9,15 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type {
-  SkillType,
-  SkillWithoutToolsType,
-  SkillWithRelationsType,
+import {
+  SKILL_VIEWS,
+  type SkillSummaryType,
+  type SkillType,
+  type SkillViewType,
+  type SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { removeNulls } from "@app/types/shared/utils/general";
+import { isString, removeNulls } from "@app/types/shared/utils/general";
 import { isBuilder } from "@app/types/user";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -23,8 +25,8 @@ import * as reporter from "io-ts-reporters";
 import uniq from "lodash/uniq";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type GetSkillsWithoutToolsResponseBody = {
-  skills: SkillWithoutToolsType[];
+export type GetSkillSummariesResponseBody = {
+  skills: SkillSummaryType[];
 };
 
 export type GetSkillsResponseBody = {
@@ -39,13 +41,16 @@ export type PostSkillResponseBody = {
   skill: SkillType;
 };
 
-// Schema for GET status query parameter.
 const SkillStatusSchema = t.union([
   t.literal("active"),
   t.literal("archived"),
   t.literal("suggested"),
   t.undefined,
 ]);
+
+function isSkillViewType(value: string): value is SkillViewType {
+  return SKILL_VIEWS.some((skillViewType) => skillViewType === value);
+}
 
 // Schema for attached knowledge.
 export const AttachedKnowledgeSchema = t.type({
@@ -98,7 +103,7 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<
-      | GetSkillsWithoutToolsResponseBody
+      | GetSkillSummariesResponseBody
       | GetSkillsResponseBody
       | GetSkillsWithRelationsResponseBody
       | PostSkillResponseBody
@@ -110,15 +115,35 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const { withRelations, withTools, status, globalSpaceOnly, isDefault } =
-        req.query;
+      const {
+        withRelations,
+        status,
+        globalSpaceOnly,
+        isDefault,
+        viewType,
+      } = req.query;
 
-      if (withRelations === "true" && withTools === "false") {
+      let skillView: SkillViewType = "full";
+      if (viewType !== undefined) {
+        if (!isString(viewType) || !isSkillViewType(viewType)) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid viewType: ${viewType}. Expected "full" or "summary".`,
+            },
+          });
+        }
+
+        skillView = viewType;
+      }
+
+      if (withRelations === "true" && skillView === "summary") {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "withTools=false is incompatible with withRelations=true.",
+            message: "viewType=summary is incompatible with withRelations=true.",
           },
         });
       }
@@ -135,14 +160,12 @@ async function handler(
       }
       const skillStatus = statusValidation.right;
 
-      // withTools defaults to true
-      const shouldIncludeTools = withTools !== "false";
-
       const skills = await SkillResource.listByWorkspace(auth, {
         status: skillStatus,
         globalSpaceOnly: globalSpaceOnly === "true",
         isDefault: isDefault === "true" ? true : undefined,
-        withTools: shouldIncludeTools,
+        withInstructions: skillView !== "summary",
+        withTools: skillView === "full",
       });
 
       if (withRelations === "true") {
@@ -180,11 +203,17 @@ async function handler(
         return res.status(200).json({ skills: skillsWithRelations });
       }
 
-      if (!shouldIncludeTools) {
+      if (skillView === "summary") {
         return res.status(200).json({
           skills: skills.map((sc) => {
-            const { tools: _tools, ...withoutTools } = sc.toJSON(auth);
-            return withoutTools;
+            const {
+              instructions,
+              instructionsHtml,
+              tools,
+              ...skillSummary
+            } = sc.toJSON(auth);
+
+            return skillSummary;
           }),
         });
       }

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -115,13 +115,8 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const {
-        withRelations,
-        status,
-        globalSpaceOnly,
-        isDefault,
-        viewType,
-      } = req.query;
+      const { withRelations, status, globalSpaceOnly, isDefault, viewType } =
+        req.query;
 
       let skillView: SkillViewType = "full";
       if (viewType !== undefined) {
@@ -143,7 +138,8 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "viewType=summary is incompatible with withRelations=true.",
+            message:
+              "viewType=summary is incompatible with withRelations=true.",
           },
         });
       }
@@ -206,12 +202,8 @@ async function handler(
       if (skillView === "summary") {
         return res.status(200).json({
           skills: skills.map((sc) => {
-            const {
-              instructions,
-              instructionsHtml,
-              tools,
-              ...skillSummary
-            } = sc.toJSON(auth);
+            const { instructions, instructionsHtml, tools, ...skillSummary } =
+              sc.toJSON(auth);
 
             return skillSummary;
           }),

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -11,9 +11,9 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import {
   SKILL_VIEWS,
-  type SkillWithoutInstructionsAndToolsType,
   type SkillType,
   type SkillViewType,
+  type SkillWithoutInstructionsAndToolsType,
   type SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -28,7 +28,7 @@ export const SkillSourceMetadataSchema = z.object({
 
 export type SkillSourceMetadata = z.infer<typeof SkillSourceMetadataSchema>;
 
-export const SkillSummarySchema = z.object({
+export const SkillWithoutInstructionsAndToolsSchema = z.object({
   id: z.number(),
   sId: z.string(),
   createdAt: z.number().nullable(),
@@ -56,9 +56,11 @@ export const SkillSummarySchema = z.object({
   extendedSkillId: z.string().nullable(),
 });
 
-export type SkillSummaryType = z.infer<typeof SkillSummarySchema>;
+export type SkillWithoutInstructionsAndToolsType = z.infer<
+  typeof SkillWithoutInstructionsAndToolsSchema
+>;
 
-export const SkillSchema = SkillSummarySchema.extend({
+export const SkillSchema = SkillWithoutInstructionsAndToolsSchema.extend({
   instructions: z.string().nullable(),
   instructionsHtml: z.string().nullable(),
   tools: z.array(MCPServerViewSchema),

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -9,6 +9,9 @@ export type SkillStatus = (typeof SKILL_STATUSES)[number];
 export const SKILL_REINFORCEMENT_MODES = ["auto", "on", "off"] as const;
 export type SkillReinforcementMode = (typeof SKILL_REINFORCEMENT_MODES)[number];
 
+export const SKILL_VIEWS = ["full", "summary"] as const;
+export type SkillViewType = (typeof SKILL_VIEWS)[number];
+
 export const SKILL_SOURCES = [
   "web_app",
   "github",
@@ -25,7 +28,7 @@ export const SkillSourceMetadataSchema = z.object({
 
 export type SkillSourceMetadata = z.infer<typeof SkillSourceMetadataSchema>;
 
-export const SkillWithoutToolsSchema = z.object({
+export const SkillSummarySchema = z.object({
   id: z.number(),
   sId: z.string(),
   createdAt: z.number().nullable(),
@@ -35,8 +38,6 @@ export const SkillWithoutToolsSchema = z.object({
   name: z.string(),
   agentFacingDescription: z.string(),
   userFacingDescription: z.string(),
-  instructions: z.string().nullable(),
-  instructionsHtml: z.string().nullable(),
   icon: z.string().nullable(),
   source: z.enum(SKILL_SOURCES).nullable(),
   sourceMetadata: SkillSourceMetadataSchema.nullable(),
@@ -55,9 +56,11 @@ export const SkillWithoutToolsSchema = z.object({
   extendedSkillId: z.string().nullable(),
 });
 
-export type SkillWithoutToolsType = z.infer<typeof SkillWithoutToolsSchema>;
+export type SkillSummaryType = z.infer<typeof SkillSummarySchema>;
 
-export const SkillSchema = SkillWithoutToolsSchema.extend({
+export const SkillSchema = SkillSummarySchema.extend({
+  instructions: z.string().nullable(),
+  instructionsHtml: z.string().nullable(),
   tools: z.array(MCPServerViewSchema),
 });
 


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/dust/pull/24664
- This PR introduces a type for skills that does not contains the instructions, allowing to remove the need for fetching the instructions.
- Fetching the instructions can be costly, especially for certain global skills such as Discover Tools: it requires fetching all the MCP server views on the global space.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
