### PR TITLE
feat(sbx): add wId claim to egress JWT and run forwarder as dust-fwd

### DIFF
--- a/egress-proxy/src/jwt.rs
+++ b/egress-proxy/src/jwt.rs
@@ -14,6 +14,7 @@ pub struct JwtValidator {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatedSandboxToken {
     pub sb_id: String,
+    pub w_id: Option<String>,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -30,6 +31,8 @@ pub enum JwtValidationError {
 struct Claims {
     #[serde(rename = "sbId")]
     sb_id: String,
+    #[serde(rename = "wId")]
+    w_id: Option<String>,
     exp: usize,
 }
 
@@ -41,8 +44,6 @@ impl JwtValidator {
     }
 
     pub fn validate(&self, raw_token: &str) -> Result<ValidatedSandboxToken, JwtValidationError> {
-        // TODO(sandbox-egress): Front will mint these JWTs during sandbox setup and write the
-        // per-sandbox policy before user code can execute.
         let mut validation = Validation::new(Algorithm::HS256);
         // TODO(sandbox-egress): Nice-to-have once front token minting is wired: make the
         // front/proxy clock-skew tolerance explicit and cover it with a unit test.
@@ -65,7 +66,21 @@ fn claims_to_validated_token(
 ) -> Result<ValidatedSandboxToken, JwtValidationError> {
     let claims = token.claims;
     let now_seconds = current_unix_timestamp_seconds()?;
+    let raw_w_id = claims.w_id;
+    let w_id = raw_w_id.as_ref().and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    });
+
     if claims.sb_id.trim().is_empty() || claims.exp == 0 {
+        return Err(JwtValidationError::InvalidClaims);
+    }
+
+    if raw_w_id.is_some() && w_id.is_none() {
         return Err(JwtValidationError::InvalidClaims);
     }
 
@@ -75,6 +90,7 @@ fn claims_to_validated_token(
 
     Ok(ValidatedSandboxToken {
         sb_id: claims.sb_id,
+        w_id,
     })
 }
 
@@ -108,6 +124,8 @@ mod tests {
     struct TestClaims<'a> {
         #[serde(rename = "sbId")]
         sb_id: &'a str,
+        #[serde(rename = "wId", skip_serializing_if = "Option::is_none")]
+        w_id: Option<&'a str>,
         iss: &'a str,
         aud: &'a str,
         exp: usize,
@@ -116,19 +134,72 @@ mod tests {
     #[test]
     fn validates_expected_claims() {
         let validator = JwtValidator::new("secret");
-        let token = token("secret", "sbx", EXPECTED_ISSUER, EXPECTED_AUDIENCE, 60);
+        let token = token(
+            "secret",
+            "sbx",
+            Some("workspace"),
+            EXPECTED_ISSUER,
+            EXPECTED_AUDIENCE,
+            60,
+        );
 
         let validated = validator
             .validate(&token)
             .expect("token with valid claims should validate");
 
         assert_eq!(validated.sb_id, "sbx");
+        assert_eq!(validated.w_id.as_deref(), Some("workspace"));
+    }
+
+    #[test]
+    fn accepts_tokens_without_workspace_id() {
+        let validator = JwtValidator::new("secret");
+        let token = token(
+            "secret",
+            "sbx",
+            None,
+            EXPECTED_ISSUER,
+            EXPECTED_AUDIENCE,
+            60,
+        );
+
+        let validated = validator
+            .validate(&token)
+            .expect("token without wId should validate during rollout");
+
+        assert_eq!(validated.sb_id, "sbx");
+        assert_eq!(validated.w_id, None);
+    }
+
+    #[test]
+    fn rejects_empty_workspace_id_when_present() {
+        let validator = JwtValidator::new("secret");
+        let token = token(
+            "secret",
+            "sbx",
+            Some("   "),
+            EXPECTED_ISSUER,
+            EXPECTED_AUDIENCE,
+            60,
+        );
+
+        assert_eq!(
+            validator.validate(&token).unwrap_err(),
+            JwtValidationError::InvalidClaims
+        );
     }
 
     #[test]
     fn rejects_expired_tokens() {
         let validator = JwtValidator::new("secret");
-        let token = token("secret", "sbx", EXPECTED_ISSUER, EXPECTED_AUDIENCE, -60);
+        let token = token(
+            "secret",
+            "sbx",
+            Some("workspace"),
+            EXPECTED_ISSUER,
+            EXPECTED_AUDIENCE,
+            -60,
+        );
 
         assert_eq!(
             validator.validate(&token).unwrap_err(),
@@ -139,7 +210,14 @@ mod tests {
     #[test]
     fn rejects_wrong_audience() {
         let validator = JwtValidator::new("secret");
-        let token = token("secret", "sbx", EXPECTED_ISSUER, "wrong", 60);
+        let token = token(
+            "secret",
+            "sbx",
+            Some("workspace"),
+            EXPECTED_ISSUER,
+            "wrong",
+            60,
+        );
 
         assert_eq!(
             validator.validate(&token).unwrap_err(),
@@ -147,7 +225,14 @@ mod tests {
         );
     }
 
-    fn token(secret: &str, sb_id: &str, iss: &str, aud: &str, exp_offset_seconds: i64) -> String {
+    fn token(
+        secret: &str,
+        sb_id: &str,
+        w_id: Option<&str>,
+        iss: &str,
+        aud: &str,
+        exp_offset_seconds: i64,
+    ) -> String {
         let now_seconds = i64::try_from(
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
@@ -159,6 +244,7 @@ mod tests {
         let exp = usize::try_from(exp_seconds).expect("expiration timestamp should fit in usize");
         let claims = TestClaims {
             sb_id,
+            w_id,
             iss,
             aud,
             exp,

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -105,27 +105,27 @@ describe("sandbox egress helpers", () => {
     expect(sandbox.writeFile).toHaveBeenCalledWith(
       auth,
       "/etc/dust/egress-token",
-      expect.anything(),
+      expect.anything()
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       1,
       auth,
       expect.stringContaining(
-        "chown dust-fwd:dust-fwd '/etc/dust/egress-token' && chmod 600 '/etc/dust/egress-token' && rm -f '/tmp/dust-forwarder.log' '/tmp/dust-egress-denied.log'",
+        "chown dust-fwd:dust-fwd '/etc/dust/egress-token' && chmod 600 '/etc/dust/egress-token' && rm -f '/tmp/dust-forwarder.log' '/tmp/dust-egress-denied.log'"
       ),
-      { user: "root" },
+      { user: "root" }
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       2,
       auth,
       expect.stringContaining("--proxy-addr '203.0.113.10:4443'"),
-      { user: "dust-fwd" },
+      { user: "dust-fwd" }
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       2,
       auth,
       expect.stringContaining("--proxy-tls-name 'eu.sandbox-egress.dust.tt'"),
-      { user: "dust-fwd" },
+      { user: "dust-fwd" }
     );
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -133,7 +133,7 @@ describe("sandbox egress helpers", () => {
         providerId: "provider-sandbox-id",
         sandboxId: "sandbox-id",
       }),
-      "Sandbox egress forwarder is healthy",
+      "Sandbox egress forwarder is healthy"
     );
   });
 
@@ -144,7 +144,7 @@ describe("sandbox egress helpers", () => {
           exitCode: 0,
           stdout: "google.com:443 denied\nevil.com:80 denied\n",
           stderr: "",
-        }),
+        })
       ),
     };
 
@@ -160,7 +160,7 @@ describe("sandbox egress helpers", () => {
     expect(sandbox.exec).toHaveBeenCalledWith(
       auth,
       expect.stringContaining("dust-egress-denied.log"),
-      { user: "root", timeoutMs: 2_000 },
+      { user: "root", timeoutMs: 2_000 }
     );
   });
 

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -110,7 +110,9 @@ describe("sandbox egress helpers", () => {
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       1,
       auth,
-      expect.stringContaining("chown dust-fwd:dust-fwd"),
+      expect.stringContaining(
+        "chown dust-fwd:dust-fwd '/etc/dust/egress-token' && chmod 600 '/etc/dust/egress-token' && rm -f '/tmp/dust-forwarder.log' '/tmp/dust-egress-denied.log'",
+      ),
       { user: "root" },
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -55,6 +55,10 @@ import {
 } from "./egress";
 
 describe("sandbox egress helpers", () => {
+  const auth = {
+    getNonNullableWorkspace: () => ({ sId: "workspace-id" }),
+  } as never;
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -67,7 +71,7 @@ describe("sandbox egress helpers", () => {
   });
 
   it("mints a proxy JWT bound to the provider sandbox id", () => {
-    const token = mintEgressJwt("provider-sandbox-id");
+    const token = mintEgressJwt("provider-sandbox-id", "workspace-id");
     const payload = jwt.verify(token, "egress-secret", {
       algorithms: ["HS256"],
       audience: "dust-egress-proxy",
@@ -75,6 +79,7 @@ describe("sandbox egress helpers", () => {
     }) as jwt.JwtPayload;
 
     expect(payload.sbId).toBe("provider-sandbox-id");
+    expect(payload.wId).toBe("workspace-id");
     expect(payload.exp).toBeGreaterThan(payload.iat ?? 0);
   });
 
@@ -91,34 +96,34 @@ describe("sandbox egress helpers", () => {
         .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
     };
 
-    const result = await setupEgressForwarder({} as never, sandbox as never);
+    const result = await setupEgressForwarder(auth, sandbox as never);
 
     expect(result).toEqual(new Ok(undefined));
     expect(mockLookup).toHaveBeenCalledWith("eu.sandbox-egress.dust.tt", {
       family: 4,
     });
     expect(sandbox.writeFile).toHaveBeenCalledWith(
-      {},
+      auth,
       "/etc/dust/egress-token",
-      expect.anything()
+      expect.anything(),
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       1,
-      {},
-      expect.stringContaining("chmod 600"),
-      { user: "root" }
+      auth,
+      expect.stringContaining("chown dust-fwd:dust-fwd"),
+      { user: "root" },
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       2,
-      {},
+      auth,
       expect.stringContaining("--proxy-addr '203.0.113.10:4443'"),
-      { user: "root" }
+      { user: "dust-fwd" },
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       2,
-      {},
+      auth,
       expect.stringContaining("--proxy-tls-name 'eu.sandbox-egress.dust.tt'"),
-      { user: "root" }
+      { user: "dust-fwd" },
     );
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -126,7 +131,7 @@ describe("sandbox egress helpers", () => {
         providerId: "provider-sandbox-id",
         sandboxId: "sandbox-id",
       }),
-      "Sandbox egress forwarder is healthy"
+      "Sandbox egress forwarder is healthy",
     );
   });
 
@@ -137,11 +142,11 @@ describe("sandbox egress helpers", () => {
           exitCode: 0,
           stdout: "google.com:443 denied\nevil.com:80 denied\n",
           stderr: "",
-        })
+        }),
       ),
     };
 
-    const result = await readNewDenyLogEntries({} as never, sandbox as never);
+    const result = await readNewDenyLogEntries(auth, sandbox as never);
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -151,9 +156,9 @@ describe("sandbox egress helpers", () => {
       ]);
     }
     expect(sandbox.exec).toHaveBeenCalledWith(
-      {},
+      auth,
       expect.stringContaining("dust-egress-denied.log"),
-      { user: "root", timeoutMs: 2_000 }
+      { user: "root", timeoutMs: 2_000 },
     );
   });
 
@@ -164,7 +169,7 @@ describe("sandbox egress helpers", () => {
         .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
     };
 
-    const result = await readNewDenyLogEntries({} as never, sandbox as never);
+    const result = await readNewDenyLogEntries(auth, sandbox as never);
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -182,7 +187,7 @@ describe("sandbox egress helpers", () => {
         .mockResolvedValue(new Err(new Error("sandbox command failed"))),
     };
 
-    const result = await setupEgressForwarder({} as never, sandbox as never);
+    const result = await setupEgressForwarder(auth, sandbox as never);
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -137,14 +137,18 @@ export async function setupEgressForwarder(
     return tokenWriteResult;
   }
 
-  const chmodResult = await runSuccessfulSandboxCommand(
+  // Older sandboxes may still have root-owned log files from before the
+  // forwarder switched to dust-fwd, so clear them before dropping privileges.
+  const prepareRuntimeFilesResult = await runSuccessfulSandboxCommand(
     auth,
     sandbox,
-    `chown dust-fwd:dust-fwd ${shellEscape(EGRESS_TOKEN_PATH)} && chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)}`,
+    `chown dust-fwd:dust-fwd ${shellEscape(EGRESS_TOKEN_PATH)} && ` +
+      `chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)} && ` +
+      `rm -f ${shellEscape(EGRESS_FORWARDER_LOG_PATH)} ${shellEscape(EGRESS_DENY_LOG_PATH)}`,
     "root",
   );
-  if (chmodResult.isErr()) {
-    return chmodResult;
+  if (prepareRuntimeFilesResult.isErr()) {
+    return prepareRuntimeFilesResult;
   }
 
   const startForwarderCommand =

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -53,7 +53,7 @@ async function runSuccessfulSandboxCommand(
   auth: Authenticator,
   sandbox: SandboxResource,
   command: string,
-  user?: string,
+  user?: string
 ): Promise<Result<void, Error>> {
   const result = await sandbox.exec(auth, command, user ? { user } : undefined);
   if (result.isErr()) {
@@ -63,8 +63,8 @@ async function runSuccessfulSandboxCommand(
   if (result.value.exitCode !== 0) {
     return new Err(
       new Error(
-        `Sandbox command failed with exit code ${result.value.exitCode}: ${result.value.stderr || result.value.stdout || command}`,
-      ),
+        `Sandbox command failed with exit code ${result.value.exitCode}: ${result.value.stderr || result.value.stdout || command}`
+      )
     );
   }
 
@@ -83,13 +83,13 @@ export function mintEgressJwt(providerId: string, workspaceId: string): string {
     {
       algorithm: "HS256",
       expiresIn: EGRESS_JWT_TTL_SECONDS,
-    },
+    }
   );
 }
 
 export async function checkEgressForwarderHealth(
   auth: Authenticator,
-  sandbox: SandboxResource,
+  sandbox: SandboxResource
 ): Promise<Result<boolean, Error>> {
   // Use ss to check if the port is bound locally rather than nc -z which opens
   // a real TCP connection through the forwarder, triggering a proxy round-trip
@@ -97,7 +97,7 @@ export async function checkEgressForwarderHealth(
   const healthResult = await sandbox.exec(
     auth,
     "ss -tln sport = :9990 | grep -q LISTEN",
-    { timeoutMs: 1_000 },
+    { timeoutMs: 1_000 }
   );
 
   if (healthResult.isErr()) {
@@ -109,7 +109,7 @@ export async function checkEgressForwarderHealth(
 
 export async function setupEgressForwarder(
   auth: Authenticator,
-  sandbox: SandboxResource,
+  sandbox: SandboxResource
 ): Promise<Result<void, Error>> {
   const logContext = {
     event: "egress.setup",
@@ -126,12 +126,12 @@ export async function setupEgressForwarder(
 
   const token = mintEgressJwt(
     sandbox.providerId,
-    auth.getNonNullableWorkspace().sId,
+    auth.getNonNullableWorkspace().sId
   );
   const tokenWriteResult = await sandbox.writeFile(
     auth,
     EGRESS_TOKEN_PATH,
-    new TextEncoder().encode(token).buffer,
+    new TextEncoder().encode(token).buffer
   );
   if (tokenWriteResult.isErr()) {
     return tokenWriteResult;
@@ -145,7 +145,7 @@ export async function setupEgressForwarder(
     `chown dust-fwd:dust-fwd ${shellEscape(EGRESS_TOKEN_PATH)} && ` +
       `chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)} && ` +
       `rm -f ${shellEscape(EGRESS_FORWARDER_LOG_PATH)} ${shellEscape(EGRESS_DENY_LOG_PATH)}`,
-    "root",
+    "root"
   );
   if (prepareRuntimeFilesResult.isErr()) {
     return prepareRuntimeFilesResult;
@@ -164,7 +164,7 @@ export async function setupEgressForwarder(
     auth,
     sandbox,
     startForwarderCommand,
-    "dust-fwd",
+    "dust-fwd"
   );
   if (startResult.isErr()) {
     return startResult;
@@ -184,7 +184,7 @@ export async function setupEgressForwarder(
   }
 
   return new Err(
-    new Error("Sandbox egress forwarder did not become healthy in time"),
+    new Error("Sandbox egress forwarder did not become healthy in time")
   );
 }
 
@@ -193,7 +193,7 @@ export async function setupEgressForwarder(
 // last read", not strictly caused by the command that just ran.
 export async function readNewDenyLogEntries(
   auth: Authenticator,
-  sandbox: SandboxResource,
+  sandbox: SandboxResource
 ): Promise<Result<string[], Error>> {
   const command =
     `_off=$(cat ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)} 2>/dev/null || echo 0); ` +

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -53,7 +53,7 @@ async function runSuccessfulSandboxCommand(
   auth: Authenticator,
   sandbox: SandboxResource,
   command: string,
-  user?: string
+  user?: string,
 ): Promise<Result<void, Error>> {
   const result = await sandbox.exec(auth, command, user ? { user } : undefined);
   if (result.isErr()) {
@@ -63,32 +63,33 @@ async function runSuccessfulSandboxCommand(
   if (result.value.exitCode !== 0) {
     return new Err(
       new Error(
-        `Sandbox command failed with exit code ${result.value.exitCode}: ${result.value.stderr || result.value.stdout || command}`
-      )
+        `Sandbox command failed with exit code ${result.value.exitCode}: ${result.value.stderr || result.value.stdout || command}`,
+      ),
     );
   }
 
   return new Ok(undefined);
 }
 
-export function mintEgressJwt(providerId: string): string {
+export function mintEgressJwt(providerId: string, workspaceId: string): string {
   return jwt.sign(
     {
       iss: "dust-front",
       aud: "dust-egress-proxy",
       sbId: providerId,
+      wId: workspaceId,
     },
     config.getEgressProxyJwtSecret(),
     {
       algorithm: "HS256",
       expiresIn: EGRESS_JWT_TTL_SECONDS,
-    }
+    },
   );
 }
 
 export async function checkEgressForwarderHealth(
   auth: Authenticator,
-  sandbox: SandboxResource
+  sandbox: SandboxResource,
 ): Promise<Result<boolean, Error>> {
   // Use ss to check if the port is bound locally rather than nc -z which opens
   // a real TCP connection through the forwarder, triggering a proxy round-trip
@@ -96,7 +97,7 @@ export async function checkEgressForwarderHealth(
   const healthResult = await sandbox.exec(
     auth,
     "ss -tln sport = :9990 | grep -q LISTEN",
-    { timeoutMs: 1_000 }
+    { timeoutMs: 1_000 },
   );
 
   if (healthResult.isErr()) {
@@ -108,7 +109,7 @@ export async function checkEgressForwarderHealth(
 
 export async function setupEgressForwarder(
   auth: Authenticator,
-  sandbox: SandboxResource
+  sandbox: SandboxResource,
 ): Promise<Result<void, Error>> {
   const logContext = {
     event: "egress.setup",
@@ -123,11 +124,14 @@ export async function setupEgressForwarder(
     return new Err(error instanceof Error ? error : new Error(String(error)));
   }
 
-  const token = mintEgressJwt(sandbox.providerId);
+  const token = mintEgressJwt(
+    sandbox.providerId,
+    auth.getNonNullableWorkspace().sId,
+  );
   const tokenWriteResult = await sandbox.writeFile(
     auth,
     EGRESS_TOKEN_PATH,
-    new TextEncoder().encode(token).buffer
+    new TextEncoder().encode(token).buffer,
   );
   if (tokenWriteResult.isErr()) {
     return tokenWriteResult;
@@ -136,16 +140,13 @@ export async function setupEgressForwarder(
   const chmodResult = await runSuccessfulSandboxCommand(
     auth,
     sandbox,
-    `chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)}`,
-    "root"
+    `chown dust-fwd:dust-fwd ${shellEscape(EGRESS_TOKEN_PATH)} && chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)}`,
+    "root",
   );
   if (chmodResult.isErr()) {
     return chmodResult;
   }
 
-  // The forwarder runs as root. The nftables rules only redirect traffic
-  // from agent-proxied (uid 1003), so root's outbound connections go
-  // straight to the internet without looping back through the proxy.
   const startForwarderCommand =
     "nohup /opt/bin/dsbx forward " +
     `--token-file ${shellEscape(EGRESS_TOKEN_PATH)} ` +
@@ -159,7 +160,7 @@ export async function setupEgressForwarder(
     auth,
     sandbox,
     startForwarderCommand,
-    "root"
+    "dust-fwd",
   );
   if (startResult.isErr()) {
     return startResult;
@@ -179,7 +180,7 @@ export async function setupEgressForwarder(
   }
 
   return new Err(
-    new Error("Sandbox egress forwarder did not become healthy in time")
+    new Error("Sandbox egress forwarder did not become healthy in time"),
   );
 }
 
@@ -188,7 +189,7 @@ export async function setupEgressForwarder(
 // last read", not strictly caused by the command that just ran.
 export async function readNewDenyLogEntries(
   auth: Authenticator,
-  sandbox: SandboxResource
+  sandbox: SandboxResource,
 ): Promise<Result<string[], Error>> {
   const command =
     `_off=$(cat ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)} 2>/dev/null || echo 0); ` +


### PR DESCRIPTION
## Description

Two small changes to the sandbox egress setup, preparing for GCS-backed per-workspace policies:

1. **JWT `wId` claim**: `mintEgressJwt` now includes a `wId` (workspace sId) claim alongside the existing `sbId`. On the proxy side, `wId` is optional in `ValidatedSandboxToken` — old sandboxes without `wId` continue to validate. The proxy validates `wId` is non-empty when present but does not use it for policy lookup yet (that comes in the GCS policy provider PR).

2. **Forwarder runs as `dust-fwd`**: The egress token file is now chowned to `dust-fwd:dust-fwd`, and the forwarder process runs as `dust-fwd` instead of `root`. The nftables rules only redirect `agent-proxied` traffic, so the forwarder doesn't need root privileges.

## Tests

- **Rust unit tests** (24 passing): new tests for `wId` validation — accepts token with `wId`, accepts token without `wId` (rollout compat), rejects empty/whitespace `wId` when present
- **Front unit tests** (5 passing): JWT minting verifies `wId` claim, forwarder setup test updated for `dust-fwd` user and `chown` command

## Risk

Low. Both changes are backward compatible:
- `wId` is optional in the proxy — no behavior change until the GCS policy provider PR lands
- The `dust-fwd` user already exists in the sandbox image and has the right permissions

## Deploy Plan

Deploy front and egress-proxy: order does not matter.