### PR TITLE
fix(sbx): run egress forwarder as root instead of dust-fwd

### DIFF
--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -110,22 +110,20 @@ describe("sandbox egress helpers", () => {
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       1,
       auth,
-      expect.stringContaining(
-        "chown dust-fwd:dust-fwd '/etc/dust/egress-token' && chmod 600 '/etc/dust/egress-token' && rm -f '/tmp/dust-forwarder.log' '/tmp/dust-egress-denied.log'"
-      ),
+      expect.stringContaining("chmod 600 '/etc/dust/egress-token'"),
       { user: "root" }
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       2,
       auth,
       expect.stringContaining("--proxy-addr '203.0.113.10:4443'"),
-      { user: "dust-fwd" }
+      { user: "root" }
     );
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       2,
       auth,
       expect.stringContaining("--proxy-tls-name 'eu.sandbox-egress.dust.tt'"),
-      { user: "dust-fwd" }
+      { user: "root" }
     );
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -137,18 +137,14 @@ export async function setupEgressForwarder(
     return tokenWriteResult;
   }
 
-  // Older sandboxes may still have root-owned log files from before the
-  // forwarder switched to dust-fwd, so clear them before dropping privileges.
-  const prepareRuntimeFilesResult = await runSuccessfulSandboxCommand(
+  const prepareTokenResult = await runSuccessfulSandboxCommand(
     auth,
     sandbox,
-    `chown dust-fwd:dust-fwd ${shellEscape(EGRESS_TOKEN_PATH)} && ` +
-      `chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)} && ` +
-      `rm -f ${shellEscape(EGRESS_FORWARDER_LOG_PATH)} ${shellEscape(EGRESS_DENY_LOG_PATH)}`,
+    `chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)}`,
     "root"
   );
-  if (prepareRuntimeFilesResult.isErr()) {
-    return prepareRuntimeFilesResult;
+  if (prepareTokenResult.isErr()) {
+    return prepareTokenResult;
   }
 
   const startForwarderCommand =
@@ -164,7 +160,7 @@ export async function setupEgressForwarder(
     auth,
     sandbox,
     startForwarderCommand,
-    "dust-fwd"
+    "root"
   );
   if (startResult.isErr()) {
     return startResult;


### PR DESCRIPTION
## Description

E2B's exec API wraps commands in `/bin/bash -l -c ...` which fails with `fork/exec /bin/sh: permission denied` when running as the `dust-fwd` user. Reverts the forwarder to running as root.

The nftables rules are uid-scoped to `agent-proxied` (uid 1003) so root traffic bypasses the proxy as expected.

## Tests

- Unit tests updated and passing

## Risk

Low. Reverts to the previous behavior (forwarder as root). Fixes a production regression introduced in #24731.

## Deploy Plan

Merge and deploy immediately.