### PR TITLE
[gated] Plan mode: live plan.md for agents, optional approval

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -742,6 +742,10 @@ export const ConversationViewer = ({
             void mutateContextUsage();
             window.dispatchEvent(new CompactionCompletedEvent());
             break;
+          case "plan_updated":
+            // Handled by a dedicated plan-mode UI hook (to be added in the UI PR); the
+            // conversation viewer itself doesn't need to react.
+            break;
           default:
             ((t: never) => {
               logger.error({ event: t }, "Unknown event type");

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -453,6 +453,12 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_events": "never_ask",
     "update_event": "low",
   },
+  "plan_mode": {
+    "close_plan": "never_ask",
+    "create_plan": "never_ask",
+    "edit_plan": "never_ask",
+    "request_plan_approval": "high",
+  },
   "poke": {
     "check_notion_page": "high",
     "check_slack_channel": "high",

--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -70,6 +70,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "user_mentions", id: 1026 },
       { name: "ask_user_question", id: 1028 },
       { name: "wakeups", id: 1031 },
+      { name: "plan_mode", id: 1032 },
     ];
     expect(
       autoInternalTools,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -49,6 +49,7 @@ import { NOTION_SERVER } from "@app/lib/api/actions/servers/notion/metadata";
 import { OPENAI_USAGE_SERVER } from "@app/lib/api/actions/servers/openai_usage/metadata";
 import { OUTLOOK_CALENDAR_SERVER } from "@app/lib/api/actions/servers/outlook/calendar_metadata";
 import { OUTLOOK_MAIL_SERVER } from "@app/lib/api/actions/servers/outlook/mail_metadata";
+import { PLAN_MODE_SERVER } from "@app/lib/api/actions/servers/plan_mode/metadata";
 import { POKE_SERVER } from "@app/lib/api/actions/servers/poke/metadata";
 import { PRIMITIVE_TYPES_DEBUGGER_SERVER } from "@app/lib/api/actions/servers/primitive_types_debugger/metadata";
 import { PRODUCTBOARD_SERVER } from "@app/lib/api/actions/servers/productboard/metadata";
@@ -211,6 +212,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "sandbox",
   "ask_user_question",
   "wakeups",
+  "plan_mode",
 ] as const;
 
 export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
@@ -1124,6 +1126,17 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: CLARI_COPILOT_SERVER,
+  },
+  plan_mode: {
+    id: 1032,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isRestricted: ({ featureFlags }) => !featureFlags.includes("plan_mode"),
+    isPreview: true,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: PLAN_MODE_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -47,6 +47,7 @@ import { default as notionServer } from "@app/lib/api/actions/servers/notion";
 import { default as openaiUsageServer } from "@app/lib/api/actions/servers/openai_usage";
 import { default as outlookCalendarServer } from "@app/lib/api/actions/servers/outlook/calendar_server";
 import { default as outlookMailServer } from "@app/lib/api/actions/servers/outlook/mail_server";
+import { default as planModeServer } from "@app/lib/api/actions/servers/plan_mode";
 import { default as pokeServer } from "@app/lib/api/actions/servers/poke";
 import { default as primitiveTypesDebuggerServer } from "@app/lib/api/actions/servers/primitive_types_debugger";
 import { default as productboardServer } from "@app/lib/api/actions/servers/productboard";
@@ -264,6 +265,8 @@ export async function getInternalMCPServer(
       return sandboxServer(auth, agentLoopContext);
     case "wakeups":
       return wakeupsServer(auth, agentLoopContext);
+    case "plan_mode":
+      return planModeServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/api/actions/servers/plan_mode/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/index.ts
@@ -1,0 +1,24 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { PLAN_MODE_SERVER_NAME } from "@app/lib/api/actions/servers/plan_mode/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/plan_mode/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer(PLAN_MODE_SERVER_NAME);
+
+  for (const tool of TOOLS) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: PLAN_MODE_SERVER_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -1,0 +1,168 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+// Initial content seeded into plan.md on create_plan.
+export const PLAN_MODE_SKELETON = `# Untitled plan
+
+## Context
+_Fill in: why we're doing this, what the user asked for._
+
+## Tasks
+- [ ] _Fill in the first task_
+`;
+
+export const PLAN_MODE_SERVER_NAME = "plan_mode" as const;
+
+export const CREATE_PLAN_TOOL_NAME = "create_plan" as const;
+export const EDIT_PLAN_TOOL_NAME = "edit_plan" as const;
+export const REQUEST_PLAN_APPROVAL_TOOL_NAME = "request_plan_approval" as const;
+export const CLOSE_PLAN_TOOL_NAME = "close_plan" as const;
+
+export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
+  create_plan: {
+    description:
+      "Create a `plan.md` file attached to this conversation, seeded with a Context + Tasks " +
+      "skeleton. This is the primary way to give the user visibility on your work: the plan " +
+      "stays live and they can follow along.\n\n" +
+      "**Default to calling this at the start of any non-trivial turn.** Non-trivial means: " +
+      "multi-step work, anything touching several files or systems, research that will span " +
+      "multiple tool calls, anything the user might plausibly want to follow along with. When " +
+      "in doubt, call it — the cost is one tool call, the upside is transparency.\n\n" +
+      "**Do NOT call** for single-shot questions, quick lookups, one-tool-call answers, pure " +
+      "clarification exchanges, or when a plan already exists in the conversation. Exactly one " +
+      "active plan is allowed per conversation; call `close_plan` to retire the current one " +
+      "first if the user wants a fresh plan.\n\n" +
+      "After creating, immediately populate the skeleton via `edit_plan`. Keep editing as you " +
+      "work: check off tasks with `- [x]`, add tasks that emerge, update the approach.\n\n" +
+      "**Approval is optional.** If the user EXPLICITLY asked for plan mode (e.g. 'use plan " +
+      "mode', 'plan this for me', 'draft a plan before you do anything'), you MUST call " +
+      "`request_plan_approval` once the plan is populated and before starting execution. " +
+      "Otherwise (agent-initiated planning for transparency), skip approval and just keep " +
+      "editing the plan as you execute.",
+    schema: {},
+    stake: "never_ask",
+    displayLabels: {
+      running: "Creating plan",
+      done: "Plan created",
+    },
+  },
+  edit_plan: {
+    description:
+      "Edit the active `plan.md` by replacing `old_string` with `new_string`. The full updated " +
+      "contents of plan.md are returned so you can see your change.\n\n" +
+      "`old_string` must match exactly once in the current file. If it matches zero or multiple " +
+      "times, the edit fails and you must retry with a more specific string.\n\n" +
+      "Use this liberally. During drafting, to flesh out the plan. During execution, to check " +
+      "off tasks with `- [x]`, mark blocked tasks with `- [!]`, or adjust the approach.\n\n" +
+      "A freshly-created plan.md (via `create_plan`) contains this exact skeleton you need to " +
+      "populate with your first edits:\n\n" +
+      "```markdown\n" +
+      PLAN_MODE_SKELETON +
+      "```",
+    schema: {
+      old_string: z
+        .string()
+        .describe(
+          "The exact string in plan.md to replace. Must match exactly once."
+        ),
+      new_string: z
+        .string()
+        .describe(
+          "The replacement string. Use an empty string to delete `old_string`."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Updating plan",
+      done: "Plan updated",
+    },
+  },
+  request_plan_approval: {
+    description:
+      "Ask the user to approve the current plan before you proceed. Optional — only call when " +
+      "the stakes warrant an explicit human checkpoint (irreversible actions, big scope, " +
+      "ambiguous intent, etc.). For transparency-only flows, skip this and just keep `edit_plan`-" +
+      "ing as you work.\n\n" +
+      "The user will see an approval card and either approve or reject.\n\n" +
+      "**If approved**: proceed with execution; keep updating plan.md via `edit_plan` as you " +
+      "work.\n\n" +
+      "**If REJECTED (tool result status: denied)**: STOP. Do NOT proceed with execution. Do " +
+      "NOT call any research, side-effect, or write tools. Your next step MUST be to call " +
+      "`ask_user_question` to ask the user what to change, offering options like: a concrete " +
+      "revision direction, 'proceed anyway without approval', or 'drop the plan'. Based on the " +
+      "user's answer: if they give you a revision, revise via `edit_plan` and call " +
+      "`request_plan_approval` again. If they say to proceed anyway, you may continue " +
+      "execution without re-requesting approval (keep updating plan.md via `edit_plan` for " +
+      "transparency). If they ask to drop the plan, call `close_plan`.\n\n" +
+      "Only call when plan.md is ready. Do not call with an incomplete plan.",
+    schema: {
+      summary: z
+        .string()
+        .optional()
+        .describe(
+          "Optional one-sentence TL;DR shown to the user as the body of the approval card. " +
+            "Provide it when the plan is long enough that a one-liner helps the user decide at " +
+            "a glance; omit for short plans."
+        ),
+    },
+    // `high` routes the tool through the existing MCP tool-approval machinery: the workflow exits
+    // cleanly with the action in `blocked_validation_required`, the UI renders an approval card,
+    // and on approve the tool handler runs (stamping approval onto plan.md). On reject the
+    // handler does not run; the agent sees the action as denied and can iterate.
+    stake: "high",
+    displayLabels: {
+      running: "Requesting plan approval",
+      done: "Plan approved",
+    },
+  },
+  close_plan: {
+    description:
+      "Retire the current plan. Call this when the user explicitly asks to drop the plan or " +
+      "abandon the task entirely (e.g. 'never mind', 'let's drop this', 'forget about the " +
+      "plan').\n\n" +
+      "After close_plan, the plan is hidden from the UI and this skill will not reference it " +
+      "again. You can call `create_plan` to start a fresh plan if the user later asks for one.\n\n" +
+      "Do NOT use close_plan to handle simple plan revisions — use `edit_plan` to iterate on " +
+      "the plan instead. Close is terminal; use it sparingly.",
+    schema: {
+      reason: z
+        .string()
+        .optional()
+        .describe(
+          "Optional one-sentence note about why the plan was closed. Not shown to the user; " +
+            "recorded for audit only."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Closing plan",
+      done: "Plan closed",
+    },
+  },
+});
+
+export const PLAN_MODE_SERVER = {
+  serverInfo: {
+    name: PLAN_MODE_SERVER_NAME,
+    version: "1.0.0",
+    description:
+      "Create and maintain a living `plan.md` that gives the user visibility on non-trivial " +
+      "work. Optionally surface the plan for explicit user approval before proceeding.",
+    icon: "ActionDocumentTextIcon" as const,
+    authorization: null,
+    documentationUrl: null,
+    instructions: null,
+  },
+  tools: Object.values(PLAN_MODE_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(PLAN_MODE_TOOLS_METADATA).map((t) => [t.name, t.stake])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -25,23 +25,10 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
   create_plan: {
     description:
       "Create a `plan.md` file attached to this conversation, seeded with a Context + Tasks " +
-      "skeleton. This is the primary way to give the user visibility on your work: the plan " +
-      "stays live and they can follow along.\n\n" +
-      "**Default to calling this at the start of any non-trivial turn.** Non-trivial means: " +
-      "multi-step work, anything touching several files or systems, research that will span " +
-      "multiple tool calls, anything the user might plausibly want to follow along with. When " +
-      "in doubt, call it — the cost is one tool call, the upside is transparency.\n\n" +
-      "**Do NOT call** for single-shot questions, quick lookups, one-tool-call answers, pure " +
-      "clarification exchanges, or when a plan already exists in the conversation. Exactly one " +
-      "active plan is allowed per conversation; call `close_plan` to retire the current one " +
-      "first if the user wants a fresh plan.\n\n" +
-      "After creating, immediately populate the skeleton via `edit_plan`. Keep editing as you " +
-      "work: check off tasks with `- [x]`, add tasks that emerge, update the approach.\n\n" +
-      "**Approval is optional.** If the user EXPLICITLY asked for plan mode (e.g. 'use plan " +
-      "mode', 'plan this for me', 'draft a plan before you do anything'), you MUST call " +
-      "`request_plan_approval` once the plan is populated and before starting execution. " +
-      "Otherwise (agent-initiated planning for transparency), skip approval and just keep " +
-      "editing the plan as you execute.",
+      "skeleton. Exactly one active plan is allowed per conversation; call `close_plan` to " +
+      "retire the current one first if the user wants a fresh plan. After creating, populate " +
+      "the skeleton via `edit_plan`.\n\n" +
+      "See skill instructions for when to call this and the end-to-end workflow.",
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -54,14 +41,14 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
       "Edit the active `plan.md` by replacing `old_string` with `new_string`. The full updated " +
       "contents of plan.md are returned so you can see your change.\n\n" +
       "`old_string` must match exactly once in the current file. If it matches zero or multiple " +
-      "times, the edit fails and you must retry with a more specific string.\n\n" +
-      "Use this liberally. During drafting, to flesh out the plan. During execution, to check " +
-      "off tasks with `- [x]`, mark blocked tasks with `- [!]`, or adjust the approach.\n\n" +
+      "times, the edit fails and you must retry with a more specific string. Use an empty " +
+      "`new_string` to delete `old_string`.\n\n" +
       "A freshly-created plan.md (via `create_plan`) contains this exact skeleton you need to " +
       "populate with your first edits:\n\n" +
       "```markdown\n" +
       PLAN_MODE_SKELETON +
-      "```",
+      "```\n\n" +
+      "See skill instructions for when to edit and how to use task markers.",
     schema: {
       old_string: z
         .string()
@@ -82,22 +69,12 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
   },
   request_plan_approval: {
     description:
-      "Ask the user to approve the current plan before you proceed. Optional — only call when " +
-      "the stakes warrant an explicit human checkpoint (irreversible actions, big scope, " +
-      "ambiguous intent, etc.). For transparency-only flows, skip this and just keep `edit_plan`-" +
-      "ing as you work.\n\n" +
-      "The user will see an approval card and either approve or reject.\n\n" +
-      "**If approved**: proceed with execution; keep updating plan.md via `edit_plan` as you " +
-      "work.\n\n" +
-      "**If REJECTED (tool result status: denied)**: STOP. Do NOT proceed with execution. Do " +
-      "NOT call any research, side-effect, or write tools. Your next step MUST be to call " +
-      "`ask_user_question` to ask the user what to change, offering options like: a concrete " +
-      "revision direction, 'proceed anyway without approval', or 'drop the plan'. Based on the " +
-      "user's answer: if they give you a revision, revise via `edit_plan` and call " +
-      "`request_plan_approval` again. If they say to proceed anyway, you may continue " +
-      "execution without re-requesting approval (keep updating plan.md via `edit_plan` for " +
-      "transparency). If they ask to drop the plan, call `close_plan`.\n\n" +
-      "Only call when plan.md is ready. Do not call with an incomplete plan.",
+      "Surface the current plan.md to the user and pause execution pending their decision. " +
+      "The user sees an approval card and either approves or rejects. On approve, the tool " +
+      "returns success and execution resumes. On reject, the tool returns with `denied` status " +
+      "and the handler does not run.\n\n" +
+      "Only call when plan.md is ready. Do not call with an incomplete plan.\n\n" +
+      "See skill instructions for when to request approval and how to handle rejection.",
     schema: {
       summary: z
         .string()
@@ -120,13 +97,10 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
   },
   close_plan: {
     description:
-      "Retire the current plan. Call this when the user explicitly asks to drop the plan or " +
-      "abandon the task entirely (e.g. 'never mind', 'let's drop this', 'forget about the " +
-      "plan').\n\n" +
-      "After close_plan, the plan is hidden from the UI and this skill will not reference it " +
-      "again. You can call `create_plan` to start a fresh plan if the user later asks for one.\n\n" +
-      "Do NOT use close_plan to handle simple plan revisions — use `edit_plan` to iterate on " +
-      "the plan instead. Close is terminal; use it sparingly.",
+      "Retire the current plan. After close_plan, the plan is hidden from the UI and this " +
+      "skill will not reference it again. You can call `create_plan` to start a fresh plan " +
+      "later. Close is terminal; use `edit_plan` to iterate on the plan instead of closing it.\n\n" +
+      "See skill instructions for when to call this.",
     schema: {
       reason: z
         .string()

--- a/front/lib/api/actions/servers/plan_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/tools/index.ts
@@ -1,0 +1,299 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  PLAN_MODE_SERVER_NAME,
+  PLAN_MODE_TOOLS_METADATA,
+  REQUEST_PLAN_APPROVAL_TOOL_NAME,
+} from "@app/lib/api/actions/servers/plan_mode/metadata";
+import { validateAction } from "@app/lib/api/assistant/conversation/validate_actions";
+import {
+  createPlanFile,
+  findActivePlanFile,
+  markPlanApproved,
+  markPlanClosed,
+} from "@app/lib/api/assistant/plan_mode";
+import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
+import {
+  getFileContent,
+  getUpdatedContentAndOccurrences,
+} from "@app/lib/api/files/utils";
+import { executeWithLock } from "@app/lib/lock";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import logger from "@app/logger/logger";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+async function publishPlanUpdated(
+  conversationId: string,
+  planFile: FileResource
+): Promise<void> {
+  await publishConversationEvent(
+    {
+      type: "plan_updated",
+      created: Date.now(),
+      conversationId,
+      planFileId: planFile.sId,
+      version: planFile.version,
+      isClosed: planFile.useCaseMetadata?.isPlanClosed === true,
+      hasApproval: planFile.useCaseMetadata?.planModeLastApproval != null,
+    },
+    { conversationId }
+  );
+}
+
+const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
+  create_plan: async (_params, { auth, agentLoopContext }) => {
+    if (!agentLoopContext?.runContext) {
+      return new Err(new MCPError("Agent loop context is required."));
+    }
+    const { conversation, agentConfiguration } = agentLoopContext.runContext;
+
+    // Guard against two concurrent create_plan attempts racing (rare but cheap to avoid). The
+    // lock keys on conversation so simultaneous creates in different conversations don't block
+    // each other.
+    const planFile = await executeWithLock(
+      `plan_mode:create:${conversation.sId}`,
+      async () => {
+        const existing = await findActivePlanFile(auth, conversation.sId);
+        if (existing) {
+          return null;
+        }
+        return createPlanFile(auth, {
+          conversationId: conversation.sId,
+          agentConfigurationId: agentConfiguration.sId,
+        });
+      }
+    );
+
+    if (!planFile) {
+      return new Err(
+        new MCPError(
+          "A plan already exists for this conversation. Use `edit_plan` to update it, or " +
+            "`close_plan` first if the user explicitly wants to drop it and start over."
+        )
+      );
+    }
+
+    await publishPlanUpdated(conversation.sId, planFile);
+
+    return new Ok([
+      {
+        type: "text",
+        text: `plan.md created (file id: ${planFile.sId}). Populate it via \`edit_plan\`.`,
+      },
+    ]);
+  },
+
+  edit_plan: async ({ old_string, new_string }, { auth, agentLoopContext }) => {
+    if (!agentLoopContext?.runContext) {
+      return new Err(new MCPError("Agent loop context is required."));
+    }
+    const { conversation, agentConfiguration } = agentLoopContext.runContext;
+
+    const planFile = await findActivePlanFile(auth, conversation.sId);
+    if (!planFile) {
+      return new Err(
+        new MCPError(
+          "No active plan.md for this conversation. Call `create_plan` first to start one."
+        )
+      );
+    }
+
+    try {
+      return await executeWithLock(`file:edit:${planFile.sId}`, async () => {
+        const currentContent = await getFileContent(auth, planFile, "original");
+        if (currentContent === null) {
+          return new Err(new MCPError("Failed to read plan.md."));
+        }
+
+        const { updatedContent, occurrences } = getUpdatedContentAndOccurrences(
+          {
+            oldString: old_string,
+            newString: new_string,
+            currentContent,
+          }
+        );
+
+        if (occurrences === 0) {
+          return new Err(
+            new MCPError(
+              `\`old_string\` not found in plan.md. Make sure it matches the file content ` +
+                `exactly (including whitespace).`
+            )
+          );
+        }
+        if (occurrences > 1) {
+          return new Err(
+            new MCPError(
+              `\`old_string\` matches ${occurrences} locations in plan.md. Provide a more ` +
+                `specific string so it matches exactly once.`
+            )
+          );
+        }
+
+        await planFile.uploadContent(auth, updatedContent);
+
+        if (
+          planFile.useCaseMetadata?.lastEditedByAgentConfigurationId !==
+          agentConfiguration.sId
+        ) {
+          await planFile.setUseCaseMetadata(auth, {
+            ...planFile.useCaseMetadata,
+            lastEditedByAgentConfigurationId: agentConfiguration.sId,
+          });
+        }
+
+        await publishPlanUpdated(conversation.sId, planFile);
+
+        return new Ok([
+          {
+            type: "text",
+            text: `plan.md updated. Current contents:\n\n${updatedContent}`,
+          },
+        ]);
+      });
+    } catch (err) {
+      return new Err(
+        new MCPError(
+          `plan.md is currently being edited by another operation: ${normalizeError(err).message}`
+        )
+      );
+    }
+  },
+
+  request_plan_approval: async ({ summary }, { auth, agentLoopContext }) => {
+    if (!agentLoopContext?.runContext) {
+      return new Err(new MCPError("Agent loop context is required."));
+    }
+    const { conversation } = agentLoopContext.runContext;
+
+    // Handler only runs after user approval (tool stake is "high" → routes through the standard
+    // MCP tool-approval flow). On reject, this function is never called; the agent sees the
+    // action as denied.
+    const planFile = await findActivePlanFile(auth, conversation.sId);
+    if (!planFile) {
+      return new Err(
+        new MCPError(
+          "No active plan.md for this conversation. `request_plan_approval` requires an " +
+            "existing plan — create one first with `create_plan` and populate it."
+        )
+      );
+    }
+
+    const user = auth.user();
+    if (!user) {
+      return new Err(
+        new MCPError("No user on auth context; cannot record approval.")
+      );
+    }
+
+    // Note: `user.sId` here is the author of the user message that triggered the agent loop,
+    // not necessarily the person who clicked Approve. The existing validate-action check
+    // requires those to be the same user, so in practice they match — but if validate-action
+    // is ever opened up, this needs to become the actual approver's sId from the approval
+    // callback.
+    const approval = await markPlanApproved(auth, planFile, user.sId);
+    if (!approval) {
+      // Plan was closed between approval request and approval decision (close_plan race).
+      return new Err(
+        new MCPError(
+          "The plan was closed while approval was pending. It cannot be approved anymore."
+        )
+      );
+    }
+
+    await publishPlanUpdated(conversation.sId, planFile);
+
+    return new Ok([
+      {
+        type: "text",
+        text:
+          `Plan approved by ${user.sId} at ${approval.approvedAt} ` +
+          `(plan.md version ${approval.fileVersion}). Proceed with execution: work through ` +
+          `the tasks in plan.md, using \`edit_plan\` to check them off as you go. Stay within ` +
+          `the approved scope; if scope changes, surface it to the user before acting.` +
+          (summary ? `\n\nSummary shown to user: ${summary}` : ""),
+      },
+    ]);
+  },
+
+  close_plan: async ({ reason }, { auth, agentLoopContext }) => {
+    if (!agentLoopContext?.runContext) {
+      return new Err(new MCPError("Agent loop context is required."));
+    }
+    const { conversation } = agentLoopContext.runContext;
+
+    const planFile = await findActivePlanFile(auth, conversation.sId);
+    if (!planFile) {
+      return new Err(
+        new MCPError(
+          "No active plan.md for this conversation. Nothing to close."
+        )
+      );
+    }
+
+    // Resolve any pending request_plan_approval action so the UI approval card disappears and
+    // the paused agent message finalizes. We reuse the canonical validate-action path so the
+    // workflow is properly relaunched — otherwise the prior agent message sits in "created"
+    // state forever and the user sees a stuck spinner.
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    if (conversationResource) {
+      const blockedActions =
+        await AgentMCPActionResource.listBlockedActionsForConversation(
+          auth,
+          conversationResource
+        );
+      for (const blocked of blockedActions) {
+        if (
+          blocked.metadata.toolName !== REQUEST_PLAN_APPROVAL_TOOL_NAME ||
+          blocked.metadata.mcpServerName !== PLAN_MODE_SERVER_NAME
+        ) {
+          continue;
+        }
+        const res = await validateAction(auth, conversationResource, {
+          actionId: blocked.actionId,
+          approvalState: "rejected",
+          messageId: blocked.messageId,
+        });
+        if (res.isErr()) {
+          logger.warn(
+            {
+              conversationId: conversation.sId,
+              actionId: blocked.actionId,
+              error: res.error,
+            },
+            "Failed to reject pending plan approval on close_plan"
+          );
+        }
+      }
+    }
+
+    await markPlanClosed(auth, planFile);
+    await publishPlanUpdated(conversation.sId, planFile);
+
+    if (reason) {
+      logger.info(
+        { conversationId: conversation.sId, planFileId: planFile.sId, reason },
+        "Plan closed by agent"
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text",
+        text:
+          "Plan closed. The plan.md is now hidden from the UI and will no longer be " +
+          "referenced. If the user later asks for a new plan, call `create_plan` to start a " +
+          "fresh one.",
+      },
+    ]);
+  },
+};
+
+export const TOOLS = buildTools(PLAN_MODE_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/plan_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/tools/index.ts
@@ -1,26 +1,19 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import {
-  PLAN_MODE_SERVER_NAME,
-  PLAN_MODE_TOOLS_METADATA,
-  REQUEST_PLAN_APPROVAL_TOOL_NAME,
-} from "@app/lib/api/actions/servers/plan_mode/metadata";
-import { validateAction } from "@app/lib/api/assistant/conversation/validate_actions";
+import { PLAN_MODE_TOOLS_METADATA } from "@app/lib/api/actions/servers/plan_mode/metadata";
 import {
   createPlanFile,
   findActivePlanFile,
   markPlanApproved,
   markPlanClosed,
+  withPlanModeLock,
 } from "@app/lib/api/assistant/plan_mode";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import {
   getFileContent,
   getUpdatedContentAndOccurrences,
 } from "@app/lib/api/files/utils";
-import { executeWithLock } from "@app/lib/lock";
-import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
@@ -51,40 +44,31 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     }
     const { conversation, agentConfiguration } = agentLoopContext.runContext;
 
-    // Guard against two concurrent create_plan attempts racing (rare but cheap to avoid). The
-    // lock keys on conversation so simultaneous creates in different conversations don't block
-    // each other.
-    const planFile = await executeWithLock(
-      `plan_mode:create:${conversation.sId}`,
-      async () => {
-        const existing = await findActivePlanFile(auth, conversation.sId);
-        if (existing) {
-          return null;
-        }
-        return createPlanFile(auth, {
-          conversationId: conversation.sId,
-          agentConfigurationId: agentConfiguration.sId,
-        });
+    return withPlanModeLock(conversation.sId, async () => {
+      const existing = await findActivePlanFile(auth, conversation.sId);
+      if (existing) {
+        return new Err(
+          new MCPError(
+            "A plan already exists for this conversation. Use `edit_plan` to update it, or " +
+              "`close_plan` first if the user explicitly wants to drop it and start over."
+          )
+        );
       }
-    );
 
-    if (!planFile) {
-      return new Err(
-        new MCPError(
-          "A plan already exists for this conversation. Use `edit_plan` to update it, or " +
-            "`close_plan` first if the user explicitly wants to drop it and start over."
-        )
-      );
-    }
+      const planFile = await createPlanFile(auth, {
+        conversationId: conversation.sId,
+        agentConfigurationId: agentConfiguration.sId,
+      });
 
-    await publishPlanUpdated(conversation.sId, planFile);
+      await publishPlanUpdated(conversation.sId, planFile);
 
-    return new Ok([
-      {
-        type: "text",
-        text: `plan.md created (file id: ${planFile.sId}). Populate it via \`edit_plan\`.`,
-      },
-    ]);
+      return new Ok([
+        {
+          type: "text",
+          text: `plan.md created (file id: ${planFile.sId}). Populate it via \`edit_plan\`.`,
+        },
+      ]);
+    });
   },
 
   edit_plan: async ({ old_string, new_string }, { auth, agentLoopContext }) => {
@@ -93,17 +77,17 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     }
     const { conversation, agentConfiguration } = agentLoopContext.runContext;
 
-    const planFile = await findActivePlanFile(auth, conversation.sId);
-    if (!planFile) {
-      return new Err(
-        new MCPError(
-          "No active plan.md for this conversation. Call `create_plan` first to start one."
-        )
-      );
-    }
-
     try {
-      return await executeWithLock(`file:edit:${planFile.sId}`, async () => {
+      return await withPlanModeLock(conversation.sId, async () => {
+        const planFile = await findActivePlanFile(auth, conversation.sId);
+        if (!planFile) {
+          return new Err(
+            new MCPError(
+              "No active plan.md for this conversation. Call `create_plan` first to start one."
+            )
+          );
+        }
+
         const currentContent = await getFileContent(auth, planFile, "original");
         if (currentContent === null) {
           return new Err(new MCPError("Failed to read plan.md."));
@@ -173,51 +157,54 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     // Handler only runs after user approval (tool stake is "high" → routes through the standard
     // MCP tool-approval flow). On reject, this function is never called; the agent sees the
     // action as denied.
-    const planFile = await findActivePlanFile(auth, conversation.sId);
-    if (!planFile) {
-      return new Err(
-        new MCPError(
-          "No active plan.md for this conversation. `request_plan_approval` requires an " +
-            "existing plan — create one first with `create_plan` and populate it."
-        )
-      );
-    }
+    return withPlanModeLock(conversation.sId, async () => {
+      const planFile = await findActivePlanFile(auth, conversation.sId);
+      if (!planFile) {
+        return new Err(
+          new MCPError(
+            "No active plan.md for this conversation. `request_plan_approval` requires an " +
+              "existing plan — create one first with `create_plan` and populate it."
+          )
+        );
+      }
 
-    const user = auth.user();
-    if (!user) {
-      return new Err(
-        new MCPError("No user on auth context; cannot record approval.")
-      );
-    }
+      const user = auth.user();
+      if (!user) {
+        return new Err(
+          new MCPError("No user on auth context; cannot record approval.")
+        );
+      }
 
-    // Note: `user.sId` here is the author of the user message that triggered the agent loop,
-    // not necessarily the person who clicked Approve. The existing validate-action check
-    // requires those to be the same user, so in practice they match — but if validate-action
-    // is ever opened up, this needs to become the actual approver's sId from the approval
-    // callback.
-    const approval = await markPlanApproved(auth, planFile, user.sId);
-    if (!approval) {
-      // Plan was closed between approval request and approval decision (close_plan race).
-      return new Err(
-        new MCPError(
-          "The plan was closed while approval was pending. It cannot be approved anymore."
-        )
-      );
-    }
+      // Note: `user.sId` here is the author of the user message that triggered the agent loop,
+      // not necessarily the person who clicked Approve. The existing validate-action check
+      // requires those to be the same user, so in practice they match — but if validate-action
+      // is ever opened up, this needs to become the actual approver's sId from the approval
+      // callback.
+      const approval = await markPlanApproved(auth, planFile, user.sId);
+      if (!approval) {
+        // Plan was closed between approval request and approval decision (close_plan race).
+        return new Err(
+          new MCPError(
+            "The plan was closed while approval was pending. It cannot be approved anymore."
+          )
+        );
+      }
 
-    await publishPlanUpdated(conversation.sId, planFile);
+      await publishPlanUpdated(conversation.sId, planFile);
 
-    return new Ok([
-      {
-        type: "text",
-        text:
-          `Plan approved by ${user.sId} at ${approval.approvedAt} ` +
-          `(plan.md version ${approval.fileVersion}). Proceed with execution: work through ` +
-          `the tasks in plan.md, using \`edit_plan\` to check them off as you go. Stay within ` +
-          `the approved scope; if scope changes, surface it to the user before acting.` +
-          (summary ? `\n\nSummary shown to user: ${summary}` : ""),
-      },
-    ]);
+      return new Ok([
+        {
+          type: "text",
+          text:
+            `Plan approved by ${user.sId} at ${approval.approvedAt} ` +
+            `(plan.md version ${approval.fileVersion}). Proceed with execution: work ` +
+            `through the tasks in plan.md, using \`edit_plan\` to check them off as you ` +
+            `go. Stay within the approved scope; if scope changes, surface it to the user ` +
+            `before acting.` +
+            (summary ? `\n\nSummary shown to user: ${summary}` : ""),
+        },
+      ]);
+    });
   },
 
   close_plan: async ({ reason }, { auth, agentLoopContext }) => {
@@ -226,73 +213,45 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     }
     const { conversation } = agentLoopContext.runContext;
 
-    const planFile = await findActivePlanFile(auth, conversation.sId);
-    if (!planFile) {
-      return new Err(
-        new MCPError(
-          "No active plan.md for this conversation. Nothing to close."
-        )
-      );
-    }
-
-    // Resolve any pending request_plan_approval action so the UI approval card disappears and
-    // the paused agent message finalizes. We reuse the canonical validate-action path so the
-    // workflow is properly relaunched — otherwise the prior agent message sits in "created"
-    // state forever and the user sees a stuck spinner.
-    const conversationResource = await ConversationResource.fetchById(
-      auth,
-      conversation.sId
-    );
-    if (conversationResource) {
-      const blockedActions =
-        await AgentMCPActionResource.listBlockedActionsForConversation(
-          auth,
-          conversationResource
+    return withPlanModeLock(conversation.sId, async () => {
+      const planFile = await findActivePlanFile(auth, conversation.sId);
+      if (!planFile) {
+        return new Err(
+          new MCPError(
+            "No active plan.md for this conversation. Nothing to close."
+          )
         );
-      for (const blocked of blockedActions) {
-        if (
-          blocked.metadata.toolName !== REQUEST_PLAN_APPROVAL_TOOL_NAME ||
-          blocked.metadata.mcpServerName !== PLAN_MODE_SERVER_NAME
-        ) {
-          continue;
-        }
-        const res = await validateAction(auth, conversationResource, {
-          actionId: blocked.actionId,
-          approvalState: "rejected",
-          messageId: blocked.messageId,
-        });
-        if (res.isErr()) {
-          logger.warn(
-            {
-              conversationId: conversation.sId,
-              actionId: blocked.actionId,
-              error: res.error,
-            },
-            "Failed to reject pending plan approval on close_plan"
-          );
-        }
       }
-    }
 
-    await markPlanClosed(auth, planFile);
-    await publishPlanUpdated(conversation.sId, planFile);
+      // Intentionally do not resolve any pending `request_plan_approval` blocked action here.
+      // The codebase only transitions blocked actions to terminal via user action on the
+      // approval card itself (UI or email). If a stale card remains after close, existing
+      // paths degrade gracefully: `markPlanApproved` already no-ops on closed plans, and a
+      // reject goes through the normal relaunch flow.
+      await markPlanClosed(auth, planFile);
+      await publishPlanUpdated(conversation.sId, planFile);
 
-    if (reason) {
-      logger.info(
-        { conversationId: conversation.sId, planFileId: planFile.sId, reason },
-        "Plan closed by agent"
-      );
-    }
+      if (reason) {
+        logger.info(
+          {
+            conversationId: conversation.sId,
+            planFileId: planFile.sId,
+            reason,
+          },
+          "Plan closed by agent"
+        );
+      }
 
-    return new Ok([
-      {
-        type: "text",
-        text:
-          "Plan closed. The plan.md is now hidden from the UI and will no longer be " +
-          "referenced. If the user later asks for a new plan, call `create_plan` to start a " +
-          "fresh one.",
-      },
-    ]);
+      return new Ok([
+        {
+          type: "text",
+          text:
+            "Plan closed. The plan.md is now hidden from the UI and will no longer be " +
+            "referenced. If the user later asks for a new plan, call `create_plan` to " +
+            "start a fresh one.",
+        },
+      ]);
+    });
   },
 };
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2685,6 +2685,7 @@ export async function isConversationEventAllowedForAuth(
     case "compaction_message_done":
     case "conversation_title":
     case "user_message_promoted":
+    case "plan_updated":
       return true;
     default:
       assertNever(type);

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -605,6 +605,7 @@ function _getDustLikeGlobalAgent(
       "mention_users",
       "sandbox",
       "projects",
+      "plan_mode",
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     omittedThinking: omittedThinking ?? false,

--- a/front/lib/api/assistant/plan_mode.ts
+++ b/front/lib/api/assistant/plan_mode.ts
@@ -1,7 +1,18 @@
 import { PLAN_MODE_SKELETON } from "@app/lib/api/actions/servers/plan_mode/metadata";
 import type { Authenticator } from "@app/lib/auth";
+import { executeWithLock } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { PlanModeApproval } from "@app/types/files";
+
+// Conversation-scoped lock for all plan-mode operations. One plan per conversation, so a single
+// lock keyed on conversation sId serializes create/edit/approve/close and prevents races (e.g.
+// edit landing on a just-closed plan, two concurrent creates, approval stamping a closed plan).
+export async function withPlanModeLock<T>(
+  conversationId: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  return executeWithLock(`plan_mode:${conversationId}`, fn);
+}
 
 // Find the currently active plan file for a conversation. "Active" = attached to the conversation
 // with `isPlanFile: true` and NOT `isPlanClosed: true`. Returns null if no active plan exists.

--- a/front/lib/api/assistant/plan_mode.ts
+++ b/front/lib/api/assistant/plan_mode.ts
@@ -1,0 +1,99 @@
+import { PLAN_MODE_SKELETON } from "@app/lib/api/actions/servers/plan_mode/metadata";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import type { PlanModeApproval } from "@app/types/files";
+
+// Find the currently active plan file for a conversation. "Active" = attached to the conversation
+// with `isPlanFile: true` and NOT `isPlanClosed: true`. Returns null if no active plan exists.
+//
+// Plan counts per conversation are small (1-2), so the TS-side filter is cheap. If plan mode
+// sees heavy use, a partial expression index on
+// `(workspaceId, useCase, (useCaseMetadata ->> 'conversationId'))` would help.
+export async function findActivePlanFile(
+  auth: Authenticator,
+  conversationId: string
+): Promise<FileResource | null> {
+  const files = await FileResource.listPlanFilesForConversation(auth, {
+    conversationId,
+  });
+  return files.find((f) => !f.useCaseMetadata?.isPlanClosed) ?? null;
+}
+
+// Create a fresh plan.md file attached to the conversation, seeded with the skeleton. Does not
+// check for existing active plans — callers should guard against that.
+export async function createPlanFile(
+  auth: Authenticator,
+  {
+    conversationId,
+    agentConfigurationId,
+  }: {
+    conversationId: string;
+    agentConfigurationId?: string;
+  }
+): Promise<FileResource> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const file = await FileResource.makeNew({
+    workspaceId: workspace.id,
+    fileName: "plan.md",
+    contentType: "text/markdown",
+    fileSize: 0,
+    useCase: "conversation",
+    useCaseMetadata: {
+      conversationId,
+      isPlanFile: true,
+      planModeLastApproval: null,
+      lastEditedByAgentConfigurationId: agentConfigurationId,
+    },
+  });
+
+  await file.uploadContent(auth, PLAN_MODE_SKELETON);
+
+  return file;
+}
+
+// Stamp the plan file with approval metadata. Called by the request_plan_approval tool handler
+// after user approval. No-ops (returns null) if the plan is already closed — this covers the race
+// where close_plan runs between approval request and approval decision.
+export async function markPlanApproved(
+  auth: Authenticator,
+  planFile: FileResource,
+  approvedByUserId: string
+): Promise<PlanModeApproval | null> {
+  if (planFile.useCaseMetadata?.isPlanClosed) {
+    return null;
+  }
+
+  const approval: PlanModeApproval = {
+    approvedAt: new Date().toISOString(),
+    approvedByUserId,
+    fileVersion: planFile.version,
+  };
+
+  await planFile.setUseCaseMetadata(auth, {
+    ...planFile.useCaseMetadata,
+    planModeLastApproval: approval,
+  });
+
+  return approval;
+}
+
+// Retire the plan. Sets `isPlanClosed: true`. The file stays in DB for audit; the skill and UI
+// stop referencing it. Any pending approval on this plan should be resolved separately by the
+// caller (close_plan handler).
+export async function markPlanClosed(
+  auth: Authenticator,
+  planFile: FileResource
+): Promise<void> {
+  if (planFile.useCaseMetadata?.isPlanClosed) {
+    return;
+  }
+  await planFile.setUseCaseMetadata(auth, {
+    ...planFile.useCaseMetadata,
+    isPlanClosed: true,
+  });
+}
+
+export function isPlanApproved(file: FileResource): boolean {
+  return file.useCaseMetadata?.planModeLastApproval != null;
+}

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -131,6 +131,7 @@ function isMessageEventParams(
     case "compaction_message_new":
     case "compaction_message_done":
     case "conversation_title":
+    case "plan_updated":
       return false;
     default:
       assertNever(eventType);

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -20,6 +20,7 @@ import type {
   CompactionMessageDoneEvent,
   CompactionMessageNewEvent,
   ConversationTitleEvent,
+  PlanUpdatedEvent,
   UserMessageNewEvent,
   UserMessagePromotedEvent,
 } from "@app/types/assistant/conversation";
@@ -47,7 +48,8 @@ export type ConversationEvents =
   | UserMessagePromotedEvent
   | AgentMessageDoneEvent
   | CompactionMessageNewEvent
-  | CompactionMessageDoneEvent;
+  | CompactionMessageDoneEvent
+  | PlanUpdatedEvent;
 
 export const TERMINAL_AGENT_MESSAGE_EVENT_TYPES: AgentMessageEvents["type"][] =
   [

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -139,6 +139,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
   sandbox: "platform",
   ask_user_question: "platform",
   wakeups: "platform",
+  plan_mode: "platform",
 };
 
 export function getToolCategory(

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -357,6 +357,28 @@ export class FileResource extends BaseResource<FileModel> {
     return files.map((f) => new this(this.model, f.get()));
   }
 
+  // List plan-mode files attached to a conversation. Callers filter active vs. closed via the
+  // returned `useCaseMetadata.isPlanClosed` flag (present only on closed plans). Ordered by
+  // createdAt DESC so the most recent plan is first.
+  static async listPlanFilesForConversation(
+    auth: Authenticator,
+    { conversationId }: { conversationId: string }
+  ): Promise<FileResource[]> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const files = await this.model.findAll({
+      where: {
+        workspaceId: owner.id,
+        useCase: "conversation",
+        status: "ready",
+        useCaseMetadata: { conversationId, isPlanFile: true },
+      },
+      order: [["createdAt", "DESC"]],
+    });
+
+    return files.map((f) => new this(this.model, f.get()));
+  }
+
   static async fetchByMountFilePaths(
     auth: Authenticator,
     mountFilePaths: string[]

--- a/front/lib/resources/skill/code_defined/plan_mode.ts
+++ b/front/lib/resources/skill/code_defined/plan_mode.ts
@@ -6,47 +6,30 @@ import {
   PLAN_MODE_SERVER_NAME,
   REQUEST_PLAN_APPROVAL_TOOL_NAME,
 } from "@app/lib/api/actions/servers/plan_mode/metadata";
-import { findActivePlanFile } from "@app/lib/api/assistant/plan_mode";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { SystemSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 
 const ASK_USER_QUESTION_TOOL_NAME =
   ASK_USER_QUESTION_TOOLS_METADATA.ask_user_question.name;
 
-// Default reminder — returned when no active plan.md exists in the conversation.
-const DEFAULT_REMINDER = `
+const PLAN_MODE_INSTRUCTIONS = `
 Plan Mode lets you maintain a live \`plan.md\` the user can follow as you work. Think of it as a shared progress view, not just an approval gate. Using it is delightful UX: the user sees what you're doing without having to ask.
 
-**Default behavior: call \`${CREATE_PLAN_TOOL_NAME}\` at the start of any non-trivial turn.** Treat plan mode as your first move unless the task is clearly trivial. "Non-trivial" includes: multi-step work, anything touching several files or systems, research that will span multiple tool calls, anything the user might plausibly want to follow along with.
+**Default behavior: call \`${CREATE_PLAN_TOOL_NAME}\` at the start of any non-trivial turn.** Non-trivial includes: multi-step work, anything touching several files or systems, research that will span multiple tool calls, anything the user might plausibly want to follow along with. When in doubt, err on the side of creating a plan: the cost is one tool call, the upside is transparency.
 
-**Stay in default mode (no plan) only for:** single-shot questions, quick lookups, one-tool-call answers, pure clarification exchanges. When in doubt, err on the side of creating a plan — the cost is one tool call, the upside is transparency.
+**Skip plan mode** for single-shot questions, quick lookups, one-tool-call answers, or pure clarification exchanges.
 
-Workflow: call \`${CREATE_PLAN_TOOL_NAME}\` first, then populate via successive \`${EDIT_PLAN_TOOL_NAME}\` calls as you understand the task and make progress.
+Exactly one active plan is allowed per conversation. If a plan already exists in this conversation (you can see it in the attachments), do NOT call \`${CREATE_PLAN_TOOL_NAME}\` again; use \`${EDIT_PLAN_TOOL_NAME}\` to iterate on the existing one.
 
-Tools:
-- \`${CREATE_PLAN_TOOL_NAME}\`: create plan.md with a seeded skeleton. One active plan per conversation.
-- \`${EDIT_PLAN_TOOL_NAME}\`: substitution edit on the active plan. Use liberally during drafting AND execution.
-- \`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\`: human checkpoint. MANDATORY when the user explicitly asked for plan mode (e.g. "use plan mode", "plan this for me"). Otherwise optional — only if stakes warrant the user explicitly OK-ing before you proceed.
-- \`${CLOSE_PLAN_TOOL_NAME}\`: retire the plan. Only call if the user explicitly asks to drop it.
-`;
+**Keep the plan updated as you work**: use \`${EDIT_PLAN_TOOL_NAME}\` to tick off completed tasks (\`- [x]\`), mark blocked ones (\`- [!]\`), add tasks that emerge, or revise the approach. The UI renders the plan live, so frequent small edits are a delight for the user, not a cost.
 
-// Returned when an active plan.md exists. Works for both the drafting phase and the post-
-// approval execution phase (the agent doesn't need to distinguish — it just keeps the plan
-// updated).
-const ACTIVE_PLAN_PROMPT = `
-You have an active \`plan.md\` attached to this conversation. The user can see it live.
+Clarifying questions go through \`${ASK_USER_QUESTION_TOOL_NAME}\`: use it liberally before drafting the plan and whenever ambiguity arises mid-execution.
 
-Keep it updated as you work:
-- Use \`${EDIT_PLAN_TOOL_NAME}\` to tick off completed tasks (\`- [x]\`), mark blocked ones (\`- [!]\`), add tasks that emerge, or revise the approach.
-- The UI renders the plan live — frequent small edits are a delight for the user, not a cost.
-
-Clarifying questions go through \`${ASK_USER_QUESTION_TOOL_NAME}\` — use them liberally before drafting the plan and whenever ambiguity arises mid-execution.
-
-**If the user explicitly asked for plan mode** (e.g. "use plan mode", "plan this for me"), you MUST call \`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\` once the plan is populated and before starting execution. Explicit opt-in signals the user wants the formal approve-before-execute flow.
-
-If plan mode was your own initiative (not user-requested) and the stakes warrant a human checkpoint (irreversible actions, big scope, ambiguous intent), call \`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\` too. Otherwise approval is optional — skip it for transparency-only flows.
+**Approval (\`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\`)**:
+- MANDATORY when the user explicitly asked for plan mode (e.g. "use plan mode", "plan this for me", "draft a plan before you do anything"). Call it once the plan is populated and before starting execution.
+- Otherwise optional. Call it only if the stakes warrant a human checkpoint (irreversible actions, big scope, ambiguous intent). For transparency-only flows, skip it and just keep editing the plan as you execute.
+- Only call when plan.md is ready. Do not call with an incomplete plan.
 
 **If \`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\` is REJECTED (tool result status: denied): STOP.** Do NOT proceed with execution under any circumstance. Do NOT call research, side-effect, or write tools.
 
@@ -55,21 +38,8 @@ Your next step MUST be to call \`${ASK_USER_QUESTION_TOOL_NAME}\` to ask the use
 - If they say to proceed anyway, continue execution without re-requesting approval (keep updating plan.md via \`${EDIT_PLAN_TOOL_NAME}\` for transparency).
 - If they ask to drop the plan, call \`${CLOSE_PLAN_TOOL_NAME}\`.
 
-If the user explicitly asks to drop the plan (e.g. "never mind", "forget about it"), call \`${CLOSE_PLAN_TOOL_NAME}\`. Otherwise do NOT close the plan — use \`${EDIT_PLAN_TOOL_NAME}\` to iterate.
+**Closing the plan (\`${CLOSE_PLAN_TOOL_NAME}\`)**: only if the user explicitly asks to drop it (e.g. "never mind", "forget about it"). Do NOT close to handle revisions; use \`${EDIT_PLAN_TOOL_NAME}\` to iterate instead.
 `;
-
-async function resolveInstructions(
-  auth: Authenticator,
-  agentLoopData: AgentLoopExecutionData | undefined
-): Promise<string> {
-  const conversationId = agentLoopData?.conversation?.sId;
-  if (!conversationId) {
-    return DEFAULT_REMINDER;
-  }
-
-  const planFile = await findActivePlanFile(auth, conversationId);
-  return planFile ? ACTIVE_PLAN_PROMPT : DEFAULT_REMINDER;
-}
 
 export const planModeSkill = {
   sId: "plan_mode",
@@ -78,12 +48,7 @@ export const planModeSkill = {
     "Let agents maintain a live plan.md the user can follow, with an optional approval step for risky work.",
   agentFacingDescription:
     "Create and maintain a plan.md for non-trivial tasks to give the user visibility. Optionally request approval for risky steps.",
-  fetchInstructions: async (
-    auth: Authenticator,
-    {
-      agentLoopData,
-    }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
-  ) => resolveInstructions(auth, agentLoopData),
+  instructions: PLAN_MODE_INSTRUCTIONS,
   mcpServers: [{ name: PLAN_MODE_SERVER_NAME }],
   version: 1,
   icon: "ActionDocumentTextIcon",

--- a/front/lib/resources/skill/code_defined/plan_mode.ts
+++ b/front/lib/resources/skill/code_defined/plan_mode.ts
@@ -1,0 +1,94 @@
+import { ASK_USER_QUESTION_TOOLS_METADATA } from "@app/lib/api/actions/servers/ask_user_question/metadata";
+import {
+  CLOSE_PLAN_TOOL_NAME,
+  CREATE_PLAN_TOOL_NAME,
+  EDIT_PLAN_TOOL_NAME,
+  PLAN_MODE_SERVER_NAME,
+  REQUEST_PLAN_APPROVAL_TOOL_NAME,
+} from "@app/lib/api/actions/servers/plan_mode/metadata";
+import { findActivePlanFile } from "@app/lib/api/assistant/plan_mode";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import type { SystemSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+
+const ASK_USER_QUESTION_TOOL_NAME =
+  ASK_USER_QUESTION_TOOLS_METADATA.ask_user_question.name;
+
+// Default reminder — returned when no active plan.md exists in the conversation.
+const DEFAULT_REMINDER = `
+Plan Mode lets you maintain a live \`plan.md\` the user can follow as you work. Think of it as a shared progress view, not just an approval gate. Using it is delightful UX: the user sees what you're doing without having to ask.
+
+**Default behavior: call \`${CREATE_PLAN_TOOL_NAME}\` at the start of any non-trivial turn.** Treat plan mode as your first move unless the task is clearly trivial. "Non-trivial" includes: multi-step work, anything touching several files or systems, research that will span multiple tool calls, anything the user might plausibly want to follow along with.
+
+**Stay in default mode (no plan) only for:** single-shot questions, quick lookups, one-tool-call answers, pure clarification exchanges. When in doubt, err on the side of creating a plan — the cost is one tool call, the upside is transparency.
+
+Workflow: call \`${CREATE_PLAN_TOOL_NAME}\` first, then populate via successive \`${EDIT_PLAN_TOOL_NAME}\` calls as you understand the task and make progress.
+
+Tools:
+- \`${CREATE_PLAN_TOOL_NAME}\`: create plan.md with a seeded skeleton. One active plan per conversation.
+- \`${EDIT_PLAN_TOOL_NAME}\`: substitution edit on the active plan. Use liberally during drafting AND execution.
+- \`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\`: human checkpoint. MANDATORY when the user explicitly asked for plan mode (e.g. "use plan mode", "plan this for me"). Otherwise optional — only if stakes warrant the user explicitly OK-ing before you proceed.
+- \`${CLOSE_PLAN_TOOL_NAME}\`: retire the plan. Only call if the user explicitly asks to drop it.
+`;
+
+// Returned when an active plan.md exists. Works for both the drafting phase and the post-
+// approval execution phase (the agent doesn't need to distinguish — it just keeps the plan
+// updated).
+const ACTIVE_PLAN_PROMPT = `
+You have an active \`plan.md\` attached to this conversation. The user can see it live.
+
+Keep it updated as you work:
+- Use \`${EDIT_PLAN_TOOL_NAME}\` to tick off completed tasks (\`- [x]\`), mark blocked ones (\`- [!]\`), add tasks that emerge, or revise the approach.
+- The UI renders the plan live — frequent small edits are a delight for the user, not a cost.
+
+Clarifying questions go through \`${ASK_USER_QUESTION_TOOL_NAME}\` — use them liberally before drafting the plan and whenever ambiguity arises mid-execution.
+
+**If the user explicitly asked for plan mode** (e.g. "use plan mode", "plan this for me"), you MUST call \`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\` once the plan is populated and before starting execution. Explicit opt-in signals the user wants the formal approve-before-execute flow.
+
+If plan mode was your own initiative (not user-requested) and the stakes warrant a human checkpoint (irreversible actions, big scope, ambiguous intent), call \`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\` too. Otherwise approval is optional — skip it for transparency-only flows.
+
+**If \`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\` is REJECTED (tool result status: denied): STOP.** Do NOT proceed with execution under any circumstance. Do NOT call research, side-effect, or write tools.
+
+Your next step MUST be to call \`${ASK_USER_QUESTION_TOOL_NAME}\` to ask the user what to change. Offer options like: a concrete revision direction, "proceed anyway without approval", or "drop the plan". Based on the user's answer:
+- If they give you a revision, revise the plan via \`${EDIT_PLAN_TOOL_NAME}\` and call \`${REQUEST_PLAN_APPROVAL_TOOL_NAME}\` again.
+- If they say to proceed anyway, continue execution without re-requesting approval (keep updating plan.md via \`${EDIT_PLAN_TOOL_NAME}\` for transparency).
+- If they ask to drop the plan, call \`${CLOSE_PLAN_TOOL_NAME}\`.
+
+If the user explicitly asks to drop the plan (e.g. "never mind", "forget about it"), call \`${CLOSE_PLAN_TOOL_NAME}\`. Otherwise do NOT close the plan — use \`${EDIT_PLAN_TOOL_NAME}\` to iterate.
+`;
+
+async function resolveInstructions(
+  auth: Authenticator,
+  agentLoopData: AgentLoopExecutionData | undefined
+): Promise<string> {
+  const conversationId = agentLoopData?.conversation?.sId;
+  if (!conversationId) {
+    return DEFAULT_REMINDER;
+  }
+
+  const planFile = await findActivePlanFile(auth, conversationId);
+  return planFile ? ACTIVE_PLAN_PROMPT : DEFAULT_REMINDER;
+}
+
+export const planModeSkill = {
+  sId: "plan_mode",
+  name: "Plan Mode",
+  userFacingDescription:
+    "Let agents maintain a live plan.md the user can follow, with an optional approval step for risky work.",
+  agentFacingDescription:
+    "Create and maintain a plan.md for non-trivial tasks to give the user visibility. Optionally request approval for risky steps.",
+  fetchInstructions: async (
+    auth: Authenticator,
+    {
+      agentLoopData,
+    }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
+  ) => resolveInstructions(auth, agentLoopData),
+  mcpServers: [{ name: PLAN_MODE_SERVER_NAME }],
+  version: 1,
+  icon: "ActionDocumentTextIcon",
+  isRestricted: async (auth: Authenticator) => {
+    const flags = await getFeatureFlags(auth);
+    return !flags.includes("plan_mode");
+  },
+} as const satisfies SystemSkillDefinition;

--- a/front/lib/resources/skill/code_defined/system_registry.ts
+++ b/front/lib/resources/skill/code_defined/system_registry.ts
@@ -2,6 +2,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { discoverKnowledgeSkill } from "@app/lib/resources/skill/code_defined/discover_knowledge";
 import { discoverSkillsSkill } from "@app/lib/resources/skill/code_defined/discover_skills";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discover_tools";
+import { planModeSkill } from "@app/lib/resources/skill/code_defined/plan_mode";
 import { sandboxSkill } from "@app/lib/resources/skill/code_defined/sandbox";
 import {
   ensureUniqueSIds,
@@ -15,6 +16,7 @@ const SYSTEM_SKILLS_ARRAY = ensureUniqueSIds([
   discoverKnowledgeSkill,
   discoverSkillsSkill,
   discoverToolsSkill,
+  planModeSkill,
   sandboxSkill,
 ] as const);
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -128,7 +128,8 @@ async function handler(
         if (
           event.data.type === "user_message_promoted" ||
           event.data.type === "compaction_message_new" ||
-          event.data.type === "compaction_message_done"
+          event.data.type === "compaction_message_done" ||
+          event.data.type === "plan_updated"
         ) {
           continue;
         }

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -327,6 +327,20 @@ async function handler(
     }
 
     case "DELETE": {
+      // Plan-mode files are agent-owned: the user interacts with them only through the agent
+      // (via messages and approval decisions), never by direct mutation. The agent can retire
+      // a plan via the `close_plan` tool.
+      if (file.useCaseMetadata?.isPlanFile) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "plan.md is managed by the agent and cannot be deleted directly. Ask the agent to close the plan.",
+          },
+        });
+      }
+
       // Check if the user is a builder for the workspace or it's a conversation file
       if (
         isUploadUseCase &&
@@ -366,6 +380,17 @@ async function handler(
     }
 
     case "POST": {
+      // Plan-mode files are agent-owned; users cannot upload over them.
+      if (file.useCaseMetadata?.isPlanFile) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "plan.md is managed by the agent and cannot be overwritten directly.",
+          },
+        });
+      }
       // Check if the user is a builder for the workspace or it's a conversation file or avatar
       if (
         isUploadUseCase &&

--- a/front/pages/api/w/[wId]/files/[fileId]/rename.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/rename.ts
@@ -63,6 +63,17 @@ async function handler(
 
   switch (req.method) {
     case "PATCH": {
+      // Plan-mode files are agent-owned; users cannot rename them.
+      if (file.useCaseMetadata?.isPlanFile) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "plan.md is managed by the agent and cannot be renamed directly.",
+          },
+        });
+      }
       // Check permissions for renaming
       if (file.useCase === "project_context") {
         if (!space || !space.canWrite(auth)) {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -682,6 +682,19 @@ export type ConversationTitleEvent = {
   title: string;
 };
 
+// Event sent when the conversation's plan.md is created, edited, approved, or closed. Carries
+// only metadata (id, version, status flags) — the UI refetches the full file contents via the
+// plan_mode GET endpoint on receipt.
+export type PlanUpdatedEvent = {
+  type: "plan_updated";
+  created: number;
+  conversationId: string;
+  planFileId: string;
+  version: number;
+  isClosed: boolean;
+  hasApproval: boolean;
+};
+
 export const ConversationMCPServerViewOrigins = [
   "agent_enabled",
   "conversation",

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -31,6 +31,14 @@ export type FileUseCase =
   // sandbox at /dust/skills/<skill-name>/<filename>.
   | "skill_attachment";
 
+// Audit trail for a plan-mode approval. Recorded on `plan.md.useCaseMetadata` when the user
+// approves a `request_plan_approval` call.
+export type PlanModeApproval = {
+  approvedAt: string; // ISO timestamp.
+  approvedByUserId: string; // sId of the approving user.
+  fileVersion: number; // FileModel.version at the moment of approval.
+};
+
 export type FileUseCaseMetadata = {
   conversationId?: string;
   skillId?: string;
@@ -42,6 +50,13 @@ export type FileUseCaseMetadata = {
   sourceIcon?: string;
   hideFromUser?: boolean;
   skipDataSourceIndexing?: boolean;
+  // Plan mode. `isPlanFile: true` marks a file as agent-owned (user can't directly mutate).
+  // `planModeLastApproval` is set when the agent's `request_plan_approval` is approved.
+  // `isPlanClosed: true` marks the plan as retired — hidden from UI and ignored by the skill.
+  // Active plans omit `isPlanClosed` (only closed plans have it set).
+  isPlanFile?: boolean;
+  planModeLastApproval?: PlanModeApproval | null;
+  isPlanClosed?: boolean;
 };
 
 export function isConversationFileUseCase(

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -266,6 +266,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable the Clari Copilot MCP server for call transcript and summary access.",
     stage: "on_demand",
   },
+  plan_mode: {
+    description:
+      "Enable the Plan Mode skill: agents maintain a live plan.md for non-trivial tasks, with an optional human-approval checkpoint.",
+    stage: "dust_only",
+  },
   official_notion_mcp: {
     description:
       "Use the official Notion MCP server instead of the internal one",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -728,6 +728,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "reinforcement_on_openai"
   | "reinforcement_ui"
   | "metronome_billing"
+  | "plan_mode"
   | "poke_mcp"
   | "restrict_agents_publishing"
   | "restrict_agents_publishing_to_admins"


### PR DESCRIPTION
## Description

**What**
A new feature-flag-gated skill (plan_mode) that lets agents maintain a live plan.md the user can follow along with.
For higher-stakes work, the agent can surface the plan for explicit approval before proceeding. Agent-facing; **no UI in this PR.**

**Tech choices worth reviewing**
System skill + internal MCP server. plan_mode registered in SYSTEM_SKILLS_ARRAY and added to the @dust agent's skills
list, so its tools are auto-enabled in the tool registry from step zero (no skill_management round-trip). Gated by the plan_mode feature flag via isRestricted.

Four tools. create_plan seeds plan.md with a Context + Tasks skeleton. edit_plan is a substitution edit used both while drafting and while executing. request_plan_approval is stake high, so it piggybacks on the existing MCP tool-approval flow (workflow parks in blocked_validation_required, user clicks approve, handler runs and stamps approval onto the file). close_plan retires a plan when the user asks to drop it and resolves any pending approval via the canonical validate-action path.

File-based state, no DB migration. All state lives on plan.md's useCaseMetadata: isPlanFile, planModeLastApproval, isPlanClosed. Planning vs. execution phase is derived from the file.

Agent-owned guard. User-facing file endpoints (DELETE, rename, POST-upload) reject mutations on isPlanFile: true files. Users interact with the plan only through the agent.

Event. New plan_updated conversation event carries only { planFileId, version, isClosed, hasApproval }. Contents-free payload so the UI can refetch on its terms.

**Agent behavior**
Prompt biases toward using plan mode by default for non-trivial turns (multi-step, multi-file, research spanning several tool calls). Approval is orthogonal: mandatory only when the user explicitly asks for plan mode, optional for agent-initiated transparency flows.

## Tests

Locally. Again, no UI work yet: 

<kbd>
<img width="461" height="1048" alt="Screenshot 2026-04-22 at 23 21 21" src="https://github.com/user-attachments/assets/82c588b9-5d6d-4fd9-93a1-def36a2793da" />
</kbd>
<kbd>
<img width="613" height="1063" alt="Screenshot 2026-04-22 at 23 22 36" src="https://github.com/user-attachments/assets/dbd47f03-5659-4bdb-8f07-6438bcfcdf69" />
</kbd>

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy. 
Activate flag on our workspace.
Run `npx tsx scripts/ensure_all_mcp_server_views_created.ts --execute`