### PR TITLE
[Agentic Prompt] Add branch context to conversation prompt

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -346,15 +346,16 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       'This conversation was branched from "Parent conversation".'
     );
     expect(text).toContain(
-      "This conversation starts from a summary of the parent conversation up to source message msg_parent_source."
+      "This conversation starts from a summary of the parent conversation at the branch point."
     );
     expect(text).toContain(
-      "Readable conversation-level tool access and enabled skills from the parent conversation were carried over into this conversation."
+      "Available tools and enabled skills from the parent conversation were carried over into this conversation."
     );
     expect(text).toContain(
-      "Direct attachments and tool outputs available at the branch point were also carried over into this conversation."
+      "Conversation attachments and tool outputs available at the branch point were also carried over into this conversation."
     );
     expect(text).not.toContain("child conversation");
+    expect(text).not.toContain("source message");
   });
 
   it("should place branch context in ephemeral tier for structured prompts", () => {

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -26,6 +26,16 @@ import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { WorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it } from "vitest";
 
+function createForkedFrom(user: NonNullable<UserMessageType["user"]>) {
+  return {
+    parentConversationId: "conv_parent",
+    parentConversationTitle: "Parent conversation",
+    sourceMessageId: "msg_parent_source",
+    branchedAt: Date.now(),
+    user,
+  };
+}
+
 describe("constructPromptMultiActions - system prompt stability", () => {
   // This test ensures that the system prompt remains stable across multiple calls
   // with the same inputs. This is critical for prompt caching - high-entropy data
@@ -42,6 +52,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
   let agentConfig2: AgentConfigurationType;
   let userMessage2: UserMessageType;
   let conversation2: ConversationType;
+  let branchingUser1: NonNullable<UserMessageType["user"]>;
 
   let modelConfig: ModelConfigurationType;
 
@@ -72,6 +83,10 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       origin: "web",
     });
     userMessage1 = um1;
+    if (!um1.user) {
+      throw new Error("Expected test user message to have a user.");
+    }
+    branchingUser1 = um1.user;
 
     // Set up second workspace with different conversation
     const setup2 = await createResourceTest({ role: "admin" });
@@ -306,6 +321,72 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     );
     expect(userSection).toBeDefined();
     expect(userSection?.content).toContain("Engineering");
+  });
+
+  it("should include branch context in flat prompts using user-facing branch wording", () => {
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: agentConfig1,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      enabledSkills: [],
+      equippedSkills: [],
+      conversation: {
+        ...conversation1,
+        forkedFrom: createForkedFrom(branchingUser1),
+      } satisfies ConversationWithoutContentType,
+    };
+
+    const sections = constructPromptMultiActions(authenticator1, params);
+    const text = systemPromptToText(sections);
+
+    expect(text).toContain("# BRANCH CONTEXT");
+    expect(text).toContain(
+      'This conversation was branched from "Parent conversation".'
+    );
+    expect(text).toContain(
+      "This conversation starts from a summary of the parent conversation up to source message msg_parent_source."
+    );
+    expect(text).toContain(
+      "Readable conversation-level tool access, enabled skills, and direct attachments and tool outputs available at the branch point were copied into this conversation."
+    );
+    expect(text).not.toContain("child conversation");
+  });
+
+  it("should place branch context in shared tier for structured prompts", () => {
+    const deepDiveConfig = {
+      ...agentConfig1,
+      sId: GLOBAL_AGENTS_SID.DEEP_DIVE,
+      scope: "global" as const,
+    };
+
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: deepDiveConfig,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      enabledSkills: [],
+      equippedSkills: [],
+      conversation: {
+        ...conversation1,
+        forkedFrom: createForkedFrom(branchingUser1),
+      } satisfies ConversationWithoutContentType,
+    };
+
+    const sections = constructPromptMultiActions(authenticator1, params);
+    const { instructions, sharedContext } = normalizePrompt(sections);
+
+    expect(instructions[0]?.content).not.toContain("# BRANCH CONTEXT");
+
+    const branchSection = sharedContext.find((section) =>
+      section.content.includes("# BRANCH CONTEXT")
+    );
+    expect(branchSection).toBeDefined();
+    expect(branchSection?.content).toContain(
+      'This conversation was branched from "Parent conversation".'
+    );
   });
 
   it("should include memoriesContext in prompt output when provided", () => {

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -349,12 +349,15 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       "This conversation starts from a summary of the parent conversation up to source message msg_parent_source."
     );
     expect(text).toContain(
-      "Readable conversation-level tool access, enabled skills, and direct attachments and tool outputs available at the branch point were copied into this conversation."
+      "Readable conversation-level tool access and enabled skills from the parent conversation were carried over into this conversation."
+    );
+    expect(text).toContain(
+      "Direct attachments and tool outputs available at the branch point were also carried over into this conversation."
     );
     expect(text).not.toContain("child conversation");
   });
 
-  it("should place branch context in shared tier for structured prompts", () => {
+  it("should place branch context in ephemeral tier for structured prompts", () => {
     const deepDiveConfig = {
       ...agentConfig1,
       sId: GLOBAL_AGENTS_SID.DEEP_DIVE,
@@ -376,11 +379,17 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     };
 
     const sections = constructPromptMultiActions(authenticator1, params);
-    const { instructions, sharedContext } = normalizePrompt(sections);
+    const { instructions, sharedContext, ephemeralContext } =
+      normalizePrompt(sections);
 
     expect(instructions[0]?.content).not.toContain("# BRANCH CONTEXT");
+    expect(
+      sharedContext.some((section) =>
+        section.content.includes("# BRANCH CONTEXT")
+      )
+    ).toBe(false);
 
-    const branchSection = sharedContext.find((section) =>
+    const branchSection = ephemeralContext.find((section) =>
       section.content.includes("# BRANCH CONTEXT")
     );
     expect(branchSection).toBeDefined();

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -82,6 +82,10 @@ function constructContextSection({
   return context;
 }
 
+function quotePromptText(text: string): string {
+  return JSON.stringify(text);
+}
+
 function constructBranchContextSection({
   conversation,
 }: {
@@ -93,17 +97,17 @@ function constructBranchContextSection({
   }
 
   const parentConversation = forkedFrom.parentConversationTitle
-    ? JSON.stringify(forkedFrom.parentConversationTitle)
+    ? quotePromptText(forkedFrom.parentConversationTitle)
     : `conversation ${forkedFrom.parentConversationId}`;
 
   return (
     "# BRANCH CONTEXT\n\n" +
     `This conversation was branched from ${parentConversation}.\n` +
-    "This conversation starts from a summary of the parent conversation " +
-    `up to source message ${forkedFrom.sourceMessageId}.\n` +
-    "Readable conversation-level tool access and enabled skills from the " +
-    "parent conversation were carried over into this conversation.\n" +
-    "Direct attachments and tool outputs available at the branch point were " +
+    "This conversation starts from a summary of the parent conversation at " +
+    "the branch point.\n" +
+    "Available tools and enabled skills from the parent conversation were " +
+    "carried over into this conversation.\n" +
+    "Conversation attachments and tool outputs available at the branch point were " +
     "also carried over into this conversation.\n"
   );
 }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -93,7 +93,7 @@ function constructBranchContextSection({
   }
 
   const parentConversation = forkedFrom.parentConversationTitle
-    ? `"${forkedFrom.parentConversationTitle}"`
+    ? JSON.stringify(forkedFrom.parentConversationTitle)
     : `conversation ${forkedFrom.parentConversationId}`;
 
   return (
@@ -101,9 +101,10 @@ function constructBranchContextSection({
     `This conversation was branched from ${parentConversation}.\n` +
     "This conversation starts from a summary of the parent conversation " +
     `up to source message ${forkedFrom.sourceMessageId}.\n` +
-    "Readable conversation-level tool access, enabled skills, and direct " +
-    "attachments and tool outputs available at the branch point were copied " +
-    "into this conversation.\n"
+    "Readable conversation-level tool access and enabled skills from the " +
+    "parent conversation were carried over into this conversation.\n" +
+    "Direct attachments and tool outputs available at the branch point were " +
+    "also carried over into this conversation.\n"
   );
 }
 
@@ -466,11 +467,11 @@ export function constructPromptMultiActions(
     // Instructions (long cache): stable per agent config — agent instructions,
     // tools (directives + server listing), skills, format docs, and guidelines.
     //
-    // Shared context (short cache): workspace- and conversation-scoped data shared across users —
-    // date, branch lineage, toolsets, workspace info. A cache breakpoint here lets different
-    // users in the same workspace share this prefix when that context is identical.
+    // Shared context (short cache): workspace-scoped data shared across users — date, toolsets,
+    // workspace info. A cache breakpoint here lets different users in the same workspace share
+    // this prefix.
     //
-    // Ephemeral context (no breakpoint): per-user data — memories, user profile.
+    // Ephemeral context (no breakpoint): per-call data — branch lineage, memories, user profile.
     const fullInstructions = [
       instructionsContent,
       toolsSection,
@@ -484,12 +485,12 @@ export function constructPromptMultiActions(
 
     const sharedContext: SystemPromptContext[] = [
       { role: "context" as const, content: contextSection },
-      { role: "context" as const, content: branchContextSection },
       { role: "context" as const, content: toolsetsContext ?? "" },
       { role: "context" as const, content: workspaceContext ?? "" },
     ].filter((s) => s.content.trim() !== "");
 
     const ephemeralContext: SystemPromptContext[] = [
+      { role: "context" as const, content: branchContextSection },
       { role: "context" as const, content: memoriesContext ?? "" },
       { role: "context" as const, content: userContext ?? "" },
     ].filter((s) => s.content.trim() !== "");

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -82,6 +82,31 @@ function constructContextSection({
   return context;
 }
 
+function constructBranchContextSection({
+  conversation,
+}: {
+  conversation?: Pick<ConversationWithoutContentType, "forkedFrom">;
+}): string {
+  const forkedFrom = conversation?.forkedFrom;
+  if (!forkedFrom) {
+    return "";
+  }
+
+  const parentConversation = forkedFrom.parentConversationTitle
+    ? `"${forkedFrom.parentConversationTitle}"`
+    : `conversation ${forkedFrom.parentConversationId}`;
+
+  return (
+    "# BRANCH CONTEXT\n\n" +
+    `This conversation was branched from ${parentConversation}.\n` +
+    "This conversation starts from a summary of the parent conversation " +
+    `up to source message ${forkedFrom.sourceMessageId}.\n` +
+    "Readable conversation-level tool access, enabled skills, and direct " +
+    "attachments and tool outputs available at the branch point were copied " +
+    "into this conversation.\n"
+  );
+}
+
 function constructToolsSection({
   hasAvailableActions,
   model,
@@ -420,6 +445,7 @@ export function constructPromptMultiActions(
     owner,
     userMessage,
   });
+  const branchContextSection = constructBranchContextSection({ conversation });
   const toolsSection = constructToolsSection({
     hasAvailableActions,
     model,
@@ -440,9 +466,9 @@ export function constructPromptMultiActions(
     // Instructions (long cache): stable per agent config — agent instructions,
     // tools (directives + server listing), skills, format docs, and guidelines.
     //
-    // Shared context (short cache): workspace-scoped data shared across users —
-    // date, toolsets, workspace info. A cache breakpoint here
-    // lets different users in the same workspace share this prefix.
+    // Shared context (short cache): workspace- and conversation-scoped data shared across users —
+    // date, branch lineage, toolsets, workspace info. A cache breakpoint here lets different
+    // users in the same workspace share this prefix when that context is identical.
     //
     // Ephemeral context (no breakpoint): per-user data — memories, user profile.
     const fullInstructions = [
@@ -458,6 +484,7 @@ export function constructPromptMultiActions(
 
     const sharedContext: SystemPromptContext[] = [
       { role: "context" as const, content: contextSection },
+      { role: "context" as const, content: branchContextSection },
       { role: "context" as const, content: toolsetsContext ?? "" },
       { role: "context" as const, content: workspaceContext ?? "" },
     ].filter((s) => s.content.trim() !== "");
@@ -480,6 +507,7 @@ export function constructPromptMultiActions(
   const allSections: SystemPromptContext[] = [
     { role: "context" as const, content: instructionsContent },
     { role: "context" as const, content: contextSection },
+    { role: "context" as const, content: branchContextSection },
     { role: "context" as const, content: toolsSection },
     { role: "context" as const, content: skillsSection },
     { role: "context" as const, content: attachmentsSection },


### PR DESCRIPTION
## Description
- Add a dedicated `# BRANCH CONTEXT` prompt section for branched conversations so the model knows the conversation was branched from a parent conversation and starts from the parent summary boundary.
- Add prompt coverage for both flat and structured prompt assembly.

## Risks
Blast radius: assistant prompt construction for branched conversations
Risk: low

## Deploy Plan
- deploy front