### PR TITLE
chore: stop indexing same-turn attachments

### DIFF
--- a/front/lib/api/files/should_skip_indexing.test.ts
+++ b/front/lib/api/files/should_skip_indexing.test.ts
@@ -1,0 +1,85 @@
+import { shouldSkipDataSourceIndexing } from "@app/lib/api/files/should_skip_indexing";
+import { describe, expect, it } from "vitest";
+
+describe("shouldSkipDataSourceIndexing", () => {
+  it("skips pasted text attachments", () => {
+    expect(
+      shouldSkipDataSourceIndexing({
+        contentType: "text/vnd.dust.attachment.pasted",
+        fileName: "pasted-text-1_2026-04-23_10-00-00.txt",
+      })
+    ).toBe(true);
+  });
+
+  it("skips Slack thread attachments", () => {
+    expect(
+      shouldSkipDataSourceIndexing({
+        contentType: "text/vnd.dust.attachment.slack.thread",
+        fileName: "thread.txt",
+      })
+    ).toBe(true);
+  });
+
+  it("skips Chrome extension page captures by filename prefix", () => {
+    expect(
+      shouldSkipDataSourceIndexing({
+        contentType: "text/markdown",
+        fileName: "[text] example.com — page title.md",
+      })
+    ).toBe(true);
+  });
+
+  it("skips audio/webm (voice recording)", () => {
+    expect(
+      shouldSkipDataSourceIndexing({
+        contentType: "audio/webm",
+        fileName: "recording.webm",
+      })
+    ).toBe(true);
+  });
+
+  it("does not skip regular text files", () => {
+    expect(
+      shouldSkipDataSourceIndexing({
+        contentType: "text/plain",
+        fileName: "notes.txt",
+      })
+    ).toBe(false);
+  });
+
+  it("does not skip regular markdown files", () => {
+    expect(
+      shouldSkipDataSourceIndexing({
+        contentType: "text/markdown",
+        fileName: "README.md",
+      })
+    ).toBe(false);
+  });
+
+  it("does not skip audio/mpeg (only audio/webm is handled)", () => {
+    expect(
+      shouldSkipDataSourceIndexing({
+        contentType: "audio/mpeg",
+        fileName: "podcast.mp3",
+      })
+    ).toBe(false);
+  });
+
+  it("does not skip files whose name merely contains [text] without the prefix", () => {
+    expect(
+      shouldSkipDataSourceIndexing({
+        contentType: "text/markdown",
+        fileName: "notes about [text] stuff.md",
+      })
+    ).toBe(false);
+  });
+
+  it("does not skip webhook_body JSON payloads (handled by temporal stamp, not this helper)", () => {
+    expect(
+      shouldSkipDataSourceIndexing({
+        contentType: "application/json",
+        fileName: "webhook_body_123_456.json",
+      })
+    ).toBe(false);
+  });
+});

--- a/front/lib/api/files/should_skip_indexing.ts
+++ b/front/lib/api/files/should_skip_indexing.ts
@@ -1,0 +1,35 @@
+import { isPastedFile } from "@app/components/assistant/conversation/input_bar/pasted_utils";
+
+const SLACK_THREAD_CONTENT_TYPE = "text/vnd.dust.attachment.slack.thread";
+const AUDIO_WEBM_CONTENT_TYPE = "audio/webm";
+// Chrome extension page captures : the extension uploads as text/markdown with no
+// distinguishing header or metadata, so the filename prefix is our only signal.
+// See extension/ui/hooks/useFileUploaderService.ts.
+const CHROME_TEXT_PREFIX = "[text] ";
+
+/**
+ * True for files that live in a conversation's data source but should never be
+ * indexed in Qdrant, because they're same-turn inline context (pasted
+ * text, Chrome page captures, Slack thread attachments, etc).
+ */
+export function shouldSkipDataSourceIndexing({
+  contentType,
+  fileName,
+}: {
+  contentType: string;
+  fileName: string;
+}): boolean {
+  if (isPastedFile(contentType)) {
+    return true;
+  }
+  if (contentType === SLACK_THREAD_CONTENT_TYPE) {
+    return true;
+  }
+  if (fileName.startsWith(CHROME_TEXT_PREFIX)) {
+    return true;
+  }
+  if (contentType === AUDIO_WEBM_CONTENT_TYPE) {
+    return true;
+  }
+  return false;
+}

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -478,11 +478,7 @@ const getProcessingFunction = ({
   }
 
   if (isSupportedAudioContentType(contentType)) {
-    if (
-      useCase === "conversation" ||
-      useCase === "upsert_document" ||
-      useCase === "project_context"
-    ) {
+    if (useCase === "upsert_document" || useCase === "project_context") {
       return upsertDocumentToDatasource;
     }
     return undefined;

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -1,5 +1,6 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { isUploadSupportedForContentType } from "@app/lib/api/files/processing";
+import { shouldSkipDataSourceIndexing } from "@app/lib/api/files/should_skip_indexing";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
@@ -170,6 +171,13 @@ async function handler(
         });
       }
 
+      const effectiveUseCaseMetadata = shouldSkipDataSourceIndexing({
+        contentType,
+        fileName,
+      })
+        ? { ...(useCaseMetadata ?? {}), skipDataSourceIndexing: true }
+        : useCaseMetadata;
+
       const file = await FileResource.makeNew({
         contentType,
         fileName,
@@ -177,7 +185,7 @@ async function handler(
         userId: user?.id ?? null,
         workspaceId: owner.id,
         useCase,
-        useCaseMetadata: useCaseMetadata,
+        useCaseMetadata: effectiveUseCaseMetadata,
       });
 
       res.status(200).json({ file: file.toPublicJSONWithUploadUrl(auth) });

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -53,9 +53,9 @@
  *       429:
  *         description: Rate limit exceeded
  */
-import { isPastedFile } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { isUploadSupportedForContentType } from "@app/lib/api/files/processing";
+import { shouldSkipDataSourceIndexing } from "@app/lib/api/files/should_skip_indexing";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
@@ -206,9 +206,10 @@ async function handler(
         });
       }
 
-      // Pasted text from the input bar is attached as same-turn context; indexing it in the
-      // conversation data source adds noise without improving retrieval.
-      const effectiveUseCaseMetadata = isPastedFile(contentType)
+      const effectiveUseCaseMetadata = shouldSkipDataSourceIndexing({
+        contentType,
+        fileName,
+      })
         ? { ...(useCaseMetadata ?? {}), skipDataSourceIndexing: true }
         : useCaseMetadata;
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

In the same vein as https://github.com/dust-tt/dust/pull/24637 and https://github.com/dust-tt/dust/pull/24279 and https://github.com/dust-tt/dust/pull/24703

This PR stops the indexation of slack threads (when calling dust from slack), audio files from the input bar, and chrome extension page text attachments.

Find all the analysis and data here : https://dust4ai.slack.com/archives/C050SM8NSPK/p1776895175540479?thread_ts=1776168536.889749&cid=C050SM8NSPK

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front