### PR TITLE
feat(slack): allow external Slack guests who are Dust workspace members

### DIFF
--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -149,6 +149,7 @@ export async function withSlackErrorHandling<T>(
 
 export type SlackUserInfo = {
   email: string | null;
+  is_email_confirmed: boolean;
   is_bot: boolean;
   display_name?: string;
   real_name?: string;
@@ -205,6 +206,7 @@ async function _getSlackUserInfo(
       // From our perspective, a Slack user bot is a bot.
       is_bot: res.user?.is_bot || false,
       email: res.user?.profile?.email || null,
+      is_email_confirmed: res.user?.is_email_confirmed || false,
       display_name: res.user?.profile?.display_name,
       real_name: res.user?.profile?.real_name,
       is_restricted: res.user?.is_restricted || false,
@@ -246,6 +248,7 @@ export async function getSlackBotInfo(
     display_name: slackBot.bot?.name,
     real_name: slackBot.bot.name,
     email: null,
+    is_email_confirmed: false,
     image_512: slackBot.bot?.icons?.image_72 || null,
     tz: null,
     is_restricted: false,

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -210,6 +210,15 @@ async function isExternalUserAllowed(
   // Whitelisted domains are in the format "domain:group_id".
   whitelistedDomains?: readonly string[]
 ): Promise<{ authorized: boolean; groupIds: string[] }> {
+  // If the email is confirmed by Slack AND the user is an active Dust workspace
+  // member, treat them like a regular member — no group restriction needed.
+  if (
+    slackUserInfo.is_email_confirmed &&
+    (await isUserAllowed(connector, slackUserInfo))
+  ) {
+    return { authorized: true, groupIds: [] };
+  }
+
   const { slackChannelId } = slackInfos;
 
   const userDomain = getSlackUserEmailDomainFromProfile(slackUserInfo);
@@ -246,6 +255,20 @@ async function isExternalUserAllowed(
   if (!isChannelPublic) {
     return { authorized: false, groupIds: [] };
   }
+
+  // Matteo 2026-04-23: Log when a whitelisted user is authorized with an unverified email.
+  // This helps us understand how many external users are being let through without
+  // Slack's email confirmation guarantee, before we decide whether to tighten this.
+  if (authorization.authorized && !slackUserInfo.is_email_confirmed) {
+    logger.warn(
+      {
+        connectorId: connector.id,
+        slackUserEmail: getSlackUserEmailFromProfile(slackUserInfo),
+      },
+      "Whitelisted Slack user authorized with unverified email."
+    );
+  }
+
   return authorization;
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7717

This PR allows external verified Slack guests who are confirmed Dust workspace members to interact with the bot without domain whitelisting requirements.

- Adds `is_email_confirmed` field to `SlackUserInfo` type to track Slack's email verification status
- Updates `isExternalUserAllowed` to bypass group restrictions for external users with Slack-confirmed emails who are active Dust workspace members
- Adds logging to monitor whitelisted users with unverified emails for future restriction decisions

Note: the [slack documentation](https://docs.slack.dev/reference/methods/users.info/) does not mention the `is_email_confirmed` field, but the field is returned in practice and included in the TypeScript types.

## Tests


## Risk

Low. The change only affects external Slack users, and adds an additional path for users who are already verified Dust workspace members with Slack-confirmed emails. Existing authorization paths remain unchanged.

## Deploy Plan

Standard deployment. No special steps required.
