### PR TITLE
Keep track of the user who updates a suggestion

### DIFF
--- a/front/components/poke/skill_suggestions/columns.tsx
+++ b/front/components/poke/skill_suggestions/columns.tsx
@@ -195,6 +195,28 @@ export function makeColumnsForSkillSuggestions(
       },
     },
     {
+      accessorKey: "updatedAt",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Updated at" />
+      ),
+      cell: ({ row }) => {
+        return formatTimestampToFriendlyDate(row.original.updatedAt);
+      },
+    },
+    {
+      accessorKey: "updatedBy",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Updated by" />
+      ),
+      cell: ({ row }) => {
+        const updatedBy = row.original.updatedBy;
+        if (!updatedBy) {
+          return "-";
+        }
+        return <span title={updatedBy.email}>{updatedBy.fullName}</span>;
+      },
+    },
+    {
       id: "content",
       header: "Content",
       cell: ({ row }) => {

--- a/front/lib/models/skill/skill_suggestion.ts
+++ b/front/lib/models/skill/skill_suggestion.ts
@@ -1,6 +1,7 @@
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
   SkillSuggestionKind,
@@ -26,9 +27,11 @@ export class SkillSuggestionModel extends WorkspaceAwareModel<SkillSuggestionMod
   declare source: SkillSuggestionSource;
   declare sourceConversationId: ForeignKey<ConversationModel["id"]> | null;
   declare groupId: string | null;
+  declare updatedByUserId: ForeignKey<UserModel["id"]> | null;
 
   declare skillConfiguration: NonAttribute<SkillConfigurationModel>;
   declare sourceConversation: NonAttribute<ConversationModel | null>;
+  declare updatedByUser: NonAttribute<UserModel | null>;
 }
 
 SkillSuggestionModel.init(
@@ -82,6 +85,14 @@ SkillSuggestionModel.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
+    updatedByUserId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      references: {
+        model: UserModel,
+        key: "id",
+      },
+    },
   },
   {
     modelName: "skill_suggestion",
@@ -132,4 +143,13 @@ SkillSuggestionModel.belongsTo(ConversationModel, {
   foreignKey: { name: "sourceConversationId", allowNull: true },
   onDelete: "RESTRICT",
   as: "sourceConversation",
+});
+
+UserModel.hasMany(SkillSuggestionModel, {
+  foreignKey: { name: "updatedByUserId", allowNull: true },
+  onDelete: "SET NULL",
+});
+SkillSuggestionModel.belongsTo(UserModel, {
+  foreignKey: { name: "updatedByUserId", allowNull: true },
+  as: "updatedByUser",
 });

--- a/front/lib/models/skill/skill_suggestion.ts
+++ b/front/lib/models/skill/skill_suggestion.ts
@@ -124,6 +124,12 @@ SkillSuggestionModel.init(
         concurrently: true,
         where: { groupId: { [Op.ne]: null } },
       },
+      {
+        name: "idx_skill_suggestions_updated_by_user_id",
+        fields: ["updatedByUserId"],
+        concurrently: true,
+        where: { updatedByUserId: { [Op.ne]: null } },
+      },
     ],
   }
 );

--- a/front/lib/resources/skill_suggestion_resource.ts
+++ b/front/lib/resources/skill_suggestion_resource.ts
@@ -4,6 +4,7 @@ import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
@@ -16,6 +17,7 @@ import type {
   SkillSuggestionSource,
   SkillSuggestionState,
   SkillSuggestionType,
+  SkillSuggestionUpdatedBy,
 } from "@app/types/suggestions/skill_suggestion";
 import { parseSkillSuggestionData } from "@app/types/suggestions/skill_suggestion";
 import type {
@@ -43,18 +45,21 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
   readonly editorsGroupId: ModelId | null;
   readonly skillConfigurationSId: string;
   readonly sourceConversationSId: string | null;
+  readonly updatedBy: SkillSuggestionUpdatedBy | null;
 
   constructor(
     model: ModelStatic<SkillSuggestionModel>,
     blob: Attributes<SkillSuggestionModel>,
     editorsGroupId: ModelId | null,
     skillConfigurationSId: string,
-    sourceConversationSId: string | null
+    sourceConversationSId: string | null,
+    updatedBy: SkillSuggestionUpdatedBy | null
   ) {
     super(SkillSuggestionModel, blob);
     this.editorsGroupId = editorsGroupId;
     this.skillConfigurationSId = skillConfigurationSId;
     this.sourceConversationSId = sourceConversationSId;
+    this.updatedBy = updatedBy;
   }
 
   /**
@@ -95,6 +100,7 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
       suggestion.get(),
       skill.editorGroup?.id ?? null,
       skill.sId,
+      null,
       null
     );
   }
@@ -122,6 +128,12 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
           as: "sourceConversation",
           required: false,
           attributes: ["sId"],
+        },
+        {
+          model: UserModel,
+          as: "updatedByUser",
+          required: false,
+          attributes: ["sId", "firstName", "lastName", "email"],
         },
       ],
       ...otherOptions,
@@ -154,12 +166,23 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
         if (!skillResource || !skillResource.canWrite(auth)) {
           return null;
         }
+        const user = suggestion.updatedByUser;
+        const updatedBy = user
+          ? {
+              sId: user.sId,
+              fullName: [user.firstName, user.lastName]
+                .filter(Boolean)
+                .join(" "),
+              email: user.email,
+            }
+          : null;
         return new this(
           SkillSuggestionModel,
           suggestion.get(),
           skillResource.editorGroup?.id ?? null,
           skillResource.sId,
-          suggestion.sourceConversation?.sId ?? null
+          suggestion.sourceConversation?.sId ?? null,
+          updatedBy
         );
       })
     );
@@ -276,15 +299,23 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
       return;
     }
 
-    await this.model.update(
-      { state },
-      {
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          id: { [Op.in]: suggestions.map((s) => s.id) },
-        },
+    // Track the user who accepted/rejected. Do not set for "outdated"
+    // (suggestion became obsolete) or "pending" (reset).
+    const updates: { state: SkillSuggestionState; updatedByUserId?: ModelId } =
+      { state };
+    if (state === "approved" || state === "rejected") {
+      const user = auth.user();
+      if (user) {
+        updates.updatedByUserId = user.id;
       }
-    );
+    }
+
+    await this.model.update(updates, {
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        id: { [Op.in]: suggestions.map((s) => s.id) },
+      },
+    });
   }
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
@@ -401,6 +432,7 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
       state: this.state,
       source: this.source,
       sourceConversationId: this.sourceConversationSId,
+      updatedBy: this.updatedBy,
       ...suggestionData,
     };
   }

--- a/front/migrations/db/migration_597.sql
+++ b/front/migrations/db/migration_597.sql
@@ -1,3 +1,7 @@
 -- Migration created on Apr 22, 2026
 ALTER TABLE "skill_suggestions"
     ADD COLUMN "updatedByUserId" BIGINT REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX CONCURRENTLY "idx_skill_suggestions_updated_by_user_id"
+    ON "skill_suggestions" ("updatedByUserId")
+    WHERE "updatedByUserId" IS NOT NULL;

--- a/front/migrations/db/migration_597.sql
+++ b/front/migrations/db/migration_597.sql
@@ -1,0 +1,3 @@
+-- Migration created on Apr 22, 2026
+ALTER TABLE "skill_suggestions"
+    ADD COLUMN "updatedByUserId" BIGINT REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
@@ -32,6 +32,7 @@ function makeInstructionSuggestion(input: {
     state: "pending",
     source: input.source ?? "synthetic",
     sourceConversationId: null,
+    updatedBy: null,
     kind: "edit",
     suggestion: {
       instructionEdits: input.instructionEdits.map((e) => ({
@@ -61,6 +62,7 @@ function makeToolSuggestion(input: {
     state: "pending",
     source: input.source ?? "synthetic",
     sourceConversationId: null,
+    updatedBy: null,
     kind: "edit",
     suggestion: {
       toolEdits: [{ action: input.action, toolId: input.toolId }],

--- a/front/types/suggestions/skill_suggestion.ts
+++ b/front/types/suggestions/skill_suggestion.ts
@@ -100,6 +100,16 @@ export function parseSkillSuggestionData(data: unknown): SkillSuggestionData {
   return SkillSuggestionDataSchema.parse(data);
 }
 
+const SkillSuggestionUpdatedBySchema = z.object({
+  sId: z.string(),
+  fullName: z.string(),
+  email: z.string(),
+});
+
+export type SkillSuggestionUpdatedBy = z.infer<
+  typeof SkillSuggestionUpdatedBySchema
+>;
+
 const BaseSkillSuggestionSchema = z.object({
   sId: z.string(),
   createdAt: z.number(),
@@ -110,6 +120,7 @@ const BaseSkillSuggestionSchema = z.object({
   state: z.enum(SKILL_SUGGESTION_STATES),
   source: z.enum(SKILL_SUGGESTION_SOURCES),
   sourceConversationId: z.string().nullable(),
+  updatedBy: SkillSuggestionUpdatedBySchema.nullable(),
 });
 
 export const SkillSuggestionSchema = BaseSkillSuggestionSchema.and(


### PR DESCRIPTION
## Description

- Add updatedByUserId column to skill_suggestions (nullable FK to users, ON DELETE SET NULL) to track who accepted/rejected a suggestion from the skill builder UI.
- SkillSuggestionResource.bulkUpdateState now stamps updatedByUserId from auth.user() when transitioning to approved or rejected — left unset for outdated (suggestion became obsolete via background pruning) and pending.
- Expose the updater on SkillSuggestionType as updatedBy: { sId, fullName, email } | null (eager-loaded via Sequelize association) and surface Updated at + Updated by columns on the Poke skill suggestions table.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run the migration first, then deploy