### PR TITLE
refactor(project-todo): key sources by itemId and make merge idempotent

### DIFF
--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -277,17 +277,19 @@ async function collectDocumentCandidates(
     })),
   ];
 
-  // Batch-fetch all existing source links for this takeaway in 3 queries
-  // instead of one per (item, user) pair.
-  const existingByKey = await ProjectTodoResource.fetchBySourceIds(auth, {
-    sourceIds: [takeawayWithSource.source.sourceId],
+  // Batch-fetch existing todos by itemId. The result map is keyed by
+  // `${itemId}:${userId}`, matching the lookup below so a hit means
+  // "this (item, user) pair is already linked to a todo — skip dedup".
+  const allItemIds = itemTriples.map((t) => t.itemId);
+  const existingByKey = await ProjectTodoResource.fetchByItemIds(auth, {
+    itemIds: allItemIds,
   });
 
   const candidates: PendingCandidate[] = [];
   let existingUpdated = 0;
   for (const { itemId, targetUserIds, blob } of itemTriples) {
     for (const userId of targetUserIds) {
-      const existing = existingByKey.get(`${itemId}:${userId}`) ?? null;
+      const existing = existingByKey.get(itemId)?.get(userId) ?? null;
       if (existing !== null) {
         // Source link exists — update content if it has changed.
         const updated = await updateTodoIfChanged(existing, auth, blob);
@@ -403,6 +405,7 @@ async function createOrLinkTodos(
       if (match !== null) {
         // Semantic duplicate found — link the new source to the existing todo.
         await match.upsertSource(auth, {
+          itemId: candidate.itemId,
           source: candidate.source,
         });
 
@@ -425,24 +428,20 @@ async function createOrLinkTodos(
         return;
       }
 
-      // No duplicate — create a fresh todo and link the source.
-      const todo = await ProjectTodoResource.makeNew(auth, {
-        spaceId: spaceModelId,
-        userId: candidate.userId,
-        createdByType: "agent",
-        createdByUserId: null,
-        createdByAgentConfigurationId: BUTLER_AGENT_SID,
-        category: candidate.blob.category,
-        text: candidate.blob.text,
-        status: candidate.blob.status,
-        doneAt: candidate.blob.doneAt,
-        actorRationale: null,
-        markedAsDoneByType: null,
-        markedAsDoneByUserId: null,
-        markedAsDoneByAgentConfigurationId: null,
-      });
-
-      await todo.upsertSource(auth, {
+      // No duplicate — create a fresh todo and link the source atomically so
+      // a Temporal retry after a partial success can't leave an orphan row.
+      const todo = await ProjectTodoResource.makeNewWithSource(auth, {
+        blob: {
+          spaceId: spaceModelId,
+          userId: candidate.userId,
+          createdByType: "agent",
+          createdByAgentConfigurationId: BUTLER_AGENT_SID,
+          category: candidate.blob.category,
+          text: candidate.blob.text,
+          status: candidate.blob.status,
+          doneAt: candidate.blob.doneAt,
+        },
+        itemId: candidate.itemId,
         source: candidate.source,
       });
 

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -235,27 +235,29 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
   }
 
-  // Batch variant: fetches the current todo row for each sourceId in one pass.
-  // Returns a map from `${sourceId}:${userId}` to the matching ProjectTodoResource.
-  static async fetchBySourceIds(
+  // Batch variant: fetches the current todo row for each itemId in one pass.
+  // Returns a map from `${itemId}:${userId}` to the matching ProjectTodoResource
+  // — missing entries mean no todo yet exists for that (item, user) pair.
+  //
+  // This is the identity lookup used by the merge workflow's Phase 1 to detect
+  // items that are already linked to a todo and can therefore skip dedup.
+  static async fetchByItemIds(
     auth: Authenticator,
-    { sourceIds }: { sourceIds: string[] }
-  ): Promise<Map<string, ProjectTodoResource>> {
-    if (sourceIds.length === 0) {
+    { itemIds }: { itemIds: string[] }
+  ): Promise<Map<string, Map<ModelId, ProjectTodoResource>>> {
+    if (itemIds.length === 0) {
       return new Map();
     }
 
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    // Step 1: Find all source links for the given item IDs.
     const sources = await ProjectTodoSourceModel.findAll({
-      where: { workspaceId, sourceId: { [Op.in]: sourceIds } },
+      where: { workspaceId, itemId: { [Op.in]: itemIds } },
     });
     if (sources.length === 0) {
       return new Map();
     }
 
-    // Step 2: Fetch the linked todo rows.
     const linkedModelIds = [...new Set(sources.map((s) => s.projectTodoId))];
     const linkedRows = await this.baseFetch(auth, {
       where: { id: { [Op.in]: linkedModelIds } },
@@ -264,19 +266,20 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       return new Map();
     }
 
-    // Build a lookup from model id → resource.
     const rowById = new Map<ModelId, ProjectTodoResource>(
       linkedRows.map((t) => [t.id, t])
     );
 
-    // Result: `${sourceId}:${userId}` → ProjectTodoResource.
-    const result = new Map<string, ProjectTodoResource>();
+    const result = new Map<string, Map<ModelId, ProjectTodoResource>>();
     for (const source of sources) {
       const todo = rowById.get(source.projectTodoId);
       if (!todo) {
         continue;
       }
-      result.set(`${source.sourceId}:${todo.userId}`, todo);
+      const byUser =
+        result.get(source.itemId) ?? new Map<ModelId, ProjectTodoResource>();
+      byUser.set(source.userId, todo);
+      result.set(source.itemId, byUser);
     }
 
     return result;
@@ -418,41 +421,69 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
 
   // ── Source links (* => todo) ─────────────────────────────────────────────
 
+  // Links the given takeaway item + source document to this todo. Idempotent
+  // by (workspaceId, itemId, userId): if a row already exists for this
+  // (item, user) pair, its fields are updated to point at this todo and
+  // source — so a Temporal activity retry after a partial success converges
+  // to the same state instead of creating a duplicate.
   async upsertSource(
     auth: Authenticator,
     {
+      itemId,
       source,
     }: {
+      itemId: string;
       source: ProjectTodoSourceInfo;
     },
     transaction?: Transaction
   ): Promise<void> {
-    const where = {
-      workspaceId: auth.getNonNullableWorkspace().id,
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const identity = {
+      workspaceId,
+      itemId,
+      userId: this.userId,
+    };
+    const payload = {
       projectTodoId: this.id,
       sourceType: source.sourceType,
       sourceId: source.sourceId,
+      sourceTitle: source.sourceTitle,
+      sourceUrl: source.sourceUrl,
     };
+
     const [sourceInstance, created] = await ProjectTodoSourceModel.findOrCreate(
       {
-        where,
-        defaults: {
-          ...where,
-          sourceTitle: source.sourceTitle,
-          sourceUrl: source.sourceUrl,
-        },
+        where: identity,
+        defaults: { ...identity, ...payload },
         transaction,
       }
     );
     if (!created) {
-      await sourceInstance.update(
-        {
-          sourceTitle: source.sourceTitle,
-          sourceUrl: source.sourceUrl,
-        },
-        { transaction }
-      );
+      await sourceInstance.update(payload, { transaction });
     }
+  }
+
+  // Atomic create + link: inserts the todo row and its first source link in
+  // a single transaction so Temporal retries can't observe a half-written
+  // state (orphan todo without a source row, or vice versa).
+  static async makeNewWithSource(
+    auth: Authenticator,
+    {
+      blob,
+      itemId,
+      source,
+    }: {
+      blob: Omit<CreationAttributes<ProjectTodoModel>, "workspaceId">;
+      itemId: string;
+      source: ProjectTodoSourceInfo;
+    },
+    transaction?: Transaction
+  ): Promise<ProjectTodoResource> {
+    return withTransaction(async (t) => {
+      const todo = await ProjectTodoResource.makeNew(auth, blob, t);
+      await todo.upsertSource(auth, { itemId, source }, t);
+      return todo;
+    }, transaction);
   }
 
   // ── Serialization ──────────────────────────────────────────────────────────

--- a/front/lib/resources/storage/models/project_todo.ts
+++ b/front/lib/resources/storage/models/project_todo.ts
@@ -371,12 +371,21 @@ export class ProjectTodoSourceModel extends WorkspaceAwareModel<ProjectTodoSourc
   declare createdAt: CreationOptional<Date>;
 
   declare projectTodoId: ForeignKey<ProjectTodoModel["id"]>;
+  // Owner of the todo this source links to. Denormalized from the parent
+  // project_todo row so the (workspaceId, itemId, userId) uniqueness can be
+  // enforced at the DB level. Always equal to projectTodo.userId.
+  declare userId: ForeignKey<UserModel["id"]>;
+  // sId of the takeaway item that produced this link. At most one row per
+  // (workspaceId, itemId, userId) — if the same item reappears later (same
+  // sId echoed by the LLM) the row is upserted, not duplicated.
+  declare itemId: string;
   declare sourceType: ProjectTodoSourceType;
   declare sourceId: string;
   declare sourceTitle: string | null;
   declare sourceUrl: string | null;
 
   declare projectTodo: NonAttribute<ProjectTodoModel>;
+  declare user: NonAttribute<UserModel>;
 }
 
 ProjectTodoSourceModel.init(
@@ -389,6 +398,17 @@ ProjectTodoSourceModel.init(
     projectTodoId: {
       type: DataTypes.BIGINT,
       allowNull: false,
+    },
+    userId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      comment:
+        "Owner of the linked todo, denormalized for uniqueness enforcement.",
+    },
+    itemId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      comment: "sId of the takeaway item that produced this source link.",
     },
     sourceType: {
       type: DataTypes.STRING,
@@ -430,8 +450,13 @@ ProjectTodoSourceModel.init(
         concurrently: true,
       },
       {
-        name: "project_todo_sources_ws_unique_idx",
-        fields: ["workspaceId", "projectTodoId", "sourceType", "sourceId"],
+        name: "project_todo_sources_userId_idx",
+        fields: ["userId"],
+        concurrently: true,
+      },
+      {
+        name: "project_todo_sources_ws_item_user_unique_idx",
+        fields: ["workspaceId", "itemId", "userId"],
         unique: true,
         concurrently: true,
       },
@@ -448,4 +473,10 @@ ProjectTodoSourceModel.belongsTo(ProjectTodoModel, {
 ProjectTodoModel.hasMany(ProjectTodoSourceModel, {
   foreignKey: { name: "projectTodoId", allowNull: false },
   as: "sources",
+});
+
+ProjectTodoSourceModel.belongsTo(UserModel, {
+  foreignKey: { name: "userId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "user",
 });

--- a/front/migrations/db/migration_603.sql
+++ b/front/migrations/db/migration_603.sql
@@ -1,0 +1,45 @@
+-- Migration created on Apr 22, 2026
+-- project_todo_sources identity shifts from (workspace, projectTodoId,
+-- sourceType, sourceId) to (workspace, itemId, userId). itemId is the sId of
+-- the takeaway item that produced this source link; userId is denormalized
+-- from the parent project_todo row so uniqueness can be enforced at the DB
+-- level without a trigger.
+
+ALTER TABLE "project_todo_sources"
+    ADD COLUMN "itemId" VARCHAR(255);
+
+ALTER TABLE "project_todo_sources"
+    ADD COLUMN "userId" BIGINT;
+
+-- Backfill from the linked project_todo row. Legacy rows were keyed per-doc,
+-- so itemId is set to sourceId as a stand-in; subsequent merges will
+-- overwrite these with real takeaway-item sIds.
+UPDATE "project_todo_sources" s
+SET "itemId" = s."sourceId",
+    "userId" = pt."userId"
+FROM "project_todos" pt
+WHERE s."projectTodoId" = pt."id";
+
+-- Collapse legacy (workspaceId, itemId, userId) conflicts before enforcing
+-- uniqueness. Keep the highest-id row per group (most recent write).
+DELETE
+FROM "project_todo_sources" s
+    USING "project_todo_sources" s2
+WHERE s."workspaceId" = s2."workspaceId"
+  AND s."itemId" = s2."itemId"
+  AND s."userId" = s2."userId"
+  AND s."id" < s2."id";
+
+ALTER TABLE "project_todo_sources"
+    ALTER COLUMN "itemId" SET NOT NULL;
+
+ALTER TABLE "project_todo_sources"
+    ALTER COLUMN "userId" SET NOT NULL;
+
+DROP INDEX IF EXISTS "project_todo_sources_ws_unique_idx";
+
+CREATE UNIQUE INDEX CONCURRENTLY "project_todo_sources_ws_item_user_unique_idx"
+    ON "project_todo_sources" ("workspaceId", "itemId", "userId");
+
+CREATE INDEX CONCURRENTLY "project_todo_sources_userId_idx"
+    ON "project_todo_sources" ("userId");


### PR DESCRIPTION
## Description

Two latent issues in the project-todo merge workflow:

1. **Phase 1 lookup was dead code.** `fetchBySourceIds` returned a map keyed
   by `${sourceId}:${userId}` (document sId) while the caller looked up by
   `${itemId}:${userId}` (takeaway item sId). The keys never matched, so
   every item fell through to the LLM dedup path every run.
2. **Phase 3 wasn't idempotent.** `makeNew` followed by `upsertSource` as
   two separate writes meant a Temporal retry after a partial success could
   produce an orphan todo or a duplicate.

Fix:

- `project_todo_sources` now carries `itemId` and denormalized `userId` with
  a unique index on `(workspaceId, itemId, userId)`.
- Migration backfills legacy rows (`itemId := sourceId`), collapses any
  duplicates that would violate the new unique, and swaps the old
  `(projectTodoId, sourceType, sourceId)` unique index.
- `fetchByItemIds` replaces `fetchBySourceIds`, and its map key matches the
  lookup — Phase 1 actually short-circuits already-linked items now.
- `makeNewWithSource` wraps the create+link in a single transaction;
  `upsertSource` keys on `(itemId, userId)` so a retry converges to the
  same row.

## Tests

No test changes — all behavior is covered by the existing `lib/project_todo`
suite (45/45). The DB-level retry invariant is enforced by the unique index;
no unit test reproduces it without a real DB.

## Risk


## Deploy Plan

