### PR TITLE
Fix: show the correct file name in project's context.

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -763,7 +763,7 @@ describe("createConversationFork", () => {
     const childFileAttachments = childAttachments.filter(isFileAttachmentType);
 
     expect(childFileAttachments).toHaveLength(1);
-    expect(childFileAttachments[0]?.title).toBe("Notes");
+    expect(childFileAttachments[0]?.title).toBe("notes.txt");
     expect(childFileAttachments[0]?.fileId).not.toBe(sourceFile.sId);
 
     const copiedFiles = await FileResource.fetchByIds(auth, [
@@ -885,7 +885,7 @@ describe("createConversationFork", () => {
     const childFileAttachments = childAttachments.filter(isFileAttachmentType);
 
     expect(childFileAttachments).toHaveLength(1);
-    expect(childFileAttachments[0]?.title).toBe("First attachment");
+    expect(childFileAttachments[0]?.title).toBe("first.txt");
 
     copyToConversationSpy.mockRestore();
     getOrCreateConversationDataSourceFromFileSpy.mockRestore();

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -824,6 +824,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
               : null))
           : source.file;
 
+      let title: string = fr.title;
       let fileStringId: string | null = null;
       let snippet: string | null = null;
       let generatedTables: string[] = [];
@@ -833,6 +834,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       let hidden = true;
 
       if (fileResource) {
+        title = fileResource.fileName;
         fileStringId = fileResource.sId;
         snippet = fileResource.snippet;
         generatedTables = fileResource.useCaseMetadata?.generatedTables ?? [];
@@ -851,6 +853,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
 
       return {
         ...baseContentFragment,
+        title,
         contentFragmentType: "file",
         expiredReason: null,
         fileId: fileStringId,


### PR DESCRIPTION
## Description

Content fragments backed by a `FileResource` were displaying `fr.title` (the original fragment title set at creation time) instead of `fileResource.fileName` (the actual file name). When a file is renamed after being attached to a project context, the UI would show the stale creation-time title.

- In `ContentFragmentResource`'s file fragment builder, override `title` with `fileResource.fileName` when a `FileResource` is resolved, before spreading into the returned object

## Tests

Local

## Risk

Low — one-line fix; only affects file-backed content fragments

## Deploy Plan

Deploy `front`
