### PR TITLE
[front] enh: batch delete MCP server view dependencies

### DIFF
--- a/front/lib/models/agent/actions/mcp_server_view_helper.ts
+++ b/front/lib/models/agent/actions/mcp_server_view_helper.ts
@@ -11,23 +11,23 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
-export const destroyMCPServerViewDependencies = async (
+export async function destroyMCPServerViewDependencies(
   auth: Authenticator,
   {
-    mcpServerViewId,
+    mcpServerViewIds,
     transaction,
   }: {
-    mcpServerViewId: ModelId;
+    mcpServerViewIds: ModelId[];
     transaction?: Transaction;
   }
-) => {
+) {
   // Delete all dependencies.
   const agentConfigurationIds = (
     await AgentMCPServerConfigurationModel.findAll({
       attributes: ["id"],
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
-        mcpServerViewId: mcpServerViewId,
+        mcpServerViewId: mcpServerViewIds,
       },
       transaction,
     })
@@ -66,7 +66,7 @@ export const destroyMCPServerViewDependencies = async (
   await AgentMCPServerConfigurationModel.destroy({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
-      mcpServerViewId: mcpServerViewId,
+      mcpServerViewId: mcpServerViewIds,
     },
     transaction,
   });
@@ -74,7 +74,7 @@ export const destroyMCPServerViewDependencies = async (
   await ConversationMCPServerViewModel.destroy({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
-      mcpServerViewId: mcpServerViewId,
+      mcpServerViewId: mcpServerViewIds,
     },
     transaction,
   });
@@ -82,8 +82,8 @@ export const destroyMCPServerViewDependencies = async (
   await SkillMCPServerConfigurationModel.destroy({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
-      mcpServerViewId: mcpServerViewId,
+      mcpServerViewId: mcpServerViewIds,
     },
     transaction,
   });
-};
+}

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -226,15 +226,9 @@ export class InternalMCPServerInMemoryResource {
       },
     });
 
-    await concurrentExecutor(
-      mcpServerViews,
-      async (mcpServerView) => {
-        await destroyMCPServerViewDependencies(auth, {
-          mcpServerViewId: mcpServerView.id,
-        });
-      },
-      { concurrency: 10 }
-    );
+    await destroyMCPServerViewDependencies(auth, {
+      mcpServerViewIds: mcpServerViews.map((view) => view.id),
+    });
 
     await MCPServerViewModel.destroy({
       where: {

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -935,7 +935,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     transaction?: Transaction
   ): Promise<Result<number, Error>> {
     await destroyMCPServerViewDependencies(auth, {
-      mcpServerViewId: this.id,
+      mcpServerViewIds: [this.id],
       transaction,
     });
 

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -287,15 +287,9 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       },
     });
 
-    await concurrentExecutor(
-      mcpServerViews,
-      async (mcpServerView) => {
-        await destroyMCPServerViewDependencies(auth, {
-          mcpServerViewId: mcpServerView.id,
-        });
-      },
-      { concurrency: 10 }
-    );
+    await destroyMCPServerViewDependencies(auth, {
+      mcpServerViewIds: mcpServerViews.map((view) => view.id),
+    });
 
     await concurrentExecutor(
       serverToolMetadatas,


### PR DESCRIPTION
## Description

- This PR removes a few parallel queries run when deleting the dependencies of MCP server views.
- Instead of running the deletion of dependencies in a loop for each MCP server view, this PR batches the deletions (`AgentMCPServerConfigurationModel`, `ConversationMCPServerViewModel`, etc..).
- This won't result in an overly large "WHERE "mcpServerViewId" IN (...)" clause as there are at most 1 view per space, and only 2 a very large proportion of the time.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
- No migration, not sure why the file is under `models`
