### PR TITLE
feat(qdrant): stop indexing some conversation files

### DIFF
--- a/front/lib/api/files/attachments.test.ts
+++ b/front/lib/api/files/attachments.test.ts
@@ -1,0 +1,125 @@
+import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
+import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
+import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import { Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/data_sources"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    getOrCreateConversationDataSourceFromFile: vi.fn(),
+  };
+});
+
+vi.mock(import("@app/lib/api/files/upsert"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    processAndUpsertToDataSource: vi.fn(),
+  };
+});
+
+describe("maybeUpsertFileAttachment", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    conversation = {
+      sId: "conv-test-sid",
+      owner: workspace,
+    } as unknown as ConversationType;
+
+    vi.mocked(getOrCreateConversationDataSourceFromFile).mockResolvedValue(
+      new Ok({} as any)
+    );
+    vi.mocked(processAndUpsertToDataSource).mockResolvedValue(
+      new Ok({} as any)
+    );
+  });
+
+  it("stamps conversationId on files without useCaseMetadata and attempts upsert", async () => {
+    const file = await FileFactory.create(auth, null, {
+      contentType: "text/plain",
+      fileName: "attachment.txt",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+    });
+
+    const result = await maybeUpsertFileAttachment(auth, {
+      contentFragments: [{ fileId: file.sId }],
+      conversation,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const reloaded = await FileResource.fetchById(auth, file.sId);
+    expect(reloaded?.useCaseMetadata).toEqual({
+      conversationId: conversation.sId,
+    });
+    expect(processAndUpsertToDataSource).toHaveBeenCalledOnce();
+  });
+
+  it("merges conversationId while preserving a pre-existing skipDataSourceIndexing flag", async () => {
+    // Webhook bodies and pasted text are stamped with skipDataSourceIndexing at creation; the
+    // attach step must preserve that flag when adding conversationId, otherwise the indexing
+    // short-circuit in processAndUpsertToDataSource would be bypassed.
+    const file = await FileFactory.create(auth, null, {
+      contentType: "application/json",
+      fileName: "webhook_body_42_1000.json",
+      fileSize: 50,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { skipDataSourceIndexing: true },
+    });
+
+    const result = await maybeUpsertFileAttachment(auth, {
+      contentFragments: [{ fileId: file.sId }],
+      conversation,
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const reloaded = await FileResource.fetchById(auth, file.sId);
+    expect(reloaded?.useCaseMetadata).toEqual({
+      skipDataSourceIndexing: true,
+      conversationId: conversation.sId,
+    });
+  });
+
+  it("does not re-run when conversationId is already set", async () => {
+    const file = await FileFactory.create(auth, null, {
+      contentType: "text/plain",
+      fileName: "attachment.txt",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: "pre-existing-conv" },
+    });
+
+    const result = await maybeUpsertFileAttachment(auth, {
+      contentFragments: [{ fileId: file.sId }],
+      conversation,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(processAndUpsertToDataSource).not.toHaveBeenCalled();
+
+    const reloaded = await FileResource.fetchById(auth, file.sId);
+    expect(reloaded?.useCaseMetadata).toEqual({
+      conversationId: "pre-existing-conv",
+    });
+  });
+});

--- a/front/lib/api/files/attachments.ts
+++ b/front/lib/api/files/attachments.ts
@@ -43,9 +43,10 @@ export async function maybeUpsertFileAttachment(
       ...fileResources.map(async (fileResource) => {
         if (
           fileResource.useCase === "conversation" &&
-          !fileResource.useCaseMetadata
+          !fileResource.useCaseMetadata?.conversationId
         ) {
           await fileResource.setUseCaseMetadata(auth, {
+            ...(fileResource.useCaseMetadata ?? {}),
             conversationId: conversation.sId,
           });
 

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -53,6 +53,7 @@
  *       429:
  *         description: Rate limit exceeded
  */
+import { isPastedFile } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { isUploadSupportedForContentType } from "@app/lib/api/files/processing";
 import type { Authenticator } from "@app/lib/auth";
@@ -205,6 +206,12 @@ async function handler(
         });
       }
 
+      // Pasted text from the input bar is attached as same-turn context; indexing it in the
+      // conversation data source adds noise without improving retrieval.
+      const effectiveUseCaseMetadata = isPastedFile(contentType)
+        ? { ...(useCaseMetadata ?? {}), skipDataSourceIndexing: true }
+        : useCaseMetadata;
+
       const file = await FileResource.makeNew({
         contentType,
         fileName,
@@ -212,7 +219,7 @@ async function handler(
         userId: user.id,
         workspaceId: owner.id,
         useCase,
-        useCaseMetadata: useCaseMetadata,
+        useCaseMetadata: effectiveUseCaseMetadata,
       });
 
       res.status(200).json({ file: file.toJSONWithUploadUrl(auth) });

--- a/front/temporal/triggers/webhook_client.ts
+++ b/front/temporal/triggers/webhook_client.ts
@@ -98,6 +98,7 @@ export async function launchTriggersWorkflows(
         title: `Webhook body (source id: ${webhookSource.id}, date: ${new Date().toISOString()})`,
       },
       fileName: `webhook_body_${webhookSource.id}_${Date.now()}.json`,
+      skipDataSourceIndexing: true,
     });
 
     if (contentFragmentRes.isErr()) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

In the same vein as https://github.com/dust-tt/dust/pull/24637 and https://github.com/dust-tt/dust/pull/24279

This PR stops the indexation of webhook bodies and pasted text blocks.
As per recent analysis, webhook bodies represent ~5% of the conversation files data indexed on QDrant, and pasted text around 10ish.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front