### PR TITLE
[front] feat: make gpt-image-2 the default image generation model

### DIFF
--- a/front/lib/api/llm/getImageGenerationLLM.test.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.test.ts
@@ -1,13 +1,8 @@
-import { SubscriptionModel } from "@app/lib/models/plan";
-import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
-import { FREE_BYOK_PLAN_CODE } from "@app/lib/plans/plan_codes";
-import { renderPlanFromModel } from "@app/lib/plans/renderers";
-import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import type { Authenticator } from "@app/lib/auth";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetLlmCredentials = vi.hoisted(() => vi.fn());
 const mockIsProviderWhitelisted = vi.hoisted(() => vi.fn());
-const mockGetFeatureFlags = vi.hoisted(() => vi.fn());
 const mockGoogleImageGenerationLLM = vi.hoisted(() => vi.fn());
 const mockOpenAIImageGenerationLLM = vi.hoisted(() => vi.fn());
 
@@ -19,14 +14,6 @@ vi.mock("@app/lib/assistant", () => ({
   isProviderWhitelisted: mockIsProviderWhitelisted,
 }));
 
-vi.mock("@app/lib/auth", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@app/lib/auth")>();
-  return {
-    ...actual,
-    getFeatureFlags: mockGetFeatureFlags,
-  };
-});
-
 vi.mock("@app/lib/api/llm/clients/google/imageGeneration", () => ({
   ImageGenerationGoogleLLM: mockGoogleImageGenerationLLM,
 }));
@@ -35,20 +22,23 @@ vi.mock("@app/lib/api/llm/clients/openai/imageGeneration", () => ({
   ImageGenerationOpenAILLM: mockOpenAIImageGenerationLLM,
 }));
 
-import { Authenticator } from "@app/lib/auth";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { GPT_IMAGE_2_MODEL_ID } from "@app/types/assistant/models/openai";
+
 import { getImageGenerationLLM } from "./getImageGenerationLLM";
+
+const CREDENTIALS = {
+  GOOGLE_AI_STUDIO_API_KEY: "test-google-key",
+  OPENAI_API_KEY: "test-openai-key",
+};
+
+const auth = {} as Authenticator;
 
 describe("getImageGenerationLLM", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockGetLlmCredentials.mockResolvedValue({
-      GOOGLE_AI_STUDIO_API_KEY: "test-google-key",
-      OPENAI_API_KEY: "test-openai-key",
-    });
-    mockGetFeatureFlags.mockResolvedValue([]);
+    mockGetLlmCredentials.mockResolvedValue(CREDENTIALS);
     mockIsProviderWhitelisted.mockReturnValue(false);
 
     mockGoogleImageGenerationLLM.mockImplementation(function (_auth, args) {
@@ -59,162 +49,63 @@ describe("getImageGenerationLLM", () => {
     });
   });
 
-  it("returns OpenAI gpt-image-2 when the feature flag is enabled", async () => {
-    mockGetFeatureFlags.mockResolvedValue(["gpt_image_2_feature"]);
-
-    const auth = makeAuth({ isByok: false });
+  it("returns OpenAI gpt-image-2 when openai is whitelisted", async () => {
+    mockIsProviderWhitelisted.mockImplementation(
+      (_auth, providerId) => providerId === "openai"
+    );
 
     const llm = await getImageGenerationLLM(auth);
 
     expect(mockOpenAIImageGenerationLLM).toHaveBeenCalledWith(auth, {
       modelId: GPT_IMAGE_2_MODEL_ID,
-      credentials: {
-        GOOGLE_AI_STUDIO_API_KEY: "test-google-key",
-        OPENAI_API_KEY: "test-openai-key",
-      },
+      credentials: CREDENTIALS,
     });
+    expect(mockGoogleImageGenerationLLM).not.toHaveBeenCalled();
     expect(llm).toEqual({
       provider: "openai",
-      args: {
-        modelId: GPT_IMAGE_2_MODEL_ID,
-        credentials: {
-          GOOGLE_AI_STUDIO_API_KEY: "test-google-key",
-          OPENAI_API_KEY: "test-openai-key",
-        },
-      },
+      args: { modelId: GPT_IMAGE_2_MODEL_ID, credentials: CREDENTIALS },
     });
   });
 
-  it("returns Gemini for unflagged workspaces on the Google route", async () => {
-    const auth = makeAuth({ isByok: false });
+  it("prefers OpenAI over Gemini when both providers are whitelisted", async () => {
+    mockIsProviderWhitelisted.mockReturnValue(true);
+
+    const llm = await getImageGenerationLLM(auth);
+
+    expect(mockOpenAIImageGenerationLLM).toHaveBeenCalledWith(auth, {
+      modelId: GPT_IMAGE_2_MODEL_ID,
+      credentials: CREDENTIALS,
+    });
+    expect(mockGoogleImageGenerationLLM).not.toHaveBeenCalled();
+    expect(llm).toEqual({
+      provider: "openai",
+      args: { modelId: GPT_IMAGE_2_MODEL_ID, credentials: CREDENTIALS },
+    });
+  });
+
+  it("falls back to Gemini when openai is not whitelisted", async () => {
+    mockIsProviderWhitelisted.mockImplementation(
+      (_auth, providerId) => providerId === "google_ai_studio"
+    );
 
     const llm = await getImageGenerationLLM(auth);
 
     expect(mockGoogleImageGenerationLLM).toHaveBeenCalledWith(auth, {
       modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
-      credentials: {
-        GOOGLE_AI_STUDIO_API_KEY: "test-google-key",
-        OPENAI_API_KEY: "test-openai-key",
-      },
+      credentials: CREDENTIALS,
     });
+    expect(mockOpenAIImageGenerationLLM).not.toHaveBeenCalled();
     expect(llm).toEqual({
       provider: "google",
-      args: {
-        modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
-        credentials: {
-          GOOGLE_AI_STUDIO_API_KEY: "test-google-key",
-          OPENAI_API_KEY: "test-openai-key",
-        },
-      },
+      args: { modelId: GEMINI_3_PRO_IMAGE_MODEL_ID, credentials: CREDENTIALS },
     });
   });
 
-  it("returns OpenAI gpt-image-2 for unflagged workspaces on the OpenAI route", async () => {
-    mockIsProviderWhitelisted.mockImplementation((_auth, providerId) => {
-      return providerId === "openai";
-    });
-
-    const auth = makeAuth({ isByok: true });
-
-    const llm = await getImageGenerationLLM(auth);
-
-    expect(mockOpenAIImageGenerationLLM).toHaveBeenCalledWith(auth, {
-      modelId: GPT_IMAGE_2_MODEL_ID,
-      credentials: {
-        GOOGLE_AI_STUDIO_API_KEY: "test-google-key",
-        OPENAI_API_KEY: "test-openai-key",
-      },
-    });
-    expect(llm).toEqual({
-      provider: "openai",
-      args: {
-        modelId: GPT_IMAGE_2_MODEL_ID,
-        credentials: {
-          GOOGLE_AI_STUDIO_API_KEY: "test-google-key",
-          OPENAI_API_KEY: "test-openai-key",
-        },
-      },
-    });
-  });
-
-  it("returns null when no image generation provider is available", async () => {
-    const auth = makeAuth({ isByok: true });
-
+  it("returns null when neither openai nor google is whitelisted", async () => {
     const llm = await getImageGenerationLLM(auth);
 
     expect(llm).toBeNull();
+    expect(mockOpenAIImageGenerationLLM).not.toHaveBeenCalled();
+    expect(mockGoogleImageGenerationLLM).not.toHaveBeenCalled();
   });
 });
-
-function makeAuth({ isByok }: { isByok: boolean }) {
-  const plan = renderPlanFromModel({
-    plan: isByok
-      ? {
-          ...FREE_NO_PLAN_DATA,
-          code: FREE_BYOK_PLAN_CODE,
-          name: "Free (BYOK)",
-          maxMessages: -1,
-          maxImagesPerWeek: 50,
-          maxUsersInWorkspace: -1,
-          maxVaultsInWorkspace: -1,
-          isSlackbotAllowed: true,
-          isManagedConfluenceAllowed: true,
-          isManagedSlackAllowed: true,
-          isManagedNotionAllowed: true,
-          isManagedGoogleDriveAllowed: true,
-          isManagedGithubAllowed: true,
-          isManagedIntercomAllowed: true,
-          isManagedWebCrawlerAllowed: true,
-          isManagedSalesforceAllowed: true,
-          isSSOAllowed: true,
-          maxDataSourcesCount: -1,
-          maxDataSourcesDocumentsCount: -1,
-          canUseProduct: true,
-          isByok: true,
-        }
-      : {
-          ...FREE_NO_PLAN_DATA,
-          code: "FREE_TEST",
-          name: "Free",
-          maxMessages: 50,
-          maxImagesPerWeek: 50,
-          maxUsersInWorkspace: 1,
-          maxVaultsInWorkspace: 1,
-          maxDataSourcesCount: 5,
-          maxDataSourcesDocumentsCount: 10,
-          maxDataSourcesDocumentsSizeMb: 2,
-          canUseProduct: true,
-          isByok: false,
-        },
-  });
-
-  const subscription = new SubscriptionResource(
-    SubscriptionModel,
-    {
-      id: -1,
-      sId: "test-subscription",
-      status: "active",
-      trialing: null,
-      paymentFailingSince: null,
-      startDate: new Date(),
-      endDate: null,
-      planId: -1,
-      stripeSubscriptionId: null,
-      metronomeContractId: null,
-      requestCancelAt: null,
-      workspaceId: -1,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    },
-    plan
-  );
-
-  return new Authenticator({
-    workspace: null,
-    user: null,
-    role: "none",
-    groupModelIds: [],
-    subscription,
-    authMethod: "internal",
-  });
-}

--- a/front/lib/api/llm/getImageGenerationLLM.test.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.test.ts
@@ -1,4 +1,7 @@
-import type { Authenticator } from "@app/lib/auth";
+import { SubscriptionModel } from "@app/lib/models/plan";
+import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
+import { renderPlanFromModel } from "@app/lib/plans/renderers";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetLlmCredentials = vi.hoisted(() => vi.fn());
@@ -22,6 +25,7 @@ vi.mock("@app/lib/api/llm/clients/openai/imageGeneration", () => ({
   ImageGenerationOpenAILLM: mockOpenAIImageGenerationLLM,
 }));
 
+import { Authenticator } from "@app/lib/auth";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { GPT_IMAGE_2_MODEL_ID } from "@app/types/assistant/models/openai";
 
@@ -32,11 +36,62 @@ const CREDENTIALS = {
   OPENAI_API_KEY: "test-openai-key",
 };
 
-const auth = {} as Authenticator;
+function makeAuth(): Authenticator {
+  const plan = renderPlanFromModel({
+    plan: {
+      ...FREE_NO_PLAN_DATA,
+      code: "FREE_TEST",
+      name: "Free",
+      maxMessages: 50,
+      maxImagesPerWeek: 50,
+      maxUsersInWorkspace: 1,
+      maxVaultsInWorkspace: 1,
+      maxDataSourcesCount: 5,
+      maxDataSourcesDocumentsCount: 10,
+      maxDataSourcesDocumentsSizeMb: 2,
+      canUseProduct: true,
+      isByok: false,
+    },
+  });
+
+  const subscription = new SubscriptionResource(
+    SubscriptionModel,
+    {
+      id: -1,
+      sId: "test-subscription",
+      status: "active",
+      trialing: null,
+      paymentFailingSince: null,
+      startDate: new Date(),
+      endDate: null,
+      planId: -1,
+      stripeSubscriptionId: null,
+      metronomeContractId: null,
+      requestCancelAt: null,
+      workspaceId: -1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    plan
+  );
+
+  return new Authenticator({
+    workspace: null,
+    user: null,
+    role: "none",
+    groupModelIds: [],
+    subscription,
+    authMethod: "internal",
+  });
+}
 
 describe("getImageGenerationLLM", () => {
+  let auth: Authenticator;
+
   beforeEach(() => {
     vi.clearAllMocks();
+
+    auth = makeAuth();
 
     mockGetLlmCredentials.mockResolvedValue(CREDENTIALS);
     mockIsProviderWhitelisted.mockReturnValue(false);

--- a/front/lib/api/llm/getImageGenerationLLM.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.ts
@@ -3,7 +3,7 @@ import { ImageGenerationOpenAILLM } from "@app/lib/api/llm/clients/openai/imageG
 import type { ImageGenerationLLM } from "@app/lib/api/llm/imageGeneration";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { isProviderWhitelisted } from "@app/lib/assistant";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { GPT_IMAGE_2_MODEL_ID } from "@app/types/assistant/models/openai";
 
@@ -13,26 +13,17 @@ export async function getImageGenerationLLM(
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
   });
-  const featureFlags = await getFeatureFlags(auth);
-  if (featureFlags.includes("gpt_image_2_feature")) {
-    return new ImageGenerationOpenAILLM(auth, {
-      modelId: GPT_IMAGE_2_MODEL_ID,
-      credentials,
-    });
-  }
-
-  const plan = auth.getNonNullablePlan();
-
-  if (!plan.isByok || isProviderWhitelisted(auth, "google_ai_studio")) {
-    return new ImageGenerationGoogleLLM(auth, {
-      modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
-      credentials,
-    });
-  }
 
   if (isProviderWhitelisted(auth, "openai")) {
     return new ImageGenerationOpenAILLM(auth, {
       modelId: GPT_IMAGE_2_MODEL_ID,
+      credentials,
+    });
+  }
+
+  if (isProviderWhitelisted(auth, "google_ai_studio")) {
+    return new ImageGenerationGoogleLLM(auth, {
+      modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
       credentials,
     });
   }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -75,10 +75,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Google Sheets MCP tool",
     stage: "rolling_out",
   },
-  gpt_image_2_feature: {
-    description: "Force OpenAI gpt-image-2 for image generation",
-    stage: "on_demand",
-  },
   http_client_tool: {
     description: "HTTP Client MCP tool for making external API requests",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -706,7 +706,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "clari_copilot_mcp"
   | "gong_tool"
   | "google_sheets_tool"
-  | "gpt_image_2_feature"
   | "hootl_subscriptions"
   | "http_client_tool"
   | "index_private_slack_channel"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -706,6 +706,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "clari_copilot_mcp"
   | "gong_tool"
   | "google_sheets_tool"
+  | "gpt_image_2_feature"
   | "hootl_subscriptions"
   | "http_client_tool"
   | "index_private_slack_channel"


### PR DESCRIPTION
## Description

Follow-up to #24686. Now that `gpt-image-2` has been validated behind the `gpt_image_2_feature` flag, make it the default image generation model.

The selector in `getImageGenerationLLM` is simplified to a single axis — the workspace provider whitelist:

- `openai` whitelisted → `gpt-image-2` (this is now the default, including for non-BYOK workspaces that previously went to Gemini).
- Otherwise `google_ai_studio` whitelisted → Gemini 3 Pro (unchanged fallback).
- Neither whitelisted → `null`.

BYOK selection is unchanged in spirit: it is still driven by what the workspace has whitelisted and configured, which is what `isProviderWhitelisted` encodes.

The `gpt_image_2_feature` flag is no longer needed and is removed, both from `WHITELISTABLE_FEATURES_CONFIG` and from the JS SDK flag union.

## Tests

- we tested the model already
- updated existing tests

## Risk

- model might be a bit slower
- existing workflows could be somewhat disrupted

## Deploy Plan

1. Merge + deploy.