### PR TITLE
Enforce wake-up cancellation rights on WakeUpResource

### DIFF
--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -319,10 +319,25 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     });
   }
 
+  canCancel(auth: Authenticator): boolean {
+    if (auth.isAdmin()) {
+      return true;
+    }
+    return auth.user()?.id === this.userId;
+  }
+
   async cancel(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<void, Error>> {
+    if (!this.canCancel(auth)) {
+      return new Err(
+        new Error(
+          "Only the wake-up owner or a workspace admin can cancel this wake-up."
+        )
+      );
+    }
+
     if (this.status !== "scheduled") {
       return new Ok(undefined);
     }

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -85,10 +85,14 @@ wake-up message with `username: "dust_system"` / `fullName: "Dust System"` inste
 
 ## Milestone 5: Security
 
-### PR 7 — Conversation interaction restrictions
+### [partial] PR 7 — Cancellation rights on `WakeUpResource`
 
-Enforce that only the wake-up owner can post in a conversation with an active wake-up.
-Cancellation permissions are owner + workspace admins.
+Enforce that only the wake-up owner (`userId`) or a workspace admin can cancel a wake-up.
+Implemented in `WakeUpResource.cancel(...)` via a `canCancel(auth)` check that short-circuits
+to an `Err` before cancelling the Temporal workflow or marking the row cancelled.
+
+Follow-up still in this milestone: restrict user message posting in a conversation with an
+active wake-up to the wake-up owner only.
 
 ## Milestone 6: API + UI
 


### PR DESCRIPTION
## Description

Scope-limited slice of PR 7 from `x/spolu/wakeup/plan.md` (security milestone): enforce that only the wake-up owner (`userId`) or a workspace admin can cancel a wake-up.

`WakeUpResource.cancel(auth, ...)` now calls a new `canCancel(auth)` check and returns an `Err` before touching the Temporal workflow or marking the row cancelled if the caller is neither the owner nor an admin. The `cancel_wakeup` tool surfaces that error back to the agent.

The companion "only the owner can post user messages in a conversation with an active wake-up" restriction is intentionally left for a follow-up per the request.

## Tests

N/A, tested locally — cancel succeeds as the owner and as an admin, fails for other users with the expected message.

## Risk

Low. The only existing caller of `cancel()` is the `cancel_wakeup` tool handler (which runs under the acting user's auth). `deleteByConversation` uses `cancelTemporalWorkflow` directly, not `cancel()`, so it is unaffected.

## Deploy Plan

- deploy `front`