### PR TITLE
[front] chore: Log cache skip/invalidation

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -130,17 +130,47 @@ export class GroupResource extends BaseResource<GroupModel> {
     { cacheNullValues: false }
   );
 
-  static invalidateGroupIdsCacheForUser = invalidateCacheWithRedis(
+  private static _invalidateGroupIdsCacheForUser = invalidateCacheWithRedis(
     (_params: { user: { id: ModelId }; workspace: { id: ModelId } }) =>
       Promise.resolve([]),
     GroupResource.groupIdsCacheKeyResolver
   );
 
-  static batchInvalidateGroupIdsCacheForUsers = batchInvalidateCacheWithRedis(
-    (_params: { user: { id: ModelId }; workspace: { id: ModelId } }) =>
-      Promise.resolve([]),
-    GroupResource.groupIdsCacheKeyResolver
-  );
+  static invalidateGroupIdsCacheForUser = async (params: {
+    user: { id: ModelId };
+    workspace: { id: ModelId };
+  }) => {
+    logger.info(
+      {
+        userModelId: params.user.id,
+        workspaceModelId: params.workspace.id,
+        method: "GroupResource.invalidateGroupIdsCacheForUser",
+      },
+      "Invalidating auth resource cache"
+    );
+    return GroupResource._invalidateGroupIdsCacheForUser(params);
+  };
+
+  private static _batchInvalidateGroupIdsCacheForUsers =
+    batchInvalidateCacheWithRedis(
+      (_params: { user: { id: ModelId }; workspace: { id: ModelId } }) =>
+        Promise.resolve([]),
+      GroupResource.groupIdsCacheKeyResolver
+    );
+
+  static batchInvalidateGroupIdsCacheForUsers = async (
+    argsList: [{ user: { id: ModelId }; workspace: { id: ModelId } }][]
+  ) => {
+    logger.info(
+      {
+        workspaceModelId: argsList[0]?.[0]?.workspace.id,
+        count: argsList.length,
+        method: "GroupResource.batchInvalidateGroupIdsCacheForUsers",
+      },
+      "Invalidating auth resource cache (batch)"
+    );
+    return GroupResource._batchInvalidateGroupIdsCacheForUsers(argsList);
+  };
 
   /**
    * WARNING: This method skips workspace membership checks. It is intended for use in
@@ -157,6 +187,14 @@ export class GroupResource extends BaseResource<GroupModel> {
     transaction?: Transaction;
   }): Promise<ModelId[]> {
     if (transaction) {
+      logger.info(
+        {
+          userModelId: user.id,
+          workspaceModelId: workspace.id,
+          method: "GroupResource.dangerouslyListUserGroupsForAuth",
+        },
+        "Skipping auth resource cache: transaction provided"
+      );
       return this.dangerouslyListUserGroupsForAuthUncached({
         user,
         workspace,

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -411,11 +411,26 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     { cacheNullValues: false }
   );
 
-  private static invalidateRoleCache = invalidateCacheWithRedis(
+  private static _invalidateRoleCache = invalidateCacheWithRedis(
     MembershipResource._getActiveRoleForUserInWorkspaceUncached,
     (params: { userModelId: ModelId; workspaceModelId: ModelId }) =>
       MembershipResource.roleCacheKeyResolver(params)
   );
+
+  private static invalidateRoleCache = async (params: {
+    userModelId: ModelId;
+    workspaceModelId: ModelId;
+  }) => {
+    logger.info(
+      {
+        userModelId: params.userModelId,
+        workspaceModelId: params.workspaceModelId,
+        method: "MembershipResource.invalidateRoleCache",
+      },
+      "Invalidating auth resource cache"
+    );
+    return MembershipResource._invalidateRoleCache(params);
+  };
 
   static async getActiveRoleForUserInWorkspace({
     user,
@@ -427,6 +442,14 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     transaction?: Transaction;
   }): Promise<MembershipRoleType | "none"> {
     if (transaction) {
+      logger.info(
+        {
+          userModelId: user.id,
+          workspaceModelId: workspace.id,
+          method: "MembershipResource.getActiveRoleForUserInWorkspace",
+        },
+        "Skipping auth resource cache: transaction provided"
+      );
       return this._getActiveRoleForUserInWorkspaceUncached({
         userModelId: user.id,
         workspaceModelId: workspace.id,

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -255,10 +255,23 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     };
   }
 
-  private static invalidateSubscriptionCache = invalidateCacheWithRedis(
+  private static _invalidateSubscriptionCache = invalidateCacheWithRedis(
     SubscriptionResource._fetchActiveByWorkspaceModelIdUncached,
     SubscriptionResource.subscriptionCacheKeyResolver
   );
+
+  private static invalidateSubscriptionCache = async (
+    workspaceModelId: ModelId
+  ) => {
+    logger.info(
+      {
+        workspaceModelId,
+        method: "SubscriptionResource.invalidateSubscriptionCache",
+      },
+      "Invalidating auth resource cache"
+    );
+    return SubscriptionResource._invalidateSubscriptionCache(workspaceModelId);
+  };
 
   /**
    * Invalidate subscription caches for all workspaces on a given plan.
@@ -324,6 +337,13 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   ): Promise<SubscriptionResource | null> {
     // Bypass cache when transaction is provided for transactional consistency
     if (transaction) {
+      logger.info(
+        {
+          workspaceModelId,
+          method: "SubscriptionResource.fetchActiveByWorkspaceModelId",
+        },
+        "Skipping auth resource cache: transaction provided"
+      );
       const res = await SubscriptionResource.fetchActiveByWorkspacesModelId(
         [workspaceModelId],
         transaction


### PR DESCRIPTION
## Description

Currently we cache auth-path resources to save millions of sql queries per day.
This is done with a redis cache with no TTL.
This means that cache miss should be very low, unless we are hitting max memory and witness eviction (which we are not)

However, we still see ~2M / day for each of them. Leaving two possibilities
- We cache invalidate way more often than initially thought.
- We pass transactions, which skip the cache layer entirely (because in theory you could read a value from a snapshot in the future or in the past)

This PR aims at measuring that by logging it.

## Tests

N/A

## Risk

Low

## Deploy Plan

- [ ] Deploy front