### PR TITLE
[front] enh: polish `/` suggestion dropdown activation

### DIFF
--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -132,6 +132,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
         }
         header="Capabilities"
         onClose={onClose}
+        size="wide"
       />
     );
   }

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -89,7 +89,6 @@ export const InputBarSlashSuggestionExtension =
             Boolean(extensionOptions.owner) &&
             Boolean(extensionOptions.enabledRef.current) &&
             extensionStorage.hasBeenFocused &&
-            editor.isFocused &&
             extensionStorage.dismissedTriggerStart !== range.from &&
             isAllowedSlashQuery(state, range),
           command: ({ editor, range, props }) => {

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -85,7 +85,6 @@ export const InputBarSlashSuggestionExtension =
           allowSpaces: true,
           startOfLine: false,
           items: () => [],
-<<<<<<< HEAD
           allow: ({ editor, state, range }) =>
             Boolean(extensionOptions.owner) &&
             Boolean(extensionOptions.enabledRef.current) &&
@@ -93,14 +92,6 @@ export const InputBarSlashSuggestionExtension =
             editor.isFocused &&
             extensionStorage.dismissedTriggerStart !== range.from &&
             isAllowedSlashQuery(state, range),
-=======
-          allow: ({ editor, state, range }) =>
-            Boolean(extensionOptions.enabledRef.current) &&
-            extensionStorage.hasBeenFocused &&
-            editor.isFocused &&
-            extensionStorage.dismissedTriggerStart !== range.from &&
-            isAllowedSlashQuery(state, range),
->>>>>>> 3a9e1a2791 (Polish slash skill suggestion activation)
           command: ({ editor, range, props }) => {
             extensionStorage.dismissedTriggerStart = null;
             editor.chain().focus().deleteRange(range).run();

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -85,10 +85,11 @@ export const InputBarSlashSuggestionExtension =
           allowSpaces: true,
           startOfLine: false,
           items: () => [],
-          allow: ({ editor, state, range }) =>
+          allow: ({ editor, state, range, isActive }) =>
             Boolean(extensionOptions.owner) &&
             Boolean(extensionOptions.enabledRef.current) &&
             extensionStorage.hasBeenFocused &&
+            (editor.isFocused || isActive) &&
             extensionStorage.dismissedTriggerStart !== range.from &&
             isAllowedSlashQuery(state, range),
           command: ({ editor, range, props }) => {

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -2,8 +2,8 @@ import { InputBarSlashSuggestionDropdown } from "@app/components/editor/extensio
 import type { SlashCommandDropdownRef } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { WorkspaceType } from "@app/types/user";
-import { Extension } from "@tiptap/core";
-import { PluginKey } from "@tiptap/pm/state";
+import { Extension, type Range } from "@tiptap/core";
+import { type EditorState, Plugin, PluginKey } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 import { ReactRenderer } from "@tiptap/react";
 import { exitSuggestion, Suggestion } from "@tiptap/suggestion";
@@ -12,6 +12,33 @@ import type { RefObject } from "react";
 export const inputBarSlashSuggestionPluginKey = new PluginKey(
   "inputBarSlashSuggestion"
 );
+
+function hasSlashCharacterAtPosition(state: EditorState, position: number) {
+  const docSize = state.doc.content.size;
+
+  if (position < 1 || position > docSize) {
+    return false;
+  }
+
+  return (
+    state.doc.textBetween(
+      position,
+      Math.min(position + 1, docSize + 1),
+      undefined,
+      "\ufffc"
+    ) === "/"
+  );
+}
+
+function isAllowedSlashQuery(state: EditorState, range: Range) {
+  const text = state.doc.textBetween(range.from, range.to, undefined, "\ufffc");
+
+  if (!text.startsWith("/")) {
+    return false;
+  }
+
+  return !text.slice(1).startsWith(" ");
+}
 
 export interface InputBarSlashSuggestionExtensionOptions {
   owner?: WorkspaceType;
@@ -26,6 +53,17 @@ export const InputBarSlashSuggestionExtension =
   Extension.create<InputBarSlashSuggestionExtensionOptions>({
     name: "inputBarSlashSuggestion",
 
+    addStorage() {
+      return {
+        hasBeenFocused: false,
+        dismissedTriggerStart: null as number | null,
+      };
+    },
+
+    onFocus() {
+      this.storage.hasBeenFocused = true;
+    },
+
     addOptions() {
       return {
         owner: undefined,
@@ -37,6 +75,7 @@ export const InputBarSlashSuggestionExtension =
 
     addProseMirrorPlugins() {
       const extensionOptions = this.options;
+      const extensionStorage = this.storage;
 
       return [
         Suggestion<SkillWithoutInstructionsAndToolsType>({
@@ -46,19 +85,37 @@ export const InputBarSlashSuggestionExtension =
           allowSpaces: true,
           startOfLine: false,
           items: () => [],
-          allow: ({ editor }) =>
+<<<<<<< HEAD
+          allow: ({ editor, state, range }) =>
             Boolean(extensionOptions.owner) &&
             Boolean(extensionOptions.enabledRef.current) &&
-            editor.isFocused,
+            extensionStorage.hasBeenFocused &&
+            editor.isFocused &&
+            extensionStorage.dismissedTriggerStart !== range.from &&
+            isAllowedSlashQuery(state, range),
+=======
+          allow: ({ editor, state, range }) =>
+            Boolean(extensionOptions.enabledRef.current) &&
+            extensionStorage.hasBeenFocused &&
+            editor.isFocused &&
+            extensionStorage.dismissedTriggerStart !== range.from &&
+            isAllowedSlashQuery(state, range),
+>>>>>>> 3a9e1a2791 (Polish slash skill suggestion activation)
           command: ({ editor, range, props }) => {
+            extensionStorage.dismissedTriggerStart = null;
             editor.chain().focus().deleteRange(range).run();
             extensionOptions.onSkillSelectRef.current?.(props);
           },
           render: () => {
             let component: ReactRenderer<SlashCommandDropdownRef> | null = null;
             let activeEditorView: EditorView | null = null;
+            let activeTriggerStart: number | null = null;
 
             const closeSuggestionDropdown = () => {
+              if (activeTriggerStart !== null) {
+                extensionStorage.dismissedTriggerStart = activeTriggerStart;
+              }
+
               if (activeEditorView) {
                 exitSuggestion(
                   activeEditorView,
@@ -85,6 +142,7 @@ export const InputBarSlashSuggestionExtension =
                   },
                   editor: props.editor,
                 });
+                activeTriggerStart = props.range.from;
 
                 document.body.appendChild(component.element);
               },
@@ -97,6 +155,7 @@ export const InputBarSlashSuggestionExtension =
                 }
 
                 activeEditorView = props.editor.view;
+                activeTriggerStart = props.range.from;
                 component?.updateProps({
                   ...props,
                   onClose: closeSuggestionDropdown,
@@ -117,12 +176,29 @@ export const InputBarSlashSuggestionExtension =
 
               onExit() {
                 activeEditorView = null;
+                activeTriggerStart = null;
                 component?.element?.remove();
                 component?.destroy();
                 component = null;
               },
             };
           },
+        }),
+        new Plugin({
+          key: new PluginKey("inputBarSlashSuggestionCleanup"),
+          view: () => ({
+            update: (view) => {
+              const dismissedTriggerStart =
+                extensionStorage.dismissedTriggerStart;
+
+              if (
+                dismissedTriggerStart !== null &&
+                !hasSlashCharacterAtPosition(view.state, dismissedTriggerStart)
+              ) {
+                extensionStorage.dismissedTriggerStart = null;
+              }
+            },
+          }),
         }),
       ];
     },

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -40,6 +40,7 @@ export interface SlashCommandDropdownProps
   emptyMessage?: string;
   header?: string;
   onClose?: () => void;
+  size?: "default" | "wide";
 }
 
 export interface SlashCommandDropdownRef {
@@ -58,6 +59,7 @@ export const SlashCommandDropdown = forwardRef<
       emptyMessage = DEFAULT_EMPTY_MESSAGE,
       header,
       onClose,
+      size = "default",
     },
     ref
   ) => {
@@ -151,7 +153,7 @@ export const SlashCommandDropdown = forwardRef<
         </DropdownMenuTrigger>
         <DropdownMenuContent
           ref={containerRef}
-          className="w-64"
+          className={size === "wide" ? "w-80" : "w-64"}
           align="start"
           avoidCollisions
           collisionPadding={12}

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -936,6 +936,34 @@ const DropdownTooltipTrigger = React.forwardRef<
     },
     ref
   ) => {
+    const [isOpen, setIsOpen] = React.useState(false);
+
+    const handleOpenChange = React.useCallback(
+      (open: boolean) => {
+        setIsOpen(open);
+        onVisibilityChange?.(open);
+      },
+      [onVisibilityChange]
+    );
+
+    React.useEffect(() => {
+      if (!isOpen) {
+        return;
+      }
+
+      const closeTooltip = () => {
+        handleOpenChange(false);
+      };
+
+      window.addEventListener("scroll", closeTooltip, true);
+      window.visualViewport?.addEventListener("scroll", closeTooltip);
+
+      return () => {
+        window.removeEventListener("scroll", closeTooltip, true);
+        window.visualViewport?.removeEventListener("scroll", closeTooltip);
+      };
+    }, [handleOpenChange, isOpen]);
+
     const tooltipContent = (
       <TooltipPrimitive.Content
         side={side}
@@ -952,8 +980,8 @@ const DropdownTooltipTrigger = React.forwardRef<
     const container = useSheetContainer(mountPortalContainer);
 
     return (
-      <TooltipPrimitive.Provider delayDuration={300}>
-        <TooltipPrimitive.Root onOpenChange={onVisibilityChange}>
+      <TooltipPrimitive.Provider delayDuration={700}>
+        <TooltipPrimitive.Root open={isOpen} onOpenChange={handleOpenChange}>
           <TooltipPrimitive.Trigger asChild className={className} ref={ref}>
             {/* Wrapper allows pointer events even when child is disabled, while maintaining proper positioning */}
             <span className="s-block s-w-full">{children}</span>


### PR DESCRIPTION
## Description

This PR refines the slash-suggestion UX in the input bar on top of the base `/` capability picker flow.

### Bugs/UI issues found

The base slash suggestion flow worked, but there were still a few rough edges:
- `Escape` only hid the menu briefly and typing could reopen the same dismissed search
- `/ ` should behave like leaving slash-search mode, not like an active query
- restored draft content ending in `/foo` could activate suggestions too eagerly
- hovering the dropdown could dismiss it because the editor lost focus
- the narrower dropdown was cramped for longer capability rows
- dropdown tooltips appeared too quickly and looked odd while scrolling

### Fixes

- do not reopen a dismissed slash suggestion for the same `/...` trigger after `Escape`
- stop suggestion mode when the slash is immediately followed by whitespace
- require the editor to have been focused before slash suggestions can activate from existing content
- keep the slash dropdown open when hovering it, instead of dismissing it on editor blur
- make the input-bar slash dropdown wider
- increase dropdown tooltip delay and close dropdown tooltips on scroll

## Tests

- Tested locally.

## Risk

- Low, behind feature flag.

## Deploy Plan

- Deploy front.
