### PR TITLE
[PoC] Index conversation in Elasticsearch

### DIFF
--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -1,7 +1,10 @@
 import { useConversations } from "@app/hooks/conversations";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { useBlockedActions } from "@app/lib/swr/blocked_actions";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type {
+  ConversationListItemType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { ReactNode } from "react";
 import {
@@ -229,7 +232,7 @@ export function BlockedActionsProvider({
       // We only show the conversation in unread inbox if actionRequired is true (and this happens only when you come back to a conversation
       // since we don't update this value on frontend side), so we don't have to update the cache if it's not in the unread inbox.
       void mutateConversations(
-        (currentData: ConversationWithoutContentType[] | undefined) =>
+        (currentData: ConversationListItemType[] | undefined) =>
           currentData?.map((c) =>
             c.sId === conversationId && c.actionRequired
               ? { ...c, actionRequired: false }

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -15,7 +15,10 @@ import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
 import { classNames } from "@app/lib/utils";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type {
+  ConversationListItemType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import {
   toMentionType,
@@ -134,7 +137,7 @@ export function ConversationContainerVirtuoso({
         );
 
         await mutateConversations(
-          (currentData: ConversationWithoutContentType[] | undefined) => [
+          (currentData: ConversationListItemType[] | undefined) => [
             // Immediately update the list of conversations in the sidebar by adding the new conversation.
             ...(currentData ?? []),
             conversationRes.value,

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -29,7 +29,7 @@ import {
   setQueryParam,
 } from "@app/lib/utils/router";
 import {
-  type ConversationWithoutContentType,
+  type ConversationListItemType,
   getConversationDisplayTitle,
   getConversationUrlAccessMode,
   isProjectConversation,
@@ -136,7 +136,7 @@ export function useConversationMenu() {
 
 interface ConversationMenuProps {
   activeConversationId: string | null;
-  conversation?: ConversationWithoutContentType;
+  conversation?: ConversationListItemType;
   onConversationBranched?: () => Promise<void> | void;
   owner: WorkspaceType;
   trigger: ReactElement;

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -56,6 +56,7 @@ import { useSpaceInfo } from "@app/lib/swr/spaces";
 import logger from "@app/logger/logger";
 import {
   type ConversationForkedChildType,
+  type ConversationListItemType,
   type ConversationWithoutContentType,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
@@ -594,7 +595,7 @@ export const ConversationViewer = ({
                 );
 
                 void mutateConversations(
-                  (currentData: ConversationWithoutContentType[] | undefined) =>
+                  (currentData: ConversationListItemType[] | undefined) =>
                     currentData?.map((c) =>
                       c.sId === conversationId
                         ? { ...c, hasError: false, unread: false }
@@ -676,7 +677,7 @@ export const ConversationViewer = ({
 
             // to refresh the list of convos in the sidebar (title)
             void mutateConversations(
-              (currentData: ConversationWithoutContentType[] | undefined) =>
+              (currentData: ConversationListItemType[] | undefined) =>
                 currentData?.map((c) =>
                   c.sId === conversationId ? { ...c, title: event.title } : c
                 ),
@@ -694,7 +695,7 @@ export const ConversationViewer = ({
 
             // Update the conversation hasError state in the local cache without making a network request.
             void mutateConversations(
-              (currentData: ConversationWithoutContentType[] | undefined) =>
+              (currentData: ConversationListItemType[] | undefined) =>
                 currentData?.map((c) =>
                   c.sId === event.conversationId
                     ? { ...c, hasError: event.status === "error" }
@@ -943,7 +944,7 @@ export const ConversationViewer = ({
         );
 
         void mutateConversations(
-          (currentData: ConversationWithoutContentType[] | undefined) =>
+          (currentData: ConversationListItemType[] | undefined) =>
             currentData?.map((c) =>
               c.sId === conversationId
                 ? { ...c, updated: new Date().getTime() }

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -48,6 +48,7 @@ import {
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
 import {
+  type ConversationListItemType,
   type ConversationWithoutContentType,
   getConversationDisplayTitle,
 } from "@app/types/assistant/conversation";
@@ -169,8 +170,8 @@ interface SearchResultsProps {
   hideTriggeredConversations: boolean;
   setHideTriggeredConversations: (hide: boolean) => void;
   isMultiSelect: boolean;
-  selectedConversations: ConversationWithoutContentType[];
-  toggleConversationSelection: (c: ConversationWithoutContentType) => void;
+  selectedConversations: ConversationListItemType[];
+  toggleConversationSelection: (c: ConversationListItemType) => void;
 }
 
 function SearchResults({
@@ -471,7 +472,7 @@ export function AgentSidebarMenu({
 
   const [isMultiSelect, setIsMultiSelect] = useState(false);
   const [selectedConversations, setSelectedConversations] = useState<
-    ConversationWithoutContentType[]
+    ConversationListItemType[]
   >([]);
   const doDelete = useDeleteConversation(owner);
 
@@ -539,7 +540,7 @@ export function AgentSidebarMenu({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const toggleConversationSelection = useCallback(
-    (c: ConversationWithoutContentType) => {
+    (c: ConversationListItemType) => {
       if (selectedConversations.includes(c)) {
         setSelectedConversations((prev) => prev.filter((id) => id !== c));
       } else {
@@ -642,7 +643,7 @@ export function AgentSidebarMenu({
   const hasTriggeredConversations = useMemo(
     () =>
       conversations.some(
-        (c: ConversationWithoutContentType) => c.triggerId !== null
+        (c: ConversationListItemType) => c.triggerId !== null
       ),
     [conversations]
   );
@@ -1071,13 +1072,13 @@ export function AgentSidebarMenu({
 
 interface UnreadConversationsSectionProps {
   label: string;
-  conversations: ConversationWithoutContentType[];
+  conversations: ConversationListItemType[];
   isMultiSelect: boolean;
   isMarkingAllAsRead: boolean;
   onMarkAllAsRead: (conversationIds: string[]) => void;
   onConversationBranched?: () => Promise<void> | void;
-  selectedConversations: ConversationWithoutContentType[];
-  toggleConversationSelection: (c: ConversationWithoutContentType) => void;
+  selectedConversations: ConversationListItemType[];
+  toggleConversationSelection: (c: ConversationListItemType) => void;
   activeConversationId: string | null;
   owner: WorkspaceType;
   titleFilter: string;
@@ -1151,11 +1152,11 @@ const ConversationList = ({
   dateLabel,
   ...props
 }: {
-  conversations: ConversationWithoutContentType[];
+  conversations: ConversationListItemType[];
   dateLabel: string;
   isMultiSelect: boolean;
-  selectedConversations: ConversationWithoutContentType[];
-  toggleConversationSelection: (c: ConversationWithoutContentType) => void;
+  selectedConversations: ConversationListItemType[];
+  toggleConversationSelection: (c: ConversationListItemType) => void;
   activeConversationId: string | null;
   onConversationBranched?: () => Promise<void> | void;
   owner: WorkspaceType;
@@ -1186,7 +1187,7 @@ const ConversationList = ({
 };
 
 function getConversationDotStatus(
-  conversation: ConversationWithoutContentType
+  conversation: ConversationListItemType
 ): "blocked" | "unread" | "idle" {
   if (conversation.actionRequired) {
     return "blocked";
@@ -1210,11 +1211,11 @@ const ConversationListItem = memo(
     activeConversationId,
     owner,
   }: {
-    conversation: ConversationWithoutContentType;
+    conversation: ConversationListItemType;
     isMultiSelect: boolean;
     onConversationBranched?: () => Promise<void> | void;
-    selectedConversations: ConversationWithoutContentType[];
-    toggleConversationSelection: (c: ConversationWithoutContentType) => void;
+    selectedConversations: ConversationListItemType[];
+    toggleConversationSelection: (c: ConversationListItemType) => void;
     activeConversationId: string | null;
     owner: WorkspaceType;
   }) => {
@@ -1308,12 +1309,12 @@ const ConversationListItem = memo(
 );
 
 interface NavigationListWithInboxProps {
-  conversations: ConversationWithoutContentType[];
+  conversations: ConversationListItemType[];
   titleFilter: string;
   isMultiSelect: boolean;
-  selectedConversations: ConversationWithoutContentType[];
+  selectedConversations: ConversationListItemType[];
   toggleConversationSelection: (
-    conversation: ConversationWithoutContentType
+    conversation: ConversationListItemType
   ) => void;
   activeConversationId: string | null;
   onConversationBranched?: () => Promise<void> | void;
@@ -1371,7 +1372,7 @@ function NavigationListWithInbox({
         conversations: readConversations,
         titleFilter,
       })
-    : ({} as Record<GroupLabel, ConversationWithoutContentType[]>);
+    : ({} as Record<GroupLabel, ConversationListItemType[]>);
 
   const conversationsContent = (
     <>

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -122,7 +122,7 @@ export function SpaceConversationListItem({
   return (
     <>
       <ConversationListItem
-        key={conversation.id}
+        key={conversation.sId}
         conversation={{
           id: conversation.sId,
           title: conversationLabel,

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -2,7 +2,7 @@ import { removeDiacritics, subFilter } from "@app/lib/utils";
 import type {
   AgentMessageType,
   CompactionMessageType,
-  ConversationWithoutContentType,
+  ConversationListItemType,
   LightAgentMessageType,
   UserMessageType,
   UserMessageTypeWithContentFragments,
@@ -17,7 +17,7 @@ import moment from "moment";
 import type { VirtuosoMessage } from "./types";
 
 function isReinforcedSkillConversation(
-  conversation: ConversationWithoutContentType
+  conversation: ConversationListItemType
 ): boolean {
   return isReinforcedSkillNotificationMetadata(
     conversation.metadata?.reinforcedSkillNotification
@@ -38,7 +38,7 @@ type GroupLabel =
 // the sidebar can show them in a dedicated "Skill suggestions" section above the Inbox; once
 // read they fall back into the date-grouped Conversations list like any other read conversation.
 export function getGroupConversationsByUnreadAndActionRequired(
-  conversations: ConversationWithoutContentType[],
+  conversations: ConversationListItemType[],
   titleFilter: string
 ) {
   return (
@@ -76,19 +76,21 @@ export function getGroupConversationsByUnreadAndActionRequired(
           inboxConversations: [],
           skillSuggestionConversations: [],
         } as {
-          readConversations: ConversationWithoutContentType[];
-          inboxConversations: ConversationWithoutContentType[];
-          skillSuggestionConversations: ConversationWithoutContentType[];
+          readConversations: ConversationListItemType[];
+          inboxConversations: ConversationListItemType[];
+          skillSuggestionConversations: ConversationListItemType[];
         }
       )
   );
 }
 
-export function getGroupConversationsByDate({
+export function getGroupConversationsByDate<
+  T extends ConversationListItemType,
+>({
   conversations,
   titleFilter,
 }: {
-  conversations: ConversationWithoutContentType[];
+  conversations: T[];
   titleFilter: string;
 }) {
   const today = moment().startOf("day");
@@ -97,7 +99,7 @@ export function getGroupConversationsByDate({
   const lastMonth = moment().subtract(1, "months").startOf("day");
   const lastYear = moment().subtract(1, "years").startOf("day");
 
-  const groups: Record<GroupLabel, ConversationWithoutContentType[]> = {
+  const groups: Record<GroupLabel, T[]> = {
     Today: [],
     Yesterday: [],
     "Last Week": [],
@@ -106,7 +108,7 @@ export function getGroupConversationsByDate({
     Older: [],
   };
 
-  conversations.forEach((conversation: ConversationWithoutContentType) => {
+  conversations.forEach((conversation: T) => {
     if (
       titleFilter &&
       !subFilter(
@@ -139,9 +141,9 @@ export function getGroupConversationsByDate({
 }
 
 export function filterTriggeredConversations(
-  conversations: ConversationWithoutContentType[],
+  conversations: ConversationListItemType[],
   hideTriggered: boolean
-): ConversationWithoutContentType[] {
+): ConversationListItemType[] {
   if (!hideTriggered) {
     return conversations;
   }

--- a/front/hooks/conversations/useConversationMarkAsRead.ts
+++ b/front/hooks/conversations/useConversationMarkAsRead.ts
@@ -1,7 +1,10 @@
 import { clientFetch } from "@app/lib/egress/client";
 import logger from "@app/logger/logger";
 import type { PatchConversationsRequestBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type {
+  ConversationListItemType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import { isProjectConversation } from "@app/types/assistant/conversation";
 import { useCallback, useEffect } from "react";
 import { useConversations } from "./useConversations";
@@ -52,7 +55,7 @@ export function useConversationMarkAsRead({
         }
         if (options?.mutateList) {
           void mutateConversations(
-            (prevState: ConversationWithoutContentType[] | undefined) =>
+            (prevState: ConversationListItemType[] | undefined) =>
               prevState?.map((c) =>
                 c.sId === conversationId ? { ...c, unread: false } : c
               ),

--- a/front/hooks/conversations/useConversations.ts
+++ b/front/hooks/conversations/useConversations.ts
@@ -4,7 +4,7 @@ import {
   useSWRInfiniteWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { ConversationListItemType } from "@app/types/assistant/conversation";
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 import type { SWRInfiniteMutatorOptions } from "swr/infinite";
@@ -12,8 +12,8 @@ import type { SWRInfiniteMutatorOptions } from "swr/infinite";
 const DEFAULT_LIMIT = 100;
 
 type ConversationsUpdater = (
-  prevData: ConversationWithoutContentType[] | undefined
-) => ConversationWithoutContentType[] | undefined;
+  prevData: ConversationListItemType[] | undefined
+) => ConversationListItemType[] | undefined;
 
 type MutateOptions = {
   revalidate?: boolean;
@@ -58,7 +58,7 @@ export function useConversations({
 
   const conversations = useMemo(() => {
     if (!data) {
-      return emptyArray<ConversationWithoutContentType>();
+      return emptyArray<ConversationListItemType>();
     }
     return data.flatMap((page) => page.conversations);
   }, [data]);

--- a/front/hooks/useDeleteConversation.ts
+++ b/front/hooks/useDeleteConversation.ts
@@ -2,7 +2,7 @@ import { useConversations } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { ConversationListItemType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback } from "react";
 
@@ -12,7 +12,7 @@ export function useDeleteConversation(owner: LightWorkspaceType) {
 
   return useCallback(
     async (
-      conversation?: ConversationWithoutContentType,
+      conversation?: ConversationListItemType,
       forceDelete: boolean = false
     ): Promise<boolean> => {
       if (!conversation) {
@@ -38,7 +38,7 @@ export function useDeleteConversation(owner: LightWorkspaceType) {
       }
 
       void mutateConversations(
-        (prevState: ConversationWithoutContentType[] | undefined) =>
+        (prevState: ConversationListItemType[] | undefined) =>
           prevState?.filter((c) => c.sId !== conversation.sId)
       );
 

--- a/front/hooks/useMoveConversationOutOfProject.tsx
+++ b/front/hooks/useMoveConversationOutOfProject.tsx
@@ -8,7 +8,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import {
-  type ConversationWithoutContentType,
+  type ConversationListItemType,
   getConversationDisplayTitle,
 } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -35,7 +35,7 @@ export function useMoveConversationOutOfProject(
   });
 
   return useCallback(
-    async (conversation: ConversationWithoutContentType): Promise<boolean> => {
+    async (conversation: ConversationListItemType): Promise<boolean> => {
       const confirmed = await confirm({
         title: "Remove from project?",
         message: (

--- a/front/hooks/useMoveConversationToProject.tsx
+++ b/front/hooks/useMoveConversationToProject.tsx
@@ -7,7 +7,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import {
-  type ConversationWithoutContentType,
+  type ConversationListItemType,
   getConversationDisplayTitle,
 } from "@app/types/assistant/conversation";
 import type { SpaceType } from "@app/types/space";
@@ -27,7 +27,7 @@ export function useMoveConversationToProject(owner: LightWorkspaceType) {
 
   return useCallback(
     async (
-      conversation: ConversationWithoutContentType,
+      conversation: ConversationListItemType,
       space: SpaceType
     ): Promise<boolean> => {
       const confirmed = await confirm({

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -10,15 +10,17 @@ let esClient: Client | null = null;
 export const ANALYTICS_ALIAS_NAME = "front.agent_message_analytics";
 export const USER_SEARCH_ALIAS_NAME = "front.user_search";
 export const AGENT_DOCUMENT_OUTPUTS_ALIAS_NAME = "front.agent_document_outputs";
+export const CONVERSATION_SEARCH_ALIAS_NAME = "front.conversation_search";
 
 /**
  * Mapping of index names to their directory locations.
  * This allows different features to organize their indices in feature-specific directories.
  */
 export const INDEX_DIRECTORIES: Record<string, string> = {
-  agent_message_analytics: "lib/analytics/indices",
-  user_search: "lib/user_search/indices",
   agent_document_outputs: "lib/analytics/indices",
+  agent_message_analytics: "lib/analytics/indices",
+  conversation_search: "lib/conversation_search/indices",
+  user_search: "lib/user_search/indices",
 };
 
 export interface ElasticsearchBaseDocument {

--- a/front/lib/conversation_search/index.ts
+++ b/front/lib/conversation_search/index.ts
@@ -1,0 +1,75 @@
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import {
+  CONVERSATION_SEARCH_ALIAS_NAME,
+  withEs,
+} from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { ConversationSearchDocument } from "@app/types/conversation_search/conversation_search";
+import type { Result } from "@app/types/shared/result";
+
+export function buildConversationSearchDocument(
+  auth: Authenticator,
+  conversation: ConversationResource,
+  participantUserIds: string[]
+): ConversationSearchDocument {
+  return {
+    conversation_id: conversation.sId,
+    created_at: conversation.createdAt.toISOString(),
+    participants: participantUserIds.map((userId) => ({ user_id: userId })),
+    requested_space_ids: conversation.getRequestedSpaceIdsFromModel(),
+    updated_at: conversation.updatedAt.toISOString(),
+    visibility: conversation.visibility,
+    workspace_id: auth.getNonNullableWorkspace().sId,
+    ...(conversation.space?.sId && { space_id: conversation.space.sId }),
+  };
+}
+
+function makeConversationDocumentId({
+  workspaceId,
+  conversationId,
+}: {
+  workspaceId: string;
+  conversationId: string;
+}): string {
+  return `${workspaceId}_${conversationId}`;
+}
+
+export async function indexConversationDocument(
+  document: ConversationSearchDocument
+): Promise<Result<void, ElasticsearchError>> {
+  const documentId = makeConversationDocumentId({
+    workspaceId: document.workspace_id,
+    conversationId: document.conversation_id,
+  });
+
+  return withEs(async (client) => {
+    await client.index({
+      index: CONVERSATION_SEARCH_ALIAS_NAME,
+      id: documentId,
+      routing: document.workspace_id,
+      document,
+    });
+  });
+}
+
+export async function deleteConversationDocument({
+  workspaceId,
+  conversationId,
+}: {
+  workspaceId: string;
+  conversationId: string;
+}): Promise<Result<void, ElasticsearchError>> {
+  const documentId = makeConversationDocumentId({
+    workspaceId,
+    conversationId,
+  });
+
+  return withEs(async (client) => {
+    await client.delete({
+      index: CONVERSATION_SEARCH_ALIAS_NAME,
+      id: documentId,
+      routing: workspaceId,
+    });
+  });
+}

--- a/front/lib/conversation_search/index.ts
+++ b/front/lib/conversation_search/index.ts
@@ -11,13 +11,25 @@ import type { Result } from "@app/types/shared/result";
 export function buildConversationSearchDocument(
   auth: Authenticator,
   conversation: ConversationResource,
-  participantUserIds: string[]
+  participants: Array<{
+    userId: string;
+    actionRequired: boolean;
+    lastReadMs: number | null;
+  }>
 ): ConversationSearchDocument {
   return {
     conversation_id: conversation.sId,
     created_at: conversation.createdAt.toISOString(),
-    participants: participantUserIds.map((userId) => ({ user_id: userId })),
+    has_error: conversation.hasError,
+    metadata: conversation.metadata ?? {},
+    participants: participants.map(({ userId, actionRequired, lastReadMs }) => ({
+      action_required: actionRequired,
+      last_read_at: lastReadMs !== null ? new Date(lastReadMs).toISOString() : null,
+      user_id: userId,
+    })),
     requested_space_ids: conversation.getRequestedSpaceIdsFromModel(),
+    title: conversation.title,
+    trigger_id: conversation.triggerSId,
     updated_at: conversation.updatedAt.toISOString(),
     visibility: conversation.visibility,
     workspace_id: auth.getNonNullableWorkspace().sId,

--- a/front/lib/conversation_search/indices/conversation_search_1.mappings.json
+++ b/front/lib/conversation_search/indices/conversation_search_1.mappings.json
@@ -18,6 +18,19 @@
     "requested_space_ids": {
       "type": "keyword"
     },
+    "title": {
+      "type": "keyword"
+    },
+    "has_error": {
+      "type": "boolean"
+    },
+    "metadata": {
+      "type": "object",
+      "dynamic": false
+    },
+    "trigger_id": {
+      "type": "keyword"
+    },
     "created_at": {
       "type": "date"
     },
@@ -29,6 +42,12 @@
       "properties": {
         "user_id": {
           "type": "keyword"
+        },
+        "action_required": {
+          "type": "boolean"
+        },
+        "last_read_at": {
+          "type": "date"
         }
       }
     }

--- a/front/lib/conversation_search/indices/conversation_search_1.mappings.json
+++ b/front/lib/conversation_search/indices/conversation_search_1.mappings.json
@@ -1,0 +1,36 @@
+{
+  "_routing": {
+    "required": true
+  },
+  "properties": {
+    "workspace_id": {
+      "type": "keyword"
+    },
+    "conversation_id": {
+      "type": "keyword"
+    },
+    "space_id": {
+      "type": "keyword"
+    },
+    "visibility": {
+      "type": "keyword"
+    },
+    "requested_space_ids": {
+      "type": "keyword"
+    },
+    "created_at": {
+      "type": "date"
+    },
+    "updated_at": {
+      "type": "date"
+    },
+    "participants": {
+      "type": "nested",
+      "properties": {
+        "user_id": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}

--- a/front/lib/conversation_search/indices/conversation_search_1.settings.europe-west1.json
+++ b/front/lib/conversation_search/indices/conversation_search_1.settings.europe-west1.json
@@ -1,0 +1,5 @@
+{
+  "number_of_shards": 3,
+  "number_of_replicas": 1,
+  "refresh_interval": "1s"
+}

--- a/front/lib/conversation_search/indices/conversation_search_1.settings.local.json
+++ b/front/lib/conversation_search/indices/conversation_search_1.settings.local.json
@@ -1,0 +1,5 @@
+{
+  "number_of_shards": 1,
+  "number_of_replicas": 0,
+  "refresh_interval": "1s"
+}

--- a/front/lib/conversation_search/indices/conversation_search_1.settings.us-central1.json
+++ b/front/lib/conversation_search/indices/conversation_search_1.settings.us-central1.json
@@ -1,0 +1,5 @@
+{
+  "number_of_shards": 3,
+  "number_of_replicas": 1,
+  "refresh_interval": "1s"
+}

--- a/front/lib/conversation_search/search.ts
+++ b/front/lib/conversation_search/search.ts
@@ -3,11 +3,15 @@ import {
   CONVERSATION_SEARCH_ALIAS_NAME,
   withEs,
 } from "@app/lib/api/elasticsearch";
+import type {
+  ConversationListItemType,
+  ConversationMetadata,
+} from "@app/types/assistant/conversation";
 import type { ConversationSearchDocument } from "@app/types/conversation_search/conversation_search";
 import type { Result } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
 
-interface ListPrivateConversationIdsFromESParams {
+interface ListPrivateConversationsFromESParams {
   accessibleSpaceIds: string[];
   lastValue?: string;
   limit: number;
@@ -16,8 +20,8 @@ interface ListPrivateConversationIdsFromESParams {
   workspaceId: string;
 }
 
-interface ListPrivateConversationIdsFromESResult {
-  conversationIds: string[];
+interface ListPrivateConversationsFromESResult {
+  items: ConversationListItemType[];
   hasMore: boolean;
   lastValue: string | null;
 }
@@ -40,15 +44,15 @@ function parseSearchAfterCursor(
   return [ts, convId];
 }
 
-export async function listPrivateConversationIdsFromES({
+export async function listPrivateConversationsFromES({
   workspaceId,
   userId,
   accessibleSpaceIds,
   limit,
   lastValue,
   orderDirection,
-}: ListPrivateConversationIdsFromESParams): Promise<
-  Result<ListPrivateConversationIdsFromESResult, ElasticsearchError>
+}: ListPrivateConversationsFromESParams): Promise<
+  Result<ListPrivateConversationsFromESResult, ElasticsearchError>
 > {
   // Filter: all values in requested_space_ids must be in the user's accessible spaces.
   // terms_set with minimum_should_match_script = doc field length implements the
@@ -111,6 +115,10 @@ export async function listPrivateConversationIdsFromES({
               nested: {
                 path: "participants",
                 query: { term: { "participants.user_id": userId } },
+                // Return the matched participant's per-user fields alongside the hit.
+                inner_hits: {
+                  size: 1,
+                },
               },
             },
             requestedSpaceIdsFilter,
@@ -128,9 +136,42 @@ export async function listPrivateConversationIdsFromES({
     const hasMore = hits.length > limit;
     const resultHits = hasMore ? hits.slice(0, limit) : hits;
 
-    const conversationIds = resultHits.flatMap((hit) =>
-      hit._source?.conversation_id ? [hit._source.conversation_id] : []
-    );
+    const items: ConversationListItemType[] = resultHits.flatMap((hit) => {
+      const source = hit._source;
+      if (!source) {
+        return [];
+      }
+
+      const innerHit =
+        hit.inner_hits?.participants?.hits?.hits?.[0]?._source ?? {};
+      const participantData = innerHit as {
+        action_required?: boolean;
+        last_read_at?: string | null;
+      };
+
+      const actionRequired = participantData.action_required ?? false;
+      const lastReadAt = participantData.last_read_at ?? null;
+      const lastReadMs =
+        lastReadAt !== null ? new Date(lastReadAt).getTime() : null;
+      const updatedMs = new Date(source.updated_at).getTime();
+
+      return [
+        {
+          actionRequired,
+          created: new Date(source.created_at).getTime(),
+          hasError: source.has_error,
+          lastReadMs,
+          metadata: source.metadata as ConversationMetadata,
+          requestedSpaceIds: source.requested_space_ids,
+          sId: source.conversation_id,
+          spaceId: source.space_id ?? null,
+          title: source.title,
+          triggerId: source.trigger_id,
+          unread: lastReadMs === null || updatedMs > lastReadMs,
+          updated: updatedMs,
+        },
+      ];
+    });
 
     const lastHit = resultHits[resultHits.length - 1];
     const newLastValue =
@@ -138,6 +179,6 @@ export async function listPrivateConversationIdsFromES({
         ? `${lastHit.sort[0]}|${lastHit.sort[1]}`
         : null;
 
-    return { conversationIds, hasMore, lastValue: newLastValue };
+    return { items, hasMore, lastValue: newLastValue };
   });
 }

--- a/front/lib/conversation_search/search.ts
+++ b/front/lib/conversation_search/search.ts
@@ -1,0 +1,143 @@
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import {
+  CONVERSATION_SEARCH_ALIAS_NAME,
+  withEs,
+} from "@app/lib/api/elasticsearch";
+import type { ConversationSearchDocument } from "@app/types/conversation_search/conversation_search";
+import type { Result } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+interface ListPrivateConversationIdsFromESParams {
+  accessibleSpaceIds: string[];
+  lastValue?: string;
+  limit: number;
+  orderDirection: "asc" | "desc";
+  userId: string;
+  workspaceId: string;
+}
+
+interface ListPrivateConversationIdsFromESResult {
+  conversationIds: string[];
+  hasMore: boolean;
+  lastValue: string | null;
+}
+
+// Cursor encodes two sort values: "<updatedAtMs>|<conversationId>". The conversation_id
+// tiebreaker guarantees stable pagination when multiple conversations share the same updated_at.
+function parseSearchAfterCursor(
+  lastValue: string | undefined
+): estypes.SortResults | undefined {
+  if (!lastValue) {
+    return undefined;
+  }
+
+  const [tsStr, convId] = lastValue.split("|");
+  const ts = parseInt(tsStr, 10);
+  if (Number.isNaN(ts) || !convId) {
+    return undefined;
+  }
+
+  return [ts, convId];
+}
+
+export async function listPrivateConversationIdsFromES({
+  workspaceId,
+  userId,
+  accessibleSpaceIds,
+  limit,
+  lastValue,
+  orderDirection,
+}: ListPrivateConversationIdsFromESParams): Promise<
+  Result<ListPrivateConversationIdsFromESResult, ElasticsearchError>
+> {
+  // Filter: all values in requested_space_ids must be in the user's accessible spaces.
+  // terms_set with minimum_should_match_script = doc field length implements the
+  // "superset check": every space the conversation references must be accessible.
+  // When accessibleSpaceIds is empty, conversations with non-empty requested_space_ids
+  // are correctly excluded (0 matches < required length).
+  // When accessibleSpaceIds is non-empty we need two cases:
+  //   1. Conversations with no space requirements (empty array → ES treats field as missing).
+  //   2. Conversations where every required space is in the user's accessible set.
+  // terms_set alone misses case 1 because ES skips documents where the field has no values,
+  // even when the Painless script would return minimum=0.
+  const requestedSpaceIdsFilter: estypes.QueryDslQueryContainer =
+    accessibleSpaceIds.length > 0
+      ? {
+          bool: {
+            should: [
+              // Case 1: no space requirements, always accessible.
+              {
+                bool: {
+                  must_not: [{ exists: { field: "requested_space_ids" } }],
+                },
+              },
+              // Case 2: all required spaces are in the user's accessible set.
+              {
+                terms_set: {
+                  requested_space_ids: {
+                    terms: accessibleSpaceIds,
+                    minimum_should_match_script: {
+                      source: "doc['requested_space_ids'].size()",
+                    },
+                  },
+                },
+              },
+            ],
+            minimum_should_match: 1,
+          },
+        }
+      : {
+          // No accessible spaces: only pass conversations with no space requirements.
+          bool: { must_not: [{ exists: { field: "requested_space_ids" } }] },
+        };
+
+  const sortOrder = orderDirection === "desc" ? "desc" : "asc";
+  const fetchLimit = limit + 1;
+  const searchAfter = parseSearchAfterCursor(lastValue);
+
+  return withEs(async (client) => {
+    const response = await client.search<ConversationSearchDocument>({
+      index: CONVERSATION_SEARCH_ALIAS_NAME,
+      routing: workspaceId,
+      size: fetchLimit,
+      query: {
+        bool: {
+          filter: [
+            { term: { workspace_id: workspaceId } },
+            { term: { visibility: "unlisted" } },
+            // Private conversations have no space_id field.
+            { bool: { must_not: [{ exists: { field: "space_id" } }] } },
+            {
+              nested: {
+                path: "participants",
+                query: { term: { "participants.user_id": userId } },
+              },
+            },
+            requestedSpaceIdsFilter,
+          ],
+        },
+      },
+      sort: [
+        { updated_at: { order: sortOrder } },
+        { conversation_id: { order: sortOrder } },
+      ],
+      ...(searchAfter && { search_after: searchAfter }),
+    });
+
+    const hits = response.hits.hits;
+    const hasMore = hits.length > limit;
+    const resultHits = hasMore ? hits.slice(0, limit) : hits;
+
+    const conversationIds = resultHits.flatMap((hit) =>
+      hit._source?.conversation_id ? [hit._source.conversation_id] : []
+    );
+
+    const lastHit = resultHits[resultHits.length - 1];
+    const newLastValue =
+      lastHit?.sort?.[0] != null && lastHit.sort[1] != null
+        ? `${lastHit.sort[0]}|${lastHit.sort[1]}`
+        : null;
+
+    return { conversationIds, hasMore, lastValue: newLastValue };
+  });
+}

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
-import { listPrivateConversationIdsFromES } from "@app/lib/conversation_search/search";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { listPrivateConversationsFromES } from "@app/lib/conversation_search/search";
 import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
 import {
   AgentMessageModel,
@@ -39,6 +40,7 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ConversationForkedChildType,
   ConversationForkedFromType,
+  ConversationListItemType,
   ConversationMCPServerViewType,
   ConversationMetadata,
   ConversationUrlAccessMode,
@@ -409,7 +411,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       space
     );
 
-    await this.triggerEsIndexing(resource.sId, workspace.sId);
+    await this.triggerEsIndexing(auth, resource.sId, workspace.sId);
 
     return resource;
   }
@@ -780,24 +782,56 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
   }
 
-  // Returns all user sIds that have ever participated in the conversation.
-  async listParticipantsForConversation(): Promise<string[]> {
+  async listParticipantsForConversation(): Promise<
+    Array<{
+      userId: string;
+      actionRequired: boolean;
+      lastReadMs: number | null;
+    }>
+  > {
     const participants = await ConversationParticipantModel.findAll({
       where: {
         conversationId: this.id,
         workspaceId: this.workspaceId,
       },
-      attributes: ["userId"],
+      attributes: ["userId", "actionRequired"],
       include: [{ model: UserModel, attributes: ["sId"] }],
     });
 
-    return participants.flatMap((p) => (p.user ? [p.user.sId] : []));
+    const userModelIds = participants.map((p) => p.userId);
+    const reads = await UserConversationReadsModel.findAll({
+      where: {
+        conversationId: this.id,
+        workspaceId: this.workspaceId,
+        userId: userModelIds,
+      },
+      attributes: ["userId", "lastReadAt"],
+    });
+    const readsByUserId = new Map(reads.map((r) => [r.userId, r.lastReadAt]));
+
+    return participants.flatMap((p) => {
+      if (!p.user) {
+        return [];
+      }
+      const lastReadAt = readsByUserId.get(p.userId) ?? null;
+      return [
+        {
+          userId: p.user.sId,
+          actionRequired: p.actionRequired,
+          lastReadMs: lastReadAt ? lastReadAt.getTime() : null,
+        },
+      ];
+    });
   }
 
   private static async triggerEsIndexing(
+    auth: Authenticator,
     conversationId: string,
     workspaceId: string
   ): Promise<void> {
+    if (!(await hasFeatureFlag(auth, "conversation_search_indexing"))) {
+      return;
+    }
     const result = await launchIndexConversationEsWorkflow({
       conversationId,
       workspaceId,
@@ -1372,7 +1406,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     await conversation.update(blob, transaction);
 
-    await this.triggerEsIndexing(sId, auth.getNonNullableWorkspace().sId);
+    await this.triggerEsIndexing(auth, sId, auth.getNonNullableWorkspace().sId);
 
     return new Ok(undefined);
   }
@@ -1525,8 +1559,29 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return this.fetchPrivateConversationsPaginated(auth, { pagination });
   }
 
-  // Lists private conversations using Elasticsearch for ordering, then hydrates
-  // full state from the DB. Falls back to DB-only on ES failure.
+  private static resourceToListItem(
+    resource: ConversationResource
+  ): ConversationListItemType {
+    return {
+      actionRequired: resource.userParticipation?.actionRequired ?? false,
+      created: resource.createdAt.getTime(),
+      hasError: resource.hasError,
+      lastReadMs: resource.userLastReadAt?.getTime() ?? null,
+      metadata: resource.metadata ?? {},
+      requestedSpaceIds: resource.getRequestedSpaceIdsFromModel(),
+      sId: resource.sId,
+      spaceId: resource.space?.sId ?? null,
+      title: resource.title,
+      triggerId: resource.triggerSId,
+      unread:
+        resource.userLastReadAt === null ||
+        resource.updatedAt > resource.userLastReadAt,
+      updated: resource.updatedAt.getTime(),
+    };
+  }
+
+  // Lists private conversations from Elasticsearch. Falls back to DB on ES
+  // failure or when the conversation_search_read feature flag is disabled.
   static async listPrivateConversationsForUserPaginatedFromES(
     auth: Authenticator,
     pagination: {
@@ -1535,13 +1590,20 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       orderDirection?: "asc" | "desc";
     }
   ): Promise<{
-    conversations: ConversationResource[];
+    conversations: ConversationListItemType[];
     hasMore: boolean;
     lastValue: string | null;
   }> {
     const user = auth.user();
     if (!user) {
       return { conversations: [], hasMore: false, lastValue: null };
+    }
+
+    if (!(await hasFeatureFlag(auth, "conversation_search_read"))) {
+      return this.listPrivateConversationsForUserPaginatedFromDB(
+        auth,
+        pagination
+      );
     }
 
     const workspace = auth.getNonNullableWorkspace();
@@ -1551,7 +1613,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       await SpaceResource.listWorkspaceSpacesAsMember(auth);
     const accessibleSpaceIds = accessibleSpaces.map((s) => s.sId);
 
-    const esResult = await listPrivateConversationIdsFromES({
+    const esResult = await listPrivateConversationsFromES({
       workspaceId: workspace.sId,
       userId: user.sId,
       accessibleSpaceIds,
@@ -1565,40 +1627,56 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         { workspaceId: workspace.sId, error: esResult.error },
         "[conversation_search] ES query failed, falling back to DB"
       );
-      return this.listPrivateConversationsForUserPaginated(auth, pagination);
-    }
-
-    const { conversationIds, hasMore, lastValue } = esResult.value;
-
-    if (conversationIds.length === 0) {
-      return { conversations: [], hasMore, lastValue };
-    }
-
-    // Targeted fetch: three indexed lookups on the ES-returned IDs only.
-    // No participation table scan — that's the slow path ES replaces.
-    const conversations = await this.fetchByIds(auth, conversationIds);
-
-    // Log discrepancies: ES returned IDs that the DB doesn't recognize.
-    const dbIds = new Set(conversations.map((c) => c.sId));
-    const missingInDb = conversationIds.filter((id) => !dbIds.has(id));
-    if (missingInDb.length > 0) {
-      logger.warn(
-        { workspaceId: workspace.sId, userId: user.sId, missingInDb },
-        "[conversation_search] ES returned conversation IDs absent from DB (stale index)"
+      return this.listPrivateConversationsForUserPaginatedFromDB(
+        auth,
+        pagination
       );
     }
 
-    // Enrich with per-user participation and read state for these conversations only.
-    await this.enrichWithParticipationAndReadState(auth, conversations);
+    const { items, hasMore, lastValue } = esResult.value;
 
-    // Preserve ES ordering.
-    const byId = new Map(conversations.map((c) => [c.sId, c]));
-    const ordered = conversationIds.flatMap((id) => {
-      const c = byId.get(id);
-      return c ? [c] : [];
-    });
+    // Validate ES results against DB to detect stale index entries.
+    if (items.length > 0) {
+      const dbConversations = await this.fetchByIds(
+        auth,
+        items.map((i) => i.sId)
+      );
+      const dbSIds = new Set(dbConversations.map((c) => c.sId));
+      const missingInDb = items
+        .map((i) => i.sId)
+        .filter((sId) => !dbSIds.has(sId));
+      if (missingInDb.length > 0) {
+        logger.warn(
+          { workspaceId: workspace.sId, userId: user.sId, missingInDb },
+          "[conversation_search] ES returned conversation IDs absent from DB (stale index)"
+        );
+      }
+    }
 
-    return { conversations: ordered, hasMore, lastValue };
+    return { conversations: items, hasMore, lastValue };
+  }
+
+  private static async listPrivateConversationsForUserPaginatedFromDB(
+    auth: Authenticator,
+    pagination: {
+      limit: number;
+      lastValue?: string;
+      orderDirection?: "asc" | "desc";
+    }
+  ): Promise<{
+    conversations: ConversationListItemType[];
+    hasMore: boolean;
+    lastValue: string | null;
+  }> {
+    const result = await this.listPrivateConversationsForUserPaginated(
+      auth,
+      pagination
+    );
+    return {
+      conversations: result.conversations.map(this.resourceToListItem),
+      hasMore: result.hasMore,
+      lastValue: result.lastValue,
+    };
   }
 
   static async listSpaceUnreadConversationsAndActivityForUser(
@@ -2055,6 +2133,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       }
     );
 
+    await this.triggerEsIndexing(
+      auth,
+      conversation.sId,
+      auth.getNonNullableWorkspace().sId
+    );
+
     return new Ok(updated);
   }
 
@@ -2082,6 +2166,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       }
     );
 
+    await this.triggerEsIndexing(
+      auth,
+      conversation.sId,
+      auth.getNonNullableWorkspace().sId
+    );
+
     return new Ok(updated);
   }
 
@@ -2106,6 +2196,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
 
     await this.triggerEsIndexing(
+      auth,
       conversation.sId,
       auth.getNonNullableWorkspace().sId
     );
@@ -2135,6 +2226,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       },
       { transaction }
     );
+
+    await this.triggerEsIndexing(
+      auth,
+      conversation.sId,
+      auth.getNonNullableWorkspace().sId
+    );
+
     return new Ok(updated);
   }
 
@@ -2156,6 +2254,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
+
+    await this.triggerEsIndexing(
+      auth,
+      conversation.sId,
+      auth.getNonNullableWorkspace().sId
+    );
+
     return new Ok(undefined);
   }
 
@@ -2293,6 +2398,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     if (status !== "none") {
       await this.triggerEsIndexing(
+        auth,
         conversation.sId,
         auth.getNonNullableWorkspace().sId
       );

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { listPrivateConversationIdsFromES } from "@app/lib/conversation_search/search";
 import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
 import {
   AgentMessageModel,
@@ -32,6 +33,8 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import logger from "@app/logger/logger";
+import { launchIndexConversationEsWorkflow } from "@app/temporal/es_indexation/client";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ConversationForkedChildType,
@@ -400,11 +403,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       { transaction }
     );
 
-    return new ConversationResource(
+    const resource = new ConversationResource(
       ConversationResource.model,
       conversation.get(),
       space
     );
+
+    await this.triggerEsIndexing(resource.sId, workspace.sId);
+
+    return resource;
   }
 
   static async countForWorkspace(
@@ -771,6 +778,33 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       this.triggerId,
       this.workspaceId
     );
+  }
+
+  // Returns all user sIds that have ever participated in the conversation.
+  async listParticipantsForConversation(): Promise<string[]> {
+    const participants = await ConversationParticipantModel.findAll({
+      where: {
+        conversationId: this.id,
+        workspaceId: this.workspaceId,
+      },
+      attributes: ["userId"],
+      include: [{ model: UserModel, attributes: ["sId"] }],
+    });
+
+    return participants.flatMap((p) => (p.user ? [p.user.sId] : []));
+  }
+
+  private static async triggerEsIndexing(
+    conversationId: string,
+    workspaceId: string
+  ): Promise<void> {
+    const result = await launchIndexConversationEsWorkflow({
+      conversationId,
+      workspaceId,
+    });
+    if (result.isErr()) {
+      throw result.error;
+    }
   }
 
   static async fetchParticipationMapForUser(
@@ -1337,6 +1371,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     }
 
     await conversation.update(blob, transaction);
+
+    await this.triggerEsIndexing(sId, auth.getNonNullableWorkspace().sId);
+
     return new Ok(undefined);
   }
 
@@ -1486,6 +1523,82 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     lastValue: string | null;
   }> {
     return this.fetchPrivateConversationsPaginated(auth, { pagination });
+  }
+
+  // Lists private conversations using Elasticsearch for ordering, then hydrates
+  // full state from the DB. Falls back to DB-only on ES failure.
+  static async listPrivateConversationsForUserPaginatedFromES(
+    auth: Authenticator,
+    pagination: {
+      limit: number;
+      lastValue?: string;
+      orderDirection?: "asc" | "desc";
+    }
+  ): Promise<{
+    conversations: ConversationResource[];
+    hasMore: boolean;
+    lastValue: string | null;
+  }> {
+    const user = auth.user();
+    if (!user) {
+      return { conversations: [], hasMore: false, lastValue: null };
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const orderDirection = pagination.orderDirection ?? "desc";
+
+    const accessibleSpaces =
+      await SpaceResource.listWorkspaceSpacesAsMember(auth);
+    const accessibleSpaceIds = accessibleSpaces.map((s) => s.sId);
+
+    const esResult = await listPrivateConversationIdsFromES({
+      workspaceId: workspace.sId,
+      userId: user.sId,
+      accessibleSpaceIds,
+      limit: pagination.limit,
+      lastValue: pagination.lastValue,
+      orderDirection,
+    });
+
+    if (esResult.isErr()) {
+      logger.error(
+        { workspaceId: workspace.sId, error: esResult.error },
+        "[conversation_search] ES query failed, falling back to DB"
+      );
+      return this.listPrivateConversationsForUserPaginated(auth, pagination);
+    }
+
+    const { conversationIds, hasMore, lastValue } = esResult.value;
+
+    if (conversationIds.length === 0) {
+      return { conversations: [], hasMore, lastValue };
+    }
+
+    // Targeted fetch: three indexed lookups on the ES-returned IDs only.
+    // No participation table scan — that's the slow path ES replaces.
+    const conversations = await this.fetchByIds(auth, conversationIds);
+
+    // Log discrepancies: ES returned IDs that the DB doesn't recognize.
+    const dbIds = new Set(conversations.map((c) => c.sId));
+    const missingInDb = conversationIds.filter((id) => !dbIds.has(id));
+    if (missingInDb.length > 0) {
+      logger.warn(
+        { workspaceId: workspace.sId, userId: user.sId, missingInDb },
+        "[conversation_search] ES returned conversation IDs absent from DB (stale index)"
+      );
+    }
+
+    // Enrich with per-user participation and read state for these conversations only.
+    await this.enrichWithParticipationAndReadState(auth, conversations);
+
+    // Preserve ES ordering.
+    const byId = new Map(conversations.map((c) => [c.sId, c]));
+    const ordered = conversationIds.flatMap((id) => {
+      const c = byId.get(id);
+      return c ? [c] : [];
+    });
+
+    return { conversations: ordered, hasMore, lastValue };
   }
 
   static async listSpaceUnreadConversationsAndActivityForUser(
@@ -1992,6 +2105,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       }
     );
 
+    await this.triggerEsIndexing(
+      conversation.sId,
+      auth.getNonNullableWorkspace().sId
+    );
+
     return new Ok(updated[0]);
   }
 
@@ -2172,6 +2290,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         );
       }
     }, transaction);
+
+    if (status !== "none") {
+      await this.triggerEsIndexing(
+        conversation.sId,
+        auth.getNonNullableWorkspace().sId
+      );
+    }
 
     return status;
   }

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -143,6 +143,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import { InternalPostConversationsRequestBodySchema } from "@app/types/api/internal/assistant";
 import type {
+  ConversationListItemType,
   ConversationType,
   ConversationWithoutContentType,
   UserMessageType,
@@ -155,7 +156,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetConversationsResponseBody = {
-  conversations: ConversationWithoutContentType[];
+  conversations: ConversationListItemType[];
   hasMore: boolean;
   lastValue: string | null;
 };
@@ -198,7 +199,7 @@ async function handler(
       const pagination = paginationRes.value;
 
       const result =
-        await ConversationResource.listPrivateConversationsForUserPaginated(
+        await ConversationResource.listPrivateConversationsForUserPaginatedFromES(
           auth,
           {
             limit: pagination.limit,
@@ -208,7 +209,7 @@ async function handler(
         );
 
       res.status(200).json({
-        conversations: result.conversations.map((c) => c.toJSON()),
+        conversations: result.conversations,
         hasMore: result.hasMore,
         lastValue: result.lastValue,
       });

--- a/front/temporal/es_indexation/activities.ts
+++ b/front/temporal/es_indexation/activities.ts
@@ -126,11 +126,17 @@ export async function indexConversationEsActivity({
   const participantUserIds =
     await conversation.listParticipantsForConversation();
 
+  console.log(
+    `Indexing conversation ${conversationId} with participants: ${JSON.stringify(participantUserIds, null, 2)}`
+  );
+
   const document = buildConversationSearchDocument(
     auth,
     conversation,
     participantUserIds
   );
+
+  console.log('>> document:', JSON.stringify(document, null, 2));
 
   const indexResult = await indexConversationDocument(document);
   if (indexResult.isErr()) {

--- a/front/temporal/es_indexation/activities.ts
+++ b/front/temporal/es_indexation/activities.ts
@@ -1,3 +1,10 @@
+import { Authenticator } from "@app/lib/auth";
+import {
+  buildConversationSearchDocument,
+  deleteConversationDocument,
+  indexConversationDocument,
+} from "@app/lib/conversation_search";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -71,5 +78,71 @@ export async function indexUserSearchActivity({
         );
       }
     }
+  }
+}
+
+export async function indexConversationEsActivity({
+  conversationId,
+  workspaceId,
+}: {
+  conversationId: string;
+  workspaceId: string;
+}): Promise<void> {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.warn(
+      { conversationId, workspaceId },
+      "[conversation_search] Workspace not found, likely scrubbed"
+    );
+    return;
+  }
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+
+  // fetchById excludes deleted conversations (no includeDeleted flag), so null covers both
+  // hard-deleted (scrubbed) and soft-deleted cases. Both should be removed from the index.
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+
+  if (!conversation) {
+    const deleteResult = await deleteConversationDocument({
+      workspaceId,
+      conversationId,
+    });
+    if (deleteResult.isErr() && deleteResult.error.statusCode !== 404) {
+      logger.error(
+        { conversationId, workspaceId, error: deleteResult.error },
+        "[conversation_search] Failed to delete conversation document"
+      );
+      throw new Error(
+        `Failed to delete conversation ${conversationId} from ES: ${deleteResult.error.message}`
+      );
+    }
+    return;
+  }
+
+  const participantUserIds =
+    await ConversationResource.listParticipantsForConversation(
+      auth,
+      conversation.id
+    );
+
+  const document = buildConversationSearchDocument(
+    auth,
+    conversation,
+    participantUserIds
+  );
+
+  const indexResult = await indexConversationDocument(document);
+  if (indexResult.isErr()) {
+    logger.error(
+      { conversationId, workspaceId, error: indexResult.error },
+      "[conversation_search] Failed to index conversation document"
+    );
+    throw new Error(
+      `Failed to index conversation ${conversationId}: ${indexResult.error.message}`
+    );
   }
 }

--- a/front/temporal/es_indexation/activities.ts
+++ b/front/temporal/es_indexation/activities.ts
@@ -124,10 +124,7 @@ export async function indexConversationEsActivity({
   }
 
   const participantUserIds =
-    await ConversationResource.listParticipantsForConversation(
-      auth,
-      conversation.id
-    );
+    await conversation.listParticipantsForConversation();
 
   const document = buildConversationSearchDocument(
     auth,

--- a/front/temporal/es_indexation/client.ts
+++ b/front/temporal/es_indexation/client.ts
@@ -76,6 +76,12 @@ export async function launchIndexConversationEsWorkflow({
         workspaceId,
       },
     });
+
+    console.log(">> Signaled workflow to index conversation:", {
+      conversationId,
+      workspaceId,
+    });
+
     return new Ok(undefined);
   } catch (e) {
     logger.error(

--- a/front/temporal/es_indexation/client.ts
+++ b/front/temporal/es_indexation/client.ts
@@ -1,13 +1,19 @@
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/es_indexation/config";
-import { makeIndexUserSearchWorkflowId } from "@app/temporal/es_indexation/helpers";
+import {
+  makeIndexConversationEsWorkflowId,
+  makeIndexUserSearchWorkflowId,
+} from "@app/temporal/es_indexation/helpers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-import { indexUserSearchSignal } from "./signals";
-import { indexUserSearchWorkflow } from "./workflows";
+import { indexConversationEsSignal, indexUserSearchSignal } from "./signals";
+import {
+  indexConversationEsWorkflow,
+  indexUserSearchWorkflow,
+} from "./workflows";
 
 export async function launchIndexUserSearchWorkflow({
   userId,
@@ -38,6 +44,48 @@ export async function launchIndexUserSearchWorkflow({
         error: e,
       },
       "Failed starting index user workflow"
+    );
+
+    return new Err(normalizeError(e));
+  }
+}
+
+export async function launchIndexConversationEsWorkflow({
+  conversationId,
+  workspaceId,
+}: {
+  conversationId: string;
+  workspaceId: string;
+}): Promise<Result<undefined, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+
+  const workflowId = makeIndexConversationEsWorkflowId({
+    workspaceId,
+    conversationId,
+  });
+
+  try {
+    await client.workflow.signalWithStart(indexConversationEsWorkflow, {
+      args: [{ conversationId, workspaceId }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      signal: indexConversationEsSignal,
+      signalArgs: undefined,
+      memo: {
+        conversationId,
+        workspaceId,
+      },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    logger.error(
+      {
+        workflowId,
+        conversationId,
+        workspaceId,
+        error: e,
+      },
+      "[conversation_search] Failed to signal conversation ES indexing workflow"
     );
 
     return new Err(normalizeError(e));

--- a/front/temporal/es_indexation/helpers.ts
+++ b/front/temporal/es_indexation/helpers.ts
@@ -5,3 +5,13 @@ export function makeIndexUserSearchWorkflowId({
 }): string {
   return `es-indexation-user-search-${userId}`;
 }
+
+export function makeIndexConversationEsWorkflowId({
+  workspaceId,
+  conversationId,
+}: {
+  workspaceId: string;
+  conversationId: string;
+}): string {
+  return `es-indexation-conversation-${workspaceId}-${conversationId}`;
+}

--- a/front/temporal/es_indexation/signals.ts
+++ b/front/temporal/es_indexation/signals.ts
@@ -3,3 +3,7 @@ import { defineSignal } from "@temporalio/workflow";
 export const indexUserSearchSignal = defineSignal<[void]>(
   "index_user_search_signal"
 );
+
+export const indexConversationEsSignal = defineSignal<[void]>(
+  "index_conversation_es_signal"
+);

--- a/front/temporal/es_indexation/workflows.ts
+++ b/front/temporal/es_indexation/workflows.ts
@@ -1,13 +1,14 @@
 import type * as activities from "@app/temporal/es_indexation/activities";
 import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
 
-import { indexUserSearchSignal } from "./signals";
+import { indexConversationEsSignal, indexUserSearchSignal } from "./signals";
 
 const DEBOUNCE_DELAY_MS = 1_000;
 
-const { indexUserSearchActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "5 minutes",
-});
+const { indexUserSearchActivity, indexConversationEsActivity } =
+  proxyActivities<typeof activities>({
+    startToCloseTimeout: "5 minutes",
+  });
 
 export async function indexUserSearchWorkflow({
   userId,
@@ -28,6 +29,31 @@ export async function indexUserSearchWorkflow({
     }
 
     await indexUserSearchActivity({ userId });
+  }
+
+  // /!\ Any signal received outside of the while loop will be lost, so don't make any async call
+  // here, which will allow the signal handler to be executed by the nodejs event loop.
+}
+
+// One workflow per conversation (enforced by workflowId). Signals coalesce concurrent mutations so
+// the activity runs at most once per in-flight workflow.
+export async function indexConversationEsWorkflow({
+  conversationId,
+  workspaceId,
+}: {
+  conversationId: string;
+  workspaceId: string;
+}): Promise<void> {
+  let signaled = false;
+
+  setHandler(indexConversationEsSignal, () => {
+    signaled = true;
+  });
+
+  while (signaled) {
+    signaled = false;
+    await indexConversationEsActivity({ conversationId, workspaceId });
+    // If another signal arrived while the activity was running, loop and re-index.
   }
 
   // /!\ Any signal received outside of the while loop will be lost, so don't make any async call

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -438,30 +438,37 @@ export type ConversationForkedChildType = {
 };
 
 /**
+ * Fields needed to render a conversation row in the sidebar list. Served
+ * directly from Elasticsearch — no DB hydration required.
+ */
+export type ConversationListItemType = {
+  actionRequired: boolean;
+  created: number;
+  hasError: boolean;
+  lastReadMs: number | null;
+  metadata: ConversationMetadata;
+  requestedSpaceIds: string[];
+  sId: string;
+  spaceId: string | null;
+  title: string | null;
+  triggerId: string | null;
+  unread: boolean;
+  updated: number;
+};
+
+/**
  * A lighter version of Conversation without the content (for menu display).
+ * Extends ConversationListItemType with DB-layer fields used when the full
+ * conversation context is available (individual conversation pages, mutations).
  *
  * @swaggerschema PrivateConversation (swagger_private_schemas.ts)
  */
-export type ConversationWithoutContentType = {
+export type ConversationWithoutContentType = ConversationListItemType & {
   id: ModelId;
-  created: number;
-  updated: number;
-  unread: boolean;
-  lastReadMs: number | null;
-  actionRequired: boolean;
-  hasError: boolean;
-  sId: string;
-  title: string | null;
-  spaceId: string | null;
-  triggerId: string | null;
   depth: number;
-  metadata: ConversationMetadata;
   branchId: string | null;
   forkedFrom?: ConversationForkedFromType;
   forkedChildren?: ConversationForkedChildType[];
-
-  // Ideally, this property should be moved to the ConversationType.
-  requestedSpaceIds: string[];
 };
 
 type ConversationDisplayTitleInput = Pick<
@@ -521,7 +528,7 @@ export function isLightConversationType(
   return "content" in conversation && !Array.isArray(conversation.content[0]);
 }
 
-export const isProjectConversation = <T extends ConversationWithoutContentType>(
+export const isProjectConversation = <T extends ConversationListItemType>(
   conversation: T
 ): conversation is T & { spaceId: string } => !!conversation.spaceId;
 

--- a/front/types/conversation_search/conversation_search.ts
+++ b/front/types/conversation_search/conversation_search.ts
@@ -3,18 +3,24 @@ import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
 /**
  * Elasticsearch document for conversation listing.
  *
- * Stores only the fields needed for filtering and ordering. Per-user mutable
- * state (actionRequired, unread) is hydrated from the DB after the ES query
- * returns the ordered set of IDs.
+ * Stores all fields needed to build a ConversationListItemType without any DB
+ * round-trip. Per-user state (actionRequired, lastReadMs) lives in the nested
+ * participants array and is retrieved per-user via inner_hits.
  */
 export interface ConversationSearchDocument extends ElasticsearchBaseDocument {
   conversation_id: string;
   created_at: string;
+  has_error: boolean;
+  metadata: Record<string, unknown>;
   participants: Array<{
+    action_required: boolean;
+    last_read_at: string | null;
     user_id: string;
   }>;
   requested_space_ids: string[];
   space_id?: string;
+  title: string | null;
+  trigger_id: string | null;
   updated_at: string;
   visibility: string;
 }

--- a/front/types/conversation_search/conversation_search.ts
+++ b/front/types/conversation_search/conversation_search.ts
@@ -1,0 +1,20 @@
+import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
+
+/**
+ * Elasticsearch document for conversation listing.
+ *
+ * Stores only the fields needed for filtering and ordering. Per-user mutable
+ * state (actionRequired, unread) is hydrated from the DB after the ES query
+ * returns the ordered set of IDs.
+ */
+export interface ConversationSearchDocument extends ElasticsearchBaseDocument {
+  conversation_id: string;
+  created_at: string;
+  participants: Array<{
+    user_id: string;
+  }>;
+  requested_space_ids: string[];
+  space_id?: string;
+  updated_at: string;
+  visibility: string;
+}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -219,6 +219,16 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable project todo tab (todos and what's new digest)",
     stage: "dust_only",
   },
+  conversation_search_indexing: {
+    description:
+      "Enable ES indexing of conversations on mutation (write path)",
+    stage: "dust_only",
+  },
+  conversation_search_read: {
+    description:
+      "Enable ES-backed conversation listing in the sidebar (read path)",
+    stage: "dust_only",
+  },
   conversations_slack_notifications: {
     description: "Enable slack notifications",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -748,6 +748,8 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "collapsible_messages"
   | "use_dust_keys"
   | "enable_compaction"
+  | "conversation_search_indexing"
+  | "conversation_search_read"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR lays the full foundation for Elasticsearch-backed private conversation listing in the sidebar. The DB query that powers the sidebar today scans all conversation participants for a user, which will not scale. ES gives us a pre-indexed, paginated, user-scoped view that can be served without joining the conversations and participants tables.

The reality is that we do not need the full conversation object to display a conversation in the sidebar.

The change will be shipped in several PRs and controlled by two independent feature flags so each half can be validated and rolled back separately:
- `conversation_search_indexing`: gates the ES write path (indexing on every mutation)
- `conversation_search_read`: gates the ES read path (sidebar list served from ES)

## Type system

New type: `ConversationListItemType`

The existing `ConversationWithoutContentType` carries `id` (ModelId), `depth`, `branchId`, `forkedFrom`, `forkedChildren`. Fields that come from the DB and have no place in an ES document.

A new `ConversationListItemType` is introduced as the minimal type needed to render the sidebar.

`ConversationWithoutContentType` becomes `ConversationListItemType & { id, depth, branchId, ... }`. An intersection that preserves backward compatibility for all existing code that works with individual conversations and ensure ES document can't derived too much from our actual needs.

All sidebar-facing hooks and components are updated to use `ConversationListItemType`. The GET `/api/w/{wId}/assistant/conversations` endpoint now returns this type.


## ES document structure

```
conversation_id       keyword
workspace_id          keyword (routing key)
visibility            keyword
space_id              keyword (absent for private conversations)
requested_space_ids   keyword[]
title                 keyword
trigger_id            keyword
has_error             boolean
metadata              object (dynamic: false — stored, not indexed)
created_at            date
updated_at            date
participants[]        nested
  user_id             keyword
  action_required     boolean
  last_read_at        date
```

Routing is on `workspace_id` meaning that all documents for a workspace land on the same shard, making the user-scoped filter fast without cross-shard queries.

The `participants` field is nested so ES can query and return per-user state independently per document. Without nested, all participant sub-objects are flattened and cross-user field matches become possible.

## Write path

> [!WARNING]
> Following PR will refactor `ConversationResource` so that we improve DevX to centralize capturing all updates and propagate them to ES.

Every mutation that changes conversation state calls `triggerEsIndexing` which (when `conversation_search_indexing` is enabled) enqueues a Temporal workflow. The workflow:
1. Fetches the `ConversationResource`
2. Calls `listParticipantsForConversation()` capturing action required, read status for each participant
3. Calls `buildConversationSearchDocument` and indexes the document

One workflow per conversation at a time. Because each run reads the full current DB state, the last run always wins with the correct snapshot. No partial update, no race between concurrent runs.

## Read path

`listPrivateConversationsFromES` queries the index with:
- `workspace_id` + `visibility`: `unlisted` + no `space_id` field (private conversations)
- A nested filter on `participants.user_id` with `inner_hits` to return the matched user's `action_required` and `last_read_at` alongside each hit (so we can't save a DB round-trip)
- A `[terms_set](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-terms-set-query#terms-set-query-script)` superset check on `requested_space_ids` to enforce space ACLs
- Sort on `updated_at` + `conversation_id` (tiebreaker) with search-after cursor pagination

The `unread` is computed at read time: `updatedAt > lastReadMs` (or `lastReadMs === null`).

`ConversationResource.listPrivateConversationsForUserPaginatedFromES` wraps this and falls back to the existing DB path when the `conversation_search_read` flag is off or ES fails to answer.

## Follow-up (not in this PR)

- Optimistic UI updates for new conversation creation and mark-as-read (sidebar should reflect state immediately without waiting for the ES re-index cycle)
- Split into three waves: (1) type plumbing, (2) write path, (3) read path activation

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
