### PR TITLE
Add hasFeature to the useEffect dependency array

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/extension",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Dust Chrome Extension",
   "scripts": {
     "clean": "rm -rf build/*",

--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/platforms/firefox/manifests/manifest.base.json
+++ b/extension/platforms/firefox/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/shared/hooks/useMcpServer.ts
+++ b/extension/shared/hooks/useMcpServer.ts
@@ -116,7 +116,7 @@ export function useMcpServer() {
       setIsConnected(false);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- workspace object excluded; workspaceId triggers re-runs.
-  }, [platform.mcp, workspaceId]);
+  }, [platform.mcp, workspaceId, hasFeature]);
 
   return {
     server,

--- a/package-lock.json
+++ b/package-lock.json
@@ -406,7 +406,7 @@
     },
     "extension": {
       "name": "@dust-tt/extension",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "ISC",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",


### PR DESCRIPTION
## Description

Fixes a React hooks exhaustive-deps violation in the `useMcpServer` hook. The `hasFeature` function is used inside the useEffect to check the `browser_extension_mcp_tools` feature flag and determine server support, but was missing from the dependency array. This could cause the effect to use stale feature flag values if they change.

This PR also bumps the extension version to prepare the future deployment.

## Tests

Manual testing in the browser extension to verify MCP server connection behavior works correctly when feature flags change.

## Risk

Low. This ensures the effect properly re-runs when feature flags change, preventing potential stale state issues.

## Deploy Plan

Deploy extension.