### PR TITLE
[front] fix duplicate inline activity content

### DIFF
--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -206,7 +206,9 @@ export const makeInitialMessageStreamState = (
     streaming: {
       actionProgress: new Map(),
       agentState: message.status === "created" ? "thinking" : "done",
-      inlineActivitySteps: message.activitySteps ?? [],
+      // Live messages rebuild inline steps from the SSE replay on mount.
+      inlineActivitySteps:
+        message.status === "created" ? [] : (message.activitySteps ?? []),
       isRetrying: false,
       lastUpdated: new Date(),
       pendingToolCalls: [],

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -1,12 +1,37 @@
-import type { PendingToolCall } from "@app/components/assistant/conversation/types";
+import { makeInitialMessageStreamState } from "@app/components/assistant/conversation/types";
 import {
   appendThinkingStep,
   removePendingToolCallForAction,
+  useAgentMessageStream,
   upsertPendingToolCall,
 } from "@app/hooks/useAgentMessageStream";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
-import type { InlineActivityStep } from "@app/types/assistant/conversation";
-import { describe, expect, it } from "vitest";
+import type {
+  InlineActivityStep,
+  LightAgentMessageType,
+} from "@app/types/assistant/conversation";
+import type { LightWorkspaceType } from "@app/types/user";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PendingToolCall } from "@app/components/assistant/conversation/types";
+
+const mockUseEventSource = vi.fn();
+const mockMutateContextUsage = vi.fn();
+const mockUseVirtuosoMethods = vi.fn();
+
+vi.mock("@app/hooks/useEventSource", () => ({
+  useEventSource: (...args: unknown[]) => mockUseEventSource(...args),
+}));
+
+vi.mock("@app/hooks/conversations", () => ({
+  useConversationContextUsage: () => ({
+    mutateContextUsage: mockMutateContextUsage,
+  }),
+}));
+
+vi.mock("@virtuoso.dev/message-list", () => ({
+  useVirtuosoMethods: () => mockUseVirtuosoMethods(),
+}));
 
 function makeAction(
   overrides: Partial<
@@ -19,6 +44,94 @@ function makeAction(
       overrides.functionCallName ?? "create_interactive_content_file",
   };
 }
+
+function makeStreamAction(
+  overrides: Partial<AgentMCPActionWithOutputType> = {}
+): AgentMCPActionWithOutputType {
+  return {
+    id: overrides.id ?? 20,
+    sId: overrides.sId ?? "act_123",
+    createdAt: overrides.createdAt ?? Date.now(),
+    updatedAt: overrides.updatedAt ?? Date.now(),
+    agentMessageId: overrides.agentMessageId ?? 11,
+    internalMCPServerName: overrides.internalMCPServerName ?? null,
+    toolName: overrides.toolName ?? "websearch",
+    mcpServerId: overrides.mcpServerId ?? "ims_123",
+    functionCallName:
+      overrides.functionCallName ?? "web_search_browse__websearch",
+    functionCallId: overrides.functionCallId ?? "toolu_123",
+    params: overrides.params ?? { query: "major world news events April 2026" },
+    citationsAllocated: overrides.citationsAllocated ?? 0,
+    status: overrides.status ?? "ready_allowed_implicitly",
+    step: overrides.step ?? 0,
+    executionDurationMs: overrides.executionDurationMs ?? null,
+    displayLabels: overrides.displayLabels ?? {
+      running: "Searching",
+      done: "Search",
+    },
+    generatedFiles: overrides.generatedFiles ?? [],
+    output: overrides.output ?? null,
+    citations: overrides.citations ?? null,
+    sandboxOrigin: overrides.sandboxOrigin,
+  };
+}
+
+function makeLightAgentMessage(
+  overrides: Partial<LightAgentMessageType> = {}
+): LightAgentMessageType {
+  return {
+    type: "agent_message",
+    sId: "msg_123",
+    version: 0,
+    rank: 0,
+    branchId: null,
+    created: Date.now(),
+    completedTs: null,
+    parentMessageId: "parent_msg_123",
+    parentAgentMessageId: null,
+    status: "created",
+    content: "Hello world from the database",
+    chainOfThought: "Thinking from the database",
+    error: null,
+    visibility: "visible",
+    richMentions: [],
+    completionDurationMs: null,
+    reactions: [],
+    configuration: {
+      sId: "agent_123",
+      name: "dust",
+      pictureUrl: "",
+      status: "active",
+      canRead: true,
+    },
+    citations: {},
+    generatedFiles: [],
+    activitySteps: [],
+    ...overrides,
+  };
+}
+
+const mockOwner: LightWorkspaceType = {
+  id: 1,
+  sId: "w_test",
+  name: "Test Workspace",
+  role: "admin",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+};
+
+beforeEach(() => {
+  mockUseEventSource.mockReset();
+  mockMutateContextUsage.mockReset();
+  mockUseVirtuosoMethods.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("upsertPendingToolCall", () => {
   it("merges a later update for the same call id", () => {
@@ -164,5 +277,196 @@ describe("appendThinkingStep", () => {
         id: "thinking-2",
       },
     ]);
+  });
+});
+
+describe("useAgentMessageStream", () => {
+  it("clears stale database content before replaying fresh-mount tokens", () => {
+    let currentMessage = makeInitialMessageStreamState(makeLightAgentMessage());
+    const snapshots: Array<{
+      content: string | null;
+      chainOfThought: string | null;
+      agentState: string;
+    }> = [];
+    let onEventCallback: ((event: string) => void) | null = null;
+
+    mockUseVirtuosoMethods.mockReturnValue({
+      data: {
+        map: (updater: (message: typeof currentMessage) => typeof currentMessage) => {
+          currentMessage = updater(currentMessage);
+          snapshots.push({
+            content: currentMessage.content,
+            chainOfThought: currentMessage.chainOfThought,
+            agentState: currentMessage.streaming.agentState,
+          });
+          return [currentMessage];
+        },
+      },
+    });
+
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+
+    renderHook(() =>
+      useAgentMessageStream({
+        agentMessage: currentMessage,
+        conversationId: "conv_123",
+        owner: mockOwner,
+        streamId: "stream_123",
+      })
+    );
+
+    act(() => {
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "1-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "Hello ",
+            classification: "tokens",
+          },
+        })
+      );
+    });
+
+    expect(snapshots[0]).toEqual({
+      content: "",
+      chainOfThought: "",
+      agentState: "thinking",
+    });
+    expect(currentMessage.content).toBe("Hello ");
+    expect(currentMessage.chainOfThought).toBe("");
+  });
+
+  it("does not restore stale thinking text from a pending throttled update after tool_params", () => {
+    vi.useFakeTimers();
+
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({
+        content: null,
+        chainOfThought: null,
+      })
+    );
+    let onEventCallback: ((event: string) => void) | null = null;
+
+    mockUseVirtuosoMethods.mockReturnValue({
+      data: {
+        map: (
+          updater: (message: typeof currentMessage) => typeof currentMessage
+        ) => {
+          currentMessage = updater(currentMessage);
+          return [currentMessage];
+        },
+      },
+    });
+
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+
+    renderHook(() =>
+      useAgentMessageStream({
+        agentMessage: currentMessage,
+        conversationId: "conv_123",
+        owner: mockOwner,
+        streamId: "stream_123",
+      })
+    );
+
+    const action = makeStreamAction();
+
+    act(() => {
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "1-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "The user wants recent world events.",
+            classification: "chain_of_thought",
+          },
+        })
+      );
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "2-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: " Let me search the web for this.",
+            classification: "chain_of_thought",
+          },
+        })
+      );
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "3-0",
+          data: {
+            type: "tool_params",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            action,
+            runIds: ["llm_trace_123"],
+            step: 0,
+          },
+        })
+      );
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "4-0",
+          data: {
+            type: "agent_action_success",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            action: {
+              ...action,
+              status: "succeeded",
+              executionDurationMs: 1000,
+            },
+            step: 0,
+          },
+        })
+      );
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(currentMessage.streaming.inlineActivitySteps).toEqual([
+      {
+        type: "thinking",
+        content:
+          "The user wants recent world events. Let me search the web for this.",
+        id: expect.stringContaining("thinking-toolparams-"),
+      },
+      {
+        type: "action",
+        label: "Search",
+        id: `action-${action.id}`,
+        actionId: action.sId,
+        internalMCPServerName: action.internalMCPServerName,
+      },
+    ]);
+    expect(currentMessage.chainOfThought).toBe("");
   });
 });

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -1,9 +1,11 @@
 import type { PendingToolCall } from "@app/components/assistant/conversation/types";
 import {
+  appendThinkingStep,
   removePendingToolCallForAction,
   upsertPendingToolCall,
 } from "@app/hooks/useAgentMessageStream";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { InlineActivityStep } from "@app/types/assistant/conversation";
 import { describe, expect, it } from "vitest";
 
 function makeAction(
@@ -112,6 +114,54 @@ describe("removePendingToolCallForAction", () => {
       {
         toolName: "create_interactive_content_file",
         toolCallIndex: 1,
+      },
+    ]);
+  });
+});
+
+describe("appendThinkingStep", () => {
+  it("deduplicates replayed thinking content even when an action step is in between", () => {
+    const steps: InlineActivityStep[] = [
+      {
+        type: "thinking",
+        content: "Looking up the repository state",
+        id: "thinking-1",
+      },
+      {
+        type: "action",
+        label: "Listed files",
+        id: "action-1",
+        actionId: "act_1",
+        internalMCPServerName: null,
+      },
+    ];
+
+    expect(
+      appendThinkingStep(
+        steps,
+        "Looking up the repository state",
+        "thinking-replayed"
+      )
+    ).toEqual(steps);
+  });
+
+  it("appends distinct thinking content", () => {
+    const steps: InlineActivityStep[] = [
+      {
+        type: "thinking",
+        content: "Inspecting the request",
+        id: "thinking-1",
+      },
+    ];
+
+    expect(
+      appendThinkingStep(steps, "Planning the patch", "thinking-2")
+    ).toEqual([
+      ...steps,
+      {
+        type: "thinking",
+        content: "Planning the patch",
+        id: "thinking-2",
       },
     ]);
   });

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -1,9 +1,10 @@
+import type { PendingToolCall } from "@app/components/assistant/conversation/types";
 import { makeInitialMessageStreamState } from "@app/components/assistant/conversation/types";
 import {
   appendThinkingStep,
   removePendingToolCallForAction,
-  useAgentMessageStream,
   upsertPendingToolCall,
+  useAgentMessageStream,
 } from "@app/hooks/useAgentMessageStream";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
@@ -13,7 +14,6 @@ import type {
 import type { LightWorkspaceType } from "@app/types/user";
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { PendingToolCall } from "@app/components/assistant/conversation/types";
 
 const mockUseEventSource = vi.fn();
 const mockMutateContextUsage = vi.fn();
@@ -292,7 +292,9 @@ describe("useAgentMessageStream", () => {
 
     mockUseVirtuosoMethods.mockReturnValue({
       data: {
-        map: (updater: (message: typeof currentMessage) => typeof currentMessage) => {
+        map: (
+          updater: (message: typeof currentMessage) => typeof currentMessage
+        ) => {
           currentMessage = updater(currentMessage);
           snapshots.push({
             content: currentMessage.content,

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -203,7 +203,7 @@ export function updateProgress(
  * Append a thinking step to the inline activity steps if the content
  * is new (not a duplicate of the last thinking step).
  */
-function appendThinkingStep(
+export function appendThinkingStep(
   steps: InlineActivityStep[],
   cotContent: string,
   id: string

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -26,37 +26,38 @@ import type { VirtuosoMessageListMethods } from "@virtuoso.dev/message-list";
 import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
 // biome-ignore lint/plugin/noBulkLodash: existing usage
 import _ from "lodash";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
-// Throttle the update of the message to avoid excessive re-renders.
-const updateMessageThrottled = _.throttle(
-  ({
-    chainOfThought,
-    content,
-    methods,
-    sId,
-  }: {
-    chainOfThought: string;
-    content: string;
-    methods: VirtuosoMessageListMethods<
-      VirtuosoMessage,
-      VirtuosoMessageListContext
-    >;
-    sId: string;
-  }) => {
-    methods.data.map((m) => {
-      if (isAgentMessageWithStreaming(m) && m.sId === sId) {
-        return {
-          ...m,
-          content,
-          chainOfThought,
-        };
-      }
-      return m;
-    });
-  },
-  100
-);
+function createUpdateMessageThrottled() {
+  return _.throttle(
+    ({
+       chainOfThought,
+       content,
+       methods,
+       sId
+    }: {
+      chainOfThought: string;
+      content: string;
+      methods: VirtuosoMessageListMethods<
+        VirtuosoMessage,
+        VirtuosoMessageListContext
+      >;
+      sId: string;
+    }) => {
+      methods.data.map((m) => {
+        if (isAgentMessageWithStreaming(m) && m.sId === sId) {
+          return {
+            ...m,
+            content,
+            chainOfThought,
+          };
+        }
+        return m;
+      });
+    },
+    100
+  );
+}
 
 export function upsertPendingToolCall(
   pendingToolCalls: PendingToolCall[],
@@ -297,6 +298,13 @@ export function useAgentMessageStream({
     VirtuosoMessage,
     VirtuosoMessageListContext
   >();
+  const updateMessageThrottled = useRef(createUpdateMessageThrottled()).current;
+
+  useEffect(() => {
+    return () => {
+      updateMessageThrottled.cancel();
+    };
+  }, [updateMessageThrottled]);
 
   const shouldStream = useMemo(
     () =>
@@ -363,6 +371,17 @@ export function useAgentMessageStream({
           ) {
             content.current = "";
             chainOfThought.current = "";
+            methods.data.map((m) => {
+              if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
+                return m;
+              }
+
+              return {
+                ...m,
+                content: "",
+                chainOfThought: "",
+              };
+            });
             isFreshMountWithContent.current = false;
           }
 
@@ -378,6 +397,7 @@ export function useAgentMessageStream({
               lastClassification.current !== null &&
               classification !== lastClassification.current
             ) {
+              updateMessageThrottled.cancel();
               const newAgentState =
                 classification === "tokens" ? "writing" : "thinking";
               methods.data.map((m) => {
@@ -479,6 +499,7 @@ export function useAgentMessageStream({
           break;
 
         case "tool_params":
+          updateMessageThrottled.cancel();
           const toolParams = eventPayload.data;
           methods.data.map((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
@@ -546,6 +567,7 @@ export function useAgentMessageStream({
 
         case "tool_error":
         case "agent_error":
+          updateMessageThrottled.cancel();
           const error = eventPayload.data.error;
           methods.data.map((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
@@ -585,6 +607,7 @@ export function useAgentMessageStream({
           break;
 
         case "agent_generation_cancelled": {
+          updateMessageThrottled.cancel();
           methods.data.map((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
               return m;
@@ -613,6 +636,7 @@ export function useAgentMessageStream({
 
         case "agent_message_gracefully_stopped":
         case "agent_message_success": {
+          updateMessageThrottled.cancel();
           const messageSuccess = eventPayload.data;
           // Flush any remaining CoT (but not content — the final text segment
           // becomes the message body via the server's canonical message).

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -298,7 +298,11 @@ export function useAgentMessageStream({
     VirtuosoMessage,
     VirtuosoMessageListContext
   >();
-  const updateMessageThrottled = useRef(createUpdateMessageThrottled()).current;
+  const updateMessageThrottledRef = useRef(null);
+  if (!updateMessageThrottledRef.current) {
+    updateMessageThrottledRef.current = createUpdateMessageThrottled();
+  }
+  const updateMessageThrottled = updateMessageThrottledRef.current;
 
   useEffect(() => {
     return () => {
@@ -700,7 +704,13 @@ export function useAgentMessageStream({
         customOnEventCallback(eventPayload);
       }
     },
-    [customOnEventCallback, methods, sId, mutateContextUsage]
+    [
+      customOnEventCallback,
+      methods,
+      sId,
+      mutateContextUsage,
+      updateMessageThrottled,
+    ]
   );
 
   const { isError } = useEventSource(

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -298,11 +298,10 @@ export function useAgentMessageStream({
     VirtuosoMessage,
     VirtuosoMessageListContext
   >();
-  const updateMessageThrottledRef = useRef(null);
-  if (!updateMessageThrottledRef.current) {
-    updateMessageThrottledRef.current = createUpdateMessageThrottled();
-  }
-  const updateMessageThrottled = updateMessageThrottledRef.current;
+  const updateMessageThrottled = useMemo(
+    () => createUpdateMessageThrottled(),
+    []
+  );
 
   useEffect(() => {
     return () => {

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -31,10 +31,10 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 function createUpdateMessageThrottled() {
   return _.throttle(
     ({
-       chainOfThought,
-       content,
-       methods,
-       sId
+      chainOfThought,
+      content,
+      methods,
+      sId,
     }: {
       chainOfThought: string;
       content: string;


### PR DESCRIPTION
## Description

Refreshing the page or switching tabs (triggering a fetch from db basically) while an agent message is still streaming could show duplicated inline activity.
Reported [here](https://dust4ai.slack.com/archives/C0AQ23Y6JGH/p1776870343303739).
This PR fixes that.

2 main issues:

1. Live messages were seeded with DB, then SSE replay rebuilt the same history (so we have stuff in double).
2. On refresh, stale live text could reappear during replay:
    - the rendered DB content / chainOfThought was not cleared immediately
    - a pending throttled update could restore stale thinking text after `tool_params`

Fix consists in:
- Start live messages (`status === "created"`) with empty inlineActivitySteps and let replay rebuild them.
- Clear rendered `content` / `chainOfThought` on the first replay token after a fresh mount.
- Scope the throttled streamed-text updater per hook instance and cancel it at real stream boundaries like classification switches, `tool_params`, and terminal/error events.

`tool_params` is where the pending thinking segment is actually flushed into inline activity.

Note: we didn't have the issue before as we were only showing the last thinking. For instance if we had thinking-1, action-1 we'd only show action-1.

## Tests

Added regressions tests for the above.

## Risk

- Medium, affects the conversation UI

## Deploy Plan

- Deploy front.
