### PR TITLE
[front] enh: use of instructions-less skills when applicable

### DIFF
--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -52,6 +52,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
     owner,
     disabled: !isOpen,
     status: "active",
+    viewType: "summary",
   });
 
   // Debounce the search query to avoid expensive fuzzy filtering on every keystroke.

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -6,19 +6,19 @@ import {
 } from "@app/components/command_palette/CommandPaletteItems";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import { Avatar, SearchInput } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 
 export type CommandPaletteItem =
   | { kind: "agent"; agent: LightAgentConfigurationType }
-  | { kind: "skill"; skill: SkillType };
+  | { kind: "skill"; skill: SkillWithoutInstructionsAndToolsType };
 
 interface CommandPaletteSearchPhaseProps {
   searchQuery: string;
   onSearchQueryChange: (query: string) => void;
   agents: LightAgentConfigurationType[];
-  skills: SkillType[];
+  skills: SkillWithoutInstructionsAndToolsType[];
   hasMoreAgents: boolean;
   hasMoreSkills: boolean;
   isLoading: boolean;
@@ -30,7 +30,7 @@ interface CommandPaletteSearchPhaseProps {
 
 function getFlatItems(
   agents: LightAgentConfigurationType[],
-  skills: SkillType[]
+  skills: SkillWithoutInstructionsAndToolsType[]
 ): CommandPaletteItem[] {
   return [
     ...agents.map((agent): CommandPaletteItem => ({ kind: "agent", agent })),

--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -1,14 +1,12 @@
 import { LinkWrapper } from "@app/lib/platform";
 import { getSkillAvatarIcon } from "@app/lib/skill";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { LightWorkspaceType } from "@app/types/user";
 import { ExternalLinkIcon, Icon, Spinner } from "@dust-tt/sparkle";
-// biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React from "react";
 
 interface SimilarSkillsDisplayProps {
   owner: LightWorkspaceType;
-  similarSkills: SkillType[];
+  similarSkills: SkillWithoutInstructionsAndToolsType[];
   isLoading: boolean;
 }
 

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -10,7 +10,7 @@ import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBu
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useSimilarSkills, useSkills } from "@app/lib/swr/skill_configurations";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import { ArrowGoBackIcon, Button, cn } from "@dust-tt/sparkle";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
@@ -33,9 +33,11 @@ export function SkillBuilderAgentFacingDescriptionSection() {
     });
 
   const { getSimilarSkills } = useSimilarSkills({ owner });
-  const { skills } = useSkills({ owner });
+  const { skills } = useSkills({ owner, viewType: "summary" });
 
-  const [similarSkills, setSimilarSkills] = useState<SkillType[]>([]);
+  const [similarSkills, setSimilarSkills] = useState<
+    SkillWithoutInstructionsAndToolsType[]
+  >([]);
   const [isLoading, setIsLoading] = useState(false);
 
   const descriptionDiffers =

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -51,6 +51,7 @@ export function SkillInfoTab({
       status: "active",
       isDefault: true,
       disabled: !showDiscoverableSkills,
+      viewType: "summary",
     });
 
   const shouldLoadSpaces = skill.requestedSpaceIds.length > 0;


### PR DESCRIPTION
## Description

- A type for skills without instructions was introduced in https://github.com/dust-tt/dust/pull/24665
- Not fetching the instructions speeds up the query.
- This PR updates the command palette, the similar skills display and the Skill info page when opened on Discover Skills to fetch without instructions as we don't display them there (we only show the name, icon, description).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
