### PR TITLE
[front] feat: support Metronome-billed enterprise upgrade flow in poke

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -127,6 +127,7 @@ export function WorkspacePage() {
 
   const {
     activeSubscription,
+    hasMetronomeBilling,
     hasDummyFeature,
     membersCount,
     metronomeCustomerId,
@@ -227,6 +228,7 @@ export function WorkspacePage() {
                   subscription={activeSubscription}
                   subscriptions={subscriptions}
                   programmaticUsageConfig={programmaticUsageConfig}
+                  hasMetronomeBilling={hasMetronomeBilling}
                 />
               </TabsContent>
               <TabsContent value="planlimitations">

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -37,12 +37,14 @@ const MICRO_USD_PER_DOLLAR = 1_000_000;
 
 interface EnterpriseUpgradeDialogProps {
   owner: WorkspaceType;
+  hasMetronomeBilling: boolean;
   subscription: SubscriptionType;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
 }
 
 export default function EnterpriseUpgradeDialog({
   owner,
+  hasMetronomeBilling,
   subscription,
   programmaticUsageConfig,
 }: EnterpriseUpgradeDialogProps) {
@@ -69,8 +71,11 @@ export default function EnterpriseUpgradeDialog({
   const form = useForm<EnterpriseUpgradeFormType>({
     resolver: ioTsResolver(EnterpriseUpgradeFormSchema),
     defaultValues: {
-      stripeSubscriptionId: subscription.stripeSubscriptionId ?? "",
-      planCode: subscription.plan.code,
+      stripeSubscriptionId: !hasMetronomeBilling
+        ? (subscription.stripeSubscriptionId ?? "")
+        : undefined,
+      metronomeContractId: "",
+      planCode: "",
       freeCreditsOverrideEnabled: freeCreditMicroUsd !== null,
       freeCreditsDollars:
         freeCreditMicroUsd !== null
@@ -152,8 +157,11 @@ export default function EnterpriseUpgradeDialog({
         <DialogHeader>
           <DialogTitle>Upgrade {owner.name} to Enterprise.</DialogTitle>
           <DialogDescription>
-            Select the enterprise plan and provide the Stripe subscription id of
-            the customer.
+            Select the enterprise plan and provide the{" "}
+            {hasMetronomeBilling
+              ? "Metronome contract ID"
+              : "Stripe subscription Id"}{" "}
+            of the customer.
           </DialogDescription>
         </DialogHeader>
         <DialogContainer>
@@ -185,12 +193,21 @@ export default function EnterpriseUpgradeDialog({
                     />
                   </div>
                   <div className="grid-cols grid items-center gap-4">
-                    <InputField
-                      control={form.control}
-                      name="stripeSubscriptionId"
-                      title="Stripe Subscription id"
-                      placeholder="sub_1234567890"
-                    />
+                    {hasMetronomeBilling ? (
+                      <InputField
+                        control={form.control}
+                        name="metronomeContractId"
+                        title="Metronome Contract ID"
+                        placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                      />
+                    ) : (
+                      <InputField
+                        control={form.control}
+                        name="stripeSubscriptionId"
+                        title="Stripe Subscription id"
+                        placeholder="sub_1234567890"
+                      />
+                    )}
                   </div>
 
                   <div className="border-t pt-4">

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -164,6 +164,7 @@ export function SubscriptionsDataTable({
 
 interface ActiveSubscriptionTableProps {
   owner: WorkspaceType;
+  hasMetronomeBilling: boolean;
   metronomeCustomerId: string | null;
   subscription: SubscriptionType;
   subscriptions: SubscriptionType[];
@@ -172,6 +173,7 @@ interface ActiveSubscriptionTableProps {
 
 export function ActiveSubscriptionTable({
   owner,
+  hasMetronomeBilling,
   metronomeCustomerId,
   subscription,
   subscriptions,
@@ -197,6 +199,7 @@ export function ActiveSubscriptionTable({
             />
             <UpgradeDowngradeModal
               owner={owner}
+              hasMetronomeBilling={hasMetronomeBilling}
               subscription={subscription}
               programmaticUsageConfig={programmaticUsageConfig}
             />
@@ -428,12 +431,14 @@ export function PlanLimitationsTable({
 
 interface UpgradeDowngradeModalProps {
   owner: WorkspaceType;
+  hasMetronomeBilling: boolean;
   subscription: SubscriptionType;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
 }
 
 function UpgradeDowngradeModal({
   owner,
+  hasMetronomeBilling,
   subscription,
   programmaticUsageConfig,
 }: UpgradeDowngradeModalProps) {
@@ -555,6 +560,7 @@ function UpgradeDowngradeModal({
                 owner={owner}
                 subscription={subscription}
                 programmaticUsageConfig={programmaticUsageConfig}
+                hasMetronomeBilling={hasMetronomeBilling}
               />
             </div>
             {isProPlanPrefix(subscription.plan.code) && (

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -189,7 +189,7 @@ export interface EnterprisePricingCents {
   floorCents: number;
 }
 
-async function syncContractQuantities(
+export async function syncContractQuantities(
   metronomeCustomerId: string,
   metronomeContractId: string,
   workspace: LightWorkspaceType,

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -11,6 +11,7 @@ import {
 import {
   provisionEnterpriseMetronomeContract,
   switchMetronomeContractPackage,
+  syncContractQuantities,
 } from "@app/lib/metronome/contracts";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import {
@@ -538,6 +539,19 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     return res !== null;
   }
 
+  static async isMetronomeContractIdAlreadyUsed(
+    metronomeContractId: string
+  ): Promise<boolean> {
+    const res = await this.model.findOne({
+      where: { metronomeContractId },
+      // WORKSPACE_ISOLATION_BYPASS: Used to check across all workspaces.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+
+    return res !== null;
+  }
+
   static async internalFetchWorkspacesWithFreeEndedSubscriptions(): Promise<{
     workspaces: LightWorkspaceType[];
   }> {
@@ -729,7 +743,12 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   static async pokeUpgradeWorkspaceToEnterprise(
     auth: Authenticator,
     enterpriseDetails: EnterpriseUpgradeFormType,
-    stripeSubscription: Stripe.Subscription
+    stripeSubscription: Stripe.Subscription | null,
+    metronome?: {
+      metronomeCustomerId: string;
+      metronomeContractId: string;
+      startingAt: string;
+    }
   ) {
     const owner = auth.getNonNullableWorkspace();
 
@@ -738,6 +757,9 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     }
 
     const plan = await this.findPlanOrThrow(enterpriseDetails.planCode);
+    if (!isEntreprisePlanPrefix(plan.code)) {
+      throw new Error(`Plan ${plan.code} is not an enterprise plan.`);
+    }
     // End the current subscription if any.
     const newSubscription = await this.internalSubscribeWorkspaceToFreePlan({
       workspaceId: owner.sId,
@@ -752,34 +774,66 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       throw new Error(`Workspace not found: ${owner.sId}`);
     }
 
-    const metronomeResult = await provisionEnterpriseMetronomeContract({
-      workspace: renderLightWorkspaceType({ workspace: workspaceResource }),
-      stripeSubscription,
-    });
-    if (metronomeResult.isErr()) {
-      // Shadow-billed: Stripe owns billing, Metronome failure is not critical.
-      logger.error(
-        {
-          workspaceId: owner.sId,
-          error: metronomeResult.error.message,
-        },
-        "Failed to provision Metronome contract for enterprise upgrade"
-      );
-      return;
-    }
+    if (metronome) {
+      if (!workspaceResource.metronomeCustomerId) {
+        await WorkspaceResource.updateMetronomeCustomerId(
+          workspaceResource.id,
+          metronome.metronomeCustomerId
+        );
+      }
 
-    const { metronomeCustomerId, metronomeContractId } = metronomeResult.value;
+      await SubscriptionResource.updateMetronomeContractId(
+        newSubscription.id,
+        metronome.metronomeContractId
+      );
 
-    if (!workspaceResource.metronomeCustomerId) {
-      await WorkspaceResource.updateMetronomeCustomerId(
-        workspaceResource.id,
-        metronomeCustomerId
+      const syncResult = await syncContractQuantities(
+        metronome.metronomeCustomerId,
+        metronome.metronomeContractId,
+        renderLightWorkspaceType({ workspace: workspaceResource }),
+        metronome.startingAt
+      );
+
+      if (syncResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: owner.sId,
+            error: syncResult.error.message,
+          },
+          "Failed to sync initial seat/MAU quantities on Metronome contract"
+        );
+      }
+    } else if (stripeSubscription) {
+      const metronomeResult = await provisionEnterpriseMetronomeContract({
+        workspace: renderLightWorkspaceType({ workspace: workspaceResource }),
+        stripeSubscription,
+      });
+
+      if (metronomeResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: owner.sId,
+            error: metronomeResult.error.message,
+          },
+          "Failed to provision Metronome contract for enterprise upgrade"
+        );
+        return;
+      }
+
+      const { metronomeCustomerId, metronomeContractId } =
+        metronomeResult.value;
+
+      if (!workspaceResource.metronomeCustomerId) {
+        await WorkspaceResource.updateMetronomeCustomerId(
+          workspaceResource.id,
+          metronomeCustomerId
+        );
+      }
+      await SubscriptionResource.updateMetronomeContractId(
+        newSubscription.id,
+        metronomeContractId
       );
     }
-    await SubscriptionResource.updateMetronomeContractId(
-      newSubscription.id,
-      metronomeContractId
-    );
   }
 
   /**

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -6,9 +6,13 @@ import {
   upsertProgrammaticUsageConfiguration,
 } from "@app/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { startOrResumeEnterprisePAYG } from "@app/lib/credits/payg";
 import type { SessionWithUser } from "@app/lib/iam/provider";
+import {
+  findMetronomeCustomerByAlias,
+  getMetronomeContractById,
+} from "@app/lib/metronome/client";
 import {
   assertStripeSubscriptionIsValid,
   getStripeSubscription,
@@ -76,6 +80,11 @@ async function handler(
         }
       );
 
+      const useMetronomeBilling = await hasFeatureFlag(
+        auth,
+        "metronome_billing"
+      );
+
       const bodyValidation = EnterpriseUpgradeFormSchema.decode(req.body);
       if (isLeft(bodyValidation)) {
         const pathError = reporter.formatValidationErrors(bodyValidation.left);
@@ -91,64 +100,190 @@ async function handler(
       }
       const body = bodyValidation.right;
 
-      const stripeSubscription = await getStripeSubscription(
-        body.stripeSubscriptionId
-      );
-      if (!stripeSubscription) {
-        const errorMessage = "The Stripe subscription does not exist.";
-        await pluginRun.recordError(errorMessage);
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: errorMessage,
-          },
+      let metronome:
+        | {
+            metronomeCustomerId: string;
+            metronomeContractId: string;
+            startingAt: string;
+          }
+        | undefined = undefined;
+
+      if (useMetronomeBilling) {
+        if (!body.metronomeContractId) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "metronomeContractId is required when metronome_billing is enabled.",
+            },
+          });
+        }
+
+        const customerResult = await findMetronomeCustomerByAlias(owner.sId);
+        if (customerResult.isErr() || !customerResult.value) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "No Metronome customer found for this workspace.",
+            },
+          });
+        }
+
+        const metronomeCustomerId = customerResult.value;
+
+        const contractResult = await getMetronomeContractById({
+          metronomeCustomerId,
+          metronomeContractId: body.metronomeContractId,
         });
+
+        if (contractResult.isErr()) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Failed to retrieve Metronome contract: ${contractResult.error.message}`,
+            },
+          });
+        }
+
+        const contract = contractResult.value;
+
+        if (contract.archived_at) {
+          const errorMessage = "The Metronome contract is archived.";
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: errorMessage,
+            },
+          });
+        }
+
+        if (
+          contract.ending_before &&
+          new Date(contract.ending_before) <= new Date()
+        ) {
+          const errorMessage = "The Metronome contract has already ended.";
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: errorMessage,
+            },
+          });
+        }
+
+        if (!contract.customer_billing_provider_configuration) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "No billing provider configured on the Metronome contract. Configure billing before upgrading.",
+            },
+          });
+        }
+
+        const isContractAlreadyUsed =
+          await SubscriptionResource.isMetronomeContractIdAlreadyUsed(
+            body.metronomeContractId
+          );
+        if (isContractAlreadyUsed) {
+          const errorMessage =
+            "The Metronome contract ID is already used by an existing subscription.";
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: errorMessage,
+            },
+          });
+        }
+
+        metronome = {
+          metronomeCustomerId,
+          metronomeContractId: body.metronomeContractId,
+          startingAt: contract.starting_at,
+        };
       }
 
-      // Ensure the stripe subscription ID has not been used before (same or different workspace).
-      const isAlreadyUsed = await SubscriptionResource.isStripeIdAlreadyUsed(
-        stripeSubscription.id
-      );
+      let stripeSubscription = null;
+      if (!useMetronomeBilling) {
+        if (!body.stripeSubscriptionId) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "stripeSubscriptionId is required when metronome billing is not enabled.",
+            },
+          });
+        }
 
-      if (isAlreadyUsed) {
-        const errorMessage =
-          "The Stripe subscription ID is already used by an existing subscription.";
-        await pluginRun.recordError(errorMessage);
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: errorMessage,
-          },
-        });
-      }
+        stripeSubscription = await getStripeSubscription(
+          body.stripeSubscriptionId
+        );
+        if (!stripeSubscription) {
+          const errorMessage = "The Stripe subscription does not exist.";
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: errorMessage,
+            },
+          });
+        }
 
-      if (!isEnterpriseSubscription(stripeSubscription)) {
-        const errorMessage =
-          "The subscription provided is not an enterprise subscription.";
-        await pluginRun.recordError(errorMessage);
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: errorMessage,
-          },
-        });
-      }
+        // Ensure the stripe subscription ID has not been used before (same or different workspace).
+        const isAlreadyUsed = await SubscriptionResource.isStripeIdAlreadyUsed(
+          stripeSubscription.id
+        );
 
-      const assertValidSubscription =
-        assertStripeSubscriptionIsValid(stripeSubscription);
-      if (assertValidSubscription.isErr()) {
-        const errorMessage = assertValidSubscription.error.invalidity_message;
-        await pluginRun.recordError(errorMessage);
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: errorMessage,
-          },
-        });
+        if (isAlreadyUsed) {
+          const errorMessage =
+            "The Stripe subscription ID is already used by an existing subscription.";
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: errorMessage,
+            },
+          });
+        }
+
+        if (!isEnterpriseSubscription(stripeSubscription)) {
+          const errorMessage =
+            "The subscription provided is not an enterprise subscription.";
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: errorMessage,
+            },
+          });
+        }
+
+        const assertValidSubscription =
+          assertStripeSubscriptionIsValid(stripeSubscription);
+        if (assertValidSubscription.isErr()) {
+          const errorMessage = assertValidSubscription.error.invalidity_message;
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: errorMessage,
+            },
+          });
+        }
       }
 
       const programmaticConfigValidation =
@@ -206,13 +341,19 @@ async function handler(
         await SubscriptionResource.pokeUpgradeWorkspaceToEnterprise(
           auth,
           body,
-          stripeSubscription
+          stripeSubscription,
+          metronome
         );
         // Restore workspace functionality after subscription upgrade
         await restoreWorkspaceAfterSubscription(auth);
 
         // If PAYG is enabled, create the PAYG credit for the current billing period
-        if (paygEnabled && paygCapMicroUsd !== null) {
+        if (
+          !useMetronomeBilling &&
+          stripeSubscription &&
+          paygEnabled &&
+          paygCapMicroUsd !== null
+        ) {
           const paygResult = await startOrResumeEnterprisePAYG({
             auth,
             stripeSubscription,

--- a/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
+++ b/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
@@ -26,6 +26,7 @@ export type PokeGetWorkspaceInfo = {
   activeSubscription: SubscriptionType;
   baseUrl: string;
   extensionConfig: ExtensionConfigurationType | null;
+  hasMetronomeBilling: boolean;
   hasDummyFeature: boolean;
   membersCount: number;
   metronomeCustomerId: string | null;
@@ -96,6 +97,10 @@ async function handler(
       const programmaticUsageConfig =
         await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
 
+      const hasMetronomeBilling = await hasFeatureFlag(
+        auth,
+        "metronome_billing"
+      );
       const hasDummyFeature = await hasFeatureFlag(
         auth,
         "dummy_feature_for_flag_testing"
@@ -117,6 +122,7 @@ async function handler(
 
       return res.status(200).json({
         activeSubscription,
+        hasMetronomeBilling,
         hasDummyFeature,
         membersCount,
         metronomeCustomerId: workspaceResource.metronomeCustomerId ?? null,

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -126,12 +126,13 @@ export type CreatePlanFormType = t.TypeOf<typeof CreatePlanFormSchema>;
 
 export const EnterpriseUpgradeFormSchema = t.intersection([
   t.type({
-    stripeSubscriptionId: NonEmptyString,
     planCode: NonEmptyString,
     freeCreditsOverrideEnabled: t.boolean,
     paygEnabled: t.boolean,
   }),
   t.partial({
+    stripeSubscriptionId: NonEmptyString,
+    metronomeContractId: NonEmptyString,
     freeCreditsDollars: t.number,
     defaultDiscountPercent: t.number,
     paygCapDollars: t.number,


### PR DESCRIPTION
## Description

When the `metronome_billing` feature flag is enabled on a workspace, the enterprise upgrade dialog now collects a Metronome contract ID instead of a Stripe subscription ID. The API validates the contract exists and has a billing provider configured before upgrading. Upgrades to a simple plan, does not handle programmatic usage configuration.

https://github.com/dust-tt/tasks/issues/7723

## Tests

Local

## Risk

Low, gated by `metronome_billing` ff

## Deploy Plan

front
