### PR TITLE
feat(poke): add conversation-scoped plugins + unstick plugin

### DIFF
--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -1,3 +1,4 @@
+import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
@@ -512,6 +513,13 @@ export function ConversationPage() {
           </LinkWrapper>
         </h3>
         <Page.Vertical align="stretch">
+          <PluginList
+            pluginResourceTarget={{
+              resourceId: conversation.sId,
+              resourceType: "conversations",
+              workspace: owner,
+            }}
+          />
           <div className="flex space-x-2">
             {langfuseUiBaseUrl && (
               <Button

--- a/front/lib/api/poke/plugins/conversations/index.ts
+++ b/front/lib/api/poke/plugins/conversations/index.ts
@@ -1,0 +1,1 @@
+export * from "./unstick";

--- a/front/lib/api/poke/plugins/conversations/unstick.ts
+++ b/front/lib/api/poke/plugins/conversations/unstick.ts
@@ -1,0 +1,112 @@
+import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
+import { createPlugin } from "@app/lib/api/poke/types";
+import type {
+  AgentMessageType,
+  ConversationType,
+} from "@app/types/assistant/conversation";
+import { Err, Ok } from "@app/types/shared/result";
+
+function findStuckAgentMessages(
+  conversation: ConversationType
+): AgentMessageType[] {
+  return conversation.content
+    .map((versions) => versions[versions.length - 1])
+    .filter(
+      (m): m is AgentMessageType =>
+        m.type === "agent_message" && m.status === "created"
+    );
+}
+
+function isLatestMessageAStreamingAgent(
+  conversation: ConversationType
+): boolean {
+  const lastRank = conversation.content[conversation.content.length - 1];
+  if (!lastRank) {
+    return false;
+  }
+  const lastMessage = lastRank[lastRank.length - 1];
+  return (
+    lastMessage.type === "agent_message" && lastMessage.status === "created"
+  );
+}
+
+export const unstickConversationPlugin = createPlugin({
+  manifest: {
+    id: "unstick-conversation",
+    name: "Unstick Conversation",
+    description:
+      "Resume a frozen conversation by marking the hung agent answer as failed and " +
+      "promoting any user messages queued behind it.",
+    resourceTypes: ["conversations"],
+    warning:
+      "Use this when a conversation appears frozen: the agent's answer is hanging " +
+      "indefinitely and any follow-up user messages aren't being processed. Running " +
+      "it will finalize the stuck answer as failed and resume the conversation.",
+    args: {},
+  },
+  isApplicableTo: (_auth, conversation) => {
+    if (!conversation) {
+      return false;
+    }
+    // If the last message is an agent in "created", it could be a live stream rather than a
+    // zombie. We hide the plugin; support can ask the user to send any follow-up message first,
+    // which queues behind the agent and makes the stuck state unambiguous.
+    if (isLatestMessageAStreamingAgent(conversation)) {
+      return false;
+    }
+    return findStuckAgentMessages(conversation).length > 0;
+  },
+  execute: async (auth, conversation) => {
+    if (!conversation) {
+      return new Err(new Error("Conversation not found."));
+    }
+
+    if (isLatestMessageAStreamingAgent(conversation)) {
+      return new Err(
+        new Error(
+          "The latest message is an agent answer still in progress. Ask the user to " +
+            "send any follow-up message (for example 'ok') and retry, so we can be sure " +
+            "the answer is truly frozen and not actively streaming."
+        )
+      );
+    }
+
+    const stuckAgents = findStuckAgentMessages(conversation);
+    if (stuckAgents.length === 0) {
+      return new Err(
+        new Error("Nothing to unstick: no hung agent answer found.")
+      );
+    }
+    if (stuckAgents.length > 1) {
+      return new Err(
+        new Error(
+          `Found ${stuckAgents.length} hung agent answers (expected one). ` +
+            `sIds: ${stuckAgents.map((a) => a.sId).join(", ")}.`
+        )
+      );
+    }
+
+    const stuck = stuckAgents[0];
+
+    await updateAgentMessageWithFinalStatus(auth, {
+      conversation,
+      agentMessage: stuck,
+      status: "failed",
+      error: {
+        code: "unstuck_by_admin",
+        message:
+          "This generation was manually marked as failed via the unstick-conversation " +
+          "poke plugin because the underlying Temporal workflow was no longer running.",
+        metadata: null,
+      },
+    });
+
+    return new Ok({
+      display: "text",
+      value:
+        `Marked agent message ${stuck.sId} as failed. ` +
+        `Any queued user messages have been promoted and a fresh agent answer has been ` +
+        `kicked off for the last one.`,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/index.ts
+++ b/front/lib/api/poke/plugins/index.ts
@@ -1,5 +1,6 @@
 export * from "./agents";
 export * from "./apps";
+export * from "./conversations";
 export * from "./data_source_views";
 export * from "./data_sources";
 export * from "./global";

--- a/front/lib/api/poke/utils.ts
+++ b/front/lib/api/poke/utils.ts
@@ -1,4 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -9,6 +10,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { ConversationType } from "@app/types/assistant/conversation";
 import type { SupportedResourceType } from "@app/types/poke/plugins";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -16,6 +18,7 @@ import type { LightWorkspaceType } from "@app/types/user";
 export type ResourceTypeMap = {
   agents: LightAgentConfigurationType;
   apps: AppResource;
+  conversations: ConversationType;
   workspaces: LightWorkspaceType;
   data_sources: DataSourceResource;
   mcp_server_views: MCPServerViewResource;
@@ -43,6 +46,11 @@ export async function fetchPluginResource<T extends SupportedResourceType>(
     case "apps":
       result = await AppResource.fetchById(auth, resourceId);
       break;
+    case "conversations": {
+      const conversationRes = await getConversation(auth, resourceId);
+      result = conversationRes.isOk() ? conversationRes.value : null;
+      break;
+    }
     case "workspaces":
       result = await getWorkspaceInfos(resourceId);
       break;

--- a/front/types/poke/plugins.ts
+++ b/front/types/poke/plugins.ts
@@ -213,6 +213,7 @@ export function createIoTsCodecFromArgs(
 
 export const supportedResourceTypes = [
   "apps",
+  "conversations",
   "data_source_views",
   "data_sources",
   "mcp_server_views",


### PR DESCRIPTION
## Description

Following: https://github.com/dust-tt/dust/pull/24661

Adds "conversations" as a poke plugin resource type, wires a plugin list on the conversation poke page, and ships the first conversation-scoped plugin: unstick-conversation.

Use case: some conversations ended up stuck after the cascade-delete bug we fixed earlier. Their retried agent message sits in status "created" forever because its Temporal workflow 400'd and never wrote a terminal status, which blocks any follow-up user messages (they sit as "pending" behind it). The plugin calls updateAgentMessageWithFinalStatus on the hung agent answer, which is the same function the Temporal activities call on normal completion. That finalizes the status, promotes any queued user messages, and kicks off a fresh agent loop for the last one.

The plugin is hidden (via isApplicableTo) when the conversation has no hung agent answer, or when the last message is itself an in-flight agent stream (so support doesn't accidentally kill a live workflow). Execute re-checks both conditions as defense in depth for direct API calls.


## Tests

Locally. 

## Risk

Limited. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
