### PR TITLE
[front] enh: tweak UI for ask user question tool

### DIFF
--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -128,8 +128,8 @@ export function UserAnswerRequired({
   return (
     <div
       className={cn(
-        "flex flex-col gap-4 rounded-3xl border border-border bg-background p-4",
-        "dark:border-border-night dark:bg-background-night"
+        "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5",
+        "dark:border-dark-night dark:bg-background-night"
       )}
     >
       <div className="text-base font-medium leading-tight text-foreground dark:text-foreground-night">


### PR DESCRIPTION
## Description

This PR polishes the UI for the question cards in the `ask_user_question` tool.
- Padding: 16px -> 20px
- Corner radius: 24px -> 16px
- Border: border -> dark

Before
<img width="711" height="424" alt="Screenshot 2026-04-22 at 2 01 00 PM" src="https://github.com/user-attachments/assets/fd5accd1-a7ba-410d-b3ab-46cc98e31296" />

After
<img width="711" height="424" alt="Screenshot 2026-04-22 at 2 01 27 PM" src="https://github.com/user-attachments/assets/7d7206f8-19a9-4a2a-a243-80ab9f3286ce" />

## Tests

- Tested.

## Risk

- Low.

## Deploy Plan

- Deploy front.
