### PR TITLE
chore(sbx): remove unused dust-fwd user from sandbox image

### DIFF
--- a/dockerfiles/sandbox-bedrock.Dockerfile
+++ b/dockerfiles/sandbox-bedrock.Dockerfile
@@ -7,8 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates curl git unzip xz-utils gnupg lsb-release netcat-openbsd nftables acl \
   && rm -rf /var/lib/apt/lists/*
 
-RUN useradd --system --no-create-home --uid 9990 --shell /bin/bash dust-fwd \
-  && mkdir -p /etc/dust \
+RUN mkdir -p /etc/dust \
   && chmod 755 /etc/dust
 
 # Add gcsfuse repository

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -59,9 +59,6 @@ describe("sandbox image registry", () => {
     const dockerfile = getSandboxBedrockDockerfile();
 
     expect(dockerfile).toContain("netcat-openbsd nftables acl");
-    expect(dockerfile).toContain(
-      "useradd --system --no-create-home --uid 9990 --shell /bin/bash dust-fwd"
-    );
     expect(dockerfile).toContain("mkdir -p /etc/dust");
     expect(dockerfile).toContain("command -v sudo >/dev/null 2>&1");
   });


### PR DESCRIPTION
## Description

The egress forwarder now runs as root (#24749) so the `dust-fwd` user (uid 9990) is no longer used. Remove it from the bedrock Dockerfile.

## Tests

- Registry test updated and passing

## Risk

None. The user is not referenced by any runtime code after #24749 merges.

## Deploy Plan

Merge after #24749. New sandbox images will no longer include the `dust-fwd` user. Existing sandboxes are unaffected.