### PR TITLE
[Sessions] Keep branching UX in place

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -140,7 +140,9 @@ interface ConversationMenuProps {
   conversation?: ConversationListItemType;
   onConversationBranched?: () => Promise<void> | void;
   owner: WorkspaceType;
-  trigger: ({ isBranching }: { isBranching: boolean }) => ReactElement;
+  trigger:
+    | ReactElement
+    | (({ isPendingAction }: { isPendingAction: boolean }) => ReactElement);
   isConversationDisplayed: boolean;
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
@@ -281,7 +283,10 @@ export function ConversationMenu({
     conversationId: activeConversationId,
     onConversationBranched: handleConversationBranched,
   });
-  const menuTrigger = trigger({ isBranching });
+  const menuTrigger =
+    typeof trigger === "function"
+      ? trigger({ isPendingAction: isBranching })
+      : trigger;
 
   const conversationLink = getConversationRoute(
     owner.sId,

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -140,7 +140,7 @@ interface ConversationMenuProps {
   conversation?: ConversationListItemType;
   onConversationBranched?: () => Promise<void> | void;
   owner: WorkspaceType;
-  trigger: ReactElement;
+  trigger: ({ isBranching }: { isBranching: boolean }) => ReactElement;
   isConversationDisplayed: boolean;
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
@@ -281,6 +281,7 @@ export function ConversationMenu({
     conversationId: activeConversationId,
     onConversationBranched: handleConversationBranched,
   });
+  const menuTrigger = trigger({ isBranching });
 
   const conversationLink = getConversationRoute(
     owner.sId,
@@ -378,7 +379,7 @@ export function ConversationMenu({
       <DropdownMenu modal={false} open={isOpen} onOpenChange={onOpenChange}>
         {triggerPosition ? (
           <>
-            {trigger}
+            {menuTrigger}
             <DropdownMenuTrigger asChild>
               <div
                 style={{
@@ -393,7 +394,7 @@ export function ConversationMenu({
             </DropdownMenuTrigger>
           </>
         ) : (
-          <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+          <DropdownMenuTrigger asChild>{menuTrigger}</DropdownMenuTrigger>
         )}
         <DropdownMenuContent onFocusOutside={(e) => e.preventDefault()}>
           <DropdownMenuItem

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -4,6 +4,7 @@ import { LeaveConversationDialog } from "@app/components/assistant/conversation/
 import { ConfirmContext } from "@app/components/Confirm";
 import {
   useBranchConversation,
+  useConversation,
   useConversationParticipants,
   useConversationParticipationOptions,
   useConversationUrlAccessMode,
@@ -214,6 +215,11 @@ export function ConversationMenu({
 
   const shouldWaitBeforeFetching =
     activeConversationId === null || user?.sId === undefined || !isOpen;
+  const { mutateConversation } = useConversation({
+    conversationId: isConversationDisplayed ? activeConversationId : null,
+    workspaceId: owner.sId,
+    options: { disabled: !isConversationDisplayed },
+  });
   const conversationParticipationOptions = useConversationParticipationOptions({
     ownerId: owner.sId,
     conversationId: activeConversationId,
@@ -263,10 +269,17 @@ export function ConversationMenu({
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
   const [showLeaveDialog, setShowLeaveDialog] = useState<boolean>(false);
   const [showRenameDialog, setShowRenameDialog] = useState<boolean>(false);
+  const handleConversationBranched = useCallback(() => {
+    if (isConversationDisplayed) {
+      void mutateConversation();
+    }
+
+    void onConversationBranched?.();
+  }, [isConversationDisplayed, mutateConversation, onConversationBranched]);
   const { branchConversation, isBranching } = useBranchConversation({
     owner,
     conversationId: activeConversationId,
-    onConversationBranched,
+    onConversationBranched: handleConversationBranched,
   });
 
   const conversationLink = getConversationRoute(

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -160,18 +160,18 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
             conversation={conversation}
             onConversationBranched={onConversationBranched}
             owner={owner}
-            trigger={({ isBranching }) => (
+            trigger={({ isPendingAction }) => (
               <Button
                 size="sm"
                 variant="ghost"
                 icon={MoreIcon}
                 aria-label="Conversation menu"
-                isLoading={isBranching}
+                isLoading={isPendingAction}
                 disabled={
                   activeConversationId === null ||
                   conversation === null ||
                   user === null ||
-                  isBranching
+                  isPendingAction
                 }
               />
             )}

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -160,19 +160,21 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
             conversation={conversation}
             onConversationBranched={onConversationBranched}
             owner={owner}
-            trigger={
+            trigger={({ isBranching }) => (
               <Button
                 size="sm"
                 variant="ghost"
                 icon={MoreIcon}
                 aria-label="Conversation menu"
+                isLoading={isBranching}
                 disabled={
                   activeConversationId === null ||
                   conversation === null ||
-                  user === null
+                  user === null ||
+                  isBranching
                 }
               />
-            }
+            )}
             isConversationDisplayed={true}
             isOpen={isMenuOpen}
             onOpenChange={handleMenuOpenChange}

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -4,7 +4,7 @@ import {
 } from "@app/components/assistant/conversation/ConversationMenu";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { useConversation } from "@app/hooks/conversations";
+import { useConversation, useConversations } from "@app/hooks/conversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
@@ -24,7 +24,7 @@ import {
   MoreIcon,
   Tooltip,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { EditConversationTitleDialog } from "./EditConversationTitleDialog";
 
@@ -40,6 +40,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     workspaceId: owner.sId,
     spaceId: conversation?.spaceId ?? null,
   });
+  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
   const router = useAppRouter();
   const isMobile = useIsMobile();
 
@@ -51,6 +52,9 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     handleRightClick,
     handleMenuOpenChange,
   } = useConversationMenu();
+  const onConversationBranched = useCallback(() => {
+    void mutateConversations();
+  }, [mutateConversations]);
 
   const currentTitle = conversation
     ? getConversationDisplayTitle(conversation)
@@ -154,6 +158,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
           <ConversationMenu
             activeConversationId={activeConversationId}
             conversation={conversation}
+            onConversationBranched={onConversationBranched}
             owner={owner}
             trigger={
               <Button

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1032,8 +1032,9 @@ export const ConversationViewer = ({
     : undefined;
 
   const onConversationBranched = useCallback(() => {
+    void mutateConversation();
     void mutateConversations();
-  }, [mutateConversations]);
+  }, [mutateConversation, mutateConversations]);
 
   // After reversal in the hook, messages[0] is the oldest page. This only
   // returns the actual first conversation message when all pages are loaded

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1285,7 +1285,7 @@ const ConversationListItem = memo(
             conversation={conversation}
             onConversationBranched={onConversationBranched}
             owner={owner}
-            trigger={<NavigationListItemAction />}
+            trigger={() => <NavigationListItemAction />}
             isConversationDisplayed={activeConversationId === conversation.sId}
             isOpen={isMenuOpen}
             onOpenChange={handleMenuOpenChange}

--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -4,8 +4,10 @@ import { getErrorFromResponse } from "@app/lib/swr/swr";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useEffect, useState } from "react";
 
-const CONVERSATION_BRANCHING_CURSOR_CLASSNAME =
-  "conversation-branching-in-progress";
+const CONVERSATION_BRANCHING_CURSOR_CLASSES = [
+  "!cursor-progress",
+  "[&_*]:!cursor-progress",
+];
 
 export function useBranchConversation({
   owner,
@@ -25,10 +27,10 @@ export function useBranchConversation({
       return;
     }
 
-    document.body.classList.add(CONVERSATION_BRANCHING_CURSOR_CLASSNAME);
+    document.body.classList.add(...CONVERSATION_BRANCHING_CURSOR_CLASSES);
 
     return () => {
-      document.body.classList.remove(CONVERSATION_BRANCHING_CURSOR_CLASSNAME);
+      document.body.classList.remove(...CONVERSATION_BRANCHING_CURSOR_CLASSES);
     };
   }, [isBranching]);
 

--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -2,12 +2,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback, useEffect, useState } from "react";
-
-const CONVERSATION_BRANCHING_CURSOR_CLASSES = [
-  "!cursor-progress",
-  "[&_*]:!cursor-progress",
-];
+import { useCallback, useState } from "react";
 
 export function useBranchConversation({
   owner,
@@ -21,18 +16,6 @@ export function useBranchConversation({
   const sendNotification = useSendNotification();
 
   const [isBranching, setIsBranching] = useState(false);
-
-  useEffect(() => {
-    if (!isBranching) {
-      return;
-    }
-
-    document.body.classList.add(...CONVERSATION_BRANCHING_CURSOR_CLASSES);
-
-    return () => {
-      document.body.classList.remove(...CONVERSATION_BRANCHING_CURSOR_CLASSES);
-    };
-  }, [isBranching]);
 
   const branchConversation = useCallback(
     async (sourceMessageId?: string): Promise<boolean> => {

--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -1,11 +1,11 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { useAppRouter } from "@app/lib/platform";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
-import { getConversationRoute } from "@app/lib/utils/router";
-import type { PostConversationForkResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/forks";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+const CONVERSATION_BRANCHING_CURSOR_CLASSNAME =
+  "conversation-branching-in-progress";
 
 export function useBranchConversation({
   owner,
@@ -17,9 +17,20 @@ export function useBranchConversation({
   onConversationBranched?: () => Promise<void> | void;
 }) {
   const sendNotification = useSendNotification();
-  const router = useAppRouter();
 
   const [isBranching, setIsBranching] = useState(false);
+
+  useEffect(() => {
+    if (!isBranching) {
+      return;
+    }
+
+    document.body.classList.add(CONVERSATION_BRANCHING_CURSOR_CLASSNAME);
+
+    return () => {
+      document.body.classList.remove(CONVERSATION_BRANCHING_CURSOR_CLASSNAME);
+    };
+  }, [isBranching]);
 
   const branchConversation = useCallback(
     async (sourceMessageId?: string): Promise<boolean> => {
@@ -55,19 +66,9 @@ export function useBranchConversation({
           return false;
         }
 
-        const {
-          conversationId: forkedConversationId,
-        }: PostConversationForkResponseBody = await res.json();
+        await res.json();
 
         void onConversationBranched?.();
-
-        await router.push(
-          getConversationRoute(owner.sId, forkedConversationId),
-          undefined,
-          {
-            shallow: true,
-          }
-        );
 
         return true;
       } catch {
@@ -81,13 +82,7 @@ export function useBranchConversation({
         setIsBranching(false);
       }
     },
-    [
-      conversationId,
-      onConversationBranched,
-      owner.sId,
-      router,
-      sendNotification,
-    ]
+    [conversationId, onConversationBranched, sendNotification, owner.sId]
   );
 
   return {

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -50,6 +50,11 @@ body {
   overflow-x: hidden;
 }
 
+.conversation-branching-in-progress,
+.conversation-branching-in-progress * {
+  cursor: progress !important;
+}
+
 #__next {
   @apply h-full;
 }

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -50,11 +50,6 @@ body {
   overflow-x: hidden;
 }
 
-.conversation-branching-in-progress,
-.conversation-branching-in-progress * {
-  cursor: progress !important;
-}
-
 #__next {
   @apply h-full;
 }


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24178 and https://github.com/dust-tt/dust/pull/24419.

Stays on the current conversation instead of redirecting to the child when branching; shows a spinner while the `/forks` request is pending, and revalidates the active conversation data when the fork returns so the parent-side fork notice appears in place. 

On below screenshots: 1. the spinner appears instead of menu (top right), 2. The fork notice appears (top of input bar) + the branched convo is on the sidebar

<img width="1695" height="1180" alt="image" src="https://github.com/user-attachments/assets/ff46c2a2-a3c9-4b4f-9164-90cf35ad1eb1" />

<img width="1695" height="1180" alt="image" src="https://github.com/user-attachments/assets/3615e662-31b4-46aa-9ba1-4451c4598a7b" />


## Risks
Blast radius: branch conversation actions in the conversation menu, title bar menu, and per-message menu in `front`
Risk: low

## Deploy Plan
- pmrr
- deploy front
