### PR TITLE
[front] - chore(SpaceSearchLayout): tweak agent dropdown

### DIFF
--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -43,7 +43,7 @@ type RowData = {
 
 type Info = CellContext<RowData, unknown>;
 
-const getTableColumns = (onAgentClick: (agentSid: string) => void) => {
+const getTableColumns = (onAgentClick: (agentId: string) => void) => {
   return [
     {
       header: "Name",
@@ -103,7 +103,7 @@ export const SpaceCategoriesList = ({
   const { hasFeature } = useFeatureFlags();
   const { setIsSearchDisabled } = React.useContext(SpaceSearchContext);
 
-  const [assistantSId, setAssistantSId] = React.useState<string | null>(null);
+  const [assistantId, setAssistantId] = React.useState<string | null>(null);
 
   const rows: RowData[] = spaceInfo
     ? removeNulls(
@@ -200,8 +200,8 @@ export const SpaceCategoriesList = ({
       <AgentDetailsSheet
         owner={owner}
         user={user}
-        agentId={assistantSId}
-        onClose={() => setAssistantSId(null)}
+        agentId={assistantId}
+        onClose={() => setAssistantId(null)}
       />
       {isEmpty && (
         <div
@@ -217,7 +217,7 @@ export const SpaceCategoriesList = ({
       {rows.length > 0 && (
         <DataTable
           data={rows}
-          columns={getTableColumns(setAssistantSId)}
+          columns={getTableColumns(setAssistantId)}
           className="pb-4"
           columnsBreakpoints={{
             usage: "md",

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -1,9 +1,10 @@
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { SpaceSearchContext } from "@app/components/spaces/search/SpaceSearchContext";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { MCP_SPECIFICATION } from "@app/lib/actions/utils_ui";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { CATEGORY_DETAILS } from "@app/lib/spaces";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { DATA_SOURCE_VIEW_CATEGORIES } from "@app/types/api/public/spaces";
@@ -42,7 +43,7 @@ type RowData = {
 
 type Info = CellContext<RowData, unknown>;
 
-const getTableColumns = () => {
+const getTableColumns = (onAgentClick: (agentSid: string) => void) => {
   return [
     {
       header: "Name",
@@ -66,7 +67,7 @@ const getTableColumns = () => {
         <DataTable.CellContent>
           <UsedByButton
             usage={info.row.original.usage}
-            onItemClick={() => {}}
+            onItemClick={onAgentClick}
           />
         </DataTable.CellContent>
       ),
@@ -98,8 +99,11 @@ export const SpaceCategoriesList = ({
     spaceId: space.sId,
   });
 
+  const { user } = useAuth();
   const { hasFeature } = useFeatureFlags();
   const { setIsSearchDisabled } = React.useContext(SpaceSearchContext);
+
+  const [assistantSId, setAssistantSId] = React.useState<string | null>(null);
 
   const rows: RowData[] = spaceInfo
     ? removeNulls(
@@ -193,6 +197,12 @@ export const SpaceCategoriesList = ({
 
   return (
     <>
+      <AgentDetailsSheet
+        owner={owner}
+        user={user}
+        agentId={assistantSId}
+        onClose={() => setAssistantSId(null)}
+      />
       {isEmpty && (
         <div
           className={cn(
@@ -207,7 +217,7 @@ export const SpaceCategoriesList = ({
       {rows.length > 0 && (
         <DataTable
           data={rows}
-          columns={getTableColumns()}
+          columns={getTableColumns(setAssistantSId)}
           className="pb-4"
           columnsBreakpoints={{
             usage: "md",

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -42,9 +42,7 @@ export const UsedByButton = ({
       : usage.agents.filter((a) => a.name.toLowerCase().includes(query));
 
   return (
-    // 1. modal={false} to make the dropdown menu non-modal and avoid a timing issue when we open the Agent side-panel modal.
     <DropdownMenu
-      modal={false}
       open={isOpen}
       onOpenChange={(open) => {
         setIsOpen(open);
@@ -57,11 +55,10 @@ export const UsedByButton = ({
         <Button
           icon={RobotIcon}
           variant="ghost-secondary"
-          isSelect={true}
+          isSelect
           size="xs"
           label={`${usage.count}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-            // 2. Avoid propagating the click to the parent element.
             e.stopPropagation();
           }}
         />
@@ -69,6 +66,7 @@ export const UsedByButton = ({
       <DropdownMenuContent
         className="h-96 w-72"
         align="end"
+        onClick={(e) => e.stopPropagation()}
         dropdownHeaders={
           <>
             <DropdownMenuSearchbar

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -4,9 +4,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   RobotIcon,
 } from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
 
 export const UsedByButton = ({
   usage,
@@ -15,18 +18,44 @@ export const UsedByButton = ({
   usage: AgentsUsageType | null;
   onItemClick: (assistantSid: string) => void;
 }) => {
-  return !usage || usage.count === 0 ? (
-    <Button
-      icon={RobotIcon}
-      variant="ghost-secondary"
-      isSelect={false}
-      size="xs"
-      label="0"
-      disabled
-    />
-  ) : (
+  const [searchText, setSearchText] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+
+  const filteredAgents = useMemo(() => {
+    if (!usage) {
+      return [];
+    }
+    const q = searchText.toLowerCase();
+    return q.length === 0
+      ? usage.agents
+      : usage.agents.filter((a) => a.name.toLowerCase().includes(q));
+  }, [usage, searchText]);
+
+  if (!usage || usage.count === 0) {
+    return (
+      <Button
+        icon={RobotIcon}
+        variant="ghost-secondary"
+        isSelect={false}
+        size="xs"
+        label="0"
+        disabled
+      />
+    );
+  }
+
+  return (
     // 1. modal={false} to make the dropdown menu non-modal and avoid a timing issue when we open the Agent side-panel modal.
-    <DropdownMenu modal={false}>
+    <DropdownMenu
+      modal={false}
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (open) {
+          setSearchText("");
+        }
+      }}
+    >
       <DropdownMenuTrigger asChild>
         <Button
           icon={RobotIcon}
@@ -40,17 +69,47 @@ export const UsedByButton = ({
           }}
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="max-w-48">
-        {usage.agents.map((agent) => (
-          <DropdownMenuItem
-            key={`assistant-picker-${agent.sId}`}
-            label={agent.name}
-            onClick={(e) => {
-              e.stopPropagation();
-              onItemClick(agent.sId);
-            }}
-          />
-        ))}
+      <DropdownMenuContent
+        className="h-96 w-72"
+        align="end"
+        dropdownHeaders={
+          <>
+            <DropdownMenuSearchbar
+              autoFocus
+              name="search-used-by-agents"
+              placeholder="Search agents"
+              value={searchText}
+              onChange={setSearchText}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && filteredAgents.length > 0) {
+                  onItemClick(filteredAgents[0].sId);
+                  setSearchText("");
+                  setIsOpen(false);
+                }
+              }}
+            />
+            <DropdownMenuSeparator />
+          </>
+        }
+      >
+        {filteredAgents.length > 0 ? (
+          filteredAgents.map((agent) => (
+            <DropdownMenuItem
+              key={`assistant-picker-${agent.sId}`}
+              label={agent.name}
+              truncateText
+              onClick={(e) => {
+                e.stopPropagation();
+                onItemClick(agent.sId);
+                setIsOpen(false);
+              }}
+            />
+          ))
+        ) : (
+          <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+            No agents found
+          </div>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -1,5 +1,6 @@
 import type { AgentsUsageType } from "@app/types/data_source";
 import {
+  Avatar,
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -9,7 +10,7 @@ import {
   DropdownMenuTrigger,
   RobotIcon,
 } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 export const UsedByButton = ({
   usage,
@@ -20,16 +21,6 @@ export const UsedByButton = ({
 }) => {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
-
-  const filteredAgents = useMemo(() => {
-    if (!usage) {
-      return [];
-    }
-    const q = searchText.toLowerCase();
-    return q.length === 0
-      ? usage.agents
-      : usage.agents.filter((a) => a.name.toLowerCase().includes(q));
-  }, [usage, searchText]);
 
   if (!usage || usage.count === 0) {
     return (
@@ -43,6 +34,12 @@ export const UsedByButton = ({
       />
     );
   }
+
+  const query = searchText.toLowerCase();
+  const filteredAgents =
+    query.length === 0
+      ? usage.agents
+      : usage.agents.filter((a) => a.name.toLowerCase().includes(query));
 
   return (
     // 1. modal={false} to make the dropdown menu non-modal and avoid a timing issue when we open the Agent side-panel modal.
@@ -96,8 +93,10 @@ export const UsedByButton = ({
           filteredAgents.map((agent) => (
             <DropdownMenuItem
               key={`assistant-picker-${agent.sId}`}
+              icon={() => <Avatar size="xs" visual={agent.pictureUrl} />}
               label={agent.name}
               truncateText
+              className="py-1"
               onClick={(e) => {
                 e.stopPropagation();
                 onItemClick(agent.sId);

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -86,6 +86,15 @@ export async function getToolsUsage(
         ),
         "sIds",
       ],
+      [
+        Sequelize.fn(
+          "array_agg",
+          Sequelize.literal(
+            '"agent_configuration"."pictureUrl" ORDER BY "agent_configuration"."name"'
+          )
+        ),
+        "pictureUrls",
+      ],
     ],
     include: [
       {
@@ -108,6 +117,7 @@ export async function getToolsUsage(
     remoteMCPServerId: ModelId;
     names: string[];
     sIds: string[];
+    pictureUrls: string[];
   }[];
 
   return res.reduce<MCPServersUsageByAgent>((acc, mcpServerViewConfig) => {
@@ -122,6 +132,7 @@ export async function getToolsUsage(
       agents: mcpServerViewConfig.sIds.map((sId, index) => ({
         sId,
         name: mcpServerViewConfig.names[index],
+        pictureUrl: mcpServerViewConfig.pictureUrls[index],
       })),
     };
     return acc;

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -33,22 +33,21 @@ export type DataSourcesUsageByAgent = Record<ModelId, AgentsUsageType | null>;
 const AGENT_CONFIG_PATH =
   '"agent_mcp_server_configuration->agent_configuration"';
 
-const agentAggregates = (): ProjectionAlias[] =>
-  (
-    [
-      ["name", "names"],
-      ["sId", "sIds"],
-      ["pictureUrl", "pictureUrls"],
-    ] as const
-  ).map(([column, alias]) => [
-    Sequelize.fn(
-      "array_agg",
-      Sequelize.literal(
-        `${AGENT_CONFIG_PATH}."${column}" ORDER BY ${AGENT_CONFIG_PATH}."name"`
-      )
-    ),
-    alias,
-  ]);
+const agentAggregates: ProjectionAlias[] = (
+  [
+    ["name", "names"],
+    ["sId", "sIds"],
+    ["pictureUrl", "pictureUrls"],
+  ] as const
+).map(([column, alias]) => [
+  Sequelize.fn(
+    "array_agg",
+    Sequelize.literal(
+      `${AGENT_CONFIG_PATH}."${column}" ORDER BY ${AGENT_CONFIG_PATH}."name"`
+    )
+  ),
+  alias,
+]);
 
 export async function getDataSourceViewsUsageByCategory({
   auth,
@@ -142,7 +141,7 @@ export async function getDataSourceViewsUsageByCategory({
       },
       attributes: [
         [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
-        ...agentAggregates(),
+        ...agentAggregates,
       ],
       include: [
         {
@@ -179,7 +178,7 @@ export async function getDataSourceViewsUsageByCategory({
       },
       attributes: [
         [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
-        ...agentAggregates(),
+        ...agentAggregates,
       ],
       include: [
         {
@@ -308,7 +307,7 @@ export async function getDataSourcesUsageByCategory({
       },
       attributes: [
         [Sequelize.col("dataSource.id"), "dataSourceId"],
-        ...agentAggregates(),
+        ...agentAggregates,
       ],
       include: [
         {
@@ -348,7 +347,7 @@ export async function getDataSourcesUsageByCategory({
       },
       attributes: [
         [Sequelize.col("dataSource.id"), "dataSourceId"],
-        ...agentAggregates(),
+        ...agentAggregates,
       ],
       include: [
         {
@@ -449,7 +448,7 @@ export async function getDataSourceUsage({
   const res = (await Promise.all([
     AgentDataSourceConfigurationModel.findOne({
       raw: true,
-      attributes: [...agentAggregates()],
+      attributes: [...agentAggregates],
       where: {
         workspaceId: owner.id,
         dataSourceId: dataSource.id,
@@ -477,7 +476,7 @@ export async function getDataSourceUsage({
     }),
     AgentTablesQueryConfigurationTableModel.findOne({
       raw: true,
-      attributes: [...agentAggregates()],
+      attributes: [...agentAggregates],
       where: {
         workspaceId: owner.id,
         dataSourceId: dataSource.id,
@@ -559,7 +558,7 @@ export async function getDataSourceViewUsage({
   const res = (await Promise.all([
     AgentDataSourceConfigurationModel.findOne({
       raw: true,
-      attributes: [...agentAggregates()],
+      attributes: [...agentAggregates],
       where: {
         workspaceId: owner.id,
         dataSourceViewId: dataSourceView.id,
@@ -587,7 +586,7 @@ export async function getDataSourceViewUsage({
     }),
     AgentTablesQueryConfigurationTableModel.findOne({
       raw: true,
-      attributes: [...agentAggregates()],
+      attributes: [...agentAggregates],
       where: {
         workspaceId: owner.id,
         dataSourceViewId: dataSourceView.id,

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -21,7 +21,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import sortBy from "lodash/sortBy";
 import uniqBy from "lodash/uniqBy";
-import type { WhereAttributeHashValue } from "sequelize";
+import type { ProjectionAlias, WhereAttributeHashValue } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
 // To use in case of heavy db load emergency with these usages queries
@@ -29,6 +29,26 @@ import { Op, Sequelize } from "sequelize";
 const DISABLE_QUERIES = false;
 
 export type DataSourcesUsageByAgent = Record<ModelId, AgentsUsageType | null>;
+
+const agentAggregates = (qualifiedAgentConfig: string): ProjectionAlias[] =>
+  (
+    [
+      ["name", "names"],
+      ["sId", "sIds"],
+      ["pictureUrl", "pictureUrls"],
+    ] as const
+  ).map(([column, alias]) => [
+    Sequelize.fn(
+      "array_agg",
+      Sequelize.literal(
+        `${qualifiedAgentConfig}."${column}" ORDER BY ${qualifiedAgentConfig}."name"`
+      )
+    ),
+    alias,
+  ]);
+
+const MCP_AGENT_CONFIG_PATH =
+  '"agent_mcp_server_configuration->agent_configuration"';
 
 export async function getDataSourceViewsUsageByCategory({
   auth,
@@ -122,24 +142,7 @@ export async function getDataSourceViewsUsageByCategory({
       },
       attributes: [
         [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "names",
-        ],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."sId" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "sIds",
-        ],
+        ...agentAggregates(MCP_AGENT_CONFIG_PATH),
       ],
       include: [
         {
@@ -176,24 +179,7 @@ export async function getDataSourceViewsUsageByCategory({
       },
       attributes: [
         [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "names",
-        ],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."sId" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "sIds",
-        ],
+        ...agentAggregates(MCP_AGENT_CONFIG_PATH),
       ],
       include: [
         {
@@ -237,6 +223,7 @@ export async function getDataSourceViewsUsageByCategory({
     dataSourceViewId: ModelId;
     names: string[];
     sIds: string[];
+    pictureUrls: string[];
   }[][];
 
   const result = res
@@ -256,6 +243,7 @@ export async function getDataSourceViewsUsageByCategory({
         .map((sId, index) => ({
           sId,
           name: dsViewConfig.names[index],
+          pictureUrl: dsViewConfig.pictureUrls[index],
         }))
         .filter(
           (agent) =>
@@ -320,24 +308,7 @@ export async function getDataSourcesUsageByCategory({
       },
       attributes: [
         [Sequelize.col("dataSource.id"), "dataSourceId"],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "names",
-        ],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."sId" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "sIds",
-        ],
+        ...agentAggregates(MCP_AGENT_CONFIG_PATH),
       ],
       include: [
         {
@@ -377,24 +348,7 @@ export async function getDataSourcesUsageByCategory({
       },
       attributes: [
         [Sequelize.col("dataSource.id"), "dataSourceId"],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "names",
-        ],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."sId" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "sIds",
-        ],
+        ...agentAggregates(MCP_AGENT_CONFIG_PATH),
       ],
       include: [
         {
@@ -430,6 +384,7 @@ export async function getDataSourcesUsageByCategory({
     dataSourceId: ModelId;
     names: string[];
     sIds: string[];
+    pictureUrls: string[];
   }[][];
 
   const result = res.flat().reduce<DataSourcesUsageByAgent>((acc, dsConfig) => {
@@ -447,6 +402,7 @@ export async function getDataSourcesUsageByCategory({
       .map((sId, index) => ({
         sId,
         name: dsConfig.names[index],
+        pictureUrl: dsConfig.pictureUrls[index],
       }))
       .filter(
         (agent) =>
@@ -493,26 +449,7 @@ export async function getDataSourceUsage({
   const res = (await Promise.all([
     AgentDataSourceConfigurationModel.findOne({
       raw: true,
-      attributes: [
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "names",
-        ],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."sId" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "sIds",
-        ],
-      ],
+      attributes: [...agentAggregates(MCP_AGENT_CONFIG_PATH)],
       where: {
         workspaceId: owner.id,
         dataSourceId: dataSource.id,
@@ -540,26 +477,7 @@ export async function getDataSourceUsage({
     }),
     AgentTablesQueryConfigurationTableModel.findOne({
       raw: true,
-      attributes: [
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "names",
-        ],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."sId" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "sIds",
-        ],
-      ],
+      attributes: [...agentAggregates(MCP_AGENT_CONFIG_PATH)],
       where: {
         workspaceId: owner.id,
         dataSourceId: dataSource.id,
@@ -585,7 +503,9 @@ export async function getDataSourceUsage({
         },
       ],
     }),
-  ])) as unknown as { names: string[]; sIds: string[] }[] | null;
+  ])) as unknown as
+    | { names: string[]; sIds: string[]; pictureUrls: string[] }[]
+    | null;
 
   if (!res) {
     return new Ok({ count: 0, agents: [] });
@@ -596,6 +516,7 @@ export async function getDataSourceUsage({
         r.sIds.map((sId, index) => ({
           sId,
           name: r.names[index],
+          pictureUrl: r.pictureUrls[index],
         }))
       )
       .filter(
@@ -638,26 +559,7 @@ export async function getDataSourceViewUsage({
   const res = (await Promise.all([
     AgentDataSourceConfigurationModel.findOne({
       raw: true,
-      attributes: [
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "names",
-        ],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."sId" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "sIds",
-        ],
-      ],
+      attributes: [...agentAggregates(MCP_AGENT_CONFIG_PATH)],
       where: {
         workspaceId: owner.id,
         dataSourceViewId: dataSourceView.id,
@@ -685,26 +587,7 @@ export async function getDataSourceViewUsage({
     }),
     AgentTablesQueryConfigurationTableModel.findOne({
       raw: true,
-      attributes: [
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "names",
-        ],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_mcp_server_configuration->agent_configuration"."sId" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
-            )
-          ),
-          "sIds",
-        ],
-      ],
+      attributes: [...agentAggregates(MCP_AGENT_CONFIG_PATH)],
       where: {
         workspaceId: owner.id,
         dataSourceViewId: dataSourceView.id,
@@ -730,7 +613,9 @@ export async function getDataSourceViewUsage({
         },
       ],
     }),
-  ])) as unknown as { names: string[]; sIds: string[] }[] | null;
+  ])) as unknown as
+    | { names: string[]; sIds: string[]; pictureUrls: string[] }[]
+    | null;
 
   if (!res) {
     return new Ok({ count: 0, agents: [] });
@@ -741,6 +626,7 @@ export async function getDataSourceViewUsage({
         r.sIds.map((sId, index) => ({
           sId,
           name: r.names[index],
+          pictureUrl: r.pictureUrls[index],
         }))
       )
       .filter(

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -30,7 +30,10 @@ const DISABLE_QUERIES = false;
 
 export type DataSourcesUsageByAgent = Record<ModelId, AgentsUsageType | null>;
 
-const agentAggregates = (qualifiedAgentConfig: string): ProjectionAlias[] =>
+const AGENT_CONFIG_PATH =
+  '"agent_mcp_server_configuration->agent_configuration"';
+
+const agentAggregates = (): ProjectionAlias[] =>
   (
     [
       ["name", "names"],
@@ -41,14 +44,11 @@ const agentAggregates = (qualifiedAgentConfig: string): ProjectionAlias[] =>
     Sequelize.fn(
       "array_agg",
       Sequelize.literal(
-        `${qualifiedAgentConfig}."${column}" ORDER BY ${qualifiedAgentConfig}."name"`
+        `${AGENT_CONFIG_PATH}."${column}" ORDER BY ${AGENT_CONFIG_PATH}."name"`
       )
     ),
     alias,
   ]);
-
-const MCP_AGENT_CONFIG_PATH =
-  '"agent_mcp_server_configuration->agent_configuration"';
 
 export async function getDataSourceViewsUsageByCategory({
   auth,
@@ -142,7 +142,7 @@ export async function getDataSourceViewsUsageByCategory({
       },
       attributes: [
         [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
-        ...agentAggregates(MCP_AGENT_CONFIG_PATH),
+        ...agentAggregates(),
       ],
       include: [
         {
@@ -179,7 +179,7 @@ export async function getDataSourceViewsUsageByCategory({
       },
       attributes: [
         [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
-        ...agentAggregates(MCP_AGENT_CONFIG_PATH),
+        ...agentAggregates(),
       ],
       include: [
         {
@@ -308,7 +308,7 @@ export async function getDataSourcesUsageByCategory({
       },
       attributes: [
         [Sequelize.col("dataSource.id"), "dataSourceId"],
-        ...agentAggregates(MCP_AGENT_CONFIG_PATH),
+        ...agentAggregates(),
       ],
       include: [
         {
@@ -348,7 +348,7 @@ export async function getDataSourcesUsageByCategory({
       },
       attributes: [
         [Sequelize.col("dataSource.id"), "dataSourceId"],
-        ...agentAggregates(MCP_AGENT_CONFIG_PATH),
+        ...agentAggregates(),
       ],
       include: [
         {
@@ -449,7 +449,7 @@ export async function getDataSourceUsage({
   const res = (await Promise.all([
     AgentDataSourceConfigurationModel.findOne({
       raw: true,
-      attributes: [...agentAggregates(MCP_AGENT_CONFIG_PATH)],
+      attributes: [...agentAggregates()],
       where: {
         workspaceId: owner.id,
         dataSourceId: dataSource.id,
@@ -477,7 +477,7 @@ export async function getDataSourceUsage({
     }),
     AgentTablesQueryConfigurationTableModel.findOne({
       raw: true,
-      attributes: [...agentAggregates(MCP_AGENT_CONFIG_PATH)],
+      attributes: [...agentAggregates()],
       where: {
         workspaceId: owner.id,
         dataSourceId: dataSource.id,
@@ -559,7 +559,7 @@ export async function getDataSourceViewUsage({
   const res = (await Promise.all([
     AgentDataSourceConfigurationModel.findOne({
       raw: true,
-      attributes: [...agentAggregates(MCP_AGENT_CONFIG_PATH)],
+      attributes: [...agentAggregates()],
       where: {
         workspaceId: owner.id,
         dataSourceViewId: dataSourceView.id,
@@ -587,7 +587,7 @@ export async function getDataSourceViewUsage({
     }),
     AgentTablesQueryConfigurationTableModel.findOne({
       raw: true,
-      attributes: [...agentAggregates(MCP_AGENT_CONFIG_PATH)],
+      attributes: [...agentAggregates()],
       where: {
         workspaceId: owner.id,
         dataSourceViewId: dataSourceView.id,

--- a/front/lib/api/agent_triggers.test.ts
+++ b/front/lib/api/agent_triggers.test.ts
@@ -42,6 +42,7 @@ describe("getWebhookSourcesUsage", () => {
         {
           sId: agent.sId,
           name: agent.name,
+          pictureUrl: agent.pictureUrl,
         },
       ],
     });
@@ -118,10 +119,12 @@ describe("getWebhookSourcesUsage", () => {
         {
           sId: agentAlpha.sId,
           name: agentAlpha.name,
+          pictureUrl: agentAlpha.pictureUrl,
         },
         {
           sId: agentBeta.sId,
           name: agentBeta.name,
+          pictureUrl: agentBeta.pictureUrl,
         },
       ],
     });

--- a/front/lib/api/agent_triggers.ts
+++ b/front/lib/api/agent_triggers.ts
@@ -13,11 +13,13 @@ const DISABLE_QUERIES = false;
 
 export type WebhookSourcesUsage = Record<ModelId, AgentsUsageType>;
 
+type AgentInfo = { sId: string; name: string; pictureUrl: string };
+
 async function getAccessibleAgentsInfoBySId({
   auth,
 }: {
   auth: Authenticator;
-}): Promise<Map<string, { sId: string; name: string }>> {
+}): Promise<Map<string, AgentInfo>> {
   const owner = auth.workspace();
 
   if (!owner || !auth.isUser()) {
@@ -50,14 +52,14 @@ async function getAccessibleAgentsInfoBySId({
       };
 
   const accessibleAgents = await AgentConfigurationModel.findAll({
-    attributes: ["id", "sId", "name"],
+    attributes: ["id", "sId", "name", "pictureUrl"],
     where: agentWhereClause,
   });
 
   return new Map(
     accessibleAgents.map((agent) => [
       agent.sId,
-      { sId: agent.sId, name: agent.name },
+      { sId: agent.sId, name: agent.name, pictureUrl: agent.pictureUrl },
     ])
   );
 }
@@ -67,7 +69,7 @@ async function getTriggersWithAgentAccesibleAgent({
   agentInfoById,
 }: {
   auth: Authenticator;
-  agentInfoById: Map<string, { sId: string; name: string }>;
+  agentInfoById: Map<string, AgentInfo>;
 }): Promise<
   Array<{
     webhookSourceViewId: number | string | null;
@@ -142,7 +144,7 @@ export async function getWebhookSourcesUsage({
     return {};
   }
 
-  const usageMap = new Map<ModelId, Map<string, string>>();
+  const usageMap = new Map<ModelId, Map<string, AgentInfo>>();
 
   for (const trigger of filteredTriggers) {
     const viewId = Number(trigger.webhookSourceViewId);
@@ -162,19 +164,19 @@ export async function getWebhookSourcesUsage({
 
     let agentsForSource = usageMap.get(sourceId);
     if (!agentsForSource) {
-      agentsForSource = new Map<string, string>();
+      agentsForSource = new Map<string, AgentInfo>();
       usageMap.set(sourceId, agentsForSource);
     }
 
-    agentsForSource.set(agentInfo.sId, agentInfo.name);
+    agentsForSource.set(agentInfo.sId, agentInfo);
   }
 
   const usage: WebhookSourcesUsage = {};
 
   usageMap.forEach((agentsMap, sourceId) => {
-    const agents = Array.from(agentsMap.entries())
-      .map(([sId, name]) => ({ sId, name }))
-      .sort((a, b) => a.name.localeCompare(b.name));
+    const agents = Array.from(agentsMap.values()).sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
 
     usage[sourceId] = {
       count: agents.length,

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -134,6 +134,7 @@ export class AppResource extends ResourceWithSpace<AppModel> {
           agentConfigurations.map((a) => ({
             sId: a.sId,
             name: a.name,
+            pictureUrl: a.pictureUrl,
           }))
         ),
       ],

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1567,7 +1567,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const agents = await this.listActiveAgents(auth);
 
     const sortedAgents = agents
-      .map((agent) => ({ sId: agent.sId, name: agent.name }))
+      .map((agent) => ({
+        sId: agent.sId,
+        name: agent.name,
+        pictureUrl: agent.pictureUrl,
+      }))
       .sort((a, b) => a.name.localeCompare(b.name));
 
     return {

--- a/front/types/data_source.ts
+++ b/front/types/data_source.ts
@@ -70,7 +70,7 @@ export type DataSourceWithConnectorDetailsType = DataSourceType &
 
 export type AgentsUsageType = {
   count: number;
-  agents: Array<{ sId: string; name: string }>;
+  agents: Array<{ sId: string; name: string; pictureUrl: string }>;
 };
 
 export function isDataSourceNameValid(name: string): Result<void, string> {


### PR DESCRIPTION
## Description

This PR enhances the agent dropdown in `SpaceCategoriesList` with search, filtering, and agent details modal integration. The `UsedByButton` dropdown now includes a searchbar. Clicking an agent opens the `AgentDetailsSheet` side panel. Additionally, the PR adds `pictureUrl` to all agent usage API results and types, and introduces a reusable helper function to reduce duplication in agent aggregation queries.

## Tests

- [x] Locally

## Risk

Low risk. Changes are primarily UI enhancements and non-breaking additions to API types. The database query refactoring uses a helper function but maintains the same SQL logic.

## Deploy Plan

Deploy front