### PR TITLE
refactor(front): add runId correlation and structured summary logs to project todo workflow

### DIFF
--- a/front/lib/project_todo/analyze_document/index.ts
+++ b/front/lib/project_todo/analyze_document/index.ts
@@ -25,10 +25,10 @@ import {
   TakeawaysResource,
 } from "@app/lib/resources/takeaways_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import logger from "@app/logger/logger";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { startActiveObservation } from "@langfuse/tracing";
+import type { Logger } from "pino";
 import { buildPromptForSourceType } from "./prompts";
 
 async function buildPromptProjectMembers(
@@ -55,11 +55,13 @@ async function buildPromptProjectMembers(
 async function callExtractActionItemsLLM(
   auth: Authenticator,
   {
+    localLogger,
     model,
     specification,
     prompt,
     document,
   }: {
+    localLogger: Logger;
     model: ModelConfigurationType;
     specification: AgentActionSpecification;
     prompt: string;
@@ -103,13 +105,8 @@ async function callExtractActionItemsLLM(
       )
   );
   if (res.isErr()) {
-    logger.error(
-      {
-        sourceId: document.id,
-        sourceType: document.type,
-        workspaceId: owner.sId,
-        error: res.error,
-      },
+    localLogger.error(
+      { error: res.error },
       "Document takeaway: LLM call failed"
     );
     return null;
@@ -117,27 +114,14 @@ async function callExtractActionItemsLLM(
 
   const action = res.value.actions?.[0];
   if (!action?.arguments) {
-    logger.warn(
-      {
-        sourceId: document.id,
-        sourceType: document.type,
-        workspaceId: owner.sId,
-      },
-      "Document takeaway: no tool call in LLM response"
-    );
+    localLogger.warn("Document takeaway: no tool call in LLM response");
     return null;
   }
 
   const parsed = ExtractTakeawaysInputSchema.safeParse(action.arguments);
   if (!parsed.success) {
-    logger.warn(
-      {
-        sourceId: document.id,
-        sourceType: document.type,
-        workspaceId: owner.sId,
-        error: parsed.error,
-        arguments: action.arguments,
-      },
+    localLogger.warn(
+      { error: parsed.error, arguments: action.arguments },
       "Document takeaway: failed to parse LLM response"
     );
     return null;
@@ -148,17 +132,29 @@ async function callExtractActionItemsLLM(
 // Maps raw LLM-extracted items to typed action items, reusing sIds from the
 // previous version when the LLM echoes them back, generating new UUIDs otherwise.
 
+export type ExtractedTakeawayStats = {
+  actionItems: number;
+  keyDecisions: number;
+  notableFacts: number;
+};
+
+// Returns counts of extracted takeaways, or null if extraction failed.
 export async function extractDocumentTakeaways(
   auth: Authenticator,
   {
+    localLogger: parentLogger,
     spaceId,
     document,
   }: {
+    localLogger: Logger;
     spaceId: string;
     document: TakeawaySourceDocument;
   }
-): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
+): Promise<ExtractedTakeawayStats | null> {
+  const localLogger = parentLogger.child({
+    sourceId: document.id,
+    sourceType: document.type,
+  });
 
   // Fetch the model and the previous version concurrently — they are independent.
   const [model, previousVersion] = await Promise.all([
@@ -169,15 +165,8 @@ export async function extractDocumentTakeaways(
     }),
   ]);
   if (!model) {
-    logger.warn(
-      {
-        sourceId: document.id,
-        sourceType: document.type,
-        workspaceId: owner.sId,
-      },
-      "Document takeaway: no whitelisted model available"
-    );
-    return;
+    localLogger.warn("Document takeaway: no whitelisted model available");
+    return null;
   }
 
   const previousActionItems = previousVersion?.actionItems ?? [];
@@ -195,21 +184,15 @@ export async function extractDocumentTakeaways(
   const specification = buildSpec();
 
   const extraction = await callExtractActionItemsLLM(auth, {
+    localLogger,
     model,
     specification,
     prompt,
     document,
   });
   if (!extraction) {
-    logger.error(
-      {
-        sourceId: document.id,
-        sourceType: document.type,
-        workspaceId: owner.sId,
-      },
-      "Document takeaway: no extraction result"
-    );
-    return;
+    localLogger.error("Document takeaway: no extraction result");
+    return null;
   }
 
   // Fetch all assignees from the action items.
@@ -243,20 +226,19 @@ export async function extractDocumentTakeaways(
     validAssigneesUserIds
   );
 
+  const stats: ExtractedTakeawayStats = {
+    actionItems: actionItems.length,
+    keyDecisions: keyDecisions.length,
+    notableFacts: notableFacts.length,
+  };
+
   if (
     actionItems.length === 0 &&
     notableFacts.length === 0 &&
     keyDecisions.length === 0
   ) {
-    logger.info(
-      {
-        sourceId: document.id,
-        sourceType: document.type,
-        workspaceId: owner.sId,
-      },
-      "Document takeaway: no takeaways extracted"
-    );
-    return;
+    localLogger.info("Document takeaway: no takeaways extracted");
+    return stats;
   }
 
   await TakeawaysResource.makeNewForDocument(auth, {
@@ -267,15 +249,14 @@ export async function extractDocumentTakeaways(
     keyDecisions,
   });
 
-  logger.info(
+  localLogger.info(
     {
-      sourceId: document.id,
-      sourceType: document.type,
-      workspaceId: owner.sId,
       actionItemCount: actionItems.length,
       notableFactCount: notableFacts.length,
       keyDecisionCount: keyDecisions.length,
     },
     "Document takeaway: analysis complete"
   );
+
+  return stats;
 }

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -49,7 +49,6 @@ import {
 } from "@app/lib/resources/takeaways_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import logger from "@app/logger/logger";
 import type { ProjectTodoSourceInfo } from "@app/types/project_todo";
 import type { ModelId } from "@app/types/shared/model_id";
 import type {
@@ -57,6 +56,7 @@ import type {
   TodoVersionedKeyDecision,
   TodoVersionedNotableFact,
 } from "@app/types/takeaways";
+import type { Logger } from "pino";
 
 // Stable identifier used when recording the creating actor for butler-created
 // project todos. This is not an actual agent configuration sId but a sentinel
@@ -81,19 +81,43 @@ type PendingCandidate = {
   source: ProjectTodoSourceInfo;
 };
 
+// ── Stats ─────────────────────────────────────────────────────────────────────
+
+export type MergeStats = {
+  takeawaysProcessed: number;
+  candidatesCollected: number;
+  existingUpdated: number;
+  deduplicated: number;
+  createdNew: number;
+};
+
+function emptyMergeStats(): MergeStats {
+  return {
+    takeawaysProcessed: 0,
+    candidatesCollected: 0,
+    existingUpdated: 0,
+    deduplicated: 0,
+    createdNew: 0,
+  };
+}
+
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 export async function mergeTakeawaysIntoProject({
+  localLogger,
   workspaceId,
   spaceId,
 }: {
+  localLogger: Logger;
   workspaceId: string;
   spaceId: string;
-}): Promise<void> {
+}): Promise<MergeStats> {
+  const stats = emptyMergeStats();
+
   const spaceModelId = getResourceIdFromSId(spaceId);
   if (spaceModelId === null) {
-    logger.error({ spaceId }, "Project todo merge: invalid space sId");
-    return;
+    localLogger.error("Project todo merge: invalid space sId");
+    return stats;
   }
 
   const adminAuth = await Authenticator.internalAdminForWorkspace(workspaceId);
@@ -104,12 +128,11 @@ export async function mergeTakeawaysIntoProject({
     { spaceModelId }
   );
 
+  stats.takeawaysProcessed = takeawaysWithSource.length;
+
   if (takeawaysWithSource.length === 0) {
-    logger.info(
-      { spaceId },
-      "Project todo merge: no takeaways found, skipping"
-    );
-    return;
+    localLogger.info("Project todo merge: no takeaways found, skipping");
+    return stats;
   }
 
   // Collect all user sIds referenced across all takeaways so we can batch-fetch
@@ -139,33 +162,41 @@ export async function mergeTakeawaysIntoProject({
 
   // ── Phase 1: collect new candidates, update already-linked items ──────────
 
-  const newCandidates = await collectNewCandidates(adminAuth, {
-    takeawaysWithSource,
-    usersById,
-  });
+  const { candidates: newCandidates, existingUpdated } =
+    await collectNewCandidates(adminAuth, {
+      takeawaysWithSource,
+      usersById,
+    });
+
+  stats.candidatesCollected = newCandidates.length;
+  stats.existingUpdated = existingUpdated;
 
   if (newCandidates.length === 0) {
-    logger.info(
-      { spaceId },
-      "Project todo merge: no new candidates found, skipping"
-    );
-    return;
+    localLogger.info("Project todo merge: no new candidates found, skipping");
+    return stats;
   }
 
   // ── Phase 2: semantic deduplication ──────────────────────────────────────
 
   const dedupMap = await buildDeduplicationMap(adminAuth, {
+    localLogger,
     newCandidates,
     spaceModelId,
   });
 
   // ── Phase 3: create or link ───────────────────────────────────────────────
 
-  await createOrLinkTodos(adminAuth, {
+  const { deduplicated, createdNew } = await createOrLinkTodos(adminAuth, {
+    localLogger,
     newCandidates,
     dedupMap,
     spaceModelId,
   });
+
+  stats.deduplicated = deduplicated;
+  stats.createdNew = createdNew;
+
+  return stats;
 }
 
 // ── Phase 1 ───────────────────────────────────────────────────────────────────
@@ -182,22 +213,24 @@ async function collectNewCandidates(
     takeawaysWithSource: TakeawaysWithSource[];
     usersById: Map<string, UserResource>;
   }
-): Promise<PendingCandidate[]> {
+): Promise<{ candidates: PendingCandidate[]; existingUpdated: number }> {
   const newCandidates: PendingCandidate[] = [];
+  let existingUpdated = 0;
 
   await concurrentExecutor(
     takeawaysWithSource,
     async (takeawayWithSource) => {
-      const candidates = await collectDocumentCandidates(auth, {
+      const result = await collectDocumentCandidates(auth, {
         takeawayWithSource,
         usersById,
       });
-      newCandidates.push(...candidates);
+      newCandidates.push(...result.candidates);
+      existingUpdated += result.existingUpdated;
     },
     { concurrency: 4 }
   );
 
-  return newCandidates;
+  return { candidates: newCandidates, existingUpdated };
 }
 
 // Processes one document's takeaway: updates todos whose source link already
@@ -211,7 +244,7 @@ async function collectDocumentCandidates(
     takeawayWithSource: TakeawaysWithSource;
     usersById: Map<string, UserResource>;
   }
-): Promise<PendingCandidate[]> {
+): Promise<{ candidates: PendingCandidate[]; existingUpdated: number }> {
   function resolveTargetUserIds(userSIds: string[]): ModelId[] {
     return userSIds
       .map((sId) => usersById.get(sId)?.id)
@@ -251,12 +284,16 @@ async function collectDocumentCandidates(
   });
 
   const candidates: PendingCandidate[] = [];
+  let existingUpdated = 0;
   for (const { itemId, targetUserIds, blob } of itemTriples) {
     for (const userId of targetUserIds) {
       const existing = existingByKey.get(`${itemId}:${userId}`) ?? null;
       if (existing !== null) {
         // Source link exists — update content if it has changed.
-        await updateTodoIfChanged(existing, auth, blob);
+        const updated = await updateTodoIfChanged(existing, auth, blob);
+        if (updated) {
+          existingUpdated++;
+        }
       } else {
         candidates.push({
           itemId,
@@ -268,7 +305,7 @@ async function collectDocumentCandidates(
     }
   }
 
-  return candidates;
+  return { candidates, existingUpdated };
 }
 
 // ── Phase 2 ───────────────────────────────────────────────────────────────────
@@ -279,17 +316,18 @@ async function collectDocumentCandidates(
 async function buildDeduplicationMap(
   auth: Authenticator,
   {
+    localLogger,
     newCandidates,
     spaceModelId,
   }: {
+    localLogger: Logger;
     newCandidates: PendingCandidate[];
     spaceModelId: ModelId;
   }
 ): Promise<DeduplicationMap> {
   const model = getFastestWhitelistedModel(auth);
   if (!model) {
-    logger.warn(
-      { workspaceId: auth.getNonNullableWorkspace().sId },
+    localLogger.warn(
       "Project todo merge: no whitelisted model, skipping deduplication"
     );
     return new Map();
@@ -341,15 +379,20 @@ async function buildDeduplicationMap(
 async function createOrLinkTodos(
   auth: Authenticator,
   {
+    localLogger,
     newCandidates,
     dedupMap,
     spaceModelId,
   }: {
+    localLogger: Logger;
     newCandidates: PendingCandidate[];
     dedupMap: DeduplicationMap;
     spaceModelId: ModelId;
   }
-): Promise<void> {
+): Promise<{ deduplicated: number; createdNew: number }> {
+  let deduplicated = 0;
+  let createdNew = 0;
+
   await concurrentExecutor(
     newCandidates,
     async (candidate) => {
@@ -369,7 +412,9 @@ async function createOrLinkTodos(
           await updateTodoIfChanged(match, auth, candidate.blob);
         }
 
-        logger.info(
+        deduplicated++;
+
+        localLogger.info(
           {
             existingTodoId: match.sId,
             itemId: candidate.itemId,
@@ -403,7 +448,9 @@ async function createOrLinkTodos(
         source: candidate.source,
       });
 
-      logger.info(
+      createdNew++;
+
+      localLogger.info(
         {
           todoId: todo.sId,
           itemId: candidate.itemId,
@@ -415,16 +462,19 @@ async function createOrLinkTodos(
     },
     { concurrency: 4 }
   );
+
+  return { deduplicated, createdNew };
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 // Creates a new version of a todo only when text, status, or doneAt has changed.
+// Returns true if an update was performed.
 async function updateTodoIfChanged(
   todo: ProjectTodoResource,
   auth: Authenticator,
   blob: TodoBlob
-): Promise<void> {
+): Promise<boolean> {
   const textChanged = todo.text !== blob.text;
   const statusChanged = todo.status !== blob.status;
   const doneAtChanged =
@@ -436,7 +486,9 @@ async function updateTodoIfChanged(
       status: blob.status,
       doneAt: blob.doneAt,
     });
+    return true;
   }
+  return false;
 }
 
 // ── Blob helpers ─────────────────────────────────────────────────────────────

--- a/front/scripts/dev/launch_project_todo_one_off.ts
+++ b/front/scripts/dev/launch_project_todo_one_off.ts
@@ -7,6 +7,7 @@ import {
   mergeTodosForProjectActivity,
 } from "@app/temporal/project_todo/activities";
 import { QUEUE_NAME } from "@app/temporal/project_todo/config";
+import { v4 as uuidv4 } from "uuid";
 
 makeScript(
   {
@@ -69,7 +70,8 @@ makeScript(
       return;
     }
 
-    await analyzeProjectTodosActivity({ workspaceId, spaceId });
-    await mergeTodosForProjectActivity({ workspaceId, spaceId });
+    const runId = uuidv4();
+    await analyzeProjectTodosActivity({ workspaceId, spaceId, runId });
+    await mergeTodosForProjectActivity({ workspaceId, spaceId, runId });
   }
 );

--- a/front/temporal/project_todo/activities.ts
+++ b/front/temporal/project_todo/activities.ts
@@ -77,27 +77,32 @@ function resultToTakeawaySourceDocument(
 export async function analyzeProjectTodosActivity({
   workspaceId,
   spaceId,
+  runId,
 }: {
   workspaceId: string;
   spaceId: string;
+  runId: string;
 }): Promise<void> {
-  logger.info({ workspaceId, spaceId }, "Starting project todo analysis");
+  const startMs = Date.now();
+  const localLogger = logger.child({ workspaceId, spaceId, runId });
+
+  localLogger.info("Starting project todo analysis");
 
   if (!workspaceId) {
-    logger.error({ workspaceId, spaceId }, "Workspace ID is required");
+    localLogger.error("Workspace ID is required");
     return;
   }
 
   const workspace = await WorkspaceResource.fetchById(workspaceId);
   if (!workspace) {
-    logger.error({ workspaceId }, "Workspace not found");
+    localLogger.error("Workspace not found");
     return;
   }
   const adminAuth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
   const space = await SpaceResource.fetchById(adminAuth, spaceId);
   if (!space || !space.isProject()) {
-    logger.error({ spaceId }, "Space not found or not a project");
+    localLogger.error("Space not found or not a project");
     return;
   }
 
@@ -118,8 +123,7 @@ export async function analyzeProjectTodosActivity({
   }
 
   if (!member) {
-    logger.info(
-      { workspaceId, spaceId },
+    localLogger.info(
       "No active members on project space; skipping todo analysis"
     );
     return;
@@ -130,10 +134,7 @@ export async function analyzeProjectTodosActivity({
     workspaceId
   );
   if (!auth) {
-    logger.error(
-      { spaceId },
-      "Failed to create authenticator for project member"
-    );
+    localLogger.error("Failed to create authenticator for project member");
     return;
   }
 
@@ -147,8 +148,8 @@ export async function analyzeProjectTodosActivity({
   });
 
   if (results.isErr()) {
-    logger.error(
-      { spaceId, error: results.error },
+    localLogger.error(
+      { error: results.error },
       "Failed to retrieve include data"
     );
     return;
@@ -158,28 +159,38 @@ export async function analyzeProjectTodosActivity({
     results.value.map((result) => resultToTakeawaySourceDocument(result))
   );
 
-  for (const document of documents) {
-    logger.info(
-      {
-        id: document.id,
-        title: document.title,
-        text: document.text,
-        type: document.type,
-        uri: document.uri,
-      },
-      "Document"
-    );
-  }
+  const stats = {
+    documentsFound: documents.length,
+    documentsAnalyzed: 0,
+    documentsFailed: 0,
+    actionItemsExtracted: 0,
+    keyDecisionsExtracted: 0,
+    notableFactsExtracted: 0,
+  };
 
   await concurrentExecutor(
     documents,
     async (document) => {
-      await extractDocumentTakeaways(auth, {
+      const result = await extractDocumentTakeaways(auth, {
+        localLogger,
         spaceId,
         document,
       });
+      if (result) {
+        stats.documentsAnalyzed++;
+        stats.actionItemsExtracted += result.actionItems;
+        stats.keyDecisionsExtracted += result.keyDecisions;
+        stats.notableFactsExtracted += result.notableFacts;
+      } else {
+        stats.documentsFailed++;
+      }
     },
     { concurrency: 10 }
+  );
+
+  localLogger.info(
+    { phase: "analyze", ...stats, durationMs: Date.now() - startMs },
+    "Project todo analysis complete"
   );
 }
 
@@ -188,19 +199,30 @@ export async function analyzeProjectTodosActivity({
 export async function mergeTodosForProjectActivity({
   workspaceId,
   spaceId,
+  runId,
 }: {
   workspaceId: string;
   spaceId: string;
+  runId: string;
 }): Promise<void> {
-  logger.info(
-    { workspaceId, spaceId },
-    "Starting merge of project todo takeaways"
-  );
+  const startMs = Date.now();
+  const localLogger = logger.child({ workspaceId, spaceId, runId });
+
+  localLogger.info("Starting merge of project todo takeaways");
 
   if (!workspaceId) {
-    logger.error({ workspaceId, spaceId }, "Workspace ID is required");
+    localLogger.error("Workspace ID is required");
     return;
   }
 
-  await mergeTakeawaysIntoProject({ workspaceId, spaceId });
+  const stats = await mergeTakeawaysIntoProject({
+    localLogger,
+    workspaceId,
+    spaceId,
+  });
+
+  localLogger.info(
+    { phase: "merge", ...stats, durationMs: Date.now() - startMs },
+    "Project todo merge complete"
+  );
 }

--- a/front/temporal/project_todo/workflows.ts
+++ b/front/temporal/project_todo/workflows.ts
@@ -1,5 +1,5 @@
 import type * as activities from "@app/temporal/project_todo/activities";
-import { proxyActivities } from "@temporalio/workflow";
+import { proxyActivities, uuid4 } from "@temporalio/workflow";
 
 const { analyzeProjectTodosActivity, mergeTodosForProjectActivity } =
   proxyActivities<typeof activities>({
@@ -16,6 +16,8 @@ export async function projectTodoWorkflow({
   workspaceId: string;
   spaceId: string;
 }): Promise<void> {
-  await analyzeProjectTodosActivity({ workspaceId, spaceId });
-  await mergeTodosForProjectActivity({ workspaceId, spaceId });
+  // Generate a unique run ID to correlate all log lines across both activities.
+  const runId = uuid4();
+  await analyzeProjectTodosActivity({ workspaceId, spaceId, runId });
+  await mergeTodosForProjectActivity({ workspaceId, spaceId, runId });
 }


### PR DESCRIPTION
## Description

Improves observability of the project TODO workflow (hourly takeaway extraction + merge) by adding two things:

- **Run correlation ID**: A `runId` (UUID) is generated at workflow start and threaded through both activities via a pino child logger. Every log line from a single run shares the same `runId`, making it trivial to filter in Datadog.
- **Structured summary logs**: Each activity emits a single summary log at completion with aggregate stats (`documentsFound`, `documentsAnalyzed`, `documentsFailed`, `actionItemsExtracted`, `candidatesCollected`, `deduplicated`, `createdNew`, `durationMs`), replacing the need to mentally reconstruct flow from scattered per-item logs.

Also refactors logging throughout the pipeline to use `localLogger` (pino child logger) instead of manually spreading context objects into every log call, and removes the verbose per-document text logging loop that was left in the analyze activity.

## Tests

Existing pre-commit hooks pass (typecheck + biome). No new tests — this is a logging-only change with no behavioral impact.
