### PR TITLE
Let admins disable extension MCP tools

### DIFF
--- a/extension/shared/hooks/useMcpServer.ts
+++ b/extension/shared/hooks/useMcpServer.ts
@@ -1,3 +1,4 @@
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import logger from "@app/logger/logger";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import { normalizeError } from "@extension/shared/lib/utils";
@@ -19,6 +20,7 @@ export function useMcpServer() {
 
   const { workspace } = useExtensionAuth();
   const workspaceId = workspace?.sId;
+  const { hasFeature } = useFeatureFlags();
 
   const disconnectServer = useCallback(async () => {
     if (platform.mcp) {
@@ -40,6 +42,14 @@ export function useMcpServer() {
     setIsSupported(true);
 
     if (!workspaceId) {
+      return;
+    }
+
+    if (
+      hasFeature("browser_extension_mcp_tools") &&
+      workspace?.metadata?.disableExtensionMcpTools === true
+    ) {
+      setIsSupported(false);
       return;
     }
 

--- a/front/components/workspace/ExtensionMcpToolsSection.tsx
+++ b/front/components/workspace/ExtensionMcpToolsSection.tsx
@@ -1,0 +1,37 @@
+import { useExtensionMcpToolsToggle } from "@app/hooks/useExtensionMcpToolsToggle";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Page, PuzzleIcon, SliderToggle } from "@dust-tt/sparkle";
+
+import { WorkspaceSection } from "./WorkspaceSection";
+
+interface ExtensionMcpToolsSectionProps {
+  owner: LightWorkspaceType;
+}
+
+export function ExtensionMcpToolsSection({
+  owner,
+}: ExtensionMcpToolsSectionProps) {
+  const { isEnabled, isChanging, doToggleExtensionMcpTools } =
+    useExtensionMcpToolsToggle({ owner });
+
+  return (
+    <WorkspaceSection title="Browser Extension Tools" icon={PuzzleIcon}>
+      <div className="flex w-full flex-row items-center gap-2">
+        <div className="flex-1">
+          <Page.P variant="secondary">
+            Allow the Dust browser extension to use MCP tools such as listing
+            and reading browser tabs. Disabling this prevents the extension from
+            automatically registering any browser tools for this workspace.
+            Users will still be able to manually attach tabs content or
+            screenshots.
+          </Page.P>
+        </div>
+        <SliderToggle
+          selected={isEnabled}
+          disabled={isChanging}
+          onClick={() => void doToggleExtensionMcpTools()}
+        />
+      </div>
+    </WorkspaceSection>
+  );
+}

--- a/front/components/workspace/WorkspaceAccessPanel.tsx
+++ b/front/components/workspace/WorkspaceAccessPanel.tsx
@@ -1,6 +1,7 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import { AuditLogsSection } from "@app/components/workspace/AuditLogsSection";
 import UserProvisioning from "@app/components/workspace/DirectorySync";
+import { ExtensionMcpToolsSection } from "@app/components/workspace/ExtensionMcpToolsSection";
 import SSOConnection from "@app/components/workspace/SSOConnection";
 import { AutoJoinToggle } from "@app/components/workspace/sso/AutoJoinToggle";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
@@ -46,6 +47,7 @@ export default function WorkspaceAccessPanel({
   });
   const { hasFeature } = useFeatureFlags();
   const showAuditLogs = plan.isAuditLogsAllowed || hasFeature("audit_logs");
+  const showExtensionMcpTools = hasFeature("browser_extension_mcp_tools");
 
   return (
     <div className="flex flex-col gap-6">
@@ -70,6 +72,12 @@ export default function WorkspaceAccessPanel({
       )}
       {showAuditLogs && <Separator />}
       {showAuditLogs && <AuditLogsSection owner={owner} />}
+      {showExtensionMcpTools && (
+        <>
+          <Separator />
+          <ExtensionMcpToolsSection owner={owner} />
+        </>
+      )}
     </div>
   );
 }

--- a/front/hooks/useExtensionMcpToolsToggle.ts
+++ b/front/hooks/useExtensionMcpToolsToggle.ts
@@ -1,0 +1,53 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useState } from "react";
+
+interface UseExtensionMcpToolsToggleProps {
+  owner: LightWorkspaceType;
+}
+
+export function useExtensionMcpToolsToggle({
+  owner,
+}: UseExtensionMcpToolsToggleProps) {
+  const [isChanging, setIsChanging] = useState(false);
+  const sendNotification = useSendNotification();
+  const [isEnabled, setIsEnabled] = useState(
+    !owner.metadata?.disableExtensionMcpTools
+  );
+
+  const doToggleExtensionMcpTools = async () => {
+    setIsChanging(true);
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          disableExtensionMcpTools: isEnabled,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to update extension MCP tools setting");
+      }
+
+      setIsEnabled(!isEnabled);
+    } catch {
+      sendNotification({
+        type: "error",
+        title: "Failed to update extension MCP tools setting",
+        description:
+          "Could not update the browser extension MCP tools setting.",
+      });
+    }
+    setIsChanging(false);
+  };
+
+  return {
+    isEnabled,
+    isChanging,
+    doToggleExtensionMcpTools,
+  };
+}

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -87,6 +87,10 @@ const WorkspaceReinforcementBatchModeUpdateBodySchema = t.type({
   allowReinforcementBatchMode: t.boolean,
 });
 
+const WorkspaceExtensionMcpToolsUpdateBodySchema = t.type({
+  disableExtensionMcpTools: t.boolean,
+});
+
 const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceAllowedDomainUpdateBodySchema,
   WorkspaceBatchDomainUpdateBodySchema,
@@ -101,6 +105,7 @@ const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceEmailAgentsUpdateBodySchema,
   WorkspaceAgentReinforcementUpdateBodySchema,
   WorkspaceReinforcementBatchModeUpdateBodySchema,
+  WorkspaceExtensionMcpToolsUpdateBodySchema,
 ]);
 
 async function handler(
@@ -254,6 +259,14 @@ async function handler(
         const newMetadata = {
           ...previousMetadata,
           allowReinforcementBatchMode: body.allowReinforcementBatchMode,
+        };
+        await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+        owner.metadata = newMetadata;
+      } else if ("disableExtensionMcpTools" in body) {
+        const previousMetadata = owner.metadata ?? {};
+        const newMetadata = {
+          ...previousMetadata,
+          disableExtensionMcpTools: body.disableExtensionMcpTools,
         };
         await workspace.updateWorkspaceSettings({ metadata: newMetadata });
         owner.metadata = newMetadata;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -286,6 +286,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable context compaction: summarize older messages to free up context window",
     stage: "dust_only",
   },
+  browser_extension_mcp_tools: {
+    description:
+      "Show the browser extension MCP tools toggle in workspace access settings",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -748,6 +748,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "collapsible_messages"
   | "use_dust_keys"
   | "enable_compaction"
+  | "browser_extension_mcp_tools"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Adds a new workspace admin setting to allow disabling browser extension MCP tools. Workspace admins can toggle whether the browser extension registers MCP tools (such as listing and reading browser tabs) for their workspace. This is controlled through a new `disableExtensionMcpTools` field in workspace metadata, gated behind the `browser_extension_mcp_tools` feature flag. Users can still manually attach tab content or screenshots when the setting is disabled.

## Tests

Manually tested the toggle in workspace access settings and verified the extension correctly respects the setting.

## Risk

Low risk, gated behind a feature flag. The change only affects browser extension MCP tool registration and doesn't impact manual attachment capabilities.

## Deploy Plan

Deploy front and extension