### PR TITLE
Add wake-up maxFires and expiration after max fires

### DIFF
--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -26,6 +26,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Attributes, Transaction, WhereOptions } from "sequelize";
 
 const ACTIVE_WAKE_UP_STATUSES: WakeUpStatus[] = ["scheduled"];
+const MAX_WAKE_UP_FIRES = 32;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface WakeUpResource extends ReadonlyAttributesType<WakeUpModel> {}
@@ -284,6 +285,10 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     );
   }
 
+  maxFires(): number {
+    return MAX_WAKE_UP_FIRES;
+  }
+
   async markFired(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
@@ -292,16 +297,31 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       return;
     }
 
+    const nextFireCount = this.fireCount + 1;
     const nextStatus: WakeUpStatus =
-      this.scheduleType === "one_shot" ? "fired" : "scheduled";
+      this.scheduleType === "one_shot"
+        ? "fired"
+        : nextFireCount >= this.maxFires()
+          ? "expired"
+          : "scheduled";
 
     await this.update(
       {
-        fireCount: this.fireCount + 1,
+        fireCount: nextFireCount,
         status: nextStatus,
       },
       transaction
     );
+  }
+
+  async cleanupTemporalIfCronExpired(
+    auth: Authenticator
+  ): Promise<Result<void, Error>> {
+    if (this.scheduleType !== "cron" || this.status !== "expired") {
+      return new Ok(undefined);
+    }
+
+    return this.cancelTemporalWorkflow(auth);
   }
 
   async delete(
@@ -359,6 +379,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       reason: this.reason,
       status: this.status,
       fireCount: this.fireCount,
+      maxFires: this.maxFires(),
     };
   }
 

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -269,11 +269,22 @@ export async function runTriggeredAgentsActivity({
 }
 
 function buildWakeUpMessageContent(wakeUp: WakeUpType): string {
-  return `<dust_system>
-This is an automatic wake-up message for a previously scheduled follow-up using the wake-up tool.
-- Wake-up ID: ${wakeUp.sId}
-</dust_system>
-Wake-up reason: ${wakeUp.reason}`;
+  let content: string = "";
+
+  content = `<dust_system>\n`;
+  content += `This is an automatic wake-up message for a previously scheduled follow-up using the wake-up tool.\n`;
+  content += `- Wake-up ID: ${wakeUp.sId} [${wakeUp.scheduleConfig.type}]\n`;
+  if (wakeUp.scheduleConfig.type === "cron") {
+    content += `- Cron expression: ${wakeUp.scheduleConfig.cron}\n`;
+    content += `- Wake-up fireCount: ${wakeUp.fireCount + 1} / ${wakeUp.maxFires}\n`;
+    if (wakeUp.fireCount + 1 >= wakeUp.maxFires) {
+      content += `- Warning: This wake-up will be automatically expired after. Recreate a new wake-up if needed.\n`;
+    }
+  }
+  content += `</dust_system>\n`;
+  content += `Wake-up reason: ${wakeUp.reason}`;
+
+  return content;
 }
 
 export async function runWakeUpActivity({
@@ -361,6 +372,18 @@ export async function runWakeUpActivity({
   }
 
   await wakeUp.markFired(auth);
+
+  const cleanupRes = await wakeUp.cleanupTemporalIfCronExpired(auth);
+  if (cleanupRes.isErr()) {
+    logger.error(
+      {
+        wakeUpId,
+        workspaceId,
+        error: normalizeError(cleanupRes.error),
+      },
+      "Failed cleaning up wake-up temporal state after fire."
+    );
+  }
 }
 
 export async function expireWakeUpActivity({

--- a/front/types/assistant/wakeups.ts
+++ b/front/types/assistant/wakeups.ts
@@ -43,5 +43,6 @@ export const WakeUpSchema = z.object({
   reason: z.string(),
   status: WakeUpStatusSchema,
   fireCount: z.number(),
+  maxFires: z.number(),
 });
 export type WakeUpType = z.infer<typeof WakeUpSchema>;

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -58,9 +58,17 @@ classification, audit events, and the cron path.
 Create the cron Temporal path for wake-ups. Reuse the existing trigger schedule patterns where
 helpful.
 
-Status: in progress. This PR now implements Temporal Schedule creation / deletion in
-`front/temporal/triggers/wakeup_client.ts`. Remaining work is cron validation, recurring fire
-semantics (`fireCount`, expiry / max-fire policy), and cron-specific guardrails.
+Status: in progress. Current state:
+- Temporal Schedule creation / deletion is implemented in
+  `front/temporal/triggers/wakeup_client.ts`.
+- `WakeUpResource.maxFires()` (backed by `MAX_WAKE_UP_FIRES = 32`) is exposed on `WakeUpType`, and
+  `markFired(...)` transitions a cron wake-up to `expired` once `fireCount >= maxFires`.
+- The wake-up `<dust_system>` message includes `fireCount / maxFires` and an expiration warning
+  when the wake-up is about to expire.
+- `cleanupTemporalAfterFire(...)` deletes the Temporal schedule after the final fire.
+
+Remaining work: cron validation, cron-specific guardrails, and any further refinements of the
+recurring fire semantics.
 
 ## Milestone 4: Agent action
 

--- a/x/spolu/wakeup/wakeup.md
+++ b/x/spolu/wakeup/wakeup.md
@@ -14,8 +14,9 @@ wake-up fires, the agent resumes in the same conversation with full context. The
 supports one-shot delays ("in 2 hours"), absolute times ("at 2026-04-16T16:00Z"), and cron
 patterns ("0 9 * * MON-FRI").
 
-Current implementation status: the backend Temporal path is implemented for one-shot wake-ups only.
-Cron scheduling, the tool surface, API endpoints, and UI are still follow-up work.
+Current implementation status: the backend Temporal path is implemented for one-shot wake-ups, and
+cron wake-ups now have schedule create / delete plus `fireCount` / `maxFires` expiration. Cron
+validation and guardrails, the tool surface, API endpoints, and UI are still follow-up work.
 
 ## Design Overview
 
@@ -37,7 +38,7 @@ Cron scheduling, the tool surface, API endpoints, and UI are still follow-up wor
 │  - scheduleConfig (fireAt timestamp | cron+tz)              │
 │  - reason (injected in wake-up message + displayed in UI)   │
 │  - status: scheduled | fired | cancelled | expired          │
-│  - fireCount                                                │
+│  - fireCount / maxFires (MAX_WAKE_UP_FIRES = 32)            │
 └──────────────────────┬──────────────────────────────────────┘
                        │
                        ▼
@@ -64,7 +65,10 @@ Cron scheduling, the tool surface, API endpoints, and UI are still follow-up wor
 │     - doNotAssociateUser: true                              │
 │     - content: <dust_system> + "Wake-up reason: ..."        │
 │     - mentions: [{ configurationId: agentConfigurationId }] │
-│  5. fireCount++ and one_shot → status = fired               │
+│  5. fireCount++ and:                                        │
+│     - one_shot → status = fired                             │
+│     - cron + fireCount >= maxFires → status = expired       │
+│       + delete Temporal schedule                            │
 │  6. Missing / inaccessible conversation → cancelled         │
 │     Retry exhaustion / timeout → expired                    │
 └─────────────────────────────────────────────────────────────┘
@@ -105,13 +109,19 @@ Wraps `WakeUpModel`. Key methods:
 - `makeNew(auth, { conversationId, agentConfigurationId, scheduleType, ... })` — creates the row
   and starts the Temporal workflow.
 - `cancel(auth)` — cancels the Temporal workflow and sets status to `cancelled`.
-- `markFired()` — increments `fireCount`, updates status for one-shot.
+- `markFired()` — increments `fireCount` and updates status:
+  - `one_shot` → `fired`
+  - `cron` + `fireCount >= maxFires()` → `expired`
+  - `cron` otherwise → stays `scheduled`
 - `markExpired()` — sets status to `expired`.
+- `maxFires()` — returns the constant `MAX_WAKE_UP_FIRES` (currently 32).
+- `cleanupTemporalAfterFire(auth)` — deletes the Temporal schedule for cron wake-ups once they
+  have reached `expired`.
 - `listByConversation(auth, conversationId)` — for UI display.
 - `listActiveByWorkspace(auth)` — for guardrail checks.
 - `fetchWakeUpAndAuthenticatorById({ workspaceId, wakeUpId })` — resolves the wake-up and the
   wake-up owner's authenticator for Temporal activities.
-- `toJSON()` — serializes to the shared `WakeUpType` shape.
+- `toJSON()` — serializes to the shared `WakeUpType` shape (including `fireCount` and `maxFires`).
 
 Also define shared Zod-backed types in `front/types/assistant/wakeups.ts`:
 
@@ -143,8 +153,10 @@ Current retry policy:
 - non-retryable error type: `WakeUpNonRetryableError`
 
 Cron wake-ups are partially implemented. `launchOrScheduleWakeUpTemporalWorkflow(...)` can now
-create a Temporal Schedule for `scheduleType: "cron"`, and
-`cancelWakeUpTemporalWorkflow(...)` can delete it. Recurring fire semantics remain follow-up work.
+create a Temporal Schedule for `scheduleType: "cron"`, and `cancelWakeUpTemporalWorkflow(...)` can
+delete it. Recurring fire semantics now track `fireCount / maxFires` and automatically expire the
+wake-up once the fire count reaches `maxFires`; the Temporal schedule is deleted after the final
+fire via `cleanupTemporalAfterFire(...)`.
 
 ### `runWakeUpActivity` (current, in `front/temporal/triggers/activities.ts`)
 
@@ -153,15 +165,19 @@ create a Temporal Schedule for `scheduleType: "cron"`, and
 2. Verify `status === "scheduled"`.
 3. Fetch the conversation resource and then the full conversation with `getConversation(...)`.
 4. Call `postUserMessage(...)` with:
-   - a `<dust_system>` block containing the wake-up sId
+   - a `<dust_system>` block containing the wake-up sId, `fireCount / maxFires`, and (when the
+     wake-up is about to reach `maxFires`) an expiration warning
    - `Wake-up reason: {reason}`
    - `context.origin: "wakeup"`
    - `context.username: "Dust"`
    - `doNotAssociateUser: true`
    - `mentions: [{ configurationId: wakeUp.agentConfigurationId }]`
-5. Mark the wake-up as fired on success.
-6. Mark the wake-up as cancelled when the conversation is missing or inaccessible.
-7. Let Temporal retry posting failures. If retries are exhausted, `expireWakeUpActivity(...)`
+5. Mark the wake-up as fired on success (`markFired(...)` handles one-shot vs cron and the
+   `fireCount >= maxFires` expiration transition).
+6. For cron wake-ups that have just expired, call `cleanupTemporalAfterFire(...)` to delete the
+   Temporal schedule.
+7. Mark the wake-up as cancelled when the conversation is missing or inaccessible.
+8. Let Temporal retry posting failures. If retries are exhausted, `expireWakeUpActivity(...)`
    marks the wake-up as expired.
 
 ## Agent Skill Interface
@@ -319,7 +335,8 @@ When a wake-up fires:
    `WakeUpModel` rows explicitly.
 
 3. **Wake-up message content**: The current implementation posts a `<dust_system>` block that
-   includes the wake-up sId, followed by `Wake-up reason: {reason}`.
+   includes the wake-up sId and `fireCount / maxFires`, and an expiration warning when the
+   wake-up is about to reach `maxFires`, followed by `Wake-up reason: {reason}`.
 
 4. **Billing**: Wake-up fires count as programmatic usage, same treatment as trigger-fired
    messages.
@@ -332,10 +349,10 @@ When a wake-up fires:
 
 - In the current codebase, `schedule_wakeup` should be wired through the internal MCP tool
   architecture rather than a legacy `front/lib/api/assistant/agent_action.ts` registry.
-- The current implementation can create / delete cron schedules, but recurring fire semantics are
-  still incomplete. A follow-up should define cron validation, `fireCount`, and expiry / max-fire
-  behavior clearly.
-- The current PR does not add explicit duplicate-fire protection yet. A follow-up should define the
+- The current implementation can create / delete cron schedules, tracks `fireCount / maxFires`,
+  and automatically expires cron wake-ups once `fireCount >= maxFires`. Remaining cron work is
+  cron validation and cron-specific guardrails.
+- Explicit duplicate-fire protection is not implemented. A follow-up should define the
   idempotency story clearly.
 - Cancel-vs-fire races are still best-effort today and should be tightened in `WakeUpResource`.
 - The current implementation retries generic posting failures and expires after retry exhaustion.


### PR DESCRIPTION
## Summary

- add `maxFires` on `WakeUpResource` (backed by a `MAX_WAKE_UP_FIRES = 32` constant) and expose it on `WakeUpType`
- expire cron wake-ups automatically once `fireCount` reaches `maxFires` and clean up the Temporal schedule
- include `fireCount / maxFires` and an expiration warning in the wake-up `<dust_system>` message when the wake-up is about to expire

## Testing

N/A for now

## Risks

None

## Deploy

- deploy `front`