### PR TITLE
[front] Route EU workspaces to Gemini for image generation

### DIFF
--- a/front/lib/api/llm/getImageGenerationLLM.test.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.test.ts
@@ -8,6 +8,7 @@ const mockGetLlmCredentials = vi.hoisted(() => vi.fn());
 const mockIsProviderWhitelisted = vi.hoisted(() => vi.fn());
 const mockGoogleImageGenerationLLM = vi.hoisted(() => vi.fn());
 const mockOpenAIImageGenerationLLM = vi.hoisted(() => vi.fn());
+const mockGetCurrentRegion = vi.hoisted(() => vi.fn());
 
 vi.mock("@app/lib/api/provider_credentials", () => ({
   getLlmCredentials: mockGetLlmCredentials,
@@ -23,6 +24,12 @@ vi.mock("@app/lib/api/llm/clients/google/imageGeneration", () => ({
 
 vi.mock("@app/lib/api/llm/clients/openai/imageGeneration", () => ({
   ImageGenerationOpenAILLM: mockOpenAIImageGenerationLLM,
+}));
+
+vi.mock("@app/lib/api/regions/config", () => ({
+  config: {
+    getCurrentRegion: mockGetCurrentRegion,
+  },
 }));
 
 import { Authenticator } from "@app/lib/auth";
@@ -95,6 +102,7 @@ describe("getImageGenerationLLM", () => {
 
     mockGetLlmCredentials.mockResolvedValue(CREDENTIALS);
     mockIsProviderWhitelisted.mockReturnValue(false);
+    mockGetCurrentRegion.mockReturnValue("us-central1");
 
     mockGoogleImageGenerationLLM.mockImplementation(function (_auth, args) {
       return { provider: "google", args };
@@ -157,6 +165,36 @@ describe("getImageGenerationLLM", () => {
   });
 
   it("returns null when neither openai nor google is whitelisted", async () => {
+    const llm = await getImageGenerationLLM(auth);
+
+    expect(llm).toBeNull();
+    expect(mockOpenAIImageGenerationLLM).not.toHaveBeenCalled();
+    expect(mockGoogleImageGenerationLLM).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Gemini in the EU region even when openai is whitelisted", async () => {
+    mockGetCurrentRegion.mockReturnValue("europe-west1");
+    mockIsProviderWhitelisted.mockReturnValue(true);
+
+    const llm = await getImageGenerationLLM(auth);
+
+    expect(mockGoogleImageGenerationLLM).toHaveBeenCalledWith(auth, {
+      modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
+      credentials: CREDENTIALS,
+    });
+    expect(mockOpenAIImageGenerationLLM).not.toHaveBeenCalled();
+    expect(llm).toEqual({
+      provider: "google",
+      args: { modelId: GEMINI_3_PRO_IMAGE_MODEL_ID, credentials: CREDENTIALS },
+    });
+  });
+
+  it("returns null in the EU region when only openai is whitelisted", async () => {
+    mockGetCurrentRegion.mockReturnValue("europe-west1");
+    mockIsProviderWhitelisted.mockImplementation(
+      (_auth, providerId) => providerId === "openai"
+    );
+
     const llm = await getImageGenerationLLM(auth);
 
     expect(llm).toBeNull();

--- a/front/lib/api/llm/getImageGenerationLLM.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.ts
@@ -2,6 +2,7 @@ import { ImageGenerationGoogleLLM } from "@app/lib/api/llm/clients/google/imageG
 import { ImageGenerationOpenAILLM } from "@app/lib/api/llm/clients/openai/imageGeneration";
 import type { ImageGenerationLLM } from "@app/lib/api/llm/imageGeneration";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import { config as regionConfig } from "@app/lib/api/regions/config";
 import { isProviderWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
@@ -14,7 +15,11 @@ export async function getImageGenerationLLM(
     skipEmbeddingApiKeyRequirement: true,
   });
 
-  if (isProviderWhitelisted(auth, "openai")) {
+  // gpt-image-2 is not available from the EU region, so EU workspaces fall
+  // back to Gemini for image generation.
+  const isEuRegion = regionConfig.getCurrentRegion() === "europe-west1";
+
+  if (!isEuRegion && isProviderWhitelisted(auth, "openai")) {
     return new ImageGenerationOpenAILLM(auth, {
       modelId: GPT_IMAGE_2_MODEL_ID,
       credentials,


### PR DESCRIPTION
## Description

`gpt-image-2` became the default image generation model in #24739, but it is not available from the EU region. This PR skips the OpenAI branch in `getImageGenerationLLM` when running in `europe-west1` so EU workspaces fall back to Gemini 3 Pro. US continues to use `gpt-image-2` by default.

Region detection uses the same `regionConfig.getCurrentRegion() === "europe-west1"` pattern already used across the codebase (e.g. `transcribe_service.ts`, `provider_credentials.ts`, `slack_whitelist_bot.ts`).

## Tests

- Added unit tests in `getImageGenerationLLM.test.ts` covering:
  - EU region falls back to Gemini even when OpenAI is whitelisted.
  - EU region returns `null` when only OpenAI is whitelisted (no Gemini fallback possible).
- Existing US-region tests kept in place via a default mock of `getCurrentRegion` returning `us-central1`.

## Risk

Low. The change is a narrow region-gated branch and is covered by tests. If the region check regressed, the worst case is EU workspaces attempting to call an unavailable OpenAI model - the same broken state as today. Rollback is a one-line revert.

## Deploy Plan

Standard deploy. No migration, no config change required (`REGION` env var already set per environment).