### PR TITLE
Add optional "replyTo" parameter for create_draft and send tools in Outlook MCP

### DIFF
--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -120,6 +120,12 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe("The email addresses to BCC"),
+      replyTo: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Reply-to email addresses. Replies will go to these addresses instead of the sender."
+        ),
       subject: z.string().describe("The subject line of the email"),
       contentType: z
         .string()
@@ -201,6 +207,12 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe("The email addresses to BCC"),
+      replyTo: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Reply-to email addresses. Replies will go to these addresses instead of the sender."
+        ),
       subject: z.string().describe("The subject line of the email"),
       contentType: z
         .enum(["text", "html"])

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -79,6 +79,12 @@ interface OutlookMessage {
       name?: string;
     };
   }>;
+  replyTo?: Array<{
+    emailAddress: {
+      address: string;
+      name?: string;
+    };
+  }>;
   body?: {
     contentType: string;
     content: string;
@@ -190,7 +196,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     } else {
       params.append(
         "$select",
-        "id,conversationId,subject,bodyPreview,importance,receivedDateTime,sentDateTime,hasAttachments,isDraft,isRead,from,toRecipients,ccRecipients,parentFolderId"
+        "id,conversationId,subject,bodyPreview,importance,receivedDateTime,sentDateTime,hasAttachments,isDraft,isRead,from,toRecipients,ccRecipients,bccRecipients,replyTo,parentFolderId"
       );
     }
 
@@ -423,7 +429,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
   },
 
   create_draft: async (
-    { to, cc, bcc, subject, contentType, body, importance = "normal" },
+    { to, cc, bcc, replyTo, subject, contentType, body, importance = "normal" },
     { authInfo }
   ) => {
     const accessToken = authInfo?.token;
@@ -453,6 +459,12 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
 
     if (bcc && bcc.length > 0) {
       message.bccRecipients = bcc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+
+    if (replyTo && replyTo.length > 0) {
+      message.replyTo = replyTo.map((email) => ({
         emailAddress: { address: email },
       }));
     }
@@ -641,6 +653,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       to,
       cc,
       bcc,
+      replyTo,
       subject,
       contentType = "text",
       body,
@@ -672,6 +685,12 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
 
     if (bcc && bcc.length > 0) {
       message.bccRecipients = bcc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+
+    if (replyTo && replyTo.length > 0) {
+      message.replyTo = replyTo.map((email) => ({
         emailAddress: { address: email },
       }));
     }


### PR DESCRIPTION
## Description

Adds the ability to set a replyTo address other than the senders. The specific use case enables an agent to send emails as the user (using standard MCP flows) but allows the person replying to instead contact the agent while responding.

## Tests

Manual testing locally.

## Risk

Low. Small blast radius. The parameter is flagged as optional and the tool description is unlikely to be misunderstood by agent.

## Deploy Plan

Standard deployment.
