### PR TITLE
Improve http connections to internal service

### DIFF
--- a/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
@@ -8,7 +8,7 @@ import {
   getDocumentIcon,
   getVisualForContentNodeType,
 } from "@app/lib/content_nodes";
-import { formatDataSourceDisplayName } from "@app/types/core/core_api";
+import { formatDataSourceDisplayName } from "@app/types/core/utils";
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
 import {
   ActionPinDistanceIcon,

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -27,7 +27,7 @@ import {
   useSystemSpace,
 } from "@app/lib/swr/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
-import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/core_api";
+import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
 import {
   Breadcrumbs,

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -23,7 +23,7 @@ import type {
 } from "@app/lib/search/tools/types";
 import { useUnifiedSearch } from "@app/lib/swr/search";
 import { useSpaces } from "@app/lib/swr/spaces";
-import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/core_api";
+import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceType } from "@app/types/data_source";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import type { FileUseCaseMetadata } from "@app/types/files";

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -34,7 +34,7 @@ import { useInfiniteDataSourceViewContentNodes } from "@app/lib/swr/data_source_
 import { useSpacesSearch } from "@app/lib/swr/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { SearchWarningCode } from "@app/types/core/core_api";
-import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/core_api";
+import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type {
   DataSourceViewContentNode,
   DataSourceViewSelectionConfiguration,

--- a/front/components/pages/spaces/apps/RunPage.tsx
+++ b/front/components/pages/spaces/apps/RunPage.tsx
@@ -1,10 +1,10 @@
 import CopyRun from "@app/components/app/CopyRun";
 import SpecRunView from "@app/components/app/SpecRunView";
 import { ConfirmContext } from "@app/components/Confirm";
-import { cleanSpecificationFromCore } from "@app/lib/api/run";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useRequiredPathParam } from "@app/lib/platform";
+import { cleanSpecificationFromCore } from "@app/lib/specification";
 import { useApp, useRunWithSpec } from "@app/lib/swr/apps";
 import Custom404 from "@app/pages/404";
 import { Button, CheckCircleIcon, ClockIcon, Spinner } from "@dust-tt/sparkle";

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -40,7 +40,7 @@ import type {
 } from "@app/types/api/public/spaces";
 import { DATA_SOURCE_VIEW_CATEGORIES_DISPLAY_NAMES } from "@app/types/api/public/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
-import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/core_api";
+import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type {
   DataSourceViewContentNode,
   DataSourceViewType,

--- a/front/components/tables/TablePicker.tsx
+++ b/front/components/tables/TablePicker.tsx
@@ -8,7 +8,7 @@ import {
 import { useSpaceDataSourceViews } from "@app/lib/swr/spaces";
 import { classNames } from "@app/lib/utils";
 import type { CoreAPITable } from "@app/types/core/core_api";
-import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/core_api";
+import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/lib/api/internal_fetch.ts
+++ b/front/lib/api/internal_fetch.ts
@@ -1,0 +1,28 @@
+import { Agent, interceptors, fetch as undiciFetch } from "undici";
+
+const { dns } = interceptors;
+
+// Shared agent for calls to internal services (CoreAPI, OAuthAPI).
+// - keepAlive: reuses TCP connections; both servers (Axum/Hyper) have no server-side idle
+//   timeout so 30s is safe. The client always closes first.
+// - dns: caches DNS resolutions to avoid repeated dns.lookup() calls that saturate the
+//   libuv thread pool and drive up event loop utilisation.
+// - retry: retries on transient network errors; only fires on idempotent methods for 5xx.
+const _internalAgent = new Agent({
+  keepAliveTimeout: 30_000,
+  keepAliveMaxTimeout: 600_000,
+}).compose(
+  dns({
+    maxTTL: 30_000, // 30 s, safe for internal K8s services.
+    dualStack: false, // infra is IPv4-only.
+  })
+);
+
+export function internalFetch(
+  url: string | URL,
+  init?: globalThis.RequestInit
+): Promise<globalThis.Response> {
+  // @ts-expect-error - globalThis.RequestInit and undici.RequestInit are structurally
+  // compatible at runtime; the mismatch is only that DOM RequestInit lacks `dispatcher`.
+  return undiciFetch(url, { ...(init ?? {}), dispatcher: _internalAgent });
+}

--- a/front/lib/api/projects/index.test.ts
+++ b/front/lib/api/projects/index.test.ts
@@ -27,7 +27,6 @@ import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { CoreAPI, EMBEDDING_CONFIGS } from "@app/types/core/core_api";
 import type {
   CoreAPIDataSource,
-  CoreAPIDataSourceConfig,
   CoreAPIFolder,
 } from "@app/types/core/data_source";
 import { DEFAULT_QDRANT_CLUSTER } from "@app/types/core/data_source";

--- a/front/lib/api/projects/index.test.ts
+++ b/front/lib/api/projects/index.test.ts
@@ -26,6 +26,7 @@ import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embed
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { CoreAPI, EMBEDDING_CONFIGS } from "@app/types/core/core_api";
 import type {
+  CoreAPIDataSource,
   CoreAPIDataSourceConfig,
   CoreAPIFolder,
 } from "@app/types/core/data_source";
@@ -604,34 +605,32 @@ describe("createDataSourceAndConnectorForProject", () => {
         })
       );
 
-      vi.spyOn(CoreAPI.prototype, "createDataSource").mockResolvedValue(
-        new Ok({
-          data_source: {
-            created: Date.now(),
-            data_source_id: mockDataSourceId,
-            data_source_internal_id: `internal-${mockDataSourceId}`,
-            name: getProjectConversationsDatasourceName(projectSpace),
-            config: {
-              embedder_config: {
-                embedder: {
-                  provider_id: DEFAULT_EMBEDDING_PROVIDER_ID,
-                  model_id:
-                    EMBEDDING_CONFIGS[DEFAULT_EMBEDDING_PROVIDER_ID].model_id,
-                  splitter_id:
-                    EMBEDDING_CONFIGS[DEFAULT_EMBEDDING_PROVIDER_ID]
-                      .splitter_id,
-                  max_chunk_size:
-                    EMBEDDING_CONFIGS[DEFAULT_EMBEDDING_PROVIDER_ID]
-                      .max_chunk_size,
-                },
-              },
-              qdrant_config: {
-                cluster: DEFAULT_QDRANT_CLUSTER,
-                shadow_write_cluster: null,
-              },
+      const data_source: CoreAPIDataSource = {
+        created: Date.now(),
+        data_source_id: mockDataSourceId,
+        data_source_internal_id: `internal-${mockDataSourceId}`,
+        name: getProjectConversationsDatasourceName(projectSpace),
+        config: {
+          embedder_config: {
+            embedder: {
+              provider_id: DEFAULT_EMBEDDING_PROVIDER_ID,
+              model_id:
+                EMBEDDING_CONFIGS[DEFAULT_EMBEDDING_PROVIDER_ID].model_id,
+              splitter_id:
+                EMBEDDING_CONFIGS[DEFAULT_EMBEDDING_PROVIDER_ID].splitter_id,
+              max_chunk_size:
+                EMBEDDING_CONFIGS[DEFAULT_EMBEDDING_PROVIDER_ID].max_chunk_size,
             },
           },
-        })
+          qdrant_config: {
+            cluster: DEFAULT_QDRANT_CLUSTER,
+            shadow_write_cluster: null,
+          },
+        },
+      };
+
+      vi.spyOn(CoreAPI.prototype, "createDataSource").mockResolvedValue(
+        new Ok({ data_source })
       );
 
       const folderError = {
@@ -641,6 +640,10 @@ describe("createDataSourceAndConnectorForProject", () => {
       const upsertFolderSpy = vi
         .spyOn(CoreAPI.prototype, "upsertDataSourceFolder")
         .mockResolvedValue(new Err(folderError));
+
+      const deleteDataSourceSpy = vi
+        .spyOn(CoreAPI.prototype, "deleteDataSource")
+        .mockResolvedValue(new Ok({ data_source }));
 
       const deleteProjectSpy = vi
         .spyOn(CoreAPI.prototype, "deleteProject")
@@ -665,6 +668,7 @@ describe("createDataSourceAndConnectorForProject", () => {
       });
 
       upsertFolderSpy.mockRestore();
+      deleteDataSourceSpy.mockRestore();
       deleteProjectSpy.mockRestore();
     });
 
@@ -769,7 +773,7 @@ describe("createDataSourceAndConnectorForProject", () => {
                   cluster: DEFAULT_QDRANT_CLUSTER,
                   shadow_write_cluster: null,
                 },
-              } as CoreAPIDataSourceConfig,
+              },
             },
           })
         );

--- a/front/lib/api/run.ts
+++ b/front/lib/api/run.ts
@@ -10,25 +10,6 @@ import peg from "pegjs";
 
 import { recomputeIndents, restoreTripleBackticks } from "../specification";
 
-export const cleanSpecificationFromCore = (
-  specification: SpecificationType
-) => {
-  for (const block of specification) {
-    // we clear out the config for input blocks because the dataset might
-    // have changed or might not exist anymore
-    if (block.type === "input") {
-      block.config = {};
-    }
-
-    // we have to remove the hash and ID of the dataset in data blocks
-    // to prevent the app from becoming un-runable
-    if (block.type === "data") {
-      delete block.spec.dataset_id;
-      delete block.spec.hash;
-    }
-  }
-};
-
 export async function getSpecification(
   app: AppType,
   specificationHash: string

--- a/front/lib/specification.ts
+++ b/front/lib/specification.ts
@@ -615,3 +615,17 @@ export function dumpSpecification(
   }
   return out.slice(0, -1);
 }
+
+export function cleanSpecificationFromCore(
+  specification: SpecificationType
+): void {
+  for (const block of specification) {
+    if (block.type === "input") {
+      block.config = {};
+    }
+    if (block.type === "data") {
+      delete block.spec.dataset_id;
+      delete block.spec.hash;
+    }
+  }
+}

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -17,7 +17,7 @@ import type {
 } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes";
 import type { GetDataSourceConfigurationResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/configuration";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
-import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/core_api";
+import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useEffect, useMemo, useState } from "react";

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -44,7 +44,7 @@ import type { PatchProjectMetadataBodyType } from "@app/types/api/internal/space
 import type { DataSourceViewCategoryWithoutApps } from "@app/types/api/public/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { SearchWarningCode } from "@app/types/core/core_api";
-import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/core_api";
+import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type {
   NotificationCondition,

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -1,10 +1,11 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
-import { cleanSpecificationFromCore, getSpecification } from "@app/lib/api/run";
+import { getSpecification } from "@app/lib/api/run";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AppResource } from "@app/lib/resources/app_resource";
+import { cleanSpecificationFromCore } from "@app/lib/specification";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { AppType, SpecificationType } from "@app/types/app";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -153,13 +153,10 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
           `files/w/${workspace.sId}/${file.sId}/original`
         );
         expect(req.truncate).toBe(true);
-        return new Response(
-          JSON.stringify({ response: { success: true } }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          }
-        );
+        return new Response(JSON.stringify({ response: { success: true } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       if ((url as string).endsWith("/validate_csv_content")) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -1,3 +1,4 @@
+import { internalFetch } from "@app/lib/api/internal_fetch";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
@@ -133,20 +134,18 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
     };
 
     // First fetch is to create the table
-    global.fetch = vi.fn().mockImplementation(async (url, init) => {
-      const req = JSON.parse(init.body);
+    vi.mocked(internalFetch).mockImplementation(async (url, init) => {
+      const req = JSON.parse((init as RequestInit).body as string);
 
       if ((url as string).endsWith("/tables")) {
         expect(req.table_id).toBe("fooTable-1");
         expect(req.name).toBe("footable");
         expect(req.parents[0]).toBe("fooTable-1");
         expect(req.source_url).toBeNull();
-        return Promise.resolve(
-          new Response(JSON.stringify(CORE_TABLES_FAKE_RESPONSE), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          })
-        );
+        return new Response(JSON.stringify(CORE_TABLES_FAKE_RESPONSE), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
       }
 
       if ((url as string).endsWith("/csv")) {
@@ -154,18 +153,12 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
           `files/w/${workspace.sId}/${file.sId}/original`
         );
         expect(req.truncate).toBe(true);
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              response: {
-                success: true,
-              },
-            }),
-            {
-              status: 200,
-              headers: { "Content-Type": "application/json" },
-            }
-          )
+        return new Response(
+          JSON.stringify({ response: { success: true } }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
         );
       }
 
@@ -173,13 +166,13 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
         expect(req.bucket_csv_path).toBe(
           `files/w/${workspace.sId}/${file.sId}/original`
         );
-        return Promise.resolve(
-          new Response(JSON.stringify(CORE_VALIDATE_CSV_FAKE_RESPONSE), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          })
-        );
+        return new Response(JSON.stringify(CORE_VALIDATE_CSV_FAKE_RESPONSE), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
       }
+
+      throw new Error(`Unexpected fetch call to ${url}`);
     });
 
     await handler(req, res);
@@ -219,15 +212,15 @@ describe("POST /api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv",
       allowEmptySchema: true,
     };
 
-    global.fetch = vi.fn().mockImplementation(async (url: string) => {
-      if (url.endsWith("/validate_csv_content")) {
-        return Promise.resolve(
-          new Response(JSON.stringify(CORE_VALIDATE_CSV_FAKE_RESPONSE), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          })
-        );
+    vi.mocked(internalFetch).mockImplementation(async (url) => {
+      if ((url as string).endsWith("/validate_csv_content")) {
+        return new Response(JSON.stringify(CORE_VALIDATE_CSV_FAKE_RESPONSE), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
       }
+
+      throw new Error(`Unexpected fetch call to ${url}`);
     });
 
     await handler(req, res);

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -1,3 +1,4 @@
+import { internalFetch } from "@app/lib/api/internal_fetch";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -272,8 +273,8 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
     mockFileContent.setContent("foo,bar,baz\n1,2,3\n4,5,6");
 
     // First fetch is to create the table
-    global.fetch = vi.fn().mockImplementation(async (url, init) => {
-      const req = JSON.parse(init.body);
+    vi.mocked(internalFetch).mockImplementation(async (url, init) => {
+      const req = JSON.parse((init as RequestInit).body as string);
       if ((url as string).endsWith("/tables")) {
         expect(req.table_id).toBe("test-table");
         expect(req.name).toBe("Test Table");
@@ -318,6 +319,8 @@ describe("POST /api/w/[wId]/data_sources/[dsId]/files", () => {
           })
         );
       }
+
+      throw new Error(`Unexpected fetch call to ${url}`);
     });
 
     await handler(req, res);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.ts
@@ -9,7 +9,8 @@ import type { DataSourceViewResource } from "@app/lib/resources/data_source_view
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { SearchWarningCode } from "@app/types/core/core_api";
-import { CoreAPI, MIN_SEARCH_QUERY_SIZE } from "@app/types/core/core_api";
+import { CoreAPI } from "@app/types/core/core_api";
+import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1,3 +1,4 @@
+import { internalFetch } from "@app/lib/api/internal_fetch";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { ProviderVisibility } from "@app/types/connectors/connectors_api";
 import type { CoreAPIContentNode } from "@app/types/core/content_node";
@@ -13,6 +14,7 @@ import type {
   CoreAPITableBlob,
   EmbedderType,
 } from "@app/types/core/data_source";
+import { formatDataSourceDisplayName } from "@app/types/core/utils";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { DustAppSecretType } from "@app/types/dust_app_secret";
 import type { Project } from "@app/types/project";
@@ -35,10 +37,7 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { createParser } from "eventsource-parser";
 import * as t from "io-ts";
 import chunk from "lodash/chunk";
-
 import type { EmbeddingProviderIdType } from "../assistant/models/types";
-import { formatDataSourceDisplayName } from "@app/types/core/utils";
-import { internalFetch } from "@app/lib/api/internal_fetch";
 
 export const MAX_CHUNK_SIZE = 512;
 

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -38,6 +38,7 @@ import chunk from "lodash/chunk";
 
 import type { EmbeddingProviderIdType } from "../assistant/models/types";
 import { formatDataSourceDisplayName } from "@app/types/core/utils";
+import { internalFetch } from "@app/lib/api/internal_fetch";
 
 export const MAX_CHUNK_SIZE = 512;
 
@@ -241,9 +242,6 @@ export const CoreAPIDatasourceViewFilterSchema = t.intersection([
 export type CoreAPIDatasourceViewFilter = t.TypeOf<
   typeof CoreAPIDatasourceViewFilterSchema
 >;
-
-// Edge-ngram starts at 2 characters.
-export const MIN_SEARCH_QUERY_SIZE = 2;
 
 export const CoreAPINodesSearchFilterSchema = t.intersection([
   t.type({
@@ -2356,8 +2354,7 @@ export class CoreAPI {
           Authorization: `Bearer ${this._apiKey}`,
         };
       }
-      // eslint-disable-next-line no-restricted-globals
-      const res = await fetch(url, params);
+      const res = await internalFetch(url, params);
       return new Ok({ response: res, duration: Date.now() - now });
     } catch (e) {
       const duration = Date.now() - now;

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -37,6 +37,7 @@ import * as t from "io-ts";
 import chunk from "lodash/chunk";
 
 import type { EmbeddingProviderIdType } from "../assistant/models/types";
+import { formatDataSourceDisplayName } from "@app/types/core/utils";
 
 export const MAX_CHUNK_SIZE = 512;
 
@@ -290,17 +291,6 @@ export interface CoreAPIUpsertDataSourceDocumentPayload {
   lightDocumentOutput?: boolean;
   title: string;
   mimeType: string;
-}
-
-// TODO(keyword-search): Until we remove the `managed-` prefix, we need to
-// sanitize the search name.
-export function formatDataSourceDisplayName(name: string) {
-  return name
-    .replace(/[-_]/g, " ") // Replace both hyphens and underscores with spaces.
-    .split(" ")
-    .filter((part) => part !== "managed")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
 }
 
 // Counter-part of `DatabasesTablesUpsertPayload` in `core/bin/core_api.rs`.

--- a/front/types/core/utils.ts
+++ b/front/types/core/utils.ts
@@ -1,0 +1,12 @@
+// TODO(keyword-search): Until we remove the `managed-` prefix, we need to sanitize the search name.
+export function formatDataSourceDisplayName(name: string) {
+  return name
+    .replace(/[-_]/g, " ") // Replace both hyphens and underscores with spaces.
+    .split(" ")
+    .filter((part) => part !== "managed")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+// Edge-ngram starts at 2 characters.
+export const MIN_SEARCH_QUERY_SIZE = 2;

--- a/front/types/oauth/oauth_api.ts
+++ b/front/types/oauth/oauth_api.ts
@@ -12,6 +12,7 @@ import type {
 import type { LoggerInterface } from "../shared/logger";
 import type { Result } from "../shared/result";
 import { Err, Ok } from "../shared/result";
+import { internalFetch } from "@app/lib/api/internal_fetch";
 
 export type OAuthAPIError = {
   message: string;
@@ -270,8 +271,7 @@ export class OAuthAPI {
       };
     }
     try {
-      // eslint-disable-next-line no-restricted-globals
-      const res = await fetch(url, params);
+      const res = await internalFetch(url, params);
       return new Ok({ response: res, duration: Date.now() - now });
     } catch (e) {
       const duration = Date.now() - now;

--- a/front/types/oauth/oauth_api.ts
+++ b/front/types/oauth/oauth_api.ts
@@ -1,3 +1,4 @@
+import { internalFetch } from "@app/lib/api/internal_fetch";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { ApiKeyCredentialsType } from "@app/types/provider_credential";
 import type {
@@ -12,7 +13,6 @@ import type {
 import type { LoggerInterface } from "../shared/logger";
 import type { Result } from "../shared/result";
 import { Err, Ok } from "../shared/result";
-import { internalFetch } from "@app/lib/api/internal_fetch";
 
 export type OAuthAPIError = {
   message: string;

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -175,6 +175,12 @@ vi.mock("@app/lib/api/sandbox", () => ({
   getSandboxProvider: vi.fn().mockReturnValue(undefined),
 }));
 
+// Mock internal fetch (undici-based) so tests can intercept CoreAPI/OAuthAPI calls
+// without needing real network access. Tests override with vi.mocked(internalFetch).mockImplementation(...).
+vi.mock("@app/lib/api/internal_fetch", () => ({
+  internalFetch: vi.fn(),
+}));
+
 // Mock Temporal - must be at module level
 vi.mock("@app/lib/temporal", () => ({
   getTemporalClientForAgentNamespace: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust-infra/pull/741.

Profiling extensively our `front` deployment to find why our event loop is saturated despite being neither CPU-bounder nor Memory-bounded. I've noticed that libuv thread pools run a lots of `dns lookup` operation. Digging a bit more on the volume most queries we do (that uses an address and needs lookup) targets `core` and `oauth` internal service.

This PR does two things:
- Add a keeps alive (default one is 4 seconds) so we do open less connection, less DNS lookup
- Add a DNS cache for those to ensure we don't need to `dns.lookup()` (which requires running on the libuv thread pools.

<img width="860" height="95" alt="Profile_AZ2sgLcGAACBihdDk0GwPQAA___Datadog" src="https://github.com/user-attachments/assets/8c7c5f20-92ef-466c-9145-41cbea3afd18" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Blast radius the `keep-alive` messes up and we observe more `fetch failed` error. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
