### PR TITLE
[front] - chore(YAML): ensure importing user in agent editors

### DIFF
--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -48,24 +48,20 @@ async function importAgentConfiguration(
   }
 
   const editorEmails = yamlConfig.editors;
-  if (editorEmails.length === 0) {
-    return new Err({
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "At least one editor is required.",
-      },
-    });
-  }
+  const fetchedEditors = await UserResource.fetchByEmails(editorEmails);
 
-  const editorUsers = await UserResource.fetchByEmails(editorEmails);
+  const uploadingUser = auth.user();
+  const editorUsers =
+    uploadingUser && !fetchedEditors.some((u) => u.id === uploadingUser.id)
+      ? [...fetchedEditors, uploadingUser]
+      : fetchedEditors;
 
   if (editorUsers.length === 0) {
     return new Err({
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "No valid editor users found.",
+        message: "At least one editor is required.",
       },
     });
   }


### PR DESCRIPTION
## Description

This PR enhances agent configuration YAML imports by ensuring the uploading user is always added as an editor. Previously, if the YAML provided empty or invalid editor emails, the import would fail with "No valid editor users found." This PR guarantees at least one valid editor exists by automatically including the authenticated user performing the upload.

## Tests

Manually tested YAML import flow with various editor configurations.

## Risk

Low - adds a safety check to prevent agent configurations from being created without valid editors.

## Deploy Plan

Deploy front