### PR TITLE
[front] enh: batch delete remote MCP server metadata

### DIFF
--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -34,7 +34,6 @@ import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_vie
 import { destroyMCPServerViewDependencies } from "@app/lib/models/agent/actions/mcp_server_view_helper";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -27,7 +27,6 @@ import {
   isResourceSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -280,24 +279,16 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       },
     });
 
-    const serverToolMetadatas = await RemoteMCPServerToolMetadataModel.findAll({
+    await destroyMCPServerViewDependencies(auth, {
+      mcpServerViewIds: mcpServerViews.map((view) => view.id),
+    });
+
+    await RemoteMCPServerToolMetadataModel.destroy({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         remoteMCPServerId: this.id,
       },
     });
-
-    await destroyMCPServerViewDependencies(auth, {
-      mcpServerViewIds: mcpServerViews.map((view) => view.id),
-    });
-
-    await concurrentExecutor(
-      serverToolMetadatas,
-      async (serverToolMetadata) => {
-        await serverToolMetadata.destroy();
-      },
-      { concurrency: 10 }
-    );
 
     // Directly delete the MCPServerView here to avoid a circular dependency.
     await MCPServerViewModel.destroy({


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/24684
- This PR batches a deletion on remote MCP server metadata.
- This PR replaces a SELECT + deletion in a loop with a DELETE WHERE.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
