### PR TITLE
Instrument and batch sandbox spin-up phases

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -122,13 +122,19 @@ export async function runSandboxBashTool(
     return new Err(new MCPError("No conversation context available."));
   }
 
+  const prepStartMs = performance.now();
+
+  const ensureStartMs = performance.now();
   const ensureResult = await SandboxResource.ensureActive(auth, conversation);
   if (ensureResult.isErr()) {
     return new Err(new MCPError(ensureResult.error.message));
   }
+  const ensureActiveDurationMs = performance.now() - ensureStartMs;
 
   const { sandbox, freshlyCreated, wokeFromSleep } = ensureResult.value;
 
+  let gcsDurationMs = 0;
+  let gcsOp: "mount" | "refresh" | "skipped" = "skipped";
   const imageResult = getSandboxImage(auth);
   if (imageResult.isOk()) {
     const image = imageResult.value;
@@ -137,7 +143,9 @@ export async function runSandboxBashTool(
       logger.error({ err }, "Telemetry start failed (fire-and-forget)")
     );
 
+    const gcsStartMs = performance.now();
     if (freshlyCreated || wokeFromSleep) {
+      gcsOp = "mount";
       const mountResult = await mountConversationFiles(
         auth,
         sandbox,
@@ -148,6 +156,7 @@ export async function runSandboxBashTool(
         return new Err(new MCPError(mountResult.error.message));
       }
     } else {
+      gcsOp = "refresh";
       const refreshResult = await refreshGcsToken(
         auth,
         sandbox,
@@ -158,6 +167,7 @@ export async function runSandboxBashTool(
         return new Err(new MCPError(refreshResult.error.message));
       }
     }
+    gcsDurationMs = performance.now() - gcsStartMs;
   } else {
     logger.error(
       { err: imageResult.error },
@@ -165,13 +175,17 @@ export async function runSandboxBashTool(
     );
   }
 
+  let egressSetupDurationMs = 0;
   if (freshlyCreated) {
+    const egressSetupStartMs = performance.now();
     const setupResult = await setupEgressForwarder(auth, sandbox);
     if (setupResult.isErr()) {
       return new Err(new MCPError(setupResult.error.message));
     }
+    egressSetupDurationMs = performance.now() - egressSetupStartMs;
   }
 
+  const healthStartMs = performance.now();
   const healthResult = await checkEgressForwarderHealth(auth, sandbox);
   if (healthResult.isErr()) {
     return new Err(new MCPError(healthResult.error.message));
@@ -200,7 +214,9 @@ export async function runSandboxBashTool(
       "Sandbox egress forwarder health check succeeded"
     );
   }
+  const healthDurationMs = performance.now() - healthStartMs;
 
+  const tokenGenStartMs = performance.now();
   const execId = generateExecId();
   const sandboxToken = await generateSandboxExecToken(auth, {
     agentConfiguration,
@@ -210,6 +226,26 @@ export async function runSandboxBashTool(
     execId,
     expiryMs: DEFAULT_EXEC_TIMEOUT_MS,
   });
+  const tokenGenDurationMs = performance.now() - tokenGenStartMs;
+
+  const totalPrepDurationMs = performance.now() - prepStartMs;
+  logger.info(
+    {
+      sandboxId: sandbox.sId,
+      conversationId: conversation.sId,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      freshlyCreated,
+      wokeFromSleep,
+      gcsOp,
+      totalPrepDurationMs,
+      ensureActiveDurationMs,
+      gcsDurationMs,
+      egressSetupDurationMs,
+      healthDurationMs,
+      tokenGenDurationMs,
+    },
+    "Sandbox ready for first command"
+  );
 
   const metricsCtx = { workspaceId: auth.getNonNullableWorkspace().sId };
   const startMs = performance.now();

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -31,6 +31,7 @@ export async function mountConversationFiles(
     return new Ok(undefined);
   }
 
+  const startMs = performance.now();
   const bucket = fileStorageConfig.getGcsPrivateUploadsBucket();
 
   const workspaceId = auth.getNonNullableWorkspace().sId;
@@ -123,7 +124,11 @@ export async function mountConversationFiles(
     return new Err(new Error(msg));
   }
 
-  childLogger.info({}, "GCS mount: conversation files mounted successfully");
+  const durationMs = performance.now() - startMs;
+  childLogger.info(
+    { durationMs },
+    "GCS mount: conversation files mounted successfully"
+  );
   return new Ok(undefined);
 }
 
@@ -143,6 +148,7 @@ export async function refreshGcsToken(
     return new Ok(undefined);
   }
 
+  const startMs = performance.now();
   const bucket = fileStorageConfig.getGcsPrivateUploadsBucket();
 
   const workspaceId = auth.getNonNullableWorkspace().sId;
@@ -170,11 +176,13 @@ export async function refreshGcsToken(
     return writeResult;
   }
 
+  const durationMs = performance.now() - startMs;
   logger.info(
     {
       sandboxId: sandbox.sId,
       workspaceId,
       conversationId: conversation.sId,
+      durationMs,
     },
     "GCS token refreshed"
   );

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -336,6 +336,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
         const createConfig = imageResult.value.toCreateConfig();
 
+        const createStartMs = performance.now();
         const createResult = await provider.create(
           {
             ...createConfig,
@@ -352,6 +353,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         if (createResult.isErr()) {
           return createResult;
         }
+        const createDurationMs = performance.now() - createStartMs;
 
         const sandbox = await SandboxResource.makeNew(auth, {
           conversationId: conversation.id,
@@ -373,7 +375,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         }
 
         logger.info(
-          { sandbox: sandbox.toLogJSON() },
+          { sandbox: sandbox.toLogJSON(), createDurationMs },
           "Created new sandbox for conversation"
         );
 
@@ -392,6 +394,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           // The sandbox was paused (betaPause) while waiting for tool approval.
           // Wake it, but do NOT fall through to recreation on failure — the
           // frozen process state and output files are unrecoverable.
+          const pendingWakeStartMs = performance.now();
           const pendingWakeResult = await provider.wake(
             existing.providerId,
             tracingOpts
@@ -403,11 +406,20 @@ export class SandboxResource extends BaseResource<SandboxModel> {
               )
             );
           }
+          logger.info(
+            {
+              sandbox: existing.toLogJSON(),
+              wakeDurationMs: performance.now() - pendingWakeStartMs,
+              previousStatus: "pending_approval",
+            },
+            "Woke sandbox"
+          );
           wokeFromSleep = true;
           break;
         }
 
         case "sleeping": {
+          const wakeStartMs = performance.now();
           const wakeResult = await provider.wake(
             existing.providerId,
             tracingOpts
@@ -424,6 +436,14 @@ export class SandboxResource extends BaseResource<SandboxModel> {
               "Failed to wake sandbox — will recreate"
             );
           } else {
+            logger.info(
+              {
+                sandbox: existing.toLogJSON(),
+                wakeDurationMs: performance.now() - wakeStartMs,
+                previousStatus: "sleeping",
+              },
+              "Woke sandbox"
+            );
             wokeFromSleep = true;
 
             break;
@@ -439,6 +459,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
           const createConfig = imageResult.value.toCreateConfig();
 
+          const createStartMs = performance.now();
           const createResult = await provider.create(
             {
               ...createConfig,
@@ -455,6 +476,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           if (createResult.isErr()) {
             return createResult;
           }
+          const createDurationMs = performance.now() - createStartMs;
           await existing.update({ providerId: createResult.value.providerId });
           freshlyCreated = true;
 
@@ -475,6 +497,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             {
               sandbox: existing.toLogJSON(),
               newProviderId: createResult.value.providerId,
+              createDurationMs,
             },
             "Recreated sandbox from deleted state"
           );


### PR DESCRIPTION
Two related changes for sandbox spin-up latency: first instrument it, then cut the cold-start cost.

## 1. Instrument spin-up phase durations (commit 1)

Adds per-phase timing so we can understand how long it takes a sandbox to become ready for the user's first command.

- `mountConversationFiles` and `refreshGcsToken` now include `durationMs` on their success log lines.
- `SandboxResource.ensureActive` logs `createDurationMs` on the create paths and `wakeDurationMs` on the wake paths. Adds a new `"Woke sandbox"` info log on both wake paths (`sleeping` and `pending_approval`) tagged with `previousStatus`.
- `runSandboxBashTool` emits a single `"Sandbox ready for first command"` log just before exec, with `totalPrepDurationMs` plus per-phase breakdown: `ensureActiveDurationMs`, `gcsDurationMs` (+ `gcsOp`: `mount` | `refresh` | `skipped`), `egressSetupDurationMs`, `healthDurationMs`, `tokenGenDurationMs`. Includes `freshlyCreated`, `wokeFromSleep`, `sandboxId`, `conversationId`, `workspaceId` for slicing in Datadog.

## 2. Bundle GCS mount and egress setup into single execs (commit 2)

Investigation via the new instrumentation + sandbox-side journal logs showed cold-start was ~6.5s, with ~3 s of that being avoidable E2B exec round-trips and a hardcoded `sleep 1`.

`mountConversationFiles`:
- 4 execs (printf token + token-server start + sleep+curl + gcsfuse mount) collapsed into 1 bundled bash script.
- Hardcoded `sleep 1` replaced with `until curl -sf …` polling at 50 ms intervals (5s budget).
- Whole script runs as root (gcsfuse needs FUSE); `/tmp/token.json` is `chmod 666` so the default-user `refreshGcsToken` write still works.

`setupEgressForwarder`:
- writeFile + chmod + dsbx-launch + health-check retry loop collapsed into 1 exec. Token now written via `printf` (JWT is base64url-safe in single quotes) instead of E2B writeFile.
- Per-exec health retry loop replaced with in-script polling (3s budget, 50 ms interval) — same total wait budget but no front round-trip per check.

Per-step error attribution preserved via `set -e`, distinct exit codes (41 = token server not ready, 42 = egress not healthy), and stderr from the failing step.

## Expected impact

| | Before | After (est.) |
|---|---|---|
| Cold start | ~6.5 s | ~4.0 s (-2.5 s) |
| Wake | ~3.5 s | ~1.8 s (-1.7 s) |
| Warm refresh | unchanged (already 1 exec) | unchanged |

Numbers will be confirmed in Datadog after deploy via the new `totalPrepDurationMs` / `gcsDurationMs` / `egressSetupDurationMs` fields on `"Sandbox ready for first command"`.

## Tests

- `lib/api/sandbox/egress.test.ts` updated to assert the bundled exec contract (5 tests pass).
- Type-check clean.
- No automated tests for the mount script — relies on the existing manual sandbox flow + the new duration logs to validate post-deploy.

## Risk

Medium. The bundled scripts are new code paths exercised on every sandbox cold start / wake. Specific risks:
- gcsfuse running as root inherited from the bundled script vs. only the gcsfuse exec previously — no functional change since gcsfuse already ran as root, but token-server.sh and the token file write now also run as root (chmod 666 mitigates the file-ownership concern for `refreshGcsToken`).
- `/etc/dust` directory must exist for the egress token write — script now `mkdir -p`s it (was previously implicit via writeFile).
- Per-step error visibility moves from distinct log messages to a single `stderr` blob + exit code. Mitigated by `set -e` and distinct exit codes.

Easy to roll back if we see regressions in cold-start success rates.

## Deploy Plan

Standard front deploy. After deploy:
1. Watch `service:front "Sandbox ready for first command"` for `@gcsDurationMs` / `@egressSetupDurationMs` p50/p95 — should drop materially on `@freshlyCreated:true` traffic.
2. Watch for non-zero exit codes from mount/egress scripts via `service:front "GCS mount script exited with code"` and `"Egress setup script exited with code"`.
3. Build a Datadog dashboard from the per-phase `Ms` fields so we can iterate further.