### PR TITLE
Await GCS mount and token refresh before running bash tool

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -138,13 +138,25 @@ export async function runSandboxBashTool(
     );
 
     if (freshlyCreated || wokeFromSleep) {
-      void mountConversationFiles(auth, sandbox, conversation, image).catch(
-        (err) => logger.error({ err }, "GCS mount failed (fire-and-forget)")
+      const mountResult = await mountConversationFiles(
+        auth,
+        sandbox,
+        conversation,
+        image
       );
+      if (mountResult.isErr()) {
+        return new Err(new MCPError(mountResult.error.message));
+      }
     } else {
-      void refreshGcsToken(auth, sandbox, conversation, image).catch((err) =>
-        logger.error({ err }, "GCS token refresh failed (fire-and-forget)")
+      const refreshResult = await refreshGcsToken(
+        auth,
+        sandbox,
+        conversation,
+        image
       );
+      if (refreshResult.isErr()) {
+        return new Err(new MCPError(refreshResult.error.message));
+      }
     }
   } else {
     logger.error(

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -20,10 +20,6 @@ const MOUNT_POINT = "/files/conversation";
  *  2. Write the token JSON to /tmp/token.json in the sandbox.
  *  3. Start the token HTTP server (netcat loop on :9876) and wait for it.
  *  4. Run gcsfuse with --token-url pointing to the local token server.
- *
- * This function is designed to be called fire-and-forget (non-blocking) after sandbox creation or
- * wake. The .mount-pending sentinel file signals to code running in the sandbox that the mount is
- * not yet ready.
  */
 export async function mountConversationFiles(
   auth: Authenticator,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We observed that models frequently couldn't see conversation files, either:
- the `.mount-pending` sentinel file was still present
- GCS FUSE hadn't finished mounting by the time the bash command ran.

This PR now awaits both calls and surfaces mount/refresh failures as proper errors instead of silently logging them.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
