### PR TITLE
feat(project-todo): detect intra-batch duplicates during dedup

### DIFF
--- a/front/lib/project_todo/deduplicate_candidates.test.ts
+++ b/front/lib/project_todo/deduplicate_candidates.test.ts
@@ -1,0 +1,176 @@
+import {
+  type DeduplicateCandidate,
+  resolveDeduplicationGroups,
+} from "@app/lib/project_todo/deduplicate_candidates";
+import type { ModelId } from "@app/types/shared/model_id";
+import { describe, expect, it } from "vitest";
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+// The resolver passes the todo reference through without reading any of its
+// fields, so tests work against a minimal structural stub — no cast to
+// ProjectTodoResource is needed thanks to the resolver's generic parameter.
+type TodoStub = { sId: string };
+
+function makeTodo(sId: string): TodoStub {
+  return { sId };
+}
+
+function makeCandidate(
+  overrides: Partial<DeduplicateCandidate> & { itemId: string }
+): DeduplicateCandidate {
+  return {
+    userId: 1 as ModelId,
+    text: "Write the report",
+    category: "to_do",
+    ...overrides,
+  };
+}
+
+// ── resolveDeduplicationGroups ────────────────────────────────────────────────
+
+describe("resolveDeduplicationGroups", () => {
+  it("emits one singleton 'new' group per candidate when the LLM returns no groups", () => {
+    const candidates = [
+      makeCandidate({ itemId: "a" }),
+      makeCandidate({ itemId: "b" }),
+    ];
+    const result = resolveDeduplicationGroups(candidates, [], []);
+
+    // Every candidate still gets its own group — sources are never dropped.
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ kind: "new", candidates: [candidates[0]] });
+    expect(result[1]).toEqual({ kind: "new", candidates: [candidates[1]] });
+  });
+
+  it("turns singleton LLM clusters into singleton 'new' groups", () => {
+    const candidates = [
+      makeCandidate({ itemId: "a" }),
+      makeCandidate({ itemId: "b" }),
+    ];
+    const result = resolveDeduplicationGroups(candidates, [], [[0], [1]]);
+
+    expect(result).toEqual([
+      { kind: "new", candidates: [candidates[0]] },
+      { kind: "new", candidates: [candidates[1]] },
+    ]);
+  });
+
+  it("maps a cluster with a single existing todo into an 'existing' group", () => {
+    // Cluster = [existing#0, candidate#0] → one "existing" group.
+    const existing = [makeTodo("todo-1")];
+    const candidates = [makeCandidate({ itemId: "a" })];
+    const result = resolveDeduplicationGroups(candidates, existing, [[0, 1]]);
+
+    expect(result).toEqual([
+      { kind: "existing", todo: existing[0], candidates: [candidates[0]] },
+    ]);
+  });
+
+  it("picks the first existing when a cluster contains multiple existing todos", () => {
+    // Two existing + one candidate. First existing wins; second existing is
+    // ignored (we don't merge existing todos here).
+    const existing = [makeTodo("todo-1"), makeTodo("todo-2")];
+    const candidates = [makeCandidate({ itemId: "a" })];
+    // Indexes: 0,1 are existing; 2 is the candidate.
+    const result = resolveDeduplicationGroups(candidates, existing, [
+      [0, 1, 2],
+    ]);
+
+    expect(result).toEqual([
+      { kind: "existing", todo: existing[0], candidates: [candidates[0]] },
+    ]);
+  });
+
+  it("links every candidate in a cluster to the first existing when one exists", () => {
+    const existing = [makeTodo("todo-1")];
+    const candidates = [
+      makeCandidate({ itemId: "a" }),
+      makeCandidate({ itemId: "b" }),
+    ];
+    // 0 = existing; 1,2 = candidates.
+    const result = resolveDeduplicationGroups(candidates, existing, [
+      [0, 1, 2],
+    ]);
+
+    expect(result).toEqual([
+      {
+        kind: "existing",
+        todo: existing[0],
+        candidates: [candidates[0], candidates[1]],
+      },
+    ]);
+  });
+
+  it("turns a candidate cluster (no existing) into one 'new' group", () => {
+    // No existing todos — every candidate shares one newly-created todo.
+    const candidates = [
+      makeCandidate({ itemId: "a" }),
+      makeCandidate({ itemId: "b" }),
+      makeCandidate({ itemId: "c" }),
+    ];
+    const result = resolveDeduplicationGroups(candidates, [], [[0, 1, 2]]);
+
+    expect(result).toEqual([{ kind: "new", candidates }]);
+  });
+
+  it("ignores out-of-range indexes in clusters", () => {
+    const candidates = [makeCandidate({ itemId: "a" })];
+    // Index 5 is out of range; the cluster effectively contains only the one
+    // valid candidate index.
+    const result = resolveDeduplicationGroups(candidates, [], [[5, 0, -1]]);
+
+    expect(result).toEqual([{ kind: "new", candidates: [candidates[0]] }]);
+  });
+
+  it("honors an index only in the first cluster it appears in", () => {
+    // If the LLM lists the same candidate in two clusters, the second
+    // occurrence is dropped so a candidate can't be silently reassigned.
+    const existing = [makeTodo("todo-1")];
+    const candidates = [
+      makeCandidate({ itemId: "a" }),
+      makeCandidate({ itemId: "b" }),
+    ];
+    // Cluster 1: existing + candidate a. Cluster 2: candidate a (duplicate) +
+    // candidate b. Candidate a stays in cluster 1; cluster 2 becomes just b.
+    const result = resolveDeduplicationGroups(candidates, existing, [
+      [0, 1],
+      [1, 2],
+    ]);
+
+    expect(result).toEqual([
+      { kind: "existing", todo: existing[0], candidates: [candidates[0]] },
+      { kind: "new", candidates: [candidates[1]] },
+    ]);
+  });
+
+  it("ignores clusters that contain no candidate", () => {
+    // A cluster of two existing todos and no candidate → dropped. The lone
+    // candidate in its own cluster survives as a "new" group.
+    const existing = [makeTodo("todo-1"), makeTodo("todo-2")];
+    const candidates = [makeCandidate({ itemId: "a" })];
+    const result = resolveDeduplicationGroups(candidates, existing, [
+      [0, 1],
+      [2],
+    ]);
+
+    expect(result).toEqual([{ kind: "new", candidates: [candidates[0]] }]);
+  });
+
+  it("emits a singleton 'new' group for candidates the LLM forgot", () => {
+    // The LLM grouped candidate a with the existing todo but forgot about
+    // candidate b — b must still end up in its own group so its source is
+    // not dropped.
+    const existing = [makeTodo("todo-1")];
+    const candidates = [
+      makeCandidate({ itemId: "a" }),
+      makeCandidate({ itemId: "b" }),
+    ];
+    const result = resolveDeduplicationGroups(candidates, existing, [[0, 1]]);
+
+    expect(result).toEqual([
+      { kind: "existing", todo: existing[0], candidates: [candidates[0]] },
+      { kind: "new", candidates: [candidates[1]] },
+    ]);
+  });
+});

--- a/front/lib/project_todo/deduplicate_candidates.ts
+++ b/front/lib/project_todo/deduplicate_candidates.ts
@@ -1,13 +1,33 @@
 // Semantic deduplication for project TODO candidates during the merge workflow.
 //
 // batchDeduplicateCandidates groups candidates by (userId, category), runs one
-// LLM call per non-empty group, and returns a map from the candidate key
-// (`${userId}:${itemId}`) to the existing ProjectTodoResource that is a
-// semantic duplicate, if any.
+// LLM call per non-empty group, and returns a flat list of DeduplicatedGroup.
+// Each group describes one todo that Phase 3 will touch:
 //
-// On LLM failure the affected group is treated as all-new (no entries in the
-// map for those candidates), so the caller always falls back to creating a
-// fresh todo rather than silently discarding data.
+//   - { kind: "existing", todo, candidates }
+//       Attach every candidate's source to the existing todo.
+//   - { kind: "new", candidates }
+//       Create one new todo using the first candidate's content, then attach
+//       every candidate's source to it.
+//
+// Every input candidate ends up in exactly one DeduplicatedGroup: if the LLM
+// forgets to include it in any partition, it is emitted as a singleton
+// "new" group so sources are never silently dropped.
+//
+// The LLM is handed one flat, numbered list of items per (userId, category)
+// group — existing todos first, then new candidates — and asked to partition
+// it into semantic clusters. Per cluster:
+//
+//   - no existing → the cluster becomes one "new" group; the first candidate
+//     drives the content, the rest attach their sources;
+//   - ≥1 existing → the cluster becomes an "existing" group pointing at the
+//     first existing todo; every candidate attaches its source to it. Any
+//     additional existing todos in the same cluster are ignored (we don't
+//     merge existing todos here).
+//
+// On LLM failure the affected (userId, category) group is treated as all-new
+// (one singleton "new" group per candidate), so the caller always falls back
+// to creating fresh todos rather than silently discarding data.
 
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
@@ -31,122 +51,114 @@ export type DeduplicateCandidate = {
   category: ProjectTodoCategory;
 };
 
-// Key: `${userId}:${itemId}`. Value: the existing ProjectTodoResource that this
-// candidate is a semantic duplicate of. Absence of a key means the candidate is
-// a genuinely new item (no duplicate found or dedup was skipped).
-export type DeduplicationMap = Map<string, ProjectTodoResource>;
+// One todo that Phase 3 will touch. A group's candidates all share the same
+// userId and category (grouping is per (userId, category) before the LLM
+// call).
+export type DeduplicatedGroup =
+  | {
+      kind: "existing";
+      todo: ProjectTodoResource;
+      candidates: DeduplicateCandidate[];
+    }
+  | {
+      kind: "new";
+      // Non-empty. candidates[0] drives the new todo's content; later entries
+      // attach their sources to that todo.
+      candidates: DeduplicateCandidate[];
+    };
 
-// Key helpers — exported so the builder (this file) and the consumer
-// (merge_into_project.ts) always use the same format.
-
-// Groups candidates/todos by user and category for per-group LLM calls.
-export function makeDedupGroupKey(
-  userId: ModelId,
-  category: ProjectTodoCategory
-): string {
-  return `${userId}:${category}`;
-}
-
-// Identifies a specific (candidate, user) pair in the DeduplicationMap.
-export function makeDedupResultKey(userId: ModelId, itemId: string): string {
-  return `${userId}:${itemId}`;
-}
+// Nested map shape for existing todos passed in by the caller:
+// userId → category → todos.
+export type ExistingTodosByGroup = Map<
+  ModelId,
+  Map<ProjectTodoCategory, ProjectTodoResource[]>
+>;
 
 // ── LLM tool ─────────────────────────────────────────────────────────────────
 
-const REPORT_DUPLICATES_FUNCTION_NAME = "report_duplicates";
+const REPORT_GROUPS_FUNCTION_NAME = "report_groups";
 
 const DeduplicationResultSchema = z.object({
-  matches: z.array(
-    z.object({
-      candidate_index: z.number().int(),
-      // Omitted when the candidate is a new, distinct item.
-      duplicate_of_sid: z.string().optional(),
-    })
-  ),
+  groups: z.array(z.array(z.number().int())),
 });
 
 function buildDeduplicationSpec(): AgentActionSpecification {
   return {
-    name: REPORT_DUPLICATES_FUNCTION_NAME,
+    name: REPORT_GROUPS_FUNCTION_NAME,
     description:
-      "Report which new candidate TODOs are semantic duplicates of existing ones.",
+      "Partition the numbered TODO items into semantic groups. Items in the same group describe the same underlying task.",
     inputSchema: {
       type: "object",
       properties: {
-        matches: {
+        groups: {
           type: "array",
-          description: "One entry per new candidate.",
+          description:
+            "Array of groups. Each group is an array of 0-based item indexes that represent the same underlying task. Every item must appear in exactly one group. Items with no duplicates form a group of size 1.",
           items: {
-            type: "object",
-            properties: {
-              candidate_index: {
-                type: "integer",
-                description: "0-based index of the candidate in the list.",
-              },
-              duplicate_of_sid: {
-                type: "string",
-                description:
-                  "sId of the matching existing TODO. Omit if the candidate is a distinct new item.",
-              },
-            },
-            required: ["candidate_index"],
+            type: "array",
+            items: { type: "integer" },
           },
         },
       },
-      required: ["matches"],
+      required: ["groups"],
     },
   };
 }
 
 // ── Prompt builder ────────────────────────────────────────────────────────────
 
+// Presents existing todos and candidates in one flat, 0-indexed list. The LLM
+// does not need to distinguish existing from new — it just groups. The caller
+// partitions groups back into (existing, candidates) by index in
+// resolveDeduplicationGroups.
 function buildDeduplicationPrompt(
   category: ProjectTodoCategory,
-  candidates: DeduplicateCandidate[],
-  existingTodos: ProjectTodoResource[]
+  existingTodos: ProjectTodoResource[],
+  candidates: DeduplicateCandidate[]
 ): string {
   const categoryLabel = category.replace(/_/g, " ");
 
-  const existingLines =
-    existingTodos.map((t) => `[${t.sId}] ${t.text}`).join("\n") || "(none)";
-
-  const candidateLines = candidates
-    .map((c, i) => `[${i}] ${c.text}`)
-    .join("\n");
+  const lines: string[] = [];
+  let i = 0;
+  for (const t of existingTodos) {
+    lines.push(`[${i}] ${t.text}`);
+    i++;
+  }
+  for (const c of candidates) {
+    lines.push(`[${i}] ${c.text}`);
+    i++;
+  }
 
   return [
-    `Deduplicate TODO items for category "${categoryLabel}".`,
+    `Group TODO items for category "${categoryLabel}" that describe the same underlying task.`,
     "",
     "Two items are duplicates only if completing one would make the other",
     "redundant. If both could independently appear on a task list without",
     "overlap, they are distinct — even if they share keywords or domain.",
-    "", //
-    "A candidate that is a more specific or more general version of an",
-    "existing TODO is still a duplicate if the core task is the same.",
     "",
-    "When in doubt, treat the candidate as new. A false duplicate merge",
-    "loses data; a missed dedup just creates a minor duplicate that can",
-    "be cleaned up later.",
+    "A more specific or more general version of the same task is still a",
+    "duplicate if the core task is the same.",
     "",
-    "Existing TODOs:",
-    existingLines,
+    "When in doubt, put items in separate groups. A false merge loses data;",
+    "a missed dedup just creates a minor duplicate that can be cleaned up",
+    "later.",
     "",
-    "New candidates:",
-    candidateLines,
+    "Items:",
+    lines.join("\n"),
     "",
-    "Call report_duplicates with one entry per candidate.",
-    "Include duplicate_of_sid only when the candidate is clearly redundant",
-    "with an existing TODO.",
+    "Call report_groups with a partition of the indexes above. Every index",
+    "must appear in exactly one group. Items with no duplicates form a",
+    "group of size 1.",
   ].join("\n");
 }
 
 // ── LLM call for a single (userId, category) group ───────────────────────────
 
-// Returns a map from candidate index (0-based) to the sId of the matching
-// existing TODO, or an empty map on failure (treat all candidates as new).
+// Returns the LLM's partitioning of `[...existingTodos, ...candidates]` as
+// an array of groups of 0-based indexes, or an empty array on failure (each
+// candidate then ends up in its own singleton "new" group downstream).
 // Precondition: all candidates must share the same category — batchDeduplicateCandidates
-// enforces this by grouping on makeDedupGroupKey before calling here.
+// enforces this by grouping on (userId, category) before calling here.
 export async function runDeduplicationLLMCall(
   auth: Authenticator,
   {
@@ -158,10 +170,10 @@ export async function runDeduplicationLLMCall(
     candidates: DeduplicateCandidate[];
     existingTodos: ProjectTodoResource[];
   }
-): Promise<Map<number, string>> {
+): Promise<number[][]> {
   const owner = auth.getNonNullableWorkspace();
   const category = candidates[0].category;
-  const prompt = buildDeduplicationPrompt(category, candidates, existingTodos);
+  const prompt = buildDeduplicationPrompt(category, existingTodos, candidates);
   const specification = buildDeduplicationSpec();
 
   const conv: ModelConversationTypeMultiActions = {
@@ -188,8 +200,8 @@ export async function runDeduplicationLLMCall(
         {
           conversation: conv,
           prompt:
-            "You identify semantic duplicates among TODO items. " +
-            "Err on the side of treating items as new — only match when clearly redundant.",
+            "You partition TODO items into semantic groups. Items in the same group describe the same underlying task. " +
+            "Err on the side of separating items — only group them when clearly redundant.",
           specifications: [specification],
           forceToolCall: specification.name,
         },
@@ -207,7 +219,7 @@ export async function runDeduplicationLLMCall(
       { error: res.error, workspaceId: owner.sId },
       "Project todo dedup: LLM call failed, treating all candidates as new"
     );
-    return new Map();
+    return [];
   }
 
   const action = res.value.actions?.[0];
@@ -216,7 +228,7 @@ export async function runDeduplicationLLMCall(
       { workspaceId: owner.sId },
       "Project todo dedup: no tool call in LLM response, treating all as new"
     );
-    return new Map();
+    return [];
   }
 
   const parsed = DeduplicationResultSchema.safeParse(action.arguments);
@@ -225,25 +237,96 @@ export async function runDeduplicationLLMCall(
       { error: parsed.error, workspaceId: owner.sId },
       "Project todo dedup: failed to parse LLM response, treating all as new"
     );
-    return new Map();
+    return [];
   }
 
-  // Map candidateIndex → matched existing sId (only when a match was reported).
-  const indexToMatchedId = new Map<number, string>();
-  for (const match of parsed.data.matches) {
-    if (match.duplicate_of_sid) {
-      indexToMatchedId.set(match.candidate_index, match.duplicate_of_sid);
+  return parsed.data.groups;
+}
+
+// ── Group resolution ─────────────────────────────────────────────────────────
+
+// Generic over the todo type so unit tests can pass a minimal structural stub
+// instead of a full ProjectTodoResource.
+type ResolvedGroupOf<TTodo> =
+  | { kind: "existing"; todo: TTodo; candidates: DeduplicateCandidate[] }
+  | { kind: "new"; candidates: DeduplicateCandidate[] };
+
+// Turns one LLM partition into a list of resolved groups. Pure so it can be
+// unit-tested without a real LLM call.
+//
+// The input list the LLM grouped is `[...existingTodos, ...candidates]`:
+// indexes in `[0, existingTodos.length)` refer to existing todos; indexes in
+// `[existingTodos.length, existingTodos.length + candidates.length)` refer to
+// candidates. Any index outside that range (LLM hallucination) is ignored.
+// An index that appears in more than one group is honored only in the first
+// group it appears in, so later groups don't silently re-assign it.
+//
+// Per-cluster resolution:
+//   - No candidate → cluster dropped.
+//   - ≥1 existing  → "existing" group pointing at the first existing (extras
+//                    ignored).
+//   - No existing  → "new" group (first candidate drives content).
+//
+// Any candidate the LLM forgot to place in a cluster is emitted as its own
+// singleton "new" group so no source ever disappears.
+export function resolveDeduplicationGroups<TTodo>(
+  candidates: DeduplicateCandidate[],
+  existingTodos: TTodo[],
+  groups: number[][]
+): Array<ResolvedGroupOf<TTodo>> {
+  const result: Array<ResolvedGroupOf<TTodo>> = [];
+  const existingCount = existingTodos.length;
+  const totalCount = existingCount + candidates.length;
+  const seen = new Set<number>();
+
+  for (const group of groups) {
+    const existingInGroup: TTodo[] = [];
+    const candidatesInGroup: DeduplicateCandidate[] = [];
+
+    for (const idx of group) {
+      if (idx < 0 || idx >= totalCount || seen.has(idx)) {
+        continue;
+      }
+      seen.add(idx);
+      if (idx < existingCount) {
+        existingInGroup.push(existingTodos[idx]);
+      } else {
+        candidatesInGroup.push(candidates[idx - existingCount]);
+      }
+    }
+
+    if (candidatesInGroup.length === 0) {
+      continue;
+    }
+
+    if (existingInGroup.length >= 1) {
+      result.push({
+        kind: "existing",
+        todo: existingInGroup[0],
+        candidates: candidatesInGroup,
+      });
+    } else {
+      result.push({ kind: "new", candidates: candidatesInGroup });
     }
   }
-  return indexToMatchedId;
+
+  // Any candidate the LLM forgot to include ends up in its own singleton
+  // "new" group — never silently dropped.
+  for (let i = 0; i < candidates.length; i++) {
+    if (!seen.has(existingCount + i)) {
+      result.push({ kind: "new", candidates: [candidates[i]] });
+    }
+  }
+
+  return result;
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
-// Runs semantic deduplication for all new candidates against existing todos.
-// Groups candidates by (userId, category), executes one LLM call per non-empty
-// group (up to 4 concurrent), and returns a DeduplicationMap keyed by
-// `${userId}:${itemId}`. Missing entries mean no duplicate was found.
+// Runs semantic deduplication for all new candidates. Groups candidates by
+// (userId, category), executes one LLM call per group (up to 4 concurrent),
+// and returns a flat list of DeduplicatedGroup covering every input
+// candidate.
 export async function batchDeduplicateCandidates(
   auth: Authenticator,
   {
@@ -253,55 +336,62 @@ export async function batchDeduplicateCandidates(
   }: {
     model: ModelConfigurationType;
     candidates: DeduplicateCandidate[];
-    existingTodosByGroup: Map<string, ProjectTodoResource[]>;
+    existingTodosByGroup: ExistingTodosByGroup;
   }
-): Promise<DeduplicationMap> {
-  const deduplicationMap: DeduplicationMap = new Map();
+): Promise<DeduplicatedGroup[]> {
+  const results: DeduplicatedGroup[] = [];
 
-  // Group candidates by (userId, category).
-  const groups = new Map<string, DeduplicateCandidate[]>();
+  // Group candidates by userId → category → candidates.
+  const candidatesByGroup = new Map<
+    ModelId,
+    Map<ProjectTodoCategory, DeduplicateCandidate[]>
+  >();
   for (const candidate of candidates) {
-    const key = makeDedupGroupKey(candidate.userId, candidate.category);
-    const group = groups.get(key) ?? [];
-    group.push(candidate);
-    groups.set(key, group);
+    const byCategory =
+      candidatesByGroup.get(candidate.userId) ??
+      new Map<ProjectTodoCategory, DeduplicateCandidate[]>();
+    const bucket = byCategory.get(candidate.category) ?? [];
+    bucket.push(candidate);
+    byCategory.set(candidate.category, bucket);
+    candidatesByGroup.set(candidate.userId, byCategory);
+  }
+
+  // Flatten to a list of (candidates, existingTodos) jobs so the executor
+  // can schedule them at a fixed parallelism.
+  const jobs: Array<{
+    groupCandidates: DeduplicateCandidate[];
+    existingTodos: ProjectTodoResource[];
+  }> = [];
+  for (const [userId, byCategory] of candidatesByGroup) {
+    const existingByCategory = existingTodosByGroup.get(userId);
+    for (const [category, groupCandidates] of byCategory) {
+      const existingTodos = existingByCategory?.get(category) ?? [];
+      jobs.push({ groupCandidates, existingTodos });
+    }
   }
 
   await concurrentExecutor(
-    Array.from(groups.entries()),
-    async ([groupKey, groupCandidates]) => {
-      const existingTodos = existingTodosByGroup.get(groupKey) ?? [];
-
-      // No existing todos to compare against — skip the LLM call.
-      if (existingTodos.length === 0) {
+    jobs,
+    async ({ groupCandidates, existingTodos }) => {
+      // Fast path: one candidate, no existing. No LLM call needed; emit a
+      // singleton "new" group directly.
+      if (existingTodos.length === 0 && groupCandidates.length <= 1) {
+        results.push({ kind: "new", candidates: groupCandidates });
         return;
       }
 
-      const indexToMatchedId = await runDeduplicationLLMCall(auth, {
+      const llmGroups = await runDeduplicationLLMCall(auth, {
         model,
         candidates: groupCandidates,
         existingTodos,
       });
 
-      const todosById = new Map(existingTodos.map((t) => [t.sId, t]));
-
-      for (let i = 0; i < groupCandidates.length; i++) {
-        const candidate = groupCandidates[i];
-        const matchedId = indexToMatchedId.get(i);
-        if (!matchedId) {
-          continue;
-        }
-        const matched = todosById.get(matchedId);
-        if (matched) {
-          deduplicationMap.set(
-            makeDedupResultKey(candidate.userId, candidate.itemId),
-            matched
-          );
-        }
-      }
+      results.push(
+        ...resolveDeduplicationGroups(groupCandidates, existingTodos, llmGroups)
+      );
     },
     { concurrency: 4 }
   );
 
-  return deduplicationMap;
+  return results;
 }

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -37,9 +37,8 @@ import { Authenticator } from "@app/lib/auth";
 import {
   batchDeduplicateCandidates,
   type DeduplicateCandidate,
-  type DeduplicationMap,
-  makeDedupGroupKey,
-  makeDedupResultKey,
+  type DeduplicatedGroup,
+  type ExistingTodosByGroup,
 } from "@app/lib/project_todo/deduplicate_candidates";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
@@ -49,7 +48,10 @@ import {
 } from "@app/lib/resources/takeaways_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { ProjectTodoSourceInfo } from "@app/types/project_todo";
+import type {
+  ProjectTodoCategory,
+  ProjectTodoSourceInfo,
+} from "@app/types/project_todo";
 import type { ModelId } from "@app/types/shared/model_id";
 import type {
   TodoVersionedActionItem,
@@ -178,7 +180,7 @@ export async function mergeTakeawaysIntoProject({
 
   // ── Phase 2: semantic deduplication ──────────────────────────────────────
 
-  const dedupMap = await buildDeduplicationMap(adminAuth, {
+  const dedupGroups = await buildDeduplicationGroups(adminAuth, {
     localLogger,
     newCandidates,
     spaceModelId,
@@ -189,7 +191,7 @@ export async function mergeTakeawaysIntoProject({
   const { deduplicated, createdNew } = await createOrLinkTodos(adminAuth, {
     localLogger,
     newCandidates,
-    dedupMap,
+    dedupGroups,
     spaceModelId,
   });
 
@@ -313,9 +315,9 @@ async function collectDocumentCandidates(
 // ── Phase 2 ───────────────────────────────────────────────────────────────────
 
 // Pre-fetches all existing todos per (userId, category) and runs batch semantic
-// deduplication via LLM. Returns an empty map if no model is available, which
-// causes all candidates to be treated as new in phase 3.
-async function buildDeduplicationMap(
+// deduplication via LLM. Returns one singleton "new" group per candidate if no
+// model is available — Phase 3 then creates fresh todos for all of them.
+async function buildDeduplicationGroups(
   auth: Authenticator,
   {
     localLogger,
@@ -326,19 +328,29 @@ async function buildDeduplicationMap(
     newCandidates: PendingCandidate[];
     spaceModelId: ModelId;
   }
-): Promise<DeduplicationMap> {
+): Promise<DeduplicatedGroup[]> {
+  const deduplicateCandidates: DeduplicateCandidate[] = newCandidates.map(
+    (c) => ({
+      itemId: c.itemId,
+      userId: c.userId,
+      text: c.blob.text,
+      category: c.blob.category,
+    })
+  );
+
   const model = getFastestWhitelistedModel(auth);
   if (!model) {
     localLogger.warn(
       "Project todo merge: no whitelisted model, skipping deduplication"
     );
-    return new Map();
+    return deduplicateCandidates.map((c) => ({ kind: "new", candidates: [c] }));
   }
 
-  // Fetch all existing todos for each unique target user in a single pass, then
-  // group them by `${userId}:${category}` for efficient lookup in the LLM calls.
+  // Fetch all existing todos for each unique target user in a single pass,
+  // then nest them under userId → category → todos for lookup by the LLM
+  // calls.
   const uniqueUserIds = [...new Set(newCandidates.map((c) => c.userId))];
-  const existingTodosByGroup = new Map<string, ProjectTodoResource[]>();
+  const existingTodosByGroup: ExistingTodosByGroup = new Map();
 
   await concurrentExecutor(
     uniqueUserIds,
@@ -347,23 +359,17 @@ async function buildDeduplicationMap(
         spaceId: spaceModelId,
         userId,
       });
+      const byCategory =
+        existingTodosByGroup.get(userId) ??
+        new Map<ProjectTodoCategory, ProjectTodoResource[]>();
       for (const todo of todos) {
-        const key = makeDedupGroupKey(userId, todo.category);
-        const group = existingTodosByGroup.get(key) ?? [];
-        group.push(todo);
-        existingTodosByGroup.set(key, group);
+        const bucket = byCategory.get(todo.category) ?? [];
+        bucket.push(todo);
+        byCategory.set(todo.category, bucket);
       }
+      existingTodosByGroup.set(userId, byCategory);
     },
     { concurrency: 4 }
-  );
-
-  const deduplicateCandidates: DeduplicateCandidate[] = newCandidates.map(
-    (c) => ({
-      itemId: c.itemId,
-      userId: c.userId,
-      text: c.blob.text,
-      category: c.blob.category,
-    })
   );
 
   return batchDeduplicateCandidates(auth, {
@@ -375,87 +381,129 @@ async function buildDeduplicationMap(
 
 // ── Phase 3 ───────────────────────────────────────────────────────────────────
 
-// For each candidate: if a semantic duplicate was found, attach the source link
-// to the existing todo (updating content for agent-created ones if needed).
-// Otherwise, create a new todo and link the source.
+// Executes one dedup group per call, atomically: groups don't share state, so
+// they run in parallel at concurrency 4.
 async function createOrLinkTodos(
   auth: Authenticator,
   {
     localLogger,
     newCandidates,
-    dedupMap,
+    dedupGroups,
     spaceModelId,
   }: {
     localLogger: Logger;
     newCandidates: PendingCandidate[];
-    dedupMap: DeduplicationMap;
+    dedupGroups: DeduplicatedGroup[];
     spaceModelId: ModelId;
   }
 ): Promise<{ deduplicated: number; createdNew: number }> {
   let deduplicated = 0;
   let createdNew = 0;
 
+  // Dedup groups reference candidates by (userId, itemId); fetch the original
+  // PendingCandidate (with blob + source) by that pair.
+  const pendingByUserItem = new Map<ModelId, Map<string, PendingCandidate>>();
+  for (const c of newCandidates) {
+    const inner =
+      pendingByUserItem.get(c.userId) ?? new Map<string, PendingCandidate>();
+    inner.set(c.itemId, c);
+    pendingByUserItem.set(c.userId, inner);
+  }
+
+  function lookupPending(c: DeduplicateCandidate): PendingCandidate | null {
+    return pendingByUserItem.get(c.userId)?.get(c.itemId) ?? null;
+  }
+
   await concurrentExecutor(
-    newCandidates,
-    async (candidate) => {
-      const match =
-        dedupMap.get(makeDedupResultKey(candidate.userId, candidate.itemId)) ??
-        null;
+    dedupGroups,
+    async (group) => {
+      if (group.kind === "existing") {
+        // Attach every candidate's source to the existing todo. The update
+        // guard lives in updateTodoIfChanged — no-op when the target todo was
+        // created by a user or already marked done by one.
+        const primary = lookupPending(group.candidates[0]);
+        if (primary) {
+          await updateTodoIfChanged(group.todo, auth, primary.blob);
+        }
+        for (const candidate of group.candidates) {
+          const pending = lookupPending(candidate);
+          if (!pending) {
+            continue;
+          }
+          await group.todo.upsertSource(auth, {
+            itemId: pending.itemId,
+            source: pending.source,
+          });
+          deduplicated++;
 
-      if (match !== null) {
-        // Semantic duplicate found — link the new source to the existing todo.
-        await match.upsertSource(auth, {
-          itemId: candidate.itemId,
-          source: candidate.source,
-        });
-
-        // User-intent guard lives in updateTodoIfChanged — it is a no-op when
-        // the target todo was created by a user or already marked done by one.
-        await updateTodoIfChanged(match, auth, candidate.blob);
-
-        deduplicated++;
-
-        localLogger.info(
-          {
-            existingTodoId: match.sId,
-            itemId: candidate.itemId,
-            userId: candidate.userId,
-            source: candidate.source,
-            createdByType: match.createdByType,
-          },
-          "Project todo merge: linked source to existing todo (semantic duplicate)"
-        );
+          localLogger.info(
+            {
+              existingTodoId: group.todo.sId,
+              itemId: pending.itemId,
+              userId: pending.userId,
+              source: pending.source,
+              createdByType: group.todo.createdByType,
+            },
+            "Project todo merge: linked source to existing todo (semantic duplicate)"
+          );
+        }
         return;
       }
 
-      // No duplicate — create a fresh todo and link the source atomically so
-      // a Temporal retry after a partial success can't leave an orphan row.
+      // kind === "new": create one todo from the first candidate, attach every
+      // other candidate's source to it.
+      const primary = lookupPending(group.candidates[0]);
+      if (!primary) {
+        return;
+      }
+
       const todo = await ProjectTodoResource.makeNewWithSource(auth, {
         blob: {
           spaceId: spaceModelId,
-          userId: candidate.userId,
+          userId: primary.userId,
           createdByType: "agent",
           createdByAgentConfigurationId: BUTLER_AGENT_SID,
-          category: candidate.blob.category,
-          text: candidate.blob.text,
-          status: candidate.blob.status,
-          doneAt: candidate.blob.doneAt,
+          category: primary.blob.category,
+          text: primary.blob.text,
+          status: primary.blob.status,
+          doneAt: primary.blob.doneAt,
         },
-        itemId: candidate.itemId,
-        source: candidate.source,
+        itemId: primary.itemId,
+        source: primary.source,
       });
-
       createdNew++;
 
       localLogger.info(
         {
           todoId: todo.sId,
-          itemId: candidate.itemId,
-          userId: candidate.userId,
-          source: candidate.source,
+          itemId: primary.itemId,
+          userId: primary.userId,
+          source: primary.source,
         },
         "Project todo merge: created new todo"
       );
+
+      for (let i = 1; i < group.candidates.length; i++) {
+        const pending = lookupPending(group.candidates[i]);
+        if (!pending) {
+          continue;
+        }
+        await todo.upsertSource(auth, {
+          itemId: pending.itemId,
+          source: pending.source,
+        });
+        deduplicated++;
+
+        localLogger.info(
+          {
+            todoId: todo.sId,
+            itemId: pending.itemId,
+            userId: pending.userId,
+            source: pending.source,
+          },
+          "Project todo merge: linked source to new todo (intra-batch duplicate)"
+        );
+      }
     },
     { concurrency: 4 }
   );

--- a/front/tests/dedup-evals/lib/dedup-executor.ts
+++ b/front/tests/dedup-evals/lib/dedup-executor.ts
@@ -52,11 +52,46 @@ export async function executeDedup(
   const existingTodos = buildMockExistingTodos(testCase);
   const candidates = buildCandidates(testCase);
 
-  const matchMap = await runDeduplicationLLMCall(auth, {
+  const llmGroups = await runDeduplicationLLMCall(auth, {
     model,
     candidates,
     existingTodos,
   });
+
+  // Current eval assertions only cover candidate→existing matches. The LLM
+  // now returns a partition over [...existingTodos, ...candidates]; project
+  // each group that contains ≥1 existing down to "candidate idx → first
+  // existing sId", dropping intra-batch follower info. Adding assertion
+  // types for intra-batch dedup is tracked separately.
+  const existingCount = existingTodos.length;
+  const matchMap = new Map<number, string>();
+  const seen = new Set<number>();
+  for (const group of llmGroups) {
+    let winnerSId: string | null = null;
+    const candidateIdxs: number[] = [];
+    for (const idx of group) {
+      if (
+        idx < 0 ||
+        idx >= existingCount + candidates.length ||
+        seen.has(idx)
+      ) {
+        continue;
+      }
+      seen.add(idx);
+      if (idx < existingCount) {
+        if (winnerSId === null) {
+          winnerSId = existingTodos[idx].sId;
+        }
+      } else {
+        candidateIdxs.push(idx - existingCount);
+      }
+    }
+    if (winnerSId !== null) {
+      for (const candidateIdx of candidateIdxs) {
+        matchMap.set(candidateIdx, winnerSId);
+      }
+    }
+  }
 
   return { matchMap };
 }


### PR DESCRIPTION
## Description

The dedup LLM call previously only compared each candidate to existing
TODOs. If the same task showed up in two different source documents in the
same batch, both candidates passed as "new" and produced two separate TODOs
— one per document — for the same underlying item.

Dedup now hands the LLM a single flat, numbered list of existing TODOs + new
candidates per `(userId, category)` and asks it to partition the list into
semantic groups via the `report_groups` tool. Each LLM-returned cluster is
resolved with three simple rules:

- cluster has no existing TODO → one "new" group; the first candidate drives
  the new TODO's content, the rest attach their sources to it;
- cluster has ≥1 existing TODO → one "existing" group pointing at the first
  existing (extras ignored — we don't merge existing TODOs here);
- cluster with no candidate → dropped.

Phase 3 iterates groups directly: for each group it either creates one new
TODO from the first candidate's blob and attaches every other candidate's
source, or attaches every candidate's source to the existing TODO (with the
standard user-intent guard). Groups don't share state, so they run in
parallel at concurrency 4 — no more serialization within a `(userId,
category)` bucket.

## Tests

10 unit tests in `deduplicate_candidates.test.ts` 

The dedup eval executor was adapted to project the new `number[][]` grouping output back to the legacy `candidateIdx → existingSId` shape so existing eval assertions keep working.
