### PR TITLE
refactor(project): improve takeaway extraction prompts and expand eval test coverage

### DIFF
--- a/front/lib/project_todo/analyze_document/action_items.ts
+++ b/front/lib/project_todo/analyze_document/action_items.ts
@@ -38,21 +38,35 @@ export function buildPromptActionItems(
   previousActionItems: TodoVersionedActionItem[]
 ): string {
   let prompt =
-    "You are a document analyst. Your job is to extract action items from a document.\n\n" +
     "Action item guidelines:\n" +
-    "- An action item is a concrete task that someone committed to doing, or was asked to do.\n" +
+    "Most documents contain few or no action items. Prefer fewer, high-confidence items " +
+    "over a noisy list. When in doubt, leave it out.\n\n" +
+    "Only extract an action item if it passes ALL four tests:\n" +
+    "1. **Commitment**: someone explicitly committed to doing a concrete task, or was " +
+    "clearly asked to do one. Only extract tasks with a clear deliverable — 'I'll fix X' " +
+    "qualifies, 'I'll think about it' does not.\n" +
+    "2. **Durability**: the task is still relevant — if it was already resolved within " +
+    "the same conversation, set status to 'done'; if the request was immediately " +
+    "fulfilled inline (e.g., answering a question), do not extract it at all.\n" +
+    "3. **Distinctness**: it is not a duplicate of another action item or a rephrasing " +
+    "of a key decision.\n" +
+    "4. **Relevance**: the task is work-related and project-relevant. Purely social plans " +
+    "(birthday lunches, personal events, casual meetups) are not action items even if someone " +
+    "commits to arranging them.\n\n" +
+    "Formatting rules:\n" +
     "- If an action item was explicitly completed or resolved in the document, set status to 'done'.\n" +
     "- Include an assignee_name only when clearly stated in the document.\n" +
     "- Include an assignee_user_id (from the project members list) when the assignee matches a known project member.\n" +
     "- Be concise: one action item per distinct task.\n" +
     "- In the description, mention users and agents by their name, NOT via their id or via a generic term like User, Agent or Bot.\n" +
-    "- In the description, refer to the assignee by Your pronouns (e.g., 'You', 'Your', 'Yours'), not by their name.\n" +
-    "- Do not include vague or aspirational items — only concrete commitments.\n\n";
+    "- In the description, refer to the assignee by Your pronouns (e.g., 'You', 'Your', 'Yours'), not by their name.\n\n";
   if (previousActionItems.length > 0) {
     prompt +=
-      "The following action items were detected in a previous analysis of this document. " +
-      "If you detect the same task again, copy its sId exactly into the output, update the other fields when appropriate. " +
-      "Omit the sId field for brand-new tasks that were not previously tracked.\n\n" +
+      "The following action items were tracked in a previous analysis of this document. " +
+      "You MUST always include ALL previously tracked items in your output — never drop them. " +
+      "For each previously tracked item: copy its sId verbatim and update status or description " +
+      "only when the document explicitly provides new information (e.g., the assignee reports it is done). " +
+      "Omit the sId field only for brand-new tasks that were not previously tracked.\n\n" +
       "Known action items:\n";
     for (const item of previousActionItems) {
       prompt += `<action_item sId="${item.sId}" status="${item.status}">`;

--- a/front/lib/project_todo/analyze_document/key_decisions.ts
+++ b/front/lib/project_todo/analyze_document/key_decisions.ts
@@ -30,10 +30,23 @@ export function buildPromptKeyDecisions(
 ): string {
   let prompt =
     "Key decision guidelines:\n" +
-    "- A key decision is a choice or resolution that was explicitly made in the document " +
-    "(e.g., a technical approach chosen, a scope change agreed upon, a trade-off accepted).\n" +
-    "- Set status to 'decided' if the decision is finalized, 'open' if it is still being deliberated.\n" +
-    "- Do not include minor preferences or passing comments — only significant, consequential decisions.\n" +
+    "Most conversations contain zero key decisions. Only extract one if it clearly passes " +
+    "the tests below. Prefer zero over a noisy list.\n\n" +
+    "Only extract a key decision if it passes ALL three tests:\n" +
+    "1. **Impact**: would reversing this decision require a new team discussion? If not, it's " +
+    "a preference or implementation detail, not a key decision. Examples that do NOT qualify: " +
+    "choosing which algorithm to use for a bug fix, deciding how to structure one person's task, " +
+    "picking a cron job approach for a nightly export, switching a query's pagination type.\n" +
+    "2. **Explicitness**: the team must have explicitly decided — not just passively acknowledged. " +
+    "Casual bystander reactions like 'Sounds good', 'Makes sense to me', or 'Good idea' do NOT " +
+    "constitute an explicit decision. Look for deliberate agreement: 'we decided', 'we've agreed', " +
+    "'we'll go with', or formal confirmation (e.g., confirmed in an all-hands or official meeting).\n" +
+    "3. **Scope**: it affects how the whole project or team operates, not just how one person " +
+    "handles their current task. Architecture choices, process changes, tooling adoptions, and " +
+    "strategic commitments qualify. Individual implementation choices do not.\n\n" +
+    "Set status to 'decided' if the decision is finalized, 'open' if it is still being " +
+    "deliberated.\n\n" +
+    "Formatting rules:\n" +
     "- In the description, mention users and agents by their name, NOT via their id or " +
     "via a generic term like User, Agent or Bot.\n" +
     "- Write each description as an objective factual statement. Name people by their actual " +
@@ -42,9 +55,11 @@ export function buildPromptKeyDecisions(
     "- Include relevant_user_ids (from the project members list) for people involved in making this decision.\n\n";
   if (previousKeyDecisions.length > 0) {
     prompt +=
-      "The following key decisions were detected in a previous analysis of this document. " +
-      "If you detect the same decision again, copy its sId exactly into the output, update the other fields when appropriate. " +
-      "Omit the sId field for brand-new decisions that were not previously tracked.\n\n" +
+      "The following key decisions were tracked in a previous analysis of this document. " +
+      "You MUST always include ALL previously tracked decisions in your output — never drop them. " +
+      "For each previously tracked decision: copy its sId verbatim and update status or description " +
+      "only when the document provides new information about it. " +
+      "Omit the sId field only for brand-new decisions not previously tracked.\n\n" +
       "Known key decisions:\n";
     for (const decision of previousKeyDecisions) {
       prompt += `<key_decision sId="${decision.sId}" status="${decision.status}">`;

--- a/front/lib/project_todo/analyze_document/notable_facts.ts
+++ b/front/lib/project_todo/analyze_document/notable_facts.ts
@@ -28,18 +28,27 @@ export function buildPromptNotableFacts(
 ): string {
   let prompt =
     "Notable fact guidelines:\n" +
-    "- A notable fact is a piece of information that would change how a project member " +
-    "plans their work or makes decisions. Good examples: deadlines discovered, technical " +
-    "constraints found, dependency changes, risks identified, scope clarifications, " +
-    "important metrics or thresholds.\n" +
-    "- Be concise and specific — one fact per distinct piece of information.\n" +
-    "- Do NOT extract: casual remarks, greetings, scheduling small-talk ('I'll be 5 min late'), " +
-    "information obvious from the project description, facts already captured as action items " +
-    "or key decisions, questions that were already answered in the conversation, or " +
-    "time-sensitive facts that will be irrelevant within 24 hours (e.g., 'server is currently " +
-    "down', 'waiting for a reply').\n" +
-    "- In the description, mention users and agents by their name, NOT via their id or " +
-    "via a generic term like User, Agent or Bot.\n" +
+    "Most information in a document is NOT a notable fact. Prefer zero notable facts over " +
+    "a noisy list. When in doubt, leave it out.\n\n" +
+    "Only extract a fact if it passes ALL three tests:\n" +
+    "1. **Actionability**: it would concretely change how a project member plans their work " +
+    "or makes a decision. Good examples: deadlines discovered, technical constraints found, " +
+    "dependency changes, risks identified, important metrics or thresholds.\n" +
+    "2. **Durability**: a new project member joining two weeks from now would still benefit " +
+    "from knowing it. Transient context does NOT qualify — skip: who is OoO today, errors " +
+    "that occurred during an incident, how a UI element works. " +
+    "If the fact only mattered during the conversation itself, it is not durable.\n" +
+    "3. **Novelty**: it is not already captured as an action item, a key decision, or " +
+    "obvious from the project description.\n\n" +
+    "Examples of what are NOT notable facts:\n" +
+    "- 'The + symbol shows there are more members than displayed' — UI clarification, not project knowledge.\n" +
+    "- 'The traffic spike from a marketing campaign caused the outage' — transient incident context.\n" +
+    "- 'The member display component needs calibration' — short-lived observation resolved in the thread.\n\n" +
+    "Formatting rules:\n" +
+    "- Be concise and specific — one fact per distinct piece of information. Do not combine " +
+    "multiple facts into a single entry.\n" +
+    "- Mention users and agents by their name, NOT via their id or via a generic term " +
+    "like User, Agent or Bot.\n" +
     "- Write each description as an objective factual statement. Name people by their actual " +
     "name when relevant. Do not use 'You' or 'Your' — these items are shown to all project " +
     "members, not just one person.\n" +
@@ -47,9 +56,11 @@ export function buildPromptNotableFacts(
     "relevant to or was stated by.\n\n";
   if (previousNotableFacts.length > 0) {
     prompt +=
-      "The following notable facts were detected in a previous analysis of this document. " +
-      "If you detect the same fact again, copy its sId exactly into the output, update the other fields when appropriate. " +
-      "Omit the sId field for brand-new facts that were not previously tracked.\n\n" +
+      "The following notable facts were tracked in a previous analysis of this document. " +
+      "You MUST always include ALL previously tracked facts in your output — never drop them. " +
+      "For each previously tracked fact: copy its sId verbatim and update the description " +
+      "only when the document provides new information about it. " +
+      "Omit the sId field only for brand-new facts not previously tracked.\n\n" +
       "Known notable facts:\n";
     for (const fact of previousNotableFacts) {
       prompt += `<notable_fact sId="${fact.sId}">`;

--- a/front/lib/project_todo/analyze_document/prompts.ts
+++ b/front/lib/project_todo/analyze_document/prompts.ts
@@ -29,7 +29,9 @@ export function buildPromptForSourceType(
         "or tasks that a human explicitly stated they need to do outside the thread.\n" +
         "- A user asking the bots to do something (e.g., 'can you check X?', 'please look into Y') " +
         "is NOT an action item — it is a query being handled in real-time by the bots.\n" +
-        "- Assignees and relevant users must always be human participants, never the bots.\n\n"
+        "- Assignees and relevant users must always be human participants, never the bots.\n" +
+        "- Short troubleshooting threads often have one action item at most and rarely contain " +
+        "notable facts or key decisions. Do not over-extract from casual back-and-forth.\n\n"
       );
     case "notion":
       return (

--- a/front/tests/takeaway-evals/lib/assertions.ts
+++ b/front/tests/takeaway-evals/lib/assertions.ts
@@ -104,11 +104,41 @@ export function validateTakeawayAssertion(
       return { success: true };
     }
 
+    case "minNotableFacts": {
+      if (result.notableFacts.length < assertion.count) {
+        return {
+          success: false,
+          error: `Expected at least ${assertion.count} notable facts, but got ${result.notableFacts.length}`,
+        };
+      }
+      return { success: true };
+    }
+
     case "maxActionItems": {
       if (result.actionItems.length > assertion.count) {
         return {
           success: false,
           error: `Expected at most ${assertion.count} action items, but got ${result.actionItems.length}`,
+        };
+      }
+      return { success: true };
+    }
+
+    case "maxKeyDecisions": {
+      if (result.keyDecisions.length > assertion.count) {
+        return {
+          success: false,
+          error: `Expected at most ${assertion.count} key decisions, but got ${result.keyDecisions.length}`,
+        };
+      }
+      return { success: true };
+    }
+
+    case "maxNotableFacts": {
+      if (result.notableFacts.length > assertion.count) {
+        return {
+          success: false,
+          error: `Expected at most ${assertion.count} notable facts, but got ${result.notableFacts.length}`,
         };
       }
       return { success: true };

--- a/front/tests/takeaway-evals/lib/types.ts
+++ b/front/tests/takeaway-evals/lib/types.ts
@@ -48,7 +48,10 @@ export type TakeawayAssertion =
       status?: "decided" | "open";
     }
   | { type: "minActionItems"; count: number }
+  | { type: "minNotableFacts"; count: number }
   | { type: "maxActionItems"; count: number }
+  | { type: "maxNotableFacts"; count: number }
+  | { type: "maxKeyDecisions"; count: number }
   | {
       type: "shouldPreserveSId";
       category: "actionItem" | "notableFact" | "keyDecision";
@@ -96,8 +99,20 @@ export function minActionItems(count: number): TakeawayAssertion {
   return { type: "minActionItems", count };
 }
 
+export function minNotableFacts(count: number): TakeawayAssertion {
+  return { type: "minNotableFacts", count };
+}
+
 export function maxActionItems(count: number): TakeawayAssertion {
   return { type: "maxActionItems", count };
+}
+
+export function maxNotableFacts(count: number): TakeawayAssertion {
+  return { type: "maxNotableFacts", count };
+}
+
+export function maxKeyDecisions(count: number): TakeawayAssertion {
+  return { type: "maxKeyDecisions", count };
 }
 
 export function shouldPreserveSId(

--- a/front/tests/takeaway-evals/test-suites/action-items.ts
+++ b/front/tests/takeaway-evals/test-suites/action-items.ts
@@ -1,5 +1,7 @@
 import {
   maxActionItems,
+  maxKeyDecisions,
+  maxNotableFacts,
   shouldExtractActionItem,
   shouldNotAssignTo,
   shouldNotExtractActionItem,
@@ -82,7 +84,7 @@ Score 3 if all 3 items extracted with correct assignees and open status.`,
         }),
         shouldNotExtractActionItem("look into"),
         shouldNotExtractActionItem("check for errors"),
-        maxActionItems(2),
+        maxActionItems(1),
       ],
       judgeCriteria: `This is a conversation with an AI agent. The agent's offer to "look into logs"
 and "check for errors" is NOT an action item — it's being handled in real-time.
@@ -223,6 +225,43 @@ Score 0 if vague items are extracted as action items.
 Score 1 if the hotfix is missing.
 Score 2 if the hotfix is extracted but vague items also appear.
 Score 3 if only the hotfix is extracted as an action item.`,
+    },
+
+    // ── No inline completion should be registered ──────────────────────────────
+
+    {
+      scenarioId: "no-inline-completion-done",
+      document: {
+        id: "doc-6",
+        title: "Morning update",
+        type: "slack",
+        text: [
+          "Alice: Quick update — I fixed the login bug this morning, the patch is live.",
+          "Bob: Thanks! I also deployed the rate limiter changes yesterday evening.",
+          "Alice: Nice. Bob, can you also update the runbook with the new rate limits?",
+        ].join("\n"),
+        uri: "https://example.com/doc-6",
+      },
+      members: [
+        { sId: "user-alice", fullName: "Alice Martin", email: "alice@co.com" },
+        { sId: "user-bob", fullName: "Bob Chen", email: "bob@co.com" },
+      ],
+      expectedAssertions: [
+        shouldExtractActionItem("runbook", {
+          assigneeUserId: "user-bob",
+          status: "open",
+        }),
+        maxActionItems(1),
+        maxNotableFacts(0),
+        maxKeyDecisions(0),
+      ],
+      judgeCriteria: `One new task assigned:
+- Bob asked to update the runbook (open)
+
+No notable facts or key decisions should be extracted from this status update.
+
+Score 0 if no tasks are extracted as open.
+Score 3 if the task item are correct with right statuses and no spurious extractions.`,
     },
   ],
 };

--- a/front/tests/takeaway-evals/test-suites/key-decisions.ts
+++ b/front/tests/takeaway-evals/test-suites/key-decisions.ts
@@ -1,6 +1,7 @@
 import {
+  maxKeyDecisions,
+  maxNotableFacts,
   shouldExtractKeyDecision,
-  shouldNotExtractActionItem,
   type TakeawayTestSuite,
 } from "@app/tests/takeaway-evals/lib/types";
 
@@ -30,6 +31,7 @@ export const keyDecisionsSuite: TakeawayTestSuite = {
       ],
       expectedAssertions: [
         shouldExtractKeyDecision("PostgreSQL", { status: "decided" }),
+        maxKeyDecisions(1),
       ],
       judgeCriteria: `The team explicitly decided on PostgreSQL. This should be extracted
 as a key decision with status "decided".
@@ -61,6 +63,7 @@ Score 3 if correctly extracted with status "decided".`,
       ],
       expectedAssertions: [
         shouldExtractKeyDecision("cache", { status: "open" }),
+        maxKeyDecisions(1),
       ],
       judgeCriteria: `The team is deliberating between Redis and Memcached but has not
 decided yet. This should be a key decision with status "open".
@@ -92,7 +95,7 @@ Score 3 if correctly extracted with status "open".`,
       ],
       expectedAssertions: [
         shouldExtractKeyDecision("Kubernetes", { status: "decided" }),
-        shouldNotExtractActionItem("single quotes"),
+        maxKeyDecisions(1),
       ],
       judgeCriteria: `The single quotes preference is trivial and should NOT be a key decision.
 The Kubernetes migration is a significant architectural decision and should be extracted.
@@ -101,6 +104,73 @@ Score 0 if the single quotes preference is extracted as a key decision.
 Score 1 if the K8s decision is missing.
 Score 2 if both the K8s decision is correct and trivial preference is excluded.
 Score 3 if only the K8s migration is extracted as a decided key decision.`,
+    },
+
+    // ── Implicit consensus should NOT be a decision ──────────────────────────
+
+    {
+      scenarioId: "implicit-consensus-excluded",
+      document: {
+        id: "doc-kd-4",
+        title: "Standup thread",
+        type: "slack",
+        text: [
+          "Alice: I'm going to use a cron job for the nightly data export.",
+          "Bob: Sounds good.",
+          "Carol: Makes sense to me.",
+        ].join("\n"),
+        uri: "https://example.com/doc-kd-4",
+      },
+      members: [
+        { sId: "user-alice", fullName: "Alice Martin", email: "alice@co.com" },
+        { sId: "user-bob", fullName: "Bob Chen", email: "bob@co.com" },
+        { sId: "user-carol", fullName: "Carol Davis", email: "carol@co.com" },
+      ],
+      expectedAssertions: [maxKeyDecisions(0), maxNotableFacts(0)],
+      judgeCriteria: `Alice states she'll use a cron job and others casually agree. This is an
+implementation detail with implicit consensus, not an explicit key decision.
+No one said "we decided" — just "sounds good."
+
+Score 0 if a key decision is extracted about cron jobs.
+Score 1 if a notable fact or action item is extracted about the cron job approach.
+Score 2 if the cron job is not extracted as a key decision but other spurious items appear.
+Score 3 if no key decisions or notable facts are extracted (action item for Alice is acceptable).`,
+    },
+
+    // ── Implementation detail vs. project decision ───────────────────────────
+
+    {
+      scenarioId: "implementation-detail-excluded",
+      document: {
+        id: "doc-kd-5",
+        title: "Bug fix discussion",
+        type: "slack",
+        text: [
+          "Alice: The pagination is broken on the dashboard — it shows duplicate rows when sorting.",
+          "Bob: I think the issue is the cursor-based pagination. Let's switch to offset-based for this query.",
+          "Alice: Good idea. Also, the team leads decided yesterday to adopt a two-week release cadence starting in May.",
+          "Carol: Yes, that was confirmed in the all-hands.",
+        ].join("\n"),
+        uri: "https://example.com/doc-kd-5",
+      },
+      members: [
+        { sId: "user-alice", fullName: "Alice Martin", email: "alice@co.com" },
+        { sId: "user-bob", fullName: "Bob Chen", email: "bob@co.com" },
+        { sId: "user-carol", fullName: "Carol Davis", email: "carol@co.com" },
+      ],
+      expectedAssertions: [
+        shouldExtractKeyDecision("release cadence", { status: "decided" }),
+        maxKeyDecisions(1),
+      ],
+      judgeCriteria: `Two potential decisions here, but only one qualifies:
+- Switching to offset-based pagination is an implementation detail for a specific bug fix —
+  reversing it wouldn't require a team discussion, so it's NOT a key decision.
+- Adopting a two-week release cadence is a project-level decision confirmed in an all-hands.
+
+Score 0 if the pagination fix is extracted as a key decision.
+Score 1 if the release cadence decision is missing.
+Score 2 if both are extracted (over-extraction).
+Score 3 if only the release cadence is extracted as a decided key decision.`,
     },
   ],
 };

--- a/front/tests/takeaway-evals/test-suites/mixed-extraction.ts
+++ b/front/tests/takeaway-evals/test-suites/mixed-extraction.ts
@@ -1,8 +1,11 @@
 import {
+  maxKeyDecisions,
+  maxNotableFacts,
   minActionItems,
   shouldExtractActionItem,
   shouldExtractKeyDecision,
   shouldExtractNotableFact,
+  shouldPreserveSId,
   type TakeawayTestSuite,
 } from "@app/tests/takeaway-evals/lib/types";
 
@@ -47,18 +50,17 @@ export const mixedExtractionSuite: TakeawayTestSuite = {
           assigneeUserId: "user-alice",
         }),
         shouldExtractNotableFact("100 requests"),
-        shouldExtractNotableFact("72%"),
         shouldExtractKeyDecision("batching", { status: "decided" }),
       ],
       judgeCriteria: `A rich meeting with all three categories present:
 - Action items: Bob (payment), Carol (email notifications), Alice (CI check)
-- Notable facts: Stripe rate limit (100 req/s), current test coverage (72%)
+- Notable fact: Stripe rate limit (100 req/s). The 72% coverage is ephemeral and acceptable to skip.
 - Key decision: implement request batching (decided)
 
 Score 0 if fewer than 2 categories have correct extractions.
 Score 1 if action items are partially correct but other categories are missing.
 Score 2 if most items are correct across all categories.
-Score 3 if all action items, notable facts, and the key decision are correctly extracted.`,
+Score 3 if all action items, the Stripe rate limit fact, and the key decision are correctly extracted.`,
     },
 
     // ── Empty/minimal document ────────────────────────────────────────────────
@@ -152,6 +154,8 @@ Score 3 if completely empty extraction (ideal for this scenario).`,
         shouldExtractActionItem("payment", { status: "done" }),
         shouldExtractActionItem("email", { status: "open" }),
         shouldExtractActionItem("monitoring"),
+        shouldPreserveSId("actionItem", "prev-ai-1"),
+        shouldPreserveSId("actionItem", "prev-ai-2"),
       ],
       judgeCriteria: `IMPORTANT CONTEXT: This is a re-analysis scenario. The system was given a
 previous version of extracted takeaways (action items, notable facts, key decisions) and is
@@ -172,6 +176,53 @@ Score 0 if action item status transitions are wrong (payment not marked done, or
 Score 1 if statuses are partially correct or the new monitoring item is missing.
 Score 2 if all three action items are present with correct statuses.
 Score 3 if action items are perfect and carried-forward notable facts/decisions are reasonable.`,
+    },
+
+    // ── Small amount of items detected ────────────────────────────────────────
+    {
+      scenarioId: "real-world-bug-report-thread",
+      document: {
+        id: "slack-C09T7N4S6GG-thread-1776758009.764779",
+        title: "initiative-projects-thread-2026-04-21_07h53",
+        type: "slack",
+        text: "$title: Thread in #initiative-projects: @seb the + button not working on team bi-weekly project (top right) Attached file : Screenshot 2026-04-21 at 09.53.09.png ( imag...\n$createdAt: 2026-04-21T07:53:29.000Z\n$updatedAt: 2026-04-21T09:22:09.000Z\n>> @Ambra [20260421 07:53]:\n@seb the + button not working on team bi-weekly project (top right)\nAttached file : Screenshot 2026-04-21 at 09.53.09.png ( image/png )\n>> @rcs [20260421 08:00]:\nSeb is OoO.\n\nIt's not a button, it's to show that there are more members of the project.\nAttached file : image.png ( image/png )\n>> @rcs [20260421 08:01]:\nCould you invite me to the project so I can have a look? I suppose it's a display issue when the number is bigger than 9\n>> @ed [20260421 08:15]:\n@rcs also, I think the component is not super well calibrated to display that many people, mlaybe reduce to 5 max?\n>> @rcs [20260421 08:16]:\nYeah, it's too small. I'll fix both at the same time!\n>> @rcs [20260421 08:25]:\n@Ambra I confirm it means \"there are more than 10 people not showed\". I'll think of something to improve it\n>> @rcs [20260421 09:22]:\nBoth are fixed =&gt; <https://github.com/dust-tt/dust/pull/24610>\n",
+        uri: "https://dust4ai.slack.com/archives/C09T7N4S6GG/p1776758009764779?thread_ts=1776758009.764779&cid=C09T7N4S6GG",
+      },
+      members: [
+        { sId: "user-seb", fullName: "Sébastien Flory", email: "seb@dust.tt" },
+        {
+          sId: "user-rcs",
+          fullName: "Rémy-Christophe Schermesser",
+          email: "rcs@dust.tt",
+        },
+        {
+          sId: "user-ed",
+          fullName: "Edouard Wautier",
+          email: "ed@dust.tt",
+        },
+      ],
+      expectedAssertions: [
+        minActionItems(1),
+        shouldExtractActionItem("display", {
+          assigneeUserId: "user-rcs",
+          status: "done",
+        }),
+        maxNotableFacts(0),
+        maxKeyDecisions(1),
+      ],
+      judgeCriteria: `A real-world Slack thread about a UI bug on the project members display.
+This is a short troubleshooting thread — sparse extraction is ideal.
+
+- Action item: rcs fixed the display issue (done — PR 24610 merged). This is the only
+  clearly extractable takeaway.
+- Notable facts: none expected. The conversation is debugging context, not durable knowledge.
+- Key decision: reducing displayed avatars to 5 max is acceptable but optional — it's a
+  minor UI tweak, not a project-level decision.
+
+Score 0 if the action item is missing or assigned to the wrong person.
+Score 1 if the action item is present but not marked as done, or multiple spurious items extracted.
+Score 2 if the action item is correct with status done and extraction is sparse.
+Score 3 if only the action item is extracted (and optionally the 5-max key decision), with zero notable facts.`,
     },
   ],
 };

--- a/front/tests/takeaway-evals/test-suites/notable-facts.ts
+++ b/front/tests/takeaway-evals/test-suites/notable-facts.ts
@@ -1,4 +1,6 @@
 import {
+  maxKeyDecisions,
+  maxNotableFacts,
   shouldExtractNotableFact,
   type TakeawayTestSuite,
 } from "@app/tests/takeaway-evals/lib/types";
@@ -66,6 +68,7 @@ Score 3 if both facts are clearly extracted with good descriptions.`,
         shouldExtractNotableFact("50,000"),
         shouldExtractNotableFact("AES-256"),
         shouldExtractNotableFact("200ms"),
+        maxNotableFacts(4),
       ],
       judgeCriteria: `A knowledge document with several important architectural facts:
 - 50,000 daily transactions
@@ -77,6 +80,116 @@ Score 0 if fewer than 2 facts extracted.
 Score 1 if only 2 facts extracted.
 Score 2 if 3+ facts extracted with reasonable descriptions.
 Score 3 if all key facts extracted with clear, concise descriptions.`,
+    },
+
+    // ── Casual conversation: zero notable facts ──────────────────────────────
+
+    {
+      scenarioId: "casual-conversation-no-facts",
+      document: {
+        id: "doc-nf-3",
+        title: "Water cooler chat",
+        type: "slack",
+        text: [
+          "Alice: Did anyone watch the game last night?",
+          "Bob: Yeah, it was a great match. I can't believe the comeback in the second half.",
+          "Carol: I missed it! Was going to watch the replay tonight.",
+          "Alice: Also, happy birthday Bob! We should grab lunch to celebrate.",
+          "Bob: Thanks! Let's do it. How about that new ramen place?",
+          "Carol: I'm in. Let me know the time.",
+        ].join("\n"),
+        uri: "https://example.com/doc-nf-3",
+      },
+      members: [
+        { sId: "user-alice", fullName: "Alice Martin", email: "alice@co.com" },
+        { sId: "user-bob", fullName: "Bob Chen", email: "bob@co.com" },
+        { sId: "user-carol", fullName: "Carol Davis", email: "carol@co.com" },
+      ],
+      expectedAssertions: [maxNotableFacts(0), maxKeyDecisions(0)],
+      judgeCriteria: `Purely social conversation with no project-relevant information.
+Nothing here would change how anyone plans their work two weeks from now.
+
+Score 0 if any notable facts are extracted.
+Score 1 if a key decision or action item is extracted from the lunch plan.
+Score 2 if one borderline item appears (e.g., birthday).
+Score 3 if zero notable facts and zero key decisions are extracted.`,
+    },
+
+    // ── Noisy debugging thread with one real fact ─────────────────────────────
+
+    {
+      scenarioId: "debugging-thread-one-fact",
+      document: {
+        id: "doc-nf-4",
+        title: "Production incident thread",
+        type: "slack",
+        text: [
+          "Alice: The API is returning 502 errors for some users since 10am",
+          "Bob: Checking the logs now... I see timeouts on the database connection pool",
+          "Alice: Could it be the connection limit? We bumped traffic yesterday with the new campaign",
+          "Bob: Found it — we're hitting the max_connections limit on the PostgreSQL instance. It's set to 100 but we need at least 200 with current traffic.",
+          "Carol: I can bump it. Done — set to 300 to give us headroom.",
+          "Alice: Confirmed, 502s are gone. Let's monitor for the next hour.",
+          "Bob: All clear. Root cause was the PostgreSQL max_connections limit at 100 was too low for our current traffic volume of ~15,000 requests per minute.",
+        ].join("\n"),
+        uri: "https://example.com/doc-nf-4",
+      },
+      members: [
+        { sId: "user-alice", fullName: "Alice Martin", email: "alice@co.com" },
+        { sId: "user-bob", fullName: "Bob Chen", email: "bob@co.com" },
+        { sId: "user-carol", fullName: "Carol Davis", email: "carol@co.com" },
+      ],
+      expectedAssertions: [
+        shouldExtractNotableFact("15,000"),
+        maxNotableFacts(2),
+        maxKeyDecisions(0),
+      ],
+      judgeCriteria: `A noisy debugging thread with lots of intermediate facts. Most are transient
+investigation context (502 errors, checking logs, timeouts). The durable facts are:
+- Current traffic volume: ~15,000 requests per minute
+- PostgreSQL max_connections was bumped to 300 (acceptable but borderline)
+
+The 502 errors, the debugging steps, and "it's fixed now" are NOT notable — they're
+ephemeral incident context that won't matter in two weeks.
+
+Score 0 if 3+ notable facts are extracted (over-extraction from noise).
+Score 1 if the traffic volume fact is missing.
+Score 2 if the traffic volume is extracted with at most one other fact.
+Score 3 if only the traffic volume (and optionally the new connection limit) are extracted, with zero key decisions.`,
+    },
+
+    // ── Cross-category: fact that could leak as action item ──────────────────
+
+    {
+      scenarioId: "fact-not-action-item",
+      document: {
+        id: "doc-nf-5",
+        title: "Vendor update",
+        type: "slack",
+        text: [
+          "Alice: FYI — our AWS contract renewed automatically last week. The new rate is $42,000/month, up from $38,000.",
+          "Bob: Ouch, that's a 10.5% increase. Good to know for budgeting.",
+          "Carol: Also, the AWS support tier was downgraded to Business from Enterprise as part of the cost review.",
+        ].join("\n"),
+        uri: "https://example.com/doc-nf-5",
+      },
+      members: [
+        { sId: "user-alice", fullName: "Alice Martin", email: "alice@co.com" },
+        { sId: "user-bob", fullName: "Bob Chen", email: "bob@co.com" },
+        { sId: "user-carol", fullName: "Carol Davis", email: "carol@co.com" },
+      ],
+      expectedAssertions: [
+        shouldExtractNotableFact("42,000"),
+        maxNotableFacts(2),
+      ],
+      judgeCriteria: `This thread contains facts, not action items. Nobody committed to doing
+anything — they're sharing information. The model should extract notable facts
+(the new AWS rate, the support tier downgrade) but NOT create action items.
+
+Score 0 if action items are extracted from this informational update.
+Score 1 if the cost increase fact is missing.
+Score 2 if facts are correct but spurious action items appear.
+Score 3 if notable facts are extracted correctly with no action items.`,
     },
   ],
 };


### PR DESCRIPTION
## Description

Reworks the takeaway extraction prompts (action items, notable facts, key decisions) to reduce over-extraction, and expands the eval test suite with better coverage.

**Prompt changes:**
- All three prompts now use a 3 (or 4)-test filter structure (e.g., actionability/durability/novelty for notable facts) instead of long exclusion lists. Default mindset is "reject unless clearly passes all tests."
- Added explicit "prefer zero over noisy" signals to each prompt.
- Slack source type prompt now calibrates for short troubleshooting threads.

**Test improvements:**
- Added missing test scenarios: inline completion (done status), implicit consensus, implementation detail vs. key decision, casual conversation (zero facts), noisy debugging thread, cross-category leakage.
- Added `maxX` caps to most tests to catch spurious extractions.
- Added `shouldPreserveSId` assertions for re-analysis tests.
- Fixed wrong assertion types and overly generous caps.
- Added a real-world Slack bug report thread test case.

## Tests


