### PR TITLE
fix: outlook shared inboxes endpoints

### DIFF
--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -37,6 +37,14 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe("Fields to include in the response."),
+      sharedMailboxAddress: z
+        .string()
+        .optional()
+        .describe(
+          "The email address of the shared mailbox to access (e.g. 'support@company.com'). " +
+            "Leave empty to access your own mailbox. " +
+            "Note: the shared mailbox address must be known in advance — there is no API to auto-discover it."
+        ),
     },
     stake: "never_ask",
     displayLabels: {
@@ -52,6 +60,14 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .string()
         .describe(
           "The ID of the message to get attachments from (from the get_messages response)"
+        ),
+      sharedMailboxAddress: z
+        .string()
+        .optional()
+        .describe(
+          "The email address of the shared mailbox to access (e.g. 'support@company.com'). " +
+            "Leave empty to access your own mailbox. " +
+            "Note: the shared mailbox address must be known in advance — there is no API to auto-discover it."
         ),
     },
     stake: "never_ask",
@@ -78,6 +94,14 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .number()
         .optional()
         .describe("Number of drafts to skip for pagination."),
+      sharedMailboxAddress: z
+        .string()
+        .optional()
+        .describe(
+          "The email address of the shared mailbox to access (e.g. 'support@company.com'). " +
+            "Leave empty to access your own mailbox. " +
+            "Note: the shared mailbox address must be known in advance — there is no API to auto-discover it."
+        ),
     },
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -27,6 +27,13 @@ const fetchFromOutlook = async (
   });
 };
 
+const getMailboxBasePath = (sharedMailboxAddress?: string): string => {
+  if (sharedMailboxAddress) {
+    return `/users/${encodeURIComponent(sharedMailboxAddress)}`;
+  }
+  return "/me";
+};
+
 const getErrorText = async (response: Response): Promise<string> => {
   try {
     const errorData = await response.json();
@@ -120,7 +127,7 @@ interface OutlookFolder {
 
 const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
   get_messages: async (
-    { search, folderName, top = 10, skip = 0, select },
+    { search, folderName, top = 10, skip = 0, select, sharedMailboxAddress },
     { authInfo }
   ) => {
     const accessToken = authInfo?.token;
@@ -128,11 +135,13 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       return new Err(new MCPError("Authentication required"));
     }
 
+    const basePath = getMailboxBasePath(sharedMailboxAddress);
+
     // If folderName is provided, search for the folder and get its ID
     let folderId: string | undefined;
     if (folderName) {
       const foldersResponse = await fetchFromOutlook(
-        "/me/mailFolders",
+        `${basePath}/mailFolders`,
         accessToken,
         {
           method: "GET",
@@ -187,8 +196,8 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
 
     // Use different endpoint if folderId is provided
     const endpoint = folderId
-      ? `/me/mailFolders/${folderId}/messages?${params.toString()}`
-      : `/me/messages?${params.toString()}`;
+      ? `${basePath}/mailFolders/${folderId}/messages?${params.toString()}`
+      : `${basePath}/messages?${params.toString()}`;
 
     const response = await fetchFromOutlook(endpoint, accessToken, {
       method: "GET",
@@ -223,17 +232,21 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     ]);
   },
 
-  get_attachments: async ({ messageId }, { authInfo }) => {
+  get_attachments: async (
+    { messageId, sharedMailboxAddress },
+    { authInfo }
+  ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
     }
 
+    const basePath = getMailboxBasePath(sharedMailboxAddress);
     const encodedMessageId = encodeURIComponent(messageId);
 
     // List all attachments for the message
     const listResponse = await fetchFromOutlook(
-      `/me/messages/${encodedMessageId}/attachments`,
+      `${basePath}/messages/${encodedMessageId}/attachments`,
       accessToken,
       { method: "GET" }
     );
@@ -340,11 +353,16 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     return new Ok(allContent);
   },
 
-  get_drafts: async ({ search, top = 10, skip = 0 }, { authInfo }) => {
+  get_drafts: async (
+    { search, top = 10, skip = 0, sharedMailboxAddress },
+    { authInfo }
+  ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
     }
+
+    const basePath = getMailboxBasePath(sharedMailboxAddress);
 
     const params = new URLSearchParams();
     params.append("$filter", "isDraft eq true");
@@ -357,7 +375,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     }
 
     const response = await fetchFromOutlook(
-      `/me/messages?${params.toString()}`,
+      `${basePath}/messages?${params.toString()}`,
       accessToken,
       { method: "GET" }
     );
@@ -374,7 +392,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       result.value || [],
       async (draft: { id: string }): Promise<OutlookMessage | null> => {
         const draftResponse = await fetchFromOutlook(
-          `/me/messages/${draft.id}`,
+          `${basePath}/messages/${draft.id}`,
           accessToken,
           { method: "GET" }
         );


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7688

This PR adds support for Outlook shared mailboxes in the mail tools.

- Added optional `sharedMailboxAddress` parameter to `get_messages`, `get_attachments`, and `get_drafts` tools
- Implemented `getMailboxBasePath()` helper function to construct the appropriate API path based on whether a shared mailbox is being accessed (`/users/{email}`) or the user's own mailbox (`/me`)
- Updated all Microsoft Graph API endpoint calls to use the dynamic base path instead of hardcoded `/me`

## Tests

No

## Risks

Low. The changes are backwards compatible - the `sharedMailboxAddress` parameter is optional, so existing calls without it will continue to work as before, accessing the user's own mailbox.

## Deploy Plan

Standard deployment. No special considerations needed.

