### PR TITLE
Reinforcement: store the conversations at the origin of the reinforcement suggestion

### DIFF
--- a/front/components/poke/skill_suggestions/columns.tsx
+++ b/front/components/poke/skill_suggestions/columns.tsx
@@ -171,6 +171,18 @@ export function makeColumnsForSkillSuggestions(
       },
     },
     {
+      accessorKey: "sourceConversationsCount",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader
+          column={column}
+          label="Source Conversations"
+        />
+      ),
+      cell: ({ row }) => {
+        return row.original.sourceConversationsCount;
+      },
+    },
+    {
       accessorKey: "analysis",
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Analysis" />

--- a/front/lib/models/skill/skill_suggestion.ts
+++ b/front/lib/models/skill/skill_suggestion.ts
@@ -26,6 +26,7 @@ export class SkillSuggestionModel extends WorkspaceAwareModel<SkillSuggestionMod
   declare state: SkillSuggestionState;
   declare source: SkillSuggestionSource;
   declare sourceConversationId: ForeignKey<ConversationModel["id"]> | null;
+  declare sourceConversationIds: string[] | null;
   declare groupId: string | null;
   declare updatedByUserId: ForeignKey<UserModel["id"]> | null;
 
@@ -80,6 +81,12 @@ SkillSuggestionModel.init(
       allowNull: true,
       comment:
         "FK to the conversation that triggered this suggestion (only set when applicable, e.g. synthetic)",
+    },
+    sourceConversationIds: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      comment:
+        "Array of conversation sIds that contributed to this suggestion.",
     },
     groupId: {
       type: DataTypes.STRING,

--- a/front/lib/models/skill/skill_suggestion.ts
+++ b/front/lib/models/skill/skill_suggestion.ts
@@ -26,7 +26,7 @@ export class SkillSuggestionModel extends WorkspaceAwareModel<SkillSuggestionMod
   declare state: SkillSuggestionState;
   declare source: SkillSuggestionSource;
   declare sourceConversationId: ForeignKey<ConversationModel["id"]> | null;
-  declare sourceConversationIds: string[] | null;
+  declare sourceConversationIds: number[] | null;
   declare groupId: string | null;
   declare updatedByUserId: ForeignKey<UserModel["id"]> | null;
 
@@ -83,10 +83,10 @@ SkillSuggestionModel.init(
         "FK to the conversation that triggered this suggestion (only set when applicable, e.g. synthetic)",
     },
     sourceConversationIds: {
-      type: DataTypes.JSONB,
+      type: DataTypes.ARRAY(DataTypes.BIGINT),
       allowNull: true,
       comment:
-        "Array of conversation sIds that contributed to this suggestion.",
+        "Array of conversation model IDs that contributed to this reinforcement suggestion.",
     },
     groupId: {
       type: DataTypes.STRING,

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -44,6 +44,7 @@ function makeInstructionSuggestion(
     state: "pending",
     source: "synthetic",
     sourceConversationId: null,
+    sourceConversationsCount: 0,
     kind: "edit",
     suggestion: {
       instructionEdits: [
@@ -71,6 +72,7 @@ function makeToolSuggestion(
     state: "pending",
     source: "synthetic",
     sourceConversationId: null,
+    sourceConversationsCount: 0,
     kind: "edit",
     suggestion: {
       toolEdits: [{ action: "add", toolId: "tool-search" }],

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -62,11 +62,13 @@ There may be situations where suggestions are co-dependent. For example, there m
 
   suggestion_tool_calls: `
 You are provided all of the attributes associated with a conversation suggestion. You MUST use these EXACT attributes to create the final suggestion.
-The only exceptions are the "analysis" and "title" attributes; these MUST be newly authored for each final suggestion.
+The only exceptions are the "analysis", "title", and "sourceSuggestionIds" attributes; these MUST be newly authored for each final suggestion.
 
 For "analysis": Provide a user-facing explanation of why the suggestion is impactful and how many conversations support it. The end user does NOT care about the technical considerations behind your thought process.
 
 For "title": You MUST provide a short, action-oriented, user-facing title that summarizes what the suggestion changes. The title MUST be at most 25 characters. Examples: "Clarify response tone", "Add Slack search tool", "Remove GitHub tool". Each suggestion MUST have a distinct title.
+
+For "sourceSuggestionIds": You MUST include the sIds of ALL the source suggestions that were consolidated into this final suggestion. Each suggestion has an sId attribute. Every final suggestion MUST reference at least one source suggestion.
 `,
 };
 
@@ -80,7 +82,7 @@ export function buildSkillAggregationSystemPrompt(): string {
 function formatSuggestion(s: SkillSuggestionType): string {
   switch (s.kind) {
     case "edit": {
-      let xml = `<suggestion kind="edit"><skillId>${escapeXml(s.skillConfigurationId)}</skillId><analysis>${escapeXml(s.analysis ?? "N/A")}</analysis>`;
+      let xml = `<suggestion kind="edit" sId="${escapeXml(s.sId)}"><skillId>${escapeXml(s.skillConfigurationId)}</skillId><analysis>${escapeXml(s.analysis ?? "N/A")}</analysis>`;
       if (s.suggestion.instructionEdits?.length) {
         xml += "<instructionEdits>";
         for (const e of s.suggestion.instructionEdits) {
@@ -221,7 +223,15 @@ export async function buildSkillAggregationBatchMap(
     return null;
   }
 
-  return new Map([["aggregation", buildReinforcedSkillsLLMParams(ctx.prompt)]]);
+  return new Map([
+    [
+      "aggregation",
+      buildReinforcedSkillsLLMParams(
+        ctx.prompt,
+        "reinforcement_aggregate_suggestions"
+      ),
+    ],
+  ]);
 }
 
 /**

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -187,7 +187,13 @@ export async function buildSkillConversationAnalysisBatchMap(
       conversationRes.value.text,
       skillTypes
     );
-    batchMap.set(conversationId, buildReinforcedSkillsLLMParams(prompt));
+    batchMap.set(
+      conversationId,
+      buildReinforcedSkillsLLMParams(
+        prompt,
+        "reinforcement_analyze_conversation"
+      )
+    );
   }
 
   if (batchMap.size === 0) {

--- a/front/lib/reinforcement/run_reinforced_analysis.test.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.test.ts
@@ -4,19 +4,22 @@ import { describe, expect, it } from "vitest";
 
 describe("buildReinforcedSkillsLLMParams", () => {
   it("places the system prompt in the prompt field", () => {
-    const params = buildReinforcedSkillsLLMParams({
-      systemPrompt: "You are a skill analyst.",
-      userMessage: "Analyze this skill.",
-    });
+    const params = buildReinforcedSkillsLLMParams(
+      {
+        systemPrompt: "You are a skill analyst.",
+        userMessage: "Analyze this skill.",
+      },
+      "reinforcement_analyze_conversation"
+    );
 
     expect(params.prompt).toBe("You are a skill analyst.");
   });
 
   it("places the user message as a single user message in the conversation", () => {
-    const params = buildReinforcedSkillsLLMParams({
-      systemPrompt: "System.",
-      userMessage: "User content here.",
-    });
+    const params = buildReinforcedSkillsLLMParams(
+      { systemPrompt: "System.", userMessage: "User content here." },
+      "reinforcement_analyze_conversation"
+    );
 
     expect(params.conversation.messages).toHaveLength(1);
     const msg = params.conversation.messages[0];
@@ -25,10 +28,10 @@ describe("buildReinforcedSkillsLLMParams", () => {
   });
 
   it("includes tool specifications for the skill suggestion tools", () => {
-    const params = buildReinforcedSkillsLLMParams({
-      systemPrompt: "System.",
-      userMessage: "User.",
-    });
+    const params = buildReinforcedSkillsLLMParams(
+      { systemPrompt: "System.", userMessage: "User." },
+      "reinforcement_analyze_conversation"
+    );
 
     const toolNames = params.specifications?.map((s) => s.name) ?? [];
     expect(toolNames).toContain("edit_skill");
@@ -36,10 +39,10 @@ describe("buildReinforcedSkillsLLMParams", () => {
   });
 
   it("each specification has a non-empty description and inputSchema", () => {
-    const params = buildReinforcedSkillsLLMParams({
-      systemPrompt: "System.",
-      userMessage: "User.",
-    });
+    const params = buildReinforcedSkillsLLMParams(
+      { systemPrompt: "System.", userMessage: "User." },
+      "reinforcement_analyze_conversation"
+    );
 
     for (const spec of params.specifications ?? []) {
       expect(spec.description).toBeTruthy();

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -467,7 +467,7 @@ async function createSkillSuggestionsFromToolCall({
       }
 
       // Resolve sourceSuggestionIds to sourceConversationIds for reinforcement suggestions.
-      let sourceConversationIds: string[] | null = null;
+      let sourceConversationIds: number[] | null = null;
       if (
         source === "reinforcement" &&
         parsed.data.sourceSuggestionIds &&
@@ -480,8 +480,8 @@ async function createSkillSuggestionsFromToolCall({
         sourceConversationIds = [
           ...new Set(
             sourceSuggestions
-              .map((s) => s.sourceConversationSId)
-              .filter((sId): sId is string => sId !== null)
+              .map((s) => s.sourceConversationId)
+              .filter((id): id is number => id !== null)
           ),
         ];
       }

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -114,10 +114,30 @@ const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
   },
 };
 
-export function buildReinforcedSkillsSpecifications(): AgentActionSpecification[] {
+const AGGREGATION_EXTRA_FIELDS: z.ZodRawShape = {
+  sourceSuggestionIds: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      "The sIds of the source suggestions this suggestion is based on. " +
+        "Must include at least one suggestion sId."
+    ),
+};
+
+export function buildReinforcedSkillsSpecifications(
+  operationType: ReinforcedSkillsOperationType
+): AgentActionSpecification[] {
+  const extraEditSkillFields =
+    operationType === "reinforcement_aggregate_suggestions"
+      ? AGGREGATION_EXTRA_FIELDS
+      : undefined;
+
   return ALL_TOOLS.map((toolName) => {
     const meta = REINFORCED_SKILLS_TOOL_DEFINITIONS[toolName];
-    const schema = z.object(meta.schema);
+    const schema =
+      toolName === "edit_skill" && extraEditSkillFields
+        ? z.object({ ...meta.schema, ...extraEditSkillFields })
+        : z.object(meta.schema);
     return {
       name: toolName,
       description: meta.description,
@@ -191,13 +211,16 @@ export function reinforcedSkillsConversationTitle(
 /**
  * Build LLMStreamParameters for a reinforced skills prompt.
  */
-export function buildReinforcedSkillsLLMParams({
-  systemPrompt,
-  userMessage,
-}: {
-  systemPrompt: string;
-  userMessage: string;
-}): LLMStreamParameters {
+export function buildReinforcedSkillsLLMParams(
+  {
+    systemPrompt,
+    userMessage,
+  }: {
+    systemPrompt: string;
+    userMessage: string;
+  },
+  operationType: ReinforcedSkillsOperationType
+): LLMStreamParameters {
   return {
     conversation: {
       messages: [
@@ -209,7 +232,7 @@ export function buildReinforcedSkillsLLMParams({
       ],
     },
     prompt: systemPrompt,
-    specifications: buildReinforcedSkillsSpecifications(),
+    specifications: buildReinforcedSkillsSpecifications(operationType),
   };
 }
 
@@ -230,7 +253,7 @@ export async function createReinforcedSkillsConversation(
     skillIds: string[];
   }
 ): Promise<string> {
-  const llmParams = buildReinforcedSkillsLLMParams(prompt);
+  const llmParams = buildReinforcedSkillsLLMParams(prompt, operationType);
   const { conversation: llmConversation, ...llmParamsWithoutConversation } =
     llmParams;
   const writeResult = await writeBatchUserMessages(auth, {
@@ -443,6 +466,26 @@ async function createSkillSuggestionsFromToolCall({
         };
       }
 
+      // Resolve sourceSuggestionIds to sourceConversationIds for reinforcement suggestions.
+      let sourceConversationIds: string[] | null = null;
+      if (
+        source === "reinforcement" &&
+        parsed.data.sourceSuggestionIds &&
+        parsed.data.sourceSuggestionIds.length > 0
+      ) {
+        const sourceSuggestions = await SkillSuggestionResource.fetchByIds(
+          auth,
+          parsed.data.sourceSuggestionIds
+        );
+        sourceConversationIds = [
+          ...new Set(
+            sourceSuggestions
+              .map((s) => s.sourceConversationSId)
+              .filter((sId): sId is string => sId !== null)
+          ),
+        ];
+      }
+
       const newSuggestion =
         await SkillSuggestionResource.createSuggestionForSkill(auth, skill, {
           kind: "edit",
@@ -455,6 +498,7 @@ async function createSkillSuggestionsFromToolCall({
           state: "pending",
           source,
           sourceConversationId: conversation?.id ?? null,
+          sourceConversationIds,
           groupId: null,
         });
 

--- a/front/lib/reinforcement/types.ts
+++ b/front/lib/reinforcement/types.ts
@@ -82,6 +82,13 @@ export const TOOL_SCHEMAS: Record<
         "A short, action-oriented user-facing title for this suggestion (MUST be at most 25 characters). " +
           "Only set this when producing final aggregated suggestions; leave unset for synthetic suggestions."
       ),
+    sourceSuggestionIds: z
+      .array(z.string())
+      .min(1)
+      .optional()
+      .describe(
+        "The sIds of the source suggestions consolidated into this suggestion."
+      ),
   }),
 };
 

--- a/front/lib/resources/skill_suggestion_resource.test.ts
+++ b/front/lib/resources/skill_suggestion_resource.test.ts
@@ -534,6 +534,38 @@ describe("SkillSuggestionResource", () => {
     });
   });
 
+  describe("sourceConversationIds", () => {
+    it("should store and retrieve sourceConversationIds", async () => {
+      const suggestion = await SkillSuggestionFactory.create(
+        authenticator,
+        skill,
+        {
+          sourceConversationIds: ["conv_abc", "conv_def"],
+        }
+      );
+
+      expect(suggestion.sourceConversationIds).toEqual([
+        "conv_abc",
+        "conv_def",
+      ]);
+
+      const fetched = await SkillSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched?.sourceConversationIds).toEqual(["conv_abc", "conv_def"]);
+    });
+
+    it("should default sourceConversationIds to null", async () => {
+      const suggestion = await SkillSuggestionFactory.create(
+        authenticator,
+        skill
+      );
+
+      expect(suggestion.sourceConversationIds).toBeNull();
+    });
+  });
+
   describe("toJSON", () => {
     it("should return a properly formatted JSON object", async () => {
       const suggestion = await SkillSuggestionFactory.create(
@@ -572,8 +604,24 @@ describe("SkillSuggestionResource", () => {
       expect(json.source).toBe("reinforcement");
       expect(json.skillConfigurationId).toBe(skill.sId);
       expect(json.sourceConversationId).toBeNull();
+      expect(json.sourceConversationsCount).toBe(0);
       expect(typeof json.createdAt).toBe("number");
       expect(typeof json.updatedAt).toBe("number");
+    });
+
+    it("should include sourceConversationIdsCount but not sourceConversationIds array", async () => {
+      const suggestion = await SkillSuggestionFactory.create(
+        authenticator,
+        skill,
+        {
+          sourceConversationIds: ["conv_abc", "conv_def"],
+        }
+      );
+
+      const json = suggestion.toJSON();
+
+      expect(json.sourceConversationsCount).toBe(2);
+      expect("sourceConversationIds" in json).toBe(false);
     });
 
     it("should round-trip a title through create, fetch, and toJSON", async () => {

--- a/front/lib/resources/skill_suggestion_resource.test.ts
+++ b/front/lib/resources/skill_suggestion_resource.test.ts
@@ -540,20 +540,17 @@ describe("SkillSuggestionResource", () => {
         authenticator,
         skill,
         {
-          sourceConversationIds: ["conv_abc", "conv_def"],
+          sourceConversationIds: [100, 200],
         }
       );
 
-      expect(suggestion.sourceConversationIds).toEqual([
-        "conv_abc",
-        "conv_def",
-      ]);
+      expect(suggestion.sourceConversationIds).toEqual([100, 200]);
 
       const fetched = await SkillSuggestionResource.fetchById(
         authenticator,
         suggestion.sId
       );
-      expect(fetched?.sourceConversationIds).toEqual(["conv_abc", "conv_def"]);
+      expect(fetched?.sourceConversationIds).toEqual([100, 200]);
     });
 
     it("should default sourceConversationIds to null", async () => {
@@ -614,7 +611,7 @@ describe("SkillSuggestionResource", () => {
         authenticator,
         skill,
         {
-          sourceConversationIds: ["conv_abc", "conv_def"],
+          sourceConversationIds: [100, 200],
         }
       );
 

--- a/front/lib/resources/skill_suggestion_resource.ts
+++ b/front/lib/resources/skill_suggestion_resource.ts
@@ -432,6 +432,7 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
       state: this.state,
       source: this.source,
       sourceConversationId: this.sourceConversationSId,
+      sourceConversationsCount: this.sourceConversationIds?.length ?? 0,
       updatedBy: this.updatedBy,
       ...suggestionData,
     };

--- a/front/migrations/db/migration_598.sql
+++ b/front/migrations/db/migration_598.sql
@@ -1,5 +1,5 @@
 -- Migration created on Apr 22, 2026
--- Store the conversation sIds that contributed to a reinforcement suggestion.
+-- Store the conversation model IDs that contributed to a reinforcement suggestion.
 
-ALTER TABLE "skill_suggestions" ADD COLUMN "sourceConversationIds" JSONB;
-COMMENT ON COLUMN "skill_suggestions"."sourceConversationIds" IS 'Array of conversation sIds that contributed to this suggestion.';
+ALTER TABLE "skill_suggestions" ADD COLUMN "sourceConversationIds" BIGINT[];
+COMMENT ON COLUMN "skill_suggestions"."sourceConversationIds" IS 'Array of conversation model IDs that contributed to this reinforcement suggestion.';

--- a/front/migrations/db/migration_598.sql
+++ b/front/migrations/db/migration_598.sql
@@ -1,0 +1,5 @@
+-- Migration created on Apr 22, 2026
+-- Store the conversation sIds that contributed to a reinforcement suggestion.
+
+ALTER TABLE "skill_suggestions" ADD COLUMN "sourceConversationIds" JSONB;
+COMMENT ON COLUMN "skill_suggestions"."sourceConversationIds" IS 'Array of conversation sIds that contributed to this suggestion.';

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -107,7 +107,7 @@ async function runReinforcedSkillsStep({
     throw conversationRes.error;
   }
 
-  const specifications = buildReinforcedSkillsSpecifications();
+  const specifications = buildReinforcedSkillsSpecifications(operationType);
   const modelConfig = llm.getModelConfig();
   const toolsJson = JSON.stringify(
     specifications.map((s) => ({
@@ -596,7 +596,9 @@ export async function startSkillConversationAnalysisBatchActivity({
   }
 
   const systemPrompt = buildSkillAnalysisSystemPrompt();
-  const specifications = buildReinforcedSkillsSpecifications();
+  const specifications = buildReinforcedSkillsSpecifications(
+    "reinforcement_analyze_conversation"
+  );
 
   const batchConversations: LlmConversationOptions[] = [];
   const orderedAnalysedConversationIds: string[] = [];
@@ -839,7 +841,9 @@ export async function startSkillAggregationBatchActivity({
   }
 
   const systemPrompt = buildSkillAggregationSystemPrompt();
-  const specifications = buildReinforcedSkillsSpecifications();
+  const specifications = buildReinforcedSkillsSpecifications(
+    "reinforcement_aggregate_suggestions"
+  );
 
   let batchConversations: LlmConversationOptions[];
 

--- a/front/tests/reinforcement-evals/lib/assertions.ts
+++ b/front/tests/reinforcement-evals/lib/assertions.ts
@@ -42,6 +42,33 @@ function getSkillId(args: Record<string, unknown>): string | undefined {
   return isString(args.skillId) ? args.skillId : undefined;
 }
 
+function getSourceSuggestionIds(args: Record<string, unknown>): string[] {
+  const ids = args.sourceSuggestionIds;
+  if (!Array.isArray(ids)) {
+    return [];
+  }
+  return ids.filter(isString);
+}
+
+function validateSourceSuggestionIds(
+  call: ToolCall,
+  expectedIds: string[]
+): AssertionResult | null {
+  const actualIds = getSourceSuggestionIds(call.arguments);
+  const expectedSet = new Set(expectedIds);
+  const actualSet = new Set(actualIds);
+  if (
+    expectedSet.size !== actualSet.size ||
+    [...expectedSet].some((id) => !actualSet.has(id))
+  ) {
+    return {
+      success: false,
+      error: `Expected sourceSuggestionIds ${JSON.stringify([...expectedSet].sort())} but got ${JSON.stringify([...actualSet].sort())}`,
+    };
+  }
+  return null;
+}
+
 function getInstructionEdits(
   args: Record<string, unknown>
 ): InstructionEditItem[] {
@@ -94,6 +121,15 @@ export function validateToolCallAssertion(
           error: `Expected edit_skill to contain instructionEdits for skillId "${assertion.skillId}", but instructionEdits is empty or missing`,
         };
       }
+      if (assertion.sourceSuggestionIds) {
+        const sourceResult = validateSourceSuggestionIds(
+          call,
+          assertion.sourceSuggestionIds
+        );
+        if (sourceResult) {
+          return sourceResult;
+        }
+      }
       return { success: true };
     }
     case "editSkillWithTool": {
@@ -118,6 +154,15 @@ export function validateToolCallAssertion(
           error: `Expected edit_skill to contain toolEdit with toolId "${assertion.toolId}", but got: ${JSON.stringify(toolEdits)}`,
         };
       }
+      if (assertion.sourceSuggestionIds) {
+        const sourceResult = validateSourceSuggestionIds(
+          call,
+          assertion.sourceSuggestionIds
+        );
+        if (sourceResult) {
+          return sourceResult;
+        }
+      }
       return { success: true };
     }
     case "editSkill": {
@@ -134,6 +179,15 @@ export function validateToolCallAssertion(
           success: false,
           error: `Expected edit_skill for skillId "${assertion.skillId}", but got skillId "${skillId}"`,
         };
+      }
+      if (assertion.sourceSuggestionIds) {
+        const sourceResult = validateSourceSuggestionIds(
+          call,
+          assertion.sourceSuggestionIds
+        );
+        if (sourceResult) {
+          return sourceResult;
+        }
       }
       return { success: true };
     }
@@ -160,6 +214,36 @@ export function validateToolCallAssertion(
           success: false,
           error: `Expected exactly ${assertion.count} edit_skill call(s), but got ${actual}`,
         };
+      }
+      return { success: true };
+    }
+    case "editSkillCallsWithSources": {
+      const editCalls = toolCalls.filter((tc) => tc.name === "edit_skill");
+      const expectedCount = assertion.sourceSuggestionIdGroups.length;
+      if (editCalls.length !== expectedCount) {
+        return {
+          success: false,
+          error: `Expected exactly ${expectedCount} edit_skill call(s), but got ${editCalls.length}`,
+        };
+      }
+      // Each call's sourceSuggestionIds must match exactly one group (order-independent).
+      const remainingGroups = assertion.sourceSuggestionIdGroups.map(
+        (g) => new Set(g)
+      );
+      for (const call of editCalls) {
+        const actualIds = new Set(getSourceSuggestionIds(call.arguments));
+        const matchIdx = remainingGroups.findIndex(
+          (group) =>
+            group.size === actualIds.size &&
+            [...group].every((id) => actualIds.has(id))
+        );
+        if (matchIdx === -1) {
+          return {
+            success: false,
+            error: `edit_skill call has sourceSuggestionIds ${JSON.stringify([...actualIds].sort())} which does not match any expected group: ${JSON.stringify(assertion.sourceSuggestionIdGroups.map((g) => g.sort()))}`,
+          };
+        }
+        remainingGroups.splice(matchIdx, 1);
       }
       return { success: true };
     }

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -28,6 +28,7 @@ import {
   buildConversationText,
   type CategorizedTestCase,
   type ExecutionResult,
+  isAggregationTestCase,
   isAnalysisTestCase,
   type MockMcpDescription,
   type MockSkillConfig,
@@ -301,7 +302,10 @@ export async function executeReinforced(
 ): Promise<ExecutionResult> {
   const llm = await getLLMInstance(auth);
   const prompt = buildPromptForTestCase(testCase);
-  const params = buildReinforcedSkillsLLMParams(prompt);
+  const operationType = isAggregationTestCase(testCase)
+    ? "reinforcement_aggregate_suggestions"
+    : "reinforcement_analyze_conversation";
+  const params = buildReinforcedSkillsLLMParams(prompt, operationType);
 
   return executeMultiStep(
     llm,
@@ -349,7 +353,13 @@ export async function executeBatch(
   let pendingParams = new Map<string, LLMStreamParameters>();
   for (const tc of testCases) {
     const prompt = buildPromptForTestCase(tc);
-    pendingParams.set(tc.scenarioId, buildReinforcedSkillsLLMParams(prompt));
+    const operationType = isAggregationTestCase(tc)
+      ? "reinforcement_aggregate_suggestions"
+      : "reinforcement_analyze_conversation";
+    pendingParams.set(
+      tc.scenarioId,
+      buildReinforcedSkillsLLMParams(prompt, operationType)
+    );
   }
 
   const results = new Map<string, ExecutionResult>();

--- a/front/tests/reinforcement-evals/lib/types.ts
+++ b/front/tests/reinforcement-evals/lib/types.ts
@@ -181,29 +181,46 @@ export interface ToolCall {
 }
 
 export type ToolCallAssertion =
-  | { type: "editSkillWithInstructions"; skillId: string }
-  | { type: "editSkillWithTool"; skillId: string; toolId: string }
-  | { type: "editSkill"; skillId: string }
+  | {
+      type: "editSkillWithInstructions";
+      skillId: string;
+      sourceSuggestionIds?: string[];
+    }
+  | {
+      type: "editSkillWithTool";
+      skillId: string;
+      toolId: string;
+      sourceSuggestionIds?: string[];
+    }
+  | { type: "editSkill"; skillId: string; sourceSuggestionIds?: string[] }
   | { type: "editSkillCallCount"; count: number }
+  | { type: "editSkillCallsWithSources"; sourceSuggestionIdGroups: string[][] }
   | { type: "noSuggestion" }
   | { type: "calledDescribeMcp"; mcpId: string };
 
 /** Expects an edit_skill call with instructionEdits for the given skill. */
-export function editSkillWithInstructions(skillId: string): ToolCallAssertion {
-  return { type: "editSkillWithInstructions", skillId };
+export function editSkillWithInstructions(
+  skillId: string,
+  sourceSuggestionIds?: string[]
+): ToolCallAssertion {
+  return { type: "editSkillWithInstructions", skillId, sourceSuggestionIds };
 }
 
 /** Expects an edit_skill call with a toolEdit for the given skill and tool. */
 export function editSkillWithTool(
   skillId: string,
-  toolId: string
+  toolId: string,
+  sourceSuggestionIds?: string[]
 ): ToolCallAssertion {
-  return { type: "editSkillWithTool", skillId, toolId };
+  return { type: "editSkillWithTool", skillId, toolId, sourceSuggestionIds };
 }
 
 /** Expects an edit_skill call for the given skill (any edit type). */
-export function editSkill(skillId: string): ToolCallAssertion {
-  return { type: "editSkill", skillId };
+export function editSkill(
+  skillId: string,
+  sourceSuggestionIds?: string[]
+): ToolCallAssertion {
+  return { type: "editSkill", skillId, sourceSuggestionIds };
 }
 
 export function noSuggestion(): ToolCallAssertion {
@@ -213,6 +230,16 @@ export function noSuggestion(): ToolCallAssertion {
 /** Expects exactly `count` edit_skill calls. */
 export function editSkillCallCount(count: number): ToolCallAssertion {
   return { type: "editSkillCallCount", count };
+}
+
+/**
+ * Expects one edit_skill call per group, where each call's sourceSuggestionIds
+ * matches exactly one of the provided groups (order of calls doesn't matter).
+ */
+export function editSkillCallsWithSources(
+  sourceSuggestionIdGroups: string[][]
+): ToolCallAssertion {
+  return { type: "editSkillCallsWithSources", sourceSuggestionIdGroups };
 }
 
 /** Expects describe_mcp to have been called with the given mcpId. */

--- a/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
@@ -1,5 +1,5 @@
 import {
-  editSkillCallCount,
+  editSkillCallsWithSources,
   editSkillWithInstructions,
   editSkillWithTool,
   mockTool,
@@ -32,6 +32,7 @@ function makeInstructionSuggestion(input: {
     state: "pending",
     source: input.source ?? "synthetic",
     sourceConversationId: null,
+    sourceConversationsCount: 0,
     updatedBy: null,
     kind: "edit",
     suggestion: {
@@ -62,6 +63,7 @@ function makeToolSuggestion(input: {
     state: "pending",
     source: input.source ?? "synthetic",
     sourceConversationId: null,
+    sourceConversationsCount: 0,
     updatedBy: null,
     kind: "edit",
     suggestion: {
@@ -136,7 +138,9 @@ export const aggregateSuggestionsSuite: TestSuite = {
         }),
       ],
       workspaceContext: WORKSPACE_CONTEXT,
-      expectedToolCalls: [editSkillWithInstructions(SKILL_SID)],
+      expectedToolCalls: [
+        editSkillWithInstructions(SKILL_SID, ["sug-1", "sug-2", "sug-3"]),
+      ],
       judgeCriteria: `The analyst MUST call edit_skill with instructionEdits for skill "${SKILL_SID}".
 The merged suggestion should:
 - Combine all three themes: warmth/empathy, natural language, and acknowledge-first approach
@@ -186,7 +190,13 @@ Score 3 if well-merged with all themes, clear structure, and analysis referencin
         }),
       ],
       workspaceContext: WORKSPACE_CONTEXT,
-      expectedToolCalls: [editSkillWithTool("skill_engineering", "mcp_jira")],
+      expectedToolCalls: [
+        editSkillWithTool("skill_engineering", "mcp_jira", [
+          "sug-1",
+          "sug-2",
+          "sug-3",
+        ]),
+      ],
       judgeCriteria: `The analyst MUST call edit_skill with toolEdits to suggest adding JIRA (mcp_jira)
 to skill "skill_engineering". The aggregated suggestion should:
 - Merge the 3 individual suggestions into a single recommendation
@@ -360,7 +370,12 @@ Score 3 if no suggestion is created.`,
         }),
       ],
       workspaceContext: WORKSPACE_CONTEXT,
-      expectedToolCalls: [editSkillCallCount(2)],
+      expectedToolCalls: [
+        editSkillCallsWithSources([
+          ["sug-tone-1", "sug-tone-2"],
+          ["sug-tool-1", "sug-tool-2"],
+        ]),
+      ],
       judgeCriteria: `The analyst receives 4 synthetic suggestions: 2 about tone (warmth/empathy and natural language)
 and 2 about CRM tool usage (search by ID, use refresh flag). These are unrelated topics and MUST
 result in 2 separate edit_skill calls — one for tone, one for CRM tool usage.

--- a/front/tests/utils/SkillSuggestionFactory.ts
+++ b/front/tests/utils/SkillSuggestionFactory.ts
@@ -20,7 +20,7 @@ export class SkillSuggestionFactory {
       title: string | null;
       state: SkillSuggestionState;
       source: SkillSuggestionSource;
-      sourceConversationIds: string[] | null;
+      sourceConversationIds: number[] | null;
     }> = {}
   ): Promise<SkillSuggestionResource> {
     return SkillSuggestionResource.createSuggestionForSkill(auth, skill, {

--- a/front/tests/utils/SkillSuggestionFactory.ts
+++ b/front/tests/utils/SkillSuggestionFactory.ts
@@ -20,6 +20,7 @@ export class SkillSuggestionFactory {
       title: string | null;
       state: SkillSuggestionState;
       source: SkillSuggestionSource;
+      sourceConversationIds: string[] | null;
     }> = {}
   ): Promise<SkillSuggestionResource> {
     return SkillSuggestionResource.createSuggestionForSkill(auth, skill, {
@@ -37,6 +38,7 @@ export class SkillSuggestionFactory {
       title: overrides.title ?? null,
       state: overrides.state ?? "pending",
       source: overrides.source ?? "reinforcement",
+      sourceConversationIds: overrides.sourceConversationIds ?? null,
     });
   }
 

--- a/front/types/suggestions/skill_suggestion.ts
+++ b/front/types/suggestions/skill_suggestion.ts
@@ -120,6 +120,7 @@ const BaseSkillSuggestionSchema = z.object({
   state: z.enum(SKILL_SUGGESTION_STATES),
   source: z.enum(SKILL_SUGGESTION_SOURCES),
   sourceConversationId: z.string().nullable(),
+  sourceConversationsCount: z.number(),
   updatedBy: SkillSuggestionUpdatedBySchema.nullable(),
 });
 


### PR DESCRIPTION
## Description

Goals of the PR:
 - store the ids of the conversations leading to a reinforcement suggestion into the DB
 - add tool so the LLM can pass these suggestions
 - update test framework to test it
 - show in Poke how many suggestions have contributed to the suggestion

Non goals
 - move the source conversation id of synthetic suggestion, will be done in follow up PR
 - display anything in the UI, will be done in a follow up PR (need some logic about which conv can be accessed)

## Tests

 - Updated eval framework tests
 - manually tested
 
<img width="1110" height="202" alt="image" src="https://github.com/user-attachments/assets/b9d9adb4-0788-4baa-b814-bd24db5e2bcc" />

<img width="3304" height="256" alt="image" src="https://github.com/user-attachments/assets/4889185c-b94c-4a59-ab04-3011e76ded1e" />

Example tool call
```json
"params": {
    "title": "Ground analysis in text",
    "skillId": "skl_Q8Ac4uf35L",
    "analysis": "Multiple conversations showed the agent fabricating interpretations — inventing metaphors, characters, or themes with no basis in the poem's actual words. Users explicitly flagged this with negative feedback. This suggestion tackles the problem on three fronts: (1) adding a mandatory first step to establish a literal reading before any interpretation, (2) reinforcing the intro with a clear \"every claim must be grounded in the text\" rule, and (3) strengthening the closing paragraph with an explicit prohibition on introducing elements absent from the poem.",
    "instructionEdits": [...
    ],
    "sourceSuggestionIds": [
      "ssu_bnZYnmhR7O",
      "ssu_nWqafLPGrM"
    ]
  },
```

## Risk

low

## Deploy Plan

lock front
merge PR
run migration
deploy front
unlock front
