### PR TITLE
Make skill reinforcement non-option on schema

### DIFF
--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -22,7 +22,7 @@ export function transformSkillTypeToFormData(
     icon: skill.icon ?? null,
     extendedSkillId: skill.extendedSkillId,
     isDefault: skill.isDefault,
-    reinforcement: skill.reinforcement ?? "auto",
+    reinforcement: skill.reinforcement,
   };
 }
 

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -19,6 +19,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     icon: null,
     source: null,
     sourceMetadata: null,
+    reinforcement: "auto",
     requestedSpaceIds: [],
     tools: [],
     fileAttachments: [],

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -18,6 +18,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     icon: null,
     source: null,
     sourceMetadata: null,
+    reinforcement: "auto",
     requestedSpaceIds: [],
     tools: [],
     fileAttachments: [],

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -54,6 +54,7 @@ function makeSkillType(config: MockSkillConfig): SkillType {
     icon: null,
     source: null,
     sourceMetadata: null,
+    reinforcement: "auto",
     requestedSpaceIds: [],
     tools: (config.tools ?? []).map((t) => ({
       id: 0,

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -41,7 +41,7 @@ export const SkillWithoutInstructionsAndToolsSchema = z.object({
   icon: z.string().nullable(),
   source: z.enum(SKILL_SOURCES).nullable(),
   sourceMetadata: SkillSourceMetadataSchema.nullable(),
-  reinforcement: z.enum(SKILL_REINFORCEMENT_MODES).optional(),
+  reinforcement: z.enum(SKILL_REINFORCEMENT_MODES),
   lastReinforcementAnalysisAt: z.string().nullable().optional(),
   requestedSpaceIds: z.array(z.string()),
   fileAttachments: z.array(


### PR DESCRIPTION
## Description

- The `skill_configurations.reinforcement` column is `NOT NULL DEFAULT 'auto'`, and `SkillResource.toJSON` always sets `reinforcement: this.reinforcement`. Yet `SkillWithoutInstructionsAndToolsSchema` marked the field `.optional()`, which didn't reflect reality.
- Remove `.optional()` from the zod schema so `SkillType.reinforcement` is required.
- Drop the now-dead `?? "auto"` fallback in `transformSkillTypeToFormData`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
