### PR TITLE
fix(project-todo): preserve user intent when merging agent todos

### DIFF
--- a/front/lib/project_todo/merge_into_project.test.ts
+++ b/front/lib/project_todo/merge_into_project.test.ts
@@ -1,14 +1,22 @@
+import type { Authenticator } from "@app/lib/auth";
 import {
   actionItemBlob,
   keyDecisionBlob,
   notableFactBlob,
+  updateTodoIfChanged,
 } from "@app/lib/project_todo/merge_into_project";
+import type { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import type {
+  ProjectTodoActorType,
+  ProjectTodoCategory,
+  ProjectTodoStatus,
+} from "@app/types/project_todo";
 import type {
   TodoVersionedActionItem,
   TodoVersionedKeyDecision,
   TodoVersionedNotableFact,
 } from "@app/types/takeaways";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -143,5 +151,171 @@ describe("notableFactBlob", () => {
       makeNotableFact({ shortDescription: "Team is 12 people" })
     );
     expect(blob.text).toBe("Team is 12 people");
+  });
+});
+
+// ── updateTodoIfChanged ───────────────────────────────────────────────────────
+
+type TodoStub = {
+  createdByType: ProjectTodoActorType;
+  markedAsDoneByType: ProjectTodoActorType | null;
+  text: string;
+  status: ProjectTodoStatus;
+  doneAt: Date | null;
+  updateWithVersion: ReturnType<typeof vi.fn>;
+};
+
+function makeTodoStub(overrides: Partial<TodoStub> = {}): TodoStub {
+  return {
+    createdByType: "agent",
+    markedAsDoneByType: null,
+    text: "Write the report",
+    status: "todo",
+    doneAt: null,
+    updateWithVersion: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeBlob(
+  overrides: Partial<{
+    category: ProjectTodoCategory;
+    text: string;
+    status: "todo" | "done";
+    doneAt: Date | null;
+  }> = {}
+) {
+  return {
+    category: "to_do" as ProjectTodoCategory,
+    text: "Write the report",
+    status: "todo" as const,
+    doneAt: null,
+    ...overrides,
+  };
+}
+
+// Auth is not touched on the early-return paths; on the update path it is
+// forwarded to updateWithVersion, which is a spy here.
+const fakeAuth = {} as Authenticator;
+
+describe("updateTodoIfChanged", () => {
+  it("returns false and does not update a user-created todo even when content changed", async () => {
+    const todo = makeTodoStub({ createdByType: "user", text: "Old text" });
+    const blob = makeBlob({ text: "New text" });
+
+    const updated = await updateTodoIfChanged(
+      todo as unknown as ProjectTodoResource,
+      fakeAuth,
+      blob
+    );
+
+    expect(updated).toBe(false);
+    expect(todo.updateWithVersion).not.toHaveBeenCalled();
+  });
+
+  it("returns false and does not update an agent-created todo that was marked done by a user", async () => {
+    // Concrete scenario: agent created the todo, user marked it done, next
+    // extraction still sees the underlying item as open. The user's completion
+    // must stick — no revert.
+    const todo = makeTodoStub({
+      createdByType: "agent",
+      markedAsDoneByType: "user",
+      status: "done",
+      doneAt: new Date("2026-04-20T10:00:00.000Z"),
+    });
+    const blob = makeBlob({ status: "todo", doneAt: null });
+
+    const updated = await updateTodoIfChanged(
+      todo as unknown as ProjectTodoResource,
+      fakeAuth,
+      blob
+    );
+
+    expect(updated).toBe(false);
+    expect(todo.updateWithVersion).not.toHaveBeenCalled();
+  });
+
+  it("returns false when nothing changed on an agent-created todo", async () => {
+    const todo = makeTodoStub({
+      text: "Write the report",
+      status: "todo",
+      doneAt: null,
+    });
+    const blob = makeBlob({
+      text: "Write the report",
+      status: "todo",
+      doneAt: null,
+    });
+
+    const updated = await updateTodoIfChanged(
+      todo as unknown as ProjectTodoResource,
+      fakeAuth,
+      blob
+    );
+
+    expect(updated).toBe(false);
+    expect(todo.updateWithVersion).not.toHaveBeenCalled();
+  });
+
+  it("updates an agent-created todo when the text changed", async () => {
+    const todo = makeTodoStub({ text: "Old text" });
+    const blob = makeBlob({ text: "New text" });
+
+    const updated = await updateTodoIfChanged(
+      todo as unknown as ProjectTodoResource,
+      fakeAuth,
+      blob
+    );
+
+    expect(updated).toBe(true);
+    expect(todo.updateWithVersion).toHaveBeenCalledTimes(1);
+    expect(todo.updateWithVersion).toHaveBeenCalledWith(fakeAuth, {
+      text: "New text",
+      status: "todo",
+      doneAt: null,
+    });
+  });
+
+  it("updates an agent-created todo when the status flipped open→done (agent detection)", async () => {
+    const doneAt = new Date("2026-04-21T12:00:00.000Z");
+    const todo = makeTodoStub({ status: "todo", doneAt: null });
+    const blob = makeBlob({ status: "done", doneAt });
+
+    const updated = await updateTodoIfChanged(
+      todo as unknown as ProjectTodoResource,
+      fakeAuth,
+      blob
+    );
+
+    expect(updated).toBe(true);
+    expect(todo.updateWithVersion).toHaveBeenCalledWith(fakeAuth, {
+      text: "Write the report",
+      status: "done",
+      doneAt,
+    });
+  });
+
+  it("updates an agent-created todo marked done by an agent (not a user)", async () => {
+    // Agent-marked completions are not treated as user-owned — the next
+    // extraction can still correct them (e.g. flip back to open).
+    const todo = makeTodoStub({
+      markedAsDoneByType: "agent",
+      status: "done",
+      doneAt: new Date("2026-04-20T10:00:00.000Z"),
+    });
+    const blob = makeBlob({ status: "todo", doneAt: null });
+
+    const updated = await updateTodoIfChanged(
+      todo as unknown as ProjectTodoResource,
+      fakeAuth,
+      blob
+    );
+
+    expect(updated).toBe(true);
+    expect(todo.updateWithVersion).toHaveBeenCalledWith(fakeAuth, {
+      text: "Write the report",
+      status: "todo",
+      doneAt: null,
+    });
   });
 });

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -406,11 +406,9 @@ async function createOrLinkTodos(
           source: candidate.source,
         });
 
-        // For agent-created todos also propagate content updates. User-created
-        // todos are left untouched: the user's text and status take priority.
-        if (match.createdByType === "agent") {
-          await updateTodoIfChanged(match, auth, candidate.blob);
-        }
+        // User-intent guard lives in updateTodoIfChanged — it is a no-op when
+        // the target todo was created by a user or already marked done by one.
+        await updateTodoIfChanged(match, auth, candidate.blob);
 
         deduplicated++;
 
@@ -468,13 +466,27 @@ async function createOrLinkTodos(
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-// Creates a new version of a todo only when text, status, or doneAt has changed.
-// Returns true if an update was performed.
-async function updateTodoIfChanged(
+// Creates a new version of a todo only when text, status, or doneAt has
+// changed, AND the todo's state is not user-owned. Returns true if an update
+// was performed.
+//
+// The agent path must never overwrite user-owned state:
+//   - If the todo was created by a user, the user's phrasing and status win.
+//   - If an agent-created todo was then marked done by a user, the user's
+//     completion sticks — even if the next extraction still reports the item
+//     as open.
+export async function updateTodoIfChanged(
   todo: ProjectTodoResource,
   auth: Authenticator,
   blob: TodoBlob
 ): Promise<boolean> {
+  if (todo.createdByType !== "agent") {
+    return false;
+  }
+  if (todo.markedAsDoneByType === "user") {
+    return false;
+  }
+
   const textChanged = todo.text !== blob.text;
   const statusChanged = todo.status !== blob.status;
   const doneAtChanged =


### PR DESCRIPTION
## Description

During the project-todo merge workflow, Phase 1's `updateTodoIfChanged` helper
could overwrite user-owned state on an agent-created TODO: if a user marked
the TODO done in the UI and the next extraction still reported the underlying
item as open, the status was silently reverted.

The guards now live inside `updateTodoIfChanged` itself, so every call site
respects them:
- user-created TODOs are never modified by the agent path;
- agent-created TODOs that were marked done by a user stay done, even if the
  next extraction reports the item as open.

Phase 3's narrower `if (match.createdByType === "agent")` guard is removed —
the helper enforces a stricter version of the same rule.

## Tests

