### PR TITLE
Add wake-up cron validation

### DIFF
--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -33,8 +33,6 @@ const MAX_WAKE_UP_FIRES = 32;
 const WAKE_UP_MIN_INTERVAL_MINUTES = 5;
 
 // Standard 5-field cron regex. Does not support # (nth occurrence) or L (last) operators.
-// Mirrors the regex used for trigger schedules in
-// `front/lib/api/assistant/configuration/triggers.ts`.
 const WAKE_UP_CRON_REGEXP =
   /^((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*(\/\d+)?|\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)$/;
 
@@ -44,8 +42,8 @@ function isValidIANATimezone(timezone: string): boolean {
 }
 
 // A cron expression is considered too frequent if its minutes field fires more than once every
-// `WAKE_UP_MIN_INTERVAL_MINUTES` minutes. Accepts a literal minute ("0", "15") or a
-// `*/N` step with `N >= WAKE_UP_MIN_INTERVAL_MINUTES`.
+// `WAKE_UP_MIN_INTERVAL_MINUTES` minutes. Accepts a literal minute ("0", "15") or a `*/N` step with
+// `N >= WAKE_UP_MIN_INTERVAL_MINUTES`.
 function isWakeUpCronTooFrequent(cron: string): boolean {
   const minutes = cron.split(" ")[0];
 

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -28,6 +28,39 @@ import type { Attributes, Transaction, WhereOptions } from "sequelize";
 const ACTIVE_WAKE_UP_STATUSES: WakeUpStatus[] = ["scheduled"];
 const MAX_WAKE_UP_FIRES = 32;
 
+// Minimum allowed interval between two cron fires, in minutes. Matches the per-conversation
+// guardrail in the wake-up design doc.
+const WAKE_UP_MIN_INTERVAL_MINUTES = 5;
+
+// Standard 5-field cron regex. Does not support # (nth occurrence) or L (last) operators.
+// Mirrors the regex used for trigger schedules in
+// `front/lib/api/assistant/configuration/triggers.ts`.
+const WAKE_UP_CRON_REGEXP =
+  /^((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*(\/\d+)?|\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)$/;
+
+function isValidIANATimezone(timezone: string): boolean {
+  const supportedTimezones = Intl.supportedValuesOf("timeZone");
+  return supportedTimezones.includes(timezone);
+}
+
+// A cron expression is considered too frequent if its minutes field fires more than once every
+// `WAKE_UP_MIN_INTERVAL_MINUTES` minutes. Accepts a literal minute ("0", "15") or a
+// `*/N` step with `N >= WAKE_UP_MIN_INTERVAL_MINUTES`.
+function isWakeUpCronTooFrequent(cron: string): boolean {
+  const minutes = cron.split(" ")[0];
+
+  if (/^\d+$/.test(minutes)) {
+    return false;
+  }
+
+  const stepMatch = /^\*\/(\d+)$/.exec(minutes);
+  if (stepMatch && parseInt(stepMatch[1], 10) >= WAKE_UP_MIN_INTERVAL_MINUTES) {
+    return false;
+  }
+
+  return true;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface WakeUpResource extends ReadonlyAttributesType<WakeUpModel> {}
 
@@ -75,6 +108,49 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     return rows.map((row) => new this(this.model, row.get()));
   }
 
+  /**
+   * Validates a cron expression and its timezone for wake-ups. Mirrors the trigger schedule
+   * validation but enforces the wake-up specific minimum interval between fires.
+   */
+  static validateCron({
+    cron,
+    timezone,
+  }: {
+    cron: string;
+    timezone: string;
+  }): Result<void, Error> {
+    if (
+      !cron ||
+      cron.split(" ").length !== 5 ||
+      !cron.match(WAKE_UP_CRON_REGEXP)
+    ) {
+      return new Err(
+        new Error(
+          "Invalid wake-up cron expression: expected 5 fields (min hour dom mon dow) " +
+            "using standard operators (* , - / ?) or 3-letter names; '#' and 'L' are not supported."
+        )
+      );
+    }
+
+    if (isWakeUpCronTooFrequent(cron)) {
+      return new Err(
+        new Error(
+          `Wake-up cron cannot fire more often than every ${WAKE_UP_MIN_INTERVAL_MINUTES} minutes.`
+        )
+      );
+    }
+
+    if (!timezone || !isValidIANATimezone(timezone)) {
+      return new Err(
+        new Error(
+          'Invalid wake-up timezone (must be an IANA timezone, i.e. "Europe/Paris").'
+        )
+      );
+    }
+
+    return new Ok(undefined);
+  }
+
   static async makeNew(
     auth: Authenticator,
     blob:
@@ -98,6 +174,16 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
   ): Promise<Result<WakeUpResource, Error>> {
     const { scheduleType, fireAt, cronExpression, cronTimezone, reason } = blob;
     const user = auth.getNonNullableUser();
+
+    if (scheduleType === "cron") {
+      const validation = this.validateCron({
+        cron: cronExpression,
+        timezone: cronTimezone,
+      });
+      if (validation.isErr()) {
+        return validation;
+      }
+    }
 
     const row = await this.model.create(
       {

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -53,12 +53,12 @@ classification, audit events, and the cron path.
 
 ## Milestone 3: Cron wake-ups
 
-### PR 5 — Cron scheduling path
+### [x] PR 5 — Cron scheduling path
 
-Create the cron Temporal path for wake-ups. Reuse the existing trigger schedule patterns where
+Create the cron Temporal path for wake-ups, reusing the existing trigger schedule patterns where
 helpful.
 
-Status: in progress. Current state:
+Done:
 - Temporal Schedule creation / deletion is implemented in
   `front/temporal/triggers/wakeup_client.ts`.
 - `WakeUpResource.maxFires()` (backed by `MAX_WAKE_UP_FIRES = 32`) is exposed on `WakeUpType`, and
@@ -66,9 +66,9 @@ Status: in progress. Current state:
 - The wake-up `<dust_system>` message includes `fireCount / maxFires` and an expiration warning
   when the wake-up is about to expire.
 - `cleanupTemporalAfterFire(...)` deletes the Temporal schedule after the final fire.
-
-Remaining work: cron validation, cron-specific guardrails, and any further refinements of the
-recurring fire semantics.
+- `WakeUpResource.validateCron({ cron, timezone })` enforces a well-formed 5-field cron
+  expression, a minimum interval of 5 minutes between fires, and a valid IANA timezone. It is
+  called from `makeNew(...)` as a defense-in-depth check.
 
 ## Milestone 4: Agent action
 

--- a/x/spolu/wakeup/wakeup.md
+++ b/x/spolu/wakeup/wakeup.md
@@ -15,8 +15,9 @@ supports one-shot delays ("in 2 hours"), absolute times ("at 2026-04-16T16:00Z")
 patterns ("0 9 * * MON-FRI").
 
 Current implementation status: the backend Temporal path is implemented for one-shot wake-ups, and
-cron wake-ups now have schedule create / delete plus `fireCount` / `maxFires` expiration. Cron
-validation and guardrails, the tool surface, API endpoints, and UI are still follow-up work.
+cron wake-ups now have schedule create / delete, `fireCount` / `maxFires` expiration, and
+validation of the cron expression and timezone at creation time. Cron-specific guardrails beyond
+validation, the tool surface, API endpoints, and UI are still follow-up work.
 
 ## Design Overview
 
@@ -115,6 +116,9 @@ Wraps `WakeUpModel`. Key methods:
   - `cron` otherwise → stays `scheduled`
 - `markExpired()` — sets status to `expired`.
 - `maxFires()` — returns the constant `MAX_WAKE_UP_FIRES` (currently 32).
+- `validateCron({ cron, timezone })` — validates a cron expression and its timezone for wake-ups:
+  well-formed 5-field cron, minimum interval of 5 minutes between fires, and valid IANA timezone.
+  Called from `makeNew(...)` as a defense-in-depth check.
 - `cleanupTemporalAfterFire(auth)` — deletes the Temporal schedule for cron wake-ups once they
   have reached `expired`.
 - `listByConversation(auth, conversationId)` — for UI display.
@@ -350,8 +354,9 @@ When a wake-up fires:
 - In the current codebase, `schedule_wakeup` should be wired through the internal MCP tool
   architecture rather than a legacy `front/lib/api/assistant/agent_action.ts` registry.
 - The current implementation can create / delete cron schedules, tracks `fireCount / maxFires`,
-  and automatically expires cron wake-ups once `fireCount >= maxFires`. Remaining cron work is
-  cron validation and cron-specific guardrails.
+  automatically expires cron wake-ups once `fireCount >= maxFires`, and validates the cron
+  expression and timezone at creation time. Remaining cron work is cron-specific guardrails
+  beyond validation.
 - Explicit duplicate-fire protection is not implemented. A follow-up should define the
   idempotency story clearly.
 - Cancel-vs-fire races are still best-effort today and should be tightened in `WakeUpResource`.


### PR DESCRIPTION
## Description

Adds `WakeUpResource.validateCron({ cron, timezone })`, inspired by the trigger schedule
validation in `front/lib/api/assistant/configuration/triggers.ts`. It enforces:

- a well-formed 5-field cron expression,
- a minimum interval of 5 minutes between fires,
- a valid IANA timezone.

`WakeUpResource.makeNew(...)` now calls it for defense in depth on cron wake-ups. Also updates the
wake-up plan and proposal to reflect the current state.

## Tests

N/A, tested locally.

## Risk

Low. Validation is only called at wake-up creation time and cron wake-ups are not yet reachable
from user code paths.

## Deploy Plan

- deploy `front`