### PR TITLE
[Branching] Thread source attachment id rewrites through compaction

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -108,6 +108,7 @@ import type {
   ToolErrorEvent,
 } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
 import type {
   AgenticMessageData,
   AgentMessageType,
@@ -2687,10 +2688,7 @@ export async function compactConversation(
   }: {
     conversation: ConversationType;
     model: SupportedModel;
-    sourceConversation?: {
-      conversationId: string;
-      messageRank: number;
-    };
+    sourceConversation?: CompactionSourceConversation;
   }
 ): Promise<
   Result<{ compactionMessage: CompactionMessageType }, APIErrorWithStatusCode>

--- a/front/temporal/agent_loop/activities/compaction.ts
+++ b/front/temporal/agent_loop/activities/compaction.ts
@@ -1,5 +1,6 @@
 import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
 import { runCompaction } from "@app/temporal/agent_loop/lib/compaction";
+import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 
 export async function compactionActivity(
@@ -15,10 +16,7 @@ export async function compactionActivity(
     compactionMessageId: string;
     compactionMessageVersion: number;
     model: SupportedModel;
-    sourceConversation?: {
-      conversationId: string;
-      messageRank: number;
-    };
+    sourceConversation?: CompactionSourceConversation;
   }
 ): Promise<void> {
   const authResult = await Authenticator.fromJSON(authType);

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -9,6 +9,7 @@ import {
   makeCompactionWorkflowId,
 } from "@app/temporal/agent_loop/lib/workflow_ids";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -126,10 +127,7 @@ export async function launchCompactionWorkflow({
   compactionMessageId: string;
   compactionMessageVersion: number;
   model: SupportedModel;
-  sourceConversation?: {
-    conversationId: string;
-    messageRank: number;
-  };
+  sourceConversation?: CompactionSourceConversation;
 }): Promise<
   Result<undefined, Error | DustError<"compaction_already_running">>
 > {

--- a/front/temporal/agent_loop/lib/compaction.test.ts
+++ b/front/temporal/agent_loop/lib/compaction.test.ts
@@ -94,6 +94,9 @@ describe("runCompaction", () => {
       sourceConversation: {
         conversationId: "conv_source",
         messageRank: 3,
+        attachmentIdReplacements: {
+          file_parent_1: "file_child_1",
+        },
       },
     });
 
@@ -112,6 +115,9 @@ describe("runCompaction", () => {
         sourceConversation: {
           conversationId: "conv_source",
           messageRank: 3,
+          attachmentIdReplacements: {
+            file_parent_1: "file_child_1",
+          },
         },
       })
     );
@@ -315,5 +321,54 @@ describe("runCompaction", () => {
         .flat()
         .some((message) => isCompactionMessageType(message))
     ).toBe(false);
+  });
+
+  it("rewrites standalone attachment ids in source compaction summaries", async () => {
+    const sourceConversationWithoutContent = await ConversationFactory.create(
+      auth,
+      {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      }
+    );
+
+    const compactionMessage = await createCompactionMessage();
+
+    vi.mocked(runMultiActionsAgent).mockImplementationOnce(async () => {
+      return new Ok({
+        actions: [],
+        generation:
+          '<analysis>Scratchpad.</analysis><summary>Use file_parent_1, `file_parent_2`, and "cf_parent_1". Keep prefixfile_parent_1suffix unchanged.</summary>',
+      });
+    });
+
+    const result = await runCompaction(auth, {
+      conversationId: conversation.sId,
+      compactionMessageId: compactionMessage.sId,
+      compactionMessageVersion: compactionMessage.version,
+      model: MODEL,
+      sourceConversation: {
+        conversationId: sourceConversationWithoutContent.sId,
+        messageRank: 0,
+        attachmentIdReplacements: {
+          file_parent_1: "file_child_1",
+          file_parent_2: "file_child_2",
+          cf_parent_1: "cf_child_1",
+        },
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const updatedCompactionMessageRow = await CompactionMessageModel.findOne({
+      where: {
+        id: compactionMessage.compactionMessageId,
+        workspaceId: workspace.id,
+      },
+    });
+
+    expect(updatedCompactionMessageRow?.content).toBe(
+      'Use file_child_1, `file_child_2`, and "cf_child_1". Keep prefixfile_parent_1suffix unchanged.'
+    );
   });
 });

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -10,6 +10,10 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type {
+  CompactionAttachmentIdReplacements,
+  CompactionSourceConversation,
+} from "@app/types/assistant/compaction";
+import type {
   CompactionMessageType,
   ConversationType,
 } from "@app/types/assistant/conversation";
@@ -68,6 +72,36 @@ function extractSummary(generation: string): string {
   return generation.replace(/<analysis>[\s\S]*?<\/analysis>/g, "").trim();
 }
 
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function replaceAttachmentIdsInSummary(
+  summary: string,
+  replacements: CompactionAttachmentIdReplacements | undefined
+): string {
+  if (!replacements || Object.keys(replacements).length === 0) {
+    return summary;
+  }
+
+  let nextSummary = summary;
+
+  for (const [sourceId, targetId] of Object.entries(replacements).sort(
+    ([leftId], [rightId]) => rightId.length - leftId.length
+  )) {
+    const pattern = new RegExp(
+      `(^|[^A-Za-z0-9_])(${escapeRegex(sourceId)})(?=$|[^A-Za-z0-9_])`,
+      "g"
+    );
+
+    nextSummary = nextSummary.replace(pattern, (_match, prefix) => {
+      return `${prefix}${targetId}`;
+    });
+  }
+
+  return nextSummary;
+}
+
 function filterConversationContentUpToRank(
   conversation: ConversationType,
   maxRank: number
@@ -115,10 +149,7 @@ export async function runCompaction(
     compactionMessageId: string;
     compactionMessageVersion: number;
     model: SupportedModel;
-    sourceConversation?: {
-      conversationId: string;
-      messageRank: number;
-    };
+    sourceConversation?: CompactionSourceConversation;
   }
 ): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
@@ -184,7 +215,10 @@ export async function runCompaction(
   let status: "succeeded" | "failed";
 
   if (summaryRes.isOk()) {
-    content = summaryRes.value;
+    content = replaceAttachmentIdsInSummary(
+      summaryRes.value,
+      sourceConversation?.attachmentIdReplacements
+    );
     status = "succeeded";
 
     logger.info(

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -23,6 +23,7 @@ import type {
   AgentLoopArgs,
   AgentLoopArgsWithTiming,
 } from "@app/types/assistant/agent_run";
+import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/common";
 import type {
@@ -148,10 +149,7 @@ export async function compactionWorkflow({
   compactionMessageId: string;
   compactionMessageVersion: number;
   model: SupportedModel;
-  sourceConversation?: {
-    conversationId: string;
-    messageRank: number;
-  };
+  sourceConversation?: CompactionSourceConversation;
 }) {
   await compactionActivity(authType, {
     conversationId,

--- a/front/types/assistant/compaction.ts
+++ b/front/types/assistant/compaction.ts
@@ -1,0 +1,7 @@
+export type CompactionAttachmentIdReplacements = Record<string, string>;
+
+export type CompactionSourceConversation = {
+  conversationId: string;
+  messageRank: number;
+  attachmentIdReplacements?: CompactionAttachmentIdReplacements;
+};

--- a/x/pr/branching.md
+++ b/x/pr/branching.md
@@ -85,14 +85,27 @@ The target design uses the compaction flow from the parallel compaction proposal
 - the child remains blocked for posting while the initial compaction is in the
   `created` state
 
-This now lands in 3 steps:
+Repurposing compaction for branching adds one important constraint around
+attachments. The source conversation rendered for compaction contains the
+source conversation attachment ids. That is correct for normal in-conversation
+compaction, but wrong for a branched child because the child receives copied
+attachments with different ids. Branch creation therefore needs to compute a
+source-to-child attachment id map and apply it before the child compaction
+message is saved, so the persisted summary points at resources the child can
+actually access.
+
+This now lands in 4 steps:
 
 1. refactor compaction so the existing workflow can keep the compaction message
    and SSE on a target conversation while summarizing a separate source
    conversation snapshot
-2. switch fork creation from the placeholder message to a real child-side
-   compaction that targets the parent conversation at the resolved source rank
-3. refine model selection so fork compaction uses the source agent message
+2. add source-backed compaction support for rewriting exact standalone
+   attachment ids from a caller-provided source-to-target replacement map
+3. switch fork creation from the placeholder message to a real child-side
+   compaction that targets the parent conversation at the resolved source rank,
+   computes that map from carried-over child attachments, and launches
+   compaction only after those child attachments have been posted
+4. refine model selection so fork compaction uses the source agent message
    model instead of the default fallback
 
 Compaction happens after the fork is created. We never compact the
@@ -171,6 +184,8 @@ In the target design, step 7 uses the real compaction shape:
 - the child starts with a `CompactionMessage`
 - that message is the history boundary for the child
 - the compaction payload explicitly states that the child is a fork
+- any attachment ids preserved in the compaction summary are rewritten to the
+  child conversation ids before the compaction message is saved
 - the child remains blocked for posting until the compaction status leaves
   `created`
 
@@ -289,17 +304,23 @@ Scope:
 - PR 1: refactor `compactConversation` so the existing workflow can summarize
   a source conversation snapshot into a compaction message owned by another
   target conversation
-- PR 2: create that compaction message in the child during fork creation and
-  summarize the parent conversation up to the resolved source message rank
-- PR 3: refine model selection so fork compaction uses the source agent
+- PR 2: allow source-backed compaction to rewrite exact standalone attachment
+  ids using a source-to-target replacement map
+- PR 3: create that compaction message in the child during fork creation,
+  summarize the parent conversation up to the resolved source message rank,
+  and pass the attachment id replacement map built from the copied child
+  attachments
+- PR 4: refine model selection so fork compaction uses the source agent
   message model instead of the current default
 
 Why separate:
 
 - the compaction refactor is independently useful and lower risk than changing
   fork creation at the same time
+- the attachment id rewrite is specific to branching, but still fits cleanly as
+  compaction-side plumbing before the fork flow starts depending on it
 - the fork integration stays small once the workflow already supports separate
-  source and target conversations
+  source and target conversations and attachment-id rewrite support
 - model selection is not product-critical for the first internal rollout and
   can follow after the functional child-side compaction path exists
 


### PR DESCRIPTION
## Description
This is part 1 of a 2-part change whose goal is to make branched conversations aware of the attachment ids that exist in the branch, not the ids from the source conversation.

This PR adds an attachment id replacement map to source-backed compaction inputs and threads it through the compaction API, Temporal workflow, and compaction activity.

Source-backed compaction summaries now rewrite exact standalone attachment ids before the compaction message is saved, while regular in-conversation compaction stays unchanged.

PR 2 will compute the source-to-child map in `forks.ts` after carrying over the child attachments and pass it into compaction.

## Risks
Blast radius: source-backed compaction payloads, currently used to initialize branched conversations
Risk: low

## Deploy Plan
- deploy front
