### PR TITLE
[front] enh: add debounce to poke workspace search

### DIFF
--- a/front/components/poke/pages/DashboardPage.tsx
+++ b/front/components/poke/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ import {
   PokeTableCell,
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
+import { useDebounce } from "@app/hooks/useDebounce";
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import {
@@ -25,9 +26,11 @@ import { UsersIcon } from "lucide-react";
 import moment from "moment";
 import type { ChangeEvent } from "react";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 
 const WORKSPACE_LIMIT = 20;
+const SEARCH_MIN_LENGTH = 3;
+const SEARCH_DEBOUNCE_MS = 300;
 
 interface WorkspaceListProps {
   title: string;

--- a/front/components/poke/pages/DashboardPage.tsx
+++ b/front/components/poke/pages/DashboardPage.tsx
@@ -32,6 +32,7 @@ const WORKSPACE_LIMIT = 20;
 interface WorkspaceListProps {
   title: string;
   workspaces: PokeWorkspaceWithRegion[];
+  isWorkspacesLoading?: boolean;
   showRegion?: boolean;
   onWorkspaceClick?: (ws: PokeWorkspaceWithRegion) => void;
 }
@@ -39,15 +40,21 @@ interface WorkspaceListProps {
 function WorkspaceList({
   title,
   workspaces,
+  isWorkspacesLoading = false,
   showRegion = false,
   onWorkspaceClick,
 }: WorkspaceListProps) {
   return (
     <>
       <h1 className="mb-4 mt-8 text-2xl font-bold">{title}</h1>
-      <ul className="flex flex-wrap gap-4">
-        {workspaces.length === 0 && <p>No workspaces found.</p>}
-        {workspaces.map((ws) => (
+      {isWorkspacesLoading ? (
+        <div className="flex justify-center py-8">
+          <Spinner size="lg" variant="color" />
+        </div>
+      ) : (
+        <ul className="flex flex-wrap gap-4">
+          {workspaces.length === 0 && <p>No workspaces found.</p>}
+          {workspaces.map((ws) => (
           <div
             key={`${ws.region ?? "default"}-${ws.id}`}
             onClick={() => onWorkspaceClick?.(ws)}
@@ -116,7 +123,8 @@ function WorkspaceList({
             </LinkWrapper>
           </div>
         ))}
-      </ul>
+        </ul>
+      )}
     </>
   );
 }
@@ -148,15 +156,23 @@ function DashboardPageSPA() {
     regionUrls,
   });
 
-  const [searchTerm, setSearchTerm] = useState("");
-  const searchDisabled = searchTerm.trim().length < 3;
+  const {
+    inputValue: searchTerm,
+    debouncedValue: debouncedSearchTerm,
+    isDebouncing,
+    setValue: setSearchTerm,
+  } = useDebounce("", {
+    delay: SEARCH_DEBOUNCE_MS,
+    minLength: SEARCH_MIN_LENGTH,
+  });
+  const searchDisabled = !isDebouncing && !debouncedSearchTerm;
 
   const {
     workspaces: searchResults,
     isWorkspacesLoading: isSearchResultsLoading,
     isWorkspacesError: isSearchResultsError,
   } = usePokeWorkspacesAllRegions({
-    search: searchTerm,
+    search: debouncedSearchTerm,
     disabled: searchDisabled,
     limit: WORKSPACE_LIMIT,
     regionUrls,
@@ -185,29 +201,27 @@ function DashboardPageSPA() {
         value={searchTerm}
         onChange={handleSearchChange}
       />
-      {isSearchResultsError && (
-        <p>An error occurred while fetching search results.</p>
-      )}
-      {!isSearchResultsLoading && !isSearchResultsError && (
-        <WorkspaceList
-          title="Search Results"
-          workspaces={searchResults}
-          showRegion
-          onWorkspaceClick={handleWorkspaceClick}
-        />
-      )}
-      {isSearchResultsLoading && !searchDisabled && (
-        <Spinner size="lg" variant="color" />
-      )}
-      {!isUpgradedWorkspacesLoading && !isUpgradedWorkspacesError && (
+      {!searchDisabled &&
+        (isSearchResultsError ? (
+          <p>An error occurred while fetching search results.</p>
+        ) : (
+          <WorkspaceList
+            title="Search Results"
+            workspaces={searchResults}
+            isWorkspacesLoading={isSearchResultsLoading || isDebouncing}
+            showRegion
+            onWorkspaceClick={handleWorkspaceClick}
+          />
+        ))}
+      {!isUpgradedWorkspacesError && (
         <WorkspaceList
           title={`Last ${WORKSPACE_LIMIT} Upgraded Workspaces`}
           workspaces={upgradedWorkspaces}
+          isWorkspacesLoading={isUpgradedWorkspacesLoading}
           showRegion
           onWorkspaceClick={handleWorkspaceClick}
         />
       )}
-      {isUpgradedWorkspacesLoading && <Spinner size="lg" variant="color" />}
     </>
   );
 }

--- a/front/components/poke/pages/DashboardPage.tsx
+++ b/front/components/poke/pages/DashboardPage.tsx
@@ -99,12 +99,10 @@ function WorkspaceList({
                         <label
                           className={classNames(
                             "rounded px-1 text-sm text-gray-500 text-white",
-                            isEntreprisePlanPrefix(
-                              ws.subscription.plan.code
-                            ) && "bg-red-500",
-                            isFriendsAndFamilyPlan(
-                              ws.subscription.plan.code
-                            ) && "bg-pink-500",
+                            isEntreprisePlanPrefix(ws.subscription.plan.code) &&
+                              "bg-red-500",
+                            isFriendsAndFamilyPlan(ws.subscription.plan.code) &&
+                              "bg-pink-500",
                             isProPlanPrefix(ws.subscription.plan.code) &&
                               "bg-orange-500",
                             isFreePlan(ws.subscription.plan.code) &&
@@ -164,15 +162,17 @@ function DashboardPageSPA() {
     delay: SEARCH_DEBOUNCE_MS,
     minLength: SEARCH_MIN_LENGTH,
   });
-  const searchDisabled = !isDebouncing && !debouncedSearchTerm;
+
+  const searchQuery = debouncedSearchTerm.trim();
+  const isSearchInputTooShort = searchTerm.trim().length < SEARCH_MIN_LENGTH;
 
   const {
     workspaces: searchResults,
     isWorkspacesLoading: isSearchResultsLoading,
     isWorkspacesError: isSearchResultsError,
   } = usePokeWorkspacesAllRegions({
-    search: debouncedSearchTerm,
-    disabled: searchDisabled,
+    search: searchQuery,
+    disabled: !searchQuery,
     limit: WORKSPACE_LIMIT,
     regionUrls,
   });
@@ -201,7 +201,7 @@ function DashboardPageSPA() {
         onChange={handleSearchChange}
       />
       <h1 className="mb-4 mt-8 text-2xl font-bold">Search Results</h1>
-      {searchDisabled ? (
+      {isSearchInputTooShort ? (
         <p className="text-muted-foreground dark:text-muted-foreground-night">
           Type at least {SEARCH_MIN_LENGTH} characters to search.
         </p>

--- a/front/components/poke/pages/DashboardPage.tsx
+++ b/front/components/poke/pages/DashboardPage.tsx
@@ -33,7 +33,6 @@ const SEARCH_MIN_LENGTH = 3;
 const SEARCH_DEBOUNCE_MS = 300;
 
 interface WorkspaceListProps {
-  title: string;
   workspaces: PokeWorkspaceWithRegion[];
   isWorkspacesLoading?: boolean;
   showRegion?: boolean;
@@ -41,94 +40,91 @@ interface WorkspaceListProps {
 }
 
 function WorkspaceList({
-  title,
   workspaces,
   isWorkspacesLoading = false,
   showRegion = false,
   onWorkspaceClick,
 }: WorkspaceListProps) {
-  return (
-    <>
-      <h1 className="mb-4 mt-8 text-2xl font-bold">{title}</h1>
-      {isWorkspacesLoading ? (
-        <div className="flex justify-center py-8">
-          <Spinner size="lg" variant="color" />
+  return isWorkspacesLoading ? (
+    <div className="flex h-44 w-80 items-center justify-center">
+      <Spinner size="lg" variant="color" />
+    </div>
+  ) : workspaces.length === 0 ? (
+    <p className="text-muted-foreground dark:text-muted-foreground-night">
+      No workspaces found.
+    </p>
+  ) : (
+    <ul className="flex flex-wrap gap-4">
+      {workspaces.map((ws) => (
+        <div
+          key={`${ws.region ?? "default"}-${ws.id}`}
+          onClick={() => onWorkspaceClick?.(ws)}
+        >
+          <LinkWrapper href={`/poke/${ws.sId}`}>
+            <li className="border-material-100 w-80 rounded-lg border p-4 transition-colors duration-200 hover:bg-gray-100 dark:hover:bg-gray-800">
+              <div className="flex items-center justify-between pb-2">
+                <h2 className="text-md flex-grow font-bold">{ws.name}</h2>
+                {showRegion && ws.region && (
+                  <Chip size="xs" color={getRegionChipColor(ws.region)}>
+                    {getRegionDisplay(ws.region)}
+                  </Chip>
+                )}
+              </div>
+              <PokeTable>
+                <PokeTableBody>
+                  <PokeTableRow>
+                    <PokeTableCell className="space-x-2" colSpan={3}>
+                      <label>
+                        Created: {moment(ws.createdAt).format("DD-MM-YYYY")}
+                      </label>
+                    </PokeTableCell>
+                  </PokeTableRow>
+                  <PokeTableRow>
+                    <PokeTableCell className="space-x-2" colSpan={3}>
+                      <div className="flex items-center gap-1.5">
+                        <Icon visual={UsersIcon} size="xs" />
+                        <span>
+                          {ws.membersCount}&nbsp; member
+                          {pluralize(ws.membersCount)}
+                        </span>
+                      </div>
+                    </PokeTableCell>
+                  </PokeTableRow>
+                  <PokeTableRow>
+                    <PokeTableCell className="space-x-2" colSpan={3}>
+                      <label className="rounded bg-green-500 px-1 text-sm text-white">
+                        {ws.sId}
+                      </label>
+                      {ws.subscription && (
+                        <label
+                          className={classNames(
+                            "rounded px-1 text-sm text-gray-500 text-white",
+                            isEntreprisePlanPrefix(
+                              ws.subscription.plan.code
+                            ) && "bg-red-500",
+                            isFriendsAndFamilyPlan(
+                              ws.subscription.plan.code
+                            ) && "bg-pink-500",
+                            isProPlanPrefix(ws.subscription.plan.code) &&
+                              "bg-orange-500",
+                            isFreePlan(ws.subscription.plan.code) &&
+                              "bg-blue-500",
+                            isOldFreePlan(ws.subscription.plan.code) &&
+                              "bg-gray-300"
+                          )}
+                        >
+                          {ws.subscription.plan.name}
+                        </label>
+                      )}
+                    </PokeTableCell>
+                  </PokeTableRow>
+                </PokeTableBody>
+              </PokeTable>
+            </li>
+          </LinkWrapper>
         </div>
-      ) : (
-        <ul className="flex flex-wrap gap-4">
-          {workspaces.length === 0 && <p>No workspaces found.</p>}
-          {workspaces.map((ws) => (
-          <div
-            key={`${ws.region ?? "default"}-${ws.id}`}
-            onClick={() => onWorkspaceClick?.(ws)}
-          >
-            <LinkWrapper href={`/poke/${ws.sId}`}>
-              <li className="border-material-100 w-80 rounded-lg border p-4 transition-colors duration-200 hover:bg-gray-100 dark:hover:bg-gray-800">
-                <div className="flex items-center justify-between pb-2">
-                  <h2 className="text-md flex-grow font-bold">{ws.name}</h2>
-                  {showRegion && ws.region && (
-                    <Chip size="xs" color={getRegionChipColor(ws.region)}>
-                      {getRegionDisplay(ws.region)}
-                    </Chip>
-                  )}
-                </div>
-                <PokeTable>
-                  <PokeTableBody>
-                    <PokeTableRow>
-                      <PokeTableCell className="space-x-2" colSpan={3}>
-                        <label>
-                          Created: {moment(ws.createdAt).format("DD-MM-YYYY")}
-                        </label>
-                      </PokeTableCell>
-                    </PokeTableRow>
-                    <PokeTableRow>
-                      <PokeTableCell className="space-x-2" colSpan={3}>
-                        <div className="flex items-center gap-1.5">
-                          <Icon visual={UsersIcon} size="xs" />
-                          <span>
-                            {ws.membersCount}&nbsp; member
-                            {pluralize(ws.membersCount)}
-                          </span>
-                        </div>
-                      </PokeTableCell>
-                    </PokeTableRow>
-                    <PokeTableRow>
-                      <PokeTableCell className="space-x-2" colSpan={3}>
-                        <label className="rounded bg-green-500 px-1 text-sm text-white">
-                          {ws.sId}
-                        </label>
-                        {ws.subscription && (
-                          <label
-                            className={classNames(
-                              "rounded px-1 text-sm text-gray-500 text-white",
-                              isEntreprisePlanPrefix(
-                                ws.subscription.plan.code
-                              ) && "bg-red-500",
-                              isFriendsAndFamilyPlan(
-                                ws.subscription.plan.code
-                              ) && "bg-pink-500",
-                              isProPlanPrefix(ws.subscription.plan.code) &&
-                                "bg-orange-500",
-                              isFreePlan(ws.subscription.plan.code) &&
-                                "bg-blue-500",
-                              isOldFreePlan(ws.subscription.plan.code) &&
-                                "bg-gray-300"
-                            )}
-                          >
-                            {ws.subscription.plan.name}
-                          </label>
-                        )}
-                      </PokeTableCell>
-                    </PokeTableRow>
-                  </PokeTableBody>
-                </PokeTable>
-              </li>
-            </LinkWrapper>
-          </div>
-        ))}
-        </ul>
-      )}
-    </>
+      ))}
+    </ul>
   );
 }
 
@@ -204,21 +200,32 @@ function DashboardPageSPA() {
         value={searchTerm}
         onChange={handleSearchChange}
       />
-      {!searchDisabled &&
-        (isSearchResultsError ? (
-          <p>An error occurred while fetching search results.</p>
-        ) : (
-          <WorkspaceList
-            title="Search Results"
-            workspaces={searchResults}
-            isWorkspacesLoading={isSearchResultsLoading || isDebouncing}
-            showRegion
-            onWorkspaceClick={handleWorkspaceClick}
-          />
-        ))}
-      {!isUpgradedWorkspacesError && (
+      <h1 className="mb-4 mt-8 text-2xl font-bold">Search Results</h1>
+      {searchDisabled ? (
+        <p className="text-muted-foreground dark:text-muted-foreground-night">
+          Type at least {SEARCH_MIN_LENGTH} characters to search.
+        </p>
+      ) : isSearchResultsError ? (
+        <p className="text-muted-foreground dark:text-muted-foreground-night">
+          An error occurred while fetching search results.
+        </p>
+      ) : (
         <WorkspaceList
-          title={`Last ${WORKSPACE_LIMIT} Upgraded Workspaces`}
+          workspaces={searchResults}
+          isWorkspacesLoading={isSearchResultsLoading || isDebouncing}
+          showRegion
+          onWorkspaceClick={handleWorkspaceClick}
+        />
+      )}
+      <h1 className="mb-4 mt-8 text-2xl font-bold">
+        Last {WORKSPACE_LIMIT} Upgraded Workspaces
+      </h1>
+      {isUpgradedWorkspacesError ? (
+        <p className="text-muted-foreground dark:text-muted-foreground-night">
+          An error occurred while fetching upgraded workspaces.
+        </p>
+      ) : (
+        <WorkspaceList
           workspaces={upgradedWorkspaces}
           isWorkspacesLoading={isUpgradedWorkspacesLoading}
           showRegion

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -4,7 +4,6 @@ import { isRegionRedirect } from "@app/lib/swr/workspaces";
 import type { GetPokeNoWorkspaceAuthContextResponseType } from "@app/pages/api/poke/auth-context";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetRegionResponseType } from "@app/pages/api/poke/region";
-import type { GetPokeWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
 import type { GetPokeWorkspaceAuthContextResponseType } from "@app/pages/api/poke/workspaces/[wId]/auth-context";
 import type { GetPokeFeaturesResponseBody } from "@app/pages/api/poke/workspaces/[wId]/features";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
@@ -66,46 +65,6 @@ export function usePokeConnectorPermissions({
     isResourcesLoading: !error && !data,
     isResourcesError: error,
     resourcesError: isAPIErrorResponse(error) ? error.error : null,
-  };
-}
-
-export function usePokeWorkspaces({
-  upgraded,
-  search,
-  disabled,
-  limit,
-}: {
-  upgraded?: boolean;
-  search?: string;
-  disabled?: boolean;
-  limit?: number;
-} = {}) {
-  const { fetcher } = useFetcher();
-  const workspacesFetcher: Fetcher<GetPokeWorkspacesResponseBody> = fetcher;
-
-  const queryParams = [
-    upgraded !== undefined ? `upgraded=${upgraded}` : null,
-    search ? `search=${search}` : null,
-    limit ? `limit=${limit}` : null,
-  ].filter((q) => q);
-
-  let query = "";
-  if (queryParams.length > 0) {
-    query = `?${queryParams.join("&")}`;
-  }
-
-  const { data, error } = useSWRWithDefaults(
-    `/api/poke/workspaces${query}`,
-    workspacesFetcher,
-    {
-      disabled,
-    }
-  );
-
-  return {
-    workspaces: data?.workspaces ?? emptyArray(),
-    isWorkspacesLoading: !error && !data,
-    isWorkspacesError: error,
   };
 }
 

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -160,7 +160,8 @@ export function usePokeWorkspacesAllRegions({
       return;
     }
 
-    let cancelled = false;
+    // Abort in-flight fetches when the effect re-runs (e.g. user is typing).
+    const abortController = new AbortController();
     setIsLoading(true);
     setIsError(false);
 
@@ -181,7 +182,10 @@ export function usePokeWorkspacesAllRegions({
           const baseUrl = regionUrls[region];
           const url = `${baseUrl}/api/poke/workspaces?${queryParams.toString()}`;
 
-          const response = await clientFetch(url, { credentials: "include" });
+          const response = await clientFetch(url, {
+            credentials: "include",
+            signal: abortController.signal,
+          });
           if (!response.ok) {
             throw new Error(`Failed to fetch from ${region}`);
           }
@@ -202,13 +206,13 @@ export function usePokeWorkspacesAllRegions({
           }
         }
 
-        if (!cancelled) {
+        if (!abortController.signal.aborted) {
           setWorkspaces(allWorkspaces);
           setIsError(hasErrors);
           setIsLoading(false);
         }
       } catch {
-        if (!cancelled) {
+        if (!abortController.signal.aborted) {
           setIsError(true);
           setIsLoading(false);
         }
@@ -218,13 +222,13 @@ export function usePokeWorkspacesAllRegions({
     void run();
 
     return () => {
-      cancelled = true;
+      abortController.abort();
     };
   }, [disabled, search, upgraded, limit, regionUrls]);
 
   return {
     workspaces,
-    isWorkspacesLoading: isLoading,
+    isWorkspacesLoading: !disabled && isLoading,
     isWorkspacesError: isError,
   };
 }


### PR DESCRIPTION
## Description

- In the main poke page, each keystroke in the searchbar runs one fetch on `/api/poke/workspaces`
- This PR changes that by debouncing the search
- Also gives a quick UI revamp by centering the Spinner and fixing a few colors and removes an unused hook

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.