### PR TITLE
fix(poke): unstick only the latest hung agent on multi-zombie conversations

### DIFF
--- a/front/lib/api/poke/plugins/conversations/unstick.ts
+++ b/front/lib/api/poke/plugins/conversations/unstick.ts
@@ -77,16 +77,11 @@ export const unstickConversationPlugin = createPlugin({
         new Error("Nothing to unstick: no hung agent answer found.")
       );
     }
-    if (stuckAgents.length > 1) {
-      return new Err(
-        new Error(
-          `Found ${stuckAgents.length} hung agent answers (expected one). ` +
-            `sIds: ${stuckAgents.map((a) => a.sId).join(", ")}.`
-        )
-      );
-    }
 
-    const stuck = stuckAgents[0];
+    // Only finalize the latest hung answer: it's the one blocking the queue. Earlier zombies
+    // (if any) are orphaned history and don't block processing; leave them alone so we do the
+    // minimum needed to resume the conversation.
+    const stuck = stuckAgents[stuckAgents.length - 1];
 
     await updateAgentMessageWithFinalStatus(auth, {
       conversation,
@@ -101,12 +96,21 @@ export const unstickConversationPlugin = createPlugin({
       },
     });
 
+    const extras =
+      stuckAgents.length > 1
+        ? ` ${stuckAgents.length - 1} earlier hung answer(s) were left alone ` +
+          `(sIds: ${stuckAgents
+            .slice(0, -1)
+            .map((a) => a.sId)
+            .join(", ")}).`
+        : "";
+
     return new Ok({
       display: "text",
       value:
         `Marked agent message ${stuck.sId} as failed. ` +
         `Any queued user messages have been promoted and a fresh agent answer has been ` +
-        `kicked off for the last one.`,
+        `kicked off for the last one.${extras}`,
     });
   },
 });


### PR DESCRIPTION
## Description

Follow-up to the unstick-conversation poke plugin. When a conversation has more than one agent answer stuck in "created", we were refusing to run. Some real-world stuck conversations have multiple zombies stacked up, so refusing just blocked support from fixing them.

The plugin now finalizes the latest hung answer only, since that is the one blocking the queue. Earlier zombies (if any) are orphaned history and do not block processing, so we leave them alone and do the minimum needed to resume the conversation. The success message reports how many earlier hung answers were left untouched, with their sIds, so support has visibility if they want to investigate further or re-run.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
