### PR TITLE
[front] - chore(charts): enhance tooltip on legend selection

### DIFF
--- a/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
+++ b/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
@@ -16,6 +16,7 @@ export interface ToolUsageTooltipProps
   extends TooltipContentProps<number, string> {
   topTools: string[];
   hoveredTool?: string | null;
+  selectedKey?: string;
   showLabel?: boolean;
 }
 
@@ -24,18 +25,20 @@ export function ChartsTooltip({
   payload,
   topTools,
   hoveredTool,
+  selectedKey,
   showLabel,
 }: ToolUsageTooltipProps) {
   if (!active || !payload || payload.length === 0) {
     return null;
   }
 
-  if (!hoveredTool) {
+  const focusedTool = selectedKey ?? hoveredTool;
+  if (!focusedTool) {
     return null;
   }
 
   const typed = payload.filter(isToolChartUsagePayload);
-  const filtered = typed.filter((p) => p.name === hoveredTool);
+  const filtered = typed.filter((p) => p.name === focusedTool);
   if (filtered.length === 0) {
     return null;
   }
@@ -182,9 +185,12 @@ function isFeedbackDistributionData(
 }
 
 export function FeedbackDistributionTooltip(
-  props: TooltipContentProps<number, string> & { activeKey?: string }
+  props: TooltipContentProps<number, string> & {
+    activeKey?: string;
+    selectedKey?: string;
+  }
 ) {
-  const { active, payload, activeKey } = props;
+  const { active, payload, activeKey, selectedKey } = props;
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -204,6 +210,7 @@ export function FeedbackDistributionTooltip(
         colorClassName: FEEDBACK_DISTRIBUTION_PALETTE[key],
       }))}
       activeKey={activeKey}
+      selectedKey={selectedKey}
     />
   );
 }

--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -67,8 +67,14 @@ export function FeedbackDistributionChart({
     disabled: !workspaceId || !agentConfigurationId || !isCustomAgent,
   });
 
-  const { activeKey, isDimmed, decorate, hoverHandlers } =
-    useSelectableSeries();
+  const {
+    selectedKey,
+    activeKey,
+    isDimmed,
+    lineActiveDot,
+    decorate,
+    hoverHandlers,
+  } = useSelectableSeries();
 
   const legendItems = decorate(
     legendFromConstant(
@@ -134,7 +140,11 @@ export function FeedbackDistributionChart({
         />
         <Tooltip
           content={(props: TooltipContentProps<number, string>) => (
-            <FeedbackDistributionTooltip {...props} activeKey={activeKey} />
+            <FeedbackDistributionTooltip
+              {...props}
+              activeKey={activeKey}
+              selectedKey={selectedKey}
+            />
           )}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
@@ -157,6 +167,8 @@ export function FeedbackDistributionChart({
           stroke="currentColor"
           strokeWidth={2}
           dot={false}
+          activeDot={lineActiveDot("positive")}
+          isAnimationActive={false}
           {...hoverHandlers("positive")}
         />
         <Line
@@ -171,6 +183,8 @@ export function FeedbackDistributionChart({
           stroke="currentColor"
           strokeWidth={2}
           dot={false}
+          activeDot={lineActiveDot("negative")}
+          isAnimationActive={false}
           {...hoverHandlers("negative")}
         />
         {isCustomAgent && (

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -55,9 +55,10 @@ function LatencyTooltip(
   props: TooltipContentProps<number, string> & {
     versionMarkers: AgentVersionMarker[];
     activeKey?: string;
+    selectedKey?: string;
   }
 ) {
-  const { active, payload, versionMarkers, activeKey } = props;
+  const { active, payload, versionMarkers, activeKey, selectedKey } = props;
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -85,6 +86,7 @@ function LatencyTooltip(
         },
       ]}
       activeKey={activeKey}
+      selectedKey={selectedKey}
     />
   );
 }
@@ -138,8 +140,14 @@ export function LatencyChart({
     }));
   }, [rawData, mode, period]);
 
-  const { activeKey, isDimmed, decorate, hoverHandlers } =
-    useSelectableSeries();
+  const {
+    selectedKey,
+    activeKey,
+    isDimmed,
+    lineActiveDot,
+    decorate,
+    hoverHandlers,
+  } = useSelectableSeries();
 
   const legendItems = decorate(
     legendFromConstant(LATENCY_LEGEND, LATENCY_PALETTE, {
@@ -205,6 +213,7 @@ export function LatencyChart({
               {...props}
               versionMarkers={versionMarkers}
               activeKey={activeKey}
+              selectedKey={selectedKey}
             />
           )}
           cursor={false}
@@ -229,6 +238,8 @@ export function LatencyChart({
           fill="url(#fillAverage)"
           stroke="currentColor"
           dot={false}
+          activeDot={lineActiveDot("average")}
+          isAnimationActive={false}
           {...hoverHandlers("average")}
         />
         <Line
@@ -243,6 +254,8 @@ export function LatencyChart({
           )}
           stroke="currentColor"
           dot={false}
+          activeDot={lineActiveDot("median")}
+          isAnimationActive={false}
           {...hoverHandlers("median")}
         />
         {isCustomAgent && (

--- a/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
@@ -130,7 +130,7 @@ export function SkillUsageChart({
       ? versionData.chartData.length === 0
       : filteredSourceItems.length === 0;
 
-  const { isDimmed, decorate } = useSelectableSeries();
+  const { selectedKey, isDimmed, decorate } = useSelectableSeries();
 
   const legendItems = useMemo(() => {
     if (skillMode === "version") {
@@ -157,10 +157,11 @@ export function SkillUsageChart({
         {...props}
         topTools={versionData.topTools}
         hoveredTool={hoveredTool}
+        selectedKey={selectedKey}
         showLabel
       />
     ),
-    [versionData.topTools, hoveredTool]
+    [versionData.topTools, hoveredTool, selectedKey]
   );
 
   const renderSourceTooltip = useCallback(
@@ -174,6 +175,9 @@ export function SkillUsageChart({
         return null;
       }
       const item = first.payload;
+      if (selectedKey !== undefined && item.skillName !== selectedKey) {
+        return null;
+      }
       const sourceEntries = Object.entries(item.sources)
         .map(([key, val]): [string, number] => [key, Number(val)])
         .sort(([, a], [, b]) => b - a);
@@ -192,7 +196,7 @@ export function SkillUsageChart({
         />
       );
     },
-    []
+    [selectedKey]
   );
 
   const handleSkillToggle = (skill: string, checked: boolean) => {
@@ -337,6 +341,7 @@ export function SkillUsageChart({
                   stackOrderKeys={versionData.topTools}
                 />
               }
+              isAnimationActive={false}
               onMouseEnter={() => setHoveredTool(toolName)}
               onMouseLeave={() => setHoveredTool(null)}
             />
@@ -369,7 +374,11 @@ export function SkillUsageChart({
             content={renderSourceTooltip}
             wrapperStyle={{ outline: "none", zIndex: 50 }}
           />
-          <Bar dataKey="totalCount" radius={[4, 4, 0, 0]}>
+          <Bar
+            dataKey="totalCount"
+            radius={[4, 4, 0, 0]}
+            isAnimationActive={false}
+          >
             {filteredSourceItems.map((item) => (
               <Cell
                 key={item.skillName}

--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -90,6 +90,7 @@ export function SourceChart({
                 title="Source breakdown"
                 rows={rows}
                 activeKey={hoveredOrigin ?? selectedKey}
+                selectedKey={selectedKey}
               />
             );
           }}
@@ -109,6 +110,7 @@ export function SourceChart({
           minAngle={4}
           paddingAngle={3}
           strokeWidth={0}
+          isAnimationActive={false}
         >
           {data.map((entry) => (
             <Cell

--- a/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
@@ -56,9 +56,12 @@ function isToolLatencyDatum(data: unknown): data is ToolLatencyDatum {
 }
 
 function ToolExecutionTimeTooltip(
-  props: TooltipContentProps<number, string> & { activeKey?: string }
+  props: TooltipContentProps<number, string> & {
+    activeKey?: string;
+    selectedKey?: string;
+  }
 ): JSX.Element | null {
-  const { active, payload, activeKey } = props;
+  const { active, payload, activeKey, selectedKey } = props;
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -95,6 +98,7 @@ function ToolExecutionTimeTooltip(
       ]}
       footer={`Executions: ${row.count}`}
       activeKey={activeKey}
+      selectedKey={selectedKey}
     />
   );
 }
@@ -193,7 +197,7 @@ export function ToolExecutionTimeChart({
     emptyMessage = "No successful tool executions for this server.";
   }
 
-  const { activeKey, isDimmed, decorate, hoverHandlers } =
+  const { selectedKey, activeKey, isDimmed, decorate, hoverHandlers } =
     useSelectableSeries();
 
   const legendItems = decorate(
@@ -286,7 +290,11 @@ export function ToolExecutionTimeChart({
         />
         <Tooltip
           content={(props: TooltipContentProps<number, string>) => (
-            <ToolExecutionTimeTooltip {...props} activeKey={activeKey} />
+            <ToolExecutionTimeTooltip
+              {...props}
+              activeKey={activeKey}
+              selectedKey={selectedKey}
+            />
           )}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
@@ -307,6 +315,7 @@ export function ToolExecutionTimeChart({
             isDimmed("p50LatencyMs") && "opacity-25"
           )}
           shape={<RoundedBarShape />}
+          isAnimationActive={false}
           {...hoverHandlers("p50LatencyMs")}
         />
         <Bar
@@ -319,6 +328,7 @@ export function ToolExecutionTimeChart({
             isDimmed("avgLatencyMs") && "opacity-25"
           )}
           shape={<RoundedBarShape />}
+          isAnimationActive={false}
           {...hoverHandlers("avgLatencyMs")}
         />
         <Bar
@@ -331,6 +341,7 @@ export function ToolExecutionTimeChart({
             isDimmed("p95LatencyMs") && "opacity-25"
           )}
           shape={<RoundedBarShape />}
+          isAnimationActive={false}
           {...hoverHandlers("p95LatencyMs")}
         />
       </BarChart>

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -76,7 +76,7 @@ export function ToolUsageChart({
     configurationNames,
   });
 
-  const { isDimmed, decorate } = useSelectableSeries();
+  const { selectedKey, isDimmed, decorate } = useSelectableSeries();
 
   const legendItems = useMemo(
     () =>
@@ -92,9 +92,14 @@ export function ToolUsageChart({
 
   const renderToolUsageTooltip = useCallback(
     (props: TooltipContentProps<number, string>) => (
-      <ChartsTooltip {...props} topTools={topTools} hoveredTool={hoveredTool} />
+      <ChartsTooltip
+        {...props}
+        topTools={topTools}
+        hoveredTool={hoveredTool}
+        selectedKey={selectedKey}
+      />
     ),
-    [topTools, hoveredTool]
+    [topTools, hoveredTool, selectedKey]
   );
 
   return (
@@ -193,6 +198,7 @@ export function ToolUsageChart({
             shape={
               <RoundedBarShape seriesKey={toolName} stackOrderKeys={topTools} />
             }
+            isAnimationActive={false}
             onMouseEnter={() => setHoveredTool(toolName)}
             onMouseLeave={() => setHoveredTool(null)}
           />

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -61,9 +61,10 @@ function UsageMetricsTooltip(
   props: TooltipContentProps<number, string> & {
     versionMarkers: AgentVersionMarker[];
     activeKey?: string;
+    selectedKey?: string;
   }
 ) {
-  const { active, payload, versionMarkers, activeKey } = props;
+  const { active, payload, versionMarkers, activeKey, selectedKey } = props;
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -99,6 +100,7 @@ function UsageMetricsTooltip(
         },
       ]}
       activeKey={activeKey}
+      selectedKey={selectedKey}
     />
   );
 }
@@ -130,8 +132,14 @@ export function UsageMetricsChart({
     disabled: !workspaceId || !agentConfigurationId || !isCustomAgent,
   });
 
-  const { activeKey, isDimmed, decorate, hoverHandlers } =
-    useSelectableSeries();
+  const {
+    selectedKey,
+    activeKey,
+    isDimmed,
+    lineActiveDot,
+    decorate,
+    hoverHandlers,
+  } = useSelectableSeries();
 
   const legendItems = decorate(
     legendFromConstant(USAGE_METRICS_LEGEND, USAGE_METRICS_PALETTE, {
@@ -237,6 +245,7 @@ export function UsageMetricsChart({
               {...props}
               versionMarkers={versionMarkers}
               activeKey={activeKey}
+              selectedKey={selectedKey}
             />
           )}
           cursor={false}
@@ -265,6 +274,8 @@ export function UsageMetricsChart({
           )}
           stroke="currentColor"
           dot={false}
+          activeDot={lineActiveDot("messages")}
+          isAnimationActive={false}
           {...hoverHandlers("messages")}
         />
         <Line
@@ -283,6 +294,8 @@ export function UsageMetricsChart({
           )}
           stroke="currentColor"
           dot={false}
+          activeDot={lineActiveDot("conversations")}
+          isAnimationActive={false}
           {...hoverHandlers("conversations")}
         />
         <Line
@@ -301,6 +314,8 @@ export function UsageMetricsChart({
           )}
           stroke="currentColor"
           dot={false}
+          activeDot={lineActiveDot("activeUsers")}
+          isAnimationActive={false}
           {...hoverHandlers("activeUsers")}
         />
         {isCustomAgent && (

--- a/front/components/charts/ChartTooltip.tsx
+++ b/front/components/charts/ChartTooltip.tsx
@@ -32,6 +32,7 @@ interface ChartTooltipProps {
   rows: TooltipRow[];
   footer?: string;
   activeKey?: string;
+  selectedKey?: string;
 }
 
 export function ChartTooltipCard({
@@ -39,7 +40,17 @@ export function ChartTooltipCard({
   rows,
   footer,
   activeKey,
+  selectedKey,
 }: ChartTooltipProps) {
+  const visibleRows =
+    selectedKey !== undefined
+      ? rows.filter((r) => (r.key ?? r.label) === selectedKey)
+      : rows;
+
+  if (visibleRows.length === 0) {
+    return null;
+  }
+
   return (
     <div
       role="tooltip"
@@ -51,7 +62,7 @@ export function ChartTooltipCard({
         </div>
       )}
       <ul className="space-y-1.5">
-        {rows.map((r) => {
+        {visibleRows.map((r) => {
           const rowKey = r.key ?? r.label;
           const isActive = rowKey === activeKey;
           return (

--- a/front/components/charts/useSelectableSeries.ts
+++ b/front/components/charts/useSelectableSeries.ts
@@ -16,6 +16,11 @@ export function useSelectableSeries() {
     [selectedKey]
   );
 
+  const lineActiveDot = useCallback(
+    (key: string): false | undefined => (isDimmed(key) ? false : undefined),
+    [isDimmed]
+  );
+
   const decorate = useCallback(
     (
       items: readonly LegendEntry[],
@@ -38,5 +43,12 @@ export function useSelectableSeries() {
     [selectedKey]
   );
 
-  return { selectedKey, activeKey, isDimmed, decorate, hoverHandlers };
+  return {
+    selectedKey,
+    activeKey,
+    isDimmed,
+    lineActiveDot,
+    decorate,
+    hoverHandlers,
+  };
 }

--- a/front/components/workspace/analytics/WorkspaceSourceChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSourceChart.tsx
@@ -174,6 +174,7 @@ export function WorkspaceSourceChart({
                 title="Source breakdown"
                 rows={rows}
                 activeKey={hoveredOrigin ?? selectedKey}
+                selectedKey={selectedKey}
               />
             );
           }}

--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -69,6 +69,7 @@ interface ToolUsageTooltipProps extends TooltipContentProps<number, string> {
   toolsWithData: string[];
   displayNameMap: Map<string, string>;
   activeKey?: string;
+  selectedKey?: string;
 }
 
 function ToolUsageTooltip({
@@ -78,6 +79,7 @@ function ToolUsageTooltip({
   active,
   payload,
   activeKey,
+  selectedKey,
 }: ToolUsageTooltipProps) {
   if (!active || !payload || payload.length === 0) {
     return null;
@@ -110,7 +112,14 @@ function ToolUsageTooltip({
     });
   }
 
-  return <ChartTooltipCard title={title} rows={rows} activeKey={activeKey} />;
+  return (
+    <ChartTooltipCard
+      title={title}
+      rows={rows}
+      activeKey={activeKey}
+      selectedKey={selectedKey}
+    />
+  );
 }
 
 interface WorkspaceToolUsageChartProps {
@@ -240,8 +249,14 @@ export function WorkspaceToolUsageChart({
     }
   };
 
-  const { activeKey, isDimmed, decorate, hoverHandlers } =
-    useSelectableSeries();
+  const {
+    selectedKey,
+    activeKey,
+    isDimmed,
+    lineActiveDot,
+    decorate,
+    hoverHandlers,
+  } = useSelectableSeries();
 
   const legendItems = decorate(
     toolsWithData.map((tool) => ({
@@ -364,6 +379,7 @@ export function WorkspaceToolUsageChart({
               toolsWithData={toolsWithData}
               displayNameMap={displayNameMap}
               activeKey={activeKey}
+              selectedKey={selectedKey}
             />
           )}
           cursor={false}
@@ -389,6 +405,8 @@ export function WorkspaceToolUsageChart({
             )}
             stroke="currentColor"
             dot={false}
+            activeDot={lineActiveDot(tool)}
+            isAnimationActive={false}
             {...hoverHandlers(tool)}
           />
         ))}

--- a/front/components/workspace/analytics/WorkspaceUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceUsageChart.tsx
@@ -158,6 +158,7 @@ function activeUsersZeroFactory(timestamp: number): ActiveUsersMetricsDatum {
 interface UsageMetricsTooltipProps extends TooltipContentProps<number, string> {
   displayMode: UsageDisplayMode;
   activeKey?: string;
+  selectedKey?: string;
 }
 
 function UsageMetricsTooltip({
@@ -165,6 +166,7 @@ function UsageMetricsTooltip({
   payload,
   displayMode,
   activeKey,
+  selectedKey,
 }: UsageMetricsTooltipProps) {
   if (!active || !payload || payload.length === 0) {
     return null;
@@ -201,7 +203,14 @@ function UsageMetricsTooltip({
         colorClassName: ACTIVE_USERS_PALETTE.mau,
       },
     ];
-    return <ChartTooltipCard title={title} rows={rows} activeKey={activeKey} />;
+    return (
+      <ChartTooltipCard
+        title={title}
+        rows={rows}
+        activeKey={activeKey}
+        selectedKey={selectedKey}
+      />
+    );
   }
 
   if (!isWorkspaceUsageMetricsDatum(first.payload)) {
@@ -226,7 +235,14 @@ function UsageMetricsTooltip({
     },
   ];
 
-  return <ChartTooltipCard title={title} rows={rows} activeKey={activeKey} />;
+  return (
+    <ChartTooltipCard
+      title={title}
+      rows={rows}
+      activeKey={activeKey}
+      selectedKey={selectedKey}
+    />
+  );
 }
 
 interface WorkspaceUsageChartProps {
@@ -258,8 +274,14 @@ export function WorkspaceUsageChart({
     disabled: !workspaceId || displayMode !== "users",
   });
 
-  const { activeKey, isDimmed, decorate, hoverHandlers } =
-    useSelectableSeries();
+  const {
+    selectedKey,
+    activeKey,
+    isDimmed,
+    lineActiveDot,
+    decorate,
+    hoverHandlers,
+  } = useSelectableSeries();
 
   const legendItems = decorate(getLegendItemsForMode(displayMode));
 
@@ -374,6 +396,7 @@ export function WorkspaceUsageChart({
               {...props}
               displayMode={displayMode}
               activeKey={activeKey}
+              selectedKey={selectedKey}
             />
           )}
           cursor={false}
@@ -399,6 +422,8 @@ export function WorkspaceUsageChart({
               )}
               stroke="currentColor"
               dot={false}
+              activeDot={lineActiveDot("messages")}
+              isAnimationActive={false}
               {...hoverHandlers("messages")}
             />
             <Line
@@ -413,6 +438,8 @@ export function WorkspaceUsageChart({
               )}
               stroke="currentColor"
               dot={false}
+              activeDot={lineActiveDot("conversations")}
+              isAnimationActive={false}
               {...hoverHandlers("conversations")}
             />
           </>
@@ -430,6 +457,8 @@ export function WorkspaceUsageChart({
               )}
               stroke="currentColor"
               dot={false}
+              activeDot={lineActiveDot("dau")}
+              isAnimationActive={false}
               {...hoverHandlers("dau")}
             />
             <Line
@@ -444,6 +473,8 @@ export function WorkspaceUsageChart({
               )}
               stroke="currentColor"
               dot={false}
+              activeDot={lineActiveDot("wau")}
+              isAnimationActive={false}
               {...hoverHandlers("wau")}
             />
             <Line
@@ -458,6 +489,8 @@ export function WorkspaceUsageChart({
               )}
               stroke="currentColor"
               dot={false}
+              activeDot={lineActiveDot("mau")}
+              isAnimationActive={false}
               {...hoverHandlers("mau")}
             />
           </>


### PR DESCRIPTION
## Description

Building on #24601's persistent legend selection and #24554's tooltip highlighting, this PR improves the tooltip behavior when a legend item is selected. When a series is selected via legend click, tooltips now filter to show only the selected series data instead of displaying all hovered series. Additionally, the PR introduces a `lineActiveDot` helper in the `useSelectableSeries` hook to conditionally disable active dots on dimmed series, ensuring visual consistency.

## Tests

Manually tested across all chart types

## Risk

Low risk. Visual-only changes to tooltip and chart interaction behavior. No data processing or API changes.

## Deploy Plan

Deploy front