### PR TITLE
[Sessions] Guard empty-conversation placeholder rank

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -922,6 +922,10 @@ export const ConversationViewer = ({
           contentFragments: contentFragmentsFromBackend,
         } = result.value;
 
+        const existingBackendUserMessage = ref.current.data.find(
+          (m) => isUserMessage(m) && m.sId === messageFromBackend.sId
+        );
+
         // If the message was created in a branch, we remove the placeholder user message and the placeholder agent messages from the list.
         if (messageFromBackend.branchId) {
           const placeHolderSids = [
@@ -933,15 +937,29 @@ export const ConversationViewer = ({
           );
         }
 
-        // map() is how we update the state of virtuoso messages.
-        ref.current.data.map((m) =>
-          areSameRankAndBranch(m, placeholderUserMsg)
-            ? {
-                ...messageFromBackend,
-                contentFragments: contentFragmentsFromBackend,
-              }
-            : m
-        );
+        if (existingBackendUserMessage) {
+          ref.current.data.findAndDelete(
+            (m) => m.sId === placeholderUserMsg.sId
+          );
+          ref.current.data.map((m) =>
+            isUserMessage(m) && m.sId === messageFromBackend.sId
+              ? {
+                  ...messageFromBackend,
+                  contentFragments: contentFragmentsFromBackend,
+                }
+              : m
+          );
+        } else {
+          // map() is how we update the state of virtuoso messages.
+          ref.current.data.map((m) =>
+            areSameRankAndBranch(m, placeholderUserMsg)
+              ? {
+                  ...messageFromBackend,
+                  contentFragments: contentFragmentsFromBackend,
+                }
+              : m
+          );
+        }
 
         void mutateConversations(
           (currentData: ConversationWithoutContentType[] | undefined) =>

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -938,20 +938,18 @@ export const ConversationViewer = ({
           );
         }
 
-        ref.current.data.findAndDelete(
-          (m) =>
-            m.sId === placeholderUserMsg.sId ||
-            (isUserMessage(m) && m.sId === messageFromBackend.sId)
-        );
+        const nextData = ref.current.data
+          .get()
+          .filter(
+            (m) =>
+              m.sId !== placeholderUserMsg.sId &&
+              !(isUserMessage(m) && m.sId === messageFromBackend.sId)
+          );
 
-        const currentData = ref.current.data.get();
-        const offset = getBranchedInsertIndex(currentData, renderedUserMessage);
+        const offset = getBranchedInsertIndex(nextData, renderedUserMessage);
+        nextData.splice(offset, 0, renderedUserMessage);
 
-        if (offset < currentData.length) {
-          ref.current.data.insert([renderedUserMessage], offset, false);
-        } else {
-          ref.current.data.append([renderedUserMessage], false);
-        }
+        ref.current.data.replace(nextData);
 
         void mutateConversations(
           (currentData: ConversationWithoutContentType[] | undefined) =>

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -922,9 +922,10 @@ export const ConversationViewer = ({
           contentFragments: contentFragmentsFromBackend,
         } = result.value;
 
-        const existingBackendUserMessage = ref.current.data.find(
-          (m) => isUserMessage(m) && m.sId === messageFromBackend.sId
-        );
+        const renderedUserMessage = {
+          ...messageFromBackend,
+          contentFragments: contentFragmentsFromBackend,
+        };
 
         // If the message was created in a branch, we remove the placeholder user message and the placeholder agent messages from the list.
         if (messageFromBackend.branchId) {
@@ -937,28 +938,19 @@ export const ConversationViewer = ({
           );
         }
 
-        if (existingBackendUserMessage) {
-          ref.current.data.findAndDelete(
-            (m) => m.sId === placeholderUserMsg.sId
-          );
-          ref.current.data.map((m) =>
-            isUserMessage(m) && m.sId === messageFromBackend.sId
-              ? {
-                  ...messageFromBackend,
-                  contentFragments: contentFragmentsFromBackend,
-                }
-              : m
-          );
+        ref.current.data.findAndDelete(
+          (m) =>
+            m.sId === placeholderUserMsg.sId ||
+            (isUserMessage(m) && m.sId === messageFromBackend.sId)
+        );
+
+        const currentData = ref.current.data.get();
+        const offset = getBranchedInsertIndex(currentData, renderedUserMessage);
+
+        if (offset < currentData.length) {
+          ref.current.data.insert([renderedUserMessage], offset, false);
         } else {
-          // map() is how we update the state of virtuoso messages.
-          ref.current.data.map((m) =>
-            areSameRankAndBranch(m, placeholderUserMsg)
-              ? {
-                  ...messageFromBackend,
-                  contentFragments: contentFragmentsFromBackend,
-                }
-              : m
-          );
+          ref.current.data.append([renderedUserMessage], false);
         }
 
         void mutateConversations(

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -805,6 +805,7 @@ export const ConversationViewer = ({
         };
 
         const lastMessageRank = Math.max(
+          0,
           ...ref.current.data.get().map((m) => m.rank)
         );
 

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -920,12 +920,20 @@ export const ConversationViewer = ({
         const {
           message: messageFromBackend,
           contentFragments: contentFragmentsFromBackend,
+          agentMessages: agentMessagesFromBackend,
         } = result.value;
 
         const renderedUserMessage = {
           ...messageFromBackend,
           contentFragments: contentFragmentsFromBackend,
         };
+        const renderedAgentMessages = agentMessagesFromBackend
+          .map((agentMessage) =>
+            makeInitialMessageStreamState(
+              getLightAgentMessageFromAgentMessage(agentMessage)
+            )
+          )
+          .sort((a, b) => a.rank - b.rank);
 
         // If the message was created in a branch, we remove the placeholder user message and the placeholder agent messages from the list.
         if (messageFromBackend.branchId) {
@@ -943,11 +951,26 @@ export const ConversationViewer = ({
           .filter(
             (m) =>
               m.sId !== placeholderUserMsg.sId &&
-              !(isUserMessage(m) && m.sId === messageFromBackend.sId)
+              !placeholderAgentMessages.some(
+                (placeholderAgentMessage) =>
+                  placeholderAgentMessage.sId === m.sId
+              ) &&
+              !(isUserMessage(m) && m.sId === messageFromBackend.sId) &&
+              !(
+                isAgentMessageWithStreaming(m) &&
+                renderedAgentMessages.some(
+                  (renderedAgentMessage) => renderedAgentMessage.sId === m.sId
+                )
+              )
           );
 
-        const offset = getBranchedInsertIndex(nextData, renderedUserMessage);
-        nextData.splice(offset, 0, renderedUserMessage);
+        for (const messageToInsert of [
+          renderedUserMessage,
+          ...renderedAgentMessages,
+        ]) {
+          const offset = getBranchedInsertIndex(nextData, messageToInsert);
+          nextData.splice(offset, 0, messageToInsert);
+        }
 
         ref.current.data.replace(nextData);
 


### PR DESCRIPTION
## Description

The optimistic first-message path computes the placeholder rank from the current visible messages. When a conversation is effectively empty on the client, that could evaluate to `Math.max(...[])` and leave the placeholder unmatched until refresh. This can happen e.g. on forked conversation which starts with no user / agent messages, only compaction. In that case, 

This defaults the base rank to `0`, which matches the child-side compaction case where the first real user message is posted into a freshly forked conversation.

<img width="1381" height="583" alt="image" src="https://github.com/user-attachments/assets/62085322-d8a5-4aaa-8807-491924d6da32" />

## Risks
Blast radius: optimistic first-message rendering in the conversation viewer.
Risk: low

## Deploy Plan
- deploy front