### PR TITLE
Add ability to give knowledge suggestions

### DIFF
--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -1,5 +1,4 @@
 import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";
-import { InstructionSuggestionExtension } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { SlashCommandExtension } from "@app/components/editor/extensions/skill_builder/SlashCommandExtension";
@@ -98,7 +97,6 @@ interface UseSkillInstructionsEditorProps {
 const skillInstructionsEditableExtensions = [
   SlashCommandExtension,
   AgentInstructionDiffExtension,
-  InstructionSuggestionExtension.configure({ showBlockHighlight: false }),
   Placeholder.configure({
     placeholder: "What does this skill do? How should it behave?",
     emptyNodeClass:

--- a/front/components/editor/extensions/skill_builder/KnowledgeNode.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNode.tsx
@@ -8,11 +8,36 @@ import {
   KnowledgeNodeView,
 } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { Node } from "@tiptap/core";
-import { ReactNodeViewRenderer } from "@tiptap/react";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import type React from "react";
 
 export interface KnowledgeNodeAttributes {
   selectedItems: KnowledgeItem[];
 }
+
+const KNOWLEDGE_CHIP_CLASS =
+  "inline-flex items-center gap-0.5 border border-current/40 rounded px-0.5 text-xs leading-tight";
+// We use this instead of Sparkle's DocumentIcon because renderHTML returns a plain DOMOutputSpec which cannot
+// contain React components, and ProseMirror's renderSpec doesn't support SVG
+// namespace elements. Using the emoji in both paths keeps additions and deletions
+// visually consistent in the suggestion diff view.
+const DOCUMENT_ICON = "📄";
+
+const KnowledgeNodeReadOnlyView: React.FC<NodeViewProps> = ({ node }) => {
+  const { selectedItems } = node.attrs;
+  const item = selectedItems[0] as KnowledgeItem | undefined;
+  if (!item) {
+    return null;
+  }
+  // No background or explicit color so diff decorations act on the content directly
+  return (
+    <NodeViewWrapper as="span" className={KNOWLEDGE_CHIP_CLASS}>
+      <span>{DOCUMENT_ICON}</span>
+      <span>{` ${item.label}`}</span>
+    </NodeViewWrapper>
+  );
+};
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -29,7 +54,14 @@ export const KNOWLEDGE_TAG_REGEX = new RegExp(
   `^<${KNOWLEDGE_TAG}\\s+([^>]+)\\s*/>`
 );
 
-export const KnowledgeNode = Node.create<{}>({
+export interface KnowledgeNodeOptions {
+  readOnly: boolean;
+}
+
+export const KnowledgeNode = Node.create<KnowledgeNodeOptions>({
+  addOptions() {
+    return { readOnly: false };
+  },
   name: KNOWLEDGE_NODE_TYPE,
 
   group: "inline",
@@ -147,7 +179,17 @@ export const KnowledgeNode = Node.create<{}>({
     const { selectedItems } = node.attrs;
 
     if (selectedItems.length > 0) {
-      return [KNOWLEDGE_TAG, HTMLAttributes];
+      const label = selectedItems[0].label;
+      return [
+        "knowledge",
+        HTMLAttributes,
+        [
+          "span",
+          { class: KNOWLEDGE_CHIP_CLASS },
+          ["span", {}, DOCUMENT_ICON],
+          ["span", {}, ` ${label}`],
+        ],
+      ];
     }
 
     // Search state is transient UI — nothing to serialize.
@@ -204,7 +246,9 @@ export const KnowledgeNode = Node.create<{}>({
   },
 
   addNodeView() {
-    return ReactNodeViewRenderer(KnowledgeNodeView);
+    return ReactNodeViewRenderer(
+      this.options.readOnly ? KnowledgeNodeReadOnlyView : KnowledgeNodeView
+    );
   },
 
   addCommands() {

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -160,7 +160,7 @@ export function SkillBuilderInstructionsEditor({
   const { editor, isContentReady } = useSkillInstructionsEditor({
     content: instructionsField.value ?? "",
     htmlContent: instructionsHtmlField.value ?? undefined,
-    isReadOnly: false,
+    isReadOnly: hasSuggestions,
     onUpdate: handleUpdate,
     onBlur: handleBlur,
     onDelete: handleDelete,
@@ -368,7 +368,10 @@ export function SkillBuilderInstructionsEditor({
 
   return (
     <div className="space-y-1 p-px">
-      <SkillInstructionsEditorContent editor={editor} isReadOnly={false} />
+      <SkillInstructionsEditorContent
+        editor={editor}
+        isReadOnly={hasSuggestions}
+      />
 
       {instructionsFieldState.error && (
         <div className="dark:text-warning-night ml-2 text-xs text-warning">

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -1,4 +1,3 @@
-import { InstructionSuggestionExtension } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { useMaybeMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { getBlockOuterHtml } from "@app/components/shared/utils";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
@@ -101,10 +100,7 @@ function InstructionEditDiffBlock({
 
   const editor = useEditor(
     {
-      extensions: [
-        ...buildSkillInstructionsExtensions(true),
-        InstructionSuggestionExtension.configure({ showBlockHighlight: false }),
-      ],
+      extensions: [...buildSkillInstructionsExtensions(true)],
       editable: false,
       content: blockHtml,
       immediatelyRender: false,

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -1,3 +1,4 @@
+import { InstructionSuggestionExtension } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { CodeExtension } from "@app/components/editor/extensions/CodeExtension";
 import { HeadingExtension } from "@app/components/editor/extensions/HeadingExtension";
 import { BlockIdExtension } from "@app/components/editor/extensions/instructions/BlockIdExtension";
@@ -84,7 +85,8 @@ export function buildSkillInstructionsExtensions(
       },
     }),
     BlockIdExtension,
-    KnowledgeNode,
+    KnowledgeNode.configure({ readOnly: isReadOnly }),
+    InstructionSuggestionExtension.configure({ showBlockHighlight: false }),
     RawMarkdownBlock,
     ...rawMarkdownBlockParsers,
   ];

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -34,8 +34,9 @@ In most conversations, the correct outcome is no configuration change. This mean
 Propose configuration changes only when <analysis_workflow> yields concrete evidence. If you are unsure, do not call edit_skill.
 
 ## Exploration tools (optional — use these if you need more context)
-- get_available_tools: Lists all tools (MCP servers) available in the workspace. Use this to discover tools you could suggest adding or to verify that suggested tools exist.
-- describe_mcp: Returns detailed information about a specific MCP server: its tools, each tool's description, and input parameters. ALWAYS call this before suggesting instruction changes that reference specific tool names or workflows for a given MCP — you need to know the exact tool names and their inputs to write accurate instructions.
+- get_available_tools: Use this to discover tools you could suggest adding or to verify that suggested tools exist.
+- describe_mcp: ALWAYS call this before suggesting instruction changes that reference specific tool names or workflows for a given MCP — you need to know the exact tool names and their inputs to write accurate instructions.
+- search_knowledge: ALWAYS call this before embedding any <knowledge> tag in an instruction edit — the tag requires node attributes (id, space, dsv, hasChildren) that must come from this tool. Use this whenever the conversation shows the agent navigating or retrieving specific data nodes that the skill instructions should directly reference. See <knowledge_nodes> for more details.
 `,
 
   skill_usage_analysis: `In <skill_context>, you have received all custom skills that were enabled in the conversation.

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -60,6 +60,24 @@ const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
       mcpId: z.string().describe("The sId of the MCP server to describe"),
     },
   },
+  search_knowledge: {
+    description:
+      "Search workspace knowledge sources to discover relevant data nodes.",
+    schema: {
+      query: z
+        .string()
+        .describe("Natural language query describing the knowledge needed."),
+      topK: z
+        .number()
+        .int()
+        .positive()
+        .max(10)
+        .optional()
+        .describe(
+          "Maximum number of document hits to retrieve per data source (default: 5, only applies when query is provided)"
+        ),
+    },
+  },
   edit_skill: {
     description:
       "Suggest edits to a skill's instructions and/or configured tools.",

--- a/front/lib/reinforcement/skill_instruction_edit_prompt.ts
+++ b/front/lib/reinforcement/skill_instruction_edit_prompt.ts
@@ -49,4 +49,30 @@ EXAMPLE 2: Full rewrite
 <structure_recommendations>
 Allowed inline formatting: \`<strong>\`, \`<em>\`, \`<code>\`, \`<a href="...">\`.
 Allowed block structures: \`<ul><li>\`, \`<ol><li>\`, \`<pre><code>\`.
-</structure_recommendations>`;
+</structure_recommendations>
+
+<knowledge_nodes>
+Instructions can reference specific workspace knowledge nodes using inline \`<knowledge>\` tags.
+During runtime, the content of the knowledge nodes is rendered directly in the instruction text.
+
+\`\`\`
+<knowledge id="NODE_ID" title="NODE_TITLE" space="SPACE_ID" dsv="DSV_ID" hasChildren="true|false"/>
+\`\`\`
+
+Attribute mapping from search_knowledge results:
+- \`id\` => \`nodeId\`
+- \`title\` => \`title\`
+- \`space\` => \`spaceId\`
+- \`dsv\` => \`dataSourceViewId\`
+- \`hasChildren\` => \`"true"\` or \`"false"\`
+
+To embed a knowledge node:
+1. Call \`search_knowledge\` with a relevant query to find candidate nodes.
+2. Pick the node whose title and content best match what the skill should reference.
+3. Embed the self-closing tag inline inside a \`<p>\` block.
+
+Example:
+\`\`\`
+<p data-block-id="a1b2c3d4">When answering questions about onboarding, refer to <knowledge id="doc_abc123" title="Onboarding Guide" space="space_xyz" dsv="dsv_456" hasChildren="false"/>.</p>
+\`\`\`
+</knowledge_nodes>`;

--- a/front/lib/reinforcement/types.ts
+++ b/front/lib/reinforcement/types.ts
@@ -5,6 +5,7 @@ export const DESCRIBE_MCP_TOOL_NAME = "describe_mcp" as const;
 
 export type ExploratoryToolName =
   | "get_available_tools"
+  | "search_knowledge"
   | typeof DESCRIBE_MCP_TOOL_NAME;
 
 export type TerminalToolName = "edit_skill";
@@ -13,6 +14,7 @@ export const TERMINAL_TOOLS: TerminalToolName[] = ["edit_skill"];
 
 export const EXPLORATORY_TOOLS: ExploratoryToolName[] = [
   "get_available_tools",
+  "search_knowledge",
   DESCRIBE_MCP_TOOL_NAME,
 ];
 

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -18,6 +18,7 @@ import {
   buildReinforcedSkillsLLMParams,
   classifySkillToolCalls,
 } from "@app/lib/reinforcement/run_reinforced_analysis";
+import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { DESCRIBE_MCP_TOOL_NAME } from "@app/lib/reinforcement/types";
 import {
   BATCH_POLL_INTERVAL_MS,
@@ -31,6 +32,7 @@ import {
   isAggregationTestCase,
   isAnalysisTestCase,
   type MockMcpDescription,
+  type MockSearchKnowledgeNode,
   type MockSkillConfig,
   type TestCase,
   type ToolCall,
@@ -51,7 +53,9 @@ function makeSkillType(config: MockSkillConfig): SkillType {
     agentFacingDescription: config.description ?? "",
     userFacingDescription: config.description ?? "",
     instructions: config.instructions ?? null,
-    instructionsHtml: null,
+    instructionsHtml: config.instructions
+      ? convertMarkdownToBlockHtml(config.instructions)
+      : null,
     icon: null,
     source: null,
     sourceMetadata: null,
@@ -196,6 +200,26 @@ function simulateExploratoryTool(
         mcpId,
         mockDescriptionToFormatInput(mcpName, desc)
       );
+    }
+    case "search_knowledge": {
+      const nodes = workspaceContext.searchKnowledgeNodes ?? [];
+      const dsvMap = new Map<string, MockSearchKnowledgeNode>();
+      for (const node of nodes) {
+        if (!dsvMap.has(node.dataSourceViewId)) {
+          dsvMap.set(node.dataSourceViewId, node);
+        }
+      }
+      const dataSourceViews = [...dsvMap.values()].map((n) => ({
+        dataSourceViewId: n.dataSourceViewId,
+        name: n.title,
+        connectorProvider: n.connectorProvider ?? null,
+        category: "folder",
+        spaceId: n.spaceId,
+        childrenCount: nodes.filter(
+          (x) => x.dataSourceViewId === n.dataSourceViewId
+        ).length,
+      }));
+      return JSON.stringify({ dataSourceViews, nodes }, null, 2);
     }
     default:
       return `Unknown exploratory tool: ${toolName}`;

--- a/front/tests/reinforcement-evals/lib/types.ts
+++ b/front/tests/reinforcement-evals/lib/types.ts
@@ -28,10 +28,22 @@ export interface MockMcpDescription {
   tools: MockMcpTool[];
 }
 
+export interface MockSearchKnowledgeNode {
+  nodeId: string;
+  title: string;
+  dataSourceViewId: string;
+  spaceId: string;
+  hasChildren: boolean;
+  connectorProvider?: string | null;
+  sourceUrl?: string | null;
+}
+
 export interface WorkspaceContext {
   tools: AvailableTool[];
   /** Optional MCP details returned when describe_mcp is called during eval. */
   mcpDescriptions?: MockMcpDescription[];
+  /** Optional knowledge nodes returned when search_knowledge is called during eval. */
+  searchKnowledgeNodes?: MockSearchKnowledgeNode[];
 }
 
 function slugify(name: string): string {

--- a/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
@@ -670,5 +670,77 @@ Score 0 if no edit_skill call is made for skill_github_reporter, or if edit_skil
 Score 1 if edit_skill is called only for skill_github_reporter but the suggestion doesn't specifically mention adding DevCode to the project list.
 Score 3 if edit_skill is called only for skill_github_reporter, the suggestion adds DevCode to the project list, and no other skills are modified.`,
     },
+    {
+      scenarioId: "knowledge-tag-vague-runbook-instructions",
+      type: "analysis",
+      skillConfigs: [
+        {
+          name: "On-call runbook shortcut",
+          sId: "skill_eval_runbook",
+          description: "Surfaces the incident runbook from workspace knowledge",
+          instructions: "Always open the incident runbook document first.",
+        },
+      ],
+      conversation: [
+        {
+          role: "user",
+          content:
+            "According to our incident runbook, when should we page the on-call engineer?",
+        },
+        {
+          role: "agent",
+          content:
+            "The **Incident runbook** says to page on-call when customer-facing APIs return 5xx for more than five minutes or when the error budget burn rate exceeds the threshold in section 2.1.",
+          actions: [
+            {
+              functionCallName: "company_data__find",
+              status: "succeeded",
+              params: { query: "incident runbook" },
+            },
+            {
+              functionCallName: "company_data__list",
+              status: "succeeded",
+              params: { nodeId: null },
+            },
+            {
+              functionCallName: "company_data__cat",
+              status: "succeeded",
+              params: { nodeId: "doc_incident_runbook" },
+            },
+          ],
+        },
+      ],
+      workspaceContext: {
+        tools: [
+          mockTool(
+            "Company data",
+            "Search, list, and read documents from connected company data sources"
+          ),
+        ],
+        searchKnowledgeNodes: [
+          {
+            nodeId: "doc_incident_runbook",
+            title: "Incident runbook",
+            dataSourceViewId: "dsv_eval_handbook",
+            spaceId: "spc_eval_workspace",
+            hasChildren: false,
+            connectorProvider: null,
+            sourceUrl: null,
+          },
+        ],
+      },
+      expectedToolCalls: [editSkillWithInstructions("skill_eval_runbook")],
+      judgeCriteria: `The analyst should treat the runbook skill instructions as underspecified: they tell the agent to open a document but not which node to read, which led to search/list work before reading the file.
+The ideal improvement is to embed a direct <knowledge> reference to the runbook node so future runs can open it without exploratory browsing.
+
+The analyst SHOULD:
+1. Call search_knowledge to discover the incident runbook node in workspace knowledge.
+2. Call edit_skill with instructionEdits for skill "skill_eval_runbook" that embed a <knowledge id="doc_incident_runbook" title="Incident runbook" space="spc_eval_workspace" dsv="dsv_eval_handbook" hasChildren="false"/> tag inline in the replacement instruction content.
+
+Score 0 if no edit_skill call is made for skill_eval_runbook.
+Score 1 if edit_skill is called with instructionEdits for skill_eval_runbook but the instruction content does not include any <knowledge> tag.
+Score 2 if edit_skill is called with instructionEdits that include a <knowledge> tag but the tag attributes are missing or incorrect (wrong nodeId, missing dsv/space, etc.).
+Score 3 if edit_skill is called with instructionEdits for skill_eval_runbook and the instruction content includes a correctly formed <knowledge id="doc_incident_runbook" ...> tag with all required attributes aligned with the search_knowledge result.`,
+    },
   ],
 };


### PR DESCRIPTION
## Description

* Prereq: https://github.com/dust-tt/dust/pull/24740
* https://github.com/dust-tt/tasks/issues/7591
* Adding ability for reinforced runs to make inline knowledge suggestions for a skill
* Trickiest part was dealing with the tiptap extensions. Ended up taking the significantly easier path of just editing the renderHtml function (as opposed to trying to generate the blocks on the fly and then putting decorations on top). See visualize below

## Tests

<img width="1464" height="785" alt="Screenshot 2026-04-22 at 10 51 14 PM" src="https://github.com/user-attachments/assets/c1c70f0d-cdb0-4551-836e-7b3b7deed871" />
<img width="1031" height="794" alt="Screenshot 2026-04-22 at 10 51 18 PM" src="https://github.com/user-attachments/assets/0f0a620d-79ed-4edf-953a-736e733da141" />

+ New integ tests passes - knowledge-tag-vague-runbook-instructions

## Risk

* Low

## Deploy Plan

1. Deploy https://github.com/dust-tt/dust/pull/24740
2. Deploy front