### PR TITLE
[front] feat: add MCP server views to input bar `/` suggestions

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -38,7 +38,10 @@ import {
 } from "@app/types/assistant/mentions";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import {
+  assertNever,
+  assertNeverAndIgnore,
+} from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { SpaceType } from "@app/types/space";
 import type { UserType, WorkspaceType } from "@app/types/user";
@@ -475,7 +478,7 @@ const InputBarContainer = ({
           onMCPServerViewSelect(capability.serverView);
           break;
         default:
-          assertNever(capability);
+          assertNeverAndIgnore(capability);
       }
 
       queueMicrotask(() => editorRef.current?.commands.focus());

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -7,6 +7,7 @@ import {
   getPastedFileName,
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
+import type { InputBarSlashSuggestionCapability } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import type { MentionsStrippedPayload } from "@app/components/editor/extensions/MentionExtension";
 import type { CustomEditorProps } from "@app/components/editor/input_bar/useCustomEditor";
 import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
@@ -244,12 +245,18 @@ const InputBarContainer = ({
     () => new Set(selectedSkills.map((skill) => skill.sId)),
     [selectedSkills]
   );
+  const selectedMCPServerViewIds = useMemo(
+    () => new Set(selectedMCPServerViews.map((serverView) => serverView.sId)),
+    [selectedMCPServerViews]
+  );
+  const selectedMCPServerViewIdsRef = useRef(selectedMCPServerViewIds);
   const selectedSkillIdsRef = useRef(selectedSkillIds);
   const shouldEnableSlashSuggestionRef = useRef(shouldEnableSlashSuggestion);
-  const onSkillSelectRef = useRef<
-    ((skill: SkillWithoutInstructionsAndToolsType) => void) | undefined
+  const onSelectRef = useRef<
+    ((capability: InputBarSlashSuggestionCapability) => void) | undefined
   >(undefined);
 
+  selectedMCPServerViewIdsRef.current = selectedMCPServerViewIds;
   selectedSkillIdsRef.current = selectedSkillIds;
   shouldEnableSlashSuggestionRef.current = shouldEnableSlashSuggestion;
 
@@ -459,13 +466,23 @@ const InputBarContainer = ({
   };
 
   const handleSlashSuggestionSelection = useCallback(
-    (skill: SkillWithoutInstructionsAndToolsType) => {
-      onSkillSelect(skill);
+    (capability: InputBarSlashSuggestionCapability) => {
+      switch (capability.kind) {
+        case "skill":
+          onSkillSelect(capability.skill);
+          break;
+        case "tool":
+          onMCPServerViewSelect(capability.serverView);
+          break;
+        default:
+          assertNever(capability);
+      }
+
       queueMicrotask(() => editorRef.current?.commands.focus());
     },
-    [onSkillSelect]
+    [onMCPServerViewSelect, onSkillSelect]
   );
-  onSkillSelectRef.current = handleSlashSuggestionSelection;
+  onSelectRef.current = handleSlashSuggestionSelection;
 
   // Current space is taken from the conversation (if already set) or from the space prop (if provided).
   const spaceId = conversation?.spaceId ?? space?.sId ?? undefined;
@@ -485,7 +502,8 @@ const InputBarContainer = ({
     onAgentMentionsStrippedRef,
     slashSuggestion: {
       enabledRef: shouldEnableSlashSuggestionRef,
-      onSkillSelectRef,
+      onSelectRef,
+      selectedMCPServerViewIdsRef,
       selectedSkillIdsRef,
     },
     onLongTextPaste: async ({ text, from, to }) => {

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -211,19 +211,6 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
       [filteredCapabilities]
     );
 
-    const capabilitiesById = useMemo(
-      () =>
-        new Map(
-          filteredCapabilities.map((capability) => [
-            capability.kind === "skill"
-              ? capability.skill.sId
-              : capability.serverView.sId,
-            capability,
-          ])
-        ),
-      [filteredCapabilities]
-    );
-
     const isCapabilitiesLoading =
       isSkillsLoading || isSpacesLoading || isServerViewsLoading;
 
@@ -250,7 +237,11 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
         ref={dropdownRef}
         items={capabilityItems}
         command={(item) => {
-          const capability = capabilitiesById.get(item.id);
+          const capability = filteredCapabilities.find((capability) =>
+            capability.kind === "skill"
+              ? capability.skill.sId === item.id
+              : capability.serverView.sId === item.id
+          );
 
           if (capability) {
             command(capability);

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -64,9 +64,9 @@ export function filterInputBarSlashSuggestions({
 }): InputBarSlashSuggestionCapability[] {
   const normalizedQuery = query.trim().toLowerCase();
 
-  const capabilities: Array<
-    InputBarSlashSuggestionCapability & { sortName: string }
-  > = [
+  const capabilities: (InputBarSlashSuggestionCapability & {
+    sortName: string;
+  })[] = [
     ...skills
       .filter((skill) => !selectedSkillIds.has(skill.sId))
       .filter((skill) =>
@@ -129,18 +129,21 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
     ref
   ) => {
     const dropdownRef = useRef<SlashCommandDropdownRef>(null);
+    const isOpen = Boolean(clientRect);
     const { spaces: globalSpaces, isSpacesLoading } = useSpaces({
+      disabled: !isOpen,
       workspaceId: owner.sId,
       kinds: ["global"],
     });
     const { skills, isSkillsLoading } = useSkills({
+      disabled: !isOpen,
       owner,
       status: "active",
       globalSpaceOnly: true,
       viewType: "summary",
     });
     const { serverViews, isLoading: isServerViewsLoading } =
-      useMCPServerViewsFromSpaces(owner, globalSpaces);
+      useMCPServerViewsFromSpaces(owner, globalSpaces, { disabled: !isOpen });
 
     const filteredCapabilities = useMemo(
       () =>
@@ -168,7 +171,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
             case "skill":
               return [
                 {
-                  action: capability.skill.sId,
+                  action: "select-skill",
                   description: capability.skill.userFacingDescription,
                   icon: getSkillAvatarIcon(capability.skill.icon),
                   id: capability.skill.sId,
@@ -187,7 +190,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
 
               return [
                 {
-                  action: capability.serverView.sId,
+                  action: "select-tool",
                   description,
                   icon: () => getAvatar(capability.serverView.server),
                   id: capability.serverView.sId,
@@ -256,7 +259,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
         clientRect={clientRect}
         emptyMessage={
           isCapabilitiesLoading
-            ? "Loading capabilities..."
+            ? "Loading capabilities…"
             : "No capabilities found"
         }
         header="Capabilities"

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -163,49 +163,48 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
 
     const capabilityItems = useMemo<SlashCommand[]>(
       () =>
-        filteredCapabilities
-          .flatMap((capability) => {
-            switch (capability.kind) {
-              case "skill":
-                return [
-                  {
-                    action: capability.skill.sId,
-                    description: capability.skill.userFacingDescription,
-                    icon: getSkillAvatarIcon(capability.skill.icon),
-                    id: capability.skill.sId,
-                    label: capability.skill.name,
-                    tooltip: capability.skill.userFacingDescription
-                      ? {
-                          description: capability.skill.userFacingDescription,
-                        }
-                      : undefined,
-                  },
-                ];
-              case "tool": {
-                const description = getMcpServerViewDescription(
-                  capability.serverView
-                );
+        filteredCapabilities.flatMap((capability) => {
+          switch (capability.kind) {
+            case "skill":
+              return [
+                {
+                  action: capability.skill.sId,
+                  description: capability.skill.userFacingDescription,
+                  icon: getSkillAvatarIcon(capability.skill.icon),
+                  id: capability.skill.sId,
+                  label: capability.skill.name,
+                  tooltip: capability.skill.userFacingDescription
+                    ? {
+                        description: capability.skill.userFacingDescription,
+                      }
+                    : undefined,
+                },
+              ];
+            case "tool": {
+              const description = getMcpServerViewDescription(
+                capability.serverView
+              );
 
-                return [
-                  {
-                    action: capability.serverView.sId,
-                    description,
-                    icon: () => getAvatar(capability.serverView.server),
-                    id: capability.serverView.sId,
-                    label: getMcpServerViewDisplayName(capability.serverView),
-                    tooltip: description
-                      ? {
-                          description,
-                        }
-                      : undefined,
-                  },
-                ];
-              }
-              default:
-                assertNeverAndIgnore(capability);
-                return [];
+              return [
+                {
+                  action: capability.serverView.sId,
+                  description,
+                  icon: () => getAvatar(capability.serverView.server),
+                  id: capability.serverView.sId,
+                  label: getMcpServerViewDisplayName(capability.serverView),
+                  tooltip: description
+                    ? {
+                        description,
+                      }
+                    : undefined,
+                },
+              ];
             }
-          }),
+            default:
+              assertNeverAndIgnore(capability);
+              return [];
+          }
+        }),
       [filteredCapabilities]
     );
 

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -15,6 +15,7 @@ import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { SuggestionProps } from "@tiptap/suggestion";
 import {
@@ -162,41 +163,49 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
 
     const capabilityItems = useMemo<SlashCommand[]>(
       () =>
-        filteredCapabilities.map((capability) => {
-          switch (capability.kind) {
-            case "skill":
-              return {
-                action: capability.skill.sId,
-                description: capability.skill.userFacingDescription,
-                icon: getSkillAvatarIcon(capability.skill.icon),
-                id: capability.skill.sId,
-                label: capability.skill.name,
-                tooltip: capability.skill.userFacingDescription
-                  ? {
-                      description: capability.skill.userFacingDescription,
-                    }
-                  : undefined,
-              };
-            case "tool": {
-              const description = getMcpServerViewDescription(
-                capability.serverView
-              );
+        filteredCapabilities
+          .flatMap((capability) => {
+            switch (capability.kind) {
+              case "skill":
+                return [
+                  {
+                    action: capability.skill.sId,
+                    description: capability.skill.userFacingDescription,
+                    icon: getSkillAvatarIcon(capability.skill.icon),
+                    id: capability.skill.sId,
+                    label: capability.skill.name,
+                    tooltip: capability.skill.userFacingDescription
+                      ? {
+                          description: capability.skill.userFacingDescription,
+                        }
+                      : undefined,
+                  },
+                ];
+              case "tool": {
+                const description = getMcpServerViewDescription(
+                  capability.serverView
+                );
 
-              return {
-                action: capability.serverView.sId,
-                description,
-                icon: () => getAvatar(capability.serverView.server),
-                id: capability.serverView.sId,
-                label: getMcpServerViewDisplayName(capability.serverView),
-                tooltip: description
-                  ? {
-                      description,
-                    }
-                  : undefined,
-              };
+                return [
+                  {
+                    action: capability.serverView.sId,
+                    description,
+                    icon: () => getAvatar(capability.serverView.server),
+                    id: capability.serverView.sId,
+                    label: getMcpServerViewDisplayName(capability.serverView),
+                    tooltip: description
+                      ? {
+                          description,
+                        }
+                      : undefined,
+                  },
+                ];
+              }
+              default:
+                assertNeverAndIgnore(capability);
+                return [];
             }
-          }
-        }),
+          }),
       [filteredCapabilities]
     );
 

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -3,8 +3,17 @@ import type {
   SlashCommandDropdownRef,
 } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
 import { SlashCommandDropdown } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
+import {
+  getMcpServerViewDescription,
+  getMcpServerViewDisplayName,
+} from "@app/lib/actions/mcp_helper";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
+import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
+import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
 import { useSkills } from "@app/lib/swr/skill_configurations";
+import { useSpaces } from "@app/lib/swr/spaces";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { SuggestionProps } from "@tiptap/suggestion";
@@ -16,86 +25,196 @@ import {
   useRef,
 } from "react";
 
+import type { InputBarSlashSuggestionCapability } from "./InputBarSlashSuggestionTypes";
+
 const MAX_SLASH_SUGGESTIONS = 10;
+
+function matchesCapabilityQuery({
+  description,
+  label,
+  query,
+}: {
+  description?: string;
+  label: string;
+  query: string;
+}) {
+  if (query.length === 0) {
+    return true;
+  }
+
+  return (
+    label.toLowerCase().includes(query) ||
+    description?.toLowerCase().includes(query) === true
+  );
+}
 
 export function filterInputBarSlashSuggestions({
   query,
+  selectedMCPServerViewIds,
   selectedSkillIds,
+  serverViews,
   skills,
 }: {
   query: string;
+  selectedMCPServerViewIds: Set<string>;
   selectedSkillIds: Set<string>;
+  serverViews: MCPServerViewType[];
   skills: SkillWithoutInstructionsAndToolsType[];
-}) {
+}): InputBarSlashSuggestionCapability[] {
   const normalizedQuery = query.trim().toLowerCase();
 
-  return skills
-    .filter((skill) => !selectedSkillIds.has(skill.sId))
-    .filter((skill) => {
-      if (normalizedQuery.length === 0) {
-        return true;
-      }
+  const capabilities: Array<
+    InputBarSlashSuggestionCapability & { sortName: string }
+  > = [
+    ...skills
+      .filter((skill) => !selectedSkillIds.has(skill.sId))
+      .filter((skill) =>
+        matchesCapabilityQuery({
+          label: skill.name,
+          description: skill.userFacingDescription,
+          query: normalizedQuery,
+        })
+      )
+      .map((skill) => ({
+        kind: "skill" as const,
+        skill,
+        sortName: skill.name.toLowerCase(),
+      })),
+    ...serverViews
+      .filter((serverView) => isJITMCPServerView(serverView))
+      .filter((serverView) => !selectedMCPServerViewIds.has(serverView.sId))
+      .filter((serverView) =>
+        matchesCapabilityQuery({
+          label: getMcpServerViewDisplayName(serverView),
+          description: getMcpServerViewDescription(serverView),
+          query: normalizedQuery,
+        })
+      )
+      .map((serverView) => ({
+        kind: "tool" as const,
+        serverView,
+        sortName: getMcpServerViewDisplayName(serverView).toLowerCase(),
+      })),
+  ];
 
-      return skill.name.toLowerCase().includes(normalizedQuery);
-    })
-    .toSorted((a, b) => a.name.localeCompare(b.name))
+  return capabilities
+    .toSorted((a, b) => a.sortName.localeCompare(b.sortName))
+    .map(({ sortName: _sortName, ...capability }) => capability)
     .slice(0, MAX_SLASH_SUGGESTIONS);
 }
 
 export const InputBarSlashSuggestionDropdown = forwardRef<
   SlashCommandDropdownRef,
   Pick<
-    SuggestionProps<SkillWithoutInstructionsAndToolsType>,
+    SuggestionProps<InputBarSlashSuggestionCapability>,
     "clientRect" | "command" | "query"
   > & {
     onClose: () => void;
     owner: LightWorkspaceType;
+    selectedMCPServerViewIdsRef: RefObject<Set<string>>;
     selectedSkillIdsRef: RefObject<Set<string>>;
   }
 >(
   (
-    { clientRect, command, query, onClose, owner, selectedSkillIdsRef },
+    {
+      clientRect,
+      command,
+      query,
+      onClose,
+      owner,
+      selectedMCPServerViewIdsRef,
+      selectedSkillIdsRef,
+    },
     ref
   ) => {
     const dropdownRef = useRef<SlashCommandDropdownRef>(null);
+    const { spaces: globalSpaces, isSpacesLoading } = useSpaces({
+      workspaceId: owner.sId,
+      kinds: ["global"],
+    });
     const { skills, isSkillsLoading } = useSkills({
       owner,
       status: "active",
       globalSpaceOnly: true,
       viewType: "summary",
     });
+    const { serverViews, isLoading: isServerViewsLoading } =
+      useMCPServerViewsFromSpaces(owner, globalSpaces);
 
-    const filteredSkills = useMemo(
+    const filteredCapabilities = useMemo(
       () =>
         filterInputBarSlashSuggestions({
           query,
+          selectedMCPServerViewIds:
+            selectedMCPServerViewIdsRef.current ?? new Set<string>(),
           selectedSkillIds: selectedSkillIdsRef.current ?? new Set<string>(),
+          serverViews,
           skills,
         }),
-      [query, selectedSkillIdsRef, skills]
+      [
+        query,
+        selectedMCPServerViewIdsRef,
+        selectedSkillIdsRef,
+        serverViews,
+        skills,
+      ]
     );
 
-    const skillItems = useMemo<SlashCommand[]>(
+    const capabilityItems = useMemo<SlashCommand[]>(
       () =>
-        filteredSkills.map((skill) => ({
-          action: skill.sId,
-          description: skill.userFacingDescription,
-          icon: getSkillAvatarIcon(skill.icon),
-          id: skill.sId,
-          label: skill.name,
-          tooltip: skill.userFacingDescription
-            ? {
-                description: skill.userFacingDescription,
-              }
-            : undefined,
-        })),
-      [filteredSkills]
+        filteredCapabilities.map((capability) => {
+          switch (capability.kind) {
+            case "skill":
+              return {
+                action: capability.skill.sId,
+                description: capability.skill.userFacingDescription,
+                icon: getSkillAvatarIcon(capability.skill.icon),
+                id: capability.skill.sId,
+                label: capability.skill.name,
+                tooltip: capability.skill.userFacingDescription
+                  ? {
+                      description: capability.skill.userFacingDescription,
+                    }
+                  : undefined,
+              };
+            case "tool": {
+              const description = getMcpServerViewDescription(
+                capability.serverView
+              );
+
+              return {
+                action: capability.serverView.sId,
+                description,
+                icon: () => getAvatar(capability.serverView.server),
+                id: capability.serverView.sId,
+                label: getMcpServerViewDisplayName(capability.serverView),
+                tooltip: description
+                  ? {
+                      description,
+                    }
+                  : undefined,
+              };
+            }
+          }
+        }),
+      [filteredCapabilities]
     );
 
-    const skillsById = useMemo(
-      () => new Map(filteredSkills.map((skill) => [skill.sId, skill])),
-      [filteredSkills]
+    const capabilitiesById = useMemo(
+      () =>
+        new Map(
+          filteredCapabilities.map((capability) => [
+            capability.kind === "skill"
+              ? capability.skill.sId
+              : capability.serverView.sId,
+            capability,
+          ])
+        ),
+      [filteredCapabilities]
     );
+
+    const isCapabilitiesLoading =
+      isSkillsLoading || isSpacesLoading || isServerViewsLoading;
 
     useImperativeHandle(
       ref,
@@ -103,7 +222,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
         onKeyDown: ({ event }) => {
           if (
             (event.key === "Enter" || event.key === "Tab") &&
-            (isSkillsLoading || skillItems.length === 0)
+            (isCapabilitiesLoading || capabilityItems.length === 0)
           ) {
             event.preventDefault();
             return true;
@@ -112,23 +231,25 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
           return dropdownRef.current?.onKeyDown({ event }) ?? false;
         },
       }),
-      [isSkillsLoading, skillItems.length]
+      [capabilityItems.length, isCapabilitiesLoading]
     );
 
     return (
       <SlashCommandDropdown
         ref={dropdownRef}
-        items={skillItems}
+        items={capabilityItems}
         command={(item) => {
-          const skill = skillsById.get(item.id);
+          const capability = capabilitiesById.get(item.id);
 
-          if (skill) {
-            command(skill);
+          if (capability) {
+            command(capability);
           }
         }}
         clientRect={clientRect}
         emptyMessage={
-          isSkillsLoading ? "Loading capabilities..." : "No capabilities found"
+          isCapabilitiesLoading
+            ? "Loading capabilities..."
+            : "No capabilities found"
         }
         header="Capabilities"
         onClose={onClose}

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -1,6 +1,5 @@
 import { InputBarSlashSuggestionDropdown } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown";
 import type { SlashCommandDropdownRef } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
-import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { WorkspaceType } from "@app/types/user";
 import { Extension, type Range } from "@tiptap/core";
 import { type EditorState, Plugin, PluginKey } from "@tiptap/pm/state";
@@ -9,6 +8,7 @@ import { ReactRenderer } from "@tiptap/react";
 import { exitSuggestion, Suggestion } from "@tiptap/suggestion";
 import type { RefObject } from "react";
 
+import type { InputBarSlashSuggestionCapability } from "./InputBarSlashSuggestionTypes";
 export const inputBarSlashSuggestionPluginKey = new PluginKey(
   "inputBarSlashSuggestion"
 );
@@ -43,9 +43,10 @@ function isAllowedSlashQuery(state: EditorState, range: Range) {
 export interface InputBarSlashSuggestionExtensionOptions {
   owner?: WorkspaceType;
   enabledRef: RefObject<boolean>;
-  onSkillSelectRef: RefObject<
-    ((skill: SkillWithoutInstructionsAndToolsType) => void) | undefined
+  onSelectRef: RefObject<
+    ((capability: InputBarSlashSuggestionCapability) => void) | undefined
   >;
+  selectedMCPServerViewIdsRef: RefObject<Set<string>>;
   selectedSkillIdsRef: RefObject<Set<string>>;
 }
 
@@ -68,7 +69,8 @@ export const InputBarSlashSuggestionExtension =
       return {
         owner: undefined,
         enabledRef: { current: false },
-        onSkillSelectRef: { current: undefined },
+        onSelectRef: { current: undefined },
+        selectedMCPServerViewIdsRef: { current: new Set<string>() },
         selectedSkillIdsRef: { current: new Set<string>() },
       };
     },
@@ -78,7 +80,7 @@ export const InputBarSlashSuggestionExtension =
       const extensionStorage = this.storage;
 
       return [
-        Suggestion<SkillWithoutInstructionsAndToolsType>({
+        Suggestion<InputBarSlashSuggestionCapability>({
           editor: this.editor,
           char: "/",
           pluginKey: inputBarSlashSuggestionPluginKey,
@@ -95,7 +97,7 @@ export const InputBarSlashSuggestionExtension =
           command: ({ editor, range, props }) => {
             extensionStorage.dismissedTriggerStart = null;
             editor.chain().focus().deleteRange(range).run();
-            extensionOptions.onSkillSelectRef.current?.(props);
+            extensionOptions.onSelectRef.current?.(props);
           },
           render: () => {
             let component: ReactRenderer<SlashCommandDropdownRef> | null = null;
@@ -129,6 +131,8 @@ export const InputBarSlashSuggestionExtension =
                     ...props,
                     onClose: closeSuggestionDropdown,
                     owner,
+                    selectedMCPServerViewIdsRef:
+                      extensionOptions.selectedMCPServerViewIdsRef,
                     selectedSkillIdsRef: extensionOptions.selectedSkillIdsRef,
                   },
                   editor: props.editor,
@@ -151,6 +155,8 @@ export const InputBarSlashSuggestionExtension =
                   ...props,
                   onClose: closeSuggestionDropdown,
                   owner,
+                  selectedMCPServerViewIdsRef:
+                    extensionOptions.selectedMCPServerViewIdsRef,
                   selectedSkillIdsRef: extensionOptions.selectedSkillIdsRef,
                 });
               },

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
@@ -1,0 +1,12 @@
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
+
+export type InputBarSlashSuggestionCapability =
+  | {
+      kind: "skill";
+      skill: SkillWithoutInstructionsAndToolsType;
+    }
+  | {
+      kind: "tool";
+      serverView: MCPServerViewType;
+    };

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -5,6 +5,7 @@ import {
   InputBarSlashSuggestionExtension,
   inputBarSlashSuggestionPluginKey,
 } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension";
+import type { InputBarSlashSuggestionCapability } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import { KeyboardShortcutsExtension } from "@app/components/editor/extensions/input_bar/KeyboardShortcutsExtension";
 import { PastedAttachmentExtension } from "@app/components/editor/extensions/input_bar/PastedAttachmentExtension";
 import { URLDetectionExtension } from "@app/components/editor/extensions/input_bar/URLDetectionExtension";
@@ -26,7 +27,6 @@ import { isSubmitMessageKey } from "@app/lib/keymaps";
 import { extractFromEditorJSON } from "@app/lib/mentions/format";
 import { isMobile } from "@app/lib/utils";
 import type { RichMention } from "@app/types/assistant/mentions";
-import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { WorkspaceType } from "@app/types/user";
 import { markdownStyles } from "@dust-tt/sparkle";
 import { Placeholder } from "@tiptap/extensions";
@@ -226,9 +226,10 @@ export interface CustomEditorProps {
   >;
   slashSuggestion?: {
     enabledRef: React.RefObject<boolean>;
-    onSkillSelectRef: React.RefObject<
-      ((skill: SkillWithoutInstructionsAndToolsType) => void) | undefined
+    onSelectRef: React.RefObject<
+      ((capability: InputBarSlashSuggestionCapability) => void) | undefined
     >;
+    selectedMCPServerViewIdsRef: React.RefObject<Set<string>>;
     selectedSkillIdsRef: React.RefObject<Set<string>>;
   };
 }
@@ -364,7 +365,9 @@ export const buildEditorExtensions = ({
       InputBarSlashSuggestionExtension.configure({
         owner,
         enabledRef: slashSuggestion.enabledRef,
-        onSkillSelectRef: slashSuggestion.onSkillSelectRef,
+        onSelectRef: slashSuggestion.onSelectRef,
+        selectedMCPServerViewIdsRef:
+          slashSuggestion.selectedMCPServerViewIdsRef,
         selectedSkillIdsRef: slashSuggestion.selectedSkillIdsRef,
       })
     );


### PR DESCRIPTION
## Description

This PR extends the input-bar slash suggestions to include MCP server views in addition to skills.

- include JIT MCP server views in the `/` suggestion list (same as capabilities picker)
- merge skills and tools into a single slash-capability list

Same logic of filtering out already selected capabilities

## Tests

- Tested locally + see app preview

## Risk

- Low, behind a feature flag.

## Deploy Plan

- Deploy front.
