### PR TITLE
[Branching] Rewrite copied frame ids in branch carry-over

### DIFF
--- a/front/lib/api/assistant/attachment_id_replacements.ts
+++ b/front/lib/api/assistant/attachment_id_replacements.ts
@@ -1,0 +1,31 @@
+import type { CompactionAttachmentIdReplacements } from "@app/types/assistant/compaction";
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function replaceStandaloneAttachmentIds(
+  content: string,
+  replacements: CompactionAttachmentIdReplacements | undefined
+): string {
+  if (!replacements || Object.keys(replacements).length === 0) {
+    return content;
+  }
+
+  let nextContent = content;
+
+  for (const [sourceId, targetId] of Object.entries(replacements).sort(
+    ([leftId], [rightId]) => rightId.length - leftId.length
+  )) {
+    const pattern = new RegExp(
+      `(^|[^A-Za-z0-9_])(${escapeRegex(sourceId)})(?=$|[^A-Za-z0-9_])`,
+      "g"
+    );
+
+    nextContent = nextContent.replace(pattern, (_match, prefix) => {
+      return `${prefix}${targetId}`;
+    });
+  }
+
+  return nextContent;
+}

--- a/front/lib/api/assistant/conversation/compaction_attachment_id_replacements.ts
+++ b/front/lib/api/assistant/conversation/compaction_attachment_id_replacements.ts
@@ -1,9 +1,15 @@
 import type { CompactionAttachmentIdReplacements } from "@app/types/assistant/compaction";
 
-function escapeRegex(text: string): string {
-  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
+/**
+ * Source-backed compaction is reused when creating conversation forks.
+ *
+ * In that flow we need to rewrite attachment ids from the source conversation to the ids that
+ * exist in the child conversation, both in the persisted compaction summary and in copied
+ * interactive-content files that embed those ids.
+ *
+ * The replacement is intentionally limited to standalone id tokens so surrounding prose and
+ * concatenated strings remain unchanged.
+ */
 export function replaceStandaloneAttachmentIds(
   content: string,
   replacements: CompactionAttachmentIdReplacements | undefined
@@ -28,4 +34,8 @@ export function replaceStandaloneAttachmentIds(
   }
 
   return nextContent;
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -356,7 +356,11 @@ function getLatestContentNodeContentFragmentId(
   throw new Error(`Missing content node content fragment for node ${nodeId}.`);
 }
 
-function mockCopyToConversation() {
+function mockCopyToConversation({
+  copyContent = false,
+}: {
+  copyContent?: boolean;
+} = {}) {
   return vi
     .spyOn(FileResource, "copyToConversation")
     .mockImplementation(async (auth, { sourceId, conversationId }) => {
@@ -378,9 +382,15 @@ function mockCopyToConversation() {
         snippet: sourceFile.snippet,
       });
 
-      const sourceContent = await getFileContent(auth, sourceFile, "original");
-      if (sourceContent !== null) {
-        await copiedFile.uploadContent(auth, sourceContent);
+      if (copyContent) {
+        const sourceContent = await getFileContent(
+          auth,
+          sourceFile,
+          "original"
+        );
+        if (sourceContent !== null) {
+          await copiedFile.uploadContent(auth, sourceContent);
+        }
       }
 
       return new Ok(copiedFile);
@@ -843,7 +853,7 @@ describe("createConversationFork", () => {
   it("copies direct conversation file attachments into the child conversation", async () => {
     const { auth, workspace, globalSpace } =
       await createPrivateApiMockRequest();
-    const copyToConversationSpy = mockCopyToConversation();
+    const copyToConversationSpy = mockCopyToConversation({ copyContent: true });
     const dataSourceView = await DataSourceViewFactory.folder(
       workspace,
       globalSpace,

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -12,7 +12,7 @@ import { createConversationFork } from "@app/lib/api/assistant/conversation/fork
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import * as dataSourcesModule from "@app/lib/api/data_sources";
 import * as fileUpsertModule from "@app/lib/api/files/upsert";
-import { getFileContent } from "@app/lib/api/files/utils";
+import * as fileUtilsModule from "@app/lib/api/files/utils";
 import { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPActionModel,
@@ -383,7 +383,7 @@ function mockCopyToConversation({
       });
 
       if (copyContent) {
-        const sourceContent = await getFileContent(
+        const sourceContent = await fileUtilsModule.getFileContent(
           auth,
           sourceFile,
           "original"
@@ -398,7 +398,7 @@ function mockCopyToConversation({
 }
 
 function mockDatasourceSeeding(
-  dataSource: Awaited<
+  dataSource = {} as Awaited<
     ReturnType<typeof DataSourceViewFactory.folder>
   >["dataSource"]
 ) {
@@ -412,6 +412,28 @@ function mockDatasourceSeeding(
   return {
     getOrCreateConversationDataSourceFromFileSpy,
     processAndUpsertToDataSourceSpy,
+  };
+}
+
+function mockFileContentStorage() {
+  const fileContents = new Map<string, string>();
+  const getFileContentSpy = vi
+    .spyOn(fileUtilsModule, "getFileContent")
+    .mockImplementation(
+      async (_auth, file) => fileContents.get(file.sId) ?? null
+    );
+  const uploadContentSpy = vi
+    .spyOn(FileResource.prototype, "uploadContent")
+    .mockImplementation(async function (this: FileResource, _auth, content) {
+      fileContents.set(this.sId, content);
+      await this.update({
+        fileSize: Buffer.byteLength(content, "utf8"),
+      });
+    });
+
+  return {
+    getFileContentSpy,
+    uploadContentSpy,
   };
 }
 
@@ -851,18 +873,12 @@ describe("createConversationFork", () => {
   });
 
   it("copies direct conversation file attachments into the child conversation", async () => {
-    const { auth, workspace, globalSpace } =
-      await createPrivateApiMockRequest();
-    const copyToConversationSpy = mockCopyToConversation({ copyContent: true });
-    const dataSourceView = await DataSourceViewFactory.folder(
-      workspace,
-      globalSpace,
-      auth.user() ?? null
-    );
+    const { auth } = await createPrivateApiMockRequest();
+    const copyToConversationSpy = mockCopyToConversation();
     const {
       getOrCreateConversationDataSourceFromFileSpy,
       processAndUpsertToDataSourceSpy,
-    } = mockDatasourceSeeding(dataSourceView.dataSource);
+    } = mockDatasourceSeeding();
 
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
@@ -969,18 +985,13 @@ describe("createConversationFork", () => {
   }, 15_000);
 
   it("rewrites copied frame file ids to the child attachment ids", async () => {
-    const { auth, workspace, globalSpace } =
-      await createPrivateApiMockRequest();
-    const copyToConversationSpy = mockCopyToConversation();
-    const dataSourceView = await DataSourceViewFactory.folder(
-      workspace,
-      globalSpace,
-      auth.user() ?? null
-    );
+    const { auth } = await createPrivateApiMockRequest();
+    const copyToConversationSpy = mockCopyToConversation({ copyContent: true });
+    const { getFileContentSpy, uploadContentSpy } = mockFileContentStorage();
     const {
       getOrCreateConversationDataSourceFromFileSpy,
       processAndUpsertToDataSourceSpy,
-    } = mockDatasourceSeeding(dataSourceView.dataSource);
+    } = mockDatasourceSeeding();
 
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
@@ -1090,7 +1101,7 @@ const untouched = "prefix${referencedFile.sId}suffix";`
       throw new Error("Missing copied frame file.");
     }
 
-    const copiedFrameContent = await getFileContent(
+    const copiedFrameContent = await fileUtilsModule.getFileContent(
       auth,
       copiedFrameFile,
       "original"
@@ -1120,8 +1131,10 @@ const untouched = "prefix${referencedFile.sId}suffix";`
     expect(processAndUpsertToDataSourceSpy).toHaveBeenCalledTimes(1);
 
     copyToConversationSpy.mockRestore();
+    getFileContentSpy.mockRestore();
     getOrCreateConversationDataSourceFromFileSpy.mockRestore();
     processAndUpsertToDataSourceSpy.mockRestore();
+    uploadContentSpy.mockRestore();
   }, 15_000);
 
   it("only copies attachments that existed at the selected source message", async () => {

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -12,6 +12,7 @@ import { createConversationFork } from "@app/lib/api/assistant/conversation/fork
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import * as dataSourcesModule from "@app/lib/api/data_sources";
 import * as fileUpsertModule from "@app/lib/api/files/upsert";
+import { getFileContent } from "@app/lib/api/files/utils";
 import { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPActionModel,
@@ -54,6 +55,7 @@ import {
   isContentFragmentType,
   isContentNodeContentFragment,
 } from "@app/types/content_fragment";
+import { frameContentType } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
@@ -375,6 +377,11 @@ function mockCopyToConversation() {
         },
         snippet: sourceFile.snippet,
       });
+
+      const sourceContent = await getFileContent(auth, sourceFile, "original");
+      if (sourceContent !== null) {
+        await copiedFile.uploadContent(auth, sourceContent);
+      }
 
       return new Ok(copiedFile);
     });
@@ -945,6 +952,162 @@ describe("createConversationFork", () => {
         }),
       })
     );
+
+    copyToConversationSpy.mockRestore();
+    getOrCreateConversationDataSourceFromFileSpy.mockRestore();
+    processAndUpsertToDataSourceSpy.mockRestore();
+  }, 15_000);
+
+  it("rewrites copied frame file ids to the child attachment ids", async () => {
+    const { auth, workspace, globalSpace } =
+      await createPrivateApiMockRequest();
+    const copyToConversationSpy = mockCopyToConversation();
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      globalSpace,
+      auth.user() ?? null
+    );
+    const {
+      getOrCreateConversationDataSourceFromFileSpy,
+      processAndUpsertToDataSourceSpy,
+    } = mockDatasourceSeeding(dataSourceView.dataSource);
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const referencedFile = await createConversationFile(auth, {
+      conversationId: parentConversation.sId,
+      fileName: "data.csv",
+      snippet: "data",
+    });
+    const frameFile = await FileFactory.create(
+      auth,
+      auth.getNonNullableUser(),
+      {
+        contentType: frameContentType,
+        fileName: "dashboard.tsx",
+        fileSize: 16,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: {
+          conversationId: parentConversation.sId,
+        },
+      }
+    );
+    await frameFile.uploadContent(
+      auth,
+      `const referencedFileId = "${referencedFile.sId}";
+const frameFileId = "${frameFile.sId}";
+const untouched = "prefix${referencedFile.sId}suffix";`
+    );
+
+    let parentConversationWithContent = await fetchConversationOrThrow(
+      auth,
+      parentConversation.sId
+    );
+    const attachmentResult = await postNewContentFragment(
+      auth,
+      parentConversationWithContent,
+      {
+        title: "Data",
+        fileId: referencedFile.sId,
+      },
+      null
+    );
+    expect(attachmentResult.isOk()).toBe(true);
+    if (attachmentResult.isErr()) {
+      throw attachmentResult.error;
+    }
+
+    parentConversationWithContent = await fetchConversationOrThrow(
+      auth,
+      parentConversation.sId
+    );
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversationWithContent,
+      rank: 1,
+      content: "Please branch this.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversationWithContent,
+      rank: 2,
+      parentId: userMessage.id,
+      status: "succeeded",
+      generatedFileId: frameFile.id,
+    });
+
+    const result = await createConversationFork(auth, {
+      conversationId: parentConversation.sId,
+      sourceMessageId: sourceMessage.sId,
+    });
+
+    expect(result.isErr()).toBe(false);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const childConversation = await fetchConversationOrThrow(
+      auth,
+      result.value
+    );
+
+    const childAttachments = await listAttachments(auth, {
+      conversation: childConversation,
+    });
+    const childFileAttachments = childAttachments.filter(isFileAttachmentType);
+
+    expect(childFileAttachments).toHaveLength(2);
+
+    const copiedDataAttachment = childFileAttachments.find(
+      (attachment) => attachment.title === "data.csv"
+    );
+    const copiedFrameAttachment = childFileAttachments.find(
+      (attachment) => attachment.title === "dashboard.tsx"
+    );
+
+    expect(copiedDataAttachment?.fileId).toBeDefined();
+    expect(copiedFrameAttachment?.fileId).toBeDefined();
+
+    const copiedFrameFile = await FileResource.fetchById(
+      auth,
+      copiedFrameAttachment!.fileId
+    );
+    expect(copiedFrameFile).not.toBeNull();
+    if (!copiedFrameFile) {
+      throw new Error("Missing copied frame file.");
+    }
+
+    const copiedFrameContent = await getFileContent(
+      auth,
+      copiedFrameFile,
+      "original"
+    );
+    expect(copiedFrameContent).toBe(
+      `const referencedFileId = "${copiedDataAttachment!.fileId}";
+const frameFileId = "${copiedFrameAttachment!.fileId}";
+const untouched = "prefix${referencedFile.sId}suffix";`
+    );
+    expect(vi.mocked(launchCompactionWorkflow)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth,
+        conversationId: childConversation.sId,
+        sourceConversation: expect.objectContaining({
+          conversationId: parentConversation.sId,
+          messageRank: sourceMessage.rank,
+          attachmentIdReplacements: expect.objectContaining({
+            [referencedFile.sId]: copiedDataAttachment!.fileId,
+            [frameFile.sId]: copiedFrameAttachment!.fileId,
+          }),
+        }),
+      })
+    );
+    expect(getOrCreateConversationDataSourceFromFileSpy).toHaveBeenCalledTimes(
+      1
+    );
+    expect(processAndUpsertToDataSourceSpy).toHaveBeenCalledTimes(1);
 
     copyToConversationSpy.mockRestore();
     getOrCreateConversationDataSourceFromFileSpy.mockRestore();

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -1,3 +1,4 @@
+import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/attachment_id_replacements";
 import {
   compactConversation,
   postNewContentFragment,
@@ -15,6 +16,7 @@ import {
   isFileTypeUpsertableForUseCase,
   processAndUpsertToDataSource,
 } from "@app/lib/api/files/upsert";
+import { getFileContent } from "@app/lib/api/files/utils";
 import { getSmallWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -37,7 +39,9 @@ import type {
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import type { SupportedModel } from "@app/types/assistant/models/types";
+import type { ContentFragmentType } from "@app/types/content_fragment";
 import { isFileContentFragment } from "@app/types/content_fragment";
+import { isInteractiveContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -57,7 +61,14 @@ type CarriedAttachment = {
   attachLogMetadata: Record<string, string>;
 };
 
+type CarriedAttachmentResult = {
+  sourceAttachmentId: string;
+  targetAttachment: ContentFragmentType;
+  carriedFile: FileResource | null;
+};
+
 const ATTACHMENT_CARRY_OVER_CONCURRENCY = 4;
+const INTERACTIVE_CONTENT_REWRITE_CONCURRENCY = 4;
 
 function filterConversationContentUpToRank(
   conversation: ConversationType,
@@ -326,6 +337,75 @@ async function addFileToConversationDatasource(
   }
 }
 
+async function rewriteCopiedInteractiveContentAttachmentIds(
+  auth: Authenticator,
+  {
+    parentConversationId,
+    childConversationId,
+    copiedFiles,
+    attachmentIdReplacements,
+  }: {
+    parentConversationId: string;
+    childConversationId: string;
+    copiedFiles: FileResource[];
+    attachmentIdReplacements: CompactionAttachmentIdReplacements;
+  }
+): Promise<void> {
+  if (Object.keys(attachmentIdReplacements).length === 0) {
+    return;
+  }
+
+  const copiedFrames = copiedFiles.filter((file) =>
+    isInteractiveContentType(file.contentType)
+  );
+  if (copiedFrames.length === 0) {
+    return;
+  }
+
+  await concurrentExecutor(
+    copiedFrames,
+    async (file) => {
+      const content = await getFileContent(auth, file, "original");
+      if (content === null) {
+        logger.error(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            parentConversationId,
+            childConversationId,
+            copiedFileId: file.sId,
+          },
+          "Failed to read copied interactive content file in forked conversation."
+        );
+        return;
+      }
+
+      const updatedContent = replaceStandaloneAttachmentIds(
+        content,
+        attachmentIdReplacements
+      );
+      if (updatedContent === content) {
+        return;
+      }
+
+      try {
+        await file.uploadContent(auth, updatedContent);
+      } catch (error) {
+        logger.error(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            parentConversationId,
+            childConversationId,
+            copiedFileId: file.sId,
+            error,
+          },
+          "Failed to rewrite copied interactive content file ids in forked conversation."
+        );
+      }
+    },
+    { concurrency: INTERACTIVE_CONTENT_REWRITE_CONCURRENCY }
+  );
+}
+
 async function carryOverConversationAttachments(
   auth: Authenticator,
   {
@@ -358,7 +438,10 @@ async function carryOverConversationAttachments(
 
     return isContentNodeAttachmentType(attachment);
   });
-  const attachmentResults = await concurrentExecutor(
+  const attachmentResults = await concurrentExecutor<
+    (typeof directConversationAttachments)[number],
+    CarriedAttachmentResult | null
+  >(
     directConversationAttachments,
     async (attachment) => {
       let carriedResult: CarriedAttachment | null;
@@ -425,28 +508,41 @@ async function carryOverConversationAttachments(
         sourceAttachmentId: isFileAttachmentType(attachment)
           ? attachment.fileId
           : attachment.contentFragmentId,
+        carriedFile,
         targetAttachment: attachmentResult.value,
       };
     },
     { concurrency: ATTACHMENT_CARRY_OVER_CONCURRENCY }
   );
 
-  return attachmentResults.reduce<CompactionAttachmentIdReplacements>(
-    (acc, result) => {
-      if (!result) {
+  const attachmentIdReplacements =
+    attachmentResults.reduce<CompactionAttachmentIdReplacements>(
+      (acc, result) => {
+        if (!result) {
+          return acc;
+        }
+
+        acc[result.sourceAttachmentId] =
+          isFileContentFragment(result.targetAttachment) &&
+          result.targetAttachment.fileId !== null
+            ? result.targetAttachment.fileId
+            : result.targetAttachment.contentFragmentId;
+
         return acc;
-      }
+      },
+      {}
+    );
 
-      acc[result.sourceAttachmentId] =
-        isFileContentFragment(result.targetAttachment) &&
-        result.targetAttachment.fileId !== null
-          ? result.targetAttachment.fileId
-          : result.targetAttachment.contentFragmentId;
+  await rewriteCopiedInteractiveContentAttachmentIds(auth, {
+    parentConversationId: parentConversation.sId,
+    childConversationId: childConversation.sId,
+    copiedFiles: attachmentResults.flatMap((result) =>
+      result?.carriedFile ? [result.carriedFile] : []
+    ),
+    attachmentIdReplacements,
+  });
 
-      return acc;
-    },
-    {}
-  );
+  return attachmentIdReplacements;
 }
 
 export async function createConversationFork(

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -1,4 +1,3 @@
-import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/attachment_id_replacements";
 import {
   compactConversation,
   postNewContentFragment,
@@ -9,6 +8,7 @@ import {
   isContentNodeAttachmentType,
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
+import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/conversation/compaction_attachment_id_replacements";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -1,3 +1,4 @@
+import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/attachment_id_replacements";
 import type { LLMConfig } from "@app/lib/api/assistant/call_llm";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { updateCompactionMessageWithContentAndFinalStatus } from "@app/lib/api/assistant/conversation";
@@ -9,10 +10,7 @@ import { isProviderWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
-import type {
-  CompactionAttachmentIdReplacements,
-  CompactionSourceConversation,
-} from "@app/types/assistant/compaction";
+import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
 import type {
   CompactionMessageType,
   ConversationType,
@@ -70,36 +68,6 @@ function extractSummary(generation: string): string {
   }
   // Fallback: if no <summary> tags, return the full generation stripped of <analysis>.
   return generation.replace(/<analysis>[\s\S]*?<\/analysis>/g, "").trim();
-}
-
-function escapeRegex(text: string): string {
-  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function replaceAttachmentIdsInSummary(
-  summary: string,
-  replacements: CompactionAttachmentIdReplacements | undefined
-): string {
-  if (!replacements || Object.keys(replacements).length === 0) {
-    return summary;
-  }
-
-  let nextSummary = summary;
-
-  for (const [sourceId, targetId] of Object.entries(replacements).sort(
-    ([leftId], [rightId]) => rightId.length - leftId.length
-  )) {
-    const pattern = new RegExp(
-      `(^|[^A-Za-z0-9_])(${escapeRegex(sourceId)})(?=$|[^A-Za-z0-9_])`,
-      "g"
-    );
-
-    nextSummary = nextSummary.replace(pattern, (_match, prefix) => {
-      return `${prefix}${targetId}`;
-    });
-  }
-
-  return nextSummary;
 }
 
 function filterConversationContentUpToRank(
@@ -215,7 +183,7 @@ export async function runCompaction(
   let status: "succeeded" | "failed";
 
   if (summaryRes.isOk()) {
-    content = replaceAttachmentIdsInSummary(
+    content = replaceStandaloneAttachmentIds(
       summaryRes.value,
       sourceConversation?.attachmentIdReplacements
     );

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -1,7 +1,7 @@
-import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/attachment_id_replacements";
 import type { LLMConfig } from "@app/lib/api/assistant/call_llm";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { updateCompactionMessageWithContentAndFinalStatus } from "@app/lib/api/assistant/conversation";
+import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/conversation/compaction_attachment_id_replacements";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24755.

Branch carry-over already remaps attachment ids for source-backed compaction. This extracts the standalone id rewrite into a shared helper and applies it to copied interactive-content files after all attachments have been copied, so frames that embed attachment ids point at the child conversation ids.

## Risks
Blast radius: branched conversations carrying over interactive-content files that reference conversation attachment ids
Risk: low

## Deploy Plan
- pmrr
- deploy front