### PR TITLE
[front] chore: cleanup init method on `DefaultRemoteMCPServerInMemoryResource`

### DIFF
--- a/front/lib/resources/default_remote_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/default_remote_mcp_server_in_memory_resource.ts
@@ -18,10 +18,10 @@ export class DefaultRemoteMCPServerInMemoryResource {
     this.config = config;
   }
 
-  private static async init(
+  private static init(
     auth: Authenticator,
     configId: number
-  ): Promise<DefaultRemoteMCPServerInMemoryResource | null> {
+  ): DefaultRemoteMCPServerInMemoryResource | null {
     const config = getDefaultRemoteMCPServerById(configId);
     if (!config) {
       return null;
@@ -46,7 +46,7 @@ export class DefaultRemoteMCPServerInMemoryResource {
         continue;
       }
 
-      const resource = await DefaultRemoteMCPServerInMemoryResource.init(
+      const resource = DefaultRemoteMCPServerInMemoryResource.init(
         auth,
         config.id
       );

--- a/front/lib/resources/default_remote_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/default_remote_mcp_server_in_memory_resource.ts
@@ -18,7 +18,7 @@ export class DefaultRemoteMCPServerInMemoryResource {
     this.config = config;
   }
 
-  private static init(
+  private static fetchById(
     auth: Authenticator,
     configId: number
   ): DefaultRemoteMCPServerInMemoryResource | null {
@@ -32,7 +32,7 @@ export class DefaultRemoteMCPServerInMemoryResource {
       workspaceId: auth.getNonNullableWorkspace().id,
     });
 
-    return new DefaultRemoteMCPServerInMemoryResource(sId, config);
+    return new this(sId, config);
   }
 
   static async listAvailableDefaultRemoteMCPServers(
@@ -46,10 +46,7 @@ export class DefaultRemoteMCPServerInMemoryResource {
         continue;
       }
 
-      const resource = DefaultRemoteMCPServerInMemoryResource.init(
-        auth,
-        config.id
-      );
+      const resource = this.fetchById(auth, config.id);
       if (resource) {
         resources.push(resource);
       }


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/24664
- This PR renames the `init` method on the class `DefaultRemoteMCPServerInMemoryResource` to match the pattern established for `InternalMCPServerInMemoryResource`, which consists in avoiding the use of async `init` methods called on each instantiation.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
