### PR TITLE
fix: run agent with private conversation urls

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -611,6 +611,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return spaceBasedAccessible;
     }
 
+    // When running a sub-agent, the user is not null and the authentication method is a
+    // system API key. Sub-conversations deliberately skip participant record creation,
+    // so the participant-restriction concept does not apply.
+    if (auth.isSystemKey()) {
+      return spaceBasedAccessible;
+    }
+
     if (spaceBasedAccessible.length === 0) {
       const participantRestrictedConversationIds = new Set(
         participantRestrictedConversations.map(


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7711

This PR fixes an issue that made the `run_agent` tool not work with private conversation urls.

When an agent calls a sub-agent we create a conversations without participants. This makes the conversation not accessible when the "private conversation URLs by default" feature is active.

This PR checks if a system API key is being used to fetch the conversation. In that case it skips the participation checks.

## Tests

Manually

## Risks

Low risk. This change only affects sub-agent executions using system API keys.

## Deploy Plan

Standard deployment - no special steps required.
