### PR TITLE
Fix: allow access to conversation when using api keys or internal, or sub conversation, even if private conversation restriction is on.

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -64,14 +64,12 @@ const DUST_INTERNAL_EMAIL_REGEXP = /^[^@]+@dust\.tt$/;
 
 const DustApiKeyNameHeader = "x-dust-api-key-name";
 
-const SANDBOX_TOKEN_AUTH_METHOD = "sandbox_token" as const;
-
 export type AuthMethodType =
   | "system_api_key"
   | "api_key"
   | "oauth"
   | "session"
-  | typeof SANDBOX_TOKEN_AUTH_METHOD
+  | "sandbox_token"
   | "internal";
 
 export const isSandboxTokenPrefix = (token: string): boolean =>
@@ -540,7 +538,7 @@ export class Authenticator {
 
     return new Ok(
       new Authenticator({
-        authMethod: SANDBOX_TOKEN_AUTH_METHOD,
+        authMethod: "sandbox_token",
         workspace,
         user,
         role: authData.role,
@@ -960,7 +958,7 @@ export class Authenticator {
   }
 
   isSandboxToken(): boolean {
-    return this._authMethod === SANDBOX_TOKEN_AUTH_METHOD;
+    return this._authMethod === "sandbox_token";
   }
 
   authMethod(): AuthMethodType {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1453,18 +1453,50 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     expect(conversationIds).not.toContain(tempSpaceConvo.sId);
   });
 
-  it.skip("should require user participation when private conversation URLs are private by default (including admins)", async () => {
+  it("should bypass participant restriction for internal auth when private conversation URLs are private by default", async () => {
     const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
       privateConversationUrlsByDefault: true,
     });
     assert(updateResult.isOk(), "Failed to enable private conversation URLs");
 
-    const refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      userAuth.getNonNullableUser().sId,
-      workspace.sId
-    );
     const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
       adminAuth.getNonNullableUser().sId,
+      workspace.sId
+    );
+    expect(refreshedAdminAuth.authMethod()).toBe("internal");
+
+    const participantRequiredConversation = await ConversationFactory.create(
+      refreshedAdminAuth,
+      {
+        agentConfigurationId: agents[0].sId,
+        requestedSpaceIds: [globalSpace.id],
+        messagesCreatedAt: [dateFromDaysAgo(2)],
+      }
+    );
+
+    const internalAdminConversations =
+      await ConversationResource.listAll(refreshedAdminAuth);
+    expect(internalAdminConversations.map((c) => c.sId)).toContain(
+      participantRequiredConversation.sId
+    );
+  });
+
+  it.each([
+    ["session"],
+    ["oauth"],
+    ["sandbox_token"],
+  ] as const)("should require participation for %s auth when private conversation URLs are private by default", async (authMethod) => {
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+    const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminAuth.getNonNullableUser().sId,
+      workspace.sId
+    );
+    const refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      userAuth.getNonNullableUser().sId,
       workspace.sId
     );
 
@@ -1477,28 +1509,130 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
       }
     );
 
-    const initialUserConversations =
-      await ConversationResource.listAll(refreshedUserAuth);
-    expect(initialUserConversations.map((c) => c.sId)).not.toContain(
+    const sessionUser = refreshedUserAuth.getNonNullableUser();
+    assert(
+      sessionUser.workOSUserId,
+      "Expected regular user to have a WorkOS user ID"
+    );
+    const userSessionAuth = await Authenticator.fromSession(
+      {
+        type: "workos",
+        sessionId: "test-session-id-user",
+        user: {
+          workOSUserId: sessionUser.workOSUserId,
+          email: sessionUser.email ?? "user@dust.tt",
+          email_verified: true,
+          name: sessionUser.username ?? "user",
+          nickname: sessionUser.username ?? "user",
+        },
+        authenticationMethod: "GoogleOAuth",
+        isSSO: false,
+        workspaceId: workspace.sId,
+        organizationId: workspace.workOSOrganizationId ?? undefined,
+        region: "us-central1",
+      },
+      workspace.sId
+    );
+
+    const userSandboxAuthRes = await Authenticator.fromSandboxToken(
+      {
+        wId: workspace.sId,
+        cId: participantRequiredConversation.sId,
+        uId: sessionUser.sId,
+        aId: agents[0].sId,
+        mId: "test-message-id-user",
+        sbId: "test-sandbox-id-user",
+        execId: "test-exec-id-user",
+      },
+      workspace.sId
+    );
+    assert(
+      userSandboxAuthRes.isOk(),
+      "Failed to create sandbox authenticator for regular user"
+    );
+
+    const userAuthForMethod =
+      authMethod === "sandbox_token"
+        ? userSandboxAuthRes.value
+        : userSessionAuth;
+    if (authMethod === "oauth") {
+      vi.spyOn(userAuthForMethod, "authMethod").mockReturnValue("oauth");
+    }
+    expect(userAuthForMethod.authMethod()).toBe(authMethod);
+
+    const nonParticipantUserConversations =
+      await ConversationResource.listAll(userAuthForMethod);
+    expect(nonParticipantUserConversations.map((c) => c.sId)).not.toContain(
       participantRequiredConversation.sId
     );
 
-    await ConversationResource.upsertParticipation(refreshedUserAuth, {
+    await ConversationResource.upsertParticipation(userAuthForMethod, {
       conversation: participantRequiredConversation,
       action: "posted",
-      user: refreshedUserAuth.getNonNullableUser().toJSON(),
+      user: userAuthForMethod.getNonNullableUser().toJSON(),
       lastReadAt: null,
     });
 
     const participantUserConversations =
-      await ConversationResource.listAll(refreshedUserAuth);
+      await ConversationResource.listAll(userAuthForMethod);
     expect(participantUserConversations.map((c) => c.sId)).toContain(
       participantRequiredConversation.sId
     );
 
-    const adminConversations =
-      await ConversationResource.listAll(refreshedAdminAuth);
-    expect(adminConversations.map((c) => c.sId)).not.toContain(
+    const sessionAdminUser = refreshedAdminAuth.getNonNullableUser();
+    assert(
+      sessionAdminUser.workOSUserId,
+      "Expected admin user to have a WorkOS user ID"
+    );
+    const adminSessionAuth = await Authenticator.fromSession(
+      {
+        type: "workos",
+        sessionId: "test-session-id-admin",
+        user: {
+          workOSUserId: sessionAdminUser.workOSUserId,
+          email: sessionAdminUser.email ?? "admin@dust.tt",
+          email_verified: true,
+          name: sessionAdminUser.username ?? "admin",
+          nickname: sessionAdminUser.username ?? "admin",
+        },
+        authenticationMethod: "GoogleOAuth",
+        isSSO: false,
+        workspaceId: workspace.sId,
+        organizationId: workspace.workOSOrganizationId ?? undefined,
+        region: "us-central1",
+      },
+      workspace.sId
+    );
+
+    const adminSandboxAuthRes = await Authenticator.fromSandboxToken(
+      {
+        wId: workspace.sId,
+        cId: participantRequiredConversation.sId,
+        uId: sessionAdminUser.sId,
+        aId: agents[0].sId,
+        mId: "test-message-id-admin",
+        sbId: "test-sandbox-id-admin",
+        execId: "test-exec-id-admin",
+      },
+      workspace.sId
+    );
+    assert(
+      adminSandboxAuthRes.isOk(),
+      "Failed to create sandbox authenticator for admin user"
+    );
+
+    const adminAuthForMethod =
+      authMethod === "sandbox_token"
+        ? adminSandboxAuthRes.value
+        : adminSessionAuth;
+    if (authMethod === "oauth") {
+      vi.spyOn(adminAuthForMethod, "authMethod").mockReturnValue("oauth");
+    }
+    expect(adminAuthForMethod.authMethod()).toBe(authMethod);
+
+    const nonParticipantAdminConversations =
+      await ConversationResource.listAll(adminAuthForMethod);
+    expect(nonParticipantAdminConversations.map((c) => c.sId)).not.toContain(
       participantRequiredConversation.sId
     );
   });
@@ -1528,6 +1662,131 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
     );
     expect(fetched).not.toBeNull();
     expect(fetched?.sId).toBe(conversation.sId);
+  });
+
+  it("should keep project conversations accessible for oauth auth when private conversation URLs are private by default", async () => {
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+    const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminAuth.getNonNullableUser().sId,
+      workspace.sId
+    );
+    const refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      userAuth.getNonNullableUser().sId,
+      workspace.sId
+    );
+
+    const projectSpace = await SpaceFactory.project(
+      workspace,
+      refreshedAdminAuth.getNonNullableUser().id
+    );
+    const addMemberResult = await projectSpace.addMembers(refreshedAdminAuth, {
+      userIds: [
+        refreshedAdminAuth.getNonNullableUser().sId,
+        refreshedUserAuth.getNonNullableUser().sId,
+      ],
+    });
+    assert(addMemberResult.isOk(), "Failed to add users to project space");
+
+    const refreshedProjectAdminAuth =
+      await Authenticator.fromUserIdAndWorkspaceId(
+        refreshedAdminAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+    const refreshedProjectReaderAuth =
+      await Authenticator.fromUserIdAndWorkspaceId(
+        refreshedUserAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+    vi.spyOn(refreshedProjectReaderAuth, "authMethod").mockReturnValue("oauth");
+
+    const projectConversation = await ConversationFactory.create(
+      refreshedProjectAdminAuth,
+      {
+        agentConfigurationId: agents[0].sId,
+        requestedSpaceIds: [projectSpace.id],
+        spaceId: projectSpace.id,
+        messagesCreatedAt: [dateFromDaysAgo(2)],
+      }
+    );
+
+    const oauthConversations = await ConversationResource.listAll(
+      refreshedProjectReaderAuth
+    );
+    expect(oauthConversations.map((c) => c.sId)).toContain(
+      projectConversation.sId
+    );
+  });
+
+  it("should keep sub-conversations accessible for session auth when private conversation URLs are private by default", async () => {
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+    const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminAuth.getNonNullableUser().sId,
+      workspace.sId
+    );
+    const refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      userAuth.getNonNullableUser().sId,
+      workspace.sId
+    );
+    const sessionUser = refreshedUserAuth.getNonNullableUser();
+    assert(
+      sessionUser.workOSUserId,
+      "Expected regular user to have a WorkOS user ID"
+    );
+
+    const userSessionAuth = await Authenticator.fromSession(
+      {
+        type: "workos",
+        sessionId: "test-session-id-subconversation",
+        user: {
+          workOSUserId: sessionUser.workOSUserId,
+          email: sessionUser.email ?? "user@dust.tt",
+          email_verified: true,
+          name: sessionUser.username ?? "user",
+          nickname: sessionUser.username ?? "user",
+        },
+        authenticationMethod: "GoogleOAuth",
+        isSSO: false,
+        workspaceId: workspace.sId,
+        organizationId: workspace.workOSOrganizationId ?? undefined,
+        region: "us-central1",
+      },
+      workspace.sId
+    );
+
+    const subConversation = await ConversationFactory.create(
+      refreshedAdminAuth,
+      {
+        agentConfigurationId: agents[0].sId,
+        requestedSpaceIds: [globalSpace.id],
+        messagesCreatedAt: [dateFromDaysAgo(2)],
+      }
+    );
+
+    await ConversationModel.update(
+      {
+        depth: 1,
+      },
+      {
+        where: {
+          workspaceId: workspace.id,
+          sId: subConversation.sId,
+        },
+      }
+    );
+
+    const sessionConversations =
+      await ConversationResource.listAll(userSessionAuth);
+    expect(sessionConversations.map((c) => c.sId)).toContain(
+      subConversation.sId
+    );
   });
 });
 
@@ -3501,7 +3760,7 @@ describe("Space Handling", () => {
       expect(result).toBe("allowed");
     });
 
-    it("should return 'conversation_access_restricted' for non-participants when private conversation URLs are private by default", async () => {
+    it("should keep space conversations accessible to non-participants when private conversation URLs are private by default", async () => {
       const updateResult = await WorkspaceResource.updateMetadata(
         workspace.id,
         {
@@ -3520,9 +3779,7 @@ describe("Space Handling", () => {
         conversations.accessible
       );
 
-      expect(result).toBe(
-        "conversation_access_restricted_by_private_by_default_url_restriction"
-      );
+      expect(result).toBe("allowed");
     });
 
     it("should return 'allowed' for non-participants when URL access mode is workspace_members", async () => {
@@ -3684,7 +3941,7 @@ describe("Space Handling", () => {
       expect(result).toBe("conversation_access_restricted");
     });
 
-    it("should restrict admin access when private conversation URLs are private by default and admin is not a participant", async () => {
+    it("should keep space conversations accessible to admins when private conversation URLs are private by default and they are not participants", async () => {
       const updateResult = await WorkspaceResource.updateMetadata(
         workspace.id,
         {
@@ -3703,9 +3960,7 @@ describe("Space Handling", () => {
         conversations.accessible
       );
 
-      expect(result).toBe(
-        "conversation_access_restricted_by_private_by_default_url_restriction"
-      );
+      expect(result).toBe("allowed");
     });
 
     it("should restore previous behavior when private conversation URLs are disabled again", async () => {
@@ -3723,9 +3978,7 @@ describe("Space Handling", () => {
         refreshedUserAuth,
         conversations.accessible
       );
-      expect(result).toBe(
-        "conversation_access_restricted_by_private_by_default_url_restriction"
-      );
+      expect(result).toBe("allowed");
 
       updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
         privateConversationUrlsByDefault: false,

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -53,6 +53,7 @@ import {
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { UserType } from "@app/types/user";
 import assert from "assert";
@@ -84,6 +85,23 @@ export type ConversationAccessType =
   | "conversation_not_found"
   | "conversation_access_restricted"
   | "conversation_access_restricted_by_private_by_default_url_restriction";
+
+const shouldByPassPrivateByDefaultUrlRestriction = (auth: Authenticator) => {
+  const authMethod = auth.authMethod();
+  switch (authMethod) {
+    case "api_key":
+    case "system_api_key":
+    case "internal":
+      // Support api key and internalAdminForWorkspace auth methods.
+      return true;
+    case "oauth":
+    case "session":
+    case "sandbox_token":
+      return false;
+    default:
+      assertNever(authMethod);
+  }
+};
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -196,8 +214,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   private static shouldApplyPrivateByDefaultUrlRestriction(conversation: {
     spaceId: ModelId | null;
+    depth: number;
   }): boolean {
-    return conversation.spaceId === null;
+    // Project and sub-conversations ignore the private by default url restriction.
+    return conversation.spaceId === null && conversation.depth === 0;
   }
 
   private static fromModel(
@@ -622,11 +642,22 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       )
     );
 
+    if (spaceBasedAccessible.length === 0) {
+      return [];
+    }
+
     if (
       !this.isPrivateConversationUrlsByDefaultEnabled(auth) ||
-      auth.isAdmin()
+      shouldByPassPrivateByDefaultUrlRestriction(auth)
     ) {
       return spaceBasedAccessible;
+    }
+
+    const user = auth.user();
+    if (!user) {
+      throw new Error(
+        "User not found while auth method is not api key, system api key, or internal"
+      );
     }
 
     const participantRestrictedConversations = spaceBasedAccessible.filter(
@@ -636,30 +667,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           "participants_only"
     );
 
-    const user = auth.user();
-    // API key auth has no user and never creates participant records, so the
-    // participant-restriction concept doesn't apply.
-    // TODO(2026-04-20 sebastien): Review implementation to support API Keys.
-    if (!user) {
-      return spaceBasedAccessible;
-    }
-
-    if (spaceBasedAccessible.length === 0) {
-      const participantRestrictedConversationIds = new Set(
-        participantRestrictedConversations.map(
-          (conversation) => conversation.id
-        )
-      );
-      return spaceBasedAccessible.filter(
-        (conversation) =>
-          !participantRestrictedConversationIds.has(conversation.id)
-      );
-    }
-
+    // No participant-restricted conversations, return the space-based accessible conversations.
     if (participantRestrictedConversations.length === 0) {
       return spaceBasedAccessible;
     }
 
+    // For all participant-restricted conversations, check if the user is a participant.
     const participations = await ConversationParticipantModel.findAll({
       where: {
         workspaceId: workspace.id,
@@ -675,6 +688,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       participations.map((p) => p.conversationId)
     );
 
+    // Return the space-based accessible conversations that are not participant-restricted.
+    // Or are participant-restricted and the user is a participant.
     return spaceBasedAccessible.filter(
       (conversation) =>
         !this.shouldApplyPrivateByDefaultUrlRestriction(conversation) ||
@@ -700,6 +715,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       this.getConversationUrlAccessModeForPrivateByDefault(conversation) ===
       "workspace_members"
     ) {
+      return true;
+    }
+
+    if (shouldByPassPrivateByDefaultUrlRestriction(auth)) {
       return true;
     }
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -9,7 +9,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { assert, describe, expect, it } from "vitest";
+import { assert, describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
 
@@ -56,8 +56,7 @@ describe("GET /api/v1/w/[wId]/assistant/conversations/[cId]", () => {
     expect(res._getStatusCode()).toBe(200);
   });
 
-  // TODO(2026-04-20 sebastien): Re-enable this test once the API is updated to support API Keys and the concept of participant-restricted conversations is reviewed.
-  it.skip("returns 404 conversation_not_found when private conversation URLs are enabled", async () => {
+  it("returns 200 when private conversation URLs are enabled for API key auth", async () => {
     const { req, res, workspace } = await setupGetRequest();
 
     const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
@@ -67,8 +66,60 @@ describe("GET /api/v1/w/[wId]/assistant/conversations/[cId]", () => {
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(404);
-    expect(res._getJSONData().error.type).toBe("conversation_not_found");
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it("returns 404 conversation_not_found when private conversation URLs are enabled for oauth auth", async () => {
+    const { req, res, workspace } = await setupGetRequest();
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "builder" });
+
+    const authModule = await import("@app/lib/auth");
+    const getSessionSpy = vi.spyOn(authModule, "getSession").mockResolvedValue({
+      type: "workos",
+      sessionId: "test-oauth-session-id",
+      user: {
+        workOSUserId: user.workOSUserId!,
+        email: user.email!,
+        email_verified: true,
+        name: user.username!,
+        nickname: user.username!,
+      },
+      authenticationMethod: "bearer",
+      isSSO: false,
+      workspaceId: workspace.sId,
+      organizationId: workspace.workOSOrganizationId ?? undefined,
+      region: "us-central1",
+    });
+
+    const originalFromSession = Authenticator.fromSession;
+    const fromSessionSpy = vi
+      .spyOn(Authenticator, "fromSession")
+      .mockImplementation(async (session, wId) => {
+        const auth = await originalFromSession.call(
+          Authenticator,
+          session,
+          wId
+        );
+        vi.spyOn(auth, "authMethod").mockReturnValue("oauth");
+        return auth;
+      });
+
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+    try {
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+      expect(res._getJSONData().error.type).toBe("conversation_not_found");
+    } finally {
+      fromSessionSpy.mockRestore();
+      getSessionSpy.mockRestore();
+    }
   });
 
   it("returns 200 for project conversations when private conversation URLs are enabled", async () => {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -138,7 +138,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]", () => {
     expect(res._getStatusCode()).toBe(200);
   });
 
-  it.skip("returns 404 conversation_not_found for admins when private conversation URLs are enabled and they are not participants", async () => {
+  it("returns 404 conversation_not_found for admins when private conversation URLs are enabled and they are not participants", async () => {
     const { req, res, workspace, globalSpace } =
       await createPrivateApiMockRequest({
         role: "admin",

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -255,6 +255,7 @@ export async function getAgentLoopDataWithAuth(
       conversationBranchId,
       PREVIOUS_INTERACTIONS_TO_PRESERVE + 1 // X previous + the last one
     );
+
     if (conversationRes.isErr()) {
       if (conversationRes.error.type === "conversation_not_found") {
         // Check if the conversation was soft-deleted.


### PR DESCRIPTION
## Description

The `privateConversationUrlsByDefault` restriction was applied too broadly, breaking three legitimate access patterns:

1. **API key / internal auth** — server-side operations (Temporal workflows, sub-agent calls, system integrations) need to read conversations without being registered as participants. Blocking them caused silent failures in the agent loop.
2. **Sub-conversations** (`depth > 0`) — agent-created sub-conversations may not have the triggering user as an explicit participant yet, but they should be accessible as part of the parent conversation flow.
3. **Project conversations via OAuth** — project members using OAuth were blocked even though project membership already scopes access correctly (covered by `shouldApplyPrivateByDefaultUrlRestriction` returning `false` for project spaces, but the `oauth` auth method was accidentally re-enabling the check).

The fix extends `shouldApplyPrivateByDefaultUrlRestriction` to also return `false` for auth methods that represent trusted server-side or scoped access.

- Bypass the participant restriction when `auth.authMethod()` is `"api_key"`, `"system_api_key"`, or `"internal"`
- Bypass for conversations with `depth > 0` (sub-conversations)
- Inline the `SANDBOX_TOKEN_AUTH_METHOD` constant (minor cleanup)
- Add comprehensive tests: internal auth bypasses; `session` / `oauth` / `sandbox_token` require participation for regular conversations; project conversations stay accessible via `oauth`; sub-conversations stay accessible via `session`

## Tests

Local + green (new tests added)

## Risk

Low — loosens restriction only for trusted auth methods and sub-conversations; user-facing `session` auth behavior is unchanged

## Deploy Plan

Deploy `front`
