### PR TITLE
feat(sbx): surface egress proxy deny log in sandbox tool output

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockCheckEgressForwarderHealth,
+  mockReadNewDenyLogEntries,
   mockGenerateExecId,
   mockGenerateSandboxExecToken,
   mockGetSandboxImage,
@@ -17,6 +18,7 @@ const {
   mockEnsureActive,
 } = vi.hoisted(() => ({
   mockCheckEgressForwarderHealth: vi.fn(),
+  mockReadNewDenyLogEntries: vi.fn(),
   mockGenerateExecId: vi.fn(),
   mockGenerateSandboxExecToken: vi.fn(),
   mockGetSandboxImage: vi.fn(),
@@ -40,6 +42,7 @@ vi.mock("@app/lib/api/config", () => ({
 
 vi.mock("@app/lib/api/sandbox/egress", () => ({
   checkEgressForwarderHealth: mockCheckEgressForwarderHealth,
+  readNewDenyLogEntries: mockReadNewDenyLogEntries,
   sandboxSupportsEgressForwarding: mockSandboxSupportsEgressForwarding,
   setupEgressForwarder: mockSetupEgressForwarder,
 }));
@@ -96,6 +99,7 @@ describe("runSandboxBashTool", () => {
     mockGetSandboxImage.mockReturnValue(new Ok({}));
     mockMountConversationFiles.mockResolvedValue(new Ok(undefined));
     mockRefreshGcsToken.mockResolvedValue(new Ok(undefined));
+    mockReadNewDenyLogEntries.mockResolvedValue(new Ok([]));
     mockRevokeExecToken.mockResolvedValue(undefined);
     mockSetupEgressForwarder.mockResolvedValue(new Ok(undefined));
     mockStartTelemetry.mockResolvedValue(undefined);

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -290,7 +290,7 @@ export async function runSandboxBashTool(
       );
     } else if (denyResult.value.length > 0) {
       output +=
-        "\n[network proxy] The following outbound request(s) were denied:\n" +
+        "\n[network proxy] Recent outbound request(s) denied by the sandbox proxy:\n" +
         denyResult.value.map((line) => `  ${line}`).join("\n");
     }
   }

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -15,6 +15,7 @@ import {
 } from "@app/lib/api/sandbox/access_tokens";
 import {
   checkEgressForwarderHealth,
+  readNewDenyLogEntries,
   sandboxSupportsEgressForwarding,
   setupEgressForwarder,
 } from "@app/lib/api/sandbox/egress";
@@ -278,6 +279,21 @@ export async function runSandboxBashTool(
     return new Err(new MCPError(execResult.error.message));
   }
 
-  const output = formatExecOutput(execResult.value);
+  let output = formatExecOutput(execResult.value);
+
+  if (execUser) {
+    const denyResult = await readNewDenyLogEntries(auth, sandbox);
+    if (denyResult.isErr()) {
+      logger.warn(
+        { err: denyResult.error, providerId: sandbox.providerId },
+        "Failed to read egress deny log"
+      );
+    } else if (denyResult.value.length > 0) {
+      output +=
+        "\n[network proxy] The following outbound request(s) were denied:\n" +
+        denyResult.value.map((line) => `  ${line}`).join("\n");
+    }
+  }
+
   return new Ok([{ type: "text" as const, text: output }]);
 }

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -50,6 +50,7 @@ vi.mock("node:dns/promises", () => ({
 
 import {
   mintEgressJwt,
+  readNewDenyLogEntries,
   sandboxSupportsEgressForwarding,
   setupEgressForwarder,
 } from "./egress";
@@ -153,6 +154,48 @@ describe("sandbox egress helpers", () => {
       }),
       "Sandbox egress forwarder is healthy"
     );
+  });
+
+  it("returns new deny log entries and advances the offset", async () => {
+    const sandbox = {
+      exec: vi.fn().mockResolvedValue(
+        new Ok({
+          exitCode: 0,
+          stdout: "google.com:443 denied\nevil.com:80 denied\n",
+          stderr: "",
+        })
+      ),
+    };
+
+    const result = await readNewDenyLogEntries({} as never, sandbox as never);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual([
+        "google.com:443 denied",
+        "evil.com:80 denied",
+      ]);
+    }
+    expect(sandbox.exec).toHaveBeenCalledWith(
+      {},
+      expect.stringContaining("dust-egress-denied.log"),
+      { user: "root", timeoutMs: 2_000 }
+    );
+  });
+
+  it("returns empty array when there are no new deny log entries", async () => {
+    const sandbox = {
+      exec: vi
+        .fn()
+        .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
+    };
+
+    const result = await readNewDenyLogEntries({} as never, sandbox as never);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual([]);
+    }
   });
 
   it("surfaces setup failures from sandbox commands", async () => {

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -194,6 +194,9 @@ export async function setupEgressForwarder(
   );
 }
 
+// Best-effort, sandbox-global deny log surfacing. The offset tracks lines
+// consumed across all exec calls, so entries returned here are "new since the
+// last read", not strictly caused by the command that just ran.
 export async function readNewDenyLogEntries(
   auth: Authenticator,
   sandbox: SandboxResource

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -10,10 +10,12 @@ import jwt from "jsonwebtoken";
 const EGRESS_FORWARDER_LISTEN_ADDR = "127.0.0.1:9990";
 const EGRESS_TOKEN_PATH = "/etc/dust/egress-token";
 const EGRESS_DENY_LOG_PATH = "/tmp/dust-egress-denied.log";
+const EGRESS_DENY_LOG_OFFSET_PATH = "/tmp/.dust-egress-deny-offset";
 const EGRESS_FORWARDER_LOG_PATH = "/tmp/dust-forwarder.log";
 const EGRESS_SETUP_WAIT_RETRIES = 6;
 const EGRESS_SETUP_WAIT_MS = 500;
 const EGRESS_JWT_TTL_SECONDS = 24 * 60 * 60;
+const MAX_DENY_LOG_LINES_PER_EXEC = 20;
 
 const REGION_PROXY_PREFIX = {
   "europe-west1": "eu",
@@ -190,4 +192,32 @@ export async function setupEgressForwarder(
   return new Err(
     new Error("Sandbox egress forwarder did not become healthy in time")
   );
+}
+
+export async function readNewDenyLogEntries(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<string[], Error>> {
+  const command =
+    `_off=$(cat ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)} 2>/dev/null || echo 0); ` +
+    `_total=$(wc -l < ${shellEscape(EGRESS_DENY_LOG_PATH)} 2>/dev/null || echo 0); ` +
+    `if [ "$_total" -gt "$_off" ]; then ` +
+    `tail -n +$((_off + 1)) ${shellEscape(EGRESS_DENY_LOG_PATH)} | head -n ${MAX_DENY_LOG_LINES_PER_EXEC}; ` +
+    `fi; ` +
+    `echo "$_total" > ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)}`;
+
+  const result = await sandbox.exec(auth, command, {
+    user: "root",
+    timeoutMs: 2_000,
+  });
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const lines = result.value.stdout
+    .split("\n")
+    .filter((line) => line.trim().length > 0);
+
+  return new Ok(lines);
 }


### PR DESCRIPTION
## Description

When the egress proxy denies an outbound request from the sandbox, the agent only sees a generic connection failure (e.g., "connection refused"). The forwarder already writes denied requests to `/tmp/dust-egress-denied.log` — this change reads new entries from that file after each command execution and appends them to the tool output.

The deny log is tracked with a line-offset marker file so only entries added since the last read are surfaced (capped at 20 lines). This is best-effort, sandbox-global surfacing — entries are "new since the previous exec", not strictly attributed to the command that just ran. The read runs as root with a 2s timeout and failures are logged but never block the main command result.

Example output the agent would see:
```
curl: (56) Recv failure: Connection reset by peer
[exit code: 56]
[network proxy] Recent outbound request(s) denied by the sandbox proxy:
  google.com:443 denied
```

## Tests

- Added unit tests for `readNewDenyLogEntries()` — verifies new entries are returned and empty log returns empty array
- Added mock to `index.test.ts` for the new export
- All 10 tests pass across both test files

## Risk

Low. The deny log read is a single extra exec per command (only when egress forwarding is active). Failures are swallowed with a warning log — they never affect the main command result.

## Deploy Plan

Standard deploy. No config changes needed — the deny log file and offset marker are ephemeral sandbox files.