### PR TITLE
Block foreign posts in conversations with an active wake-up

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -85,6 +85,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -661,6 +662,14 @@ export async function postUserMessage(
     });
   }
 
+  const canInteractRes = await WakeUpResource.canUserInteract(
+    auth,
+    conversation
+  );
+  if (canInteractRes.isErr()) {
+    return canInteractRes;
+  }
+
   const agentMentions = mentions.filter(isAgentMention);
   let runningAgentMessage = conversation.content
     .flat()
@@ -1151,6 +1160,14 @@ export async function editUserMessage(
         message: "Only the author of the message can edit it",
       },
     });
+  }
+
+  const canInteractRes = await WakeUpResource.canUserInteract(
+    auth,
+    conversation
+  );
+  if (canInteractRes.isErr()) {
+    return canInteractRes;
   }
 
   let userMessage: UserMessageType | null = null;

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -279,9 +279,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       return new Ok(undefined);
     }
     const currentUserId = auth.user()?.id ?? null;
-    const foreignWakeUp = activeWakeUps.find(
-      (w) => w.userId !== currentUserId
-    );
+    const foreignWakeUp = activeWakeUps.find((w) => w.userId !== currentUserId);
     if (!foreignWakeUp) {
       return new Ok(undefined);
     }

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -261,12 +261,9 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
 
   /**
    * Checks whether the caller can post or edit user messages in a conversation that has active
-   * wake-ups. Rejects when any active (scheduled) wake-up is owned by a user other than the
-   * current one — this keeps the agent running under the owner's auth from being steered by
-   * another user before the wake-up fires. The wake-up activity itself posts under the owner's
-   * auth (via `fetchWakeUpAndAuthenticatorById`), so fires are never blocked.
-   *
-   * The `(workspaceId, conversationId, status)` index covers this query.
+   * wake-ups. Rejects when any active (scheduled) wake-up is owned by a user other than the current
+   * one (his keeps the agent running under the owner's auth from being steered by another user
+   * before the wake-up fires).
    */
   static async canUserInteract(
     auth: Authenticator,

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -19,6 +19,7 @@ import type {
   WakeUpStatus,
   WakeUpType,
 } from "@app/types/assistant/wakeups";
+import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -229,11 +230,13 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
 
   static async listByConversation(
     auth: Authenticator,
-    conversation: ConversationWithoutContentType
+    conversation: ConversationWithoutContentType,
+    { status }: { status?: WakeUpStatus | WakeUpStatus[] } = {}
   ): Promise<WakeUpResource[]> {
     return this.baseFetch(auth, {
       where: {
         conversationId: conversation.id,
+        ...(status !== undefined ? { status } : {}),
       },
       order: [
         ["createdAt", "ASC"],
@@ -253,6 +256,44 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
         ["createdAt", "ASC"],
         ["id", "ASC"],
       ],
+    });
+  }
+
+  /**
+   * Checks whether the caller can post or edit user messages in a conversation that has active
+   * wake-ups. Rejects when any active (scheduled) wake-up is owned by a user other than the
+   * current one — this keeps the agent running under the owner's auth from being steered by
+   * another user before the wake-up fires. The wake-up activity itself posts under the owner's
+   * auth (via `fetchWakeUpAndAuthenticatorById`), so fires are never blocked.
+   *
+   * The `(workspaceId, conversationId, status)` index covers this query.
+   */
+  static async canUserInteract(
+    auth: Authenticator,
+    conversation: ConversationWithoutContentType
+  ): Promise<Result<void, APIErrorWithStatusCode>> {
+    const activeWakeUps = await this.listByConversation(auth, conversation, {
+      status: ACTIVE_WAKE_UP_STATUSES,
+    });
+    if (activeWakeUps.length === 0) {
+      return new Ok(undefined);
+    }
+    const currentUserId = auth.user()?.id ?? null;
+    const foreignWakeUp = activeWakeUps.find(
+      (w) => w.userId !== currentUserId
+    );
+    if (!foreignWakeUp) {
+      return new Ok(undefined);
+    }
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "This conversation has an active wake-up owned by another user. " +
+          "Only the wake-up owner can post or edit messages until the " +
+          "wake-up fires or is cancelled.",
+      },
     });
   }
 

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -85,14 +85,26 @@ wake-up message with `username: "dust_system"` / `fullName: "Dust System"` inste
 
 ## Milestone 5: Security
 
-### [partial] PR 7 — Cancellation rights on `WakeUpResource`
+### [x] PR 7 — Cancellation rights on `WakeUpResource`
 
-Enforce that only the wake-up owner (`userId`) or a workspace admin can cancel a wake-up.
-Implemented in `WakeUpResource.cancel(...)` via a `canCancel(auth)` check that short-circuits
-to an `Err` before cancelling the Temporal workflow or marking the row cancelled.
+Two slices:
 
-Follow-up still in this milestone: restrict user message posting in a conversation with an
-active wake-up to the wake-up owner only.
+1. **Cancellation rights (`WakeUpResource.cancel`)** — only the wake-up owner (`userId`) or
+   a workspace admin can cancel. Enforced via a `canCancel(auth)` check in `cancel(...)`
+   that returns an `Err` before touching the Temporal workflow or marking the row
+   cancelled.
+
+2. **Post / edit restriction** — while a conversation has an active (scheduled) wake-up,
+   only the wake-up owner can post or edit user messages. Shared logic lives on
+   `WakeUpResource.canUserInteract(auth, conversation)`, which returns an
+   `APIErrorWithStatusCode` (409 `invalid_request_error`) when any active wake-up is
+   owned by a user other than the caller. Called from both `postUserMessage` and
+   `editUserMessage` in `front/lib/api/assistant/conversation.ts`. The wake-up activity
+   posts under the owner's auth (via `fetchWakeUpAndAuthenticatorById`), so fires are
+   never blocked.
+
+`retryAgentMessage` is intentionally not gated — it does not take user input beyond
+selecting an existing agent message.
 
 ## Milestone 6: API + UI
 

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -85,11 +85,7 @@ wake-up message with `username: "dust_system"` / `fullName: "Dust System"` inste
 
 ## Milestone 5: Security
 
-<<<<<<< HEAD
-### [x] PR 7 — Cancellation rights on `WakeUpResource`
-=======
 ### [x] PR 7 — Conversation interaction restrictions
->>>>>>> 32194272b4 (format check)
 
 Two slices:
 

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -85,7 +85,11 @@ wake-up message with `username: "dust_system"` / `fullName: "Dust System"` inste
 
 ## Milestone 5: Security
 
+<<<<<<< HEAD
 ### [x] PR 7 — Cancellation rights on `WakeUpResource`
+=======
+### [x] PR 7 — Conversation interaction restrictions
+>>>>>>> 32194272b4 (format check)
 
 Two slices:
 


### PR DESCRIPTION
## Description

Companion slice to the cancellation-rights change on `WakeUpResource` (#24734) covering the second half of PR 7 in `x/spolu/wakeup/plan.md`.

`postUserMessage` and `editUserMessage` now lists active (scheduled) wake-ups on the conversation and rejects with a 409 `invalid_request_error` when any is owned by a different user than the caller. Without this guard, another user could steer the agent before the wake-up fires while it still runs under the owner's auth.

## Tests

N/A, tested locally — foreign posts return the expected 409; owner and admin/system posts work; the wake-up activity fires and posts normally.

## Risk

High touches conversation main logic. But also, no wake-up in prod and everything looks fine in dev.

## Deploy Plan

- deploy `front`