### PR TITLE
[front] fix scroll issue in Configure MCP Server dialog

### DIFF
--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -43,7 +43,6 @@ import type { WorkspaceType } from "@app/types/user";
 import {
   ContentMessage,
   Dialog,
-  DialogContainer,
   DialogContent,
   DialogFooter,
   DialogHeader,
@@ -537,7 +536,7 @@ export function CreateMCPServerDialog({
               Configure {toolName}
             </DialogTitle>
           </DialogHeader>
-          <DialogContainer className="max-h-[80vh]">
+          <div className="overflow-y-auto px-5 py-4">
             <div className="space-y-4">
               {serverError && (
                 <ContentMessage
@@ -610,7 +609,7 @@ export function CreateMCPServerDialog({
                 internalMCPServer={internalMCPServer}
               />
             </div>
-          </DialogContainer>
+          </div>
           <DialogFooter
             leftButtonProps={{
               label: "Cancel",


### PR DESCRIPTION
## Description
This PR is to fix scrolling issue when you select Static OAuth in MCP Sever configuration dialog. I wanted to fix it properly in sparkle side but couldn't wrap my head around, I will temporary fix this by not using DialogContainer 🥲

before:
<img width="1650" height="568" alt="CleanShot 2026-04-22 at 17 32 19@2x" src="https://github.com/user-attachments/assets/1c97fa46-3ef2-4568-8900-61520c160cde" />


after: 
<img width="1666" height="682" alt="CleanShot 2026-04-22 at 17 32 07@2x" src="https://github.com/user-attachments/assets/5910518e-128b-42ba-978b-d9c40f08d89d" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
