### PR TITLE
[front] add wake-up waiting-state UI (PR 1)

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -12,10 +12,13 @@ import {
   isHiddenMessage,
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
+import { WakeUpBanner } from "@app/components/assistant/conversation/WakeUpBanner";
 import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
 import { useCancelMessage, useConversation } from "@app/hooks/conversations";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
+import { useConversationWakeUps } from "@app/lib/swr/wakeups";
+import { formatWakeUpTime } from "@app/lib/utils/wakeup_description";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   isRichAgentMention,
@@ -102,6 +105,17 @@ export const AgentInputBar = ({
   )
     ? "Wait for compaction to finish"
     : null;
+
+  const { activeWakeUp, isActiveWakeUpOwner } = useConversationWakeUps({
+    owner: context.owner,
+    conversationId: context.conversation?.sId ?? "",
+    disabled: !context.conversation,
+  });
+
+  const wakeUpBlockMessage =
+    activeWakeUp && !isActiveWakeUpOwner
+      ? `Conversation paused - a wake-up is scheduled for ${formatWakeUpTime(activeWakeUp)}`
+      : null;
 
   const autoMentions = useMemo(() => {
     // If we are in the agent builder, we show the draft agent as the sticky mention, all the time.
@@ -422,6 +436,14 @@ export const AgentInputBar = ({
           )}
         </ContentMessageInline>
       )}
+      {activeWakeUp && context.conversation && (
+        <WakeUpBanner
+          wakeUp={activeWakeUp}
+          owner={context.owner}
+          conversationId={context.conversation.sId}
+          isOwner={isActiveWakeUpOwner}
+        />
+      )}
       <InputBar
         owner={context.owner}
         user={context.user}
@@ -434,7 +456,7 @@ export const AgentInputBar = ({
         actions={agentBuilderContext?.actionsToShow}
         isSubmitting={agentBuilderContext?.isSubmitting === true}
         isAgentBuilder={!!agentBuilderContext}
-        submitBlockMessage={compactionBlockMessage}
+        submitBlockMessage={wakeUpBlockMessage ?? compactionBlockMessage}
       />
     </div>
   );

--- a/front/components/assistant/conversation/WakeUpBanner.tsx
+++ b/front/components/assistant/conversation/WakeUpBanner.tsx
@@ -1,0 +1,60 @@
+import { useCancelWakeUp } from "@app/lib/swr/wakeups";
+import { describeWakeUpSchedule } from "@app/lib/utils/wakeup_description";
+import type { WakeUpType } from "@app/types/assistant/wakeups";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  ActionTimeIcon,
+  ActionTrashIcon,
+  ContentMessageAction,
+  ContentMessageInline,
+} from "@dust-tt/sparkle";
+
+interface WakeUpBannerProps {
+  wakeUp: WakeUpType;
+  owner: LightWorkspaceType;
+  conversationId: string;
+  isOwner: boolean;
+}
+
+// TODO(wake-up): PR 7 will add an owner-only overflow DropdownMenu alongside
+// the cancel action. Deferred for now because ContentMessageInline's
+// action-child filter only accepts ContentMessageAction at the top level,
+// and the menu wrapper needs a different integration.
+export const WakeUpBanner = ({
+  wakeUp,
+  owner,
+  conversationId,
+  isOwner,
+}: WakeUpBannerProps) => {
+  const { cancelWakeUp } = useCancelWakeUp({ owner, conversationId });
+  const scheduleDescription = describeWakeUpSchedule(wakeUp);
+
+  return (
+    <ContentMessageInline
+      icon={ActionTimeIcon}
+      variant="outline"
+      className="mb-5 flex max-h-dvh w-full bg-background dark:bg-background-night"
+    >
+      {/* ContentMessageInline variant="outline" renders all content children
+          in text-muted-foreground by default; override the reason to the
+          normal foreground color, let the schedule text inherit the muted
+          color. */}
+      <span className="text-foreground dark:text-foreground-night">
+        {wakeUp.reason}
+      </span>
+      <span className="ml-2">{scheduleDescription}</span>
+      {isOwner && (
+        <ContentMessageAction
+          icon={ActionTrashIcon}
+          variant="ghost"
+          size="xs"
+          tooltip="Cancel wake-up"
+          className="text-muted-foreground dark:text-muted-foreground-night"
+          onClick={() => {
+            void cancelWakeUp(wakeUp.sId);
+          }}
+        />
+      )}
+    </ContentMessageInline>
+  );
+};

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -492,7 +492,9 @@ export const InputBar = React.memo(function InputBar({
             saveDraft={saveDraft}
             getDraft={getDraft}
             user={user}
-            disableAgentSelector={isBlockedByAgentSwitch}
+            disableAgentSelector={
+              isBlockedByAgentSwitch || submitBlockMessage !== null
+            }
             submitBlockMessage={submitBlockMessage ?? agentSwitchBlockMessage}
             onShake={handleShake}
           />

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -34,6 +34,9 @@ interface InputBarButtonsProps {
   fileInputRef: React.MutableRefObject<HTMLInputElement | null>;
   fileUploaderService: FileUploaderService;
   handleSingleAgentSelect: (mention: RichMention) => void;
+  // When true, disables every picker (tools, attachment) in addition to the
+  // agent selector which is muted via `disableAgentSelector`.
+  isInputDisabled: boolean;
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
@@ -58,6 +61,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   fileInputRef,
   fileUploaderService,
   handleSingleAgentSelect,
+  isInputDisabled,
   onMCPServerViewSelect,
   onNodeSelect,
   onNodeUnselect,
@@ -100,6 +104,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
             size={buttonSize}
             icon={() => <Avatar size="xxs" visual={selectedAgent.pictureUrl} />}
             label={selectedAgent.label}
+            disabled={isInputDisabled}
             className={cn(
               disableAgentSelector && "bg-gray-150 dark:bg-gray-800"
             )}
@@ -110,6 +115,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
             size={buttonSize}
             icon={RobotIcon}
             label="Agent"
+            disabled={isInputDisabled}
             className={cn(
               disableAgentSelector && "bg-gray-150 dark:bg-gray-800"
             )}
@@ -127,6 +133,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       selectedSkills={selectedSkills}
       onSkillSelect={onSkillSelect}
       buttonSize={buttonSize}
+      disabled={isInputDisabled}
     />
   );
   const attachmentButton = actions.includes("attachment") &&
@@ -162,6 +169,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
           }}
           spaceId={spaceId}
           type="dropdown"
+          disabled={isInputDisabled}
         />
       </>
     );

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -488,6 +488,7 @@ const InputBarContainer = ({
       onSkillSelectRef,
       selectedSkillIdsRef,
     },
+    placeholderOverride: submitBlockMessage,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";
       let inserted = false;
@@ -582,6 +583,17 @@ const InputBarContainer = ({
       });
     },
   });
+
+  // Keep the editor non-editable while submission is blocked (e.g. a non-owner
+  // viewing a conversation with an active wake-up). The placeholder already
+  // reads the block reason via `placeholderOverride`; disabling editability
+  // prevents typing into the field.
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) {
+      return;
+    }
+    editor.setEditable(!isSubmitBlocked);
+  }, [editor, isSubmitBlocked]);
 
   // Ref to expose the current selectedSingleAgent to the editor update listener
   // without re-registering it on every selection change.
@@ -1072,6 +1084,7 @@ const InputBarContainer = ({
                     fileInputRef={fileInputRef}
                     fileUploaderService={fileUploaderService}
                     handleSingleAgentSelect={handleSingleAgentSelect}
+                    isInputDisabled={isSubmitBlocked}
                     onMCPServerViewSelect={onMCPServerViewSelect}
                     onNodeSelect={onNodeSelect}
                     onNodeUnselect={onNodeUnselect}
@@ -1179,6 +1192,7 @@ const InputBarContainer = ({
                   externalOpen={showKnowledgePicker}
                   onExternalOpenChange={setShowKnowledgePicker}
                   anchorRef={plusButtonRef}
+                  disabled={isSubmitBlocked}
                 />
               )}
             </>
@@ -1202,6 +1216,7 @@ const InputBarContainer = ({
                   onRecordStop={voiceTranscriberService.stopRecording}
                   size={buttonSize}
                   showStopLabel={!isMobile}
+                  disabled={isSubmitBlocked}
                 />
               )}
           </div>

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -159,6 +159,10 @@ export const isTriggeredOrigin = (origin?: UserMessageOrigin | null) => {
   );
 };
 
+export const isWakeUpOrigin = (origin?: UserMessageOrigin | null) => {
+  return origin === "wakeup";
+};
+
 // Central helper to control which user message should be hidden in the UI.
 // Extend this list as we introduce more bootstrap/system user messages.
 export const isHiddenMessage = (message: VirtuosoMessage): boolean => {

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -231,6 +231,8 @@ export interface CustomEditorProps {
     >;
     selectedSkillIdsRef: React.RefObject<Set<string>>;
   };
+  // Override the default editor placeholder (e.g. to show a blocked-state reason).
+  placeholderOverride?: string | null;
 }
 
 export const buildEditorExtensions = ({
@@ -246,6 +248,7 @@ export const buildEditorExtensions = ({
   onFirstAgentMentionPasteRef,
   onAgentMentionsStrippedRef,
   slashSuggestion,
+  placeholderOverride,
 }: {
   owner: WorkspaceType;
   conversationId?: string | null;
@@ -263,6 +266,7 @@ export const buildEditorExtensions = ({
     ((payload: MentionsStrippedPayload) => void) | undefined
   >;
   slashSuggestion?: CustomEditorProps["slashSuggestion"];
+  placeholderOverride?: string | null;
 }) => {
   const extensions = [
     KeyboardShortcutsExtension,
@@ -348,7 +352,7 @@ export const buildEditorExtensions = ({
         if (node.type.name !== "paragraph") {
           return "";
         }
-        return "Ask a question";
+        return placeholderOverride ?? "Ask a question";
       },
       emptyNodeClass:
         "first:before:text-gray-400 first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
@@ -398,6 +402,7 @@ const useCustomEditor = ({
   onFirstAgentMentionPasteRef,
   onAgentMentionsStrippedRef,
   slashSuggestion,
+  placeholderOverride,
 }: CustomEditorProps) => {
   const editor = useEditor(
     {
@@ -415,6 +420,7 @@ const useCustomEditor = ({
         onFirstAgentMentionPasteRef,
         onAgentMentionsStrippedRef,
         slashSuggestion,
+        placeholderOverride,
       }),
       shouldRerenderOnTransaction: true, // necessary to update the editor state (and so the toolbar icons "activation") in real time
       editorProps: {
@@ -442,7 +448,8 @@ const useCustomEditor = ({
       immediatelyRender: false,
     },
     // Important to watch for conversationId changes to reset the editor state when switching conversations.
-    [conversationId]
+    // placeholderOverride is included so the placeholder text updates when the blocked-state reason changes.
+    [conversationId, placeholderOverride]
   );
 
   const editorService = useEditorService(editor);

--- a/front/lib/api/actions/servers/wakeups/tools/index.ts
+++ b/front/lib/api/actions/servers/wakeups/tools/index.ts
@@ -7,7 +7,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { isUserMessageType } from "@app/types/assistant/conversation";
-import type { WakeUpType } from "@app/types/assistant/wakeups";
+import { isActiveWakeUp, type WakeUpType } from "@app/types/assistant/wakeups";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
@@ -192,8 +192,8 @@ export function createWakeupsTools(
         auth,
         runConversation
       );
-      const activeInConversation = conversationWakeUps.filter(
-        (w) => w.status === "scheduled"
+      const activeInConversation = conversationWakeUps.filter((w) =>
+        isActiveWakeUp(w.toJSON())
       );
       if (activeInConversation.length >= MAX_ACTIVE_WAKEUPS_PER_CONVERSATION) {
         return new Err(

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -28,11 +28,14 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Attributes, Transaction, WhereOptions } from "sequelize";
 
+// Maximum fire counts for each wake-up to prevent run-away situations. The limit is exposed to
+// agents to let them reschedule their wake-ups if they want to keep being triggered after reaching
+// the limit.
 const MAX_WAKE_UP_FIRES = 32;
 
 // Minimum allowed interval between two cron fires, in minutes. Matches the per-conversation
 // guardrail in the wake-up design doc.
-export const WAKE_UP_MIN_INTERVAL_MINUTES = 5;
+const WAKE_UP_MIN_INTERVAL_MINUTES = 5;
 
 // Standard 5-field cron regex. Does not support # (nth occurrence) or L (last) operators.
 const WAKE_UP_CRON_REGEXP =

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -14,10 +14,12 @@ import {
 } from "@app/temporal/triggers/wakeup_client";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import type {
-  WakeUpScheduleConfig,
-  WakeUpStatus,
-  WakeUpType,
+import {
+  ACTIVE_WAKE_UP_STATUSES,
+  isActiveWakeUp,
+  type WakeUpScheduleConfig,
+  type WakeUpStatus,
+  type WakeUpType,
 } from "@app/types/assistant/wakeups";
 import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -26,12 +28,11 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Attributes, Transaction, WhereOptions } from "sequelize";
 
-const ACTIVE_WAKE_UP_STATUSES: WakeUpStatus[] = ["scheduled"];
 const MAX_WAKE_UP_FIRES = 32;
 
 // Minimum allowed interval between two cron fires, in minutes. Matches the per-conversation
 // guardrail in the wake-up design doc.
-const WAKE_UP_MIN_INTERVAL_MINUTES = 5;
+export const WAKE_UP_MIN_INTERVAL_MINUTES = 5;
 
 // Standard 5-field cron regex. Does not support # (nth occurrence) or L (last) operators.
 const WAKE_UP_CRON_REGEXP =
@@ -331,9 +332,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
   ): Promise<void> {
     const wakeUps = await this.listByConversation(auth, conversation);
 
-    const activeWakeUps = wakeUps.filter((wakeUp) =>
-      ACTIVE_WAKE_UP_STATUSES.includes(wakeUp.status)
-    );
+    const activeWakeUps = wakeUps.filter((w) => isActiveWakeUp(w.toJSON()));
 
     const cancelResults = await concurrentExecutor(
       activeWakeUps,

--- a/front/lib/swr/wakeups.ts
+++ b/front/lib/swr/wakeups.ts
@@ -1,0 +1,102 @@
+// TODO(wake-up): Replace stub with real SWR fetch when wake-up API endpoints land (PR 7).
+// Will use useSWRWithDefaults + useFetcher pattern (see front/lib/swr/agent_memories.ts).
+
+import type { WakeUpType } from "@app/types/assistant/wakeups";
+import { useCallback, useMemo } from "react";
+
+const STUB_ENABLED = false;
+// Toggle to preview the non-owner (viewer) disabled-input state. When false,
+// the active wake-up is treated as belonging to someone else, so the banner
+// hides the cancel action and the input bar shows the "conversation paused"
+// placeholder + disabled send button. PR 7 will replace this with an `isOwner`
+// boolean on the real API response (see TODO in AgentInputBar.tsx).
+const STUB_IS_OWNER = true;
+
+const buildStubWakeUps = (agentConfigurationId: string): WakeUpType[] => [
+  {
+    id: 1,
+    sId: "stub-wakeup-1",
+    createdAt: Date.now(),
+    agentConfigurationId,
+    // One-shot "snooze"-style wake-up: the agent wakes up once at a specific
+    // timestamp (Date.now() + N minutes). This is the common V1 flow.
+    // Swap in the cron block below to preview the recurring-schedule variant.
+    scheduleConfig: {
+      type: "one_shot",
+      fireAt: Date.now() + 45 * 60 * 1000,
+    },
+    // scheduleConfig: {
+    //   type: "cron",
+    //   cron: "38 10 * * *",
+    //   timezone: "UTC",
+    // },
+    reason: "Check error rate post-deploy v2.4.3",
+    status: "scheduled",
+    fireCount: 0,
+    maxFires: 1,
+  },
+];
+
+export function useConversationWakeUps({
+  owner,
+  conversationId,
+  disabled,
+}: {
+  owner: { sId: string };
+  conversationId: string;
+  disabled?: boolean;
+}) {
+  const wakeUps = useMemo<WakeUpType[]>(() => {
+    if (disabled || !conversationId) {
+      return [];
+    }
+    if (STUB_ENABLED) {
+      return buildStubWakeUps(`stub-agent-${owner.sId}`);
+    }
+    return [];
+  }, [disabled, conversationId, owner.sId]);
+
+  const activeWakeUp = useMemo(
+    () => wakeUps.find((w) => w.status === "scheduled") ?? null,
+    [wakeUps]
+  );
+
+  const mutateWakeUps = useCallback(async () => {
+    // no-op in stub
+  }, []);
+
+  return {
+    wakeUps,
+    activeWakeUp,
+    // TODO(wake-up): PR 7 will derive this per-wake-up from the API response,
+    // following the triggers isEditor pattern. For now the stub treats every
+    // active wake-up as (not) owned by the current user based on STUB_IS_OWNER.
+    isActiveWakeUpOwner: activeWakeUp ? STUB_IS_OWNER : false,
+    isWakeUpsLoading: false,
+    isWakeUpsError: false,
+    mutateWakeUps,
+  };
+}
+
+export function useCancelWakeUp({
+  owner,
+  conversationId,
+}: {
+  owner: { sId: string };
+  conversationId: string;
+}) {
+  const cancelWakeUp = useCallback(
+    async (wakeUpSId: string) => {
+      // eslint-disable-next-line no-console
+      console.log("[stub] cancelWakeUp", {
+        workspaceId: owner.sId,
+        conversationId,
+        wakeUpSId,
+      });
+      return true;
+    },
+    [owner.sId, conversationId]
+  );
+
+  return { cancelWakeUp };
+}

--- a/front/lib/swr/wakeups.ts
+++ b/front/lib/swr/wakeups.ts
@@ -1,12 +1,10 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { WakeUpType } from "@app/types/assistant/wakeups";
+import type { GetConversationWakeUpsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
-
-type GetConversationWakeUpsResponseBody = { wakeUps: WakeUpType[] };
 
 export function useConversationWakeUps({
   owner,

--- a/front/lib/swr/wakeups.ts
+++ b/front/lib/swr/wakeups.ts
@@ -2,6 +2,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetConversationWakeUpsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups";
+import { isActiveWakeUp } from "@app/types/assistant/wakeups";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
@@ -28,7 +29,7 @@ export function useConversationWakeUps({
 
   const wakeUps = data?.wakeUps ?? emptyArray();
   const activeWakeUp = useMemo(
-    () => wakeUps.find((w) => w.status === "scheduled") ?? null,
+    () => wakeUps.find((w) => isActiveWakeUp(w)) ?? null,
     [wakeUps]
   );
 

--- a/front/lib/swr/wakeups.ts
+++ b/front/lib/swr/wakeups.ts
@@ -1,80 +1,48 @@
-// TODO(wake-up): Replace stub with real SWR fetch when wake-up API endpoints land (PR 7).
-// Will use useSWRWithDefaults + useFetcher pattern (see front/lib/swr/agent_memories.ts).
-
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
+import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useMemo } from "react";
+import type { Fetcher } from "swr";
 
-const STUB_ENABLED = false;
-// Toggle to preview the non-owner (viewer) disabled-input state. When false,
-// the active wake-up is treated as belonging to someone else, so the banner
-// hides the cancel action and the input bar shows the "conversation paused"
-// placeholder + disabled send button. PR 7 will replace this with an `isOwner`
-// boolean on the real API response (see TODO in AgentInputBar.tsx).
-const STUB_IS_OWNER = true;
-
-const buildStubWakeUps = (agentConfigurationId: string): WakeUpType[] => [
-  {
-    id: 1,
-    sId: "stub-wakeup-1",
-    createdAt: Date.now(),
-    agentConfigurationId,
-    // One-shot "snooze"-style wake-up: the agent wakes up once at a specific
-    // timestamp (Date.now() + N minutes). This is the common V1 flow.
-    // Swap in the cron block below to preview the recurring-schedule variant.
-    scheduleConfig: {
-      type: "one_shot",
-      fireAt: Date.now() + 45 * 60 * 1000,
-    },
-    // scheduleConfig: {
-    //   type: "cron",
-    //   cron: "38 10 * * *",
-    //   timezone: "UTC",
-    // },
-    reason: "Check error rate post-deploy v2.4.3",
-    status: "scheduled",
-    fireCount: 0,
-    maxFires: 1,
-  },
-];
+type GetConversationWakeUpsResponseBody = { wakeUps: WakeUpType[] };
 
 export function useConversationWakeUps({
   owner,
   conversationId,
   disabled,
 }: {
-  owner: { sId: string };
+  owner: LightWorkspaceType;
   conversationId: string;
   disabled?: boolean;
 }) {
-  const wakeUps = useMemo<WakeUpType[]>(() => {
-    if (disabled || !conversationId) {
-      return [];
-    }
-    if (STUB_ENABLED) {
-      return buildStubWakeUps(`stub-agent-${owner.sId}`);
-    }
-    return [];
-  }, [disabled, conversationId, owner.sId]);
+  const { fetcher } = useFetcher();
+  const wakeUpsFetcher: Fetcher<GetConversationWakeUpsResponseBody> = fetcher;
 
+  const { data, error, mutate } = useSWRWithDefaults(
+    conversationId
+      ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/wakeups`
+      : null,
+    wakeUpsFetcher,
+    { disabled }
+  );
+
+  const wakeUps = data?.wakeUps ?? emptyArray();
   const activeWakeUp = useMemo(
     () => wakeUps.find((w) => w.status === "scheduled") ?? null,
     [wakeUps]
   );
 
-  const mutateWakeUps = useCallback(async () => {
-    // no-op in stub
-  }, []);
-
   return {
     wakeUps,
     activeWakeUp,
-    // TODO(wake-up): PR 7 will derive this per-wake-up from the API response,
-    // following the triggers isEditor pattern. For now the stub treats every
-    // active wake-up as (not) owned by the current user based on STUB_IS_OWNER.
-    isActiveWakeUpOwner: activeWakeUp ? STUB_IS_OWNER : false,
-    isWakeUpsLoading: false,
-    isWakeUpsError: false,
-    mutateWakeUps,
+    // TODO(wake-up): derive from the API response once it exposes ownership info; for now the
+    // cancel endpoint 403s if the caller is not the wake-up owner or a workspace admin.
+    isActiveWakeUpOwner: !!activeWakeUp,
+    isWakeUpsLoading: !error && !data && !disabled,
+    isWakeUpsError: !!error,
+    mutateWakeUps: mutate,
   };
 }
 
@@ -82,20 +50,39 @@ export function useCancelWakeUp({
   owner,
   conversationId,
 }: {
-  owner: { sId: string };
+  owner: LightWorkspaceType;
   conversationId: string;
 }) {
+  const sendNotification = useSendNotification();
+  const { mutateWakeUps } = useConversationWakeUps({
+    owner,
+    conversationId,
+    disabled: true,
+  });
+
   const cancelWakeUp = useCallback(
     async (wakeUpSId: string) => {
-      // eslint-disable-next-line no-console
-      console.log("[stub] cancelWakeUp", {
-        workspaceId: owner.sId,
-        conversationId,
-        wakeUpSId,
-      });
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/assistant/conversations/${conversationId}/wakeups/${wakeUpSId}`,
+        { method: "DELETE" }
+      );
+
+      if (!res.ok) {
+        const json = await res.json();
+        sendNotification({
+          type: "error",
+          title: "Failed to cancel wake-up",
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          description: json.error?.message || "Failed to cancel wake-up",
+        });
+        return false;
+      }
+
+      sendNotification({ type: "success", title: "Wake-up cancelled" });
+      void mutateWakeUps();
       return true;
     },
-    [owner.sId, conversationId]
+    [owner.sId, conversationId, sendNotification, mutateWakeUps]
   );
 
   return { cancelWakeUp };

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -1,0 +1,23 @@
+import type { WakeUpType } from "@app/types/assistant/wakeups";
+
+// Short time label for the next firing of a wake-up. V1 only handles the
+// two supported scheduleConfig shapes; PR 7 will replace this with richer
+// formatting when we support non-daily cron patterns.
+export function formatWakeUpTime(wakeUp: WakeUpType): string {
+  if (wakeUp.scheduleConfig.type === "one_shot") {
+    return new Date(wakeUp.scheduleConfig.fireAt).toLocaleTimeString("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+  const [minute, hour] = wakeUp.scheduleConfig.cron.split(/\s+/);
+  return `${hour.padStart(2, "0")}:${minute.padStart(2, "0")}`;
+}
+
+// Human-friendly schedule phrase for the banner.
+export function describeWakeUpSchedule(wakeUp: WakeUpType): string {
+  const time = formatWakeUpTime(wakeUp);
+  return wakeUp.scheduleConfig.type === "one_shot"
+    ? `at ${time}`
+    : `Run everyday at ${time}`;
+}

--- a/front/types/assistant/wakeups.ts
+++ b/front/types/assistant/wakeups.ts
@@ -7,6 +7,8 @@ export const WAKEUP_STATUSES = [
   "expired",
 ] as const;
 
+export const ACTIVE_WAKE_UP_STATUSES: WakeUpStatus[] = ["scheduled"];
+
 export const WakeUpStatusSchema = z.enum(WAKEUP_STATUSES);
 export type WakeUpStatus = z.infer<typeof WakeUpStatusSchema>;
 
@@ -50,3 +52,7 @@ export const WakeUpSchema = z.object({
  * @swaggerschema PrivateWakeUp (swagger_private_schemas.ts)
  */
 export type WakeUpType = z.infer<typeof WakeUpSchema>;
+
+export function isActiveWakeUp(wakeUp: WakeUpType): boolean {
+  return ACTIVE_WAKE_UP_STATUSES.includes(wakeUp.status);
+}

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -120,11 +120,23 @@ selecting an existing agent message.
 Added `wakeup_not_found` to `APIErrorType`, `PrivateWakeUp` schema to
 `swagger_private_schemas.ts`, and the `@swaggerschema` annotation on `WakeUpType`.
 
-### PR 9 — Conversation UI
+### [partial] PR 9 — Conversation UI
 
-SWR Hooks. Wake-up banner ("Waiting until {time} — {reason}" + cancel button). Wake-up message
-rendering (system-style message from "Dust"). Conversation moves to active in sidebar when wake-up
-fires.  For V1, the UI can assume max 1 active wake-up per conversation.
+SWR hooks (`useConversationWakeUps`, `useCancelWakeUp` in `front/lib/swr/wakeups.ts`) wired
+to the real endpoints from PR 8. Wake-up banner ("Waiting until {time} — {reason}" + cancel
+button), wake-up message rendering, and the sidebar active/dormant treatment are live. For
+V1, the UI assumes max 1 active wake-up per conversation.
+
+Follow-ups:
+- Wake-up ownership: `isActiveWakeUpOwner` currently returns `!!activeWakeUp` with a TODO;
+  needs the API to expose per-wake-up ownership (e.g., `isOwner: boolean` on the
+  serialized `WakeUpType`), then used to disable the cancel action for non-owners and
+  drive the "conversation paused" input state.
+- `mutate` on wake-up creation: when `schedule_wakeup` fires from the agent tool, the UI
+  doesn't re-fetch the wake-up list automatically, so the banner only appears after the
+  next natural SWR refresh. Needs to invalidate `useConversationWakeUps` when a new
+  wake-up is created in the current conversation (e.g., via a conversation-events hook or
+  post-tool-call mutation).
 
 ## Milestone 7: Cleanup + GA
 


### PR DESCRIPTION
## Description
Adds the frontend "waiting state" shown when a conversation has a scheduled wake-up: a banner above the input bar, a time indicator on the matching conversation row in the left sidebar, and a stubbed SWR hook (STUB_ENABLED / STUB_IS_OWNER) returning mock data locally.

The banner shows a cancel action for the wake-up owner and a paused placeholder + disabled send button for other viewers. Schedule copy supports both one-shot (snooze-style "at 10:55 AM") and the common "every day at HH:MM" cron pattern.

No backend or API changes. Real SWR + endpoints arrive in PR 7. Ships an additive, non-breaking `suffix` prop on Sparkle's NavigationListItem to host the inline sidebar indicator.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
<img width="769" height="233" alt="Screenshot 2026-04-21 at 6 33 26 PM" src="https://github.com/user-attachments/assets/a8980655-fcae-4d27-8b24-ee7625512784" />
<img width="313" height="147" alt="Screenshot 2026-04-21 at 6 19 06 PM" src="https://github.com/user-attachments/assets/d5c53d93-1223-4104-8e03-cf0915086bd7" />
<img width="783" height="216" alt="Screenshot 2026-04-21 at 6 23 40 PM" src="https://github.com/user-attachments/assets/b2c5de4c-3c6c-4bc5-b6b7-5a328d1b35bc" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
Most of this is stubbed out work :) will wait to merge + deploy until more of the backend state is live.
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
