### PR TITLE
Fix spurious revalidation triggered by mutation-only useConversations subscribers

### DIFF
--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -211,7 +211,10 @@ export function BlockedActionsProvider({
     [blockedActionsQueue]
   );
 
-  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
 
   const removeAllBlockedActionsForMessage = useCallback(
     ({

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -67,7 +67,10 @@ export function ConversationContainerVirtuoso({
 
   const sendNotification = useSendNotification();
 
-  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
 
   const createConversationWithMessage = useCreateConversationWithMessage({
     owner,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -298,7 +298,10 @@ export const ConversationViewer = ({
     }
   }, [shouldShowPushNotificationActivation, askForPermission]);
 
-  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
 
   const {
     isLoadingInitialData,

--- a/front/hooks/conversations/useConversationMarkAsRead.ts
+++ b/front/hooks/conversations/useConversationMarkAsRead.ts
@@ -19,7 +19,10 @@ export function useConversationMarkAsRead({
   conversation?: ConversationWithoutContentType;
   workspaceId: string;
 }) {
-  const { mutateConversations } = useConversations({ workspaceId });
+  const { mutateConversations } = useConversations({
+    workspaceId,
+    options: { disabled: true },
+  });
 
   const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
     workspaceId,

--- a/front/hooks/conversations/useConversationParticipants.ts
+++ b/front/hooks/conversations/useConversationParticipants.ts
@@ -102,7 +102,10 @@ export const useJoinConversation = ({
 }): (() => Promise<boolean>) => {
   const sendNotification = useSendNotification();
 
-  const { mutateConversations } = useConversations({ workspaceId: ownerId });
+  const { mutateConversations } = useConversations({
+    workspaceId: ownerId,
+    options: { disabled: true },
+  });
   const { mutateConversationParticipants } = useConversationParticipants({
     conversationId,
     workspaceId: ownerId,

--- a/front/hooks/conversations/useConversationUrlAccessMode.ts
+++ b/front/hooks/conversations/useConversationUrlAccessMode.ts
@@ -22,7 +22,10 @@ export function useConversationUrlAccessMode({
     workspaceId: owner.sId,
     options: { disabled: true },
   });
-  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
   const [
     isUpdatingConversationUrlAccessMode,
     setIsUpdatingConversationUrlAccessMode,

--- a/front/hooks/conversations/useConversations.ts
+++ b/front/hooks/conversations/useConversations.ts
@@ -22,9 +22,11 @@ type MutateOptions = {
 export function useConversations({
   workspaceId,
   limit = DEFAULT_LIMIT,
+  options,
 }: {
   workspaceId: string;
   limit?: number;
+  options?: { disabled?: boolean };
 }) {
   const { fetcher } = useFetcher();
   const conversationsFetcher: Fetcher<GetConversationsResponseBody> = fetcher;
@@ -53,6 +55,7 @@ export function useConversations({
         revalidateFirstPage: false,
         revalidateOnFocus: false,
         revalidateOnReconnect: false,
+        disabled: options?.disabled,
       }
     );
 
@@ -114,7 +117,7 @@ export function useConversations({
 
   return {
     conversations,
-    isConversationsLoading: !error && !data,
+    isConversationsLoading: !error && !data && !options?.disabled,
     isConversationsError: error,
     mutateConversations,
     hasMore,

--- a/front/hooks/useDeleteConversation.ts
+++ b/front/hooks/useDeleteConversation.ts
@@ -8,7 +8,10 @@ import { useCallback } from "react";
 
 export function useDeleteConversation(owner: LightWorkspaceType) {
   const sendNotification = useSendNotification();
-  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
 
   return useCallback(
     async (

--- a/front/hooks/useMarkAllConversationsAsRead.ts
+++ b/front/hooks/useMarkAllConversationsAsRead.ts
@@ -20,7 +20,10 @@ export function useMarkAllConversationsAsRead({
 }: useMarkAllConversationsAsReadParams) {
   const [isMarkingAllAsRead, setIsMarkingAllAsRead] = useState(false);
   const sendNotification = useSendNotification();
-  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
 
   const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
     workspaceId: owner.sId,

--- a/front/hooks/useMoveConversationOutOfProject.tsx
+++ b/front/hooks/useMoveConversationOutOfProject.tsx
@@ -21,7 +21,10 @@ export function useMoveConversationOutOfProject(
   const sendNotification = useSendNotification();
   const confirm = useContext(ConfirmContext);
 
-  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
 
   const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
     workspaceId: owner.sId,

--- a/front/hooks/useMoveConversationToProject.tsx
+++ b/front/hooks/useMoveConversationToProject.tsx
@@ -18,7 +18,10 @@ export function useMoveConversationToProject(owner: LightWorkspaceType) {
   const sendNotification = useSendNotification();
   const confirm = useContext(ConfirmContext);
 
-  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
 
   const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
     workspaceId: owner.sId,

--- a/front/hooks/useUpdateConversationTitle.ts
+++ b/front/hooks/useUpdateConversationTitle.ts
@@ -17,7 +17,10 @@ export function useUpdateConversationTitle({
     workspaceId: owner.sId,
     options: { disabled: true },
   });
-  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
 
   return useCallback(
     async (title: string): Promise<boolean> => {

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -158,8 +158,8 @@ export function useSWRInfiniteWithDefaults<TKey extends Key, TData>(
     ) => {
       // When disabled, the SWR key is null so result.mutate is a no-op.
       // unstable_serialize produces the exact internal cache key useSWRInfinite uses,
-      // so globalMutate correctly reaches all mounted subscribers — including for
-      // optimistic updaters passed as the data argument.
+      // so globalMutate correctly reaches all mounted subscribers (including for
+      // optimistic updaters passed as the data argument).
       const key = unstable_serialize(getKey);
       if (data !== undefined || opts !== undefined) {
         return globalMutate(key, data, opts);

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -15,7 +15,7 @@ import type {
   SWRInfiniteConfiguration,
   SWRInfiniteKeyLoader,
 } from "swr/infinite";
-import useSWRInfinite from "swr/infinite";
+import useSWRInfinite, { unstable_serialize } from "swr/infinite";
 
 const EMPTY_ARRAY = Object.freeze([]);
 
@@ -128,10 +128,55 @@ export function useSWRWithDefaults<TKey extends Key, TData>(
 export function useSWRInfiniteWithDefaults<TKey extends Key, TData>(
   getKey: SWRInfiniteKeyLoader<TData, TKey>,
   fetcher: Fetcher<TData, TKey> | null,
-  config?: SWRInfiniteConfiguration
+  config?: SWRInfiniteConfiguration & { disabled?: boolean }
 ) {
+  const { mutate: globalMutate } = useSWRConfig();
   const mergedConfig = { ...DEFAULT_SWR_CONFIG, ...config };
-  return useSWRInfinite<TData>(getKey, fetcher, mergedConfig);
+  const disabled = !!mergedConfig.disabled;
+
+  const keyLoader = useCallback(
+    (pageIndex: number, previousPageData: TData | null) =>
+      disabled ? null : getKey(pageIndex, previousPageData),
+    [disabled, getKey]
+  );
+
+  // Returning null from an SWR Infinite key loader is documented behavior to stop pagination.
+  // The cast bridges the gap between TKey and TKey|null in the type system.
+  const result = useSWRInfinite<TData>(
+    keyLoader as SWRInfiniteKeyLoader<TData, TKey>,
+    fetcher,
+    mergedConfig
+  );
+
+  const mutateWhenDisabled = useCallback(
+    (
+      data?:
+        | TData[]
+        | Promise<TData[] | undefined>
+        | MutatorCallback<TData[] | undefined>,
+      opts?: boolean | MutatorOptions<any, any>
+    ) => {
+      // When disabled, the SWR key is null so result.mutate is a no-op.
+      // unstable_serialize produces the exact internal cache key useSWRInfinite uses,
+      // so globalMutate correctly reaches all mounted subscribers — including for
+      // optimistic updaters passed as the data argument.
+      const key = unstable_serialize(getKey);
+      if (data !== undefined || opts !== undefined) {
+        return globalMutate(key, data, opts);
+      }
+      return globalMutate(key);
+    },
+    [getKey, globalMutate]
+  );
+
+  // Always return the same shape so the mutate type is consistent for callers.
+  // When disabled, as the key is null, result.mutate is a no-op, so we replace it.
+  return {
+    ...result,
+    mutate: (disabled
+      ? mutateWhenDisabled
+      : result.mutate) as typeof result.mutate,
+  };
 }
 
 export const appendPaginationParams = (


### PR DESCRIPTION


## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Several hooks and components (`ConversationViewer`, `ConversationContainer`, `BlockedActionsProvider`, and a handful of action hooks) were calling `useConversations` exclusively to obtain `mutateConversations`, never reading
the conversations array. This turned out to be silently costly.

SWR determines when to revalidate based on hook subscriptions, not on whether the caller actually consumes the data. Every `useSWR` or `useSWRInfinite` call with a non-null key registers a live subscriber against an internal cache entry. The cache key for `useSWRInfinite` is not the URL itself. SWR prefixes it with `$inf$` and serializes the result of calling
the key loader at index 0, which makes it opaque to `globalMutate` unless you go through `unstable_serialize` from `swr/infinite` (see [docs](https://swr.vercel.app/docs/pagination#global-mutate-with-useswrinfinite)). When a
subscriber mounts and the cached data is considered stale, `revalidateIfStale` (default: true) fires a background fetch unconditionally, regardless of whether the component ever reads from the cache.

The issue was noticed while testing ES backed pagination locally:
- creating a new conversation, adding it optimistically with `revalidate: false`, and then navigating into it causes `ConversationViewer` to fully remount (it carries `key={conversationId}` to force a clean Virtuoso state).

That remount registers a fresh subscriber, which immediately schedules a background revalidation of the conversations list. Because the optimistic update uses `revalidate: false` it suppresses the revalidation it owns, but it has no effect on revalidations triggered by other subscribers. The in-flight fetch returns before the new conversation is visible in the
backend response, overwrites the cache, and the conversation disappears from the sidebar.

The fix introduces in this PR adds a `disabled` option to `useConversations` that prevents the hook
from registering as a subscriber and making any fetch, while keeping `mutateConversations` fully functional: the disabled path uses `globalMutate(unstable_serialize(getKey), ...)` to reach the same internal cache entry that the live `SidebarMenu` subscriber owns

➡️ All callers that only need the mutator now opt in with `options: { disabled: true }`, leaving `SidebarMenu` as the single active subscriber responsible for fetching and displaying the list.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
