### PR TITLE
[Sessions] Keep parent conversation responsive while branching

### DIFF
--- a/front/components/assistant/conversation/ConversationForkNotice.tsx
+++ b/front/components/assistant/conversation/ConversationForkNotice.tsx
@@ -3,6 +3,7 @@ import { LinkWrapper } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
+import { Spinner } from "@dust-tt/sparkle";
 
 interface ConversationForkNoticeProps {
   message: ConversationForkNoticeType;
@@ -23,18 +24,33 @@ export function ConversationForkNotice({
     <div className="flex items-center gap-3">
       <div className="h-px flex-1 bg-border dark:bg-border-dark-night" />
       <div className="min-w-0 break-words text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
-        <span>
-          {getForkingUserDisplayName(message)} branched this conversation:{" "}
-        </span>
-        <LinkWrapper
-          href={getConversationRoute(owner.sId, message.childConversationId)}
-          className="text-foreground transition duration-200 hover:underline dark:text-foreground-night"
-        >
-          {getConversationDisplayTitle({
-            title: message.childConversationTitle,
-            created: message.created,
-          })}
-        </LinkWrapper>
+        {message.isPending ? (
+          <span className="inline-flex items-center gap-2">
+            <span>
+              {getForkingUserDisplayName(message)} is branching this
+              conversation
+            </span>
+            <Spinner size="xs" />
+          </span>
+        ) : (
+          <>
+            <span>
+              {getForkingUserDisplayName(message)} branched this conversation:{" "}
+            </span>
+            <LinkWrapper
+              href={getConversationRoute(
+                owner.sId,
+                message.childConversationId
+              )}
+              className="text-foreground transition duration-200 hover:underline dark:text-foreground-night"
+            >
+              {getConversationDisplayTitle({
+                title: message.childConversationTitle,
+                created: message.created,
+              })}
+            </LinkWrapper>
+          </>
+        )}
       </div>
       <div className="h-px flex-1 bg-border dark:bg-border-dark-night" />
     </div>

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -37,6 +37,10 @@ import {
   useConversations,
 } from "@app/hooks/conversations";
 import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
+import {
+  type PendingConversationBranch,
+  useConversationBranchingState,
+} from "@app/hooks/conversations/useConversationBranchingState";
 import { useConversationEvents } from "@app/hooks/useConversationEvents";
 import { useEnableBrowserNotification } from "@app/hooks/useEnableBrowserNotification";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -176,6 +180,7 @@ function makeConversationForkNoticeMessage(
     rank: sourceMessage.rank,
     branchId: null,
     visibility: "visible",
+    isPending: false,
     sourceMessageId: forkedChild.sourceMessageId,
     childConversationId: forkedChild.childConversationId,
     childConversationTitle: forkedChild.childConversationTitle,
@@ -183,15 +188,59 @@ function makeConversationForkNoticeMessage(
   };
 }
 
+function getPendingForkSourceMessageId(
+  messages: VirtuosoMessage[],
+  pendingForkNotice: PendingConversationBranch
+): string | null {
+  if (pendingForkNotice.sourceMessageId) {
+    return pendingForkNotice.sourceMessageId;
+  }
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message && isAgentMessageWithStreaming(message)) {
+      return message.sId;
+    }
+  }
+
+  return null;
+}
+
+function makePendingConversationForkNoticeMessage(
+  sourceMessage: VirtuosoMessage,
+  pendingForkNotice: PendingConversationBranch,
+  user: UserType
+): ConversationForkNotice {
+  return {
+    type: "conversation_fork_notice",
+    sId: `conversation-fork-notice-pending-${pendingForkNotice.startedAt}`,
+    created: sourceMessage.created,
+    rank: sourceMessage.rank,
+    branchId: null,
+    visibility: "visible",
+    isPending: true,
+    sourceMessageId: sourceMessage.sId,
+    childConversationId: null,
+    childConversationTitle: null,
+    user,
+  };
+}
+
 function addConversationForkNotices(
   messages: VirtuosoMessage[],
-  forkedChildren: ConversationForkedChildType[] = []
+  forkedChildren: ConversationForkedChildType[] = [],
+  pendingForkNotice: PendingConversationBranch | null,
+  currentUser: UserType
 ): VirtuosoMessage[] {
   const renderedMessages = messages.filter(
     (message) => !isConversationForkNotice(message)
   );
 
-  if (forkedChildren.length === 0) {
+  const pendingForkSourceMessageId = pendingForkNotice
+    ? getPendingForkSourceMessageId(renderedMessages, pendingForkNotice)
+    : null;
+
+  if (!pendingForkSourceMessageId && forkedChildren.length === 0) {
     return renderedMessages;
   }
 
@@ -227,6 +276,22 @@ function addConversationForkNotices(
         makeConversationForkNoticeMessage(message, forkedChild)
       )
     );
+
+    if (
+      pendingForkNotice &&
+      pendingForkSourceMessageId === message.sId &&
+      !forkedChildrenForMessage.some(
+        (forkedChild) => forkedChild.branchedAt >= pendingForkNotice.startedAt
+      )
+    ) {
+      mergedMessages.push(
+        makePendingConversationForkNoticeMessage(
+          message,
+          pendingForkNotice,
+          currentUser
+        )
+      );
+    }
   }
 
   return mergedMessages;
@@ -299,6 +364,8 @@ export const ConversationViewer = ({
   }, [shouldShowPushNotificationActivation, askForPermission]);
 
   const { mutateConversations } = useConversations({ workspaceId: owner.sId });
+  const { inFlightBranch, pendingForkNotice, clearPendingForkNotice } =
+    useConversationBranchingState(conversationId);
 
   const {
     isLoadingInitialData,
@@ -359,7 +426,9 @@ export const ConversationViewer = ({
       const messagesToRender = convertLightMessageTypeToVirtuosoMessages(raw);
       const messagesAndNotices = addConversationForkNotices(
         messagesToRender,
-        conversation.forkingData?.forkedChildren
+        conversation.forkingData?.forkedChildren,
+        pendingForkNotice,
+        user
       );
 
       setInitialListData(messagesAndNotices);
@@ -408,10 +477,12 @@ export const ConversationViewer = ({
     initialListData,
     conversation,
     messages,
+    pendingForkNotice,
     setInitialListData,
     isValidating,
     conversation?.unread,
     conversation?.lastReadMs,
+    user,
   ]);
 
   // Sync the virtuoso ref with the side panel context.
@@ -469,7 +540,9 @@ export const ConversationViewer = ({
       ref.current.data.prepend(
         addConversationForkNotices(
           renderedOlderMessages,
-          conversation?.forkingData?.forkedChildren
+          conversation?.forkingData?.forkedChildren,
+          pendingForkNotice,
+          user
         )
       );
     }
@@ -487,11 +560,18 @@ export const ConversationViewer = ({
       ref.current.data.append(
         addConversationForkNotices(
           renderedRecentMessages,
-          conversation?.forkingData?.forkedChildren
+          conversation?.forkingData?.forkedChildren,
+          pendingForkNotice,
+          user
         )
       );
     }
-  }, [conversation?.forkingData?.forkedChildren, messages]);
+  }, [
+    conversation?.forkingData?.forkedChildren,
+    messages,
+    pendingForkNotice,
+    user,
+  ]);
 
   useEffect(() => {
     if (!ref.current || !ref.current.data.get().length) {
@@ -501,7 +581,9 @@ export const ConversationViewer = ({
     const currentData = ref.current.data.get();
     const reconciledData = addConversationForkNotices(
       currentData,
-      conversation?.forkingData?.forkedChildren
+      conversation?.forkingData?.forkedChildren,
+      pendingForkNotice,
+      user
     );
 
     if (
@@ -527,7 +609,7 @@ export const ConversationViewer = ({
       }
       index += 1;
     }
-  }, [conversation?.forkingData?.forkedChildren]);
+  }, [conversation?.forkingData?.forkedChildren, pendingForkNotice, user]);
 
   const { feedbacks } = useConversationFeedbacks({
     conversationId: conversationId ?? "",
@@ -1027,13 +1109,53 @@ export const ConversationViewer = ({
     );
   }, [feedbacks]);
 
+  useEffect(() => {
+    if (!pendingForkNotice || inFlightBranch) {
+      return;
+    }
+
+    void mutateConversation();
+  }, [inFlightBranch, mutateConversation, pendingForkNotice]);
+
+  useEffect(() => {
+    if (!pendingForkNotice) {
+      return;
+    }
+
+    const sourceMessageId = getPendingForkSourceMessageId(
+      convertLightMessageTypeToVirtuosoMessages(
+        messages.flatMap((m) => m.messages)
+      ),
+      pendingForkNotice
+    );
+
+    if (!sourceMessageId) {
+      return;
+    }
+
+    const matchingFork = conversation?.forkingData?.forkedChildren?.some(
+      (forkedChild) =>
+        forkedChild.sourceMessageId === sourceMessageId &&
+        forkedChild.branchedAt >= pendingForkNotice.startedAt
+    );
+
+    if (matchingFork) {
+      clearPendingForkNotice();
+    }
+  }, [
+    clearPendingForkNotice,
+    conversation?.forkingData?.forkedChildren,
+    messages,
+    pendingForkNotice,
+  ]);
+
   const isProjectMember = conversation?.spaceId
     ? (spaceInfo?.isMember ?? false) // Default false while loading (restrictive)
     : undefined;
 
   const onConversationBranched = useCallback(() => {
-    void mutateConversations();
-  }, [mutateConversations]);
+    void mutateConversation();
+  }, [mutateConversation]);
 
   // After reversal in the hook, messages[0] is the oldest page. This only
   // returns the actual first conversation message when all pages are loaded

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -79,7 +79,7 @@ export type AgentMessageWithStreaming = LightAgentMessageWithActionsType & {
   };
 };
 
-export type ConversationForkNotice = {
+type BaseConversationForkNotice = {
   type: "conversation_fork_notice";
   sId: string;
   created: number;
@@ -87,10 +87,20 @@ export type ConversationForkNotice = {
   branchId: null;
   visibility: "visible";
   sourceMessageId: string;
-  childConversationId: string;
-  childConversationTitle: string | null;
   user: UserType;
 };
+
+export type ConversationForkNotice =
+  | (BaseConversationForkNotice & {
+      isPending: true;
+      childConversationId: null;
+      childConversationTitle: null;
+    })
+  | (BaseConversationForkNotice & {
+      isPending: false;
+      childConversationId: string;
+      childConversationTitle: string | null;
+    });
 
 export type AgentMessageStateEvent = (
   | AgentMessageEvents

--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -9,6 +9,16 @@ import { useCallback } from "react";
 
 import { useConversationBranchingState } from "./useConversationBranchingState";
 
+const BRANCHING_WINDOW_TITLE = "Opening branched conversation...";
+
+function initializeBranchingWindow(newWindow: Window) {
+  newWindow.opener = null;
+  newWindow.document.write(
+    `<!doctype html><html><head><title>${BRANCHING_WINDOW_TITLE}</title></head><body><p>${BRANCHING_WINDOW_TITLE}</p></body></html>`
+  );
+  newWindow.document.close();
+}
+
 export function useBranchConversation({
   owner,
   conversationId,
@@ -37,7 +47,7 @@ export function useBranchConversation({
         typeof window !== "undefined" ? window.open("", "_blank") : null;
 
       if (childConversationWindow) {
-        childConversationWindow.opener = null;
+        initializeBranchingWindow(childConversationWindow);
       }
 
       try {

--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -1,11 +1,13 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { useAppRouter } from "@app/lib/platform";
+import { ConversationsUpdatedEvent } from "@app/lib/notifications/events";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { PostConversationForkResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/forks";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
+
+import { useConversationBranchingState } from "./useConversationBranchingState";
 
 export function useBranchConversation({
   owner,
@@ -17,17 +19,26 @@ export function useBranchConversation({
   onConversationBranched?: () => Promise<void> | void;
 }) {
   const sendNotification = useSendNotification();
-  const router = useAppRouter();
-
-  const [isBranching, setIsBranching] = useState(false);
+  const {
+    isBranching,
+    startBranching,
+    markBranchCreated,
+    clearBranchingState,
+  } = useConversationBranchingState(conversationId);
 
   const branchConversation = useCallback(
     async (sourceMessageId?: string): Promise<boolean> => {
-      if (!conversationId) {
+      if (!conversationId || isBranching) {
         return false;
       }
 
-      setIsBranching(true);
+      startBranching(sourceMessageId);
+      const childConversationWindow =
+        typeof window !== "undefined" ? window.open("", "_blank") : null;
+
+      if (childConversationWindow) {
+        childConversationWindow.opener = null;
+      }
 
       try {
         const requestBody = sourceMessageId ? { sourceMessageId } : {};
@@ -51,6 +62,8 @@ export function useBranchConversation({
             title: "Failed to branch conversation",
             description: errorData.message,
           });
+          childConversationWindow?.close();
+          clearBranchingState();
 
           return false;
         }
@@ -59,34 +72,42 @@ export function useBranchConversation({
           conversationId: forkedConversationId,
         }: PostConversationForkResponseBody = await res.json();
 
+        markBranchCreated();
+        window.dispatchEvent(new ConversationsUpdatedEvent());
         void onConversationBranched?.();
 
-        await router.push(
-          getConversationRoute(owner.sId, forkedConversationId),
-          undefined,
-          {
-            shallow: true,
-          }
+        const forkedConversationRoute = getConversationRoute(
+          owner.sId,
+          forkedConversationId
         );
+
+        if (childConversationWindow) {
+          childConversationWindow.location.assign(forkedConversationRoute);
+        } else {
+          window.open(forkedConversationRoute, "_blank");
+        }
 
         return true;
       } catch {
+        childConversationWindow?.close();
+        clearBranchingState();
         sendNotification({
           type: "error",
           title: "Failed to branch conversation",
         });
 
         return false;
-      } finally {
-        setIsBranching(false);
       }
     },
     [
+      clearBranchingState,
       conversationId,
+      isBranching,
+      markBranchCreated,
       onConversationBranched,
       owner.sId,
-      router,
       sendNotification,
+      startBranching,
     ]
   );
 

--- a/front/hooks/conversations/useConversationBranchingState.ts
+++ b/front/hooks/conversations/useConversationBranchingState.ts
@@ -1,0 +1,138 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+export type PendingConversationBranch = {
+  sourceMessageId: string | null;
+  startedAt: number;
+};
+
+type ConversationBranchingState = {
+  inFlightBranch: PendingConversationBranch | null;
+  pendingForkNotice: PendingConversationBranch | null;
+};
+
+const EMPTY_BRANCHING_STATE: ConversationBranchingState = {
+  inFlightBranch: null,
+  pendingForkNotice: null,
+};
+
+const branchingStateByConversationId = new Map<
+  string,
+  ConversationBranchingState
+>();
+const listeners = new Set<() => void>();
+
+function emitChange() {
+  listeners.forEach((listener) => listener());
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getConversationBranchingState(
+  conversationId?: string | null
+): ConversationBranchingState {
+  if (!conversationId) {
+    return EMPTY_BRANCHING_STATE;
+  }
+
+  return (
+    branchingStateByConversationId.get(conversationId) ?? EMPTY_BRANCHING_STATE
+  );
+}
+
+function setConversationBranchingState(
+  conversationId: string,
+  state: ConversationBranchingState
+) {
+  if (!state.inFlightBranch && !state.pendingForkNotice) {
+    branchingStateByConversationId.delete(conversationId);
+  } else {
+    branchingStateByConversationId.set(conversationId, state);
+  }
+
+  emitChange();
+}
+
+export function useConversationBranchingState(conversationId?: string | null) {
+  const state = useSyncExternalStore(
+    subscribe,
+    () => getConversationBranchingState(conversationId),
+    () => EMPTY_BRANCHING_STATE
+  );
+
+  const startBranching = useCallback(
+    (sourceMessageId?: string) => {
+      if (!conversationId) {
+        return null;
+      }
+
+      const branch: PendingConversationBranch = {
+        sourceMessageId: sourceMessageId ?? null,
+        startedAt: Date.now(),
+      };
+
+      setConversationBranchingState(conversationId, {
+        inFlightBranch: branch,
+        pendingForkNotice: branch,
+      });
+
+      return branch;
+    },
+    [conversationId]
+  );
+
+  const markBranchCreated = useCallback(() => {
+    if (!conversationId) {
+      return;
+    }
+
+    const currentState = getConversationBranchingState(conversationId);
+    if (!currentState.inFlightBranch) {
+      return;
+    }
+
+    setConversationBranchingState(conversationId, {
+      inFlightBranch: null,
+      pendingForkNotice: currentState.pendingForkNotice,
+    });
+  }, [conversationId]);
+
+  const clearBranchingState = useCallback(() => {
+    if (!conversationId) {
+      return;
+    }
+
+    setConversationBranchingState(conversationId, EMPTY_BRANCHING_STATE);
+  }, [conversationId]);
+
+  const clearPendingForkNotice = useCallback(() => {
+    if (!conversationId) {
+      return;
+    }
+
+    const currentState = getConversationBranchingState(conversationId);
+    if (!currentState.pendingForkNotice) {
+      return;
+    }
+
+    setConversationBranchingState(conversationId, {
+      ...currentState,
+      pendingForkNotice: null,
+    });
+  }, [conversationId]);
+
+  return {
+    inFlightBranch: state.inFlightBranch,
+    pendingForkNotice: state.pendingForkNotice,
+    isBranching: state.inFlightBranch !== null,
+    startBranching,
+    markBranchCreated,
+    clearBranchingState,
+    clearPendingForkNotice,
+  };
+}


### PR DESCRIPTION
## Description
Follows the recent Sessions branching UX work.

- disables additional branch actions for a conversation while a fork request is in flight, shared across the branch entry points
- opens the forked child conversation in a new tab and shows an eager pending fork notice with a spinner in the parent until the real lineage notice arrives
- fixes the stale branch-context prompt helper to use `forkingData`, which was required to keep `tsgo` green on this branch

## Risks
Blast radius: private conversation branching UX in front, plus branch-context prompt generation typing
Risk: standard

## Deploy Plan
- deploy front