### PR TITLE
Add ability for sidekick to search for individual document nodes

### DIFF
--- a/front/components/markdown/suggestion/SidekickSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/SidekickSuggestionCard.tsx
@@ -16,7 +16,11 @@ import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
-import type { DataSourceViewType } from "@app/types/data_source_view";
+import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
+import type {
+  DataSourceViewContentNode,
+  DataSourceViewType,
+} from "@app/types/data_source_view";
 import { defaultSelectionConfiguration } from "@app/types/data_source_view";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type {
@@ -474,13 +478,23 @@ const KNOWLEDGE_METHOD_ACTION_VERB: Record<string, string> = {
   query_tables: "Query",
 };
 
+const MAX_VISIBLE_NODES = 2;
+
+function formatNodeScopeTitles(nodes: DataSourceViewContentNode[]): string {
+  const visible = nodes.slice(0, MAX_VISIBLE_NODES);
+  const rest = nodes.length - MAX_VISIBLE_NODES;
+  const titles = visible.map((n) => n.title).join(", ");
+  return rest > 0 ? `${titles} (+${rest} more)` : titles;
+}
+
 function buildNewKnowledgeAction(
   serverView: MCPServerViewType,
   method: string,
   dataSourceView: DataSourceViewType,
   displayName: string,
   description: string | null,
-  currentActions: AgentBuilderFormData["actions"]
+  currentActions: AgentBuilderFormData["actions"],
+  selectedNodes: DataSourceViewContentNode[]
 ): ReturnType<typeof getDefaultMCPAction> {
   const newAction = getDefaultMCPAction(serverView);
   if (method === "query_tables") {
@@ -504,9 +518,9 @@ function buildNewKnowledgeAction(
   newAction.configuration.dataSourceConfigurations = {
     [dataSourceView.sId]: {
       dataSourceView,
-      selectedResources: [],
+      selectedResources: selectedNodes,
       excludedResources: [],
-      isSelectAll: true,
+      isSelectAll: selectedNodes.length === 0,
       tagsFilter: null,
     },
   };
@@ -543,17 +557,32 @@ function KnowledgeSuggestionCard({
   const cardState = mapSuggestionStateToCardState(state);
   const { acceptSuggestion, rejectSuggestion } = useSidekickSuggestions();
   const { setValue, getValues } = useFormContext<AgentBuilderFormData>();
+  const { owner } = useAgentBuilderContext();
 
   const isAddition = suggestion.action === "add";
   const { dataSourceView, serverView } = relations;
   const method = suggestion.method ?? "search";
   const isQueryTables = method === "query_tables";
   const displayName = getDisplayNameForDataSource(dataSourceView.dataSource);
+  const hasNodeScope =
+    suggestion.nodeIds != null && suggestion.nodeIds.length > 0;
+
+  const { nodes: selectedNodes, isNodesLoading } =
+    useDataSourceViewContentNodes({
+      owner,
+      dataSourceView,
+      internalIds: suggestion.nodeIds,
+      viewType: "document",
+      disabled: !hasNodeScope,
+    });
 
   const handleAccept = async (
     agentSuggestion: AgentKnowledgeSuggestionWithRelationsType
   ) => {
     if (!serverView) {
+      return;
+    }
+    if (hasNodeScope && isNodesLoading) {
       return;
     }
     const success = await acceptSuggestion(agentSuggestion);
@@ -570,7 +599,8 @@ function KnowledgeSuggestionCard({
             dataSourceView,
             displayName,
             suggestion.description ?? null,
-            currentActions
+            currentActions,
+            selectedNodes
           ),
         ]
       : removeFirstWhere(currentActions, (action) =>
@@ -595,6 +625,20 @@ function KnowledgeSuggestionCard({
       ].getLogoComponent()
     : FolderIcon;
 
+  const hasVisibleScope = hasNodeScope && selectedNodes.length > 0;
+  const description =
+    hasVisibleScope || analysis ? (
+      <div className="flex flex-col gap-1">
+        {hasVisibleScope && (
+          <span>
+            <span className="font-medium">Selections:</span>{" "}
+            {formatNodeScopeTitles(selectedNodes)}
+          </span>
+        )}
+        {analysis && <span>{analysis}</span>}
+      </div>
+    ) : undefined;
+
   const labels = isAddition
     ? {
         title: `Add ${displayName} as knowledge source`,
@@ -611,7 +655,7 @@ function KnowledgeSuggestionCard({
     <ActionCardBlock
       {...labels}
       visual={<Avatar icon={icon} size="sm" />}
-      description={analysis ?? undefined}
+      description={description}
       state={cardState}
       rejectedTitle={`${displayName} knowledge rejected`}
       actionsPosition="header"

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -25,7 +25,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_agent_insights": "never_ask",
     "get_agent_template": "never_ask",
     "get_available_agents": "never_ask",
-    "get_available_knowledge": "never_ask",
     "get_available_models": "never_ask",
     "get_available_skills": "never_ask",
     "get_available_tools": "never_ask",

--- a/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
@@ -123,15 +123,14 @@ async function useRealGetAgentFeedbacks() {
 }
 
 describe("agent_sidekick_context tools", () => {
-  describe("get_available_knowledge", () => {
-    it("returns knowledge organized by spaces and categories", async () => {
+  describe("search_knowledge", () => {
+    it("returns data source views and empty nodes in browse mode (no query)", async () => {
       const { authenticator, globalSpace, workspace } =
         await createResourceTest({ role: "admin" });
 
-      // Create a folder data source view in the global space.
       await DataSourceViewFactory.folder(workspace, globalSpace);
 
-      const tool = getToolByName("get_available_knowledge");
+      const tool = getToolByName("search_knowledge");
       const result = await tool.handler({}, createTestExtra(authenticator));
 
       expect(result.isOk()).toBe(true);
@@ -140,50 +139,14 @@ describe("agent_sidekick_context tools", () => {
         expect(content.type).toBe("text");
         if (content.type === "text") {
           const parsed = JSON.parse(content.text);
-          expect(parsed.count).toBeDefined();
-          expect(parsed.count.spaces).toBeGreaterThanOrEqual(1);
-          expect(parsed.count.dataSources).toBeGreaterThanOrEqual(1);
-          expect(parsed.spaces).toBeDefined();
-          expect(Array.isArray(parsed.spaces)).toBe(true);
+          expect(Array.isArray(parsed.dataSourceViews)).toBe(true);
+          expect(parsed.dataSourceViews.length).toBeGreaterThanOrEqual(1);
+          expect(Array.isArray(parsed.nodes)).toBe(true);
+          expect(parsed.nodes.length).toBe(0);
 
-          // Find the global space.
-          const foundSpace = parsed.spaces.find(
-            (s: { sId: string }) => s.sId === globalSpace.sId
-          );
-          expect(foundSpace).toBeDefined();
-          expect(foundSpace.categories).toBeDefined();
-          expect(Array.isArray(foundSpace.categories)).toBe(true);
-        }
-      }
-    });
-
-    it("filters by spaceId when provided", async () => {
-      const { authenticator, globalSpace, workspace } =
-        await createResourceTest({ role: "admin" });
-
-      // Create another space.
-      const regularSpace = await SpaceFactory.regular(workspace);
-
-      // Create folder data sources in both spaces.
-      await DataSourceViewFactory.folder(workspace, globalSpace);
-      await DataSourceViewFactory.folder(workspace, regularSpace);
-
-      const tool = getToolByName("get_available_knowledge");
-
-      // Filter to global space only.
-      const result = await tool.handler(
-        { spaceId: globalSpace.sId },
-        createTestExtra(authenticator)
-      );
-
-      expect(result.isOk()).toBe(true);
-      if (result.isOk()) {
-        const content = result.value[0];
-        expect(content.type).toBe("text");
-        if (content.type === "text") {
-          const parsed = JSON.parse(content.text);
-          expect(parsed.count.spaces).toBe(1);
-          expect(parsed.spaces[0].sId).toBe(globalSpace.sId);
+          const dsv = parsed.dataSourceViews[0];
+          expect(dsv.dataSourceViewId).toBeDefined();
+          expect(dsv.spaceId).toBeDefined();
         }
       }
     });
@@ -192,12 +155,9 @@ describe("agent_sidekick_context tools", () => {
       const { authenticator, globalSpace, workspace } =
         await createResourceTest({ role: "admin" });
 
-      // Create a folder data source.
       await DataSourceViewFactory.folder(workspace, globalSpace);
 
-      const tool = getToolByName("get_available_knowledge");
-
-      // Filter to folder category only.
+      const tool = getToolByName("search_knowledge");
       const result = await tool.handler(
         { category: "folder" },
         createTestExtra(authenticator)
@@ -209,26 +169,11 @@ describe("agent_sidekick_context tools", () => {
         expect(content.type).toBe("text");
         if (content.type === "text") {
           const parsed = JSON.parse(content.text);
-          // All categories should be "folder".
-          for (const space of parsed.spaces) {
-            for (const cat of space.categories) {
-              expect(cat.category).toBe("folder");
-            }
+          for (const dsv of parsed.dataSourceViews) {
+            expect(dsv.category).toBe("folder");
           }
         }
       }
-    });
-
-    it("returns error for invalid spaceId", async () => {
-      const { authenticator } = await createResourceTest({ role: "admin" });
-
-      const tool = getToolByName("get_available_knowledge");
-      const result = await tool.handler(
-        { spaceId: "non-existent-space-id" },
-        createTestExtra(authenticator)
-      );
-
-      expect(result.isErr()).toBe(true);
     });
 
     it("does not return knowledge from spaces the user cannot access", async () => {
@@ -239,10 +184,9 @@ describe("agent_sidekick_context tools", () => {
       // Create a restricted space (user won't be a member).
       const restrictedSpace = await SpaceFactory.regular(workspace);
 
-      // Create a folder in the restricted space.
       await DataSourceViewFactory.folder(workspace, restrictedSpace);
 
-      const tool = getToolByName("get_available_knowledge");
+      const tool = getToolByName("search_knowledge");
       const result = await tool.handler({}, createTestExtra(authenticator));
 
       expect(result.isOk()).toBe(true);
@@ -251,11 +195,10 @@ describe("agent_sidekick_context tools", () => {
         expect(content.type).toBe("text");
         if (content.type === "text") {
           const parsed = JSON.parse(content.text);
-          // The restricted space should not be in the results.
-          const foundRestrictedSpace = parsed.spaces.find(
-            (s: { sId: string }) => s.sId === restrictedSpace.sId
+          const restrictedFound = parsed.dataSourceViews.find(
+            (d: { spaceId: string }) => d.spaceId === restrictedSpace.sId
           );
-          expect(foundRestrictedSpace).toBeUndefined();
+          expect(restrictedFound).toBeUndefined();
         }
       }
     });

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -74,7 +74,13 @@ const KnowledgeSuggestionSchema = z.object({
   dataSourceViewId: z
     .string()
     .describe(
-      "The string id of the data source view to add or remove as knowledge (for method 'search', from get_available_knowledge/search_knowledge)"
+      "The string id of the data source view to add or remove as knowledge (can be found from the search_knowledge results)"
+    ),
+  nodeIds: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Optional node IDs to scope the knowledge to specific documents within the data source view. Omit to add the whole data source."
     ),
   description: z
     .string()
@@ -96,29 +102,6 @@ const ModelSuggestionSchema = z.object({
 });
 
 export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
-  get_available_knowledge: {
-    description:
-      "List available knowledge data source views grouped by space and category. " +
-      "Returns spaces, each with categories (managed, folder, website) containing data source views. " +
-      "Use dataSourceViewId when calling suggest_knowledge. " +
-      "Use nodeId for list/find/cat on company_data. " +
-      "Optionally filter by spaceId or category.",
-    schema: {
-      spaceId: z
-        .string()
-        .optional()
-        .describe("Optional space ID to filter results to a specific space."),
-      category: z
-        .enum(KNOWLEDGE_CATEGORIES)
-        .optional()
-        .describe("Optional category to filter: managed, folder, or website."),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Listing available knowledge",
-      done: "List available knowledge",
-    },
-  },
   get_available_models: {
     description:
       "Get the list of available models. Can optionally filter by provider.",
@@ -370,13 +353,15 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
   },
   search_knowledge: {
     description:
-      "Semantic search across workspace **search** knowledge sources (documents, folders, websites) to find which contain content relevant to a query. " +
-      "Returns matching data source views with hit counts and document titles. Use for suggesting search knowledge (method 'search').",
+      "Browse or search workspace knowledge sources. " +
+      "Without a query: lists all available data source views. " +
+      "With a query: semantically searches and returns matching data source views with individual document nodes.",
     schema: {
       query: z
         .string()
+        .optional()
         .describe(
-          "Natural language query describing the knowledge needed (e.g., 'historical closed opportunities', 'customer support tickets')"
+          "Natural language query describing the knowledge needed. Omit to list all available sources."
         ),
       topK: z
         .number()
@@ -386,7 +371,13 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
         .optional()
         .default(5)
         .describe(
-          "Maximum number of documents to retrieve per data source (default: 5)"
+          "Maximum number of document hits to retrieve per data source (default: 5, only applies when query is provided)"
+        ),
+      category: z
+        .enum(KNOWLEDGE_CATEGORIES)
+        .optional()
+        .describe(
+          "Optional category to filter results: 'managed' (connected platforms), 'folder', or 'website'."
         ),
     },
     stake: "never_ask",
@@ -397,7 +388,7 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
   },
   suggest_knowledge: {
     description:
-      "Suggest adding or removing knowledge. Get sources from \`get_available_knowledge\` (one call returns all); each source has a knowledgeMethod field — use that as the method here. " +
+      "Suggest adding or removing knowledge. Get sources from \`search_knowledge\` (call without a query to list all); each source has a knowledgeMethod field — use that as the method here. " +
       "method 'search': semantic search over documents, folders, websites. method 'query_tables': SQL over Snowflake/BigQuery warehouses. " +
       "If a pending suggestion for the same data source already exists, it will be automatically marked as outdated. " +
       `There can't be more than ${MAX_PENDING_KNOWLEDGE_SUGGESTIONS} pending knowledge suggestions. ` +

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -41,7 +41,6 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
 import type {
@@ -58,14 +57,12 @@ import { isAgentMention } from "@app/types/assistant/mentions";
 import { isModelProviderId } from "@app/types/assistant/models/providers";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isContentFragmentType } from "@app/types/content_fragment";
-import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
 import { CoreAPI } from "@app/types/core/core_api";
 import { isJobType } from "@app/types/job_type";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { isString, removeNulls } from "@app/types/shared/utils/general";
-import type { SpaceType } from "@app/types/space";
+import { isString } from "@app/types/shared/utils/general";
 import type {
   AgentSuggestionSource,
   AgentSuggestionState,
@@ -98,24 +95,16 @@ type LimitedSuggestionKind =
   | "skills"
   | "knowledge";
 
-interface KnowledgeDataSource {
-  dataSourceViewId: string;
+interface SearchKnowledgeNode {
   nodeId: string;
-  name: string;
+  title: string;
+  parentFolderId: string;
+  parents: string[];
+  dataSourceViewId: string;
+  spaceId: string;
+  hasChildren: boolean;
   connectorProvider: string | null;
-}
-
-interface KnowledgeCategoryData {
-  category: DataSourceViewCategory;
-  displayName: string;
-  dataSources: KnowledgeDataSource[];
-}
-
-interface KnowledgeSpace {
-  sId: string;
-  name: string;
-  kind: SpaceType["kind"];
-  categories: KnowledgeCategoryData[];
+  sourceUrl: string | null;
 }
 
 function getMaxPendingSuggestions(kind: LimitedSuggestionKind): number {
@@ -548,120 +537,25 @@ import type { z } from "zod";
 
 /**
  * Lists all knowledge data source views across all spaces the user has access to.
- * Filters to knowledge categories (managed, folder, website).
+ * Filters to knowledge categories (managed, folder, website), with optional category narrowing.
  */
 async function listAllKnowledgeDataSourceViews(
-  auth: Authenticator
+  auth: Authenticator,
+  category?: DataSourceViewCategory
 ): Promise<DataSourceViewResource[]> {
   const spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
   const allViews = await DataSourceViewResource.listBySpaces(auth, spaces);
 
-  return allViews.filter((dsv) =>
-    SIDEKICK_KNOWLEDGE_CATEGORIES_SET.has(dsv.toJSON().category)
-  );
+  return allViews.filter((dsv) => {
+    const dsvCategory = dsv.toJSON().category;
+    if (category) {
+      return dsvCategory === category;
+    }
+    return SIDEKICK_KNOWLEDGE_CATEGORIES_SET.has(dsvCategory);
+  });
 }
 
 const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
-  get_available_knowledge: async ({ spaceId, category }, { auth }) => {
-    // Get all spaces the user is a member of.
-    let spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
-
-    // Filter to specific space if provided.
-    if (spaceId) {
-      spaces = spaces.filter((s) => s.sId === spaceId);
-      if (spaces.length === 0) {
-        return new Err(
-          new MCPError(`Space not found or not accessible: ${spaceId}`, {
-            tracked: false,
-          })
-        );
-      }
-    }
-
-    // Determine which categories to fetch.
-    const categoriesToFetch: DataSourceViewCategory[] = category
-      ? [category]
-      : SIDEKICK_KNOWLEDGE_CATEGORIES;
-
-    // Fetch data source views for all spaces in parallel.
-    const spaceResults = await concurrentExecutor(
-      spaces,
-      async (space) => {
-        // Fetch data source views for this space.
-        const dataSourceViews = await DataSourceViewResource.listBySpace(
-          auth,
-          space
-        );
-
-        // Filter and group by category.
-        const categoriesData: KnowledgeCategoryData[] = [];
-
-        for (const cat of categoriesToFetch) {
-          const viewsForCategory = dataSourceViews
-            .filter((dsv) => dsv.toJSON().category === cat)
-            .map((dsv) => {
-              const json = dsv.toJSON();
-              return {
-                dataSourceViewId: json.sId,
-                nodeId: `${DATA_SOURCE_NODE_ID}-${json.dataSource.dustAPIDataSourceId}`,
-                name: getDisplayNameForDataSource(json.dataSource),
-                connectorProvider: json.dataSource.connectorProvider,
-              };
-            });
-
-          if (viewsForCategory.length > 0) {
-            categoriesData.push({
-              category: cat,
-              displayName: getCategoryDisplayName(cat),
-              dataSources: viewsForCategory,
-            });
-          }
-        }
-
-        // Only include spaces that have at least one category with data.
-        if (categoriesData.length === 0) {
-          return null;
-        }
-
-        return {
-          sId: space.sId,
-          name: space.name,
-          kind: space.kind,
-          categories: categoriesData,
-        } satisfies KnowledgeSpace;
-      },
-      { concurrency: 8 }
-    );
-
-    // Filter out null results (spaces with no data sources).
-    const knowledgeSpaces = removeNulls(spaceResults);
-
-    // Calculate totals.
-    let totalDataSources = 0;
-    for (const space of knowledgeSpaces) {
-      for (const cat of space.categories) {
-        totalDataSources += cat.dataSources.length;
-      }
-    }
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text: JSON.stringify(
-          {
-            count: {
-              spaces: knowledgeSpaces.length,
-              dataSources: totalDataSources,
-            },
-            spaces: knowledgeSpaces,
-          },
-          null,
-          2
-        ),
-      },
-    ]);
-  },
-
   get_available_models: async ({ providerId }, { auth }) => {
     let models = await getAvailableModelsForWorkspace(auth);
 
@@ -1302,15 +1196,19 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  search_knowledge: async ({ query, topK }, { auth }) => {
-    const dataSourceViews = await listAllKnowledgeDataSourceViews(auth);
+  search_knowledge: async ({ query, topK, category }, { auth }) => {
+    const dataSourceViews = await listAllKnowledgeDataSourceViews(
+      auth,
+      category
+    );
 
     if (dataSourceViews.length === 0) {
       return new Ok([
         {
           type: "text" as const,
           text: JSON.stringify({
-            matches: [],
+            dataSourceViews: [],
+            nodes: [],
             message: "No knowledge sources found in the workspace.",
           }),
         },
@@ -1318,14 +1216,17 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
 
     const dataSourceEntries = dataSourceViews.map((view) => {
-      const dataSource = view.toJSON().dataSource;
+      const viewJson = view.toJSON();
+      const dataSource = viewJson.dataSource;
       return {
         apiId: dataSource.dustAPIDataSourceId,
         dataSourceView: {
           sId: view.sId,
           name: getDisplayNameForDataSource(dataSource),
           connectorProvider: dataSource.connectorProvider,
+          category: viewJson.category,
         },
+        spaceId: viewJson.spaceId,
         searchArg: {
           projectId: dataSource.dustAPIProjectId,
           dataSourceId: dataSource.dustAPIDataSourceId,
@@ -1334,6 +1235,25 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
         documentTitles: <string[]>[],
       };
     });
+
+    // Browse mode: no query, return all DSVs with no nodes.
+    if (!query) {
+      const dataSourceViews = dataSourceEntries.map((entry) => ({
+        dataSourceViewId: entry.dataSourceView.sId,
+        name: entry.dataSourceView.name,
+        connectorProvider: entry.dataSourceView.connectorProvider,
+        category: entry.dataSourceView.category,
+        spaceId: entry.spaceId,
+      }));
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify({ dataSourceViews, nodes: [] }, null, 2),
+        },
+      ]);
+    }
+
+    // Search mode: semantic search, return matching data source views + individual nodes.
     const dataSourceByDustAPIId = new Map(
       dataSourceEntries.map((entry) => [entry.apiId, entry])
     );
@@ -1356,25 +1276,44 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       );
     }
 
+    const nodes: SearchKnowledgeNode[] = [];
+
     for (const document of searchResults.value.documents) {
       const entry = dataSourceByDustAPIId.get(document.data_source_id);
       if (entry) {
         entry.documentTitles.push(document.title ?? document.document_id);
+        const ancestors = document.parents.filter(
+          (p) => p !== document.document_id
+        );
+        nodes.push({
+          nodeId: document.document_id,
+          title: document.title ?? document.document_id,
+          parentFolderId: document.parent_id ?? entry.dataSourceView.sId,
+          parents: [...ancestors, entry.dataSourceView.sId],
+          dataSourceViewId: entry.dataSourceView.sId,
+          spaceId: entry.spaceId,
+          hasChildren: false,
+          connectorProvider: entry.dataSourceView.connectorProvider,
+          sourceUrl: document.source_url ?? null,
+        });
       }
     }
 
-    const matches = dataSourceEntries
+    const roots = dataSourceEntries
       .filter((entry) => entry.documentTitles.length > 0)
       .map((entry) => ({
-        dataSourceView: entry.dataSourceView,
-        matchCount: entry.documentTitles.length,
-        documentTitles: entry.documentTitles,
+        dataSourceViewId: entry.dataSourceView.sId,
+        name: entry.dataSourceView.name,
+        connectorProvider: entry.dataSourceView.connectorProvider,
+        category: entry.dataSourceView.category,
+        spaceId: entry.spaceId,
+        childrenCount: entry.documentTitles.length,
       }));
 
     return new Ok([
       {
         type: "text" as const,
-        text: JSON.stringify({ matches }, null, 2),
+        text: JSON.stringify({ dataSourceViews: roots, nodes }, null, 2),
       },
     ]);
   },
@@ -1393,14 +1332,15 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
 
     // Validate that the data source view exists and is accessible.
-    const { action, method, dataSourceViewId, description } = params.suggestion;
+    const { action, method, dataSourceViewId, nodeIds, description } =
+      params.suggestion;
     const view = await DataSourceViewResource.fetchById(auth, dataSourceViewId);
 
     if (!view) {
       return new Err(
         new MCPError(
           `The data source view ID "${dataSourceViewId}" is invalid or not accessible. ` +
-            `Use get_available_knowledge or search_knowledge to find valid data source views.`,
+            `Use search_knowledge to find valid data source views.`,
           { tracked: false }
         )
       );
@@ -1450,6 +1390,7 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
       action,
       method,
       dataSourceViewId,
+      nodeIds,
       description,
     };
 
@@ -1885,19 +1826,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 };
-
-function getCategoryDisplayName(category: DataSourceViewCategory): string {
-  switch (category) {
-    case "managed":
-      return "Connected data";
-    case "folder":
-      return "Folders";
-    case "website":
-      return "Websites";
-    default:
-      return category;
-  }
-}
 
 export const TOOLS = buildTools(
   AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA,

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -109,11 +109,17 @@ ${SHARED_PROMPT_SECTIONS.skillsToolsGuidance}
 
   knowledgeGuidance: `<knowledge_guidance>
 Finding the right sources:
-Always call \`search_knowledge\` first to identify relevant sources, then pass the matching \`dataSourceViewId\`. Max 3 pending suggestions.
+Always call \`search_knowledge\` first to identify relevant sources. Max 3 pending suggestions.
+
+The response has two levels:
+- \`dataSourceViews\`: the available data sources. Pass \`dataSourceViewId\` to \`suggest_knowledge\` to add the whole source.
+- \`nodes\`: individual documents found by search. Pass \`dataSourceViewId\` and one or more \`nodeId\` values as \`nodeIds\` to \`suggest_knowledge\` to scope to those specific documents.
+
+Strongly prefer suggesting whole data sources — more flexible, lets the agent search all content. Only use \`nodeIds\` when there is a clear reason to scope to specific documents.
 
 Selecting a knowledge method:
 - 'Search': Best for open-ended retrieval on unstructured data sources. This is what you should suggest in most cases.
-- 'Query Tables': ONLY suggest when \`search_knowledge\` results or \`get_available_knowledge\` indicate the source contains structured data (warehouses, spreadsheets, tables). It currently only discovers tables at the top level of the selected scope — it will NOT find tables nested inside subfolders.
+- 'Query Tables': ONLY suggest when results indicate the source contains structured data (warehouses, spreadsheets, tables). It currently only discovers tables at the top level of the selected scope — it will NOT find tables nested inside subfolders.
 
 Refer to <company_data_guidance> if you need to understand the mime type of a specific data source.
 

--- a/front/tests/sidekick-evals/lib/mock-responses.ts
+++ b/front/tests/sidekick-evals/lib/mock-responses.ts
@@ -85,94 +85,64 @@ export function getMockToolResponse(
         "</available_tools>",
       ].join("\n"),
 
-    get_available_knowledge: () => ({
-      count: {
-        spaces: 3,
-        dataSources: 6,
-      },
-      spaces: [
+    search_knowledge: () => ({
+      dataSourceViews: [
         {
-          sId: "space_1",
-          name: "Engineering",
-          kind: "regular",
-          categories: [
-            {
-              category: "managed",
-              displayName: "Connected data",
-              dataSources: [
-                {
-                  dataSourceViewId: "dsv_notion_1",
-                  nodeId: "datasource_node_id-notion_ds_1",
-                  name: "Notion",
-                  connectorProvider: "notion",
-                },
-                {
-                  dataSourceViewId: "dsv_slack_1",
-                  nodeId: "datasource_node_id-slack_ds_1",
-                  name: "Slack",
-                  connectorProvider: "slack",
-                },
-              ],
-            },
-            {
-              category: "folder",
-              displayName: "Folders",
-              dataSources: [
-                {
-                  dataSourceViewId: "dsv_folder_1",
-                  nodeId: "datasource_node_id-folder_ds_1",
-                  name: "Product Requirements",
-                  connectorProvider: null,
-                },
-              ],
-            },
-          ],
+          dataSourceView: {
+            sId: "dsv_notion_1",
+            name: "Notion",
+            connectorProvider: "notion",
+            category: "managed",
+          },
+          spaceId: "space_1",
         },
         {
-          sId: "space_2",
-          name: "Marketing",
-          kind: "regular",
-          categories: [
-            {
-              category: "website",
-              displayName: "Websites",
-              dataSources: [
-                {
-                  dataSourceViewId: "dsv_website_1",
-                  nodeId: "datasource_node_id-website_ds_1",
-                  name: "Company Blog",
-                  connectorProvider: "webcrawler",
-                },
-              ],
-            },
-          ],
+          dataSourceView: {
+            sId: "dsv_slack_1",
+            name: "Slack",
+            connectorProvider: "slack",
+            category: "managed",
+          },
+          spaceId: "space_1",
         },
         {
-          sId: "space_3",
-          name: "Company Data",
-          kind: "global",
-          categories: [
-            {
-              category: "managed",
-              displayName: "Connected data",
-              dataSources: [
-                {
-                  dataSourceViewId: "dsv_snowflake_1",
-                  nodeId: "datasource_node_id-snowflake_ds_1",
-                  name: "Snowflake",
-                  connectorProvider: "snowflake",
-                },
-                {
-                  dataSourceViewId: "dsv_github_1",
-                  nodeId: "datasource_node_id-github_ds_1",
-                  name: "GitHub",
-                  connectorProvider: "github",
-                },
-              ],
-            },
-          ],
+          dataSourceView: {
+            sId: "dsv_folder_1",
+            name: "Product Requirements",
+            connectorProvider: null,
+            category: "folder",
+          },
+          spaceId: "space_1",
+        },
+        {
+          dataSourceView: {
+            sId: "dsv_website_1",
+            name: "Company Blog",
+            connectorProvider: "webcrawler",
+            category: "website",
+          },
+          spaceId: "space_2",
+        },
+        {
+          dataSourceView: {
+            sId: "dsv_snowflake_1",
+            name: "Snowflake",
+            connectorProvider: "snowflake",
+            category: "managed",
+          },
+          spaceId: "space_3",
+        },
+        {
+          dataSourceView: {
+            sId: "dsv_github_1",
+            name: "GitHub",
+            connectorProvider: "github",
+            category: "managed",
+          },
+          spaceId: "space_3",
         },
       ],
+      nodes: [],
     }),
 
     get_agent_feedback: () => ({
@@ -246,20 +216,6 @@ export function getMockToolResponse(
 
     suggest_sub_agent: () =>
       `:agent_suggestion[]{sId=mock_sId_${++mockSuggestionCounter} kind=sub_agent}`,
-
-    search_knowledge: () => ({
-      results: [
-        {
-          dataSourceViewId: "ds_notion_1",
-          dataSourceName: "Engineering Wiki",
-          hitCount: 5,
-          documents: [
-            { title: "Product FAQ", score: 0.92 },
-            { title: "Troubleshooting Guide", score: 0.88 },
-          ],
-        },
-      ],
-    }),
 
     search_agent_templates: () => ({
       templates: [

--- a/front/tests/sidekick-evals/test-suites/instructions-with-context.ts
+++ b/front/tests/sidekick-evals/test-suites/instructions-with-context.ts
@@ -23,7 +23,7 @@ export const instructionsWithContextSuite: TestSuite = {
       expectedToolCalls: ["get_agent_config"],
       judgeCriteria: `Should map knowledge sources to agent's needs (HR policies, security, expenses).
 Should make specific recommendations with rationale.
-May use get_available_knowledge or search_knowledge to discover sources.
+May use search_knowledge to discover sources.
 May offer to update instructions once knowledge is connected.`,
     },
     {

--- a/front/types/suggestions/agent_suggestion.ts
+++ b/front/types/suggestions/agent_suggestion.ts
@@ -83,6 +83,7 @@ const KnowledgeSuggestionSchema = z.object({
       "'Search' for semantic search on unstructured data. 'Query table' to generate SQL-like queries against structured data."
     ),
   dataSourceViewId: z.string(),
+  nodeIds: z.array(z.string()).optional(),
   description: z.string().optional(),
 });
 


### PR DESCRIPTION
## Description

* Adding ability to return node IDs of individual knowledge items
* Extend sidekick to be able to scope knowledge to individual items
* Refactor redundant knowledge search tools into one singular search_knowledge tool that can return all information
* Some of this is not strictly required for reinforcement, but since we will reuse the same tool, taking this opportunity to extend sidekick with the new functionality
* https://github.com/dust-tt/tasks/issues/7591

## Tests

<img width="596" height="207" alt="Screenshot 2026-04-22 at 3 14 22 PM" src="https://github.com/user-attachments/assets/95bbb166-532b-455f-bea7-baabc4058d71" />
<img width="759" height="457" alt="Screenshot 2026-04-22 at 3 14 45 PM" src="https://github.com/user-attachments/assets/ad4af0a7-5f57-4d47-bd1d-6f91d7eb2bb2" />


## Risk

* Low

## Deploy Plan

* Deploy front