### PR TITLE
Add wake-up conversation API endpoints

### DIFF
--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -1027,6 +1027,61 @@
  *           type: boolean
  *         dismissed:
  *           type: boolean
+ *     PrivateWakeUp:
+ *       type: object
+ *       description: A wake-up scheduled in a conversation to re-invoke the agent at a later time.
+ *       required:
+ *         - id
+ *         - sId
+ *         - createdAt
+ *         - agentConfigurationId
+ *         - scheduleConfig
+ *         - reason
+ *         - status
+ *         - fireCount
+ *         - maxFires
+ *       properties:
+ *         id:
+ *           type: integer
+ *         sId:
+ *           type: string
+ *         createdAt:
+ *           type: integer
+ *           description: Unix timestamp (milliseconds).
+ *         agentConfigurationId:
+ *           type: string
+ *         scheduleConfig:
+ *           oneOf:
+ *             - type: object
+ *               required: [type, fireAt]
+ *               properties:
+ *                 type:
+ *                   type: string
+ *                   enum: [one_shot]
+ *                 fireAt:
+ *                   type: integer
+ *                   description: Unix timestamp (milliseconds) when the wake-up should fire.
+ *             - type: object
+ *               required: [type, cron, timezone]
+ *               properties:
+ *                 type:
+ *                   type: string
+ *                   enum: [cron]
+ *                 cron:
+ *                   type: string
+ *                   description: 5-field cron expression.
+ *                 timezone:
+ *                   type: string
+ *                   description: IANA timezone name.
+ *         reason:
+ *           type: string
+ *         status:
+ *           type: string
+ *           enum: [scheduled, fired, cancelled, expired]
+ *         fireCount:
+ *           type: integer
+ *         maxFires:
+ *           type: integer
  *     PrivateMention:
  *       type: object
  *       description: A mention in a message (agent or user).

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/[wuId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/[wuId]/index.ts
@@ -76,6 +76,8 @@ async function handler(
     });
   }
 
+  // The fetchConversationWithoutContent method checks for conversation accessibility (inside the
+  // resource through `baseFetchWithAuthorization`
   const conversationRes =
     await ConversationResource.fetchConversationWithoutContent(auth, cId);
   if (conversationRes.isErr()) {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/[wuId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/[wuId]/index.ts
@@ -90,7 +90,7 @@ async function handler(
     return apiError(req, res, {
       status_code: 404,
       api_error: {
-        type: "wake_up_not_found",
+        type: "wakeup_not_found",
         message: "Wake-up not found in this conversation.",
       },
     });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/[wuId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/[wuId]/index.ts
@@ -1,0 +1,124 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/wakeups/{wuId}:
+ *   delete:
+ *     summary: Cancel a wake-up
+ *     description: Cancel a scheduled wake-up. Only the wake-up owner or a workspace admin can cancel.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: wuId
+ *         required: true
+ *         description: sId of the wake-up to cancel
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully cancelled (or already terminal)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 wakeUp:
+ *                   $ref: '#/components/schemas/PrivateWakeUp'
+ *       403:
+ *         description: Caller is not the wake-up owner or a workspace admin
+ *       404:
+ *         description: Wake-up not found in this conversation
+ */
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WakeUpType } from "@app/types/assistant/wakeups";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type DeleteConversationWakeUpResponseBody = {
+  wakeUp: WakeUpType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<DeleteConversationWakeUpResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const { cId, wuId } = req.query;
+  if (!isString(cId) || !isString(wuId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Invalid query parameters, `cId` and `wuId` (strings) are required.",
+      },
+    });
+  }
+
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(auth, cId);
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+  const conversation = conversationRes.value;
+
+  const wakeUp = await WakeUpResource.fetchById(auth, wuId);
+  if (!wakeUp || wakeUp.conversationId !== conversation.id) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "wake_up_not_found",
+        message: "Wake-up not found in this conversation.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "DELETE": {
+      const cancelRes = await wakeUp.cancel(auth);
+      if (cancelRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: cancelRes.error.message,
+          },
+        });
+      }
+      res.status(200).json({ wakeUp: wakeUp.toJSON() });
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/index.ts
@@ -53,7 +53,9 @@ export type GetConversationWakeUpsResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetConversationWakeUpsResponseBody>>,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetConversationWakeUpsResponseBody>
+  >,
   auth: Authenticator
 ): Promise<void> {
   const { cId } = req.query;

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/index.ts
@@ -1,0 +1,98 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/wakeups:
+ *   get:
+ *     summary: List wake-ups for a conversation
+ *     description: Retrieve all wake-ups scheduled in a conversation (any status).
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved wake-ups
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 wakeUps:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/PrivateWakeUp'
+ *       401:
+ *         description: Unauthorized
+ */
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WakeUpType } from "@app/types/assistant/wakeups";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetConversationWakeUpsResponseBody = {
+  wakeUps: WakeUpType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetConversationWakeUpsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const { cId } = req.query;
+  if (!isString(cId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(auth, cId);
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+  const conversation = conversationRes.value;
+
+  switch (req.method) {
+    case "GET": {
+      const wakeUps = await WakeUpResource.listByConversation(
+        auth,
+        conversation
+      );
+      res.status(200).json({ wakeUps: wakeUps.map((w) => w.toJSON()) });
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups/index.ts
@@ -69,6 +69,8 @@ async function handler(
     });
   }
 
+  // The fetchConversationWithoutContent method checks for conversation accessibility (inside the
+  // resource through `baseFetchWithAuthorization`
   const conversationRes =
     await ConversationResource.fetchConversationWithoutContent(auth, cId);
   if (conversationRes.isErr()) {

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -7548,6 +7548,129 @@
         }
       }
     },
+    "/api/w/{wId}/assistant/conversations/{cId}/wakeups/{wuId}": {
+      "delete": {
+        "summary": "Cancel a wake-up",
+        "description": "Cancel a scheduled wake-up. Only the wake-up owner or a workspace admin can cancel.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "wuId",
+            "required": true,
+            "description": "sId of the wake-up to cancel",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully cancelled (or already terminal)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "wakeUp": {
+                      "$ref": "#/components/schemas/PrivateWakeUp"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not the wake-up owner or a workspace admin"
+          },
+          "404": {
+            "description": "Wake-up not found in this conversation"
+          }
+        }
+      }
+    },
+    "/api/w/{wId}/assistant/conversations/{cId}/wakeups": {
+      "get": {
+        "summary": "List wake-ups for a conversation",
+        "description": "Retrieve all wake-ups scheduled in a conversation (any status).",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved wake-ups",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "wakeUps": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/PrivateWakeUp"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
     "/api/w/{wId}/assistant/conversations": {
       "get": {
         "summary": "List conversations",
@@ -10946,6 +11069,101 @@
           },
           "dismissed": {
             "type": "boolean"
+          }
+        }
+      },
+      "PrivateWakeUp": {
+        "type": "object",
+        "description": "A wake-up scheduled in a conversation to re-invoke the agent at a later time.",
+        "required": [
+          "id",
+          "sId",
+          "createdAt",
+          "agentConfigurationId",
+          "scheduleConfig",
+          "reason",
+          "status",
+          "fireCount",
+          "maxFires"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "sId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "integer",
+            "description": "Unix timestamp (milliseconds)."
+          },
+          "agentConfigurationId": {
+            "type": "string"
+          },
+          "scheduleConfig": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "type",
+                  "fireAt"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "one_shot"
+                    ]
+                  },
+                  "fireAt": {
+                    "type": "integer",
+                    "description": "Unix timestamp (milliseconds) when the wake-up should fire."
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type",
+                  "cron",
+                  "timezone"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "cron"
+                    ]
+                  },
+                  "cron": {
+                    "type": "string",
+                    "description": "5-field cron expression."
+                  },
+                  "timezone": {
+                    "type": "string",
+                    "description": "IANA timezone name."
+                  }
+                }
+              }
+            ]
+          },
+          "reason": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "scheduled",
+              "fired",
+              "cancelled",
+              "expired"
+            ]
+          },
+          "fireCount": {
+            "type": "integer"
+          },
+          "maxFires": {
+            "type": "integer"
           }
         }
       },

--- a/front/types/assistant/wakeups.ts
+++ b/front/types/assistant/wakeups.ts
@@ -45,4 +45,8 @@ export const WakeUpSchema = z.object({
   fireCount: z.number(),
   maxFires: z.number(),
 });
+
+/**
+ * @swaggerschema PrivateWakeUp (swagger_private_schemas.ts)
+ */
 export type WakeUpType = z.infer<typeof WakeUpSchema>;

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -159,6 +159,8 @@ const API_ERROR_TYPES = [
   "project_metadata_not_found",
   // Suggestions
   "agent_suggestion_not_found",
+  // Wake-ups
+  "wake_up_not_found",
 ] as const;
 
 export type RegionRedirectError = {

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -160,7 +160,7 @@ const API_ERROR_TYPES = [
   // Suggestions
   "agent_suggestion_not_found",
   // Wake-ups
-  "wake_up_not_found",
+  "wakeup_not_found",
 ] as const;
 
 export type RegionRedirectError = {

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -108,16 +108,23 @@ selecting an existing agent message.
 
 ## Milestone 6: API + UI
 
-### PR 8 — Wake-up API endpoints
+### [x] PR 8 — Wake-up API endpoints
 
-`GET/DELETE /api/w/[wId]/assistant/conversations/[cId]/wakeups`. List active wake-ups, cancel by
-sId. SWR hooks. Keep private Swagger docs/annotations in sync.
+- `GET /api/w/[wId]/assistant/conversations/[cId]/wakeups` — lists all wake-ups for the
+  conversation (any status). Response: `{ wakeUps: WakeUpType[] }`.
+- `DELETE /api/w/[wId]/assistant/conversations/[cId]/wakeups/[wuId]` — cancels the
+  referenced wake-up; permission-gated by `WakeUpResource.cancel(...)` (owner or workspace
+  admin). Returns `{ wakeUp: WakeUpType }` with the updated status. 403 on permission
+  denied, 404 when the wake-up does not belong to the conversation.
+
+Added `wake_up_not_found` to `APIErrorType`, `PrivateWakeUp` schema to
+`swagger_private_schemas.ts`, and the `@swaggerschema` annotation on `WakeUpType`.
 
 ### PR 9 — Conversation UI
 
-Wake-up banner ("Waiting until {time} — {reason}" + cancel button). Wake-up message rendering
-(system-style message from "Dust"). Conversation moves to active in sidebar when wake-up fires.
-For V1, the UI can assume max 1 active wake-up per conversation.
+SWR Hooks. Wake-up banner ("Waiting until {time} — {reason}" + cancel button). Wake-up message
+rendering (system-style message from "Dust"). Conversation moves to active in sidebar when wake-up
+fires.  For V1, the UI can assume max 1 active wake-up per conversation.
 
 ## Milestone 7: Cleanup + GA
 

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -117,7 +117,7 @@ selecting an existing agent message.
   admin). Returns `{ wakeUp: WakeUpType }` with the updated status. 403 on permission
   denied, 404 when the wake-up does not belong to the conversation.
 
-Added `wake_up_not_found` to `APIErrorType`, `PrivateWakeUp` schema to
+Added `wakeup_not_found` to `APIErrorType`, `PrivateWakeUp` schema to
 `swagger_private_schemas.ts`, and the `@swaggerschema` annotation on `WakeUpType`.
 
 ### PR 9 — Conversation UI


### PR DESCRIPTION
## Description

PR 8 of the wake-up plan (`x/spolu/wakeup/plan.md`).

- `GET /api/w/[wId]/assistant/conversations/[cId]/wakeups` — lists all wake-ups for the conversation (any status). Response: `{ wakeUps: WakeUpType[] }`.
- `DELETE /api/w/[wId]/assistant/conversations/[cId]/wakeups/[wuId]` — cancels the referenced wake-up. Permission-gated by the existing `WakeUpResource.cancel(...)` check (owner or workspace admin). Returns `{ wakeUp: WakeUpType }` with the updated status. 403 on permission denied, 404 when the wake-up does not belong to the conversation.

Also:
- `wake_up_not_found` added to `APIErrorType`.
- `PrivateWakeUp` schema added in `swagger_private_schemas.ts`.
- `@swaggerschema` annotation on `WakeUpType`.

SWR hooks + UI are left for PR 9 per the plan.

## Tests

N/A, tested locally via curl — list returns the expected shape; delete respects owner/admin permissions.

## Risk

Low. New endpoints only; no existing routes changed. Behavior is gated by conversation access (same middleware as the other conversation endpoints) and the existing `cancel` permission logic on `WakeUpResource`.

## Deploy Plan

- deploy `front`