### PR TITLE
feat(sbx): GCS-backed egress policies with two-level merge

### DIFF
--- a/egress-proxy/Cargo.lock
+++ b/egress-proxy/Cargo.lock
@@ -68,6 +68,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +264,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,14 +310,19 @@ dependencies = [
  "axum",
  "clap",
  "jsonwebtoken",
+ "moka",
+ "reqwest",
  "rustls",
  "serde",
+ "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+ "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -284,6 +339,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -335,6 +411,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -359,8 +447,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -370,9 +460,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -472,6 +564,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -480,13 +589,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -494,6 +611,16 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "indexmap"
@@ -505,6 +632,22 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -535,6 +678,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -594,6 +739,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +783,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +822,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -688,6 +865,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +896,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -728,12 +975,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -763,6 +1039,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +1089,12 @@ dependencies = [
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -798,6 +1118,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -810,6 +1131,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -946,7 +1268,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -999,6 +1321,15 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -1019,7 +1350,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1034,6 +1374,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1392,21 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1094,6 +1460,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1184,10 +1568,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -1208,16 +1613,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1254,6 +1696,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1320,6 +1772,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1496,6 +1977,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/egress-proxy/Cargo.toml
+++ b/egress-proxy/Cargo.toml
@@ -12,13 +12,18 @@ anyhow = "1.0"
 axum = "=0.8.4"
 clap = { version = "=4.5.40", features = ["derive", "env"] }
 jsonwebtoken = { version = "10.3.0", default-features = false, features = ["aws_lc_rs"] }
+moka = { version = "0.12", features = ["future"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rustls = "0.23"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 thiserror = "1.0.57"
 tokio = { version = "1.38", features = ["full"] }
 tokio-rustls = "0.26"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+url = "=2.4.1"
+urlencoding = "2.1"
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/egress-proxy/src/config.rs
+++ b/egress-proxy/src/config.rs
@@ -1,8 +1,10 @@
-use crate::policy::TemporaryAllowlist;
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
+
+const DEFAULT_POLICY_BASE_URL: &str = "https://storage.googleapis.com/storage/v1";
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -11,7 +13,9 @@ pub struct Config {
     pub tls_cert_path: PathBuf,
     pub tls_key_path: PathBuf,
     pub jwt_secret: String,
-    pub temporary_allowlist: TemporaryAllowlist,
+    pub policy_bucket: String,
+    pub policy_base_url: String,
+    pub policy_cache_ttl: Duration,
     pub unsafe_skip_ssrf_check: bool,
 }
 
@@ -33,8 +37,18 @@ struct RawConfig {
     #[arg(long, env = "EGRESS_PROXY_JWT_SECRET")]
     jwt_secret: String,
 
-    #[arg(long, env = "EGRESS_PROXY_ALLOWED_DOMAINS")]
-    allowed_domains: String,
+    #[arg(long, env = "EGRESS_PROXY_POLICY_BUCKET")]
+    policy_bucket: String,
+
+    #[arg(long, env = "EGRESS_PROXY_POLICY_CACHE_TTL_SECS", default_value = "60")]
+    policy_cache_ttl_secs: u64,
+
+    #[arg(
+        long,
+        env = "EGRESS_PROXY_POLICY_BASE_URL",
+        default_value = DEFAULT_POLICY_BASE_URL
+    )]
+    policy_base_url: String,
 
     #[arg(long, env = "EGRESS_PROXY_ENV", default_value = "production")]
     environment: String,
@@ -57,9 +71,20 @@ impl TryFrom<RawConfig> for Config {
             return Err(anyhow!("EGRESS_PROXY_JWT_SECRET must not be empty"));
         }
 
-        // TODO(sandbox-egress): Remove EGRESS_PROXY_ALLOWED_DOMAINS when a later PR replaces the
-        // temporary process-wide allowlist with GCS-backed per-sandbox policies.
-        let temporary_allowlist = TemporaryAllowlist::parse(&raw.allowed_domains)?;
+        if raw.policy_bucket.trim().is_empty() {
+            return Err(anyhow!("EGRESS_PROXY_POLICY_BUCKET must not be empty"));
+        }
+
+        if raw.policy_cache_ttl_secs == 0 {
+            return Err(anyhow!(
+                "EGRESS_PROXY_POLICY_CACHE_TTL_SECS must be greater than 0"
+            ));
+        }
+
+        let policy_base_url = raw.policy_base_url.trim().trim_end_matches('/').to_string();
+        if policy_base_url.is_empty() {
+            return Err(anyhow!("EGRESS_PROXY_POLICY_BASE_URL must not be empty"));
+        }
 
         // TODO(sandbox-egress): Remove this test-only bypass once integration tests can exercise
         // forwarding through a non-private deterministic upstream.
@@ -76,7 +101,9 @@ impl TryFrom<RawConfig> for Config {
             tls_cert_path: raw.tls_cert,
             tls_key_path: raw.tls_key,
             jwt_secret: raw.jwt_secret,
-            temporary_allowlist,
+            policy_bucket: raw.policy_bucket,
+            policy_base_url,
+            policy_cache_ttl: Duration::from_secs(raw.policy_cache_ttl_secs),
             unsafe_skip_ssrf_check,
         })
     }
@@ -95,7 +122,10 @@ fn parse_bool_env(value: Option<&str>) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_bool_env;
+    use super::{parse_bool_env, Config, RawConfig, DEFAULT_POLICY_BASE_URL};
+    use anyhow::Result;
+    use std::net::SocketAddr;
+    use std::path::PathBuf;
 
     #[test]
     fn parses_bool_env() {
@@ -108,5 +138,40 @@ mod tests {
         assert!(parse_bool_env(Some("YES")).is_err());
         assert!(parse_bool_env(Some("NO")).is_err());
         assert!(parse_bool_env(Some("maybe")).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_policy_cache_ttl() {
+        assert!(Config::try_from(raw_config(|raw| {
+            raw.policy_cache_ttl_secs = 0;
+        }))
+        .is_err());
+    }
+
+    #[test]
+    fn trims_policy_base_url_trailing_slash() -> Result<()> {
+        let config = Config::try_from(raw_config(|raw| {
+            raw.policy_base_url = format!("{DEFAULT_POLICY_BASE_URL}/");
+        }))?;
+
+        assert_eq!(config.policy_base_url, DEFAULT_POLICY_BASE_URL);
+        Ok(())
+    }
+
+    fn raw_config(update: impl FnOnce(&mut RawConfig)) -> RawConfig {
+        let mut raw = RawConfig {
+            listen_addr: "0.0.0.0:4443".parse::<SocketAddr>().unwrap(),
+            health_addr: "0.0.0.0:8080".parse::<SocketAddr>().unwrap(),
+            tls_cert: PathBuf::from("tls.crt"),
+            tls_key: PathBuf::from("tls.key"),
+            jwt_secret: "secret".to_string(),
+            policy_bucket: "test-bucket".to_string(),
+            policy_cache_ttl_secs: 60,
+            policy_base_url: DEFAULT_POLICY_BASE_URL.to_string(),
+            environment: "production".to_string(),
+            unsafe_skip_ssrf_check: None,
+        };
+        update(&mut raw);
+        raw
     }
 }

--- a/egress-proxy/src/connection.rs
+++ b/egress-proxy/src/connection.rs
@@ -1,9 +1,11 @@
 use crate::blocklist::{is_globally_blocked_domain, is_unsafe_ip};
 use crate::config::Config;
 use crate::dns::DnsResolver;
+use crate::gcs::GcsPolicyProvider;
 use crate::handshake::{read_handshake, Handshake, HandshakeError, ALLOW_RESPONSE, DENY_RESPONSE};
 use crate::jwt::{JwtValidationError, JwtValidator, ValidatedSandboxToken};
-use crate::policy::TemporaryAllowlist;
+use crate::policy::Action;
+use anyhow::Result;
 use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -21,7 +23,7 @@ const UPSTREAM_CONNECT_TIMEOUT_SECONDS: u64 = 5;
 #[derive(Clone)]
 pub struct ConnectionState {
     jwt_validator: JwtValidator,
-    temporary_allowlist: TemporaryAllowlist,
+    policy_provider: GcsPolicyProvider,
     dns_resolver: DnsResolver,
     unsafe_skip_ssrf_check: bool,
 }
@@ -40,7 +42,7 @@ pub enum DenyReason {
     ExpiredJwt,
     InvalidClaims,
     GlobalBlocklist,
-    NotInTemporaryAllowlist,
+    PolicyDenied,
     DnsResolutionFailed,
     UnsafeResolvedIp,
     UpstreamConnectFailed,
@@ -48,13 +50,17 @@ pub enum DenyReason {
 }
 
 impl ConnectionState {
-    pub fn new(config: &Config) -> Self {
-        Self {
+    pub fn new(config: &Config) -> Result<Self> {
+        Ok(Self {
             jwt_validator: JwtValidator::new(&config.jwt_secret),
-            temporary_allowlist: config.temporary_allowlist.clone(),
+            policy_provider: GcsPolicyProvider::new(
+                config.policy_bucket.clone(),
+                config.policy_cache_ttl,
+                config.policy_base_url.clone(),
+            )?,
             dns_resolver: DnsResolver::new(),
             unsafe_skip_ssrf_check: config.unsafe_skip_ssrf_check,
-        }
+        })
     }
 }
 
@@ -70,7 +76,7 @@ impl DenyReason {
             Self::ExpiredJwt => "expired_jwt",
             Self::InvalidClaims => "invalid_claims",
             Self::GlobalBlocklist => "global_blocklist",
-            Self::NotInTemporaryAllowlist => "not_in_temporary_allowlist",
+            Self::PolicyDenied => "policy_denied",
             Self::DnsResolutionFailed => "dns_resolution_failed",
             Self::UnsafeResolvedIp => "unsafe_resolved_ip",
             Self::UpstreamConnectFailed => "upstream_connect_failed",
@@ -170,18 +176,20 @@ async fn handle_connection_inner(
         return Err(DenyReason::GlobalBlocklist);
     }
 
-    if !state
-        .temporary_allowlist
-        .allows(&request.domain, &token.sb_id)
+    if state
+        .policy_provider
+        .evaluate(token.w_id.as_deref(), &token.sb_id, &request.domain)
+        .await
+        != Action::Allow
     {
         deny(
             stream,
-            DenyReason::NotInTemporaryAllowlist,
+            DenyReason::PolicyDenied,
             Some(&token),
             Some(&request),
         )
         .await;
-        return Err(DenyReason::NotInTemporaryAllowlist);
+        return Err(DenyReason::PolicyDenied);
     }
 
     let upstream_addresses = match timeout(

--- a/egress-proxy/src/gcs.rs
+++ b/egress-proxy/src/gcs.rs
@@ -1,0 +1,242 @@
+use crate::policy::{Action, Policy};
+use anyhow::{anyhow, Context, Result};
+use moka::future::Cache;
+use moka::Expiry;
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+use tracing::warn;
+
+const DEFAULT_NEGATIVE_CACHE_TTL_SECONDS: u64 = 10;
+const GCP_METADATA_TOKEN_URL: &str =
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+
+#[derive(Clone)]
+pub struct GcsPolicyProvider {
+    client: Client,
+    bucket: String,
+    base_url: String,
+    cache: Cache<String, CacheEntry>,
+    access_token_cache: Arc<Mutex<Option<(String, Instant)>>>,
+}
+
+#[derive(Clone)]
+enum CacheEntry {
+    Found(Policy),
+    Missing,
+}
+
+#[derive(Clone)]
+struct CacheExpiry {
+    positive_ttl: Duration,
+    negative_ttl: Duration,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+impl GcsPolicyProvider {
+    pub fn new(bucket: String, positive_ttl: Duration, base_url: String) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .context("failed to build GCS HTTP client")?;
+        let cache = Cache::builder()
+            .max_capacity(10_000)
+            .expire_after(CacheExpiry {
+                positive_ttl,
+                negative_ttl: Duration::from_secs(DEFAULT_NEGATIVE_CACHE_TTL_SECONDS),
+            })
+            .build();
+
+        Ok(Self {
+            client,
+            bucket,
+            base_url,
+            cache,
+            access_token_cache: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    pub async fn get_workspace_policy(&self, w_id: &str) -> Result<Option<Policy>> {
+        self.get_policy(&format!("w:{w_id}"), &format!("workspaces/{w_id}.json"))
+            .await
+    }
+
+    pub async fn get_sandbox_policy(&self, sb_id: &str) -> Result<Option<Policy>> {
+        self.get_policy(&format!("s:{sb_id}"), &format!("sandboxes/{sb_id}.json"))
+            .await
+    }
+
+    pub async fn evaluate(&self, w_id: Option<&str>, sb_id: &str, domain: &str) -> Action {
+        let workspace_action = match w_id {
+            Some(workspace_id) => match self.get_workspace_policy(workspace_id).await {
+                Ok(Some(policy)) => policy.evaluate(domain),
+                Ok(None) => Action::Deny,
+                Err(error) => {
+                    warn!(error = %error, w_id = workspace_id, "workspace policy lookup failed");
+                    Action::Deny
+                }
+            },
+            None => Action::Deny,
+        };
+
+        if workspace_action == Action::Allow {
+            return Action::Allow;
+        }
+
+        match self.get_sandbox_policy(sb_id).await {
+            Ok(Some(policy)) => policy.evaluate(domain),
+            Ok(None) => Action::Deny,
+            Err(error) => {
+                warn!(error = %error, sb_id, "sandbox policy lookup failed");
+                Action::Deny
+            }
+        }
+    }
+
+    async fn get_policy(&self, cache_key: &str, object_name: &str) -> Result<Option<Policy>> {
+        if let Some(entry) = self.cache.get(cache_key).await {
+            return Ok(entry.into_policy());
+        }
+
+        let policy = self.fetch_policy(object_name).await?;
+        let cache_entry = match policy {
+            Some(policy) => CacheEntry::Found(policy),
+            None => CacheEntry::Missing,
+        };
+
+        self.cache
+            .insert(cache_key.to_string(), cache_entry.clone())
+            .await;
+
+        Ok(cache_entry.into_policy())
+    }
+
+    async fn fetch_policy(&self, object_name: &str) -> Result<Option<Policy>> {
+        let access_token = self.get_access_token().await?;
+        let object_name = urlencoding::encode(object_name);
+        let url = format!(
+            "{}/b/{}/o/{}?alt=media",
+            self.base_url, self.bucket, object_name
+        );
+
+        let response = self
+            .client
+            .get(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .context("failed to fetch GCS policy object")?;
+
+        match response.status() {
+            StatusCode::OK => {
+                let bytes = response
+                    .bytes()
+                    .await
+                    .context("failed to read GCS policy object body")?;
+                let policy = serde_json::from_slice::<Policy>(&bytes)
+                    .context("failed to deserialize GCS policy object")?;
+                Ok(Some(policy))
+            }
+            StatusCode::NOT_FOUND => Ok(None),
+            status => Err(anyhow!("GCS policy fetch returned status {status}")),
+        }
+    }
+
+    async fn get_access_token(&self) -> Result<String> {
+        if let Ok(token) = std::env::var("GOOGLE_CLOUD_ACCESS_TOKEN") {
+            let trimmed = token.trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed.to_string());
+            }
+        }
+
+        {
+            let cache = self.access_token_cache.lock().await;
+            if let Some((token, expires_at)) = cache.as_ref() {
+                if Instant::now() < *expires_at {
+                    return Ok(token.clone());
+                }
+            }
+        }
+
+        let response = self
+            .client
+            .get(GCP_METADATA_TOKEN_URL)
+            .header("Metadata-Flavor", "Google")
+            .send()
+            .await
+            .context("failed to fetch GCP access token from metadata server")?
+            .error_for_status()
+            .context("metadata server returned an error for access token request")?;
+        let token_response = response
+            .json::<TokenResponse>()
+            .await
+            .context("failed to parse GCP access token response")?;
+
+        let expires_at =
+            Instant::now() + Duration::from_secs(token_response.expires_in.saturating_sub(300));
+        let token = token_response.access_token;
+
+        let mut cache = self.access_token_cache.lock().await;
+        *cache = Some((token.clone(), expires_at));
+
+        Ok(token)
+    }
+}
+
+impl CacheEntry {
+    fn into_policy(self) -> Option<Policy> {
+        match self {
+            Self::Found(policy) => Some(policy),
+            Self::Missing => None,
+        }
+    }
+}
+
+impl Expiry<String, CacheEntry> for CacheExpiry {
+    fn expire_after_create(
+        &self,
+        _key: &String,
+        value: &CacheEntry,
+        _created_at: Instant,
+    ) -> Option<Duration> {
+        Some(self.ttl_for(value))
+    }
+
+    fn expire_after_read(
+        &self,
+        _key: &String,
+        _value: &CacheEntry,
+        _read_at: Instant,
+        duration_until_expiry: Option<Duration>,
+        _last_modified_at: Instant,
+    ) -> Option<Duration> {
+        duration_until_expiry
+    }
+
+    fn expire_after_update(
+        &self,
+        _key: &String,
+        value: &CacheEntry,
+        _updated_at: Instant,
+        _duration_until_expiry: Option<Duration>,
+    ) -> Option<Duration> {
+        Some(self.ttl_for(value))
+    }
+}
+
+impl CacheExpiry {
+    fn ttl_for(&self, value: &CacheEntry) -> Duration {
+        match value {
+            CacheEntry::Found(_) => self.positive_ttl,
+            CacheEntry::Missing => self.negative_ttl,
+        }
+    }
+}

--- a/egress-proxy/src/handshake.rs
+++ b/egress-proxy/src/handshake.rs
@@ -1,4 +1,4 @@
-use crate::domain::{normalize_domain_or_ip, DomainValidationError};
+use crate::domain::{normalize_dns_name, DomainValidationError};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
@@ -92,7 +92,7 @@ fn normalize_domain(domain: &str) -> Result<String, HandshakeError> {
         return Ok(String::new());
     }
 
-    match normalize_domain_or_ip(domain) {
+    match normalize_dns_name(domain) {
         Ok(domain) => Ok(domain),
         Err(DomainValidationError::Empty) => Err(HandshakeError::MalformedHandshake),
         Err(DomainValidationError::Invalid) => Err(HandshakeError::MalformedHandshake),
@@ -193,6 +193,7 @@ mod tests {
             build_frame("token", " example.com", 443),
             build_frame("token", "example..com", 443),
             build_frame("token", "host:443", 443),
+            build_frame("token", "127.0.0.1", 443),
             build_frame("token", ".", 443),
             build_frame("token", "example.com", 0),
         ] {

--- a/egress-proxy/src/jwt.rs
+++ b/egress-proxy/src/jwt.rs
@@ -14,6 +14,7 @@ pub struct JwtValidator {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatedSandboxToken {
     pub sb_id: String,
+    pub w_id: Option<String>,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -30,6 +31,8 @@ pub enum JwtValidationError {
 struct Claims {
     #[serde(rename = "sbId")]
     sb_id: String,
+    #[serde(rename = "wId")]
+    w_id: Option<String>,
     exp: usize,
 }
 
@@ -41,8 +44,6 @@ impl JwtValidator {
     }
 
     pub fn validate(&self, raw_token: &str) -> Result<ValidatedSandboxToken, JwtValidationError> {
-        // TODO(sandbox-egress): Front will mint these JWTs during sandbox setup and write the
-        // per-sandbox policy before user code can execute.
         let mut validation = Validation::new(Algorithm::HS256);
         // TODO(sandbox-egress): Nice-to-have once front token minting is wired: make the
         // front/proxy clock-skew tolerance explicit and cover it with a unit test.
@@ -65,7 +66,21 @@ fn claims_to_validated_token(
 ) -> Result<ValidatedSandboxToken, JwtValidationError> {
     let claims = token.claims;
     let now_seconds = current_unix_timestamp_seconds()?;
+    let raw_w_id = claims.w_id;
+    let w_id = raw_w_id.as_ref().and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    });
+
     if claims.sb_id.trim().is_empty() || claims.exp == 0 {
+        return Err(JwtValidationError::InvalidClaims);
+    }
+
+    if raw_w_id.is_some() && w_id.is_none() {
         return Err(JwtValidationError::InvalidClaims);
     }
 
@@ -75,6 +90,7 @@ fn claims_to_validated_token(
 
     Ok(ValidatedSandboxToken {
         sb_id: claims.sb_id,
+        w_id,
     })
 }
 
@@ -108,6 +124,8 @@ mod tests {
     struct TestClaims<'a> {
         #[serde(rename = "sbId")]
         sb_id: &'a str,
+        #[serde(rename = "wId", skip_serializing_if = "Option::is_none")]
+        w_id: Option<&'a str>,
         iss: &'a str,
         aud: &'a str,
         exp: usize,
@@ -116,19 +134,72 @@ mod tests {
     #[test]
     fn validates_expected_claims() {
         let validator = JwtValidator::new("secret");
-        let token = token("secret", "sbx", EXPECTED_ISSUER, EXPECTED_AUDIENCE, 60);
+        let token = token(
+            "secret",
+            "sbx",
+            Some("workspace"),
+            EXPECTED_ISSUER,
+            EXPECTED_AUDIENCE,
+            60,
+        );
 
         let validated = validator
             .validate(&token)
             .expect("token with valid claims should validate");
 
         assert_eq!(validated.sb_id, "sbx");
+        assert_eq!(validated.w_id.as_deref(), Some("workspace"));
+    }
+
+    #[test]
+    fn accepts_tokens_without_workspace_id() {
+        let validator = JwtValidator::new("secret");
+        let token = token(
+            "secret",
+            "sbx",
+            None,
+            EXPECTED_ISSUER,
+            EXPECTED_AUDIENCE,
+            60,
+        );
+
+        let validated = validator
+            .validate(&token)
+            .expect("token without wId should validate during rollout");
+
+        assert_eq!(validated.sb_id, "sbx");
+        assert_eq!(validated.w_id, None);
+    }
+
+    #[test]
+    fn rejects_empty_workspace_id_when_present() {
+        let validator = JwtValidator::new("secret");
+        let token = token(
+            "secret",
+            "sbx",
+            Some("   "),
+            EXPECTED_ISSUER,
+            EXPECTED_AUDIENCE,
+            60,
+        );
+
+        assert_eq!(
+            validator.validate(&token).unwrap_err(),
+            JwtValidationError::InvalidClaims
+        );
     }
 
     #[test]
     fn rejects_expired_tokens() {
         let validator = JwtValidator::new("secret");
-        let token = token("secret", "sbx", EXPECTED_ISSUER, EXPECTED_AUDIENCE, -60);
+        let token = token(
+            "secret",
+            "sbx",
+            Some("workspace"),
+            EXPECTED_ISSUER,
+            EXPECTED_AUDIENCE,
+            -60,
+        );
 
         assert_eq!(
             validator.validate(&token).unwrap_err(),
@@ -139,7 +210,14 @@ mod tests {
     #[test]
     fn rejects_wrong_audience() {
         let validator = JwtValidator::new("secret");
-        let token = token("secret", "sbx", EXPECTED_ISSUER, "wrong", 60);
+        let token = token(
+            "secret",
+            "sbx",
+            Some("workspace"),
+            EXPECTED_ISSUER,
+            "wrong",
+            60,
+        );
 
         assert_eq!(
             validator.validate(&token).unwrap_err(),
@@ -147,7 +225,14 @@ mod tests {
         );
     }
 
-    fn token(secret: &str, sb_id: &str, iss: &str, aud: &str, exp_offset_seconds: i64) -> String {
+    fn token(
+        secret: &str,
+        sb_id: &str,
+        w_id: Option<&str>,
+        iss: &str,
+        aud: &str,
+        exp_offset_seconds: i64,
+    ) -> String {
         let now_seconds = i64::try_from(
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
@@ -159,6 +244,7 @@ mod tests {
         let exp = usize::try_from(exp_seconds).expect("expiration timestamp should fit in usize");
         let claims = TestClaims {
             sb_id,
+            w_id,
             iss,
             aud,
             exp,

--- a/egress-proxy/src/main.rs
+++ b/egress-proxy/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod connection;
 mod dns;
 mod domain;
+mod gcs;
 mod handshake;
 mod health;
 mod jwt;
@@ -10,7 +11,7 @@ mod policy;
 mod server;
 mod tls;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use config::Config;
 use tracing::{error, info};
 
@@ -23,6 +24,9 @@ async fn main() {
 }
 
 async fn run() -> Result<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .map_err(|_| anyhow!("failed to install rustls crypto provider"))?;
     init_tracing();
 
     let config = Config::from_env()?;

--- a/egress-proxy/src/policy.rs
+++ b/egress-proxy/src/policy.rs
@@ -1,9 +1,25 @@
-use crate::domain::{normalize_dns_name, normalize_domain_or_ip};
+use crate::domain::normalize_dns_name;
 use anyhow::{anyhow, Result};
+use serde::{Deserialize, Deserializer};
 
-#[derive(Debug, Clone)]
-pub struct TemporaryAllowlist {
-    patterns: Vec<DomainPattern>,
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Policy {
+    default_action: Action,
+    rules: Vec<PolicyRule>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Action {
+    Allow,
+    Deny,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PolicyRule {
+    domain: DomainPattern,
+    action: Action,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12,43 +28,20 @@ enum DomainPattern {
     WildcardSuffix(String),
 }
 
-impl TemporaryAllowlist {
-    pub fn parse(value: &str) -> Result<Self> {
-        let mut patterns = Vec::new();
-
-        for raw_entry in value.split(',') {
-            let entry = raw_entry.trim();
-            if entry.is_empty() {
-                continue;
+impl Policy {
+    pub fn evaluate(&self, domain: &str) -> Action {
+        for rule in &self.rules {
+            if rule.domain.matches(domain) {
+                return rule.action;
             }
-            patterns.push(DomainPattern::parse(entry)?);
         }
 
-        if patterns.is_empty() {
-            return Err(anyhow!("EGRESS_PROXY_ALLOWED_DOMAINS must not be empty"));
-        }
-
-        Ok(Self { patterns })
-    }
-
-    pub fn allows(&self, domain: &str, sb_id: &str) -> bool {
-        // TODO(sandbox-egress): Replace this static env allowlist with the GCS-backed
-        // per-sandbox policy provider. The production policy source is
-        // gs://<regional-sandbox-egress-policies>/policies/{sbId}.json.
-
-        // TODO(sandbox-egress): Use sb_id to fetch policies/{sbId}.json from GCS. PR 1 uses
-        // the same temporary allowlist for every sandbox so we can validate the proxy protocol
-        // independently from front and GCS integration.
-        let _ = sb_id;
-
-        self.patterns.iter().any(|pattern| pattern.matches(domain))
+        self.default_action
     }
 }
 
 impl DomainPattern {
     fn parse(value: &str) -> Result<Self> {
-        // TODO(sandbox-egress): Replace the minimal domain allowlist with the full policy schema
-        // (defaultAction + rules) once front starts writing policy files.
         let value = value.trim().to_ascii_lowercase();
         if let Some(suffix) = value.strip_prefix("*.") {
             let suffix = normalize_dns_name(suffix)
@@ -59,9 +52,9 @@ impl DomainPattern {
             return Ok(Self::WildcardSuffix(suffix));
         }
 
-        let value =
-            normalize_domain_or_ip(&value).map_err(|_| anyhow!("invalid domain entry: {value}"))?;
-        Ok(Self::Exact(value))
+        let exact =
+            normalize_dns_name(&value).map_err(|_| anyhow!("invalid domain entry: {value}"))?;
+        Ok(Self::Exact(exact))
     }
 
     fn matches(&self, domain: &str) -> bool {
@@ -76,51 +69,101 @@ impl DomainPattern {
     }
 }
 
-// TODO(sandbox-egress): Add a bounded TTL cache for GCS policies to avoid reading on
-// every connection.
+impl<'de> Deserialize<'de> for DomainPattern {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(&value).map_err(serde::de::Error::custom)
+    }
+}
 
 #[cfg(test)]
 mod tests {
-    use super::TemporaryAllowlist;
+    use super::{Action, Policy};
 
     #[test]
     fn exact_domains_match_case_insensitively_after_parse() {
-        let allowlist =
-            TemporaryAllowlist::parse("Example.COM").expect("valid domain entry should parse");
+        let policy: Policy = serde_json::from_str(
+            r#"{
+                "defaultAction": "deny",
+                "rules": [{ "domain": "Example.COM", "action": "allow" }]
+            }"#,
+        )
+        .expect("valid policy should parse");
 
-        assert!(allowlist.allows("example.com", "sbx"));
-        assert!(!allowlist.allows("api.example.com", "sbx"));
-    }
-
-    #[test]
-    fn exact_ip_literals_are_valid_entries() {
-        let allowlist = TemporaryAllowlist::parse("127.0.0.1,::ffff:127.0.0.1")
-            .expect("valid IP literal entries should parse");
-
-        assert!(allowlist.allows("127.0.0.1", "sbx"));
-        assert!(allowlist.allows("::ffff:127.0.0.1", "sbx"));
+        assert_eq!(policy.evaluate("example.com"), Action::Allow);
+        assert_eq!(policy.evaluate("api.example.com"), Action::Deny);
     }
 
     #[test]
     fn wildcard_matches_subdomains_only() {
-        let allowlist =
-            TemporaryAllowlist::parse("*.example.com").expect("valid wildcard entry should parse");
+        let policy: Policy = serde_json::from_str(
+            r#"{
+                "defaultAction": "deny",
+                "rules": [{ "domain": "*.example.com", "action": "allow" }]
+            }"#,
+        )
+        .expect("valid policy should parse");
 
-        assert!(allowlist.allows("api.example.com", "sbx"));
-        assert!(allowlist.allows("a.b.example.com", "sbx"));
-        assert!(!allowlist.allows("example.com", "sbx"));
+        assert_eq!(policy.evaluate("api.example.com"), Action::Allow);
+        assert_eq!(policy.evaluate("a.b.example.com"), Action::Allow);
+        assert_eq!(policy.evaluate("example.com"), Action::Deny);
     }
 
     #[test]
-    fn invalid_entries_fail_startup() {
-        assert!(TemporaryAllowlist::parse("example.com, bad domain").is_err());
-        assert!(TemporaryAllowlist::parse(" , ").is_err());
-        assert!(TemporaryAllowlist::parse("*").is_err());
-        assert!(TemporaryAllowlist::parse("*.*.com").is_err());
-        assert!(TemporaryAllowlist::parse("*example.com").is_err());
-        assert!(TemporaryAllowlist::parse(".example.com").is_err());
-        assert!(TemporaryAllowlist::parse("example..com").is_err());
-        assert!(TemporaryAllowlist::parse("host:443").is_err());
-        assert!(TemporaryAllowlist::parse("*.com").is_err());
+    fn first_matching_rule_wins() {
+        let policy: Policy = serde_json::from_str(
+            r#"{
+                "defaultAction": "allow",
+                "rules": [
+                    { "domain": "*.example.com", "action": "deny" },
+                    { "domain": "api.example.com", "action": "allow" }
+                ]
+            }"#,
+        )
+        .expect("valid policy should parse");
+
+        assert_eq!(policy.evaluate("api.example.com"), Action::Deny);
+        assert_eq!(policy.evaluate("other.example.com"), Action::Deny);
+        assert_eq!(policy.evaluate("dust.tt"), Action::Allow);
+    }
+
+    #[test]
+    fn invalid_entries_fail_deserialization() {
+        for domain in [
+            "127.0.0.1",
+            "::1",
+            "*",
+            "*.*.com",
+            "*example.com",
+            ".example.com",
+            "example..com",
+            "host:443",
+            "*.com",
+        ] {
+            let policy = format!(
+                r#"{{
+                    "defaultAction": "deny",
+                    "rules": [{{ "domain": "{domain}", "action": "allow" }}]
+                }}"#
+            );
+            assert!(
+                serde_json::from_str::<Policy>(&policy).is_err(),
+                "{domain} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_action_fails_deserialization() {
+        assert!(serde_json::from_str::<Policy>(
+            r#"{
+                    "defaultAction": "deny",
+                    "rules": [{ "domain": "example.com", "action": "block" }]
+                }"#,
+        )
+        .is_err());
     }
 }

--- a/egress-proxy/src/server.rs
+++ b/egress-proxy/src/server.rs
@@ -22,7 +22,7 @@ pub async fn run(config: Config) -> Result<()> {
     let proxy_addr = listener.local_addr()?;
     let health_listener = TcpListener::bind(config.health_addr).await?;
     let health_addr = health_listener.local_addr()?;
-    let state = Arc::new(ConnectionState::new(&config));
+    let state = Arc::new(ConnectionState::new(&config)?);
 
     // TODO(sandbox-egress): Confirm final certificate provisioning path once the Kubernetes
     // deployment and DNS name are introduced.

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -1,13 +1,22 @@
 use anyhow::{anyhow, Result};
+use axum::extract::State;
+use axum::http::{header, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use axum::routing::any;
+use axum::Router;
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use rustls::pki_types::{pem::PemObject, CertificateDer, ServerName};
 use rustls::RootCertStore;
 use serde::Serialize;
+use serde_json::json;
+use std::collections::HashMap;
 use std::fs::write;
+use std::io::Read;
 use std::net::{Ipv6Addr, SocketAddr, TcpListener as StdTcpListener};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
+use std::sync::Once;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -18,19 +27,48 @@ use tokio_rustls::TlsConnector;
 const SECRET: &str = "test-secret";
 const ALLOW_RESPONSE: u8 = 0x00;
 const DENY_RESPONSE: u8 = 0x01;
+const TEST_BUCKET: &str = "test-egress-policies";
+const TEST_WORKSPACE_ID: &str = "workspace-123";
+const TEST_SANDBOX_ID: &str = "test-egress-proxy";
+static INSTALL_RUSTLS_PROVIDER: Once = Once::new();
 
 struct ProxyProcess {
     child: Child,
     _temp_dir: TempDir,
+    _mock_gcs: MockGcsServer,
     ca_cert_path: PathBuf,
     proxy_addr: SocketAddr,
     health_addr: SocketAddr,
+}
+
+struct MockGcsServer {
+    addr: SocketAddr,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Clone)]
+struct MockGcsState {
+    objects: Arc<HashMap<String, MockGcsResponse>>,
+}
+
+#[derive(Clone)]
+enum MockGcsResponse {
+    Policy(String),
+    Status(StatusCode),
+}
+
+#[derive(Default)]
+struct MockPolicies {
+    sandbox: Option<MockGcsResponse>,
+    workspace: Option<MockGcsResponse>,
 }
 
 #[derive(Debug, Serialize)]
 struct TestClaims {
     #[serde(rename = "sbId")]
     sb_id: String,
+    #[serde(rename = "wId", skip_serializing_if = "Option::is_none")]
+    w_id: Option<String>,
     iss: String,
     aud: String,
     exp: usize,
@@ -40,6 +78,12 @@ impl Drop for ProxyProcess {
     fn drop(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
+    }
+}
+
+impl Drop for MockGcsServer {
+    fn drop(&mut self) {
+        self.handle.abort();
     }
 }
 
@@ -68,7 +112,9 @@ async fn invalid_tls_assets_fail_startup() -> Result<()> {
         .env("EGRESS_PROXY_TLS_CERT", temp_dir.path().join("missing.crt"))
         .env("EGRESS_PROXY_TLS_KEY", &tls_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
-        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "example.com")
+        .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
+        .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
+        .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
         .env("EGRESS_PROXY_ENV", "production")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -78,7 +124,7 @@ async fn invalid_tls_assets_fail_startup() -> Result<()> {
 }
 
 #[tokio::test]
-async fn invalid_allowed_domain_fails_startup() -> Result<()> {
+async fn missing_policy_bucket_fails_startup() -> Result<()> {
     let temp_dir = TempDir::new()?;
     let certs = generate_test_certs(temp_dir.path())?;
     let proxy_addr = free_addr()?;
@@ -90,7 +136,8 @@ async fn invalid_allowed_domain_fails_startup() -> Result<()> {
         .env("EGRESS_PROXY_TLS_CERT", &certs.server_cert_path)
         .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
-        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "example..com")
+        .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
+        .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
         .env("EGRESS_PROXY_ENV", "production")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -105,6 +152,143 @@ async fn allowed_domain_forwards_bytes() -> Result<()> {
         start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
     let proxy = start_proxy("localhost", true, "test").await?;
     let token = make_token(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn workspace_policy_allows_bytes_without_sandbox_policy() -> Result<()> {
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_policies(
+        MockPolicies {
+            workspace: Some(policy_response(&["localhost"])),
+            ..MockPolicies::default()
+        },
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn workspace_lookup_failure_falls_back_to_sandbox_policy() -> Result<()> {
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_policies(
+        MockPolicies {
+            sandbox: Some(policy_response(&["localhost"])),
+            workspace: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
+        },
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn sandbox_lookup_failure_falls_back_to_workspace_policy() -> Result<()> {
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_policies(
+        MockPolicies {
+            sandbox: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
+            workspace: Some(policy_response(&["localhost"])),
+        },
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn sandbox_policy_still_applies_when_token_has_no_workspace_id() -> Result<()> {
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy("localhost", true, "test").await?;
+    let token = make_token_with_claims(
+        SECRET,
+        FullClaims {
+            sb_id: TEST_SANDBOX_ID,
+            w_id: None,
+            iss: "dust-front",
+            aud: "dust-egress-proxy",
+            exp_offset_seconds: 60,
+        },
+    );
     let mut stream = connect_forwarder(&proxy).await?;
 
     stream
@@ -164,7 +348,8 @@ async fn invalid_issuer_returns_deny() -> Result<()> {
     let token = make_token_with_claims(
         SECRET,
         FullClaims {
-            sb_id: "test-egress-proxy",
+            sb_id: TEST_SANDBOX_ID,
+            w_id: Some(TEST_WORKSPACE_ID),
             iss: "wrong-front",
             aud: "dust-egress-proxy",
             exp_offset_seconds: 60,
@@ -183,7 +368,8 @@ async fn invalid_audience_returns_deny() -> Result<()> {
     let token = make_token_with_claims(
         SECRET,
         FullClaims {
-            sb_id: "test-egress-proxy",
+            sb_id: TEST_SANDBOX_ID,
+            w_id: Some(TEST_WORKSPACE_ID),
             iss: "dust-front",
             aud: "wrong-audience",
             exp_offset_seconds: 60,
@@ -203,6 +389,7 @@ async fn empty_sandbox_id_claim_returns_deny() -> Result<()> {
         SECRET,
         FullClaims {
             sb_id: "   ",
+            w_id: Some(TEST_WORKSPACE_ID),
             iss: "dust-front",
             aud: "dust-egress-proxy",
             exp_offset_seconds: 60,
@@ -360,7 +547,9 @@ async fn unsafe_ssrf_bypass_fails_startup_outside_test_env() -> Result<()> {
         .env("EGRESS_PROXY_TLS_CERT", certs.server_cert_path)
         .env("EGRESS_PROXY_TLS_KEY", certs.server_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
-        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "127.0.0.1")
+        .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
+        .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
+        .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
         .env("EGRESS_PROXY_ENV", "production")
         .env("EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK", "1")
         .stdout(Stdio::null())
@@ -384,7 +573,9 @@ async fn health_bind_failure_fails_startup() -> Result<()> {
         .env("EGRESS_PROXY_TLS_CERT", certs.server_cert_path)
         .env("EGRESS_PROXY_TLS_KEY", certs.server_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
-        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "localhost")
+        .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
+        .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
+        .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
         .env("EGRESS_PROXY_ENV", "production")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -509,10 +700,35 @@ async fn start_proxy(
     unsafe_skip_ssrf_check: bool,
     environment: &str,
 ) -> Result<ProxyProcess> {
+    let policy = policy_response(
+        &allowed_domains
+            .split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .collect::<Vec<_>>(),
+    );
+
+    start_proxy_with_policies(
+        MockPolicies {
+            sandbox: Some(policy),
+            ..MockPolicies::default()
+        },
+        unsafe_skip_ssrf_check,
+        environment,
+    )
+    .await
+}
+
+async fn start_proxy_with_policies(
+    policies: MockPolicies,
+    unsafe_skip_ssrf_check: bool,
+    environment: &str,
+) -> Result<ProxyProcess> {
     let temp_dir = TempDir::new()?;
     let certs = generate_test_certs(temp_dir.path())?;
     let proxy_addr = free_addr()?;
     let health_addr = free_addr()?;
+    let mock_gcs = start_mock_gcs_server(policies).await?;
 
     let mut command = Command::new(env!("CARGO_BIN_EXE_egress-proxy"));
     command
@@ -521,10 +737,15 @@ async fn start_proxy(
         .env("EGRESS_PROXY_TLS_CERT", &certs.server_cert_path)
         .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
-        .env("EGRESS_PROXY_ALLOWED_DOMAINS", allowed_domains)
+        .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
+        .env(
+            "EGRESS_PROXY_POLICY_BASE_URL",
+            format!("http://{}", mock_gcs.addr),
+        )
+        .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
         .env("EGRESS_PROXY_ENV", environment)
         .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stderr(Stdio::piped());
 
     if unsafe_skip_ssrf_check {
         command.env("EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK", "1");
@@ -533,6 +754,7 @@ async fn start_proxy(
     let mut proxy = ProxyProcess {
         child: command.spawn()?,
         _temp_dir: temp_dir,
+        _mock_gcs: mock_gcs,
         ca_cert_path: certs.ca_cert_path,
         proxy_addr,
         health_addr,
@@ -543,10 +765,70 @@ async fn start_proxy(
     Ok(proxy)
 }
 
+async fn start_mock_gcs_server(policies: MockPolicies) -> Result<MockGcsServer> {
+    let mut objects = HashMap::new();
+    if let Some(workspace) = policies.workspace {
+        objects.insert(format!("workspaces/{TEST_WORKSPACE_ID}.json"), workspace);
+    }
+    if let Some(sandbox) = policies.sandbox {
+        objects.insert(format!("sandboxes/{TEST_SANDBOX_ID}.json"), sandbox);
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let state = MockGcsState {
+        objects: Arc::new(objects),
+    };
+    let app = Router::new()
+        .fallback(any(mock_gcs_handler))
+        .with_state(state);
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    Ok(MockGcsServer { addr, handle })
+}
+
+async fn mock_gcs_handler(State(state): State<MockGcsState>, uri: Uri) -> Response {
+    let Some(encoded_object) = uri.path().split("/o/").nth(1) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let Ok(object_name) = urlencoding::decode(encoded_object) else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+
+    match state.objects.get(object_name.as_ref()) {
+        Some(MockGcsResponse::Policy(body)) => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            body.clone(),
+        )
+            .into_response(),
+        Some(MockGcsResponse::Status(status)) => status.into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+fn policy_response(domains: &[&str]) -> MockGcsResponse {
+    MockGcsResponse::Policy(
+        json!({
+            "defaultAction": "deny",
+            "rules": domains
+                .iter()
+                .map(|domain| json!({ "action": "allow", "domain": domain }))
+                .collect::<Vec<_>>(),
+        })
+        .to_string(),
+    )
+}
+
 async fn wait_for_health(child: &mut Child, health_addr: SocketAddr) -> Result<()> {
     for _ in 0..100 {
         if let Some(status) = child.try_wait()? {
-            return Err(anyhow!("proxy exited before becoming healthy: {status}"));
+            let stderr = read_child_stderr(child)?;
+            return Err(anyhow!(
+                "proxy exited before becoming healthy: {status}; stderr: {stderr}"
+            ));
         }
 
         if let Ok(response) = http_get(health_addr, "/healthz").await {
@@ -559,6 +841,16 @@ async fn wait_for_health(child: &mut Child, health_addr: SocketAddr) -> Result<(
     }
 
     Err(anyhow!("proxy did not become healthy"))
+}
+
+fn read_child_stderr(child: &mut Child) -> Result<String> {
+    let Some(stderr) = child.stderr.as_mut() else {
+        return Ok("<stderr not captured>".to_string());
+    };
+
+    let mut output = String::new();
+    stderr.read_to_string(&mut output)?;
+    Ok(output.trim().to_string())
 }
 
 async fn wait_for_startup_failure(child: &mut Child) -> Result<()> {
@@ -611,6 +903,10 @@ async fn send_raw_frame(proxy: &ProxyProcess, frame: &[u8]) -> Result<Option<u8>
 async fn connect_forwarder(
     proxy: &ProxyProcess,
 ) -> Result<tokio_rustls::client::TlsStream<TcpStream>> {
+    INSTALL_RUSTLS_PROVIDER.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+
     let mut root_store = RootCertStore::empty();
     for cert in load_certs(&proxy.ca_cert_path)? {
         root_store.add(cert)?;
@@ -664,7 +960,8 @@ fn make_token(secret: &str, exp_offset_seconds: i64) -> String {
     make_token_with_claims(
         secret,
         FullClaims {
-            sb_id: "test-egress-proxy",
+            sb_id: TEST_SANDBOX_ID,
+            w_id: Some(TEST_WORKSPACE_ID),
             iss: "dust-front",
             aud: "dust-egress-proxy",
             exp_offset_seconds,
@@ -684,6 +981,7 @@ fn make_token_with_claims(secret: &str, claims: FullClaims<'_>) -> String {
     };
     let claims = TestClaims {
         sb_id: claims.sb_id.to_string(),
+        w_id: claims.w_id.map(str::to_string),
         iss: claims.iss.to_string(),
         aud: claims.aud.to_string(),
         exp: usize::try_from(exp).expect("expiration timestamp should fit in usize"),
@@ -705,6 +1003,7 @@ struct TestCerts {
 
 struct FullClaims<'a> {
     sb_id: &'a str,
+    w_id: Option<&'a str>,
     iss: &'a str,
     aud: &'a str,
     exp_offset_seconds: i64,

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -208,6 +208,9 @@ const config = {
 
     return port;
   },
+  getEgressPolicyBucket: (): string => {
+    return EnvironmentConfig.getEnvVariable("EGRESS_PROXY_POLICY_BUCKET");
+  },
   getEgressProxyTlsName: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("EGRESS_PROXY_TLS_NAME");
   },

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -55,6 +55,10 @@ import {
 } from "./egress";
 
 describe("sandbox egress helpers", () => {
+  const auth = {
+    getNonNullableWorkspace: () => ({ sId: "workspace-id" }),
+  } as never;
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -67,7 +71,7 @@ describe("sandbox egress helpers", () => {
   });
 
   it("mints a proxy JWT bound to the provider sandbox id", () => {
-    const token = mintEgressJwt("provider-sandbox-id");
+    const token = mintEgressJwt("provider-sandbox-id", "workspace-id");
     const payload = jwt.verify(token, "egress-secret", {
       algorithms: ["HS256"],
       audience: "dust-egress-proxy",
@@ -75,6 +79,7 @@ describe("sandbox egress helpers", () => {
     }) as jwt.JwtPayload;
 
     expect(payload.sbId).toBe("provider-sandbox-id");
+    expect(payload.wId).toBe("workspace-id");
     expect(payload.exp).toBeGreaterThan(payload.iat ?? 0);
   });
 
@@ -91,34 +96,34 @@ describe("sandbox egress helpers", () => {
         .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
     };
 
-    const result = await setupEgressForwarder({} as never, sandbox as never);
+    const result = await setupEgressForwarder(auth, sandbox as never);
 
     expect(result).toEqual(new Ok(undefined));
     expect(mockLookup).toHaveBeenCalledWith("eu.sandbox-egress.dust.tt", {
       family: 4,
     });
     expect(sandbox.writeFile).toHaveBeenCalledWith(
-      {},
+      auth,
       "/etc/dust/egress-token",
       expect.anything()
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       1,
-      {},
-      expect.stringContaining("chmod 600"),
+      auth,
+      expect.stringContaining("chown dust-fwd:dust-fwd"),
       { user: "root" }
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       2,
-      {},
+      auth,
       expect.stringContaining("--proxy-addr '203.0.113.10:4443'"),
-      { user: "root" }
+      { user: "dust-fwd" }
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       2,
-      {},
+      auth,
       expect.stringContaining("--proxy-tls-name 'eu.sandbox-egress.dust.tt'"),
-      { user: "root" }
+      { user: "dust-fwd" }
     );
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -141,7 +146,7 @@ describe("sandbox egress helpers", () => {
       ),
     };
 
-    const result = await readNewDenyLogEntries({} as never, sandbox as never);
+    const result = await readNewDenyLogEntries(auth, sandbox as never);
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -151,7 +156,7 @@ describe("sandbox egress helpers", () => {
       ]);
     }
     expect(sandbox.exec).toHaveBeenCalledWith(
-      {},
+      auth,
       expect.stringContaining("dust-egress-denied.log"),
       { user: "root", timeoutMs: 2_000 }
     );
@@ -164,7 +169,7 @@ describe("sandbox egress helpers", () => {
         .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
     };
 
-    const result = await readNewDenyLogEntries({} as never, sandbox as never);
+    const result = await readNewDenyLogEntries(auth, sandbox as never);
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -182,7 +187,7 @@ describe("sandbox egress helpers", () => {
         .mockResolvedValue(new Err(new Error("sandbox command failed"))),
     };
 
-    const result = await setupEgressForwarder({} as never, sandbox as never);
+    const result = await setupEgressForwarder(auth, sandbox as never);
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -71,12 +71,13 @@ async function runSuccessfulSandboxCommand(
   return new Ok(undefined);
 }
 
-export function mintEgressJwt(providerId: string): string {
+export function mintEgressJwt(providerId: string, workspaceId: string): string {
   return jwt.sign(
     {
       iss: "dust-front",
       aud: "dust-egress-proxy",
       sbId: providerId,
+      wId: workspaceId,
     },
     config.getEgressProxyJwtSecret(),
     {
@@ -123,7 +124,10 @@ export async function setupEgressForwarder(
     return new Err(error instanceof Error ? error : new Error(String(error)));
   }
 
-  const token = mintEgressJwt(sandbox.providerId);
+  const token = mintEgressJwt(
+    sandbox.providerId,
+    auth.getNonNullableWorkspace().sId
+  );
   const tokenWriteResult = await sandbox.writeFile(
     auth,
     EGRESS_TOKEN_PATH,
@@ -136,16 +140,13 @@ export async function setupEgressForwarder(
   const chmodResult = await runSuccessfulSandboxCommand(
     auth,
     sandbox,
-    `chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)}`,
+    `chown dust-fwd:dust-fwd ${shellEscape(EGRESS_TOKEN_PATH)} && chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)}`,
     "root"
   );
   if (chmodResult.isErr()) {
     return chmodResult;
   }
 
-  // The forwarder runs as root. The nftables rules only redirect traffic
-  // from agent-proxied (uid 1003), so root's outbound connections go
-  // straight to the internet without looping back through the proxy.
   const startForwarderCommand =
     "nohup /opt/bin/dsbx forward " +
     `--token-file ${shellEscape(EGRESS_TOKEN_PATH)} ` +
@@ -159,7 +160,7 @@ export async function setupEgressForwarder(
     auth,
     sandbox,
     startForwarderCommand,
-    "root"
+    "dust-fwd"
   );
   if (startResult.isErr()) {
     return startResult;

--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -1,0 +1,81 @@
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockDelete,
+  mockGetBucketInstance,
+  mockGetEgressPolicyBucket,
+  mockUploadRawContentToBucket,
+} = vi.hoisted(() => ({
+  mockDelete: vi.fn(),
+  mockGetBucketInstance: vi.fn(),
+  mockGetEgressPolicyBucket: vi.fn(),
+  mockUploadRawContentToBucket: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getEgressPolicyBucket: mockGetEgressPolicyBucket,
+  },
+}));
+
+vi.mock("@app/lib/file_storage", () => ({
+  getBucketInstance: mockGetBucketInstance,
+}));
+
+import {
+  deleteSandboxPolicy,
+  EMPTY_EGRESS_POLICY,
+  writeSandboxPolicy,
+} from "./egress_policy";
+
+describe("sandbox egress policy storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGetEgressPolicyBucket.mockReturnValue("egress-policy-bucket");
+    mockUploadRawContentToBucket.mockResolvedValue(undefined);
+    mockDelete.mockResolvedValue(undefined);
+    mockGetBucketInstance.mockReturnValue({
+      delete: mockDelete,
+      uploadRawContentToBucket: mockUploadRawContentToBucket,
+    });
+  });
+
+  it("writes sandbox policy files under the sandbox prefix", async () => {
+    const result = await writeSandboxPolicy("provider-sandbox-id", {
+      defaultAction: "deny",
+      rules: [{ action: "allow", domain: "example.com" }],
+    });
+
+    expect(result).toEqual(new Ok(undefined));
+    expect(mockGetBucketInstance).toHaveBeenCalledWith("egress-policy-bucket");
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
+      content: JSON.stringify({
+        defaultAction: "deny",
+        rules: [{ action: "allow", domain: "example.com" }],
+      }),
+      contentType: "application/json",
+      filePath: "sandboxes/provider-sandbox-id.json",
+    });
+  });
+
+  it("deletes sandbox policy files and ignores missing objects", async () => {
+    const result = await deleteSandboxPolicy("provider-sandbox-id");
+
+    expect(result).toEqual(new Ok(undefined));
+    expect(mockDelete).toHaveBeenCalledWith(
+      "sandboxes/provider-sandbox-id.json",
+      {
+        ignoreNotFound: true,
+      }
+    );
+  });
+
+  it("exports the empty deny-all sandbox policy", () => {
+    expect(EMPTY_EGRESS_POLICY).toEqual({
+      defaultAction: "deny",
+      rules: [],
+    });
+  });
+});

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -1,0 +1,66 @@
+import config from "@app/lib/api/config";
+import { getBucketInstance } from "@app/lib/file_storage";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export type EgressPolicyAction = "allow" | "deny";
+
+export interface EgressPolicyRule {
+  action: EgressPolicyAction;
+  domain: string;
+}
+
+export interface EgressPolicy {
+  defaultAction: EgressPolicyAction;
+  rules: EgressPolicyRule[];
+}
+
+export const EMPTY_EGRESS_POLICY: EgressPolicy = {
+  defaultAction: "deny",
+  rules: [],
+};
+
+function getSandboxPolicyPath(providerId: string): string {
+  return `sandboxes/${providerId}.json`;
+}
+
+function getPolicyBucket() {
+  return getBucketInstance(config.getEgressPolicyBucket());
+}
+
+export async function writeSandboxPolicy(
+  providerId: string,
+  policy: EgressPolicy
+): Promise<Result<void, Error>> {
+  try {
+    await getPolicyBucket().uploadRawContentToBucket({
+      content: JSON.stringify(policy),
+      contentType: "application/json",
+      filePath: getSandboxPolicyPath(providerId),
+    });
+
+    return new Ok(undefined);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+export async function writeEmptySandboxPolicy(
+  providerId: string
+): Promise<Result<void, Error>> {
+  return writeSandboxPolicy(providerId, EMPTY_EGRESS_POLICY);
+}
+
+export async function deleteSandboxPolicy(
+  providerId: string
+): Promise<Result<void, Error>> {
+  try {
+    await getPolicyBucket().delete(getSandboxPolicyPath(providerId), {
+      ignoreNotFound: true,
+    });
+
+    return new Ok(undefined);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,6 +1,10 @@
 import config from "@app/lib/api/config";
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { revokeAllExecTokensForSandbox } from "@app/lib/api/sandbox/access_tokens";
+import {
+  deleteSandboxPolicy,
+  writeEmptySandboxPolicy,
+} from "@app/lib/api/sandbox/egress_policy";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import {
   recordLifecycleOperation,
@@ -277,6 +281,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         }
       }
 
+      await this.cleanupSandboxPolicy(sandbox.providerId, {
+        sandbox: sandbox.toLogJSON(),
+      });
+
       await SandboxModel.destroy({
         where: {
           id: sandbox.id,
@@ -304,6 +312,45 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     return executeWithLock(`sandbox:lifecycle:${conversationId}`, () =>
       fn(provider)
     );
+  }
+
+  private static async cleanupSandboxPolicy(
+    providerId: string,
+    logContext: Record<string, unknown>
+  ): Promise<void> {
+    const deleteResult = await deleteSandboxPolicy(providerId);
+    if (deleteResult.isErr()) {
+      logger.error(
+        {
+          ...logContext,
+          providerId,
+          error: deleteResult.error.message,
+        },
+        "Failed to delete sandbox egress policy."
+      );
+    }
+  }
+
+  private static async destroyProviderSandboxBestEffort(
+    provider: SandboxProvider,
+    providerId: string,
+    tracingOpts: { workspaceId: string },
+    logContext: Record<string, unknown>
+  ): Promise<void> {
+    const destroyResult = await provider.destroy(providerId, tracingOpts);
+    if (
+      destroyResult.isErr() &&
+      !(destroyResult.error instanceof SandboxNotFoundError)
+    ) {
+      logger.error(
+        {
+          ...logContext,
+          providerId,
+          error: destroyResult.error.message,
+        },
+        "Failed to destroy sandbox at provider during cleanup."
+      );
+    }
   }
 
   /**
@@ -351,6 +398,23 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         );
         if (createResult.isErr()) {
           return createResult;
+        }
+
+        const writePolicyResult = await writeEmptySandboxPolicy(
+          createResult.value.providerId
+        );
+        if (writePolicyResult.isErr()) {
+          await this.destroyProviderSandboxBestEffort(
+            provider,
+            createResult.value.providerId,
+            tracingOpts,
+            {
+              conversationId: conversation.sId,
+              workspaceId: auth.getNonNullableWorkspace().sId,
+            }
+          );
+
+          return writePolicyResult;
         }
 
         const sandbox = await SandboxResource.makeNew(auth, {
@@ -432,6 +496,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         // Falls through to recreation when wake fails.
 
         case "deleted": {
+          const oldProviderId = existing.providerId;
           const imageResult = getSandboxImage(auth);
           if (imageResult.isErr()) {
             return imageResult;
@@ -455,8 +520,33 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           if (createResult.isErr()) {
             return createResult;
           }
+
+          const writePolicyResult = await writeEmptySandboxPolicy(
+            createResult.value.providerId
+          );
+          if (writePolicyResult.isErr()) {
+            await this.destroyProviderSandboxBestEffort(
+              provider,
+              createResult.value.providerId,
+              tracingOpts,
+              {
+                conversationId: conversation.sId,
+                sandbox: existing.toLogJSON(),
+                workspaceId: auth.getNonNullableWorkspace().sId,
+              }
+            );
+
+            return writePolicyResult;
+          }
+
           await existing.update({ providerId: createResult.value.providerId });
           freshlyCreated = true;
+
+          await this.cleanupSandboxPolicy(oldProviderId, {
+            conversationId: conversation.sId,
+            sandbox: existing.toLogJSON(),
+            workspaceId: auth.getNonNullableWorkspace().sId,
+          });
 
           const startTelemetry = await provider.exec(
             createResult.value.providerId,
@@ -527,6 +617,10 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             "Sandbox not found at provider during sleep — marking deleted."
           );
           await sandbox.updateStatus("deleted", { ctx });
+          await this.cleanupSandboxPolicy(sandbox.providerId, {
+            sandbox: sandbox.toLogJSON(),
+            workspaceId: auth.getNonNullableWorkspace().sId,
+          });
           return new Ok(undefined);
         }
         return result;
@@ -631,12 +725,20 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             "Sandbox not found at provider during destroy — marking deleted."
           );
           await sandbox.updateStatus("deleted", { ctx });
+          await this.cleanupSandboxPolicy(sandbox.providerId, {
+            sandbox: sandbox.toLogJSON(),
+            workspaceId: auth.getNonNullableWorkspace().sId,
+          });
           return new Ok(undefined);
         }
         return result;
       }
 
       await sandbox.updateStatus("deleted", { ctx });
+      await this.cleanupSandboxPolicy(sandbox.providerId, {
+        sandbox: sandbox.toLogJSON(),
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      });
       recordLifecycleOperation("destroy", ctx);
 
       void revokeAllExecTokensForSandbox(sandbox.sId).catch((err) =>

--- a/front/lib/resources/sandbox_resource_egress.test.ts
+++ b/front/lib/resources/sandbox_resource_egress.test.ts
@@ -1,0 +1,205 @@
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockDeleteSandboxPolicy,
+  mockExecuteWithLock,
+  mockGetDatadogApiKey,
+  mockGetSandboxImage,
+  mockGetSandboxProvider,
+  mockWriteEmptySandboxPolicy,
+} = vi.hoisted(() => ({
+  mockDeleteSandboxPolicy: vi.fn(),
+  mockExecuteWithLock: vi.fn(),
+  mockGetDatadogApiKey: vi.fn(),
+  mockGetSandboxImage: vi.fn(),
+  mockGetSandboxProvider: vi.fn(),
+  mockWriteEmptySandboxPolicy: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/api/config")>();
+
+  return {
+    default: {
+      ...actual.default,
+      getDatadogApiKey: mockGetDatadogApiKey,
+    },
+  };
+});
+
+vi.mock("@app/lib/api/sandbox", () => ({
+  getSandboxProvider: mockGetSandboxProvider,
+}));
+
+vi.mock("@app/lib/api/sandbox/egress_policy", () => ({
+  deleteSandboxPolicy: mockDeleteSandboxPolicy,
+  writeEmptySandboxPolicy: mockWriteEmptySandboxPolicy,
+}));
+
+vi.mock("@app/lib/api/sandbox/image", () => ({
+  getSandboxImage: mockGetSandboxImage,
+}));
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: mockExecuteWithLock,
+}));
+
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import type { ConversationType } from "@app/types/assistant/conversation";
+
+describe("SandboxResource egress policy lifecycle", () => {
+  let authenticator: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockGetDatadogApiKey.mockReturnValue(undefined);
+    mockGetSandboxImage.mockReturnValue(
+      new Ok({
+        toCreateConfig: () => ({
+          envVars: {},
+          imageId: { imageName: "dust-base", tag: "latest" },
+        }),
+      })
+    );
+    mockWriteEmptySandboxPolicy.mockResolvedValue(new Ok(undefined));
+    mockDeleteSandboxPolicy.mockResolvedValue(new Ok(undefined));
+
+    const testSetup = await createResourceTest({ role: "admin" });
+    authenticator = testSetup.authenticator;
+
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+  });
+
+  it("writes an empty sandbox policy when creating a sandbox", async () => {
+    const provider = makeProvider({
+      create: vi.fn().mockResolvedValue(new Ok({ providerId: "provider-1" })),
+    });
+    mockGetSandboxProvider.mockReturnValue(provider);
+
+    const result = await SandboxResource.ensureActive(
+      authenticator,
+      conversation
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.freshlyCreated).toBe(true);
+      expect(result.value.wokeFromSleep).toBe(false);
+    }
+    expect(mockWriteEmptySandboxPolicy).toHaveBeenCalledWith("provider-1");
+  });
+
+  it("destroys the provider sandbox when policy initialization fails", async () => {
+    const provider = makeProvider({
+      create: vi.fn().mockResolvedValue(new Ok({ providerId: "provider-1" })),
+      destroy: vi.fn().mockResolvedValue(new Ok(undefined)),
+    });
+    mockGetSandboxProvider.mockReturnValue(provider);
+    mockWriteEmptySandboxPolicy.mockResolvedValue(
+      new Err(new Error("policy write failed"))
+    );
+
+    const result = await SandboxResource.ensureActive(
+      authenticator,
+      conversation
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("policy write failed");
+    }
+    expect(provider.destroy).toHaveBeenCalledWith("provider-1", {
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+    expect(
+      await SandboxResource.fetchByConversationId(
+        authenticator,
+        conversation.sId
+      )
+    ).toBeNull();
+  });
+
+  it("recreates deleted sandboxes with a new policy file and cleans up the old one", async () => {
+    const existingSandbox = await SandboxFactory.create(
+      authenticator,
+      conversation,
+      { status: "deleted" }
+    );
+    const oldProviderId = existingSandbox.providerId;
+    const provider = makeProvider({
+      create: vi.fn().mockResolvedValue(new Ok({ providerId: "provider-2" })),
+    });
+    mockGetSandboxProvider.mockReturnValue(provider);
+
+    const result = await SandboxResource.ensureActive(
+      authenticator,
+      conversation
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockWriteEmptySandboxPolicy).toHaveBeenCalledWith("provider-2");
+    expect(mockDeleteSandboxPolicy).toHaveBeenCalledWith(oldProviderId);
+
+    const reloaded = await SandboxResource.fetchByConversationId(
+      authenticator,
+      conversation.sId
+    );
+    expect(reloaded?.providerId).toBe("provider-2");
+    expect(reloaded?.status).toBe("running");
+  });
+
+  it("deletes the sandbox policy when deleting the sandbox resource", async () => {
+    const sandbox = await SandboxFactory.create(authenticator, conversation);
+    const provider = makeProvider();
+    mockGetSandboxProvider.mockReturnValue(provider);
+
+    const result = await SandboxResource.deleteByConversationId(
+      authenticator,
+      conversation.sId
+    );
+
+    expect(result).toEqual(new Ok(undefined));
+    expect(provider.destroy).toHaveBeenCalledWith(sandbox.providerId, {
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+    expect(mockDeleteSandboxPolicy).toHaveBeenCalledWith(sandbox.providerId);
+    expect(
+      await SandboxResource.fetchByConversationId(
+        authenticator,
+        conversation.sId
+      )
+    ).toBeNull();
+  });
+});
+
+function makeProvider(overrides: Record<string, unknown> = {}) {
+  return {
+    create: vi.fn().mockResolvedValue(new Ok({ providerId: "provider-1" })),
+    destroy: vi.fn().mockResolvedValue(new Ok(undefined)),
+    exec: vi
+      .fn()
+      .mockResolvedValue(new Ok({ exitCode: 0, stderr: "", stdout: "" })),
+    listFiles: vi.fn(),
+    readFile: vi.fn(),
+    sleep: vi.fn(),
+    wake: vi.fn(),
+    writeFile: vi.fn(),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Description

Replace the static `EGRESS_PROXY_ALLOWED_DOMAINS` env-var allowlist with a GCS-backed two-level policy system. The proxy now reads per-workspace (`workspaces/{wId}.json`) and per-sandbox (`sandboxes/{sbId}.json`) policy files from a regional GCS bucket and merges them: a domain is allowed if **either** policy allows it.

**Proxy side:**
- Add `wId` (workspace ID) claim to the JWT — optional during rollout for backward compatibility with pre-change sandboxes
- New `gcs.rs`: GCS policy reader with moka async LRU cache (60s positive TTL, 10s negative TTL), GCP metadata server auth with token caching, `GOOGLE_CLOUD_ACCESS_TOKEN` env-var override for tests
- Rewrite `policy.rs`: `Policy` + `PolicyRule` + `Action` with first-match-wins evaluation. IP literals rejected at deserialization. `DomainPattern` (exact + wildcard suffix) preserved from the old code
- Replace `TemporaryAllowlist` check in `connection.rs` with `policy_provider.evaluate()` — returns `Action` directly, errors logged at warn and treated as deny-all
- Config: add `EGRESS_PROXY_POLICY_BUCKET` and `EGRESS_PROXY_POLICY_BASE_URL`, remove `EGRESS_PROXY_ALLOWED_DOMAINS`
- Integration tests with a mock GCS HTTP server covering: workspace-only allows, sandbox-only allows, workspace lookup failure falls back to sandbox, sandbox lookup failure falls back to workspace, token without `wId` (compat), both missing = deny

**Front side:**
- `mintEgressJwt` now includes `wId` (workspace sId) claim
- New `egress_policy.ts`: write/delete sandbox policy files via `getBucketInstance`
- `SandboxResource` lifecycle wires policy create/cleanup at every state transition:
  - `ensureActive` (new): writes empty sandbox policy after provider create; rolls back provider sandbox if policy write fails
  - `ensureActive` (recreation from deleted): writes new policy, cleans up old one
  - `deleteByConversationId`, `dangerouslySleepIfRunning` (provider gone), `dangerouslyDestroyIfSleeping`: clean up sandbox policy

Workspace policy files are part of the runtime lookup contract but are **not** managed by front in this change — they are authored separately.

## Tests

- **Rust unit tests** (28 passing): policy parsing/evaluation, JWT validation with/without `wId`, config validation, domain pattern matching, IP literal rejection, cache TTL behavior
- **Rust integration tests**: full end-to-end with mock GCS server, proxy binary, TLS, covering all policy merge scenarios
- **Front unit tests** (12 passing): `egress.test.ts` (JWT minting with `wId`, forwarder setup, deny log), `egress_policy.test.ts` (write/delete sandbox policy), `sandbox_resource_egress.test.ts` (policy lifecycle on create, recreation, delete, rollback on failure)
- TypeScript type-check passes (only pre-existing unrelated error)

## Risk

- **Low**: The proxy is not yet deployed with GCS policies in production. This is a code-only change — the GCS bucket and IAM setup are done separately via infrastructure.
- **Backward compat**: `wId` is optional in the JWT. Old sandboxes without `wId` will have workspace policy skipped (sandbox-only evaluation). Safe as long as front is deployed first.
- **Policy write failure**: If GCS is unreachable at sandbox creation time, the provider sandbox is destroyed and the error surfaced to the user — no orphaned sandboxes without policies.
- **Rollback**: Safe to rollback front independently. Proxy rollback would require re-adding `EGRESS_PROXY_ALLOWED_DOMAINS` to config.

## Deploy Plan

1. **Deploy front first** — new sandboxes start minting `wId` JWTs and writing `sandboxes/{sbId}.json` to GCS at creation time
2. Create the GCS bucket (`dust-egress-policies-<region>`) and configure workload identity IAM
3. Prepare workspace policy files where needed
4. Wait for pre-change sandboxes to age out (max ~24h) or recycle them
5. Deploy the GCS-only proxy and remove `EGRESS_PROXY_ALLOWED_DOMAINS` from infra config