### PR TITLE
Invalidate wake-ups SWR cache on agent tool success

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -54,6 +54,7 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
+import { useConversationWakeUps } from "@app/lib/swr/wakeups";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import type { FetchConversationMessageResponseLight } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]";
@@ -234,6 +235,11 @@ export function AgentMessage({
     owner,
     options: { disabled: true },
   });
+  const { mutateWakeUps } = useConversationWakeUps({
+    owner,
+    conversationId,
+    disabled: true,
+  });
 
   const methods = useVirtuosoMethods<
     VirtuosoMessage,
@@ -367,6 +373,9 @@ export function AgentMessage({
               void mutateSandboxStatus();
               void mutateSandboxFiles();
             }
+            if (action.internalMCPServerName === "wakeups") {
+              void mutateWakeUps();
+            }
             break;
           }
           case "end-of-stream":
@@ -388,6 +397,7 @@ export function AgentMessage({
         mutateConversationAttachments,
         mutateSandboxStatus,
         mutateSandboxFiles,
+        mutateWakeUps,
       ]
     ),
     streamId,


### PR DESCRIPTION
## Description

Hooks `mutateWakeUps()` into the existing `agent_action_success` event branch in `AgentMessage.tsx`, matching on `action.internalMCPServerName === "wakeups"`. Covers `schedule_wakeup`, `cancel_wakeup`, and `list_wakeups` in one check. Mirrors the existing sandbox-server pattern in the same file.

## Tests

N/A

## Risk

None

## Deploy Plan

- deploy `front`