### PR TITLE
Add wakeups internal MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -648,6 +648,11 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_tests": "never_ask",
     "list_vulnerabilities": "never_ask",
   },
+  "wakeups": {
+    "cancel_wakeup": "low",
+    "list_wakeups": "never_ask",
+    "schedule_wakeup": "low",
+  },
   "web_search_&_browse": {
     "webbrowser": "never_ask",
     "websearch": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -69,6 +69,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "sandbox", id: 1024 },
       { name: "user_mentions", id: 1026 },
       { name: "ask_user_question", id: 1028 },
+      { name: "wakeups", id: 1031 },
     ];
     expect(
       autoInternalTools,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1100,6 +1100,18 @@ export const INTERNAL_MCP_SERVERS = {
     timeoutMs: undefined,
     metadata: ASK_USER_QUESTION_SERVER,
   },
+  wakeups: {
+    id: 1029,
+    availability: "auto",
+    allowMultipleInstances: false,
+    isPreview: true,
+    isRestricted: ({ featureFlags }) =>
+      !featureFlags.includes("enable_wakeups"),
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: WAKEUPS_SERVER,
+  },
   clari_copilot: {
     id: 1030,
     availability: "manual",
@@ -1112,17 +1124,6 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: CLARI_COPILOT_SERVER,
-  },
-  wakeups: {
-    id: 1031,
-    availability: "auto",
-    allowMultipleInstances: false,
-    isPreview: true,
-    isRestricted: ({ featureFlags }) => !featureFlags.includes("enable_wakeups"),
-    tools_arguments_requiring_approval: undefined,
-    tools_retry_policies: undefined,
-    timeoutMs: undefined,
-    metadata: WAKEUPS_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1115,7 +1115,7 @@ export const INTERNAL_MCP_SERVERS = {
   },
   wakeups: {
     id: 1031,
-    availability: "auto_hidden_builder",
+    availability: "auto",
     allowMultipleInstances: false,
     isPreview: true,
     isRestricted: ({ featureFlags }) => !featureFlags.includes("wakeups"),

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -80,6 +80,7 @@ import { UKG_READY_SERVER } from "@app/lib/api/actions/servers/ukg_ready/metadat
 import { USER_MENTIONS_SERVER } from "@app/lib/api/actions/servers/user_mentions/metadata";
 import { VAL_TOWN_SERVER } from "@app/lib/api/actions/servers/val_town/metadata";
 import { VANTA_SERVER } from "@app/lib/api/actions/servers/vanta/metadata";
+import { WAKEUPS_SERVER } from "@app/lib/api/actions/servers/wakeups/metadata";
 import {
   WEB_SEARCH_BROWSE_SERVER,
   WEB_SEARCH_BROWSE_SERVER_NAME,
@@ -209,6 +210,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "poke",
   "sandbox",
   "ask_user_question",
+  "wakeups",
 ] as const;
 
 export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
@@ -1110,6 +1112,17 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: CLARI_COPILOT_SERVER,
+  },
+  wakeups: {
+    id: 1031,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isPreview: true,
+    isRestricted: ({ featureFlags }) => !featureFlags.includes("wakeups"),
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: WAKEUPS_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1101,7 +1101,7 @@ export const INTERNAL_MCP_SERVERS = {
     metadata: ASK_USER_QUESTION_SERVER,
   },
   wakeups: {
-    id: 1029,
+    id: 1031,
     availability: "auto",
     allowMultipleInstances: false,
     isPreview: true,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1118,7 +1118,7 @@ export const INTERNAL_MCP_SERVERS = {
     availability: "auto",
     allowMultipleInstances: false,
     isPreview: true,
-    isRestricted: ({ featureFlags }) => !featureFlags.includes("wakeups"),
+    isRestricted: ({ featureFlags }) => !featureFlags.includes("enable_wakeups"),
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -74,6 +74,7 @@ import { default as ukgReadyServer } from "@app/lib/api/actions/servers/ukg_read
 import { default as userMentionsServer } from "@app/lib/api/actions/servers/user_mentions";
 import { default as valtownServer } from "@app/lib/api/actions/servers/val_town";
 import { default as vantaServer } from "@app/lib/api/actions/servers/vanta";
+import { default as wakeupsServer } from "@app/lib/api/actions/servers/wakeups";
 import { default as webSearchBrowseServer } from "@app/lib/api/actions/servers/web_search_browse";
 import { default as zendeskServer } from "@app/lib/api/actions/servers/zendesk";
 import type { Authenticator } from "@app/lib/auth";
@@ -261,6 +262,8 @@ export async function getInternalMCPServer(
       return statuspageServer(auth, agentLoopContext);
     case "sandbox":
       return sandboxServer(auth, agentLoopContext);
+    case "wakeups":
+      return wakeupsServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/api/actions/servers/wakeups/index.ts
+++ b/front/lib/api/actions/servers/wakeups/index.ts
@@ -1,0 +1,26 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { WAKEUPS_SERVER_NAME } from "@app/lib/api/actions/servers/wakeups/metadata";
+import { createWakeupsTools } from "@app/lib/api/actions/servers/wakeups/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer(WAKEUPS_SERVER_NAME);
+
+  const tools = createWakeupsTools(auth, agentLoopContext);
+
+  for (const tool of tools) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: WAKEUPS_SERVER_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -1,0 +1,99 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const WAKEUPS_SERVER_NAME = "wakeups" as const;
+
+export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
+  schedule_wakeup: {
+    description:
+      "Schedule a wake-up that re-posts in this conversation at a future time and re-invokes " +
+      "the agent. Use this to check back on something later, remind the user, or poll until a " +
+      "condition is met. The `when` field accepts three formats: " +
+      '(1) relative duration like "in 2h", "in 30m", "in 1d"; ' +
+      '(2) absolute ISO 8601 timestamp like "2026-04-16T16:00:00Z"; ' +
+      '(3) 5-field cron expression like "0 9 * * MON-FRI". ' +
+      "Cron expressions fire recurrently until a fire cap is reached. Only one active wake-up " +
+      "is allowed per conversation at a time.",
+    schema: {
+      when: z
+        .string()
+        .describe(
+          'When to wake up. One of: relative duration ("in 2h", "in 30m", "in 1d"), ' +
+            'ISO 8601 timestamp ("2026-04-16T16:00:00Z"), or 5-field cron expression ("0 9 * * MON-FRI").'
+        ),
+      reason: z
+        .string()
+        .min(1)
+        .describe(
+          "Short, user-facing explanation of why the wake-up is being scheduled. " +
+            "Displayed in the UI and included in the wake-up prompt so the agent has context when it resumes."
+        ),
+      timezone: z
+        .string()
+        .optional()
+        .describe(
+          "IANA timezone (e.g. 'Europe/Paris'). Required only when `when` is a cron expression. " +
+            "If omitted, falls back to the user's timezone from the conversation."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Scheduling wake-up",
+      done: "Schedule wake-up",
+    },
+  },
+  list_wakeups: {
+    description:
+      "List wake-ups for the current conversation with their status, schedule, and reason. " +
+      "Useful for checking what's already scheduled before creating a new wake-up, or for " +
+      "finding the wakeUpId needed to cancel a wake-up.",
+    schema: {},
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing wake-ups",
+      done: "List wake-ups",
+    },
+  },
+  cancel_wakeup: {
+    description:
+      "Cancel a previously scheduled wake-up by its wakeUpId. The wake-up must belong to the " +
+      "current conversation. Cancelling an already-fired, cancelled, or expired wake-up is a no-op.",
+    schema: {
+      wakeUpId: z
+        .string()
+        .describe(
+          "The sId of the wake-up to cancel, as returned by `schedule_wakeup` or `list_wakeups`."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Cancelling wake-up",
+      done: "Cancel wake-up",
+    },
+  },
+});
+
+export const WAKEUPS_SERVER = {
+  serverInfo: {
+    name: WAKEUPS_SERVER_NAME,
+    version: "1.0.0",
+    description:
+      "Schedule wake-ups that re-invoke the agent in this conversation at a later time.",
+    authorization: null,
+    icon: "ActionTimeIcon",
+    documentationUrl: null,
+    instructions: null,
+  },
+  tools: Object.values(WAKEUPS_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(WAKEUPS_TOOLS_METADATA).map((t) => [t.name, t.stake])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -9,14 +9,14 @@ export const WAKEUPS_SERVER_NAME = "wakeups" as const;
 export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
   schedule_wakeup: {
     description:
-      "Schedule a wake-up that re-posts in this conversation at a future time and re-invokes " +
-      "the agent. Use this to check back on something later, remind the user, or poll until a " +
-      "condition is met. The `when` field accepts three formats: " +
+      "Schedule a wake-up that posts a user message at a future time to re-invoke " +
+      "the agent. Use this to check back on something later, remind the user, poll until a " +
+      "condition is met or schedule recurring work. The `when` field accepts three formats: " +
       '(1) relative duration like "in 2h", "in 30m", "in 1d"; ' +
       '(2) absolute ISO 8601 timestamp like "2026-04-16T16:00:00Z"; ' +
-      '(3) 5-field cron expression like "0 9 * * MON-FRI". ' +
+      '(3) 5-field cron expression like "0 9 * * MON-FRI". (# and L are not supported).' +
       "Cron expressions fire recurrently until a fire cap is reached. Only one active wake-up " +
-      "is allowed per conversation at a time.",
+      "is allowed at a time.",
     schema: {
       when: z
         .string()
@@ -29,14 +29,14 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
         .min(1)
         .describe(
           "Short, user-facing explanation of why the wake-up is being scheduled. " +
-            "Displayed in the UI and included in the wake-up prompt so the agent has context when it resumes."
+            "Displayed in the UI and included in the wake-up message so the agent has context when it resumes."
         ),
       timezone: z
         .string()
         .optional()
         .describe(
           "IANA timezone (e.g. 'Europe/Paris'). Required only when `when` is a cron expression. " +
-            "If omitted, falls back to the user's timezone from the conversation."
+            "If omitted, falls back to the user's timezone."
         ),
     },
     stake: "low",
@@ -47,9 +47,9 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
   },
   list_wakeups: {
     description:
-      "List wake-ups for the current conversation with their status, schedule, and reason. " +
+      "List wake-ups with their status, schedule, and reason. " +
       "Useful for checking what's already scheduled before creating a new wake-up, or for " +
-      "finding the wakeUpId needed to cancel a wake-up.",
+      "finding the wake-up ID needed to cancel a wake-up.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -59,13 +59,13 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
   },
   cancel_wakeup: {
     description:
-      "Cancel a previously scheduled wake-up by its wakeUpId. The wake-up must belong to the " +
-      "current conversation. Cancelling an already-fired, cancelled, or expired wake-up is a no-op.",
+      "Cancel a previously scheduled wake-up by ID. " +
+      "Cancelling an already-fired, cancelled, or expired wake-up is a no-op.",
     schema: {
       wakeUpId: z
         .string()
         .describe(
-          "The sId of the wake-up to cancel, as returned by `schedule_wakeup` or `list_wakeups`."
+          "The ID of the wake-up to cancel, as returned by `schedule_wakeup` or `list_wakeups`."
         ),
     },
     stake: "low",
@@ -80,8 +80,7 @@ export const WAKEUPS_SERVER = {
   serverInfo: {
     name: WAKEUPS_SERVER_NAME,
     version: "1.0.0",
-    description:
-      "Schedule wake-ups that re-invoke the agent in this conversation at a later time.",
+    description: "Schedule wake-ups that re-invoke the agent at a later time.",
     authorization: null,
     icon: "ActionTimeIcon",
     documentationUrl: null,

--- a/front/lib/api/actions/servers/wakeups/tools/index.ts
+++ b/front/lib/api/actions/servers/wakeups/tools/index.ts
@@ -9,6 +9,7 @@ import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { isUserMessageType } from "@app/types/assistant/conversation";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Per-conversation guardrails. Enforced at tool-call time so the agent gets a clear error instead
 // of silently over-scheduling.
@@ -105,6 +106,8 @@ function renderScheduleConfig(wakeUp: WakeUpType): string {
       return `one-shot at ${new Date(wakeUp.scheduleConfig.fireAt).toISOString()}`;
     case "cron":
       return `cron "${wakeUp.scheduleConfig.cron}" (${wakeUp.scheduleConfig.timezone})`;
+    default:
+      assertNever(wakeUp.scheduleConfig);
   }
 }
 

--- a/front/lib/api/actions/servers/wakeups/tools/index.ts
+++ b/front/lib/api/actions/servers/wakeups/tools/index.ts
@@ -10,25 +10,13 @@ import { isUserMessageType } from "@app/types/assistant/conversation";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import { Err, Ok } from "@app/types/shared/result";
 
-// Per-conversation and per-workspace guardrails. Mirrors the limits documented in the wake-up
-// design doc; enforced at tool-call time so the agent gets a clear error instead of silently
-// over-scheduling.
+// Per-conversation guardrails. Enforced at tool-call time so the agent gets a clear error instead
+// of silently over-scheduling.
 const MAX_ACTIVE_WAKEUPS_PER_CONVERSATION = 1;
-const MAX_ACTIVE_WAKEUPS_PER_WORKSPACE = 256;
 
 // One-shot wake-ups cannot be scheduled further than this into the future. Prevents
 // far-future orphans. Matches the "Max one-shot delay | 1 month" guardrail.
 const MAX_ONE_SHOT_DELAY_MS = 31 * 24 * 60 * 60 * 1000;
-
-type ParsedWhen =
-  | {
-      kind: "one_shot";
-      fireAt: Date;
-    }
-  | {
-      kind: "cron";
-      cron: string;
-    };
 
 const RELATIVE_DURATION_REGEXP = /^in\s+(\d+)\s*(m|h|d)$/i;
 
@@ -69,11 +57,16 @@ function parseIsoTimestamp(input: string): Date | null {
   return date;
 }
 
-function looksLikeCron(input: string): boolean {
-  return input.trim().split(/\s+/).length === 5;
-}
-
-function parseWhen(when: string): ParsedWhen | null {
+function parseWhen(when: string):
+  | {
+      kind: "one_shot";
+      fireAt: Date;
+    }
+  | {
+      kind: "cron";
+      cron: string;
+    }
+  | null {
   const trimmed = when.trim();
 
   const relative = parseRelativeDuration(trimmed);
@@ -86,7 +79,8 @@ function parseWhen(when: string): ParsedWhen | null {
     return { kind: "one_shot", fireAt: iso };
   }
 
-  if (looksLikeCron(trimmed)) {
+  // If looks like cron
+  if (trimmed.split(/\s+/).length === 5) {
     return { kind: "cron", cron: trimmed };
   }
 
@@ -204,15 +198,6 @@ export function createWakeupsTools(
             `This conversation already has ${activeInConversation.length} active wake-up(s); ` +
               `the limit is ${MAX_ACTIVE_WAKEUPS_PER_CONVERSATION}. Cancel the existing wake-up ` +
               "before scheduling a new one."
-          )
-        );
-      }
-
-      const workspaceActive = await WakeUpResource.listActiveByWorkspace(auth);
-      if (workspaceActive.length >= MAX_ACTIVE_WAKEUPS_PER_WORKSPACE) {
-        return new Err(
-          new MCPError(
-            `Workspace has reached the maximum of ${MAX_ACTIVE_WAKEUPS_PER_WORKSPACE} active wake-ups.`
           )
         );
       }

--- a/front/lib/api/actions/servers/wakeups/tools/index.ts
+++ b/front/lib/api/actions/servers/wakeups/tools/index.ts
@@ -1,0 +1,351 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { WAKEUPS_TOOLS_METADATA } from "@app/lib/api/actions/servers/wakeups/metadata";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import { isUserMessageType } from "@app/types/assistant/conversation";
+import type { WakeUpType } from "@app/types/assistant/wakeups";
+import { Err, Ok } from "@app/types/shared/result";
+
+// Per-conversation and per-workspace guardrails. Mirrors the limits documented in the wake-up
+// design doc; enforced at tool-call time so the agent gets a clear error instead of silently
+// over-scheduling.
+const MAX_ACTIVE_WAKEUPS_PER_CONVERSATION = 1;
+const MAX_ACTIVE_WAKEUPS_PER_WORKSPACE = 256;
+
+// One-shot wake-ups cannot be scheduled further than this into the future. Prevents
+// far-future orphans. Matches the "Max one-shot delay | 1 month" guardrail.
+const MAX_ONE_SHOT_DELAY_MS = 31 * 24 * 60 * 60 * 1000;
+
+type ParsedWhen =
+  | {
+      kind: "one_shot";
+      fireAt: Date;
+    }
+  | {
+      kind: "cron";
+      cron: string;
+    };
+
+const RELATIVE_DURATION_REGEXP = /^in\s+(\d+)\s*(m|h|d)$/i;
+
+function parseRelativeDuration(input: string): Date | null {
+  const match = RELATIVE_DURATION_REGEXP.exec(input.trim());
+  if (!match) {
+    return null;
+  }
+
+  const amount = parseInt(match[1], 10);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return null;
+  }
+
+  const unit = match[2].toLowerCase();
+  const unitMs =
+    unit === "m"
+      ? 60 * 1000
+      : unit === "h"
+        ? 60 * 60 * 1000
+        : 24 * 60 * 60 * 1000;
+
+  return new Date(Date.now() + amount * unitMs);
+}
+
+function parseIsoTimestamp(input: string): Date | null {
+  const trimmed = input.trim();
+  // Require a year-led ISO-ish prefix to avoid accidentally parsing things like "2h" as 2 AM.
+  if (!/^\d{4}-\d{2}-\d{2}[T ]/.test(trimmed)) {
+    return null;
+  }
+
+  const date = new Date(trimmed);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date;
+}
+
+function looksLikeCron(input: string): boolean {
+  return input.trim().split(/\s+/).length === 5;
+}
+
+function parseWhen(when: string): ParsedWhen | null {
+  const trimmed = when.trim();
+
+  const relative = parseRelativeDuration(trimmed);
+  if (relative) {
+    return { kind: "one_shot", fireAt: relative };
+  }
+
+  const iso = parseIsoTimestamp(trimmed);
+  if (iso) {
+    return { kind: "one_shot", fireAt: iso };
+  }
+
+  if (looksLikeCron(trimmed)) {
+    return { kind: "cron", cron: trimmed };
+  }
+
+  return null;
+}
+
+function getUserTimezone(
+  agentLoopContext?: AgentLoopContextType
+): string | null {
+  const content = agentLoopContext?.runContext?.conversation?.content;
+  if (!content) {
+    return null;
+  }
+
+  const userMessage = content.flat().findLast(isUserMessageType);
+  return userMessage?.context.timezone ?? null;
+}
+
+function renderScheduleConfig(wakeUp: WakeUpType): string {
+  switch (wakeUp.scheduleConfig.type) {
+    case "one_shot":
+      return `one-shot at ${new Date(wakeUp.scheduleConfig.fireAt).toISOString()}`;
+    case "cron":
+      return `cron "${wakeUp.scheduleConfig.cron}" (${wakeUp.scheduleConfig.timezone})`;
+  }
+}
+
+function renderWakeUp(wakeUp: WakeUpType): string {
+  return (
+    `- ${wakeUp.sId} — ${renderScheduleConfig(wakeUp)}\n` +
+    `  Status: ${wakeUp.status} (${wakeUp.fireCount}/${wakeUp.maxFires} fires)\n` +
+    `  Reason: ${wakeUp.reason}`
+  );
+}
+
+export function createWakeupsTools(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+) {
+  const handlers: ToolHandlers<typeof WAKEUPS_TOOLS_METADATA> = {
+    schedule_wakeup: async ({ when, reason, timezone }) => {
+      if (!agentLoopContext?.runContext) {
+        return new Err(
+          new MCPError(
+            "Wake-ups can only be scheduled from within a conversation."
+          )
+        );
+      }
+
+      const { conversation: runConversation, agentConfiguration } =
+        agentLoopContext.runContext;
+
+      const parsed = parseWhen(when);
+      if (!parsed) {
+        return new Err(
+          new MCPError(
+            `Unable to parse \`when\`="${when}". Expected a relative duration ` +
+              '("in 2h"), an ISO 8601 timestamp ("2026-04-16T16:00:00Z"), or a 5-field cron ' +
+              'expression ("0 9 * * MON-FRI").'
+          )
+        );
+      }
+
+      if (parsed.kind === "one_shot") {
+        const delayMs = parsed.fireAt.getTime() - Date.now();
+        if (delayMs <= 0) {
+          return new Err(
+            new MCPError(
+              `Cannot schedule a wake-up in the past (${parsed.fireAt.toISOString()}).`
+            )
+          );
+        }
+        if (delayMs > MAX_ONE_SHOT_DELAY_MS) {
+          return new Err(
+            new MCPError(
+              `One-shot wake-ups cannot be scheduled more than ${MAX_ONE_SHOT_DELAY_MS / (24 * 60 * 60 * 1000)} days in the future.`
+            )
+          );
+        }
+      }
+
+      let cronTimezone: string | null = null;
+      if (parsed.kind === "cron") {
+        cronTimezone = timezone ?? getUserTimezone(agentLoopContext);
+        if (!cronTimezone) {
+          return new Err(
+            new MCPError(
+              "Cron wake-ups require a `timezone` (IANA name, e.g. 'Europe/Paris'). " +
+                "None was provided and no timezone could be inferred from the conversation."
+            )
+          );
+        }
+      }
+
+      const conversation = await ConversationResource.fetchById(
+        auth,
+        runConversation.sId
+      );
+      if (!conversation) {
+        return new Err(
+          new MCPError("Current conversation could not be loaded.")
+        );
+      }
+
+      const conversationWakeUps = await WakeUpResource.listByConversation(
+        auth,
+        runConversation
+      );
+      const activeInConversation = conversationWakeUps.filter(
+        (w) => w.status === "scheduled"
+      );
+      if (activeInConversation.length >= MAX_ACTIVE_WAKEUPS_PER_CONVERSATION) {
+        return new Err(
+          new MCPError(
+            `This conversation already has ${activeInConversation.length} active wake-up(s); ` +
+              `the limit is ${MAX_ACTIVE_WAKEUPS_PER_CONVERSATION}. Cancel the existing wake-up ` +
+              "before scheduling a new one."
+          )
+        );
+      }
+
+      const workspaceActive = await WakeUpResource.listActiveByWorkspace(auth);
+      if (workspaceActive.length >= MAX_ACTIVE_WAKEUPS_PER_WORKSPACE) {
+        return new Err(
+          new MCPError(
+            `Workspace has reached the maximum of ${MAX_ACTIVE_WAKEUPS_PER_WORKSPACE} active wake-ups.`
+          )
+        );
+      }
+
+      const blob =
+        parsed.kind === "one_shot"
+          ? {
+              scheduleType: "one_shot" as const,
+              fireAt: parsed.fireAt,
+              cronExpression: null,
+              cronTimezone: null,
+              reason,
+            }
+          : {
+              scheduleType: "cron" as const,
+              fireAt: null,
+              cronExpression: parsed.cron,
+              // parsed.kind === "cron" means we resolved cronTimezone above.
+              cronTimezone: cronTimezone as string,
+              reason,
+            };
+
+      const result = await WakeUpResource.makeNew(
+        auth,
+        blob,
+        conversation,
+        agentConfiguration
+      );
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(`Failed to schedule wake-up: ${result.error.message}`)
+        );
+      }
+
+      const wakeUp = result.value.toJSON();
+      return new Ok([
+        {
+          type: "text" as const,
+          text:
+            `Scheduled wake-up ${wakeUp.sId}.\n\n` +
+            `Schedule: ${renderScheduleConfig(wakeUp)}\n` +
+            `Reason: ${wakeUp.reason}`,
+        },
+      ]);
+    },
+
+    list_wakeups: async () => {
+      if (!agentLoopContext?.runContext) {
+        return new Err(
+          new MCPError(
+            "Wake-ups can only be listed from within a conversation."
+          )
+        );
+      }
+
+      const { conversation } = agentLoopContext.runContext;
+
+      const wakeUps = await WakeUpResource.listByConversation(
+        auth,
+        conversation
+      );
+
+      if (wakeUps.length === 0) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: "No wake-ups in this conversation.",
+          },
+        ]);
+      }
+
+      const rendered = wakeUps
+        .map((w) => renderWakeUp(w.toJSON()))
+        .join("\n\n");
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Wake-ups in this conversation:\n\n${rendered}`,
+        },
+      ]);
+    },
+
+    cancel_wakeup: async ({ wakeUpId }) => {
+      if (!agentLoopContext?.runContext) {
+        return new Err(
+          new MCPError(
+            "Wake-ups can only be cancelled from within a conversation."
+          )
+        );
+      }
+
+      const { conversation } = agentLoopContext.runContext;
+
+      const wakeUp = await WakeUpResource.fetchById(auth, wakeUpId);
+      if (!wakeUp) {
+        return new Err(new MCPError(`Wake-up ${wakeUpId} not found.`));
+      }
+
+      if (wakeUp.conversationId !== conversation.id) {
+        return new Err(
+          new MCPError(
+            `Wake-up ${wakeUpId} does not belong to the current conversation.`
+          )
+        );
+      }
+
+      const previousStatus = wakeUp.status;
+      const cancelResult = await wakeUp.cancel(auth);
+      if (cancelResult.isErr()) {
+        return new Err(
+          new MCPError(
+            `Failed to cancel wake-up ${wakeUpId}: ${cancelResult.error.message}`
+          )
+        );
+      }
+
+      if (previousStatus !== "scheduled") {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Wake-up ${wakeUpId} was already ${previousStatus}; nothing to do.`,
+          },
+        ]);
+      }
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Cancelled wake-up ${wakeUpId}.`,
+        },
+      ]);
+    },
+  };
+
+  return buildTools(WAKEUPS_TOOLS_METADATA, handlers);
+}

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -138,6 +138,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
   poke: "platform",
   sandbox: "platform",
   ask_user_question: "platform",
+  wakeups: "platform",
 };
 
 export function getToolCategory(

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -353,14 +353,13 @@ export async function runWakeUpActivity({
     mentions: [{ configurationId: wakeUp.agentConfigurationId }],
     context: {
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
-      username: "Dust",
-      fullName: "Dust",
+      username: "dust_system",
+      fullName: "Dust System",
       email: null,
       profilePictureUrl: null,
       origin: "wakeup",
     },
     skipToolsValidation: false,
-    doNotAssociateUser: true,
   });
 
   if (postMessageResult.isErr()) {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -300,7 +300,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable Microsoft sensitivity labels for data classification on connectors and MCP servers",
     stage: "on_demand",
   },
-  wakeups: {
+  enable_wakeups: {
     description:
       "Enable the wakeups MCP server, letting agents schedule wake-ups in a conversation.",
     stage: "dust_only",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -300,6 +300,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable Microsoft sensitivity labels for data classification on connectors and MCP servers",
     stage: "on_demand",
   },
+  wakeups: {
+    description:
+      "Enable the wakeups MCP server, letting agents schedule wake-ups in a conversation.",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -751,6 +751,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "enable_compaction"
   | "browser_extension_mcp_tools"
   | "sensitivity_labels"
+  | "wakeups"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -751,7 +751,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "enable_compaction"
   | "browser_extension_mcp_tools"
   | "sensitivity_labels"
-  | "wakeups"
+  | "enable_wakeups"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -72,13 +72,16 @@ Done:
 
 ## Milestone 4: Agent action
 
-### PR 6 — schedule_wakeup tool (one-shot + cron)
+### [x] PR 6 — `wakeups` internal MCP server
 
-Agent tool definition for `schedule_wakeup`. Deterministic `when` parsing (relative durations, ISO
-timestamps, cron expressions). Guardrail enforcement (max 1 active per conversation, min interval,
-max delay, workspace limits). Returns confirmation with scheduled time and wake-up sId. Gate
-behind feature flag. In the current codebase, wire this through the internal MCP tool
-architecture rather than a legacy `agent_action.ts` registry.
+Adds the `wakeups` internal MCP server (id 1031, `availability: "auto"`, preview, gated
+behind the new `enable_wakeups` feature flag) exposing `schedule_wakeup`, `list_wakeups`,
+and `cancel_wakeup` to agents. `when` is parsed deterministically (relative duration, ISO
+8601, 5-field cron); cron timezone falls back to the last user message's timezone.
+Guardrails enforced at tool-call time: max 1 active wake-up per conversation, max 256 per
+workspace, max 31-day one-shot delay. Also updates `runWakeUpActivity` to post the
+wake-up message with `username: "dust_system"` / `fullName: "Dust System"` instead of
+`doNotAssociateUser: true`.
 
 ## Milestone 5: Security
 

--- a/x/spolu/wakeup/wakeup.md
+++ b/x/spolu/wakeup/wakeup.md
@@ -62,8 +62,8 @@ validation, the tool surface, API endpoints, and UI are still follow-up work.
 │  3. Fetch conversation and call getConversation(...)        │
 │  4. postUserMessage into the conversation:                  │
 │     - origin: "wakeup"                                      │
-│     - username: "Dust"                                      │
-│     - doNotAssociateUser: true                              │
+│     - username: "dust_system"                               │
+│     - fullName: "Dust System"                               │
 │     - content: <dust_system> + "Wake-up reason: ..."        │
 │     - mentions: [{ configurationId: agentConfigurationId }] │
 │  5. fireCount++ and:                                        │
@@ -173,8 +173,8 @@ fire via `cleanupTemporalAfterFire(...)`.
      wake-up is about to reach `maxFires`) an expiration warning
    - `Wake-up reason: {reason}`
    - `context.origin: "wakeup"`
-   - `context.username: "Dust"`
-   - `doNotAssociateUser: true`
+   - `context.username: "dust_system"`
+   - `context.fullName: "Dust System"`
    - `mentions: [{ configurationId: wakeUp.agentConfigurationId }]`
 5. Mark the wake-up as fired on success (`markFired(...)` handles one-shot vs cron and the
    `fireCount >= maxFires` expiration transition).
@@ -186,22 +186,42 @@ fire via `cleanupTemporalAfterFire(...)`.
 
 ## Agent Skill Interface
 
-The wake-up is exposed as an always-enabled agent action (like retrieval or browse). The agent
-calls it as a tool:
+The wake-up capability is exposed through the `wakeups` internal MCP server (server id
+1031, `availability: "auto"`, gated behind the `enable_wakeups` feature flag while in
+preview). It registers three tools:
 
 ```
 schedule_wakeup({
-  when: string,   // "in 2h", "in 30m", "2026-04-16T16:00:00Z", "0 9 * * MON-FRI"
-  reason: string  // Displayed in UI, injected in wake-up message
+  when: string,     // "in 2h", "in 30m", "2026-04-16T16:00:00Z", "0 9 * * MON-FRI"
+  reason: string,   // Displayed in UI, injected in wake-up message
+  timezone?: string // IANA timezone, required only for cron (falls back to the
+                    // last user message's timezone if omitted)
 })
+list_wakeups({})
+cancel_wakeup({ wakeUpId: string })
 ```
 
-The `when` field is parsed server-side:
-- Relative durations ("in Xh", "in Xm") → `scheduleType: "one_shot"`, compute `fireAt`.
-- ISO timestamps → `scheduleType: "one_shot"`, use directly as `fireAt`.
-- Cron expressions → `scheduleType: "cron"`, with default `maxFires` from guardrails.
+The `when` field is parsed server-side, deterministically, in this order:
+- Relative durations (`"in Xm"`, `"in Xh"`, `"in Xd"`) → `scheduleType: "one_shot"`,
+  compute `fireAt`.
+- ISO 8601 timestamps (must start with `YYYY-MM-DD`) → `scheduleType: "one_shot"`, use
+  directly as `fireAt`.
+- 5-field cron expressions → `scheduleType: "cron"`, validated by
+  `WakeUpResource.validateCron(...)`.
 
-Returns to the agent: confirmation with the scheduled time and wake-up ID.
+Guardrails enforced at tool-call time:
+- Max 1 active wake-up per conversation.
+- Max 256 active wake-ups per workspace.
+- One-shot delay must be > 0 and ≤ 31 days.
+
+`list_wakeups` returns all wake-ups (any status) for the current conversation. Handlers
+resolve the current conversation and agent configuration from
+`agentLoopContext.runContext`, so the tools only function from within a running agent
+loop. `cancel_wakeup` verifies that the target wake-up belongs to the current
+conversation before cancelling.
+
+All three tools return the wake-up `sId` in their response so the agent can reference it
+later.
 
 ## Message Origin
 


### PR DESCRIPTION
## Description

Adds the `wakeups` internal MCP server (id 1031, `availability: "auto"`, preview) with three tools for agents:

- `schedule_wakeup({ when, reason, timezone? })` — `when` is parsed deterministically as a relative duration (`"in 2h"`, `"in 30m"`, `"in 1d"`), an ISO 8601 timestamp, or a 5-field cron expression. For cron, timezone falls back to the last user message's timezone. Guardrails enforced at call time: max 1 active wake-up per conversation, max 256 per workspace, max 31-day one-shot delay, no past one-shots.
- `list_wakeups({})` — lists all wake-ups for the current conversation.
- `cancel_wakeup({ wakeUpId })` — verifies the wake-up belongs to the current conversation before cancelling; no-op when already terminal.

All three require `agentLoopContext.runContext` and operate on the current conversation + agent configuration.

Gated behind the new `enable_wakeups` feature flag.

Also updates `runWakeUpActivity` to post the wake-up message with `username: "dust_system"` / `fullName: "Dust System"` instead of `doNotAssociateUser: true`, so the wake-up message is clearly system-authored in the conversation.

==> Plan is to hide origin: wakeup messages in the UI.

## Tests

N/A, tested locally end-to-end with a one-shot and cron wake-ups.

## Risk

Low. Gated behind flag.

## Deploy Plan

- deploy `front`