### PR TITLE
perf(sbx): bundle GCS mount and egress setup into single execs

### DIFF
--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -83,17 +83,13 @@ describe("sandbox egress helpers", () => {
     expect(payload.exp).toBeGreaterThan(payload.iat ?? 0);
   });
 
-  it("writes the token, starts the forwarder, and waits for health", async () => {
+  it("runs a single bundled setup exec that writes the token, starts the forwarder, and waits for health", async () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
       exec: vi
         .fn()
-        .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
-        .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
-        .mockResolvedValueOnce(new Ok({ exitCode: 1, stdout: "", stderr: "" }))
-        .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
+        .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
     };
 
     const result = await setupEgressForwarder(auth, sandbox as never);
@@ -102,29 +98,15 @@ describe("sandbox egress helpers", () => {
     expect(mockLookup).toHaveBeenCalledWith("eu.sandbox-egress.dust.tt", {
       family: 4,
     });
-    expect(sandbox.writeFile).toHaveBeenCalledWith(
-      auth,
-      "/etc/dust/egress-token",
-      expect.anything()
-    );
-    expect(sandbox.exec).toHaveBeenNthCalledWith(
-      1,
-      auth,
-      expect.stringContaining("chmod 600 '/etc/dust/egress-token'"),
-      { user: "root" }
-    );
-    expect(sandbox.exec).toHaveBeenNthCalledWith(
-      2,
-      auth,
-      expect.stringContaining("--proxy-addr '203.0.113.10:4443'"),
-      { user: "root" }
-    );
-    expect(sandbox.exec).toHaveBeenNthCalledWith(
-      2,
-      auth,
-      expect.stringContaining("--proxy-tls-name 'eu.sandbox-egress.dust.tt'"),
-      { user: "root" }
-    );
+    expect(sandbox.exec).toHaveBeenCalledTimes(1);
+    const [, script, opts] = sandbox.exec.mock.calls[0];
+    expect(script).toContain("printf '%s'");
+    expect(script).toContain("> /etc/dust/egress-token");
+    expect(script).toContain("chmod 600 /etc/dust/egress-token");
+    expect(script).toContain("--proxy-addr '203.0.113.10:4443'");
+    expect(script).toContain("--proxy-tls-name 'eu.sandbox-egress.dust.tt'");
+    expect(script).toContain("ss -tln sport = :9990");
+    expect(opts).toMatchObject({ user: "root" });
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({
         event: "egress.setup",
@@ -181,7 +163,6 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
       exec: vi
         .fn()
         .mockResolvedValue(new Err(new Error("sandbox command failed"))),

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -12,8 +12,8 @@ const EGRESS_TOKEN_PATH = "/etc/dust/egress-token";
 const EGRESS_DENY_LOG_PATH = "/tmp/dust-egress-denied.log";
 const EGRESS_DENY_LOG_OFFSET_PATH = "/tmp/.dust-egress-deny-offset";
 const EGRESS_FORWARDER_LOG_PATH = "/tmp/dust-forwarder.log";
-const EGRESS_SETUP_WAIT_RETRIES = 6;
-const EGRESS_SETUP_WAIT_MS = 500;
+const EGRESS_SETUP_HEALTH_TIMEOUT_SECONDS = 3;
+const EGRESS_SETUP_TIMEOUT_MS = 5_000;
 const EGRESS_JWT_TTL_SECONDS = 24 * 60 * 60;
 const MAX_DENY_LOG_LINES_PER_EXEC = 20;
 
@@ -39,36 +39,10 @@ function shellEscape(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
-async function sleep(delayMs: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, delayMs));
-}
-
 async function resolveProxyAddr(): Promise<string> {
   const proxyHost = getProxyHost();
   const { address } = await lookup(proxyHost, { family: 4 });
   return address;
-}
-
-async function runSuccessfulSandboxCommand(
-  auth: Authenticator,
-  sandbox: SandboxResource,
-  command: string,
-  user?: string
-): Promise<Result<void, Error>> {
-  const result = await sandbox.exec(auth, command, user ? { user } : undefined);
-  if (result.isErr()) {
-    return result;
-  }
-
-  if (result.value.exitCode !== 0) {
-    return new Err(
-      new Error(
-        `Sandbox command failed with exit code ${result.value.exitCode}: ${result.value.stderr || result.value.stdout || command}`
-      )
-    );
-  }
-
-  return new Ok(undefined);
 }
 
 export function mintEgressJwt(providerId: string, workspaceId: string): string {
@@ -128,26 +102,36 @@ export async function setupEgressForwarder(
     sandbox.providerId,
     auth.getNonNullableWorkspace().sId
   );
-  const tokenWriteResult = await sandbox.writeFile(
-    auth,
-    EGRESS_TOKEN_PATH,
-    new TextEncoder().encode(token).buffer
-  );
-  if (tokenWriteResult.isErr()) {
-    return tokenWriteResult;
+
+  const setupScript = buildEgressSetupScript({ token, proxyAddr });
+  const result = await sandbox.exec(auth, setupScript, {
+    user: "root",
+    timeoutMs: EGRESS_SETUP_TIMEOUT_MS,
+  });
+  if (result.isErr()) {
+    return result;
   }
 
-  const prepareTokenResult = await runSuccessfulSandboxCommand(
-    auth,
-    sandbox,
-    `chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)}`,
-    "root"
-  );
-  if (prepareTokenResult.isErr()) {
-    return prepareTokenResult;
+  if (result.value.exitCode !== 0) {
+    return new Err(
+      new Error(
+        `Egress setup script exited with code ${result.value.exitCode}: ${result.value.stderr}`
+      )
+    );
   }
 
-  const startForwarderCommand =
+  logger.info(logContext, "Sandbox egress forwarder is healthy");
+  return new Ok(undefined);
+}
+
+function buildEgressSetupScript({
+  token,
+  proxyAddr,
+}: {
+  token: string;
+  proxyAddr: string;
+}): string {
+  const dsbxCommand =
     "nohup /opt/bin/dsbx forward " +
     `--token-file ${shellEscape(EGRESS_TOKEN_PATH)} ` +
     `--proxy-addr ${shellEscape(`${proxyAddr}:${config.getEgressProxyPort()}`)} ` +
@@ -156,32 +140,22 @@ export async function setupEgressForwarder(
     `--deny-log ${shellEscape(EGRESS_DENY_LOG_PATH)} ` +
     `>${shellEscape(EGRESS_FORWARDER_LOG_PATH)} 2>&1 &`;
 
-  const startResult = await runSuccessfulSandboxCommand(
-    auth,
-    sandbox,
-    startForwarderCommand,
-    "root"
-  );
-  if (startResult.isErr()) {
-    return startResult;
-  }
-
-  for (let i = 0; i < EGRESS_SETUP_WAIT_RETRIES; i++) {
-    const healthResult = await checkEgressForwarderHealth(auth, sandbox);
-    if (healthResult.isErr()) {
-      return healthResult;
-    }
-    if (healthResult.value) {
-      logger.info(logContext, "Sandbox egress forwarder is healthy");
-      return new Ok(undefined);
-    }
-
-    await sleep(EGRESS_SETUP_WAIT_MS);
-  }
-
-  return new Err(
-    new Error("Sandbox egress forwarder did not become healthy in time")
-  );
+  return `set -e
+mkdir -p /etc/dust
+printf '%s' ${shellEscape(token)} > ${EGRESS_TOKEN_PATH}
+chmod 600 ${EGRESS_TOKEN_PATH}
+${dsbxCommand}
+deadline=$(( $(date +%s) + ${EGRESS_SETUP_HEALTH_TIMEOUT_SECONDS} ))
+while true; do
+  if ss -tln sport = :9990 | grep -q LISTEN; then
+    exit 0
+  fi
+  if [ $(date +%s) -ge $deadline ]; then
+    echo "Egress forwarder not healthy after ${EGRESS_SETUP_HEALTH_TIMEOUT_SECONDS}s" >&2
+    exit 42
+  fi
+  sleep 0.05
+done`;
 }
 
 // Best-effort, sandbox-global deny log surfacing. The offset tracks lines

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -9,17 +9,23 @@ import type { ConversationType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-const MOUNT_TIMEOUT_MS = 30_000;
+const MOUNT_TIMEOUT_MS = 35_000;
 const MOUNT_POINT = "/files/conversation";
+const TOKEN_FILE = "/tmp/token.json";
+const TOKEN_SERVER_READY_TIMEOUT_SECONDS = 5;
 
 /**
  * Mount GCS conversation files into a running sandbox via gcsfuse.
  *
  * The mount sequence:
  *  1. Mint a downscoped token scoped to the conversation prefix.
- *  2. Write the token JSON to /tmp/token.json in the sandbox.
- *  3. Start the token HTTP server (netcat loop on :9876) and wait for it.
- *  4. Run gcsfuse with --token-url pointing to the local token server.
+ *  2. In a single sandbox exec: write token, start token server, poll until
+ *     it's listening, then run gcsfuse. Bundling avoids ~3 E2B exec
+ *     round-trips (~270 ms each) plus the previous hardcoded `sleep 1`.
+ *
+ * The bundled script runs as root because gcsfuse needs root for FUSE.
+ * /tmp/token.json is chmod'd 666 so refreshGcsToken (default user) can
+ * overwrite it later.
  */
 export async function mountConversationFiles(
   auth: Authenticator,
@@ -47,7 +53,6 @@ export async function mountConversationFiles(
     prefix,
   });
 
-  // 1. Mint downscoped token.
   const tokenResult = await mintDownscopedGcsToken({ bucket, prefix });
   if (tokenResult.isErr()) {
     childLogger.error(
@@ -65,61 +70,28 @@ export async function mountConversationFiles(
     expires_in: expiresInSeconds,
   });
 
-  // 2. Write token file into the sandbox.
-  const writeResult = await sandbox.exec(
-    auth,
-    `printf '%s' '${escapeSingleQuotes(tokenJson)}' > /tmp/token.json`
-  );
-  if (writeResult.isErr()) {
-    childLogger.error(
-      { err: writeResult.error },
-      "GCS mount: failed to write token file"
-    );
-    return writeResult;
-  }
-
-  // 3. Start token server and wait until it's listening.
-  // The server script is a netcat loop baked into the template.
-  // Start in background, then verify with a separate exec (matching PoC).
-  const startResult = await sandbox.exec(
-    auth,
-    "bash /home/agent/.bin/token-server.sh > /tmp/server.log 2>&1 &"
-  );
-  if (startResult.isErr()) {
-    childLogger.error(
-      { err: startResult.error },
-      "GCS mount: failed to start token server"
-    );
-    return startResult;
-  }
-
-  const checkResult = await sandbox.exec(
-    auth,
-    "sleep 1 && curl -sf http://127.0.0.1:9876 > /dev/null 2>&1"
-  );
-  if (checkResult.isErr() || checkResult.value.exitCode !== 0) {
-    const msg = "Token server not ready after 1s";
-    childLogger.error({}, msg);
-    return new Err(new Error(msg));
-  }
-
-  // 4. Mount via gcsfuse (runs as root for FUSE permissions).
-  const mountCmd = buildMountCommand({ bucket, prefix });
-  const mountResult = await sandbox.exec(auth, mountCmd, {
+  const mountScript = buildMountScript({ tokenJson, bucket, prefix });
+  const mountResult = await sandbox.exec(auth, mountScript, {
     timeoutMs: MOUNT_TIMEOUT_MS,
     user: "root",
   });
   if (mountResult.isErr()) {
     childLogger.error(
       { err: mountResult.error },
-      "GCS mount: gcsfuse mount failed"
+      "GCS mount: exec failed"
     );
     return mountResult;
   }
 
   if (mountResult.value.exitCode !== 0) {
-    const msg = `gcsfuse exited with code ${mountResult.value.exitCode}: ${mountResult.value.stderr}`;
-    childLogger.error({ stderr: mountResult.value.stderr }, msg);
+    const msg = `GCS mount script exited with code ${mountResult.value.exitCode}: ${mountResult.value.stderr}`;
+    childLogger.error(
+      {
+        exitCode: mountResult.value.exitCode,
+        stderr: mountResult.value.stderr,
+      },
+      msg
+    );
     return new Err(new Error(msg));
   }
 
@@ -182,10 +154,12 @@ export async function refreshGcsToken(
   return new Ok(undefined);
 }
 
-function buildMountCommand({
+function buildMountScript({
+  tokenJson,
   bucket,
   prefix,
 }: {
+  tokenJson: string;
   bucket: string;
   prefix: string;
 }): string {
@@ -206,7 +180,23 @@ function buildMountCommand({
     `--enable-hns=false`,
   ].join(" ");
 
-  return `timeout 30 gcsfuse ${flags} ${bucket} ${MOUNT_POINT} 2>&1`;
+  // chmod 666 so refreshGcsToken (default user) can overwrite the file later.
+  return `set -e
+printf '%s' '${escapeSingleQuotes(tokenJson)}' > ${TOKEN_FILE}
+chmod 666 ${TOKEN_FILE}
+bash /home/agent/.bin/token-server.sh > /tmp/server.log 2>&1 &
+deadline=$(( $(date +%s) + ${TOKEN_SERVER_READY_TIMEOUT_SECONDS} ))
+while true; do
+  if curl -sf http://127.0.0.1:9876 > /dev/null 2>&1; then
+    break
+  fi
+  if [ $(date +%s) -ge $deadline ]; then
+    echo "Token server not ready after ${TOKEN_SERVER_READY_TIMEOUT_SECONDS}s" >&2
+    exit 41
+  fi
+  sleep 0.05
+done
+timeout 30 gcsfuse ${flags} ${bucket} ${MOUNT_POINT} 2>&1`;
 }
 
 function escapeSingleQuotes(s: string): string {


### PR DESCRIPTION
## Description

Both `mountConversationFiles` and `setupEgressForwarder` previously issued multiple sequential E2B execs, costing ~130–270 ms of round-trip per exec. Both are now a single bundled bash script.

**GCS mount:**
- 4 execs (printf token + token-server start + sleep+curl + gcsfuse mount) collapsed into 1 bundled bash script.
- Hardcoded `sleep 1` replaced with `until curl -sf …` polling at 50 ms intervals (5s budget).
- Whole script runs as root (gcsfuse needs FUSE); `/tmp/token.json` is `chmod 666` so the default-user `refreshGcsToken` write still works.

**Egress setup:**
- writeFile + chmod + dsbx-launch + health-check retry loop collapsed into 1 exec. Token now written via `printf` (JWT is base64url-safe in single quotes) instead of E2B writeFile.
- Per-exec health retry loop replaced with in-script polling (3s budget, 50 ms interval) — same total wait budget but no front round-trip per check.

Per-step error attribution preserved via `set -e`, distinct exit codes (41 = token server not ready, 42 = egress not healthy), and stderr from the failing step.

## Measured impact

Validated end-to-end against real E2B sandboxes (3 fresh creates per side, all destroyed in `finally`):

| | Mean | Median | Range |
|---|---|---|---|
| OLD mount sequence | 1982 ms | 1968 ms | 1904–2074 ms |
| NEW bundled mount | **518 ms** | 527 ms | 480–549 ms |
| **Mount savings** | **1463 ms (-74 %)** | | |
| Per-exec round-trip (`/bin/true`) | 134 ms | 118 ms | 112–204 ms (n=18) |

OLD mount per-step breakdown (means):
- `printf token`: 375 ms (one exec round-trip + the actual write)
- `start token-server`: 138 ms
- `sleep 1 && curl`: **1177 ms** ← the hardcoded sleep dominated
- `gcsfuse mount`: 291 ms

The `sleep 1` alone was ~1.18 s of pure waste — that's most of the win. Bundling 3 round-trips into 1 saves another ~250 ms.

**Egress estimate (not directly benchmarked, JWT secret unset in hive):** removing 3 round-trips ≈ ~400 ms locally, likely closer to ~800 ms in prod (round-trips appear slower against the prod E2B region). Per-exec round-trip on prod was ~270 ms in journal-log timestamps; locally it's ~134 ms.

## Tests

- `lib/api/sandbox/egress.test.ts` updated to assert the bundled exec contract (5/5 pass).
- Type-check clean.
- End-to-end mount path validated against real E2B (results above).

## Risk

Medium. Bundled scripts are new code paths exercised on every sandbox cold start / wake.

- gcsfuse already ran as root, but token-server.sh and the token file write now also run as root. `chmod 666` mitigates the file-ownership concern for `refreshGcsToken`.
- `/etc/dust` directory must exist for the egress token write — script now `mkdir -p`s it (was implicit via writeFile).
- Per-step error visibility moves from distinct log messages to a single stderr blob + exit code. Mitigated by `set -e` and distinct exit codes.

Easy to roll back if cold-start success rates regress.

## Deploy Plan

Standard front deploy. After deploy, watch for non-zero exit codes from the mount/egress scripts via:
- `service:front "GCS mount script exited with code"`
- `service:front "Egress setup script exited with code"`