### PR TITLE
feat(sbx): remove E2B-level allowlist and pre-PR1 compat gate

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -11,7 +11,6 @@ const {
   mockRecordToolDuration,
   mockRefreshGcsToken,
   mockRevokeExecToken,
-  mockSandboxSupportsEgressForwarding,
   mockSetupEgressForwarder,
   mockStartTelemetry,
   mockWrapCommand,
@@ -26,7 +25,6 @@ const {
   mockRecordToolDuration: vi.fn(),
   mockRefreshGcsToken: vi.fn(),
   mockRevokeExecToken: vi.fn(),
-  mockSandboxSupportsEgressForwarding: vi.fn(),
   mockSetupEgressForwarder: vi.fn(),
   mockStartTelemetry: vi.fn(),
   mockWrapCommand: vi.fn(),
@@ -43,7 +41,6 @@ vi.mock("@app/lib/api/config", () => ({
 vi.mock("@app/lib/api/sandbox/egress", () => ({
   checkEgressForwarderHealth: mockCheckEgressForwarderHealth,
   readNewDenyLogEntries: mockReadNewDenyLogEntries,
-  sandboxSupportsEgressForwarding: mockSandboxSupportsEgressForwarding,
   setupEgressForwarder: mockSetupEgressForwarder,
 }));
 
@@ -127,46 +124,6 @@ describe("runSandboxBashTool", () => {
     } as never;
   }
 
-  it("keeps executing as the default user when the sandbox is pre-PR1", async () => {
-    const sandbox = {
-      providerId: "provider-id",
-      sId: "sandbox-id",
-      exec: vi
-        .fn()
-        .mockResolvedValue(
-          new Ok({ exitCode: 0, stdout: "hello", stderr: "" })
-        ),
-    };
-
-    mockEnsureActive.mockResolvedValue(
-      new Ok({
-        freshlyCreated: false,
-        sandbox,
-        wokeFromSleep: false,
-      })
-    );
-    mockSandboxSupportsEgressForwarding.mockResolvedValue(new Ok(false));
-
-    const result = await runSandboxBashTool(
-      { command: "echo hello", description: "Run command" },
-      makeExtra()
-    );
-
-    expect(result.isOk()).toBe(true);
-    expect(mockSetupEgressForwarder).not.toHaveBeenCalled();
-    expect(mockCheckEgressForwarderHealth).not.toHaveBeenCalled();
-    expect(sandbox.exec).toHaveBeenCalledWith(
-      expect.anything(),
-      "wrapped:echo hello",
-      expect.objectContaining({
-        envVars: expect.objectContaining({
-          DUST_SANDBOX_TOKEN: "sandbox-token",
-        }),
-      })
-    );
-    expect(sandbox.exec.mock.calls[0][2]).not.toHaveProperty("user");
-  });
-
   it("executes as agent-proxied when the forwarder is healthy", async () => {
     const sandbox = {
       providerId: "provider-id",
@@ -185,7 +142,7 @@ describe("runSandboxBashTool", () => {
         wokeFromSleep: false,
       })
     );
-    mockSandboxSupportsEgressForwarding.mockResolvedValue(new Ok(true));
+
     mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(true));
 
     const result = await runSandboxBashTool(
@@ -222,7 +179,7 @@ describe("runSandboxBashTool", () => {
         wokeFromSleep: true,
       })
     );
-    mockSandboxSupportsEgressForwarding.mockResolvedValue(new Ok(true));
+
     mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(false));
 
     const result = await runSandboxBashTool(
@@ -261,7 +218,7 @@ describe("runSandboxBashTool", () => {
         wokeFromSleep: false,
       })
     );
-    mockSandboxSupportsEgressForwarding.mockResolvedValue(new Ok(true));
+
     mockSetupEgressForwarder.mockResolvedValue(
       new Err(new Error("setup failed"))
     );

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -16,7 +16,6 @@ import {
 import {
   checkEgressForwarderHealth,
   readNewDenyLogEntries,
-  sandboxSupportsEgressForwarding,
   setupEgressForwarder,
 } from "@app/lib/api/sandbox/egress";
 import {
@@ -172,62 +171,40 @@ export async function runSandboxBashTool(
     );
   }
 
-  const egressCompatResult = await sandboxSupportsEgressForwarding(
-    auth,
-    sandbox
-  );
-  if (egressCompatResult.isErr()) {
-    return new Err(new MCPError(egressCompatResult.error.message));
+  if (freshlyCreated) {
+    const setupResult = await setupEgressForwarder(auth, sandbox);
+    if (setupResult.isErr()) {
+      return new Err(new MCPError(setupResult.error.message));
+    }
   }
 
-  let execUser: string | undefined;
-  if (!egressCompatResult.value) {
-    logger.info(
+  const healthResult = await checkEgressForwarderHealth(auth, sandbox);
+  if (healthResult.isErr()) {
+    return new Err(new MCPError(healthResult.error.message));
+  }
+
+  if (!healthResult.value) {
+    logger.warn(
       {
-        event: "egress.compat_skip",
+        event: "egress.health_fail",
         providerId: sandbox.providerId,
         sandboxId: sandbox.sId,
       },
-      "Skipping sandbox egress setup for an incompatible sandbox"
+      "Sandbox egress forwarder health check failed, restarting"
     );
+    const setupResult = await setupEgressForwarder(auth, sandbox);
+    if (setupResult.isErr()) {
+      return new Err(new MCPError(setupResult.error.message));
+    }
   } else {
-    if (freshlyCreated) {
-      const setupResult = await setupEgressForwarder(auth, sandbox);
-      if (setupResult.isErr()) {
-        return new Err(new MCPError(setupResult.error.message));
-      }
-    }
-
-    const healthResult = await checkEgressForwarderHealth(auth, sandbox);
-    if (healthResult.isErr()) {
-      return new Err(new MCPError(healthResult.error.message));
-    }
-
-    if (!healthResult.value) {
-      logger.warn(
-        {
-          event: "egress.health_fail",
-          providerId: sandbox.providerId,
-          sandboxId: sandbox.sId,
-        },
-        "Sandbox egress forwarder health check failed, restarting"
-      );
-      const setupResult = await setupEgressForwarder(auth, sandbox);
-      if (setupResult.isErr()) {
-        return new Err(new MCPError(setupResult.error.message));
-      }
-    } else {
-      logger.info(
-        {
-          event: "egress.health_ok",
-          providerId: sandbox.providerId,
-          sandboxId: sandbox.sId,
-        },
-        "Sandbox egress forwarder health check succeeded"
-      );
-    }
-
-    execUser = "agent-proxied";
+    logger.info(
+      {
+        event: "egress.health_ok",
+        providerId: sandbox.providerId,
+        sandboxId: sandbox.sId,
+      },
+      "Sandbox egress forwarder health check succeeded"
+    );
   }
 
   const execId = generateExecId();
@@ -260,7 +237,7 @@ export async function runSandboxBashTool(
       DUST_SANDBOX_TOKEN: sandboxToken,
       DUST_API_URL: `${sandboxAPIBase}/api/v1/w/${auth.getNonNullableWorkspace().sId}`,
     },
-    ...(execUser ? { user: execUser } : {}),
+    user: "agent-proxied",
   });
 
   const durationMs = performance.now() - startMs;
@@ -281,18 +258,16 @@ export async function runSandboxBashTool(
 
   let output = formatExecOutput(execResult.value);
 
-  if (execUser) {
-    const denyResult = await readNewDenyLogEntries(auth, sandbox);
-    if (denyResult.isErr()) {
-      logger.warn(
-        { err: denyResult.error, providerId: sandbox.providerId },
-        "Failed to read egress deny log"
-      );
-    } else if (denyResult.value.length > 0) {
-      output +=
-        "\n[network proxy] Recent outbound request(s) denied by the sandbox proxy:\n" +
-        denyResult.value.map((line) => `  ${line}`).join("\n");
-    }
+  const denyResult = await readNewDenyLogEntries(auth, sandbox);
+  if (denyResult.isErr()) {
+    logger.warn(
+      { err: denyResult.error, providerId: sandbox.providerId },
+      "Failed to read egress deny log"
+    );
+  } else if (denyResult.value.length > 0) {
+    output +=
+      "\n[network proxy] Recent outbound request(s) denied by the sandbox proxy:\n" +
+      denyResult.value.map((line) => `  ${line}`).join("\n");
   }
 
   return new Ok([{ type: "text" as const, text: output }]);

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -51,7 +51,6 @@ vi.mock("node:dns/promises", () => ({
 import {
   mintEgressJwt,
   readNewDenyLogEntries,
-  sandboxSupportsEgressForwarding,
   setupEgressForwarder,
 } from "./egress";
 
@@ -77,31 +76,6 @@ describe("sandbox egress helpers", () => {
 
     expect(payload.sbId).toBe("provider-sandbox-id");
     expect(payload.exp).toBeGreaterThan(payload.iat ?? 0);
-  });
-
-  it("detects incompatible sandboxes from the compat probe exit code", async () => {
-    const sandbox = {
-      exec: vi
-        .fn()
-        .mockResolvedValue(new Ok({ exitCode: 1, stdout: "", stderr: "" })),
-    };
-
-    const result = await sandboxSupportsEgressForwarding(
-      {} as never,
-      sandbox as never
-    );
-
-    expect(result).toEqual(new Ok(false));
-    expect(sandbox.exec).toHaveBeenCalledWith(
-      {},
-      expect.stringContaining("test -x /opt/bin/dsbx")
-    );
-    expect(sandbox.exec).toHaveBeenCalledWith(
-      {},
-      expect.stringContaining(
-        "systemctl is-active --quiet dust-egress-nftables.service"
-      )
-    );
   });
 
   it("writes the token, starts the forwarder, and waits for health", async () => {

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -86,22 +86,6 @@ export function mintEgressJwt(providerId: string): string {
   );
 }
 
-export async function sandboxSupportsEgressForwarding(
-  auth: Authenticator,
-  sandbox: SandboxResource
-): Promise<Result<boolean, Error>> {
-  const probeResult = await sandbox.exec(
-    auth,
-    "test -d /etc/dust && id agent-proxied >/dev/null 2>&1 && test -x /opt/bin/dsbx && systemctl is-active --quiet dust-egress-nftables.service"
-  );
-
-  if (probeResult.isErr()) {
-    return probeResult;
-  }
-
-  return new Ok(probeResult.value.exitCode === 0);
-}
-
 export async function checkEgressForwarderHealth(
   auth: Authenticator,
   sandbox: SandboxResource

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -1,7 +1,7 @@
 import { PROFILE_DIR } from "@app/lib/api/sandbox/image/profile";
 import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import {
-  ALLOWLIST_NETWORK_POLICY,
+  PROXY_ONLY_NETWORK_POLICY,
   type ToolEntry,
 } from "@app/lib/api/sandbox/image/types";
 import logger from "@app/logger/logger";
@@ -328,7 +328,7 @@ SHELLEOF`,
   ])
   .withCapability("gcsfuse")
   .withResources({ vcpu: 2, memoryMb: 2048 })
-  .withNetwork(ALLOWLIST_NETWORK_POLICY)
+  .withNetwork(PROXY_ONLY_NETWORK_POLICY)
   .setWorkdir("/home/agent")
   .withToolManifest()
   .register({

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -85,17 +85,19 @@ export interface NetworkPolicy {
   readonly allowlist?: readonly string[];
 }
 
-export const ALLOWLIST_NETWORK_POLICY: NetworkPolicy = {
+// Agent commands run as agent-proxied (uid 1003) whose traffic is redirected
+// by nftables to the in-sandbox egress proxy. The E2B-level allowlist covers
+// services that root processes access directly (bypassing the proxy).
+export const PROXY_ONLY_NETWORK_POLICY: NetworkPolicy = {
   mode: "deny_all",
   allowlist: [
+    // GCS — gcsfuse mounts run as root
     "storage.googleapis.com",
-    "dust.tt",
-    "*.dust.tt",
-    // Datadog EU — sandbox telemetry
+    // Datadog EU — sandbox telemetry runs as root
     "http-intake.logs.datadoghq.eu",
     "api.datadoghq.eu",
-    // Regional egress proxy — the forwarder connects by IP (resolved by front),
-    // so E2B's domain-based allowOut doesn't cover it. These are reserved GCP LB IPs.
+    // Regional egress proxy — the forwarder (root) connects by resolved IP,
+    // but E2B's domain-based allowOut needs the wildcard too.
     "*.sandbox-egress.dust.tt",
     "104.199.4.80/32", // eu.sandbox-egress.dust.tt
     "104.154.146.142/32", // us.sandbox-egress.dust.tt


### PR DESCRIPTION
## Description

The egress proxy (nftables + dsbx forwarder) is now the sole mechanism for outbound traffic filtering in sandboxes. This PR removes two legacy layers:

- **E2B-level domain allowlist narrowed** (`ALLOWLIST_NETWORK_POLICY` → `PROXY_ONLY_NETWORK_POLICY`): Previously the E2B allowlist included `dust.tt`, `*.dust.tt`, and other app-level domains. These are no longer needed since `agent-proxied` traffic goes through the egress proxy. The new policy only allows services that root processes access directly (bypassing nftables): GCS (`storage.googleapis.com`) for gcsfuse mounts, Datadog for telemetry, and the egress proxy itself.

- **Pre-PR1 compat probe** (`sandboxSupportsEgressForwarding()`): This function probed each sandbox for egress support (checking `/etc/dust`, `agent-proxied` user, `dsbx` binary, `nftables` service). If the probe failed, commands ran as the default user without egress filtering. Now that all images include egress support, this gate is removed — commands always run as `agent-proxied` and the forwarder is always set up.

## Tests

- Updated unit tests in `egress.test.ts`, `tools/index.test.ts`, `sandbox_image.test.ts`
- Removed the pre-PR1 compat test case, all remaining tests pass (59 tests across 3 files)

## Risk

**Medium** — This changes sandbox networking behavior:
- Removing the compat gate means old sandbox images (without egress support) will fail.
- If the forwarder crashes and nftables rules are still in place, `agent-proxied` traffic will be blocked (fail-closed, which is the desired behavior).

## Deploy Plan

Deploy front.