### PR TITLE
[front] feat: add keyboard navigation in `UserAnswerRequired`

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -242,6 +242,9 @@ export const AgentInputBar = ({
   }, [methods, listOffset, visibleListHeight, bottomOffset]);
 
   const blockedActions = getBlockedActions(context.user.sId);
+  const hasUserAnswerRequired = blockedActions.some(
+    (action) => action.status === "blocked_user_answer_required"
+  );
 
   // Keep blockedActionIndex in sync when blockedActions array changes.
   useEffect(() => {
@@ -429,7 +432,7 @@ export const AgentInputBar = ({
         stickyMentions={autoMentions}
         conversation={context.conversation}
         draftKey={context.draftKey}
-        disableAutoFocus={isMobile}
+        disableAutoFocus={isMobile || hasUserAnswerRequired}
         disableUserMentions={!!agentBuilderContext}
         actions={agentBuilderContext?.actionsToShow}
         isSubmitting={agentBuilderContext?.isSubmitting === true}

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -228,13 +228,13 @@ describe("UserAnswerRequired", () => {
     const betaOption = screen.getByRole("button", { name: /Beta/i });
 
     await waitFor(() => expect(keyboardContainer).toHaveFocus());
-    expect(alphaOption).toHaveClass("bg-muted-background/60");
-    expect(betaOption).not.toHaveClass("bg-muted-background/60");
+    expect(alphaOption).toHaveClass("bg-primary-100");
+    expect(betaOption).not.toHaveClass("bg-primary-100");
 
     fireEvent.keyDown(keyboardContainer, { key: "ArrowDown" });
 
-    expect(betaOption).toHaveClass("bg-muted-background/60");
-    expect(alphaOption).not.toHaveClass("bg-muted-background/60");
+    expect(betaOption).toHaveClass("bg-primary-100");
+    expect(alphaOption).not.toHaveClass("bg-primary-100");
   });
 
   it("submits the active option with Enter in single-select mode", async () => {
@@ -320,13 +320,13 @@ describe("UserAnswerRequired", () => {
     const customInput = screen.getByPlaceholderText("Type something else");
 
     await waitFor(() => expect(keyboardContainer).toHaveFocus());
-    expect(alphaOption).toHaveClass("bg-muted-background/60");
+    expect(alphaOption).toHaveClass("bg-primary-100");
 
     await user.keyboard("h");
 
     expect(customInput).toHaveFocus();
     expect(customInput).toHaveValue("h");
-    expect(alphaOption).not.toHaveClass("bg-muted-background/60");
+    expect(alphaOption).not.toHaveClass("bg-primary-100");
 
     await user.type(customInput, "ello");
     fireEvent.keyDown(customInput, { key: "Enter", metaKey: true });

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -1,0 +1,406 @@
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UserAnswerRequired } from "./UserAnswerRequired";
+
+const removeCompletedActionMock = vi.fn();
+const answerQuestionMock = vi.fn();
+
+vi.mock("@app/lib/auth/AuthContext", () => ({
+  useAuth: () => ({
+    user: { sId: "user_1" },
+  }),
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/BlockedActionsProvider",
+  () => ({
+    useBlockedActionsContext: () => ({
+      removeCompletedAction: removeCompletedActionMock,
+    }),
+  })
+);
+
+vi.mock("@app/hooks/useAnswerUserQuestion", () => ({
+  useAnswerUserQuestion: () => ({
+    answerQuestion: answerQuestionMock,
+    isSubmitting: false,
+    errorMessage: null,
+  }),
+}));
+
+vi.mock("@dust-tt/sparkle", () => {
+  const cn = (...values: Array<unknown>) =>
+    values
+      .flatMap((value) => (Array.isArray(value) ? value : [value]))
+      .filter(Boolean)
+      .join(" ");
+
+  const OptionCard = ({
+    label,
+    description,
+    selected,
+    className,
+    onClick,
+    disabled,
+  }: {
+    label: string;
+    description?: string | null;
+    selected?: boolean;
+    className?: string;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick?.();
+        }
+      }}
+      disabled={disabled}
+      className={className}
+      data-selected={selected ? "true" : "false"}
+    >
+      <span>{label}</span>
+      {description ? <span>{description}</span> : null}
+    </button>
+  );
+
+  const Card = ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <div className={className}>{children}</div>;
+
+  const Counter = ({ value }: { value: number }) => <span>{value}</span>;
+
+  const Input = React.forwardRef<
+    HTMLInputElement,
+    React.InputHTMLAttributes<HTMLInputElement> & {
+      containerClassName?: string;
+    }
+  >(({ containerClassName, ...props }, ref) => (
+    <div className={containerClassName}>
+      <input ref={ref} {...props} />
+    </div>
+  ));
+  Input.displayName = "Input";
+
+  const Button = ({
+    label,
+    onClick,
+    disabled,
+    isLoading,
+    "aria-label": ariaLabel,
+  }: {
+    label?: string;
+    onClick?: () => void;
+    disabled?: boolean;
+    isLoading?: boolean;
+    "aria-label"?: string;
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled || isLoading}
+      aria-label={ariaLabel}
+    >
+      {label ?? ariaLabel}
+    </button>
+  );
+
+  const Spinner = () => <div>Loading</div>;
+  const ArrowUpIcon = () => null;
+
+  return {
+    ArrowUpIcon,
+    Button,
+    Card,
+    Counter,
+    cn,
+    Input,
+    OptionCard,
+    Spinner,
+  };
+});
+
+const owner = {
+  id: 1,
+  sId: "w_1",
+  name: "Workspace",
+  role: "user",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+} as LightWorkspaceType;
+
+function makeBlockedAction({
+  multiSelect = false,
+}: {
+  multiSelect?: boolean;
+} = {}): BlockedToolExecution & {
+  status: "blocked_user_answer_required";
+} {
+  return {
+    conversationId: "conv_1",
+    messageId: "msg_1",
+    actionId: "action_1",
+    userId: "user_1",
+    configurationId: "config_1",
+    created: 1,
+    metadata: {
+      toolName: "tool",
+      mcpServerName: "server",
+      agentName: "agent",
+    },
+    inputs: {},
+    status: "blocked_user_answer_required",
+    authorizationInfo: null,
+    question: {
+      question: "Choose an option",
+      multiSelect,
+      options: [
+        {
+          label: "Alpha",
+          description: "First option",
+        },
+        {
+          label: "Beta",
+          description: "Second option",
+        },
+      ],
+    },
+  };
+}
+
+function getKeyboardContainer(container: HTMLElement) {
+  const element = container.querySelector("div[tabindex='0']");
+
+  if (!(element instanceof HTMLDivElement)) {
+    throw new Error("Keyboard container not found");
+  }
+
+  return element;
+}
+
+describe("UserAnswerRequired", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    answerQuestionMock.mockResolvedValue({ success: true });
+  });
+
+  it("highlights the first option by default and moves the highlight with arrow keys", async () => {
+    const { container } = render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction()}
+        triggeringUser={null}
+        owner={owner}
+        conversationId="conv_1"
+        messageId="msg_1"
+      />
+    );
+
+    const keyboardContainer = getKeyboardContainer(container);
+    const alphaOption = screen.getByRole("button", { name: /Alpha/i });
+    const betaOption = screen.getByRole("button", { name: /Beta/i });
+
+    await waitFor(() => expect(keyboardContainer).toHaveFocus());
+    expect(alphaOption).toHaveClass("bg-muted-background/60");
+    expect(betaOption).not.toHaveClass("bg-muted-background/60");
+
+    fireEvent.keyDown(keyboardContainer, { key: "ArrowDown" });
+
+    expect(betaOption).toHaveClass("bg-muted-background/60");
+    expect(alphaOption).not.toHaveClass("bg-muted-background/60");
+  });
+
+  it("submits the active option with Enter in single-select mode", async () => {
+    const { container } = render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction()}
+        triggeringUser={null}
+        owner={owner}
+        conversationId="conv_1"
+        messageId="msg_1"
+      />
+    );
+
+    const keyboardContainer = getKeyboardContainer(container);
+
+    fireEvent.keyDown(keyboardContainer, { key: "ArrowDown" });
+    fireEvent.keyDown(keyboardContainer, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(answerQuestionMock).toHaveBeenCalledWith({
+        conversationId: "conv_1",
+        messageId: "msg_1",
+        actionId: "action_1",
+        answer: { selectedOptions: [1] },
+      });
+    });
+    expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
+  });
+
+  it("toggles options with Space and Enter, then submits with Cmd+Enter in multi-select mode", async () => {
+    const { container } = render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction({ multiSelect: true })}
+        triggeringUser={null}
+        owner={owner}
+        conversationId="conv_1"
+        messageId="msg_1"
+      />
+    );
+
+    const keyboardContainer = getKeyboardContainer(container);
+    const alphaOption = screen.getByRole("button", { name: /Alpha/i });
+    const betaOption = screen.getByRole("button", { name: /Beta/i });
+
+    fireEvent.keyDown(keyboardContainer, { key: " " });
+    fireEvent.keyDown(keyboardContainer, { key: "ArrowDown" });
+    fireEvent.keyDown(keyboardContainer, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(alphaOption).toHaveAttribute("data-selected", "true");
+      expect(betaOption).toHaveAttribute("data-selected", "true");
+    });
+
+    fireEvent.keyDown(keyboardContainer, {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    await waitFor(() => {
+      expect(answerQuestionMock).toHaveBeenCalledWith({
+        conversationId: "conv_1",
+        messageId: "msg_1",
+        actionId: "action_1",
+        answer: { selectedOptions: [0, 1] },
+      });
+    });
+  });
+
+  it("moves focus into the custom input and types there when a printable key is pressed", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction({ multiSelect: true })}
+        triggeringUser={null}
+        owner={owner}
+        conversationId="conv_1"
+        messageId="msg_1"
+      />
+    );
+
+    const keyboardContainer = getKeyboardContainer(container);
+    const customInput = screen.getByPlaceholderText("Type something else");
+
+    await waitFor(() => expect(keyboardContainer).toHaveFocus());
+
+    await user.keyboard("h");
+
+    expect(customInput).toHaveFocus();
+    expect(customInput).toHaveValue("h");
+
+    await user.type(customInput, "ello");
+    fireEvent.keyDown(customInput, { key: "Enter", metaKey: true });
+
+    await waitFor(() => {
+      expect(answerQuestionMock).toHaveBeenCalledWith({
+        conversationId: "conv_1",
+        messageId: "msg_1",
+        actionId: "action_1",
+        answer: {
+          selectedOptions: [],
+          customResponse: "hello",
+        },
+      });
+    });
+  });
+
+  it("submits the current multi-select choices when Cmd+Enter is pressed on a focused option", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction({ multiSelect: true })}
+        triggeringUser={null}
+        owner={owner}
+        conversationId="conv_1"
+        messageId="msg_1"
+      />
+    );
+
+    const alphaOption = screen.getByRole("button", { name: /Alpha/i });
+    const betaOption = screen.getByRole("button", { name: /Beta/i });
+
+    await user.click(alphaOption);
+    await act(async () => {
+      betaOption.focus();
+    });
+
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
+
+    await waitFor(() => {
+      expect(answerQuestionMock).toHaveBeenCalledWith({
+        conversationId: "conv_1",
+        messageId: "msg_1",
+        actionId: "action_1",
+        answer: { selectedOptions: [0] },
+      });
+    });
+    expect(betaOption).toHaveAttribute("data-selected", "false");
+  });
+
+  it("requires Cmd+Enter from the custom response input in multi-select mode", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction({ multiSelect: true })}
+        triggeringUser={null}
+        owner={owner}
+        conversationId="conv_1"
+        messageId="msg_1"
+      />
+    );
+
+    const customInput = screen.getByPlaceholderText("Type something else");
+
+    await user.type(customInput, "Other answer");
+    await user.keyboard("{Enter}");
+
+    expect(answerQuestionMock).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(customInput, { key: "Enter", metaKey: true });
+
+    await waitFor(() => {
+      expect(answerQuestionMock).toHaveBeenCalledWith({
+        conversationId: "conv_1",
+        messageId: "msg_1",
+        actionId: "action_1",
+        answer: {
+          selectedOptions: [],
+          customResponse: "Other answer",
+        },
+      });
+    });
+  });
+});

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -310,14 +310,17 @@ describe("UserAnswerRequired", () => {
     );
 
     const keyboardContainer = getKeyboardContainer(container);
+    const alphaOption = screen.getByRole("button", { name: /Alpha/i });
     const customInput = screen.getByPlaceholderText("Type something else");
 
     await waitFor(() => expect(keyboardContainer).toHaveFocus());
+    expect(alphaOption).toHaveClass("bg-muted-background/60");
 
     await user.keyboard("h");
 
     expect(customInput).toHaveFocus();
     expect(customInput).toHaveValue("h");
+    expect(alphaOption).not.toHaveClass("bg-muted-background/60");
 
     await user.type(customInput, "ello");
     fireEvent.keyDown(customInput, { key: "Enter", metaKey: true });

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -367,6 +367,33 @@ describe("UserAnswerRequired", () => {
     expect(alphaOption).toHaveAttribute("data-selected", "false");
   });
 
+  it("moves back to the last option when Backspace is pressed on an empty custom input", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction()}
+        triggeringUser={null}
+        owner={owner}
+        conversationId="conv_1"
+        messageId="msg_1"
+      />
+    );
+
+    const keyboardContainer = getKeyboardContainer(container);
+    const alphaOption = screen.getByRole("button", { name: /Alpha/i });
+    const betaOption = screen.getByRole("button", { name: /Beta/i });
+    const customInput = screen.getByPlaceholderText("Type something else");
+
+    await user.click(customInput);
+    expect(customInput).toHaveFocus();
+
+    fireEvent.keyDown(customInput, { key: "Backspace" });
+
+    expect(keyboardContainer).toHaveFocus();
+    expect(betaOption).toHaveClass("bg-primary-100");
+    expect(alphaOption).not.toHaveClass("bg-primary-100");
+  });
+
   it("submits the current multi-select choices when Cmd+Enter is pressed on a focused option", async () => {
     const user = userEvent.setup();
 

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -335,7 +335,7 @@ describe("UserAnswerRequired", () => {
     });
   });
 
-  it("keeps selected options on input focus and clears them once typing starts", async () => {
+  it("clears selected options when the custom input receives focus", async () => {
     const user = userEvent.setup();
 
     render(
@@ -355,9 +355,6 @@ describe("UserAnswerRequired", () => {
     expect(alphaOption).toHaveAttribute("data-selected", "true");
 
     await user.click(customInput);
-    expect(alphaOption).toHaveAttribute("data-selected", "true");
-
-    await user.type(customInput, "x");
     expect(alphaOption).toHaveAttribute("data-selected", "false");
   });
 

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -335,6 +335,32 @@ describe("UserAnswerRequired", () => {
     });
   });
 
+  it("keeps selected options on input focus and clears them once typing starts", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction({ multiSelect: true })}
+        triggeringUser={null}
+        owner={owner}
+        conversationId="conv_1"
+        messageId="msg_1"
+      />
+    );
+
+    const alphaOption = screen.getByRole("button", { name: /Alpha/i });
+    const customInput = screen.getByPlaceholderText("Type something else");
+
+    await user.click(alphaOption);
+    expect(alphaOption).toHaveAttribute("data-selected", "true");
+
+    await user.click(customInput);
+    expect(alphaOption).toHaveAttribute("data-selected", "true");
+
+    await user.type(customInput, "x");
+    expect(alphaOption).toHaveAttribute("data-selected", "false");
+  });
+
   it("submits the current multi-select choices when Cmd+Enter is pressed on a focused option", async () => {
     const user = userEvent.setup();
 

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -53,6 +53,8 @@ vi.mock("@dust-tt/sparkle", () => {
     className,
     onClick,
     disabled,
+    onFocusCapture,
+    onMouseEnter,
   }: {
     label: string;
     description?: string | null;
@@ -60,16 +62,20 @@ vi.mock("@dust-tt/sparkle", () => {
     className?: string;
     onClick?: () => void;
     disabled?: boolean;
+    onFocusCapture?: React.FocusEventHandler<HTMLButtonElement>;
+    onMouseEnter?: React.MouseEventHandler<HTMLButtonElement>;
   }) => (
     <button
       type="button"
       onClick={onClick}
+      onFocusCapture={onFocusCapture}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           onClick?.();
         }
       }}
+      onMouseEnter={onMouseEnter}
       disabled={disabled}
       className={className}
       data-selected={selected ? "true" : "false"}

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -139,7 +139,7 @@ vi.mock("@dust-tt/sparkle", () => {
   };
 });
 
-const owner = {
+const owner: LightWorkspaceType = {
   id: 1,
   sId: "w_1",
   name: "Workspace",
@@ -149,7 +149,7 @@ const owner = {
   defaultEmbeddingProvider: null,
   sharingPolicy: "workspace_only",
   metronomeCustomerId: null,
-} as LightWorkspaceType;
+};
 
 function makeBlockedAction({
   multiSelect = false,

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -62,7 +62,7 @@ export function UserAnswerRequired({
   // biome-ignore lint/correctness/useExhaustiveDependencies: blockedAction.actionId is an intentional reset trigger
   useEffect(() => {
     setActiveOptionIndex(0);
-    containerRef.current?.focus();
+    containerRef.current?.focus({ preventScroll: true });
   }, [blockedAction.actionId]);
 
   async function submitAnswer(
@@ -147,7 +147,7 @@ export function UserAnswerRequired({
     handleOptionClick(activeOptionIndex);
   }
 
-  function handleContainerKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+  function handleContainerKeyDownCapture(e: KeyboardEvent<HTMLDivElement>) {
     if (
       e.target instanceof HTMLInputElement ||
       e.target instanceof HTMLTextAreaElement ||
@@ -156,11 +156,19 @@ export function UserAnswerRequired({
       return;
     }
 
-    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-      if (question.multiSelect) {
-        e.preventDefault();
-        handleSubmit();
-      }
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && question.multiSelect) {
+      e.preventDefault();
+      e.stopPropagation();
+      handleSubmit();
+    }
+  }
+
+  function handleContainerKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (
+      e.target instanceof HTMLInputElement ||
+      e.target instanceof HTMLTextAreaElement ||
+      (e.target instanceof HTMLElement && e.target.isContentEditable)
+    ) {
       return;
     }
 
@@ -201,6 +209,7 @@ export function UserAnswerRequired({
     <div
       ref={containerRef}
       tabIndex={0}
+      onKeyDownCapture={handleContainerKeyDownCapture}
       onKeyDown={handleContainerKeyDown}
       className={cn(
         "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-none",

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -160,6 +160,11 @@ export function UserAnswerRequired({
     customResponseInputRef.current?.focus();
   }
 
+  function handleCustomResponseChange(value: string) {
+    setSelectedOptions([]);
+    setCustomResponse(value);
+  }
+
   function handleContainerKeyDownCapture(e: KeyboardEvent<HTMLDivElement>) {
     if (
       e.target instanceof HTMLInputElement ||
@@ -302,10 +307,7 @@ export function UserAnswerRequired({
               )}
               placeholder="Type something else"
               value={customResponse}
-              onFocus={() => {
-                setSelectedOptions([]);
-              }}
-              onChange={(e) => setCustomResponse(e.target.value)}
+              onChange={(e) => handleCustomResponseChange(e.target.value)}
               onKeyDown={(e) => {
                 if (
                   e.key === "Enter" &&

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -298,7 +298,7 @@ export function UserAnswerRequired({
               value={question.options.length + 1}
               size="sm"
               variant="ghost"
-              className="shrink-0 bg-border-dark dark:bg-border-dark-night"
+              className="shrink-0 bg-border-darker dark:bg-border-darker-night"
             />
             <Input
               ref={customResponseInputRef}

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -50,6 +50,7 @@ export function UserAnswerRequired({
   const [customResponse, setCustomResponse] = useState("");
   const [isSkipPending, setIsSkipPending] = useState(false);
   const [activeOptionIndex, setActiveOptionIndex] = useState(0);
+  const [isCustomResponseFocused, setIsCustomResponseFocused] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const customResponseInputRef = useRef<HTMLInputElement>(null);
 
@@ -59,6 +60,8 @@ export function UserAnswerRequired({
   const trimmedCustomResponse = customResponse.trim();
   const isCustomResponseSelected =
     trimmedCustomResponse.length > 0 && selectedOptions.length === 0;
+  const isCustomResponseActive =
+    isCustomResponseFocused || isCustomResponseSelected;
   const canSubmit =
     trimmedCustomResponse.length > 0 || selectedOptions.length > 0;
 
@@ -69,6 +72,7 @@ export function UserAnswerRequired({
   // biome-ignore lint/correctness/useExhaustiveDependencies: blockedAction.actionId is an intentional reset trigger
   useEffect(() => {
     setActiveOptionIndex(0);
+    setIsCustomResponseFocused(false);
     containerRef.current?.focus({ preventScroll: true });
   }, [blockedAction.actionId]);
 
@@ -96,6 +100,7 @@ export function UserAnswerRequired({
       return;
     }
 
+    setIsCustomResponseFocused(false);
     setActiveOptionIndex(index);
 
     if (question.multiSelect) {
@@ -155,6 +160,7 @@ export function UserAnswerRequired({
   }
 
   function handleStartCustomResponse(character: string) {
+    setIsCustomResponseFocused(true);
     setSelectedOptions([]);
     setCustomResponse((prev) => `${prev}${character}`);
     customResponseInputRef.current?.focus();
@@ -199,11 +205,13 @@ export function UserAnswerRequired({
     switch (e.key) {
       case "ArrowDown":
         e.preventDefault();
+        setIsCustomResponseFocused(false);
         moveActiveOption(1);
         containerRef.current?.focus();
         break;
       case "ArrowUp":
         e.preventDefault();
+        setIsCustomResponseFocused(false);
         moveActiveOption(-1);
         containerRef.current?.focus();
         break;
@@ -252,8 +260,14 @@ export function UserAnswerRequired({
           {question.options.map((option, index) => (
             <div
               key={index}
-              onFocusCapture={() => setActiveOptionIndex(index)}
-              onMouseEnter={() => setActiveOptionIndex(index)}
+              onFocusCapture={() => {
+                setIsCustomResponseFocused(false);
+                setActiveOptionIndex(index);
+              }}
+              onMouseEnter={() => {
+                setIsCustomResponseFocused(false);
+                setActiveOptionIndex(index);
+              }}
             >
               <OptionCard
                 label={option.label}
@@ -262,6 +276,7 @@ export function UserAnswerRequired({
                 selected={selectedOptions.includes(index)}
                 className={cn(
                   activeOptionIndex === index &&
+                    !isCustomResponseActive &&
                     !selectedOptions.includes(index) &&
                     "bg-muted-background/60 dark:bg-muted-background-night/60"
                 )}
@@ -307,7 +322,11 @@ export function UserAnswerRequired({
               )}
               placeholder="Type something else"
               value={customResponse}
-              onFocus={() => setSelectedOptions([])}
+              onFocus={() => {
+                setIsCustomResponseFocused(true);
+                setSelectedOptions([]);
+              }}
+              onBlur={() => setIsCustomResponseFocused(false)}
               onChange={(e) => handleCustomResponseChange(e.target.value)}
               onKeyDown={(e) => {
                 if (

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -307,6 +307,7 @@ export function UserAnswerRequired({
               )}
               placeholder="Type something else"
               value={customResponse}
+              onFocus={() => setSelectedOptions([])}
               onChange={(e) => handleCustomResponseChange(e.target.value)}
               onKeyDown={(e) => {
                 if (

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -285,13 +285,12 @@ export function UserAnswerRequired({
           <Card
             variant="tertiary"
             className={cn(
-              "flex w-full items-center gap-2 rounded-2xl p-3 transition-colors",
+              "w-full items-center gap-2 transition-colors",
               isCustomResponseActive
                 ? "bg-primary-100 dark:bg-primary-100-night"
                 : [
-                    "bg-background hover:bg-primary-100",
-                    "dark:bg-background-night",
-                    "dark:hover:bg-primary-100-night",
+                    "bg-background dark:bg-background-night ",
+                    "hover:bg-primary-100 dark:hover:bg-primary-100-night",
                   ]
             )}
           >
@@ -299,10 +298,7 @@ export function UserAnswerRequired({
               value={question.options.length + 1}
               size="sm"
               variant="ghost"
-              className={cn(
-                "shrink-0 bg-border-dark text-muted-foreground",
-                "dark:bg-border-dark-night dark:text-muted-foreground-night"
-              )}
+              className="shrink-0 bg-border-dark dark:bg-border-dark-night"
             />
             <Input
               ref={customResponseInputRef}

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -276,7 +276,7 @@ export function UserAnswerRequired({
                 activeOptionIndex === index &&
                   !isCustomResponseActive &&
                   !selectedOptions.includes(index) &&
-                  "bg-muted-background/60 dark:bg-muted-background-night/60"
+                  "bg-primary-100 dark:bg-primary-100-night"
               )}
               onClick={() => handleOptionClick(index)}
               disabled={isAnswerSubmitting}
@@ -287,11 +287,11 @@ export function UserAnswerRequired({
             className={cn(
               "flex w-full items-center gap-2 rounded-2xl p-3 transition-colors",
               isCustomResponseActive
-                ? "bg-muted-background/60 dark:bg-muted-background-night/60"
+                ? "bg-primary-100 dark:bg-primary-100-night"
                 : [
-                    "bg-background hover:bg-muted-background/60",
+                    "bg-background hover:bg-primary-100",
                     "dark:bg-background-night",
-                    "dark:hover:bg-muted-background-night/60",
+                    "dark:hover:bg-primary-100-night",
                   ]
             )}
           >

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -27,6 +27,12 @@ interface UserAnswerRequiredProps {
   messageId: string;
 }
 
+function isPrintableKey(e: KeyboardEvent<HTMLDivElement>) {
+  return (
+    e.key.length === 1 && e.key !== " " && !e.altKey && !e.ctrlKey && !e.metaKey
+  );
+}
+
 export function UserAnswerRequired({
   blockedAction,
   triggeringUser,
@@ -45,6 +51,7 @@ export function UserAnswerRequired({
   const [isSkipPending, setIsSkipPending] = useState(false);
   const [activeOptionIndex, setActiveOptionIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
+  const customResponseInputRef = useRef<HTMLInputElement>(null);
 
   const { question } = blockedAction;
   const isTriggeredByCurrentUser = blockedAction.userId === user?.sId;
@@ -147,6 +154,12 @@ export function UserAnswerRequired({
     handleOptionClick(activeOptionIndex);
   }
 
+  function handleStartCustomResponse(character: string) {
+    setSelectedOptions([]);
+    setCustomResponse((prev) => `${prev}${character}`);
+    customResponseInputRef.current?.focus();
+  }
+
   function handleContainerKeyDownCapture(e: KeyboardEvent<HTMLDivElement>) {
     if (
       e.target instanceof HTMLInputElement ||
@@ -169,6 +182,12 @@ export function UserAnswerRequired({
       e.target instanceof HTMLTextAreaElement ||
       (e.target instanceof HTMLElement && e.target.isContentEditable)
     ) {
+      return;
+    }
+
+    if (isPrintableKey(e)) {
+      e.preventDefault();
+      handleStartCustomResponse(e.key);
       return;
     }
 
@@ -271,6 +290,7 @@ export function UserAnswerRequired({
               )}
             />
             <Input
+              ref={customResponseInputRef}
               id={`custom-response-${blockedAction.actionId}`}
               containerClassName="flex-1"
               className={cn(

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -258,8 +258,12 @@ export function UserAnswerRequired({
       ) : (
         <div className="flex flex-col gap-2">
           {question.options.map((option, index) => (
-            <div
+            <OptionCard
               key={index}
+              label={option.label}
+              description={option.description}
+              counterValue={index + 1}
+              selected={selectedOptions.includes(index)}
               onFocusCapture={() => {
                 setIsCustomResponseFocused(false);
                 setActiveOptionIndex(index);
@@ -268,22 +272,15 @@ export function UserAnswerRequired({
                 setIsCustomResponseFocused(false);
                 setActiveOptionIndex(index);
               }}
-            >
-              <OptionCard
-                label={option.label}
-                description={option.description}
-                counterValue={index + 1}
-                selected={selectedOptions.includes(index)}
-                className={cn(
-                  activeOptionIndex === index &&
-                    !isCustomResponseActive &&
-                    !selectedOptions.includes(index) &&
-                    "bg-muted-background/60 dark:bg-muted-background-night/60"
-                )}
-                onClick={() => handleOptionClick(index)}
-                disabled={isAnswerSubmitting}
-              />
-            </div>
+              className={cn(
+                activeOptionIndex === index &&
+                  !isCustomResponseActive &&
+                  !selectedOptions.includes(index) &&
+                  "bg-muted-background/60 dark:bg-muted-background-night/60"
+              )}
+              onClick={() => handleOptionClick(index)}
+              disabled={isAnswerSubmitting}
+            />
           ))}
           <Card
             variant="tertiary"

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -286,8 +286,6 @@ export function UserAnswerRequired({
             variant="tertiary"
             className={cn(
               "flex w-full items-center gap-2 rounded-2xl p-3 transition-colors",
-              isCustomResponseSelected &&
-                "border-border dark:border-border-night",
               isCustomResponseActive
                 ? "bg-muted-background/60 dark:bg-muted-background-night/60"
                 : [

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -14,7 +14,8 @@ import {
   OptionCard,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import type { KeyboardEvent } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface UserAnswerRequiredProps {
   blockedAction: BlockedToolExecution & {
@@ -42,6 +43,8 @@ export function UserAnswerRequired({
   const [selectedOptions, setSelectedOptions] = useState<number[]>([]);
   const [customResponse, setCustomResponse] = useState("");
   const [isSkipPending, setIsSkipPending] = useState(false);
+  const [activeOptionIndex, setActiveOptionIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const { question } = blockedAction;
   const isTriggeredByCurrentUser = blockedAction.userId === user?.sId;
@@ -49,9 +52,18 @@ export function UserAnswerRequired({
   const trimmedCustomResponse = customResponse.trim();
   const isCustomResponseSelected =
     trimmedCustomResponse.length > 0 && selectedOptions.length === 0;
+  const canSubmit =
+    trimmedCustomResponse.length > 0 || selectedOptions.length > 0;
 
   const isAnswerSubmitting = isSubmitting && !isSkipPending;
   const isSkipSubmitting = isSubmitting && isSkipPending;
+
+  // Reset the keyboard cursor and focus when a new blocked action replaces the current one.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: blockedAction.actionId is an intentional reset trigger
+  useEffect(() => {
+    setActiveOptionIndex(0);
+    containerRef.current?.focus();
+  }, [blockedAction.actionId]);
 
   async function submitAnswer(
     answer: UserQuestionAnswer,
@@ -71,10 +83,13 @@ export function UserAnswerRequired({
 
     setIsSkipPending(false);
   }
+
   function handleOptionClick(index: number) {
     if (isSubmitting) {
       return;
     }
+
+    setActiveOptionIndex(index);
 
     if (question.multiSelect) {
       setSelectedOptions((prev) =>
@@ -89,12 +104,23 @@ export function UserAnswerRequired({
     void submitAnswer({ selectedOptions: [index] });
   }
 
+  function moveActiveOption(direction: 1 | -1) {
+    if (question.options.length === 0) {
+      return;
+    }
+
+    setActiveOptionIndex(
+      (prev) =>
+        (prev + direction + question.options.length) % question.options.length
+    );
+  }
+
   function handleSubmit() {
     if (isSubmitting) {
       return;
     }
 
-    if (!isCustomResponseSelected && selectedOptions.length === 0) {
+    if (!canSubmit) {
       return;
     }
 
@@ -113,6 +139,52 @@ export function UserAnswerRequired({
     void submitAnswer({ selectedOptions: [] }, { isSkip: true });
   }
 
+  function handleActiveOptionSelection() {
+    if (question.options.length === 0) {
+      return;
+    }
+
+    handleOptionClick(activeOptionIndex);
+  }
+
+  function handleContainerKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (
+      e.target instanceof HTMLInputElement ||
+      e.target instanceof HTMLTextAreaElement ||
+      (e.target instanceof HTMLElement && e.target.isContentEditable)
+    ) {
+      return;
+    }
+
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      if (question.multiSelect) {
+        e.preventDefault();
+        handleSubmit();
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        moveActiveOption(1);
+        containerRef.current?.focus();
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        moveActiveOption(-1);
+        containerRef.current?.focus();
+        break;
+      case "Enter":
+      case " ":
+        if (e.currentTarget === e.target) {
+          e.preventDefault();
+          handleActiveOptionSelection();
+        }
+        break;
+    }
+  }
+
   if (!isTriggeredByCurrentUser) {
     return (
       <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
@@ -127,8 +199,11 @@ export function UserAnswerRequired({
 
   return (
     <div
+      ref={containerRef}
+      tabIndex={0}
+      onKeyDown={handleContainerKeyDown}
       className={cn(
-        "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5",
+        "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-none",
         "dark:border-dark-night dark:bg-background-night"
       )}
     >
@@ -142,15 +217,25 @@ export function UserAnswerRequired({
       ) : (
         <div className="flex flex-col gap-2">
           {question.options.map((option, index) => (
-            <OptionCard
+            <div
               key={index}
-              label={option.label}
-              description={option.description}
-              counterValue={index + 1}
-              selected={selectedOptions.includes(index)}
-              onClick={() => handleOptionClick(index)}
-              disabled={isAnswerSubmitting}
-            />
+              onFocusCapture={() => setActiveOptionIndex(index)}
+              onMouseEnter={() => setActiveOptionIndex(index)}
+            >
+              <OptionCard
+                label={option.label}
+                description={option.description}
+                counterValue={index + 1}
+                selected={selectedOptions.includes(index)}
+                className={cn(
+                  activeOptionIndex === index &&
+                    !selectedOptions.includes(index) &&
+                    "bg-muted-background/60 dark:bg-muted-background-night/60"
+                )}
+                onClick={() => handleOptionClick(index)}
+                disabled={isAnswerSubmitting}
+              />
+            </div>
           ))}
           <Card
             variant="tertiary"
@@ -193,7 +278,10 @@ export function UserAnswerRequired({
               }}
               onChange={(e) => setCustomResponse(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter") {
+                if (
+                  e.key === "Enter" &&
+                  (!question.multiSelect || e.metaKey || e.ctrlKey)
+                ) {
                   e.preventDefault();
                   handleSubmit();
                 }
@@ -222,9 +310,7 @@ export function UserAnswerRequired({
           variant="highlight"
           size="sm"
           isLoading={isAnswerSubmitting}
-          disabled={
-            trimmedCustomResponse.length === 0 && selectedOptions.length === 0
-          }
+          disabled={!canSubmit}
           onClick={handleSubmit}
           aria-label="Send answer"
         />

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -321,6 +321,18 @@ export function UserAnswerRequired({
               onChange={(e) => handleCustomResponseChange(e.target.value)}
               onKeyDown={(e) => {
                 if (
+                  e.key === "Backspace" &&
+                  customResponse.length === 0 &&
+                  question.options.length > 0
+                ) {
+                  e.preventDefault();
+                  setIsCustomResponseFocused(false);
+                  setActiveOptionIndex(question.options.length - 1);
+                  containerRef.current?.focus();
+                  return;
+                }
+
+                if (
                   e.key === "Enter" &&
                   (!question.multiSelect || e.metaKey || e.ctrlKey)
                 ) {

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -291,8 +291,8 @@ export function UserAnswerRequired({
               "flex w-full items-center gap-2 rounded-2xl p-3 transition-colors",
               isCustomResponseSelected &&
                 "border-border dark:border-border-night",
-              isCustomResponseSelected
-                ? "bg-muted-background dark:bg-muted-background-night"
+              isCustomResponseActive
+                ? "bg-muted-background/60 dark:bg-muted-background-night/60"
                 : [
                     "bg-background hover:bg-muted-background/60",
                     "dark:bg-background-night",

--- a/sparkle/src/components/OptionCard.tsx
+++ b/sparkle/src/components/OptionCard.tsx
@@ -40,7 +40,7 @@ export function OptionCard({
     <Card
       variant={variant}
       className={cn(
-        "s-flex s-w-full s-items-center s-gap-2 s-rounded-2xl s-p-3 s-text-left s-transition-colors",
+        "s-w-full s-items-center s-gap-2 s-rounded-2xl s-text-left s-transition-colors",
         !disabled && "s-cursor-pointer",
         disabled && "s-pointer-events-none s-opacity-60",
         !selected &&
@@ -59,13 +59,10 @@ export function OptionCard({
           value={counterValue}
           size="sm"
           variant="ghost"
-          className={cn(
-            "s-shrink-0 s-bg-border-dark s-text-muted-foreground",
-            "dark:s-bg-border-dark-night dark:s-text-muted-foreground-night"
-          )}
+          className="s-shrink-0 s-bg-border-dark dark:s-bg-border-dark-night"
         />
       )}
-      <div className="s-flex s-flex-col">
+      <div className="s-flex s-min-w-0 s-flex-1 s-flex-col">
         <span className="s-text-sm s-font-medium s-text-foreground dark:s-text-foreground-night">
           {label}
         </span>

--- a/sparkle/src/components/OptionCard.tsx
+++ b/sparkle/src/components/OptionCard.tsx
@@ -11,6 +11,8 @@ export interface OptionCardProps {
   disabled?: boolean;
   className?: string;
   onClick?: () => void;
+  onFocusCapture?: React.FocusEventHandler<HTMLDivElement>;
+  onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
 }
 
 export function OptionCard({
@@ -21,6 +23,8 @@ export function OptionCard({
   disabled = false,
   className,
   onClick,
+  onFocusCapture,
+  onMouseEnter,
 }: OptionCardProps) {
   const variant: CardVariantType = selected ? "active" : "tertiary";
   const isInteractive = onClick !== undefined && !disabled;
@@ -45,6 +49,8 @@ export function OptionCard({
       )}
       onClick={disabled ? undefined : onClick}
       onKeyDown={isInteractive ? handleKeyDown : undefined}
+      onFocusCapture={onFocusCapture}
+      onMouseEnter={onMouseEnter}
       tabIndex={disabled ? -1 : isInteractive ? 0 : undefined}
       aria-pressed={isInteractive ? selected : undefined}
     >


### PR DESCRIPTION
## Description

This PR adds keyboard support for navigating answers when asked by the agent via the `ask_user_question` tool.

- adds a keyboard-active option cursor that starts on the first choice
- lets users move between options with `ArrowUp` / `ArrowDown`
- applies the hover visual to the keyboard-active option
- supports `Enter` / `Space` to act on the active option
- supports `Cmd/Ctrl+Enter` to submit in multi-select mode
- typing while having the component focused immediately starts typing in the input and selects it

Also took this opportunity to fix the padding and colors of the Counter next to the text input.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
