### PR TITLE
Add UI toggle to disable reinforcement

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -233,7 +233,10 @@ export default function SkillBuilder({
           <SkillBuilderInstructionsSection />
           {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
           <SkillBuilderToolsSection extendedSkill={extendedSkill} />
-          <SkillBuilderSettingsOrComparisonFooter skill={skill} />
+          <SkillBuilderSettingsOrComparisonFooter
+            skill={skill}
+            hasReinforcedAgents={hasReinforcedAgents}
+          />
         </div>
       </ScrollArea>
       <BarFooter
@@ -303,8 +306,10 @@ export default function SkillBuilder({
 
 function SkillBuilderSettingsOrComparisonFooter({
   skill,
+  hasReinforcedAgents,
 }: {
   skill?: SkillType;
+  hasReinforcedAgents: boolean;
 }) {
   const { compareVersion } = useSkillVersionComparisonContext();
 
@@ -312,5 +317,10 @@ function SkillBuilderSettingsOrComparisonFooter({
     return <SkillBuilderVersionComparisonFooter />;
   }
 
-  return <SkillBuilderSettingsSection skill={skill} />;
+  return (
+    <SkillBuilderSettingsSection
+      skill={skill}
+      hasReinforcedAgents={hasReinforcedAgents}
+    />
+  );
 }

--- a/front/components/skill_builder/SkillBuilderEnableSuggestionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderEnableSuggestionsSection.tsx
@@ -1,11 +1,17 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { InformationCircleIcon, SliderToggle, Tooltip } from "@dust-tt/sparkle";
 import { useFormContext } from "react-hook-form";
 
 export function SkillBuilderEnableSuggestionsSection() {
+  const { hasFeature } = useFeatureFlags();
   const { watch, setValue } = useFormContext<SkillBuilderFormData>();
   const reinforcement = watch("reinforcement");
   const enabled = reinforcement !== "off";
+
+  if (!hasFeature("reinforcement_ui")) {
+    return null;
+  }
 
   const handleToggle = () => {
     setValue("reinforcement", enabled ? "off" : "auto", { shouldDirty: true });

--- a/front/components/skill_builder/SkillBuilderEnableSuggestionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderEnableSuggestionsSection.tsx
@@ -1,17 +1,11 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { InformationCircleIcon, SliderToggle, Tooltip } from "@dust-tt/sparkle";
 import { useFormContext } from "react-hook-form";
 
 export function SkillBuilderEnableSuggestionsSection() {
-  const { hasFeature } = useFeatureFlags();
   const { watch, setValue } = useFormContext<SkillBuilderFormData>();
   const reinforcement = watch("reinforcement");
   const enabled = reinforcement !== "off";
-
-  if (!hasFeature("reinforcement_ui")) {
-    return null;
-  }
 
   const handleToggle = () => {
     setValue("reinforcement", enabled ? "off" : "auto", { shouldDirty: true });

--- a/front/components/skill_builder/SkillBuilderEnableSuggestionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderEnableSuggestionsSection.tsx
@@ -1,0 +1,28 @@
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { InformationCircleIcon, SliderToggle, Tooltip } from "@dust-tt/sparkle";
+import { useFormContext } from "react-hook-form";
+
+export function SkillBuilderEnableSuggestionsSection() {
+  const { watch, setValue } = useFormContext<SkillBuilderFormData>();
+  const reinforcement = watch("reinforcement");
+  const enabled = reinforcement !== "off";
+
+  const handleToggle = () => {
+    setValue("reinforcement", enabled ? "off" : "auto", { shouldDirty: true });
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <SliderToggle selected={enabled} onClick={handleToggle} size="xs" />
+      <span className="text-sm text-foreground dark:text-foreground-night">
+        Enable suggestions
+      </span>
+      <Tooltip
+        label="Dust will analyze how this skill is used and suggest improvements to its instructions over time."
+        trigger={
+          <InformationCircleIcon className="text-muted-foreground dark:text-muted-foreground-night h-4 w-4" />
+        }
+      />
+    </div>
+  );
+}

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -1,4 +1,5 @@
 import { actionSchema } from "@app/components/shared/tools_picker/types";
+import { SKILL_REINFORCEMENT_MODES } from "@app/types/assistant/skill_configuration";
 import { editorUserSchema } from "@app/types/editors";
 import { createContext } from "react";
 import type { UseFormReturn } from "react-hook-form";
@@ -38,6 +39,7 @@ export const skillBuilderFormSchema = z.object({
   icon: z.string().nullable(),
   extendedSkillId: z.string().nullable(),
   isDefault: z.boolean(),
+  reinforcement: z.enum(SKILL_REINFORCEMENT_MODES),
   fileAttachments: z.array(fileAttachmentSchema),
   attachedKnowledge: z.array(attachedKnowledgeSchema).optional(),
 });

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -1,3 +1,4 @@
+import { SkillBuilderEnableSuggestionsSection } from "@app/components/skill_builder/SkillBuilderEnableSuggestionsSection";
 import { SkillBuilderIconSection } from "@app/components/skill_builder/SkillBuilderIconSection";
 import { SkillBuilderIsDefaultSection } from "@app/components/skill_builder/SkillBuilderIsDefaultSection";
 import { SkillBuilderNameSection } from "@app/components/skill_builder/SkillBuilderNameSection";
@@ -42,8 +43,9 @@ export function SkillBuilderSettingsSection({
         <Collapsible defaultOpen>
           <CollapsibleTrigger variant="secondary">Advanced</CollapsibleTrigger>
           <CollapsibleContent>
-            <div className="pt-3">
+            <div className="space-y-3 pt-3">
               <SkillBuilderIsDefaultSection />
+              <SkillBuilderEnableSuggestionsSection />
             </div>
           </CollapsibleContent>
         </Collapsible>

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -14,10 +14,12 @@ import {
 
 interface SkillBuilderSettingsSectionProps {
   skill?: SkillType;
+  hasReinforcedAgents: boolean;
 }
 
 export function SkillBuilderSettingsSection({
   skill,
+  hasReinforcedAgents,
 }: SkillBuilderSettingsSectionProps) {
   return (
     <div className="space-y-5">
@@ -45,7 +47,7 @@ export function SkillBuilderSettingsSection({
           <CollapsibleContent>
             <div className="space-y-3 pt-3">
               <SkillBuilderIsDefaultSection />
-              <SkillBuilderEnableSuggestionsSection />
+              {hasReinforcedAgents && <SkillBuilderEnableSuggestionsSection />}
             </div>
           </CollapsibleContent>
         </Collapsible>

--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -22,6 +22,7 @@ export function transformSkillTypeToFormData(
     icon: skill.icon ?? null,
     extendedSkillId: skill.extendedSkillId,
     isDefault: skill.isDefault,
+    reinforcement: skill.reinforcement ?? "auto",
   };
 }
 
@@ -47,5 +48,6 @@ export function getDefaultSkillFormData({
     icon: null,
     extendedSkillId,
     isDefault: false,
+    reinforcement: "auto",
   };
 }

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -47,6 +47,7 @@ export async function submitSkillBuilderForm({
         icon: formData.icon,
         extendedSkillId: formData.extendedSkillId,
         isDefault: formData.isDefault,
+        ...(skillId ? { reinforcement: formData.reinforcement } : {}),
         tools: formData.tools.map((tool) => ({
           mcpServerViewId: tool.configuration.mcpServerViewId,
         })),

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1900,6 +1900,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       isDefault,
       mcpServerViews,
       name,
+      reinforcement,
       requestedSpaceIds,
       source,
       sourceMetadata,
@@ -1915,6 +1916,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       isDefault?: boolean;
       mcpServerViews: MCPServerViewResource[];
       name: string;
+      reinforcement?: SkillReinforcementMode;
       requestedSpaceIds: ModelId[];
       source?: SkillSourceType;
       sourceMetadata?: SkillSourceMetadata;
@@ -1949,6 +1951,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(source ? { source } : {}),
           ...(sourceMetadata ? { sourceMetadata } : {}),
           ...(isDefault !== undefined ? { isDefault } : {}),
+          ...(reinforcement !== undefined ? { reinforcement } : {}),
         },
         transaction
       );

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -66,6 +66,11 @@ const PatchSkillRequestBodySchema = t.intersection([
     fileAttachments: t.array(t.type({ fileId: t.string })),
     isDefault: t.boolean,
     instructionsHtml: t.union([t.string, t.null]),
+    reinforcement: t.union([
+      t.literal("auto"),
+      t.literal("on"),
+      t.literal("off"),
+    ]),
   }),
 ]);
 
@@ -328,6 +333,10 @@ async function handler(
         userFacingDescription: body.userFacingDescription,
         ...(shouldActivate ? { status: "active" as const } : {}),
       });
+
+      if (body.reinforcement && body.reinforcement !== skill.reinforcement) {
+        await skill.updateReinforcement(body.reinforcement);
+      }
 
       await pruneOutdatedSkillEditSuggestions(auth, skill);
 

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -329,14 +329,11 @@ async function handler(
         isDefault: body.isDefault,
         mcpServerViews,
         name,
+        reinforcement: body.reinforcement,
         requestedSpaceIds,
         userFacingDescription: body.userFacingDescription,
         ...(shouldActivate ? { status: "active" as const } : {}),
       });
-
-      if (body.reinforcement && body.reinforcement !== skill.reinforcement) {
-        await skill.updateReinforcement(body.reinforcement);
-      }
 
       await pruneOutdatedSkillEditSuggestions(auth, skill);
 


### PR DESCRIPTION
## Description

- Adds a new "Enable suggestions" toggle in the Advanced section of the skill builder (edit mode only)
- Toggle ON → reinforcement = "auto", Toggle OFF → reinforcement = "off" (we don't currently use "on")
- Only shows up if the reinforcement UI flag is on

## Tests

Manual

## Risk

Low

## Deploy Plan

Front