### PR TITLE
feat(sbx): add GCS policy provider with debug endpoint (dark deploy)

### DIFF
--- a/egress-proxy/Cargo.lock
+++ b/egress-proxy/Cargo.lock
@@ -68,6 +68,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +264,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,14 +310,18 @@ dependencies = [
  "axum",
  "clap",
  "jsonwebtoken",
+ "moka",
+ "reqwest",
  "rustls",
  "serde",
+ "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
 ]
 
 [[package]]
@@ -284,6 +338,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -335,6 +410,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -359,8 +446,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -370,9 +459,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -472,6 +563,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -480,13 +588,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -494,6 +610,16 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "indexmap"
@@ -505,6 +631,22 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -535,6 +677,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -594,6 +738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +782,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +821,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -688,6 +864,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +895,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -728,12 +974,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -763,6 +1038,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +1088,12 @@ dependencies = [
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -798,6 +1117,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -810,6 +1130,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -946,7 +1267,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -999,6 +1320,15 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -1019,7 +1349,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1034,6 +1373,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1391,21 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1094,6 +1459,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1184,10 +1567,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -1208,16 +1612,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1254,6 +1695,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1320,6 +1771,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1496,6 +1976,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/egress-proxy/Cargo.lock
+++ b/egress-proxy/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,10 +88,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
@@ -209,6 +235,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +313,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +365,7 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "gcp_auth",
  "jsonwebtoken",
  "moka",
  "reqwest",
@@ -374,6 +431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +484,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +506,32 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "gcp_auth"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b3d0b409a042a380111af38136310839af8ac1a0917fb6e84515ed1e4bf3ee"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "ring",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
 ]
 
 [[package]]
@@ -477,6 +572,25 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -555,6 +669,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -576,6 +691,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -603,6 +719,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -811,6 +951,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,6 +970,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking"
@@ -856,6 +1011,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1125,6 +1300,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,10 +1346,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1446,6 +1665,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1754,16 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -1803,10 +2045,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/egress-proxy/Cargo.toml
+++ b/egress-proxy/Cargo.toml
@@ -12,13 +12,17 @@ anyhow = "1.0"
 axum = "=0.8.4"
 clap = { version = "=4.5.40", features = ["derive", "env"] }
 jsonwebtoken = { version = "10.3.0", default-features = false, features = ["aws_lc_rs"] }
+moka = { version = "0.12", features = ["future"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rustls = "0.23"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 thiserror = "1.0.57"
 tokio = { version = "1.38", features = ["full"] }
 tokio-rustls = "0.26"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+urlencoding = "2.1"
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/egress-proxy/Cargo.toml
+++ b/egress-proxy/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 anyhow = "1.0"
 axum = "=0.8.4"
 clap = { version = "=4.5.40", features = ["derive", "env"] }
+gcp_auth = "0.12.6"
 jsonwebtoken = { version = "10.3.0", default-features = false, features = ["aws_lc_rs"] }
 moka = { version = "0.12", features = ["future"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/egress-proxy/src/config.rs
+++ b/egress-proxy/src/config.rs
@@ -3,6 +3,9 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
+
+const DEFAULT_POLICY_BASE_URL: &str = "https://storage.googleapis.com/storage/v1";
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -12,6 +15,9 @@ pub struct Config {
     pub tls_key_path: PathBuf,
     pub jwt_secret: String,
     pub temporary_allowlist: TemporaryAllowlist,
+    pub policy_bucket: String,
+    pub policy_base_url: String,
+    pub policy_cache_ttl: Duration,
     pub unsafe_skip_ssrf_check: bool,
 }
 
@@ -36,6 +42,19 @@ struct RawConfig {
     #[arg(long, env = "EGRESS_PROXY_ALLOWED_DOMAINS")]
     allowed_domains: String,
 
+    #[arg(long, env = "EGRESS_PROXY_POLICY_BUCKET")]
+    policy_bucket: String,
+
+    #[arg(long, env = "EGRESS_PROXY_POLICY_CACHE_TTL_SECS", default_value = "60")]
+    policy_cache_ttl_secs: u64,
+
+    #[arg(
+        long,
+        env = "EGRESS_PROXY_POLICY_BASE_URL",
+        default_value = DEFAULT_POLICY_BASE_URL
+    )]
+    policy_base_url: String,
+
     #[arg(long, env = "EGRESS_PROXY_ENV", default_value = "production")]
     environment: String,
 
@@ -57,9 +76,22 @@ impl TryFrom<RawConfig> for Config {
             return Err(anyhow!("EGRESS_PROXY_JWT_SECRET must not be empty"));
         }
 
-        // TODO(sandbox-egress): Remove EGRESS_PROXY_ALLOWED_DOMAINS when a later PR replaces the
-        // temporary process-wide allowlist with GCS-backed per-sandbox policies.
         let temporary_allowlist = TemporaryAllowlist::parse(&raw.allowed_domains)?;
+
+        if raw.policy_bucket.trim().is_empty() {
+            return Err(anyhow!("EGRESS_PROXY_POLICY_BUCKET must not be empty"));
+        }
+
+        if raw.policy_cache_ttl_secs == 0 {
+            return Err(anyhow!(
+                "EGRESS_PROXY_POLICY_CACHE_TTL_SECS must be greater than 0"
+            ));
+        }
+
+        let policy_base_url = raw.policy_base_url.trim().trim_end_matches('/').to_string();
+        if policy_base_url.is_empty() {
+            return Err(anyhow!("EGRESS_PROXY_POLICY_BASE_URL must not be empty"));
+        }
 
         // TODO(sandbox-egress): Remove this test-only bypass once integration tests can exercise
         // forwarding through a non-private deterministic upstream.
@@ -77,6 +109,9 @@ impl TryFrom<RawConfig> for Config {
             tls_key_path: raw.tls_key,
             jwt_secret: raw.jwt_secret,
             temporary_allowlist,
+            policy_bucket: raw.policy_bucket,
+            policy_base_url,
+            policy_cache_ttl: Duration::from_secs(raw.policy_cache_ttl_secs),
             unsafe_skip_ssrf_check,
         })
     }
@@ -95,7 +130,10 @@ fn parse_bool_env(value: Option<&str>) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_bool_env;
+    use super::{parse_bool_env, Config, RawConfig, DEFAULT_POLICY_BASE_URL};
+    use anyhow::Result;
+    use std::net::SocketAddr;
+    use std::path::PathBuf;
 
     #[test]
     fn parses_bool_env() {
@@ -108,5 +146,41 @@ mod tests {
         assert!(parse_bool_env(Some("YES")).is_err());
         assert!(parse_bool_env(Some("NO")).is_err());
         assert!(parse_bool_env(Some("maybe")).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_policy_cache_ttl() {
+        assert!(Config::try_from(raw_config(|raw| {
+            raw.policy_cache_ttl_secs = 0;
+        }))
+        .is_err());
+    }
+
+    #[test]
+    fn trims_policy_base_url_trailing_slash() -> Result<()> {
+        let config = Config::try_from(raw_config(|raw| {
+            raw.policy_base_url = format!("{DEFAULT_POLICY_BASE_URL}/");
+        }))?;
+
+        assert_eq!(config.policy_base_url, DEFAULT_POLICY_BASE_URL);
+        Ok(())
+    }
+
+    fn raw_config(update: impl FnOnce(&mut RawConfig)) -> RawConfig {
+        let mut raw = RawConfig {
+            listen_addr: "0.0.0.0:4443".parse::<SocketAddr>().unwrap(),
+            health_addr: "0.0.0.0:8080".parse::<SocketAddr>().unwrap(),
+            tls_cert: PathBuf::from("tls.crt"),
+            tls_key: PathBuf::from("tls.key"),
+            jwt_secret: "secret".to_string(),
+            allowed_domains: "example.com".to_string(),
+            policy_bucket: "test-bucket".to_string(),
+            policy_cache_ttl_secs: 60,
+            policy_base_url: DEFAULT_POLICY_BASE_URL.to_string(),
+            environment: "production".to_string(),
+            unsafe_skip_ssrf_check: None,
+        };
+        update(&mut raw);
+        raw
     }
 }

--- a/egress-proxy/src/gcs.rs
+++ b/egress-proxy/src/gcs.rs
@@ -1,0 +1,243 @@
+use crate::policy::Policy;
+use anyhow::{anyhow, Context, Result};
+use moka::future::Cache;
+use moka::Expiry;
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+use tracing::warn;
+
+const DEFAULT_NEGATIVE_CACHE_TTL_SECONDS: u64 = 10;
+const GCP_METADATA_TOKEN_URL: &str =
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+
+#[derive(Clone)]
+pub struct GcsPolicyProvider {
+    client: Client,
+    bucket: String,
+    base_url: String,
+    cache: Cache<String, CacheEntry>,
+    access_token_cache: Arc<Mutex<Option<(String, Instant)>>>,
+}
+
+#[derive(Clone)]
+enum CacheEntry {
+    Found(Policy),
+    Missing,
+}
+
+#[derive(Clone)]
+struct CacheExpiry {
+    positive_ttl: Duration,
+    negative_ttl: Duration,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+impl GcsPolicyProvider {
+    pub fn new(bucket: String, positive_ttl: Duration, base_url: String) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .context("failed to build GCS HTTP client")?;
+        let cache = Cache::builder()
+            .max_capacity(10_000)
+            .expire_after(CacheExpiry {
+                positive_ttl,
+                negative_ttl: Duration::from_secs(DEFAULT_NEGATIVE_CACHE_TTL_SECONDS),
+            })
+            .build();
+
+        Ok(Self {
+            client,
+            bucket,
+            base_url,
+            cache,
+            access_token_cache: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    pub async fn get_workspace_policy(&self, w_id: &str) -> Result<Option<Policy>> {
+        self.get_policy(&format!("w:{w_id}"), &format!("workspaces/{w_id}.json"))
+            .await
+    }
+
+    pub async fn get_sandbox_policy(&self, sb_id: &str) -> Result<Option<Policy>> {
+        self.get_policy(&format!("s:{sb_id}"), &format!("sandboxes/{sb_id}.json"))
+            .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn evaluate(&self, w_id: Option<&str>, sb_id: &str, domain: &str) -> bool {
+        let workspace_allows = match w_id {
+            Some(workspace_id) => match self.get_workspace_policy(workspace_id).await {
+                Ok(Some(policy)) => policy.allows(domain),
+                Ok(None) => false,
+                Err(error) => {
+                    warn!(error = %error, w_id = workspace_id, "workspace policy lookup failed");
+                    false
+                }
+            },
+            None => false,
+        };
+
+        if workspace_allows {
+            return true;
+        }
+
+        match self.get_sandbox_policy(sb_id).await {
+            Ok(Some(policy)) => policy.allows(domain),
+            Ok(None) => false,
+            Err(error) => {
+                warn!(error = %error, sb_id, "sandbox policy lookup failed");
+                false
+            }
+        }
+    }
+
+    async fn get_policy(&self, cache_key: &str, object_name: &str) -> Result<Option<Policy>> {
+        if let Some(entry) = self.cache.get(cache_key).await {
+            return Ok(entry.into_policy());
+        }
+
+        let policy = self.fetch_policy(object_name).await?;
+        let cache_entry = match policy {
+            Some(policy) => CacheEntry::Found(policy),
+            None => CacheEntry::Missing,
+        };
+
+        self.cache
+            .insert(cache_key.to_string(), cache_entry.clone())
+            .await;
+
+        Ok(cache_entry.into_policy())
+    }
+
+    async fn fetch_policy(&self, object_name: &str) -> Result<Option<Policy>> {
+        let access_token = self.get_access_token().await?;
+        let object_name = urlencoding::encode(object_name);
+        let url = format!(
+            "{}/b/{}/o/{}?alt=media",
+            self.base_url, self.bucket, object_name
+        );
+
+        let response = self
+            .client
+            .get(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .context("failed to fetch GCS policy object")?;
+
+        match response.status() {
+            StatusCode::OK => {
+                let bytes = response
+                    .bytes()
+                    .await
+                    .context("failed to read GCS policy object body")?;
+                let policy = serde_json::from_slice::<Policy>(&bytes)
+                    .context("failed to deserialize GCS policy object")?;
+                Ok(Some(policy))
+            }
+            StatusCode::NOT_FOUND => Ok(None),
+            status => Err(anyhow!("GCS policy fetch returned status {status}")),
+        }
+    }
+
+    async fn get_access_token(&self) -> Result<String> {
+        if let Ok(token) = std::env::var("GOOGLE_CLOUD_ACCESS_TOKEN") {
+            let trimmed = token.trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed.to_string());
+            }
+        }
+
+        {
+            let cache = self.access_token_cache.lock().await;
+            if let Some((token, expires_at)) = cache.as_ref() {
+                if Instant::now() < *expires_at {
+                    return Ok(token.clone());
+                }
+            }
+        }
+
+        let response = self
+            .client
+            .get(GCP_METADATA_TOKEN_URL)
+            .header("Metadata-Flavor", "Google")
+            .send()
+            .await
+            .context("failed to fetch GCP access token from metadata server")?
+            .error_for_status()
+            .context("metadata server returned an error for access token request")?;
+        let token_response = response
+            .json::<TokenResponse>()
+            .await
+            .context("failed to parse GCP access token response")?;
+
+        let expires_at =
+            Instant::now() + Duration::from_secs(token_response.expires_in.saturating_sub(300));
+        let token = token_response.access_token;
+
+        let mut cache = self.access_token_cache.lock().await;
+        *cache = Some((token.clone(), expires_at));
+
+        Ok(token)
+    }
+}
+
+impl CacheEntry {
+    fn into_policy(self) -> Option<Policy> {
+        match self {
+            Self::Found(policy) => Some(policy),
+            Self::Missing => None,
+        }
+    }
+}
+
+impl Expiry<String, CacheEntry> for CacheExpiry {
+    fn expire_after_create(
+        &self,
+        _key: &String,
+        value: &CacheEntry,
+        _created_at: Instant,
+    ) -> Option<Duration> {
+        Some(self.ttl_for(value))
+    }
+
+    fn expire_after_read(
+        &self,
+        _key: &String,
+        _value: &CacheEntry,
+        _read_at: Instant,
+        duration_until_expiry: Option<Duration>,
+        _last_modified_at: Instant,
+    ) -> Option<Duration> {
+        duration_until_expiry
+    }
+
+    fn expire_after_update(
+        &self,
+        _key: &String,
+        value: &CacheEntry,
+        _updated_at: Instant,
+        _duration_until_expiry: Option<Duration>,
+    ) -> Option<Duration> {
+        Some(self.ttl_for(value))
+    }
+}
+
+impl CacheExpiry {
+    fn ttl_for(&self, value: &CacheEntry) -> Duration {
+        match value {
+            CacheEntry::Found(_) => self.positive_ttl,
+            CacheEntry::Missing => self.negative_ttl,
+        }
+    }
+}

--- a/egress-proxy/src/gcs.rs
+++ b/egress-proxy/src/gcs.rs
@@ -3,15 +3,11 @@ use anyhow::{anyhow, Context, Result};
 use moka::future::Cache;
 use moka::Expiry;
 use reqwest::{Client, StatusCode};
-use serde::Deserialize;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex;
 use tracing::warn;
 
 const DEFAULT_NEGATIVE_CACHE_TTL_SECONDS: u64 = 10;
-const GCP_METADATA_TOKEN_URL: &str =
-    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+const GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.read_only";
 
 #[derive(Clone)]
 pub struct GcsPolicyProvider {
@@ -19,7 +15,7 @@ pub struct GcsPolicyProvider {
     bucket: String,
     base_url: String,
     cache: Cache<String, CacheEntry>,
-    access_token_cache: Arc<Mutex<Option<(String, Instant)>>>,
+    auth: Option<std::sync::Arc<dyn gcp_auth::TokenProvider>>,
 }
 
 #[derive(Clone)]
@@ -34,14 +30,8 @@ struct CacheExpiry {
     negative_ttl: Duration,
 }
 
-#[derive(Debug, Deserialize)]
-struct TokenResponse {
-    access_token: String,
-    expires_in: u64,
-}
-
 impl GcsPolicyProvider {
-    pub fn new(bucket: String, positive_ttl: Duration, base_url: String) -> Result<Self> {
+    pub async fn new(bucket: String, positive_ttl: Duration, base_url: String) -> Result<Self> {
         let client = Client::builder()
             .timeout(Duration::from_secs(5))
             .build()
@@ -54,12 +44,23 @@ impl GcsPolicyProvider {
             })
             .build();
 
+        // Skip GCP auth setup when a static token is provided (tests).
+        let auth = if std::env::var("GOOGLE_CLOUD_ACCESS_TOKEN").is_ok() {
+            None
+        } else {
+            Some(
+                gcp_auth::provider()
+                    .await
+                    .context("failed to initialize GCP authentication")?,
+            )
+        };
+
         Ok(Self {
             client,
             bucket,
             base_url,
             cache,
-            access_token_cache: Arc::new(Mutex::new(None)),
+            auth,
         })
     }
 
@@ -151,6 +152,7 @@ impl GcsPolicyProvider {
     }
 
     async fn get_access_token(&self) -> Result<String> {
+        // Static token bypass for tests.
         if let Ok(token) = std::env::var("GOOGLE_CLOUD_ACCESS_TOKEN") {
             let trimmed = token.trim();
             if !trimmed.is_empty() {
@@ -158,37 +160,18 @@ impl GcsPolicyProvider {
             }
         }
 
-        {
-            let cache = self.access_token_cache.lock().await;
-            if let Some((token, expires_at)) = cache.as_ref() {
-                if Instant::now() < *expires_at {
-                    return Ok(token.clone());
-                }
-            }
-        }
+        let auth = self.auth.as_ref().ok_or_else(|| {
+            anyhow!(
+                "no GCP credentials: set GOOGLE_APPLICATION_CREDENTIALS or GOOGLE_CLOUD_ACCESS_TOKEN"
+            )
+        })?;
 
-        let response = self
-            .client
-            .get(GCP_METADATA_TOKEN_URL)
-            .header("Metadata-Flavor", "Google")
-            .send()
+        let token = auth
+            .token(&[GCS_SCOPE])
             .await
-            .context("failed to fetch GCP access token from metadata server")?
-            .error_for_status()
-            .context("metadata server returned an error for access token request")?;
-        let token_response = response
-            .json::<TokenResponse>()
-            .await
-            .context("failed to parse GCP access token response")?;
+            .context("failed to get GCP access token")?;
 
-        let expires_at =
-            Instant::now() + Duration::from_secs(token_response.expires_in.saturating_sub(300));
-        let token = token_response.access_token;
-
-        let mut cache = self.access_token_cache.lock().await;
-        *cache = Some((token.clone(), expires_at));
-
-        Ok(token)
+        Ok(token.as_str().to_string())
     }
 }
 

--- a/egress-proxy/src/health.rs
+++ b/egress-proxy/src/health.rs
@@ -1,12 +1,28 @@
+use crate::gcs::GcsPolicyProvider;
+use crate::policy::Policy;
 use anyhow::Result;
-use axum::{routing::get, Router};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 use tokio::sync::watch;
-use tracing::info;
+use tracing::{info, warn};
 
-pub async fn serve(listener: TcpListener, mut shutdown: watch::Receiver<bool>) -> Result<()> {
+pub async fn serve(
+    listener: TcpListener,
+    policy_provider: GcsPolicyProvider,
+    mut shutdown: watch::Receiver<bool>,
+) -> Result<()> {
     let local_addr = listener.local_addr()?;
-    let app = Router::new().route("/healthz", get(healthz));
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/debug/policy", get(debug_policy))
+        .with_state(policy_provider);
 
     info!(addr = %local_addr, "health server started");
 
@@ -27,4 +43,88 @@ async fn healthz() -> &'static str {
     // TODO(sandbox-egress): Add readiness checks once the proxy listener and policy provider are
     // wired.
     "ok"
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DebugPolicyQuery {
+    w_id: Option<String>,
+    sb_id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DebugPolicyResponse {
+    workspace: DebugPolicyResult,
+    sandbox: DebugPolicyResult,
+}
+
+#[derive(Debug, Serialize)]
+struct DebugPolicyResult {
+    policy: Option<Policy>,
+    error: Option<String>,
+}
+
+// TODO(sandbox-egress): Remove this debug endpoint once PR 2b is deployed and verified.
+async fn debug_policy(
+    State(policy_provider): State<GcsPolicyProvider>,
+    Query(query): Query<DebugPolicyQuery>,
+) -> impl IntoResponse {
+    let sb_id = query.sb_id.trim();
+    if sb_id.is_empty() {
+        return (StatusCode::BAD_REQUEST, "sbId must not be empty").into_response();
+    }
+
+    let workspace = match query
+        .w_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|w_id| !w_id.is_empty())
+    {
+        Some(w_id) => fetch_workspace_policy(&policy_provider, w_id).await,
+        None => DebugPolicyResult {
+            policy: None,
+            error: None,
+        },
+    };
+    let sandbox = fetch_sandbox_policy(&policy_provider, sb_id).await;
+
+    Json(DebugPolicyResponse { workspace, sandbox }).into_response()
+}
+
+async fn fetch_workspace_policy(
+    policy_provider: &GcsPolicyProvider,
+    w_id: &str,
+) -> DebugPolicyResult {
+    match policy_provider.get_workspace_policy(w_id).await {
+        Ok(policy) => DebugPolicyResult {
+            policy,
+            error: None,
+        },
+        Err(error) => {
+            warn!(error = %error, w_id, "workspace policy debug lookup failed");
+            DebugPolicyResult {
+                policy: None,
+                error: Some(error.to_string()),
+            }
+        }
+    }
+}
+
+async fn fetch_sandbox_policy(
+    policy_provider: &GcsPolicyProvider,
+    sb_id: &str,
+) -> DebugPolicyResult {
+    match policy_provider.get_sandbox_policy(sb_id).await {
+        Ok(policy) => DebugPolicyResult {
+            policy,
+            error: None,
+        },
+        Err(error) => {
+            warn!(error = %error, sb_id, "sandbox policy debug lookup failed");
+            DebugPolicyResult {
+                policy: None,
+                error: Some(error.to_string()),
+            }
+        }
+    }
 }

--- a/egress-proxy/src/main.rs
+++ b/egress-proxy/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod connection;
 mod dns;
 mod domain;
+mod gcs;
 mod handshake;
 mod health;
 mod jwt;
@@ -10,7 +11,7 @@ mod policy;
 mod server;
 mod tls;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use config::Config;
 use tracing::{error, info};
 
@@ -23,6 +24,9 @@ async fn main() {
 }
 
 async fn run() -> Result<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .map_err(|_| anyhow!("failed to install rustls crypto provider"))?;
     init_tracing();
 
     let config = Config::from_env()?;

--- a/egress-proxy/src/policy.rs
+++ b/egress-proxy/src/policy.rs
@@ -1,5 +1,12 @@
 use crate::domain::{normalize_dns_name, normalize_domain_or_ip};
 use anyhow::{anyhow, Result};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Policy {
+    allowed_domains: Vec<DomainPattern>,
+}
 
 #[derive(Debug, Clone)]
 pub struct TemporaryAllowlist {
@@ -12,6 +19,14 @@ enum DomainPattern {
     WildcardSuffix(String),
 }
 
+impl Policy {
+    pub fn allows(&self, domain: &str) -> bool {
+        self.allowed_domains
+            .iter()
+            .any(|pattern| pattern.matches(domain))
+    }
+}
+
 impl TemporaryAllowlist {
     pub fn parse(value: &str) -> Result<Self> {
         let mut patterns = Vec::new();
@@ -21,7 +36,7 @@ impl TemporaryAllowlist {
             if entry.is_empty() {
                 continue;
             }
-            patterns.push(DomainPattern::parse(entry)?);
+            patterns.push(DomainPattern::parse_allowlist_entry(entry)?);
         }
 
         if patterns.is_empty() {
@@ -46,9 +61,7 @@ impl TemporaryAllowlist {
 }
 
 impl DomainPattern {
-    fn parse(value: &str) -> Result<Self> {
-        // TODO(sandbox-egress): Replace the minimal domain allowlist with the full policy schema
-        // (defaultAction + rules) once front starts writing policy files.
+    fn parse_allowlist_entry(value: &str) -> Result<Self> {
         let value = value.trim().to_ascii_lowercase();
         if let Some(suffix) = value.strip_prefix("*.") {
             let suffix = normalize_dns_name(suffix)
@@ -64,6 +77,22 @@ impl DomainPattern {
         Ok(Self::Exact(value))
     }
 
+    fn parse_policy_entry(value: &str) -> Result<Self> {
+        let value = value.trim().to_ascii_lowercase();
+        if let Some(suffix) = value.strip_prefix("*.") {
+            let suffix = normalize_dns_name(suffix)
+                .map_err(|_| anyhow!("invalid wildcard domain entry: {value}"))?;
+            if suffix.split('.').count() < 2 {
+                return Err(anyhow!("invalid wildcard domain entry: {value}"));
+            }
+            return Ok(Self::WildcardSuffix(suffix));
+        }
+
+        let value =
+            normalize_dns_name(&value).map_err(|_| anyhow!("invalid domain entry: {value}"))?;
+        Ok(Self::Exact(value))
+    }
+
     fn matches(&self, domain: &str) -> bool {
         match self {
             Self::Exact(exact) => domain == exact,
@@ -76,15 +105,34 @@ impl DomainPattern {
     }
 }
 
-// TODO(sandbox-egress): Add a bounded TTL cache for GCS policies to avoid reading on
-// every connection.
+impl<'de> Deserialize<'de> for DomainPattern {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse_policy_entry(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for DomainPattern {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Exact(domain) => serializer.serialize_str(domain),
+            Self::WildcardSuffix(suffix) => serializer.serialize_str(&format!("*.{suffix}")),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
-    use super::TemporaryAllowlist;
+    use super::{Policy, TemporaryAllowlist};
 
     #[test]
-    fn exact_domains_match_case_insensitively_after_parse() {
+    fn temporary_allowlist_matches_exact_domains_case_insensitively_after_parse() {
         let allowlist =
             TemporaryAllowlist::parse("Example.COM").expect("valid domain entry should parse");
 
@@ -93,7 +141,7 @@ mod tests {
     }
 
     #[test]
-    fn exact_ip_literals_are_valid_entries() {
+    fn temporary_allowlist_accepts_exact_ip_literals() {
         let allowlist = TemporaryAllowlist::parse("127.0.0.1,::ffff:127.0.0.1")
             .expect("valid IP literal entries should parse");
 
@@ -102,7 +150,7 @@ mod tests {
     }
 
     #[test]
-    fn wildcard_matches_subdomains_only() {
+    fn temporary_allowlist_wildcard_matches_subdomains_only() {
         let allowlist =
             TemporaryAllowlist::parse("*.example.com").expect("valid wildcard entry should parse");
 
@@ -112,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_entries_fail_startup() {
+    fn temporary_allowlist_rejects_invalid_entries() {
         assert!(TemporaryAllowlist::parse("example.com, bad domain").is_err());
         assert!(TemporaryAllowlist::parse(" , ").is_err());
         assert!(TemporaryAllowlist::parse("*").is_err());
@@ -122,5 +170,71 @@ mod tests {
         assert!(TemporaryAllowlist::parse("example..com").is_err());
         assert!(TemporaryAllowlist::parse("host:443").is_err());
         assert!(TemporaryAllowlist::parse("*.com").is_err());
+    }
+
+    #[test]
+    fn policy_matches_exact_domains_case_insensitively_after_parse() {
+        let policy: Policy = serde_json::from_str(
+            r#"{
+                "allowedDomains": ["Example.COM"]
+            }"#,
+        )
+        .expect("valid policy should parse");
+
+        assert!(policy.allows("example.com"));
+        assert!(!policy.allows("api.example.com"));
+    }
+
+    #[test]
+    fn policy_wildcard_matches_subdomains_only() {
+        let policy: Policy = serde_json::from_str(
+            r#"{
+                "allowedDomains": ["*.example.com"]
+            }"#,
+        )
+        .expect("valid policy should parse");
+
+        assert!(policy.allows("api.example.com"));
+        assert!(policy.allows("a.b.example.com"));
+        assert!(!policy.allows("example.com"));
+    }
+
+    #[test]
+    fn policy_returns_false_when_domain_is_not_allowlisted() {
+        let policy: Policy = serde_json::from_str(
+            r#"{
+                "allowedDomains": ["api.example.com", "*.example.com"]
+            }"#,
+        )
+        .expect("valid policy should parse");
+
+        assert!(policy.allows("api.example.com"));
+        assert!(policy.allows("other.example.com"));
+        assert!(!policy.allows("dust.tt"));
+    }
+
+    #[test]
+    fn policy_rejects_invalid_entries_during_deserialization() {
+        for domain in [
+            "127.0.0.1",
+            "::1",
+            "*",
+            "*.*.com",
+            "*example.com",
+            ".example.com",
+            "example..com",
+            "host:443",
+            "*.com",
+        ] {
+            let policy = format!(
+                r#"{{
+                    "allowedDomains": ["{domain}"]
+                }}"#
+            );
+            assert!(
+                serde_json::from_str::<Policy>(&policy).is_err(),
+                "{domain} should be rejected"
+            );
+        }
     }
 }

--- a/egress-proxy/src/server.rs
+++ b/egress-proxy/src/server.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::connection::{handle_connection, ConnectionState};
+use crate::gcs::GcsPolicyProvider;
 use crate::health;
 use crate::tls::load_tls_acceptor;
 use anyhow::{anyhow, Result};
@@ -22,13 +23,22 @@ pub async fn run(config: Config) -> Result<()> {
     let proxy_addr = listener.local_addr()?;
     let health_listener = TcpListener::bind(config.health_addr).await?;
     let health_addr = health_listener.local_addr()?;
+    let policy_provider = GcsPolicyProvider::new(
+        config.policy_bucket.clone(),
+        config.policy_cache_ttl,
+        config.policy_base_url.clone(),
+    )?;
     let state = Arc::new(ConnectionState::new(&config));
 
     // TODO(sandbox-egress): Confirm final certificate provisioning path once the Kubernetes
     // deployment and DNS name are introduced.
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-    let mut health_handle = tokio::spawn(health::serve(health_listener, shutdown_rx.clone()));
+    let mut health_handle = tokio::spawn(health::serve(
+        health_listener,
+        policy_provider,
+        shutdown_rx.clone(),
+    ));
     let mut proxy_handle = tokio::spawn(run_proxy_listener(
         listener,
         tls_acceptor,

--- a/egress-proxy/src/server.rs
+++ b/egress-proxy/src/server.rs
@@ -27,7 +27,8 @@ pub async fn run(config: Config) -> Result<()> {
         config.policy_bucket.clone(),
         config.policy_cache_ttl,
         config.policy_base_url.clone(),
-    )?;
+    )
+    .await?;
     let state = Arc::new(ConnectionState::new(&config));
 
     // TODO(sandbox-egress): Confirm final certificate provisioning path once the Kubernetes

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -1,13 +1,21 @@
 use anyhow::{anyhow, Result};
+use axum::extract::State;
+use axum::http::{header, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use axum::routing::any;
+use axum::Router;
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use rustls::pki_types::{pem::PemObject, CertificateDer, ServerName};
 use rustls::RootCertStore;
 use serde::Serialize;
+use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::fs::write;
 use std::net::{Ipv6Addr, SocketAddr, TcpListener as StdTcpListener};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
+use std::sync::Once;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -18,13 +26,40 @@ use tokio_rustls::TlsConnector;
 const SECRET: &str = "test-secret";
 const ALLOW_RESPONSE: u8 = 0x00;
 const DENY_RESPONSE: u8 = 0x01;
+const TEST_BUCKET: &str = "test-egress-policies";
+const TEST_WORKSPACE_ID: &str = "workspace-123";
+const TEST_SANDBOX_ID: &str = "sandbox-123";
+static INSTALL_RUSTLS_PROVIDER: Once = Once::new();
 
 struct ProxyProcess {
     child: Child,
     _temp_dir: TempDir,
+    _mock_gcs: Option<MockGcsServer>,
     ca_cert_path: PathBuf,
     proxy_addr: SocketAddr,
     health_addr: SocketAddr,
+}
+
+struct MockGcsServer {
+    addr: SocketAddr,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Clone)]
+struct MockGcsState {
+    objects: Arc<HashMap<String, MockGcsResponse>>,
+}
+
+#[derive(Clone)]
+enum MockGcsResponse {
+    Policy(String),
+    Status(StatusCode),
+}
+
+#[derive(Default)]
+struct MockPolicies {
+    sandbox: Option<MockGcsResponse>,
+    workspace: Option<MockGcsResponse>,
 }
 
 #[derive(Debug, Serialize)]
@@ -40,6 +75,12 @@ impl Drop for ProxyProcess {
     fn drop(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
+    }
+}
+
+impl Drop for MockGcsServer {
+    fn drop(&mut self) {
+        self.handle.abort();
     }
 }
 
@@ -69,6 +110,9 @@ async fn invalid_tls_assets_fail_startup() -> Result<()> {
         .env("EGRESS_PROXY_TLS_KEY", &tls_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
         .env("EGRESS_PROXY_ALLOWED_DOMAINS", "example.com")
+        .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
+        .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
+        .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
         .env("EGRESS_PROXY_ENV", "production")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -91,6 +135,33 @@ async fn invalid_allowed_domain_fails_startup() -> Result<()> {
         .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
         .env("EGRESS_PROXY_ALLOWED_DOMAINS", "example..com")
+        .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
+        .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
+        .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
+        .env("EGRESS_PROXY_ENV", "production")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    wait_for_startup_failure(&mut child).await
+}
+
+#[tokio::test]
+async fn missing_policy_bucket_fails_startup() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let certs = generate_test_certs(temp_dir.path())?;
+    let proxy_addr = free_addr()?;
+    let health_addr = free_addr()?;
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_egress-proxy"))
+        .env("EGRESS_PROXY_LISTEN_ADDR", proxy_addr.to_string())
+        .env("EGRESS_PROXY_HEALTH_ADDR", health_addr.to_string())
+        .env("EGRESS_PROXY_TLS_CERT", &certs.server_cert_path)
+        .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
+        .env("EGRESS_PROXY_JWT_SECRET", SECRET)
+        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "example.com")
+        .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
+        .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
         .env("EGRESS_PROXY_ENV", "production")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -122,6 +193,98 @@ async fn allowed_domain_forwards_bytes() -> Result<()> {
 
     drop(stream);
     wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn debug_policy_returns_fetched_workspace_and_sandbox_policies() -> Result<()> {
+    let proxy = start_proxy_with_mock_gcs(
+        "example.com",
+        MockPolicies {
+            workspace: Some(policy_response(&["github.com", "*.github.com"])),
+            sandbox: Some(policy_response(&["sandbox.example.com"])),
+        },
+        false,
+        "production",
+    )
+    .await?;
+
+    let response = http_get(
+        proxy.health_addr,
+        &format!("/debug/policy?wId={TEST_WORKSPACE_ID}&sbId={TEST_SANDBOX_ID}"),
+    )
+    .await?;
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"));
+    let body: Value = serde_json::from_str(http_response_body(&response)?)?;
+
+    assert_eq!(
+        body["workspace"]["policy"]["allowedDomains"],
+        json!(["github.com", "*.github.com"])
+    );
+    assert_eq!(body["workspace"]["error"], Value::Null);
+    assert_eq!(
+        body["sandbox"]["policy"]["allowedDomains"],
+        json!(["sandbox.example.com"])
+    );
+    assert_eq!(body["sandbox"]["error"], Value::Null);
+    Ok(())
+}
+
+#[tokio::test]
+async fn debug_policy_returns_null_for_missing_policies() -> Result<()> {
+    let proxy =
+        start_proxy_with_mock_gcs("example.com", MockPolicies::default(), false, "production")
+            .await?;
+
+    let response = http_get(
+        proxy.health_addr,
+        &format!("/debug/policy?wId={TEST_WORKSPACE_ID}&sbId={TEST_SANDBOX_ID}"),
+    )
+    .await?;
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"));
+    let body: Value = serde_json::from_str(http_response_body(&response)?)?;
+
+    assert_eq!(body["workspace"]["policy"], Value::Null);
+    assert_eq!(body["workspace"]["error"], Value::Null);
+    assert_eq!(body["sandbox"]["policy"], Value::Null);
+    assert_eq!(body["sandbox"]["error"], Value::Null);
+    Ok(())
+}
+
+#[tokio::test]
+async fn debug_policy_returns_errors_for_failed_fetches() -> Result<()> {
+    let proxy = start_proxy_with_mock_gcs(
+        "example.com",
+        MockPolicies {
+            workspace: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
+            sandbox: Some(policy_response(&["sandbox.example.com"])),
+        },
+        false,
+        "production",
+    )
+    .await?;
+
+    let response = http_get(
+        proxy.health_addr,
+        &format!("/debug/policy?wId={TEST_WORKSPACE_ID}&sbId={TEST_SANDBOX_ID}"),
+    )
+    .await?;
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"));
+    let body: Value = serde_json::from_str(http_response_body(&response)?)?;
+
+    assert_eq!(body["workspace"]["policy"], Value::Null);
+    assert!(body["workspace"]["error"]
+        .as_str()
+        .expect("workspace error should be present")
+        .contains("GCS policy fetch returned status 500 Internal Server Error"));
+    assert_eq!(
+        body["sandbox"]["policy"]["allowedDomains"],
+        json!(["sandbox.example.com"])
+    );
+    assert_eq!(body["sandbox"]["error"], Value::Null);
     Ok(())
 }
 
@@ -361,6 +524,9 @@ async fn unsafe_ssrf_bypass_fails_startup_outside_test_env() -> Result<()> {
         .env("EGRESS_PROXY_TLS_KEY", certs.server_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
         .env("EGRESS_PROXY_ALLOWED_DOMAINS", "127.0.0.1")
+        .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
+        .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
+        .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
         .env("EGRESS_PROXY_ENV", "production")
         .env("EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK", "1")
         .stdout(Stdio::null())
@@ -385,6 +551,9 @@ async fn health_bind_failure_fails_startup() -> Result<()> {
         .env("EGRESS_PROXY_TLS_KEY", certs.server_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
         .env("EGRESS_PROXY_ALLOWED_DOMAINS", "localhost")
+        .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
+        .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
+        .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
         .env("EGRESS_PROXY_ENV", "production")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -509,10 +678,26 @@ async fn start_proxy(
     unsafe_skip_ssrf_check: bool,
     environment: &str,
 ) -> Result<ProxyProcess> {
+    start_proxy_with_mock_gcs(
+        allowed_domains,
+        MockPolicies::default(),
+        unsafe_skip_ssrf_check,
+        environment,
+    )
+    .await
+}
+
+async fn start_proxy_with_mock_gcs(
+    allowed_domains: &str,
+    policies: MockPolicies,
+    unsafe_skip_ssrf_check: bool,
+    environment: &str,
+) -> Result<ProxyProcess> {
     let temp_dir = TempDir::new()?;
     let certs = generate_test_certs(temp_dir.path())?;
     let proxy_addr = free_addr()?;
     let health_addr = free_addr()?;
+    let mock_gcs = start_mock_gcs_server(policies).await?;
 
     let mut command = Command::new(env!("CARGO_BIN_EXE_egress-proxy"));
     command
@@ -522,9 +707,15 @@ async fn start_proxy(
         .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
         .env("EGRESS_PROXY_ALLOWED_DOMAINS", allowed_domains)
+        .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
+        .env(
+            "EGRESS_PROXY_POLICY_BASE_URL",
+            format!("http://{}", mock_gcs.addr),
+        )
+        .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
         .env("EGRESS_PROXY_ENV", environment)
         .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stderr(Stdio::piped());
 
     if unsafe_skip_ssrf_check {
         command.env("EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK", "1");
@@ -533,6 +724,7 @@ async fn start_proxy(
     let mut proxy = ProxyProcess {
         child: command.spawn()?,
         _temp_dir: temp_dir,
+        _mock_gcs: Some(mock_gcs),
         ca_cert_path: certs.ca_cert_path,
         proxy_addr,
         health_addr,
@@ -543,10 +735,66 @@ async fn start_proxy(
     Ok(proxy)
 }
 
+async fn start_mock_gcs_server(policies: MockPolicies) -> Result<MockGcsServer> {
+    let mut objects = HashMap::new();
+    if let Some(workspace) = policies.workspace {
+        objects.insert(format!("workspaces/{TEST_WORKSPACE_ID}.json"), workspace);
+    }
+    if let Some(sandbox) = policies.sandbox {
+        objects.insert(format!("sandboxes/{TEST_SANDBOX_ID}.json"), sandbox);
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let state = MockGcsState {
+        objects: Arc::new(objects),
+    };
+    let app = Router::new()
+        .fallback(any(mock_gcs_handler))
+        .with_state(state);
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    Ok(MockGcsServer { addr, handle })
+}
+
+async fn mock_gcs_handler(State(state): State<MockGcsState>, uri: Uri) -> Response {
+    let Some(encoded_object) = uri.path().split("/o/").nth(1) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let Ok(object_name) = urlencoding::decode(encoded_object) else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+
+    match state.objects.get(object_name.as_ref()) {
+        Some(MockGcsResponse::Policy(body)) => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            body.clone(),
+        )
+            .into_response(),
+        Some(MockGcsResponse::Status(status)) => status.into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+fn policy_response(domains: &[&str]) -> MockGcsResponse {
+    MockGcsResponse::Policy(
+        json!({
+            "allowedDomains": domains,
+        })
+        .to_string(),
+    )
+}
+
 async fn wait_for_health(child: &mut Child, health_addr: SocketAddr) -> Result<()> {
     for _ in 0..100 {
         if let Some(status) = child.try_wait()? {
-            return Err(anyhow!("proxy exited before becoming healthy: {status}"));
+            let stderr = read_child_stderr(child)?;
+            return Err(anyhow!(
+                "proxy exited before becoming healthy: {status}; stderr: {stderr}"
+            ));
         }
 
         if let Ok(response) = http_get(health_addr, "/healthz").await {
@@ -559,6 +807,16 @@ async fn wait_for_health(child: &mut Child, health_addr: SocketAddr) -> Result<(
     }
 
     Err(anyhow!("proxy did not become healthy"))
+}
+
+fn read_child_stderr(child: &mut Child) -> Result<String> {
+    let Some(stderr) = child.stderr.as_mut() else {
+        return Ok("<stderr not captured>".to_string());
+    };
+
+    let mut output = String::new();
+    std::io::Read::read_to_string(stderr, &mut output)?;
+    Ok(output.trim().to_string())
 }
 
 async fn wait_for_startup_failure(child: &mut Child) -> Result<()> {
@@ -583,6 +841,13 @@ async fn http_get(addr: SocketAddr, path: &str) -> Result<String> {
     let mut response = Vec::new();
     stream.read_to_end(&mut response).await?;
     Ok(String::from_utf8(response)?)
+}
+
+fn http_response_body(response: &str) -> Result<&str> {
+    response
+        .split("\r\n\r\n")
+        .nth(1)
+        .ok_or_else(|| anyhow!("HTTP response missing body"))
 }
 
 async fn send_handshake(
@@ -611,6 +876,10 @@ async fn send_raw_frame(proxy: &ProxyProcess, frame: &[u8]) -> Result<Option<u8>
 async fn connect_forwarder(
     proxy: &ProxyProcess,
 ) -> Result<tokio_rustls::client::TlsStream<TcpStream>> {
+    INSTALL_RUSTLS_PROVIDER.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+
     let mut root_store = RootCertStore::empty();
     for cert in load_certs(&proxy.ca_cert_path)? {
         root_store.add(cert)?;


### PR DESCRIPTION
## Description

Add the GCS-backed policy provider to the egress proxy without changing any connection behavior. The proxy still uses `EGRESS_PROXY_ALLOWED_DOMAINS` for allow/deny decisions. The GCS provider runs alongside it so we can verify it works in production before cutting over.

What's new:
- `policy.rs`: New `Policy` struct for the `{ "allowedDomains": [...] }` schema, coexisting with the existing `TemporaryAllowlist`
- `gcs.rs`: `GcsPolicyProvider` with moka cache and GCP metadata server auth
- `config.rs`: New env vars `EGRESS_PROXY_POLICY_BUCKET`, `EGRESS_PROXY_POLICY_BASE_URL`, `EGRESS_PROXY_POLICY_CACHE_TTL_SECS` (existing `ALLOWED_DOMAINS` kept)
- `health.rs`: `GET /debug/policy?wId=...&sbId=...` endpoint on the internal health port to verify GCS reads work. Temporary, will be removed once cutover is done.

`connection.rs` and `handshake.rs` are untouched.

## Tests

- Unit tests for policy deserialization, config validation
- Integration tests with a mock GCS HTTP server for the debug endpoint (policy found, missing, error cases)
- All pass locally

## Risk

Low. No change to connection behavior. New required env var `EGRESS_PROXY_POLICY_BUCKET` must be set before deploying.

## Deploy Plan

1. Set `EGRESS_PROXY_POLICY_BUCKET` env var (keep `EGRESS_PROXY_ALLOWED_DOMAINS`)
2. Deploy
3. Verify from inside the pod: `curl http://localhost:8080/debug/policy?wId=<wId>&sbId=<sbId>`