### PR TITLE
[front] enh: Reduce connections requirements for api/v1/w/[wId]/spaces/[spaceId]/conversations

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversations/index.ts
@@ -93,7 +93,7 @@ async function handler(
       const conversationsFull = await concurrentExecutor(
         spaceConversations,
         async (c) => getConversation(auth, c.sId, true), // includeDeleted = true
-        { concurrency: 10 }
+        { concurrency: 4 }
       );
 
       const conversations = removeNulls(


### PR DESCRIPTION
## Description

Piggy-backing on #24491, reducing the max concurrency on getConversation down to 4.

## Tests

N/A

## Risk

Low

## Deploy Plan

- [ ] Deploy front