### PR TITLE
[front] enh: remove N+1 in api/v1/w/[wId]/assistant/conversations/[cI…

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1173,14 +1173,12 @@ export async function editUserMessage(
   let agentMessages: AgentMessageType[] = [];
 
   const results = await Promise.all([
-    Promise.all(
-      mentions.filter(isAgentMention).map((mention) =>
-        getAgentConfiguration(auth, {
-          agentId: mention.configurationId,
-          variant: "light",
-        })
-      )
-    ),
+    getAgentConfigurations(auth, {
+      agentIds: mentions
+        .filter(isAgentMention)
+        .map((mention) => mention.configurationId),
+      variant: "light",
+    }),
     ConversationResource.upsertParticipation(auth, {
       conversation,
       action: "posted",
@@ -1188,7 +1186,7 @@ export async function editUserMessage(
     }),
   ]);
 
-  const agentConfigurations = removeNulls(results[0]);
+  const agentConfigurations = results[0];
 
   for (const agentConfig of agentConfigurations) {
     if (!canAccessAgent(agentConfig)) {

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -494,7 +494,13 @@ export const createAgentMessages = async (
             });
           },
           {
-            concurrency: 10,
+            // jd @ 23/04/2026
+            // all callsites of this function pass a transaction
+            // so concurent executor is purely cosmetic
+            // eventually we will get rid of these monstruous transactions
+            // so not putting a for loop
+            // and downsizing from 10 to max peak concurrency - 1
+            concurrency: 4,
           }
         );
       }

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -494,7 +494,7 @@ export const createAgentMessages = async (
             });
           },
           {
-            // jd @ 23/04/2026
+            // TODO(20260423 jd)
             // all callsites of this function pass a transaction
             // so concurent executor is purely cosmetic
             // eventually we will get rid of these monstruous transactions

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
@@ -154,18 +154,16 @@ async function handler(
       // Find user by email
       const users = await UserResource.listByEmail(userEmail);
       if (users.length > 0) {
-        // Get the first user (there might be multiple with same email)
         const workspace = auth.getNonNullableWorkspace();
-        for (const u of users) {
-          const memberships = await MembershipResource.getActiveMemberships({
-            users: [u],
-            workspace,
-          });
-          if (memberships.memberships.length > 0) {
-            userResource = u;
-            user = u.toJSON();
-            break;
-          }
+        const { memberships } = await MembershipResource.getActiveMemberships({
+          users,
+          workspace,
+        });
+        const activeUserIds = new Set(memberships.map((m) => m.userId));
+        const firstActive = users.find((u) => activeUserIds.has(u.id));
+        if (firstActive) {
+          userResource = firstActive;
+          user = firstActive.toJSON();
         }
       }
     }


### PR DESCRIPTION
## Description

- Remove a bunch of low hanging fruits while searching for N+1 queries in api/v1/w/[wId]/assistant/conversations/[cId]/messages
- This endpoint was not a big source of concurrent connections, but found a few intriguing choices, that I aligned with the golden path.

## Tests

N/A

## Risk

Low

## Deploy Plan

- [ ] Deploy front