### PR TITLE
[Branching] Copy processed file blobs when forking attachments

### DIFF
--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -206,6 +206,7 @@ async function carryOverFile(
   const copiedFile = await FileResource.copyToConversation(auth, {
     sourceId: attachment.fileId,
     conversationId: childConversationId,
+    includeProcessedVersion: true,
   });
 
   if (copiedFile.isErr()) {

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -3,6 +3,7 @@ import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";
+import { copyContent } from "@app/lib/utils/files";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -226,6 +227,11 @@ describe("FileResource", () => {
       expect(copiedFile.snippet).toBe("copied snippet");
       expect(copiedFile.useCaseMetadata?.conversationId).toBe("new-conv-id");
       expect(copiedFile.isReady).toBe(true);
+      const copyCall = vi.mocked(copyContent).mock.calls.at(-1);
+      expect(copyCall?.[0]).toBe(auth);
+      expect(copyCall?.[1].sId).toBe(sourceFile.sId);
+      expect(copyCall?.[2].sId).toBe(copiedFile.sId);
+      expect(copyCall?.[3]).toEqual({ includeProcessedVersion: undefined });
     });
 
     it("should return error when source file not found", async () => {
@@ -322,6 +328,11 @@ describe("FileResource", () => {
       expect(copiedFile.useCase).toBe("upsert_document");
       expect(copiedFile.useCaseMetadata?.spaceId).toBe("space-1");
       expect(copiedFile.useCaseMetadata?.conversationId).toBeUndefined();
+      const copyCall = vi.mocked(copyContent).mock.calls.at(-1);
+      expect(copyCall?.[0]).toBe(auth);
+      expect(copyCall?.[1].sId).toBe(sourceFile.sId);
+      expect(copyCall?.[2].sId).toBe(copiedFile.sId);
+      expect(copyCall?.[3]).toEqual({ includeProcessedVersion: undefined });
     });
 
     it("should copy a conversation file to a different conversation", async () => {
@@ -365,6 +376,40 @@ describe("FileResource", () => {
         sourceIcon: "github",
         hideFromUser: true,
       });
+      const copyCall = vi.mocked(copyContent).mock.calls.at(-1);
+      expect(copyCall?.[0]).toBe(auth);
+      expect(copyCall?.[1].sId).toBe(sourceFile.sId);
+      expect(copyCall?.[2].sId).toBe(copiedFile.sId);
+      expect(copyCall?.[3]).toEqual({ includeProcessedVersion: undefined });
+    });
+
+    it("should opt into processed version copying for conversation copies when requested", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const sourceFile = await FileFactory.create(auth, null, {
+        contentType: "application/pdf",
+        fileName: "source.pdf",
+        fileSize: testFileContent.length,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "parent-conv-id" },
+      });
+
+      const result = await FileResource.copyToConversation(auth, {
+        sourceId: sourceFile.sId,
+        conversationId: "child-conv-id",
+        includeProcessedVersion: true,
+      });
+
+      assert(result.isOk(), "copyToConversation should succeed");
+
+      const copyCall = vi.mocked(copyContent).mock.calls.at(-1);
+      expect(copyCall?.[0]).toBe(auth);
+      expect(copyCall?.[1].sId).toBe(sourceFile.sId);
+      expect(copyCall?.[2].sId).toBe(result.value.sId);
+      expect(copyCall?.[3]).toEqual({ includeProcessedVersion: true });
     });
 
     it("should preserve tool_output use case when copying to a conversation", async () => {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1478,10 +1478,12 @@ export class FileResource extends BaseResource<FileModel> {
       sourceId,
       useCase,
       useCaseMetadata,
+      includeProcessedVersion,
     }: {
       sourceId: string;
       useCase: FileUseCase;
       useCaseMetadata?: FileUseCaseMetadata;
+      includeProcessedVersion?: boolean;
     }
   ): Promise<
     Result<
@@ -1507,7 +1509,9 @@ export class FileResource extends BaseResource<FileModel> {
         snippet: sourceFile.snippet,
       });
 
-      await copyContent(auth, sourceFile, newFile);
+      await copyContent(auth, sourceFile, newFile, {
+        includeProcessedVersion,
+      });
       await newFile.markAsReady(auth);
 
       return new Ok(newFile);
@@ -1521,9 +1525,11 @@ export class FileResource extends BaseResource<FileModel> {
     {
       sourceId,
       conversationId,
+      includeProcessedVersion,
     }: {
       sourceId: string;
       conversationId: string;
+      includeProcessedVersion?: boolean;
     }
   ): Promise<
     Result<
@@ -1559,6 +1565,7 @@ export class FileResource extends BaseResource<FileModel> {
         ...restMetadata,
         conversationId,
       },
+      includeProcessedVersion,
     });
   }
 }

--- a/front/lib/utils/files.test.ts
+++ b/front/lib/utils/files.test.ts
@@ -1,0 +1,111 @@
+import type { Authenticator } from "@app/lib/auth";
+import { copyContent } from "@app/lib/utils/files";
+import type { AllSupportedFileContentType } from "@app/types/files";
+import { Readable, Writable } from "stream";
+import { describe, expect, it, vi } from "vitest";
+
+type FileVersion = "original" | "processed";
+
+function makeWritable(chunks: Buffer[]) {
+  return new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      callback();
+    },
+  });
+}
+
+function makeSourceFile(contentType: AllSupportedFileContentType) {
+  const originalContent = Buffer.from("original-content");
+  const processedContent = Buffer.from("processed-content");
+
+  return {
+    contentType,
+    originalContent,
+    processedContent,
+    getReadStream: vi.fn(
+      ({ version }: { auth: Authenticator; version: FileVersion }) =>
+        Readable.from([
+          version === "original" ? originalContent : processedContent,
+        ])
+    ),
+  };
+}
+
+describe("copyContent", () => {
+  it("copies only the original version for files without processing", async () => {
+    const auth = {} as Authenticator;
+    const originalChunks: Buffer[] = [];
+    const processedChunks: Buffer[] = [];
+    const sourceFile = makeSourceFile("text/plain");
+    const targetFile = {
+      getWriteStream: vi.fn(
+        ({ version }: { auth: Authenticator; version: FileVersion }) =>
+          version === "original"
+            ? makeWritable(originalChunks)
+            : makeWritable(processedChunks)
+      ),
+    };
+
+    await copyContent(
+      auth,
+      sourceFile as unknown as Parameters<typeof copyContent>[1],
+      targetFile as unknown as Parameters<typeof copyContent>[2]
+    );
+
+    expect(sourceFile.getReadStream).toHaveBeenCalledTimes(1);
+    expect(sourceFile.getReadStream).toHaveBeenCalledWith({
+      auth,
+      version: "original",
+    });
+    expect(targetFile.getWriteStream).toHaveBeenCalledTimes(1);
+    expect(targetFile.getWriteStream).toHaveBeenCalledWith({
+      auth,
+      version: "original",
+    });
+    expect(Buffer.concat(originalChunks)).toEqual(sourceFile.originalContent);
+    expect(processedChunks).toHaveLength(0);
+  });
+
+  it("copies both original and processed versions for processed files", async () => {
+    const auth = {} as Authenticator;
+    const originalChunks: Buffer[] = [];
+    const processedChunks: Buffer[] = [];
+    const sourceFile = makeSourceFile("application/pdf");
+    const targetFile = {
+      getWriteStream: vi.fn(
+        ({ version }: { auth: Authenticator; version: FileVersion }) =>
+          version === "original"
+            ? makeWritable(originalChunks)
+            : makeWritable(processedChunks)
+      ),
+    };
+
+    await copyContent(
+      auth,
+      sourceFile as unknown as Parameters<typeof copyContent>[1],
+      targetFile as unknown as Parameters<typeof copyContent>[2]
+    );
+
+    expect(sourceFile.getReadStream).toHaveBeenCalledTimes(2);
+    expect(sourceFile.getReadStream).toHaveBeenNthCalledWith(1, {
+      auth,
+      version: "original",
+    });
+    expect(sourceFile.getReadStream).toHaveBeenNthCalledWith(2, {
+      auth,
+      version: "processed",
+    });
+    expect(targetFile.getWriteStream).toHaveBeenCalledTimes(2);
+    expect(targetFile.getWriteStream).toHaveBeenNthCalledWith(1, {
+      auth,
+      version: "original",
+    });
+    expect(targetFile.getWriteStream).toHaveBeenNthCalledWith(2, {
+      auth,
+      version: "processed",
+    });
+    expect(Buffer.concat(originalChunks)).toEqual(sourceFile.originalContent);
+    expect(Buffer.concat(processedChunks)).toEqual(sourceFile.processedContent);
+  });
+});

--- a/front/lib/utils/files.test.ts
+++ b/front/lib/utils/files.test.ts
@@ -79,7 +79,7 @@ describe("copyContent", () => {
     expect(processedChunks).toHaveLength(0);
   });
 
-  it("copies both original and processed versions for processed files", async () => {
+  it("copies only the original version for processed files by default", async () => {
     const auth = {} as Authenticator;
     const originalChunks: Buffer[] = [];
     const processedChunks: Buffer[] = [];
@@ -103,6 +103,47 @@ describe("copyContent", () => {
       auth,
       sourceFile as unknown as Parameters<typeof copyContent>[1],
       targetFile as unknown as Parameters<typeof copyContent>[2]
+    );
+
+    expect(sourceFile.getReadStream).toHaveBeenCalledTimes(1);
+    expect(sourceFile.getReadStream).toHaveBeenCalledWith({
+      auth,
+      version: "original",
+    });
+    expect(targetFile.getWriteStream).toHaveBeenCalledTimes(1);
+    expect(targetFile.getWriteStream).toHaveBeenCalledWith({
+      auth,
+      version: "original",
+    });
+    expect(Buffer.concat(originalChunks)).toEqual(sourceFile.originalContent);
+    expect(processedChunks).toHaveLength(0);
+  });
+
+  it("copies both original and processed versions when requested", async () => {
+    const auth = {} as Authenticator;
+    const originalChunks: Buffer[] = [];
+    const processedChunks: Buffer[] = [];
+    const sourceFile = makeSourceFile("application/pdf");
+    const targetFile = {
+      getWriteStream: vi.fn(
+        ({
+          version,
+        }: {
+          auth: Authenticator;
+          version: FileVersion;
+          overrideContentType?: string;
+        }) =>
+          version === "original"
+            ? makeWritable(originalChunks)
+            : makeWritable(processedChunks)
+      ),
+    };
+
+    await copyContent(
+      auth,
+      sourceFile as unknown as Parameters<typeof copyContent>[1],
+      targetFile as unknown as Parameters<typeof copyContent>[2],
+      { includeProcessedVersion: true }
     );
 
     expect(sourceFile.getReadStream).toHaveBeenCalledTimes(2);

--- a/front/lib/utils/files.test.ts
+++ b/front/lib/utils/files.test.ts
@@ -1,3 +1,4 @@
+import { getProcessedContentType } from "@app/lib/api/files/processing";
 import type { Authenticator } from "@app/lib/auth";
 import { copyContent } from "@app/lib/utils/files";
 import type { AllSupportedFileContentType } from "@app/types/files";
@@ -29,6 +30,11 @@ function makeSourceFile(contentType: AllSupportedFileContentType) {
           version === "original" ? originalContent : processedContent,
         ])
     ),
+  } satisfies {
+    contentType: AllSupportedFileContentType;
+    originalContent: Buffer;
+    processedContent: Buffer;
+    getReadStream: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -40,7 +46,13 @@ describe("copyContent", () => {
     const sourceFile = makeSourceFile("text/plain");
     const targetFile = {
       getWriteStream: vi.fn(
-        ({ version }: { auth: Authenticator; version: FileVersion }) =>
+        ({
+          version,
+        }: {
+          auth: Authenticator;
+          version: FileVersion;
+          overrideContentType?: string;
+        }) =>
           version === "original"
             ? makeWritable(originalChunks)
             : makeWritable(processedChunks)
@@ -74,7 +86,13 @@ describe("copyContent", () => {
     const sourceFile = makeSourceFile("application/pdf");
     const targetFile = {
       getWriteStream: vi.fn(
-        ({ version }: { auth: Authenticator; version: FileVersion }) =>
+        ({
+          version,
+        }: {
+          auth: Authenticator;
+          version: FileVersion;
+          overrideContentType?: string;
+        }) =>
           version === "original"
             ? makeWritable(originalChunks)
             : makeWritable(processedChunks)
@@ -104,6 +122,7 @@ describe("copyContent", () => {
     expect(targetFile.getWriteStream).toHaveBeenNthCalledWith(2, {
       auth,
       version: "processed",
+      overrideContentType: getProcessedContentType(sourceFile.contentType),
     });
     expect(Buffer.concat(originalChunks)).toEqual(sourceFile.originalContent);
     expect(Buffer.concat(processedChunks)).toEqual(sourceFile.processedContent);

--- a/front/lib/utils/files.ts
+++ b/front/lib/utils/files.ts
@@ -1,6 +1,10 @@
-import { hasProcessedVersion } from "@app/lib/api/files/processing";
+import {
+  getProcessedContentType,
+  hasProcessedVersion,
+} from "@app/lib/api/files/processing";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
+import assert from "assert";
 import { pipeline } from "stream/promises";
 
 export async function copyContent(
@@ -24,8 +28,15 @@ export async function copyContent(
     return;
   }
 
+  const processedContentType = getProcessedContentType(sourceFile.contentType);
+  assert(processedContentType);
+
   await pipeline(
     sourceFile.getReadStream({ auth, version: "processed" }),
-    targetFile.getWriteStream({ auth, version: "processed" })
+    targetFile.getWriteStream({
+      auth,
+      version: "processed",
+      overrideContentType: processedContentType,
+    })
   );
 }

--- a/front/lib/utils/files.ts
+++ b/front/lib/utils/files.ts
@@ -1,3 +1,4 @@
+import { hasProcessedVersion } from "@app/lib/api/files/processing";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { pipeline } from "stream/promises";
@@ -17,5 +18,14 @@ export async function copyContent(
   await pipeline(
     readStream,
     targetFile.getWriteStream({ auth, version: "original" })
+  );
+
+  if (!hasProcessedVersion(sourceFile.contentType)) {
+    return;
+  }
+
+  await pipeline(
+    sourceFile.getReadStream({ auth, version: "processed" }),
+    targetFile.getWriteStream({ auth, version: "processed" })
   );
 }

--- a/front/lib/utils/files.ts
+++ b/front/lib/utils/files.ts
@@ -10,7 +10,10 @@ import { pipeline } from "stream/promises";
 export async function copyContent(
   auth: Authenticator,
   sourceFile: FileResource,
-  targetFile: FileResource
+  targetFile: FileResource,
+  {
+    includeProcessedVersion = false,
+  }: { includeProcessedVersion?: boolean } = {}
 ) {
   // Get a read stream from the source file's original version.
   const readStream = sourceFile.getReadStream({
@@ -24,7 +27,10 @@ export async function copyContent(
     targetFile.getWriteStream({ auth, version: "original" })
   );
 
-  if (!hasProcessedVersion(sourceFile.contentType)) {
+  if (
+    !includeProcessedVersion ||
+    !hasProcessedVersion(sourceFile.contentType)
+  ) {
     return;
   }
 


### PR DESCRIPTION
## Description
Fixes regression in https://github.com/dust-tt/dust/pull/24727.

Forked conversation attachments need the canonical `processed` blob for file types like PDFs, because the copied file is marked ready and then materializes both `original` and `processed` into its mount path. This change keeps processed-blob copying explicit: `copyContent()` only duplicates the processed blob when the caller opts in, and fork attachment carryover is the path that now enables it.

When the processed blob is copied, the processed content type metadata is preserved so downstream mount-path copies and signed downloads stay consistent with the original processed upload path.

## Risks
Blast radius: file duplication paths that rely on `copyContent()`, with forked conversation attachment carryover explicitly opting into processed copies.
Risk: low

## Deploy Plan
- pmrr
- deploy front
