### PR TITLE
[Branching] Remap branch attachment ids before compaction

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -46,6 +46,11 @@ import type {
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import { isCompactionMessageType } from "@app/types/assistant/conversation";
+import {
+  isContentFragmentType,
+  isContentNodeContentFragment,
+  isFileContentFragment,
+} from "@app/types/content_fragment";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
@@ -275,6 +280,46 @@ async function fetchConversationOrThrow(
   }
 
   return result.value;
+}
+
+function getLatestFileContentFragmentId(
+  conversation: ConversationType,
+  fileId: string
+): string {
+  for (const versions of conversation.content) {
+    const latestVersion = versions[versions.length - 1];
+
+    if (
+      latestVersion &&
+      isContentFragmentType(latestVersion) &&
+      isFileContentFragment(latestVersion) &&
+      latestVersion.fileId === fileId
+    ) {
+      return latestVersion.contentFragmentId;
+    }
+  }
+
+  throw new Error(`Missing file content fragment for file ${fileId}.`);
+}
+
+function getLatestContentNodeContentFragmentId(
+  conversation: ConversationType,
+  nodeId: string
+): string {
+  for (const versions of conversation.content) {
+    const latestVersion = versions[versions.length - 1];
+
+    if (
+      latestVersion &&
+      isContentFragmentType(latestVersion) &&
+      isContentNodeContentFragment(latestVersion) &&
+      latestVersion.nodeId === nodeId
+    ) {
+      return latestVersion.contentFragmentId;
+    }
+  }
+
+  throw new Error(`Missing content node content fragment for node ${nodeId}.`);
 }
 
 function mockCopyToConversation() {
@@ -725,6 +770,9 @@ describe("createConversationFork", () => {
       null
     );
     expect(attachmentResult.isOk()).toBe(true);
+    if (attachmentResult.isErr()) {
+      throw attachmentResult.error;
+    }
 
     parentConversationWithContent = await fetchConversationOrThrow(
       auth,
@@ -765,6 +813,10 @@ describe("createConversationFork", () => {
     expect(childFileAttachments).toHaveLength(1);
     expect(childFileAttachments[0]?.title).toBe("Notes");
     expect(childFileAttachments[0]?.fileId).not.toBe(sourceFile.sId);
+    const childFileContentFragmentId = getLatestFileContentFragmentId(
+      childConversation,
+      childFileAttachments[0]!.fileId
+    );
 
     const copiedFiles = await FileResource.fetchByIds(auth, [
       childFileAttachments[0]!.fileId,
@@ -780,6 +832,21 @@ describe("createConversationFork", () => {
     expect(processAndUpsertToDataSourceSpy).toHaveBeenCalledTimes(1);
     expect(processAndUpsertToDataSourceSpy.mock.calls[0]?.[2].file.sId).toBe(
       copiedFiles[0]?.sId
+    );
+    expect(vi.mocked(launchCompactionWorkflow)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth,
+        conversationId: childConversation.sId,
+        sourceConversation: expect.objectContaining({
+          conversationId: parentConversation.sId,
+          messageRank: sourceMessage.rank,
+          attachmentIdReplacements: {
+            [sourceFile.sId]: childFileAttachments[0]!.fileId,
+            [attachmentResult.value.contentFragmentId]:
+              childFileContentFragmentId,
+          },
+        }),
+      })
     );
 
     copyToConversationSpy.mockRestore();
@@ -988,6 +1055,19 @@ describe("createConversationFork", () => {
     expect(processAndUpsertToDataSourceSpy.mock.calls[0]?.[2].file.sId).toBe(
       copiedFiles[0]?.sId
     );
+    expect(vi.mocked(launchCompactionWorkflow)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth,
+        conversationId: childConversation.sId,
+        sourceConversation: expect.objectContaining({
+          conversationId: parentConversation.sId,
+          messageRank: sourceMessage.rank,
+          attachmentIdReplacements: expect.objectContaining({
+            [sourceToolOutput.sId]: childFileAttachments[0]!.fileId,
+          }),
+        }),
+      })
+    );
 
     copyToConversationSpy.mockRestore();
     getOrCreateConversationDataSourceFromFileSpy.mockRestore();
@@ -1169,6 +1249,9 @@ describe("createConversationFork", () => {
       null
     );
     expect(firstAttachmentResult.isOk()).toBe(true);
+    if (firstAttachmentResult.isErr()) {
+      throw firstAttachmentResult.error;
+    }
 
     parentConversationWithContent = await fetchConversationOrThrow(
       auth,
@@ -1229,6 +1312,24 @@ describe("createConversationFork", () => {
     expect(childContentNodeAttachments[0]?.nodeId).toBe("node_before_fork");
     expect(childContentNodeAttachments[0]?.nodeDataSourceViewId).toBe(
       dataSourceView.sId
+    );
+    const childContentNodeFragmentId = getLatestContentNodeContentFragmentId(
+      childConversation,
+      "node_before_fork"
+    );
+    expect(vi.mocked(launchCompactionWorkflow)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth,
+        conversationId: childConversation.sId,
+        sourceConversation: expect.objectContaining({
+          conversationId: parentConversation.sId,
+          messageRank: sourceMessage.rank,
+          attachmentIdReplacements: {
+            [firstAttachmentResult.value.contentFragmentId]:
+              childContentNodeFragmentId,
+          },
+        }),
+      })
     );
 
     getContentFragmentBlobSpy.mockRestore();

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -49,7 +49,6 @@ import { isCompactionMessageType } from "@app/types/assistant/conversation";
 import {
   isContentFragmentType,
   isContentNodeContentFragment,
-  isFileContentFragment,
 } from "@app/types/content_fragment";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Ok } from "@app/types/shared/result";
@@ -280,26 +279,6 @@ async function fetchConversationOrThrow(
   }
 
   return result.value;
-}
-
-function getLatestFileContentFragmentId(
-  conversation: ConversationType,
-  fileId: string
-): string {
-  for (const versions of conversation.content) {
-    const latestVersion = versions[versions.length - 1];
-
-    if (
-      latestVersion &&
-      isContentFragmentType(latestVersion) &&
-      isFileContentFragment(latestVersion) &&
-      latestVersion.fileId === fileId
-    ) {
-      return latestVersion.contentFragmentId;
-    }
-  }
-
-  throw new Error(`Missing file content fragment for file ${fileId}.`);
 }
 
 function getLatestContentNodeContentFragmentId(
@@ -813,10 +792,6 @@ describe("createConversationFork", () => {
     expect(childFileAttachments).toHaveLength(1);
     expect(childFileAttachments[0]?.title).toBe("Notes");
     expect(childFileAttachments[0]?.fileId).not.toBe(sourceFile.sId);
-    const childFileContentFragmentId = getLatestFileContentFragmentId(
-      childConversation,
-      childFileAttachments[0]!.fileId
-    );
 
     const copiedFiles = await FileResource.fetchByIds(auth, [
       childFileAttachments[0]!.fileId,
@@ -842,8 +817,6 @@ describe("createConversationFork", () => {
           messageRank: sourceMessage.rank,
           attachmentIdReplacements: {
             [sourceFile.sId]: childFileAttachments[0]!.fileId,
-            [attachmentResult.value.contentFragmentId]:
-              childFileContentFragmentId,
           },
         }),
       })

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -383,15 +383,25 @@ async function carryOverConversationAttachments(
   });
   const sourceFileContentFragmentIdsByFileId =
     getLatestFileContentFragmentIdsByFileId(parentConversationAtSource);
+  const sourceFileContentFragmentIndexByFileId = new Map<string, number>();
   const attachmentsToCarryOver: AttachmentToCarryOver[] =
     directConversationAttachments.map((attachment) => {
       if (isFileAttachmentType(attachment)) {
-        const sourceContentFragmentId =
-          attachment.source === "user"
-            ? (sourceFileContentFragmentIdsByFileId
-                .get(attachment.fileId)
-                ?.shift() ?? null)
-            : null;
+        let sourceContentFragmentId: string | null = null;
+
+        if (attachment.source === "user") {
+          const contentFragmentIds =
+            sourceFileContentFragmentIdsByFileId.get(attachment.fileId) ?? [];
+          const nextContentFragmentIndex =
+            sourceFileContentFragmentIndexByFileId.get(attachment.fileId) ?? 0;
+
+          sourceContentFragmentId =
+            contentFragmentIds[nextContentFragmentIndex] ?? null;
+          sourceFileContentFragmentIndexByFileId.set(
+            attachment.fileId,
+            nextContentFragmentIndex + 1
+          );
+        }
 
         return {
           attachment,

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -42,10 +42,7 @@ import { MISTRAL_SMALL_MODEL_CONFIG } from "@app/types/assistant/models/mistral"
 import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import { GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG } from "@app/types/assistant/models/xai";
-import {
-  isContentFragmentType,
-  isFileContentFragment,
-} from "@app/types/content_fragment";
+import { isFileContentFragment } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -55,11 +52,6 @@ export type CreateConversationForkErrorCode =
   | "conversation_not_found"
   | "invalid_request_error"
   | "internal_error";
-
-type AttachmentToCarryOver = {
-  attachment: ContentNodeAttachmentType | FileAttachmentType;
-  sourceContentFragmentId: string | null;
-};
 
 type CarriedAttachment = {
   carriedAttachment:
@@ -83,37 +75,6 @@ function filterConversationContentUpToRank(
       return latestVersion ? latestVersion.rank <= maxRank : false;
     }),
   };
-}
-
-function getLatestFileContentFragmentIdsByFileId(
-  conversation: ConversationType
-): Map<string, string[]> {
-  const fileContentFragmentIdsByFileId = new Map<string, string[]>();
-
-  for (const versions of conversation.content) {
-    const latestVersion = versions[versions.length - 1];
-
-    if (
-      !latestVersion ||
-      !isContentFragmentType(latestVersion) ||
-      !isFileContentFragment(latestVersion) ||
-      latestVersion.contentFragmentVersion !== "latest" ||
-      latestVersion.fileId === null ||
-      latestVersion.isInProjectContext
-    ) {
-      continue;
-    }
-
-    const contentFragmentIds =
-      fileContentFragmentIdsByFileId.get(latestVersion.fileId) ?? [];
-    contentFragmentIds.push(latestVersion.contentFragmentId);
-    fileContentFragmentIdsByFileId.set(
-      latestVersion.fileId,
-      contentFragmentIds
-    );
-  }
-
-  return fileContentFragmentIdsByFileId;
 }
 
 function getForkCompactionModel(auth: Authenticator): SupportedModel | null {
@@ -381,44 +342,9 @@ async function carryOverConversationAttachments(
 
     return isContentNodeAttachmentType(attachment);
   });
-  const sourceFileContentFragmentIdsByFileId =
-    getLatestFileContentFragmentIdsByFileId(parentConversationAtSource);
-  const sourceFileContentFragmentIndexByFileId = new Map<string, number>();
-  const attachmentsToCarryOver: AttachmentToCarryOver[] =
-    directConversationAttachments.map((attachment) => {
-      if (isFileAttachmentType(attachment)) {
-        let sourceContentFragmentId: string | null = null;
-
-        if (attachment.source === "user") {
-          const contentFragmentIds =
-            sourceFileContentFragmentIdsByFileId.get(attachment.fileId) ?? [];
-          const nextContentFragmentIndex =
-            sourceFileContentFragmentIndexByFileId.get(attachment.fileId) ?? 0;
-
-          sourceContentFragmentId =
-            contentFragmentIds[nextContentFragmentIndex] ?? null;
-          sourceFileContentFragmentIndexByFileId.set(
-            attachment.fileId,
-            nextContentFragmentIndex + 1
-          );
-        }
-
-        return {
-          attachment,
-          sourceContentFragmentId,
-        };
-      }
-
-      return {
-        attachment,
-        sourceContentFragmentId: attachment.contentFragmentId,
-      };
-    });
-  const attachmentIdReplacements: CompactionAttachmentIdReplacements = {};
-
-  await concurrentExecutor(
-    attachmentsToCarryOver,
-    async ({ attachment, sourceContentFragmentId }) => {
+  const attachmentResults = await concurrentExecutor(
+    directConversationAttachments,
+    async (attachment) => {
       let carriedResult: CarriedAttachment | null;
 
       if (isFileAttachmentType(attachment)) {
@@ -434,7 +360,7 @@ async function carryOverConversationAttachments(
       }
 
       if (!carriedResult) {
-        return;
+        return null;
       }
 
       const {
@@ -463,21 +389,7 @@ async function carryOverConversationAttachments(
           attachErrorMessage
         );
 
-        return;
-      }
-
-      if (
-        isFileAttachmentType(attachment) &&
-        isFileContentFragment(attachmentResult.value) &&
-        attachmentResult.value.fileId !== null
-      ) {
-        attachmentIdReplacements[attachment.fileId] =
-          attachmentResult.value.fileId;
-      }
-
-      if (sourceContentFragmentId) {
-        attachmentIdReplacements[sourceContentFragmentId] =
-          attachmentResult.value.contentFragmentId;
+        return null;
       }
 
       const shouldCopyFileToDatasource =
@@ -492,11 +404,33 @@ async function carryOverConversationAttachments(
           carriedFile,
         });
       }
+
+      return {
+        sourceAttachmentId: isFileAttachmentType(attachment)
+          ? attachment.fileId
+          : attachment.contentFragmentId,
+        targetAttachment: attachmentResult.value,
+      };
     },
     { concurrency: ATTACHMENT_CARRY_OVER_CONCURRENCY }
   );
 
-  return attachmentIdReplacements;
+  return attachmentResults.reduce<CompactionAttachmentIdReplacements>(
+    (acc, result) => {
+      if (!result) {
+        return acc;
+      }
+
+      acc[result.sourceAttachmentId] =
+        isFileContentFragment(result.targetAttachment) &&
+        result.targetAttachment.fileId !== null
+          ? result.targetAttachment.fileId
+          : result.targetAttachment.contentFragmentId;
+
+      return acc;
+    },
+    {}
+  );
 }
 
 export async function createConversationFork(

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -31,6 +31,7 @@ import type {
   ContentFragmentInputWithContentNode,
   ContentFragmentInputWithFileIdType,
 } from "@app/types/api/internal/assistant";
+import type { CompactionAttachmentIdReplacements } from "@app/types/assistant/compaction";
 import type {
   ConversationType,
   ConversationWithoutContentType,
@@ -41,6 +42,10 @@ import { MISTRAL_SMALL_MODEL_CONFIG } from "@app/types/assistant/models/mistral"
 import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import { GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG } from "@app/types/assistant/models/xai";
+import {
+  isContentFragmentType,
+  isFileContentFragment,
+} from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -50,6 +55,11 @@ export type CreateConversationForkErrorCode =
   | "conversation_not_found"
   | "invalid_request_error"
   | "internal_error";
+
+type AttachmentToCarryOver = {
+  attachment: ContentNodeAttachmentType | FileAttachmentType;
+  sourceContentFragmentId: string | null;
+};
 
 type CarriedAttachment = {
   carriedAttachment:
@@ -73,6 +83,37 @@ function filterConversationContentUpToRank(
       return latestVersion ? latestVersion.rank <= maxRank : false;
     }),
   };
+}
+
+function getLatestFileContentFragmentIdsByFileId(
+  conversation: ConversationType
+): Map<string, string[]> {
+  const fileContentFragmentIdsByFileId = new Map<string, string[]>();
+
+  for (const versions of conversation.content) {
+    const latestVersion = versions[versions.length - 1];
+
+    if (
+      !latestVersion ||
+      !isContentFragmentType(latestVersion) ||
+      !isFileContentFragment(latestVersion) ||
+      latestVersion.contentFragmentVersion !== "latest" ||
+      latestVersion.fileId === null ||
+      latestVersion.isInProjectContext
+    ) {
+      continue;
+    }
+
+    const contentFragmentIds =
+      fileContentFragmentIdsByFileId.get(latestVersion.fileId) ?? [];
+    contentFragmentIds.push(latestVersion.contentFragmentId);
+    fileContentFragmentIdsByFileId.set(
+      latestVersion.fileId,
+      contentFragmentIds
+    );
+  }
+
+  return fileContentFragmentIdsByFileId;
 }
 
 function getForkCompactionModel(auth: Authenticator): SupportedModel | null {
@@ -319,7 +360,7 @@ async function carryOverConversationAttachments(
     childConversation: ConversationType;
     sourceMessageRank: number;
   }
-): Promise<void> {
+): Promise<CompactionAttachmentIdReplacements> {
   const parentConversationAtSource = filterConversationContentUpToRank(
     parentConversation,
     sourceMessageRank
@@ -340,10 +381,34 @@ async function carryOverConversationAttachments(
 
     return isContentNodeAttachmentType(attachment);
   });
+  const sourceFileContentFragmentIdsByFileId =
+    getLatestFileContentFragmentIdsByFileId(parentConversationAtSource);
+  const attachmentsToCarryOver: AttachmentToCarryOver[] =
+    directConversationAttachments.map((attachment) => {
+      if (isFileAttachmentType(attachment)) {
+        const sourceContentFragmentId =
+          attachment.source === "user"
+            ? (sourceFileContentFragmentIdsByFileId
+                .get(attachment.fileId)
+                ?.shift() ?? null)
+            : null;
+
+        return {
+          attachment,
+          sourceContentFragmentId,
+        };
+      }
+
+      return {
+        attachment,
+        sourceContentFragmentId: attachment.contentFragmentId,
+      };
+    });
+  const attachmentIdReplacements: CompactionAttachmentIdReplacements = {};
 
   await concurrentExecutor(
-    directConversationAttachments,
-    async (attachment) => {
+    attachmentsToCarryOver,
+    async ({ attachment, sourceContentFragmentId }) => {
       let carriedResult: CarriedAttachment | null;
 
       if (isFileAttachmentType(attachment)) {
@@ -391,6 +456,20 @@ async function carryOverConversationAttachments(
         return;
       }
 
+      if (
+        isFileAttachmentType(attachment) &&
+        isFileContentFragment(attachmentResult.value) &&
+        attachmentResult.value.fileId !== null
+      ) {
+        attachmentIdReplacements[attachment.fileId] =
+          attachmentResult.value.fileId;
+      }
+
+      if (sourceContentFragmentId) {
+        attachmentIdReplacements[sourceContentFragmentId] =
+          attachmentResult.value.contentFragmentId;
+      }
+
       const shouldCopyFileToDatasource =
         carriedFile !== null &&
         !carriedFile.useCaseMetadata?.skipDataSourceIndexing &&
@@ -406,6 +485,8 @@ async function carryOverConversationAttachments(
     },
     { concurrency: ATTACHMENT_CARRY_OVER_CONCURRENCY }
   );
+
+  return attachmentIdReplacements;
 }
 
 export async function createConversationFork(
@@ -557,21 +638,28 @@ export async function createConversationFork(
       },
       "Failed to reload parent conversation for fork attachment carryover."
     );
-  } else {
-    await carryOverConversationAttachments(auth, {
-      parentConversation: parentConversationWithContent.value,
-      childConversation: childConversation.value,
-      sourceMessageRank: childConversationId.value.sourceMessageRank,
-    });
   }
+
+  const attachmentIdReplacements = parentConversationWithContent.isOk()
+    ? await carryOverConversationAttachments(auth, {
+        parentConversation: parentConversationWithContent.value,
+        childConversation: childConversation.value,
+        sourceMessageRank: childConversationId.value.sourceMessageRank,
+      })
+    : undefined;
+  const sourceConversation = {
+    conversationId: parentConversation.sId,
+    messageRank: childConversationId.value.sourceMessageRank,
+    ...(attachmentIdReplacements &&
+    Object.keys(attachmentIdReplacements).length > 0
+      ? { attachmentIdReplacements }
+      : {}),
+  };
 
   const compactionResult = await compactConversation(auth, {
     conversation: childConversation.value,
     model: forkCompactionModel,
-    sourceConversation: {
-      conversationId: parentConversation.sId,
-      messageRank: childConversationId.value.sourceMessageRank,
-    },
+    sourceConversation,
   });
 
   if (compactionResult.isErr()) {


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24725.

During branch creation, attachment carry-over now records source attachment ids to the child conversation ids and passes that map into source-backed compaction, so the saved summary refers to attachments the branched conversation can actually access.

This covers direct conversation files, carried-over tool output files, and content-node attachments.

## Risks
Blast radius: branched conversation initialization and source-backed compaction attachment references
Risk: low

## Deploy Plan
- pmrr
- deploy front
