### PR TITLE
Keep track of the notification convo for skill suggestions

### DIFF
--- a/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
+++ b/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
@@ -67,6 +67,17 @@ export function SkillSuggestionDetailsPage() {
         >
           {suggestion.skillConfigurationId}
         </LinkWrapper>
+        {suggestion.notificationConversationId && (
+          <>
+            &nbsp;· Notification&nbsp;
+            <LinkWrapper
+              href={`/poke/${owner.sId}/conversation/${suggestion.notificationConversationId}`}
+              className="text-highlight-500"
+            >
+              {suggestion.notificationConversationId}
+            </LinkWrapper>
+          </>
+        )}
       </p>
 
       <div className="mt-4 space-y-6">

--- a/front/components/poke/skill_suggestions/columns.tsx
+++ b/front/components/poke/skill_suggestions/columns.tsx
@@ -163,6 +163,26 @@ export function makeColumnsForSkillSuggestions(
       },
     },
     {
+      accessorKey: "notificationConversationId",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Notification" />
+      ),
+      cell: ({ row }) => {
+        const conversationId = row.original.notificationConversationId;
+        if (!conversationId) {
+          return "-";
+        }
+        return (
+          <a
+            href={`/poke/${owner.sId}/conversation/${conversationId}`}
+            className="text-action-500 hover:underline"
+          >
+            {conversationId}
+          </a>
+        );
+      },
+    },
+    {
       accessorKey: "analysis",
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Analysis" />

--- a/front/lib/models/skill/skill_suggestion.ts
+++ b/front/lib/models/skill/skill_suggestion.ts
@@ -28,7 +28,7 @@ export class SkillSuggestionModel extends WorkspaceAwareModel<SkillSuggestionMod
   declare sourceConversationIds: number[] | null;
   declare groupId: string | null;
   declare updatedByUserId: ForeignKey<UserModel["id"]> | null;
-  declare notificationConversationId: ForeignKey<
+  declare notificationConversationModelId: ForeignKey<
     ConversationModel["id"]
   > | null;
 
@@ -96,13 +96,14 @@ SkillSuggestionModel.init(
         key: "id",
       },
     },
-    notificationConversationId: {
+    notificationConversationModelId: {
       type: DataTypes.BIGINT,
       allowNull: true,
       references: {
         model: ConversationModel,
         key: "id",
       },
+      field: "notificationConversationId",
       comment:
         "Conversation created to notify editors about this reinforcement suggestion.",
     },

--- a/front/lib/models/skill/skill_suggestion.ts
+++ b/front/lib/models/skill/skill_suggestion.ts
@@ -1,3 +1,4 @@
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
@@ -27,9 +28,13 @@ export class SkillSuggestionModel extends WorkspaceAwareModel<SkillSuggestionMod
   declare sourceConversationIds: number[] | null;
   declare groupId: string | null;
   declare updatedByUserId: ForeignKey<UserModel["id"]> | null;
+  declare notificationConversationId: ForeignKey<
+    ConversationModel["id"]
+  > | null;
 
   declare skillConfiguration: NonAttribute<SkillConfigurationModel>;
   declare updatedByUser: NonAttribute<UserModel | null>;
+  declare notificationConversation: NonAttribute<ConversationModel | null>;
 }
 
 SkillSuggestionModel.init(
@@ -91,6 +96,16 @@ SkillSuggestionModel.init(
         key: "id",
       },
     },
+    notificationConversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      references: {
+        model: ConversationModel,
+        key: "id",
+      },
+      comment:
+        "Conversation created to notify editors about this reinforcement suggestion.",
+    },
   },
   {
     modelName: "skill_suggestion",
@@ -123,6 +138,11 @@ SkillSuggestionModel.init(
         concurrently: true,
         where: { updatedByUserId: { [Op.ne]: null } },
       },
+      {
+        name: "idx_skill_suggestions_notification_conversation_id",
+        fields: ["notificationConversationId"],
+        concurrently: true,
+      },
     ],
   }
 );
@@ -145,4 +165,14 @@ UserModel.hasMany(SkillSuggestionModel, {
 SkillSuggestionModel.belongsTo(UserModel, {
   foreignKey: { name: "updatedByUserId", allowNull: true },
   as: "updatedByUser",
+});
+
+SkillSuggestionModel.belongsTo(ConversationModel, {
+  foreignKey: { name: "notificationConversationId", allowNull: true },
+  onDelete: "SET NULL",
+  as: "notificationConversation",
+});
+ConversationModel.hasMany(SkillSuggestionModel, {
+  foreignKey: { name: "notificationConversationId", allowNull: true },
+  onDelete: "SET NULL",
 });

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -236,8 +236,9 @@ export async function buildSkillAggregationBatchMap(
 
 /**
  * Create a conversation with the pending suggestions for the skill editors.
+ * It's a single notification conversation that's sent to all editors of the skill.
  */
-export async function createSkillSuggestionsConversations(
+export async function createSkillSuggestionsConversation(
   auth: Authenticator,
   skill: SkillResource,
   editors: UserType[]
@@ -275,6 +276,12 @@ export async function createSkillSuggestionsConversations(
       },
     },
   });
+
+  await SkillSuggestionResource.bulkSetNotificationConversation(
+    auth,
+    pendingSuggestions,
+    conversation.id
+  );
 
   const contentFragmentRes = await toFileContentFragment(auth, {
     contentFragment: {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -5988,6 +5988,9 @@ const KNOWN_CONVERSATION_RELATED_MODELS = [
   "message",
   "project_todo_conversation",
   "sandbox",
+  // skill_suggestion.notificationConversationId is ON DELETE SET NULL, so no
+  // explicit cleanup is needed in destroyConversation — the DB clears it.
+  "skill_suggestion",
   "user_conversation_reads",
   "wake_up",
 ];

--- a/front/lib/resources/skill_suggestion_resource.test.ts
+++ b/front/lib/resources/skill_suggestion_resource.test.ts
@@ -1,3 +1,4 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
@@ -529,6 +530,77 @@ describe("SkillSuggestionResource", () => {
         authenticator,
         [],
         "approved"
+      );
+      // No error thrown.
+    });
+  });
+
+  describe("bulkSetNotificationConversation", () => {
+    it("should set the notification conversation on every given suggestion", async () => {
+      const s1 = await SkillSuggestionFactory.create(authenticator, skill);
+      const s2 = await SkillSuggestionFactory.create(authenticator, skill);
+
+      const conversation = await createConversation(authenticator, {
+        title: "Notification",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      await SkillSuggestionResource.bulkSetNotificationConversation(
+        authenticator,
+        [s1, s2],
+        conversation.id
+      );
+
+      const fetched = await SkillSuggestionResource.fetchByIds(authenticator, [
+        s1.sId,
+        s2.sId,
+      ]);
+      expect(fetched).toHaveLength(2);
+      expect(
+        fetched.every((s) => s.notificationConversationId === conversation.sId)
+      ).toBe(true);
+      expect(
+        fetched.every(
+          (s) => s.toJSON().notificationConversationId === conversation.sId
+        )
+      ).toBe(true);
+    });
+
+    it("should not affect other suggestions", async () => {
+      const s1 = await SkillSuggestionFactory.create(authenticator, skill);
+      const s2 = await SkillSuggestionFactory.create(authenticator, skill);
+
+      const conversation = await createConversation(authenticator, {
+        title: "Notification",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      await SkillSuggestionResource.bulkSetNotificationConversation(
+        authenticator,
+        [s1],
+        conversation.id
+      );
+
+      const fetchedS2 = await SkillSuggestionResource.fetchById(
+        authenticator,
+        s2.sId
+      );
+      expect(fetchedS2?.notificationConversationId).toBeNull();
+    });
+
+    it("should be a no-op for empty array", async () => {
+      const conversation = await createConversation(authenticator, {
+        title: "Notification",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      await SkillSuggestionResource.bulkSetNotificationConversation(
+        authenticator,
+        [],
+        conversation.id
       );
       // No error thrown.
     });

--- a/front/lib/resources/skill_suggestion_resource.ts
+++ b/front/lib/resources/skill_suggestion_resource.ts
@@ -51,13 +51,13 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
     model: ModelStatic<SkillSuggestionModel>,
     blob: Attributes<SkillSuggestionModel>,
     editorsGroupId: ModelId | null,
-    skillConfigurationId: string,
+    skillConfigurationSId: string,
     updatedBy: SkillSuggestionUpdatedBy | null,
     notificationConversationId: string | null
   ) {
     super(SkillSuggestionModel, blob);
     this.editorsGroupId = editorsGroupId;
-    this.skillConfigurationSId = skillConfigurationId;
+    this.skillConfigurationSId = skillConfigurationSId;
     this.updatedBy = updatedBy;
     this.notificationConversationId = notificationConversationId;
   }

--- a/front/lib/resources/skill_suggestion_resource.ts
+++ b/front/lib/resources/skill_suggestion_resource.ts
@@ -45,21 +45,21 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
   readonly editorsGroupId: ModelId | null;
   readonly skillConfigurationSId: string;
   readonly updatedBy: SkillSuggestionUpdatedBy | null;
-  readonly notificationConversationSId: string | null;
+  readonly notificationConversationId: string | null;
 
   constructor(
     model: ModelStatic<SkillSuggestionModel>,
     blob: Attributes<SkillSuggestionModel>,
     editorsGroupId: ModelId | null,
-    skillConfigurationSId: string,
+    skillConfigurationId: string,
     updatedBy: SkillSuggestionUpdatedBy | null,
-    notificationConversationSId: string | null
+    notificationConversationId: string | null
   ) {
     super(SkillSuggestionModel, blob);
     this.editorsGroupId = editorsGroupId;
-    this.skillConfigurationSId = skillConfigurationSId;
+    this.skillConfigurationSId = skillConfigurationId;
     this.updatedBy = updatedBy;
-    this.notificationConversationSId = notificationConversationSId;
+    this.notificationConversationId = notificationConversationId;
   }
 
   /**
@@ -305,7 +305,7 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
     }
 
     await this.model.update(
-      { notificationConversationId },
+      { notificationConversationModelId: notificationConversationId },
       {
         where: {
           workspaceId: auth.getNonNullableWorkspace().id,
@@ -457,7 +457,7 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
       state: this.state,
       source: this.source,
       sourceConversationsCount: this.sourceConversationIds?.length ?? 0,
-      notificationConversationId: this.notificationConversationSId,
+      notificationConversationId: this.notificationConversationId,
       updatedBy: this.updatedBy,
       ...suggestionData,
     };

--- a/front/lib/resources/skill_suggestion_resource.ts
+++ b/front/lib/resources/skill_suggestion_resource.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -44,18 +45,21 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
   readonly editorsGroupId: ModelId | null;
   readonly skillConfigurationSId: string;
   readonly updatedBy: SkillSuggestionUpdatedBy | null;
+  readonly notificationConversationSId: string | null;
 
   constructor(
     model: ModelStatic<SkillSuggestionModel>,
     blob: Attributes<SkillSuggestionModel>,
     editorsGroupId: ModelId | null,
     skillConfigurationSId: string,
-    updatedBy: SkillSuggestionUpdatedBy | null
+    updatedBy: SkillSuggestionUpdatedBy | null,
+    notificationConversationSId: string | null
   ) {
     super(SkillSuggestionModel, blob);
     this.editorsGroupId = editorsGroupId;
     this.skillConfigurationSId = skillConfigurationSId;
     this.updatedBy = updatedBy;
+    this.notificationConversationSId = notificationConversationSId;
   }
 
   /**
@@ -96,6 +100,7 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
       suggestion.get(),
       skill.editorGroup?.id ?? null,
       skill.sId,
+      null,
       null
     );
   }
@@ -123,6 +128,12 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
           as: "updatedByUser",
           required: false,
           attributes: ["sId", "firstName", "lastName", "email"],
+        },
+        {
+          model: ConversationModel,
+          as: "notificationConversation",
+          required: false,
+          attributes: ["sId"],
         },
       ],
       ...otherOptions,
@@ -170,7 +181,8 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
           suggestion.get(),
           skillResource.editorGroup?.id ?? null,
           skillResource.sId,
-          updatedBy
+          updatedBy,
+          suggestion.notificationConversation?.sId ?? null
         );
       })
     );
@@ -276,6 +288,31 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
       ],
       limit: filters?.limit,
     });
+  }
+
+  /**
+   * Sets the notification conversation on every given suggestion. Used after
+   * creating the reinforcement notification conversation to link back from each
+   * suggestion that was surfaced in it.
+   */
+  static async bulkSetNotificationConversation(
+    auth: Authenticator,
+    suggestions: SkillSuggestionResource[],
+    notificationConversationId: ModelId
+  ): Promise<void> {
+    if (suggestions.length === 0) {
+      return;
+    }
+
+    await this.model.update(
+      { notificationConversationId },
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          id: { [Op.in]: suggestions.map((s) => s.id) },
+        },
+      }
+    );
   }
 
   static async bulkUpdateState(
@@ -420,6 +457,7 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
       state: this.state,
       source: this.source,
       sourceConversationsCount: this.sourceConversationIds?.length ?? 0,
+      notificationConversationId: this.notificationConversationSId,
       updatedBy: this.updatedBy,
       ...suggestionData,
     };

--- a/front/migrations/db/migration_600.sql
+++ b/front/migrations/db/migration_600.sql
@@ -1,0 +1,12 @@
+-- Migration created on Apr 23, 2026
+-- Add notificationConversationId: the conversation created to notify skill editors
+-- about pending reinforcement suggestions. Only set for reinforcement suggestions.
+
+ALTER TABLE "skill_suggestions"
+ADD COLUMN "notificationConversationId" BIGINT
+REFERENCES "conversations" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+COMMENT ON COLUMN "skill_suggestions"."notificationConversationId" IS 'Conversation created to notify editors about this reinforcement suggestion.';
+
+CREATE INDEX CONCURRENTLY "idx_skill_suggestions_notification_conversation_id"
+    ON "skill_suggestions" ("notificationConversationId");

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -15,7 +15,7 @@ import { notifySkillSuggestionsReady } from "@app/lib/notifications/workflows/sk
 import {
   buildSkillAggregationBatchMap,
   buildSkillAggregationSystemPrompt,
-  createSkillSuggestionsConversations,
+  createSkillSuggestionsConversation,
   loadSkillAggregationContext,
 } from "@app/lib/reinforcement/aggregate_suggestions";
 import {
@@ -497,7 +497,7 @@ export async function finalizeSkillAggregationActivity({
       editors: editorTypes,
       suggestionCount: suggestionsCreated,
     });
-    await createSkillSuggestionsConversations(auth, skill, editorTypes);
+    await createSkillSuggestionsConversation(auth, skill, editorTypes);
   }
 
   logger.info(

--- a/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
@@ -32,6 +32,7 @@ function makeInstructionSuggestion(input: {
     state: "pending",
     source: input.source ?? "synthetic",
     sourceConversationsCount: 0,
+    notificationConversationId: null,
     updatedBy: null,
     kind: "edit",
     suggestion: {
@@ -62,6 +63,7 @@ function makeToolSuggestion(input: {
     state: "pending",
     source: input.source ?? "synthetic",
     sourceConversationsCount: 0,
+    notificationConversationId: null,
     updatedBy: null,
     kind: "edit",
     suggestion: {

--- a/front/types/suggestions/skill_suggestion.ts
+++ b/front/types/suggestions/skill_suggestion.ts
@@ -120,6 +120,7 @@ const BaseSkillSuggestionSchema = z.object({
   state: z.enum(SKILL_SUGGESTION_STATES),
   source: z.enum(SKILL_SUGGESTION_SOURCES),
   sourceConversationsCount: z.number(),
+  notificationConversationId: z.string().nullable(),
   updatedBy: SkillSuggestionUpdatedBySchema.nullable(),
 });
 


### PR DESCRIPTION
## Description

Summary

- Adds optional notificationConversationId FK on skill_suggestions pointing to the reinforcement notification conversation. Set on all suggestions surfaced by createSkillSuggestionsConversation; remains null for synthetic suggestions.
- Exposes the conversation's sId in SkillSuggestionType (not the model id), surfaces it in the Poke skill suggestions table and on the Poke suggestion details page as a link to /poke/{wId}/conversation/{sId}.

Changes

- Migration 600: ALTER TABLE skill_suggestions ADD COLUMN notificationConversationId BIGINT REFERENCES conversations(id) ON DELETE SET NULL + concurrent index.
- SkillSuggestionModel: field, association (belongsTo/hasMany), index.
- SkillSuggestionResource: join ConversationModel in baseFetch (sId only), carry notificationConversationSId, emit in toJSON, new bulkSetNotificationConversation helper.
- aggregate_suggestions.ts: persists the link right after createConversation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run migration first, then deploy front