### PR TITLE
fix(cancel): fix usage of batchRenderAgentMessages after merge

### DIFF
--- a/front/lib/api/cancel.ts
+++ b/front/lib/api/cancel.ts
@@ -60,7 +60,9 @@ export async function cancelMessageGeneration(
   const agentMessagesRes = await batchRenderAgentMessages(
     auth,
     messageRows,
-    "full"
+    "full",
+    null,
+    new Map()
   );
 
   if (agentMessagesRes.isErr()) {


### PR DESCRIPTION
## Description

batchRenderAgentMessages arguments has been updated in parallel of a previous [PR](https://github.com/dust-tt/dust/pull/24663)
The CI did not detect the error before merging
=> updating use of  batchRenderAgentMessages in cancel.ts to fix the issue

## Tests

- npx tsgo --noEmit 

## Risk

Very low, mentions are not used in cancel code

## Deploy Plan

Deploy front