### PR TITLE
fix(sbx): use ss instead of nc for egress forwarder health check

### DIFF
--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -104,9 +104,14 @@ export async function checkEgressForwarderHealth(
   auth: Authenticator,
   sandbox: SandboxResource
 ): Promise<Result<boolean, Error>> {
-  const healthResult = await sandbox.exec(auth, "nc -z 127.0.0.1 9990", {
-    timeoutMs: 1_000,
-  });
+  // Use ss to check if the port is bound locally rather than nc -z which opens
+  // a real TCP connection through the forwarder, triggering a proxy round-trip
+  // and noisy <unknown> deny log entries on every health check.
+  const healthResult = await sandbox.exec(
+    auth,
+    "ss -tln sport = :9990 | grep -q LISTEN",
+    { timeoutMs: 1_000 }
+  );
 
   if (healthResult.isErr()) {
     return healthResult;


### PR DESCRIPTION
## Description

The egress forwarder health check used `nc -z 127.0.0.1 9990`, which opens a real TCP connection through the forwarder. Since there's no TLS handshake or domain in a bare `nc -z`, the forwarder forwards it to the proxy which denies it — producing noisy `DENIED <unknown>:9990 (reason: proxy_denied)` entries in the deny log on every health check (i.e. every tool call).

Switches to `ss -tln sport = :9990 | grep -q LISTEN` which checks if the port is bound locally without opening a connection. Same semantics (port listening = forwarder alive), no proxy round-trip, no deny log noise.

Verified on a live E2B sandbox:
- `ss` returns exit 1 before forwarder starts, exit 0 after
- No deny log entries from the health check

## Tests

Tested on live E2B sandbox. Existing unit tests still pass (mock exec chain is unchanged).

## Risk

**Low.** `ss` is part of `iproute2` which is installed in the base image. Same pass/fail semantics as `nc -z`.

## Deploy Plan

Standard deploy.