### PR TITLE
[front] membership_resource: fix parallel sql req in getLatestMembers…

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -307,13 +307,21 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     }
 
     // Get all the memberships matching the criteria.
-    const { rows, count } = await this.model.findAndCountAll({
+    const rows = await this.model.findAll({
       ...findOptions,
       // WORKSPACE_ISOLATION_BYPASS: Used to find latest memberships across users and workspace is
       // optional.
       // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
+
+    let count = rows.length;
+
+    // Only do the count if we are paginating, otherwise we can use the length of the rows as there is no limit by default
+    if (paginationParams) {
+      count = await MembershipModel.count(findOptions);
+    }
+
     // Then, we only keep the latest membership for each (user, workspace).
     const latestMembershipByUserAndWorkspace = new Map<
       string,


### PR DESCRIPTION
## Description

MembershipResource.getLatestMemberships() used findAndCountAll() that does 2 sql requests in parallel (select and count) which can lead to many concurrent queries if used inside a concurrent executor (as it was done for api skills withRelations=true)
Besides, the function is mainly called without pagination currently
=> call the count request only for pagination

## Tests

Tested locally

## Risk

Low, could only add latency for pagination

## Deploy Plan

Deploy front