### PR TITLE
feat(sbx): wire GCS policy into egress proxy connection handler

### DIFF
--- a/egress-proxy/README.md
+++ b/egress-proxy/README.md
@@ -6,17 +6,16 @@ Current functionality:
 
 - `/healthz` process health endpoint.
 - TLS certificate and private-key loading.
-- startup validation for proxy config, TLS assets, JWT secret, and the temporary allowlist.
+- startup validation for proxy config, TLS assets, JWT secret, and GCS policy bucket.
 - TLS-terminated proxy listener for sandbox forwarder connections.
-- handshake parsing, JWT validation, temporary allowlist enforcement, and global DoH blocklist
-  enforcement.
+- handshake parsing, JWT validation, GCS-backed per-sandbox/workspace policy enforcement, and
+  global DoH blocklist enforcement.
 - server-side DNS resolution, SSRF checks on resolved addresses, upstream TCP connection, and
   bidirectional byte forwarding.
 - Docker build and GitHub workflow coverage.
 
 Not implemented yet:
 
-- GCS policy reads
 - configurable idle or max-lifetime policy for established tunnels
 
 ## Configuration
@@ -27,7 +26,8 @@ EGRESS_PROXY_HEALTH_ADDR=0.0.0.0:8080
 EGRESS_PROXY_TLS_CERT=/etc/certs/tls.crt
 EGRESS_PROXY_TLS_KEY=/etc/certs/tls.key
 EGRESS_PROXY_JWT_SECRET=<shared with front>
-EGRESS_PROXY_ALLOWED_DOMAINS=example.com,*.example.com
+EGRESS_PROXY_POLICY_BUCKET=<gcs bucket name>
+EGRESS_PROXY_POLICY_CACHE_TTL_SECS=60
 EGRESS_PROXY_ENV=production
 EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK=
 ```

--- a/egress-proxy/README.md
+++ b/egress-proxy/README.md
@@ -26,11 +26,16 @@ EGRESS_PROXY_HEALTH_ADDR=0.0.0.0:8080
 EGRESS_PROXY_TLS_CERT=/etc/certs/tls.crt
 EGRESS_PROXY_TLS_KEY=/etc/certs/tls.key
 EGRESS_PROXY_JWT_SECRET=<shared with front>
+EGRESS_PROXY_ALLOWED_DOMAINS=dust.tt,eu.dust.tt
 EGRESS_PROXY_POLICY_BUCKET=<gcs bucket name>
 EGRESS_PROXY_POLICY_CACHE_TTL_SECS=60
 EGRESS_PROXY_ENV=production
 EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK=
 ```
+
+`EGRESS_PROXY_ALLOWED_DOMAINS` is an optional comma-separated list of domains allowed for all
+sandboxes (the "default allowlist"). This is merged with per-workspace and per-sandbox GCS
+policies. A domain is allowed if it appears in any of the three sources.
 
 `EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK` only accepts `1`, `0`, or unset. `1` is test-only and
 startup rejects it unless `EGRESS_PROXY_ENV=test`.

--- a/egress-proxy/src/config.rs
+++ b/egress-proxy/src/config.rs
@@ -1,3 +1,4 @@
+use crate::policy::DefaultAllowlist;
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use std::net::SocketAddr;
@@ -13,6 +14,7 @@ pub struct Config {
     pub tls_cert_path: PathBuf,
     pub tls_key_path: PathBuf,
     pub jwt_secret: String,
+    pub default_allowlist: Option<DefaultAllowlist>,
     pub policy_bucket: String,
     pub policy_base_url: String,
     pub policy_cache_ttl: Duration,
@@ -36,6 +38,9 @@ struct RawConfig {
 
     #[arg(long, env = "EGRESS_PROXY_JWT_SECRET")]
     jwt_secret: String,
+
+    #[arg(long, env = "EGRESS_PROXY_ALLOWED_DOMAINS")]
+    allowed_domains: Option<String>,
 
     #[arg(long, env = "EGRESS_PROXY_POLICY_BUCKET")]
     policy_bucket: String,
@@ -71,6 +76,11 @@ impl TryFrom<RawConfig> for Config {
             return Err(anyhow!("EGRESS_PROXY_JWT_SECRET must not be empty"));
         }
 
+        let default_allowlist = match raw.allowed_domains {
+            Some(ref value) if !value.trim().is_empty() => Some(DefaultAllowlist::parse(value)?),
+            _ => None,
+        };
+
         if raw.policy_bucket.trim().is_empty() {
             return Err(anyhow!("EGRESS_PROXY_POLICY_BUCKET must not be empty"));
         }
@@ -101,6 +111,7 @@ impl TryFrom<RawConfig> for Config {
             tls_cert_path: raw.tls_cert,
             tls_key_path: raw.tls_key,
             jwt_secret: raw.jwt_secret,
+            default_allowlist,
             policy_bucket: raw.policy_bucket,
             policy_base_url,
             policy_cache_ttl: Duration::from_secs(raw.policy_cache_ttl_secs),
@@ -165,6 +176,7 @@ mod tests {
             tls_cert: PathBuf::from("tls.crt"),
             tls_key: PathBuf::from("tls.key"),
             jwt_secret: "secret".to_string(),
+            allowed_domains: None,
             policy_bucket: "test-bucket".to_string(),
             policy_cache_ttl_secs: 60,
             policy_base_url: DEFAULT_POLICY_BASE_URL.to_string(),

--- a/egress-proxy/src/config.rs
+++ b/egress-proxy/src/config.rs
@@ -1,4 +1,3 @@
-use crate::policy::TemporaryAllowlist;
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use std::net::SocketAddr;
@@ -14,7 +13,6 @@ pub struct Config {
     pub tls_cert_path: PathBuf,
     pub tls_key_path: PathBuf,
     pub jwt_secret: String,
-    pub temporary_allowlist: TemporaryAllowlist,
     pub policy_bucket: String,
     pub policy_base_url: String,
     pub policy_cache_ttl: Duration,
@@ -38,9 +36,6 @@ struct RawConfig {
 
     #[arg(long, env = "EGRESS_PROXY_JWT_SECRET")]
     jwt_secret: String,
-
-    #[arg(long, env = "EGRESS_PROXY_ALLOWED_DOMAINS")]
-    allowed_domains: String,
 
     #[arg(long, env = "EGRESS_PROXY_POLICY_BUCKET")]
     policy_bucket: String,
@@ -76,8 +71,6 @@ impl TryFrom<RawConfig> for Config {
             return Err(anyhow!("EGRESS_PROXY_JWT_SECRET must not be empty"));
         }
 
-        let temporary_allowlist = TemporaryAllowlist::parse(&raw.allowed_domains)?;
-
         if raw.policy_bucket.trim().is_empty() {
             return Err(anyhow!("EGRESS_PROXY_POLICY_BUCKET must not be empty"));
         }
@@ -108,7 +101,6 @@ impl TryFrom<RawConfig> for Config {
             tls_cert_path: raw.tls_cert,
             tls_key_path: raw.tls_key,
             jwt_secret: raw.jwt_secret,
-            temporary_allowlist,
             policy_bucket: raw.policy_bucket,
             policy_base_url,
             policy_cache_ttl: Duration::from_secs(raw.policy_cache_ttl_secs),
@@ -173,7 +165,6 @@ mod tests {
             tls_cert: PathBuf::from("tls.crt"),
             tls_key: PathBuf::from("tls.key"),
             jwt_secret: "secret".to_string(),
-            allowed_domains: "example.com".to_string(),
             policy_bucket: "test-bucket".to_string(),
             policy_cache_ttl_secs: 60,
             policy_base_url: DEFAULT_POLICY_BASE_URL.to_string(),

--- a/egress-proxy/src/connection.rs
+++ b/egress-proxy/src/connection.rs
@@ -1,9 +1,9 @@
 use crate::blocklist::{is_globally_blocked_domain, is_unsafe_ip};
 use crate::config::Config;
 use crate::dns::DnsResolver;
+use crate::gcs::GcsPolicyProvider;
 use crate::handshake::{read_handshake, Handshake, HandshakeError, ALLOW_RESPONSE, DENY_RESPONSE};
 use crate::jwt::{JwtValidationError, JwtValidator, ValidatedSandboxToken};
-use crate::policy::TemporaryAllowlist;
 use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -21,7 +21,7 @@ const UPSTREAM_CONNECT_TIMEOUT_SECONDS: u64 = 5;
 #[derive(Clone)]
 pub struct ConnectionState {
     jwt_validator: JwtValidator,
-    temporary_allowlist: TemporaryAllowlist,
+    policy_provider: GcsPolicyProvider,
     dns_resolver: DnsResolver,
     unsafe_skip_ssrf_check: bool,
 }
@@ -40,7 +40,7 @@ pub enum DenyReason {
     ExpiredJwt,
     InvalidClaims,
     GlobalBlocklist,
-    NotInTemporaryAllowlist,
+    PolicyDenied,
     DnsResolutionFailed,
     UnsafeResolvedIp,
     UpstreamConnectFailed,
@@ -48,10 +48,10 @@ pub enum DenyReason {
 }
 
 impl ConnectionState {
-    pub fn new(config: &Config) -> Self {
+    pub fn new(config: &Config, policy_provider: GcsPolicyProvider) -> Self {
         Self {
             jwt_validator: JwtValidator::new(&config.jwt_secret),
-            temporary_allowlist: config.temporary_allowlist.clone(),
+            policy_provider,
             dns_resolver: DnsResolver::new(),
             unsafe_skip_ssrf_check: config.unsafe_skip_ssrf_check,
         }
@@ -70,7 +70,7 @@ impl DenyReason {
             Self::ExpiredJwt => "expired_jwt",
             Self::InvalidClaims => "invalid_claims",
             Self::GlobalBlocklist => "global_blocklist",
-            Self::NotInTemporaryAllowlist => "not_in_temporary_allowlist",
+            Self::PolicyDenied => "policy_denied",
             Self::DnsResolutionFailed => "dns_resolution_failed",
             Self::UnsafeResolvedIp => "unsafe_resolved_ip",
             Self::UpstreamConnectFailed => "upstream_connect_failed",
@@ -171,17 +171,18 @@ async fn handle_connection_inner(
     }
 
     if !state
-        .temporary_allowlist
-        .allows(&request.domain, &token.sb_id)
+        .policy_provider
+        .evaluate(token.w_id.as_deref(), &token.sb_id, &request.domain)
+        .await
     {
         deny(
             stream,
-            DenyReason::NotInTemporaryAllowlist,
+            DenyReason::PolicyDenied,
             Some(&token),
             Some(&request),
         )
         .await;
-        return Err(DenyReason::NotInTemporaryAllowlist);
+        return Err(DenyReason::PolicyDenied);
     }
 
     let upstream_addresses = match timeout(

--- a/egress-proxy/src/connection.rs
+++ b/egress-proxy/src/connection.rs
@@ -4,6 +4,7 @@ use crate::dns::DnsResolver;
 use crate::gcs::GcsPolicyProvider;
 use crate::handshake::{read_handshake, Handshake, HandshakeError, ALLOW_RESPONSE, DENY_RESPONSE};
 use crate::jwt::{JwtValidationError, JwtValidator, ValidatedSandboxToken};
+use crate::policy::DefaultAllowlist;
 use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -21,6 +22,7 @@ const UPSTREAM_CONNECT_TIMEOUT_SECONDS: u64 = 5;
 #[derive(Clone)]
 pub struct ConnectionState {
     jwt_validator: JwtValidator,
+    default_allowlist: Option<DefaultAllowlist>,
     policy_provider: GcsPolicyProvider,
     dns_resolver: DnsResolver,
     unsafe_skip_ssrf_check: bool,
@@ -51,6 +53,7 @@ impl ConnectionState {
     pub fn new(config: &Config, policy_provider: GcsPolicyProvider) -> Self {
         Self {
             jwt_validator: JwtValidator::new(&config.jwt_secret),
+            default_allowlist: config.default_allowlist.clone(),
             policy_provider,
             dns_resolver: DnsResolver::new(),
             unsafe_skip_ssrf_check: config.unsafe_skip_ssrf_check,
@@ -170,10 +173,16 @@ async fn handle_connection_inner(
         return Err(DenyReason::GlobalBlocklist);
     }
 
-    if !state
-        .policy_provider
-        .evaluate(token.w_id.as_deref(), &token.sb_id, &request.domain)
-        .await
+    let default_allows = state
+        .default_allowlist
+        .as_ref()
+        .is_some_and(|allowlist| allowlist.allows(&request.domain));
+
+    if !default_allows
+        && !state
+            .policy_provider
+            .evaluate(token.w_id.as_deref(), &token.sb_id, &request.domain)
+            .await
     {
         deny(
             stream,

--- a/egress-proxy/src/domain.rs
+++ b/egress-proxy/src/domain.rs
@@ -6,7 +6,7 @@ pub enum DomainValidationError {
     Invalid,
 }
 
-pub fn normalize_domain_or_ip(value: &str) -> Result<String, DomainValidationError> {
+fn normalize_domain_or_ip(value: &str) -> Result<String, DomainValidationError> {
     let value = value.to_ascii_lowercase();
     let value = value.strip_suffix('.').unwrap_or(&value).to_string();
 

--- a/egress-proxy/src/gcs.rs
+++ b/egress-proxy/src/gcs.rs
@@ -74,7 +74,6 @@ impl GcsPolicyProvider {
             .await
     }
 
-    #[allow(dead_code)]
     pub async fn evaluate(&self, w_id: Option<&str>, sb_id: &str, domain: &str) -> bool {
         let workspace_allows = match w_id {
             Some(workspace_id) => match self.get_workspace_policy(workspace_id).await {

--- a/egress-proxy/src/handshake.rs
+++ b/egress-proxy/src/handshake.rs
@@ -1,4 +1,4 @@
-use crate::domain::{normalize_domain_or_ip, DomainValidationError};
+use crate::domain::{normalize_dns_name, DomainValidationError};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
@@ -92,7 +92,7 @@ fn normalize_domain(domain: &str) -> Result<String, HandshakeError> {
         return Ok(String::new());
     }
 
-    match normalize_domain_or_ip(domain) {
+    match normalize_dns_name(domain) {
         Ok(domain) => Ok(domain),
         Err(DomainValidationError::Empty) => Err(HandshakeError::MalformedHandshake),
         Err(DomainValidationError::Invalid) => Err(HandshakeError::MalformedHandshake),
@@ -195,6 +195,10 @@ mod tests {
             build_frame("token", "host:443", 443),
             build_frame("token", ".", 443),
             build_frame("token", "example.com", 0),
+            build_frame("token", "127.0.0.1", 443),
+            build_frame("token", "::1", 443),
+            build_frame("token", "::ffff:127.0.0.1", 443),
+            build_frame("token", "169.254.169.254", 443),
         ] {
             let mut reader = frame.as_slice();
 

--- a/egress-proxy/src/health.rs
+++ b/egress-proxy/src/health.rs
@@ -1,28 +1,12 @@
-use crate::gcs::GcsPolicyProvider;
-use crate::policy::Policy;
 use anyhow::Result;
-use axum::{
-    extract::{Query, State},
-    http::StatusCode,
-    response::IntoResponse,
-    routing::get,
-    Json, Router,
-};
-use serde::{Deserialize, Serialize};
+use axum::{routing::get, Router};
 use tokio::net::TcpListener;
 use tokio::sync::watch;
-use tracing::{info, warn};
+use tracing::info;
 
-pub async fn serve(
-    listener: TcpListener,
-    policy_provider: GcsPolicyProvider,
-    mut shutdown: watch::Receiver<bool>,
-) -> Result<()> {
+pub async fn serve(listener: TcpListener, mut shutdown: watch::Receiver<bool>) -> Result<()> {
     let local_addr = listener.local_addr()?;
-    let app = Router::new()
-        .route("/healthz", get(healthz))
-        .route("/debug/policy", get(debug_policy))
-        .with_state(policy_provider);
+    let app = Router::new().route("/healthz", get(healthz));
 
     info!(addr = %local_addr, "health server started");
 
@@ -40,91 +24,5 @@ pub async fn serve(
 }
 
 async fn healthz() -> &'static str {
-    // TODO(sandbox-egress): Add readiness checks once the proxy listener and policy provider are
-    // wired.
     "ok"
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct DebugPolicyQuery {
-    w_id: Option<String>,
-    sb_id: String,
-}
-
-#[derive(Debug, Serialize)]
-struct DebugPolicyResponse {
-    workspace: DebugPolicyResult,
-    sandbox: DebugPolicyResult,
-}
-
-#[derive(Debug, Serialize)]
-struct DebugPolicyResult {
-    policy: Option<Policy>,
-    error: Option<String>,
-}
-
-// TODO(sandbox-egress): Remove this debug endpoint once PR 2b is deployed and verified.
-async fn debug_policy(
-    State(policy_provider): State<GcsPolicyProvider>,
-    Query(query): Query<DebugPolicyQuery>,
-) -> impl IntoResponse {
-    let sb_id = query.sb_id.trim();
-    if sb_id.is_empty() {
-        return (StatusCode::BAD_REQUEST, "sbId must not be empty").into_response();
-    }
-
-    let workspace = match query
-        .w_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|w_id| !w_id.is_empty())
-    {
-        Some(w_id) => fetch_workspace_policy(&policy_provider, w_id).await,
-        None => DebugPolicyResult {
-            policy: None,
-            error: None,
-        },
-    };
-    let sandbox = fetch_sandbox_policy(&policy_provider, sb_id).await;
-
-    Json(DebugPolicyResponse { workspace, sandbox }).into_response()
-}
-
-async fn fetch_workspace_policy(
-    policy_provider: &GcsPolicyProvider,
-    w_id: &str,
-) -> DebugPolicyResult {
-    match policy_provider.get_workspace_policy(w_id).await {
-        Ok(policy) => DebugPolicyResult {
-            policy,
-            error: None,
-        },
-        Err(error) => {
-            warn!(error = %error, w_id, "workspace policy debug lookup failed");
-            DebugPolicyResult {
-                policy: None,
-                error: Some(error.to_string()),
-            }
-        }
-    }
-}
-
-async fn fetch_sandbox_policy(
-    policy_provider: &GcsPolicyProvider,
-    sb_id: &str,
-) -> DebugPolicyResult {
-    match policy_provider.get_sandbox_policy(sb_id).await {
-        Ok(policy) => DebugPolicyResult {
-            policy,
-            error: None,
-        },
-        Err(error) => {
-            warn!(error = %error, sb_id, "sandbox policy debug lookup failed");
-            DebugPolicyResult {
-                policy: None,
-                error: Some(error.to_string()),
-            }
-        }
-    }
 }

--- a/egress-proxy/src/policy.rs
+++ b/egress-proxy/src/policy.rs
@@ -1,4 +1,4 @@
-use crate::domain::{normalize_dns_name, normalize_domain_or_ip};
+use crate::domain::normalize_dns_name;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -6,11 +6,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[serde(rename_all = "camelCase")]
 pub struct Policy {
     allowed_domains: Vec<DomainPattern>,
-}
-
-#[derive(Debug, Clone)]
-pub struct TemporaryAllowlist {
-    patterns: Vec<DomainPattern>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,56 +22,7 @@ impl Policy {
     }
 }
 
-impl TemporaryAllowlist {
-    pub fn parse(value: &str) -> Result<Self> {
-        let mut patterns = Vec::new();
-
-        for raw_entry in value.split(',') {
-            let entry = raw_entry.trim();
-            if entry.is_empty() {
-                continue;
-            }
-            patterns.push(DomainPattern::parse_allowlist_entry(entry)?);
-        }
-
-        if patterns.is_empty() {
-            return Err(anyhow!("EGRESS_PROXY_ALLOWED_DOMAINS must not be empty"));
-        }
-
-        Ok(Self { patterns })
-    }
-
-    pub fn allows(&self, domain: &str, sb_id: &str) -> bool {
-        // TODO(sandbox-egress): Replace this static env allowlist with the GCS-backed
-        // per-sandbox policy provider. The production policy source is
-        // gs://<regional-sandbox-egress-policies>/policies/{sbId}.json.
-
-        // TODO(sandbox-egress): Use sb_id to fetch policies/{sbId}.json from GCS. PR 1 uses
-        // the same temporary allowlist for every sandbox so we can validate the proxy protocol
-        // independently from front and GCS integration.
-        let _ = sb_id;
-
-        self.patterns.iter().any(|pattern| pattern.matches(domain))
-    }
-}
-
 impl DomainPattern {
-    fn parse_allowlist_entry(value: &str) -> Result<Self> {
-        let value = value.trim().to_ascii_lowercase();
-        if let Some(suffix) = value.strip_prefix("*.") {
-            let suffix = normalize_dns_name(suffix)
-                .map_err(|_| anyhow!("invalid wildcard domain entry: {value}"))?;
-            if suffix.split('.').count() < 2 {
-                return Err(anyhow!("invalid wildcard domain entry: {value}"));
-            }
-            return Ok(Self::WildcardSuffix(suffix));
-        }
-
-        let value =
-            normalize_domain_or_ip(&value).map_err(|_| anyhow!("invalid domain entry: {value}"))?;
-        Ok(Self::Exact(value))
-    }
-
     fn parse_policy_entry(value: &str) -> Result<Self> {
         let value = value.trim().to_ascii_lowercase();
         if let Some(suffix) = value.strip_prefix("*.") {
@@ -129,48 +75,7 @@ impl Serialize for DomainPattern {
 
 #[cfg(test)]
 mod tests {
-    use super::{Policy, TemporaryAllowlist};
-
-    #[test]
-    fn temporary_allowlist_matches_exact_domains_case_insensitively_after_parse() {
-        let allowlist =
-            TemporaryAllowlist::parse("Example.COM").expect("valid domain entry should parse");
-
-        assert!(allowlist.allows("example.com", "sbx"));
-        assert!(!allowlist.allows("api.example.com", "sbx"));
-    }
-
-    #[test]
-    fn temporary_allowlist_accepts_exact_ip_literals() {
-        let allowlist = TemporaryAllowlist::parse("127.0.0.1,::ffff:127.0.0.1")
-            .expect("valid IP literal entries should parse");
-
-        assert!(allowlist.allows("127.0.0.1", "sbx"));
-        assert!(allowlist.allows("::ffff:127.0.0.1", "sbx"));
-    }
-
-    #[test]
-    fn temporary_allowlist_wildcard_matches_subdomains_only() {
-        let allowlist =
-            TemporaryAllowlist::parse("*.example.com").expect("valid wildcard entry should parse");
-
-        assert!(allowlist.allows("api.example.com", "sbx"));
-        assert!(allowlist.allows("a.b.example.com", "sbx"));
-        assert!(!allowlist.allows("example.com", "sbx"));
-    }
-
-    #[test]
-    fn temporary_allowlist_rejects_invalid_entries() {
-        assert!(TemporaryAllowlist::parse("example.com, bad domain").is_err());
-        assert!(TemporaryAllowlist::parse(" , ").is_err());
-        assert!(TemporaryAllowlist::parse("*").is_err());
-        assert!(TemporaryAllowlist::parse("*.*.com").is_err());
-        assert!(TemporaryAllowlist::parse("*example.com").is_err());
-        assert!(TemporaryAllowlist::parse(".example.com").is_err());
-        assert!(TemporaryAllowlist::parse("example..com").is_err());
-        assert!(TemporaryAllowlist::parse("host:443").is_err());
-        assert!(TemporaryAllowlist::parse("*.com").is_err());
-    }
+    use super::Policy;
 
     #[test]
     fn policy_matches_exact_domains_case_insensitively_after_parse() {

--- a/egress-proxy/src/policy.rs
+++ b/egress-proxy/src/policy.rs
@@ -14,11 +14,46 @@ enum DomainPattern {
     WildcardSuffix(String),
 }
 
+/// Per-sandbox or per-workspace policy deserialized from GCS.
 impl Policy {
     pub fn allows(&self, domain: &str) -> bool {
         self.allowed_domains
             .iter()
             .any(|pattern| pattern.matches(domain))
+    }
+}
+
+/// Global default allowlist parsed from `EGRESS_PROXY_ALLOWED_DOMAINS`. Domains in this list are
+/// allowed for every sandbox regardless of GCS policy. Intended for infrastructure domains like
+/// `dust.tt` that all sandboxes need.
+#[derive(Debug, Clone)]
+pub struct DefaultAllowlist {
+    patterns: Vec<DomainPattern>,
+}
+
+impl DefaultAllowlist {
+    pub fn parse(value: &str) -> Result<Self> {
+        let mut patterns = Vec::new();
+
+        for raw_entry in value.split(',') {
+            let entry = raw_entry.trim();
+            if entry.is_empty() {
+                continue;
+            }
+            patterns.push(DomainPattern::parse_policy_entry(entry)?);
+        }
+
+        if patterns.is_empty() {
+            return Err(anyhow!(
+                "EGRESS_PROXY_ALLOWED_DOMAINS is set but contains no valid domain entries"
+            ));
+        }
+
+        Ok(Self { patterns })
+    }
+
+    pub fn allows(&self, domain: &str) -> bool {
+        self.patterns.iter().any(|pattern| pattern.matches(domain))
     }
 }
 
@@ -75,7 +110,7 @@ impl Serialize for DomainPattern {
 
 #[cfg(test)]
 mod tests {
-    use super::Policy;
+    use super::{DefaultAllowlist, Policy};
 
     #[test]
     fn policy_matches_exact_domains_case_insensitively_after_parse() {
@@ -116,6 +151,37 @@ mod tests {
         assert!(policy.allows("api.example.com"));
         assert!(policy.allows("other.example.com"));
         assert!(!policy.allows("dust.tt"));
+    }
+
+    #[test]
+    fn default_allowlist_matches_exact_and_wildcard_domains() {
+        let allowlist =
+            DefaultAllowlist::parse("dust.tt, *.dust.tt").expect("valid entries should parse");
+
+        assert!(allowlist.allows("dust.tt"));
+        assert!(allowlist.allows("eu.dust.tt"));
+        assert!(allowlist.allows("app.eu.dust.tt"));
+        assert!(!allowlist.allows("example.com"));
+    }
+
+    #[test]
+    fn default_allowlist_rejects_ip_literals() {
+        assert!(DefaultAllowlist::parse("127.0.0.1").is_err());
+        assert!(DefaultAllowlist::parse("::1").is_err());
+        assert!(DefaultAllowlist::parse("dust.tt, 10.0.0.1").is_err());
+    }
+
+    #[test]
+    fn default_allowlist_rejects_empty_input() {
+        assert!(DefaultAllowlist::parse("").is_err());
+        assert!(DefaultAllowlist::parse(" , ").is_err());
+    }
+
+    #[test]
+    fn default_allowlist_rejects_invalid_entries() {
+        assert!(DefaultAllowlist::parse("*.com").is_err());
+        assert!(DefaultAllowlist::parse("example..com").is_err());
+        assert!(DefaultAllowlist::parse("bad domain").is_err());
     }
 
     #[test]

--- a/egress-proxy/src/server.rs
+++ b/egress-proxy/src/server.rs
@@ -29,17 +29,11 @@ pub async fn run(config: Config) -> Result<()> {
         config.policy_base_url.clone(),
     )
     .await?;
-    let state = Arc::new(ConnectionState::new(&config));
+    let state = Arc::new(ConnectionState::new(&config, policy_provider));
 
-    // TODO(sandbox-egress): Confirm final certificate provisioning path once the Kubernetes
-    // deployment and DNS name are introduced.
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-    let mut health_handle = tokio::spawn(health::serve(
-        health_listener,
-        policy_provider,
-        shutdown_rx.clone(),
-    ));
+    let mut health_handle = tokio::spawn(health::serve(health_listener, shutdown_rx.clone()));
     let mut proxy_handle = tokio::spawn(run_proxy_listener(
         listener,
         tls_acceptor,

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -52,6 +52,7 @@ struct MockGcsState {
 #[derive(Clone)]
 enum MockGcsResponse {
     Policy(String),
+    Status(StatusCode),
 }
 
 #[derive(Default)]
@@ -180,6 +181,7 @@ async fn workspace_policy_allows_domain() -> Result<()> {
             workspace: Some(policy_response(&["localhost"])),
             sandbox: None,
         },
+        None,
         true,
         "test",
     )
@@ -214,6 +216,7 @@ async fn sandbox_policy_allows_when_workspace_has_no_policy() -> Result<()> {
             workspace: None,
             sandbox: Some(policy_response(&["localhost"])),
         },
+        None,
         true,
         "test",
     )
@@ -246,6 +249,7 @@ async fn denied_when_neither_workspace_nor_sandbox_allows_domain() -> Result<()>
             workspace: Some(policy_response(&["other.example.com"])),
             sandbox: Some(policy_response(&["another.example.com"])),
         },
+        None,
         false,
         "production",
     )
@@ -255,6 +259,88 @@ async fn denied_when_neither_workspace_nor_sandbox_allows_domain() -> Result<()>
     let response = send_handshake(&proxy, &token, "denied.example.com", 443).await?;
 
     assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn workspace_gcs_failure_falls_back_to_sandbox() -> Result<()> {
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
+            sandbox: Some(policy_response(&["localhost"])),
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token_with_workspace(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn sandbox_gcs_failure_denies_connection() -> Result<()> {
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: None,
+            sandbox: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
+        },
+        None,
+        false,
+        "production",
+    )
+    .await?;
+    let token = make_token(SECRET, 60);
+
+    let response = send_handshake(&proxy, &token, "example.com", 443).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
+async fn default_allowlist_allows_when_gcs_has_no_policy() -> Result<()> {
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy =
+        start_proxy_with_mock_gcs(MockPolicies::default(), Some("localhost"), true, "test").await?;
+    let token = make_token(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
     Ok(())
 }
 
@@ -652,7 +738,13 @@ async fn sigterm_aborts_stuck_tunnel_after_drain_timeout() -> Result<()> {
 }
 
 async fn start_proxy(unsafe_skip_ssrf_check: bool, environment: &str) -> Result<ProxyProcess> {
-    start_proxy_with_mock_gcs(MockPolicies::default(), unsafe_skip_ssrf_check, environment).await
+    start_proxy_with_mock_gcs(
+        MockPolicies::default(),
+        None,
+        unsafe_skip_ssrf_check,
+        environment,
+    )
+    .await
 }
 
 async fn start_proxy_with_sandbox_policy(
@@ -665,6 +757,7 @@ async fn start_proxy_with_sandbox_policy(
             workspace: None,
             sandbox: Some(policy_response(allowed_domains)),
         },
+        None,
         unsafe_skip_ssrf_check,
         environment,
     )
@@ -673,6 +766,7 @@ async fn start_proxy_with_sandbox_policy(
 
 async fn start_proxy_with_mock_gcs(
     policies: MockPolicies,
+    default_allowed_domains: Option<&str>,
     unsafe_skip_ssrf_check: bool,
     environment: &str,
 ) -> Result<ProxyProcess> {
@@ -698,6 +792,10 @@ async fn start_proxy_with_mock_gcs(
         .env("EGRESS_PROXY_ENV", environment)
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
+
+    if let Some(domains) = default_allowed_domains {
+        command.env("EGRESS_PROXY_ALLOWED_DOMAINS", domains);
+    }
 
     if unsafe_skip_ssrf_check {
         command.env("EGRESS_PROXY_UNSAFE_SKIP_SSRF_CHECK", "1");
@@ -756,6 +854,7 @@ async fn mock_gcs_handler(State(state): State<MockGcsState>, uri: Uri) -> Respon
             body.clone(),
         )
             .into_response(),
+        Some(MockGcsResponse::Status(status)) => (*status).into_response(),
         None => StatusCode::NOT_FOUND.into_response(),
     }
 }

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -56,13 +56,18 @@ enum MockGcsResponse {
 
 #[derive(Default)]
 struct MockPolicies {
+    workspace: Option<MockGcsResponse>,
     sandbox: Option<MockGcsResponse>,
 }
+
+const TEST_WORKSPACE_ID: &str = "workspace-456";
 
 #[derive(Debug, Serialize)]
 struct TestClaims {
     #[serde(rename = "sbId")]
     sb_id: String,
+    #[serde(rename = "wId", skip_serializing_if = "Option::is_none")]
+    w_id: Option<String>,
     iss: String,
     aud: String,
     exp: usize,
@@ -167,6 +172,93 @@ async fn allowed_domain_forwards_bytes() -> Result<()> {
 }
 
 #[tokio::test]
+async fn workspace_policy_allows_domain() -> Result<()> {
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: Some(policy_response(&["localhost"])),
+            sandbox: None,
+        },
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token_with_workspace(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn sandbox_policy_allows_when_workspace_has_no_policy() -> Result<()> {
+    let (upstream_port, mut upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: None,
+            sandbox: Some(policy_response(&["localhost"])),
+        },
+        true,
+        "test",
+    )
+    .await?;
+    let token = make_token_with_workspace(SECRET, 60);
+    let mut stream = connect_forwarder(&proxy).await?;
+
+    stream
+        .write_all(&build_frame(&token, "localhost", upstream_port)?)
+        .await?;
+
+    let mut response = [0; 1];
+    stream.read_exact(&mut response).await?;
+    assert_eq!(response[0], ALLOW_RESPONSE);
+
+    stream.write_all(b"ping").await?;
+    let mut echoed = [0; 4];
+    stream.read_exact(&mut echoed).await?;
+    assert_eq!(&echoed, b"ping");
+
+    drop(stream);
+    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn denied_when_neither_workspace_nor_sandbox_allows_domain() -> Result<()> {
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: Some(policy_response(&["other.example.com"])),
+            sandbox: Some(policy_response(&["another.example.com"])),
+        },
+        false,
+        "production",
+    )
+    .await?;
+    let token = make_token_with_workspace(SECRET, 60);
+
+    let response = send_handshake(&proxy, &token, "denied.example.com", 443).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
+    Ok(())
+}
+
+#[tokio::test]
 async fn denied_domain_returns_deny() -> Result<()> {
     let proxy = start_proxy(false, "production").await?;
     let token = make_token(SECRET, 60);
@@ -206,6 +298,7 @@ async fn invalid_issuer_returns_deny() -> Result<()> {
         SECRET,
         FullClaims {
             sb_id: TEST_SANDBOX_ID,
+            w_id: None,
             iss: "wrong-front",
             aud: "dust-egress-proxy",
             exp_offset_seconds: 60,
@@ -225,6 +318,7 @@ async fn invalid_audience_returns_deny() -> Result<()> {
         SECRET,
         FullClaims {
             sb_id: TEST_SANDBOX_ID,
+            w_id: None,
             iss: "dust-front",
             aud: "wrong-audience",
             exp_offset_seconds: 60,
@@ -244,6 +338,7 @@ async fn empty_sandbox_id_claim_returns_deny() -> Result<()> {
         SECRET,
         FullClaims {
             sb_id: "   ",
+            w_id: None,
             iss: "dust-front",
             aud: "dust-egress-proxy",
             exp_offset_seconds: 60,
@@ -567,6 +662,7 @@ async fn start_proxy_with_sandbox_policy(
 ) -> Result<ProxyProcess> {
     start_proxy_with_mock_gcs(
         MockPolicies {
+            workspace: None,
             sandbox: Some(policy_response(allowed_domains)),
         },
         unsafe_skip_ssrf_check,
@@ -623,6 +719,9 @@ async fn start_proxy_with_mock_gcs(
 
 async fn start_mock_gcs_server(policies: MockPolicies) -> Result<MockGcsServer> {
     let mut objects = HashMap::new();
+    if let Some(workspace) = policies.workspace {
+        objects.insert(format!("workspaces/{TEST_WORKSPACE_ID}.json"), workspace);
+    }
     if let Some(sandbox) = policies.sandbox {
         objects.insert(format!("sandboxes/{TEST_SANDBOX_ID}.json"), sandbox);
     }
@@ -809,6 +908,20 @@ fn make_token(secret: &str, exp_offset_seconds: i64) -> String {
         secret,
         FullClaims {
             sb_id: TEST_SANDBOX_ID,
+            w_id: None,
+            iss: "dust-front",
+            aud: "dust-egress-proxy",
+            exp_offset_seconds,
+        },
+    )
+}
+
+fn make_token_with_workspace(secret: &str, exp_offset_seconds: i64) -> String {
+    make_token_with_claims(
+        secret,
+        FullClaims {
+            sb_id: TEST_SANDBOX_ID,
+            w_id: Some(TEST_WORKSPACE_ID),
             iss: "dust-front",
             aud: "dust-egress-proxy",
             exp_offset_seconds,
@@ -828,6 +941,7 @@ fn make_token_with_claims(secret: &str, claims: FullClaims<'_>) -> String {
     };
     let claims = TestClaims {
         sb_id: claims.sb_id.to_string(),
+        w_id: claims.w_id.map(|s| s.to_string()),
         iss: claims.iss.to_string(),
         aud: claims.aud.to_string(),
         exp: usize::try_from(exp).expect("expiration timestamp should fit in usize"),
@@ -849,6 +963,7 @@ struct TestCerts {
 
 struct FullClaims<'a> {
     sb_id: &'a str,
+    w_id: Option<&'a str>,
     iss: &'a str,
     aud: &'a str,
     exp_offset_seconds: i64,

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -8,7 +8,7 @@ use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use rustls::pki_types::{pem::PemObject, CertificateDer, ServerName};
 use rustls::RootCertStore;
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::json;
 use std::collections::HashMap;
 use std::fs::write;
 use std::net::{Ipv6Addr, SocketAddr, TcpListener as StdTcpListener};
@@ -27,7 +27,6 @@ const SECRET: &str = "test-secret";
 const ALLOW_RESPONSE: u8 = 0x00;
 const DENY_RESPONSE: u8 = 0x01;
 const TEST_BUCKET: &str = "test-egress-policies";
-const TEST_WORKSPACE_ID: &str = "workspace-123";
 const TEST_SANDBOX_ID: &str = "sandbox-123";
 static INSTALL_RUSTLS_PROVIDER: Once = Once::new();
 
@@ -53,13 +52,11 @@ struct MockGcsState {
 #[derive(Clone)]
 enum MockGcsResponse {
     Policy(String),
-    Status(StatusCode),
 }
 
 #[derive(Default)]
 struct MockPolicies {
     sandbox: Option<MockGcsResponse>,
-    workspace: Option<MockGcsResponse>,
 }
 
 #[derive(Debug, Serialize)]
@@ -86,7 +83,7 @@ impl Drop for MockGcsServer {
 
 #[tokio::test]
 async fn healthz_returns_ok() -> Result<()> {
-    let proxy = start_proxy("example.com", false, "production").await?;
+    let proxy = start_proxy(false, "production").await?;
 
     let response = http_get(proxy.health_addr, "/healthz").await?;
 
@@ -109,32 +106,6 @@ async fn invalid_tls_assets_fail_startup() -> Result<()> {
         .env("EGRESS_PROXY_TLS_CERT", temp_dir.path().join("missing.crt"))
         .env("EGRESS_PROXY_TLS_KEY", &tls_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
-        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "example.com")
-        .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
-        .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
-        .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
-        .env("EGRESS_PROXY_ENV", "production")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()?;
-
-    wait_for_startup_failure(&mut child).await
-}
-
-#[tokio::test]
-async fn invalid_allowed_domain_fails_startup() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-    let certs = generate_test_certs(temp_dir.path())?;
-    let proxy_addr = free_addr()?;
-    let health_addr = free_addr()?;
-
-    let mut child = Command::new(env!("CARGO_BIN_EXE_egress-proxy"))
-        .env("EGRESS_PROXY_LISTEN_ADDR", proxy_addr.to_string())
-        .env("EGRESS_PROXY_HEALTH_ADDR", health_addr.to_string())
-        .env("EGRESS_PROXY_TLS_CERT", &certs.server_cert_path)
-        .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
-        .env("EGRESS_PROXY_JWT_SECRET", SECRET)
-        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "example..com")
         .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
         .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
         .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
@@ -159,7 +130,6 @@ async fn missing_policy_bucket_fails_startup() -> Result<()> {
         .env("EGRESS_PROXY_TLS_CERT", &certs.server_cert_path)
         .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
-        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "example.com")
         .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
         .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
         .env("EGRESS_PROXY_ENV", "production")
@@ -174,7 +144,7 @@ async fn missing_policy_bucket_fails_startup() -> Result<()> {
 async fn allowed_domain_forwards_bytes() -> Result<()> {
     let (upstream_port, mut upstream_handles) =
         start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
-    let proxy = start_proxy("localhost", true, "test").await?;
+    let proxy = start_proxy_with_sandbox_policy(&["localhost"], true, "test").await?;
     let token = make_token(SECRET, 60);
     let mut stream = connect_forwarder(&proxy).await?;
 
@@ -197,100 +167,8 @@ async fn allowed_domain_forwards_bytes() -> Result<()> {
 }
 
 #[tokio::test]
-async fn debug_policy_returns_fetched_workspace_and_sandbox_policies() -> Result<()> {
-    let proxy = start_proxy_with_mock_gcs(
-        "example.com",
-        MockPolicies {
-            workspace: Some(policy_response(&["github.com", "*.github.com"])),
-            sandbox: Some(policy_response(&["sandbox.example.com"])),
-        },
-        false,
-        "production",
-    )
-    .await?;
-
-    let response = http_get(
-        proxy.health_addr,
-        &format!("/debug/policy?wId={TEST_WORKSPACE_ID}&sbId={TEST_SANDBOX_ID}"),
-    )
-    .await?;
-
-    assert!(response.starts_with("HTTP/1.1 200 OK"));
-    let body: Value = serde_json::from_str(http_response_body(&response)?)?;
-
-    assert_eq!(
-        body["workspace"]["policy"]["allowedDomains"],
-        json!(["github.com", "*.github.com"])
-    );
-    assert_eq!(body["workspace"]["error"], Value::Null);
-    assert_eq!(
-        body["sandbox"]["policy"]["allowedDomains"],
-        json!(["sandbox.example.com"])
-    );
-    assert_eq!(body["sandbox"]["error"], Value::Null);
-    Ok(())
-}
-
-#[tokio::test]
-async fn debug_policy_returns_null_for_missing_policies() -> Result<()> {
-    let proxy =
-        start_proxy_with_mock_gcs("example.com", MockPolicies::default(), false, "production")
-            .await?;
-
-    let response = http_get(
-        proxy.health_addr,
-        &format!("/debug/policy?wId={TEST_WORKSPACE_ID}&sbId={TEST_SANDBOX_ID}"),
-    )
-    .await?;
-
-    assert!(response.starts_with("HTTP/1.1 200 OK"));
-    let body: Value = serde_json::from_str(http_response_body(&response)?)?;
-
-    assert_eq!(body["workspace"]["policy"], Value::Null);
-    assert_eq!(body["workspace"]["error"], Value::Null);
-    assert_eq!(body["sandbox"]["policy"], Value::Null);
-    assert_eq!(body["sandbox"]["error"], Value::Null);
-    Ok(())
-}
-
-#[tokio::test]
-async fn debug_policy_returns_errors_for_failed_fetches() -> Result<()> {
-    let proxy = start_proxy_with_mock_gcs(
-        "example.com",
-        MockPolicies {
-            workspace: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
-            sandbox: Some(policy_response(&["sandbox.example.com"])),
-        },
-        false,
-        "production",
-    )
-    .await?;
-
-    let response = http_get(
-        proxy.health_addr,
-        &format!("/debug/policy?wId={TEST_WORKSPACE_ID}&sbId={TEST_SANDBOX_ID}"),
-    )
-    .await?;
-
-    assert!(response.starts_with("HTTP/1.1 200 OK"));
-    let body: Value = serde_json::from_str(http_response_body(&response)?)?;
-
-    assert_eq!(body["workspace"]["policy"], Value::Null);
-    assert!(body["workspace"]["error"]
-        .as_str()
-        .expect("workspace error should be present")
-        .contains("GCS policy fetch returned status 500 Internal Server Error"));
-    assert_eq!(
-        body["sandbox"]["policy"]["allowedDomains"],
-        json!(["sandbox.example.com"])
-    );
-    assert_eq!(body["sandbox"]["error"], Value::Null);
-    Ok(())
-}
-
-#[tokio::test]
 async fn denied_domain_returns_deny() -> Result<()> {
-    let proxy = start_proxy("example.com", false, "production").await?;
+    let proxy = start_proxy(false, "production").await?;
     let token = make_token(SECRET, 60);
 
     let response = send_handshake(&proxy, &token, "denied.example.com", 443).await?;
@@ -301,7 +179,7 @@ async fn denied_domain_returns_deny() -> Result<()> {
 
 #[tokio::test]
 async fn invalid_jwt_returns_deny() -> Result<()> {
-    let proxy = start_proxy("example.com", false, "production").await?;
+    let proxy = start_proxy(false, "production").await?;
     let token = make_token("wrong-secret", 60);
 
     let response = send_handshake(&proxy, &token, "example.com", 443).await?;
@@ -312,7 +190,7 @@ async fn invalid_jwt_returns_deny() -> Result<()> {
 
 #[tokio::test]
 async fn expired_jwt_returns_deny() -> Result<()> {
-    let proxy = start_proxy("example.com", false, "production").await?;
+    let proxy = start_proxy(false, "production").await?;
     let token = make_token(SECRET, -60);
 
     let response = send_handshake(&proxy, &token, "example.com", 443).await?;
@@ -323,11 +201,11 @@ async fn expired_jwt_returns_deny() -> Result<()> {
 
 #[tokio::test]
 async fn invalid_issuer_returns_deny() -> Result<()> {
-    let proxy = start_proxy("example.com", false, "production").await?;
+    let proxy = start_proxy(false, "production").await?;
     let token = make_token_with_claims(
         SECRET,
         FullClaims {
-            sb_id: "test-egress-proxy",
+            sb_id: TEST_SANDBOX_ID,
             iss: "wrong-front",
             aud: "dust-egress-proxy",
             exp_offset_seconds: 60,
@@ -342,11 +220,11 @@ async fn invalid_issuer_returns_deny() -> Result<()> {
 
 #[tokio::test]
 async fn invalid_audience_returns_deny() -> Result<()> {
-    let proxy = start_proxy("example.com", false, "production").await?;
+    let proxy = start_proxy(false, "production").await?;
     let token = make_token_with_claims(
         SECRET,
         FullClaims {
-            sb_id: "test-egress-proxy",
+            sb_id: TEST_SANDBOX_ID,
             iss: "dust-front",
             aud: "wrong-audience",
             exp_offset_seconds: 60,
@@ -361,7 +239,7 @@ async fn invalid_audience_returns_deny() -> Result<()> {
 
 #[tokio::test]
 async fn empty_sandbox_id_claim_returns_deny() -> Result<()> {
-    let proxy = start_proxy("example.com", false, "production").await?;
+    let proxy = start_proxy(false, "production").await?;
     let token = make_token_with_claims(
         SECRET,
         FullClaims {
@@ -380,7 +258,7 @@ async fn empty_sandbox_id_claim_returns_deny() -> Result<()> {
 
 #[tokio::test]
 async fn allowed_loopback_without_ssrf_bypass_returns_deny() -> Result<()> {
-    let proxy = start_proxy("localhost", false, "production").await?;
+    let proxy = start_proxy_with_sandbox_policy(&["localhost"], false, "production").await?;
     let token = make_token(SECRET, 60);
 
     let response = send_handshake(&proxy, &token, "localhost", 443).await?;
@@ -397,9 +275,16 @@ async fn unsafe_ip_literals_return_deny() -> Result<()> {
         "127.0.0.1",
         "::1",
         "::ffff:127.0.0.1",
+        "10.0.0.1",
+        "::ffff:10.0.0.1",
+        "172.16.0.1",
+        "::ffff:172.16.0.1",
+        "192.168.1.1",
+        "::ffff:192.168.1.1",
+        "169.254.169.254",
         "::ffff:169.254.169.254",
     ] {
-        let proxy = start_proxy(domain, false, "production").await?;
+        let proxy = start_proxy(false, "production").await?;
         let response = send_handshake(&proxy, &token, domain, 443).await?;
 
         assert_eq!(
@@ -414,7 +299,7 @@ async fn unsafe_ip_literals_return_deny() -> Result<()> {
 
 #[tokio::test]
 async fn globally_blocklisted_domain_returns_deny() -> Result<()> {
-    let proxy = start_proxy("dns.google", false, "production").await?;
+    let proxy = start_proxy(false, "production").await?;
     let token = make_token(SECRET, 60);
 
     let response = send_handshake(&proxy, &token, "dns.google", 443).await?;
@@ -426,7 +311,7 @@ async fn globally_blocklisted_domain_returns_deny() -> Result<()> {
 #[tokio::test]
 async fn dns_resolution_failure_returns_deny() -> Result<()> {
     let unresolved_domain = "sandbox-egress-contract-test.invalid";
-    let proxy = start_proxy(unresolved_domain, false, "production").await?;
+    let proxy = start_proxy_with_sandbox_policy(&[unresolved_domain], false, "production").await?;
     let token = make_token(SECRET, 60);
 
     let response = send_handshake(&proxy, &token, unresolved_domain, 443).await?;
@@ -437,7 +322,7 @@ async fn dns_resolution_failure_returns_deny() -> Result<()> {
 
 #[tokio::test]
 async fn empty_domain_returns_deny() -> Result<()> {
-    let proxy = start_proxy("example.com", false, "production").await?;
+    let proxy = start_proxy(false, "production").await?;
     let token = make_token(SECRET, 60);
 
     let response = send_handshake(&proxy, &token, "", 443).await?;
@@ -449,7 +334,7 @@ async fn empty_domain_returns_deny() -> Result<()> {
 #[tokio::test]
 async fn upstream_connect_failure_returns_deny() -> Result<()> {
     let upstream_addr = free_addr()?;
-    let proxy = start_proxy("localhost", true, "test").await?;
+    let proxy = start_proxy_with_sandbox_policy(&["localhost"], true, "test").await?;
     let token = make_token(SECRET, 60);
 
     let response = send_handshake(&proxy, &token, "localhost", upstream_addr.port()).await?;
@@ -460,7 +345,7 @@ async fn upstream_connect_failure_returns_deny() -> Result<()> {
 
 #[tokio::test]
 async fn truncated_handshake_closes_without_response() -> Result<()> {
-    let proxy = start_proxy("example.com", false, "production").await?;
+    let proxy = start_proxy(false, "production").await?;
     let mut stream = connect_forwarder(&proxy).await?;
 
     stream.write_all(&[0x01, 0x00]).await?;
@@ -480,7 +365,7 @@ async fn truncated_handshake_closes_without_response() -> Result<()> {
 
 #[tokio::test]
 async fn complete_malformed_handshakes_return_deny() -> Result<()> {
-    let proxy = start_proxy("example.com", false, "production").await?;
+    let proxy = start_proxy(false, "production").await?;
     let token = make_token(SECRET, 60);
 
     for frame in [
@@ -499,7 +384,7 @@ async fn complete_malformed_handshakes_return_deny() -> Result<()> {
 
 #[tokio::test]
 async fn unsupported_protocol_version_returns_deny() -> Result<()> {
-    let proxy = start_proxy("example.com", false, "production").await?;
+    let proxy = start_proxy(false, "production").await?;
     let token = make_token(SECRET, 60);
     let mut frame = build_frame(&token, "example.com", 443)?;
     frame[0] = 0x02;
@@ -523,7 +408,6 @@ async fn unsafe_ssrf_bypass_fails_startup_outside_test_env() -> Result<()> {
         .env("EGRESS_PROXY_TLS_CERT", certs.server_cert_path)
         .env("EGRESS_PROXY_TLS_KEY", certs.server_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
-        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "127.0.0.1")
         .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
         .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
         .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
@@ -550,7 +434,6 @@ async fn health_bind_failure_fails_startup() -> Result<()> {
         .env("EGRESS_PROXY_TLS_CERT", certs.server_cert_path)
         .env("EGRESS_PROXY_TLS_KEY", certs.server_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
-        .env("EGRESS_PROXY_ALLOWED_DOMAINS", "localhost")
         .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
         .env("EGRESS_PROXY_POLICY_BASE_URL", "http://127.0.0.1:1")
         .env("GOOGLE_CLOUD_ACCESS_TOKEN", "test-access-token")
@@ -574,7 +457,7 @@ async fn relay_supports_upstream_banner_and_large_response() -> Result<()> {
             response: response.clone(),
         })
         .await?;
-    let proxy = start_proxy("localhost", true, "test").await?;
+    let proxy = start_proxy_with_sandbox_policy(&["localhost"], true, "test").await?;
     let token = make_token(SECRET, 60);
     let mut stream = connect_forwarder(&proxy).await?;
 
@@ -608,7 +491,7 @@ async fn sigterm_keeps_active_tunnel_alive_until_client_closes() -> Result<()> {
             chunks: vec![b"pingpong".to_vec(), b"pingpong".to_vec()],
         })
         .await?;
-    let mut proxy = start_proxy("localhost", true, "test").await?;
+    let mut proxy = start_proxy_with_sandbox_policy(&["localhost"], true, "test").await?;
     let token = make_token(SECRET, 60);
     let mut stream = connect_forwarder(&proxy).await?;
 
@@ -642,7 +525,7 @@ async fn sigterm_keeps_active_tunnel_alive_until_client_closes() -> Result<()> {
 async fn sigterm_aborts_stuck_tunnel_after_drain_timeout() -> Result<()> {
     let (upstream_port, mut upstream_handles) =
         start_localhost_servers(UpstreamBehavior::HoldUntilPeerCloses).await?;
-    let mut proxy = start_proxy("localhost", true, "test").await?;
+    let mut proxy = start_proxy_with_sandbox_policy(&["localhost"], true, "test").await?;
     let token = make_token(SECRET, 60);
     let mut stream = connect_forwarder(&proxy).await?;
 
@@ -673,14 +556,19 @@ async fn sigterm_aborts_stuck_tunnel_after_drain_timeout() -> Result<()> {
     Ok(())
 }
 
-async fn start_proxy(
-    allowed_domains: &str,
+async fn start_proxy(unsafe_skip_ssrf_check: bool, environment: &str) -> Result<ProxyProcess> {
+    start_proxy_with_mock_gcs(MockPolicies::default(), unsafe_skip_ssrf_check, environment).await
+}
+
+async fn start_proxy_with_sandbox_policy(
+    allowed_domains: &[&str],
     unsafe_skip_ssrf_check: bool,
     environment: &str,
 ) -> Result<ProxyProcess> {
     start_proxy_with_mock_gcs(
-        allowed_domains,
-        MockPolicies::default(),
+        MockPolicies {
+            sandbox: Some(policy_response(allowed_domains)),
+        },
         unsafe_skip_ssrf_check,
         environment,
     )
@@ -688,7 +576,6 @@ async fn start_proxy(
 }
 
 async fn start_proxy_with_mock_gcs(
-    allowed_domains: &str,
     policies: MockPolicies,
     unsafe_skip_ssrf_check: bool,
     environment: &str,
@@ -706,7 +593,6 @@ async fn start_proxy_with_mock_gcs(
         .env("EGRESS_PROXY_TLS_CERT", &certs.server_cert_path)
         .env("EGRESS_PROXY_TLS_KEY", &certs.server_key_path)
         .env("EGRESS_PROXY_JWT_SECRET", SECRET)
-        .env("EGRESS_PROXY_ALLOWED_DOMAINS", allowed_domains)
         .env("EGRESS_PROXY_POLICY_BUCKET", TEST_BUCKET)
         .env(
             "EGRESS_PROXY_POLICY_BASE_URL",
@@ -737,9 +623,6 @@ async fn start_proxy_with_mock_gcs(
 
 async fn start_mock_gcs_server(policies: MockPolicies) -> Result<MockGcsServer> {
     let mut objects = HashMap::new();
-    if let Some(workspace) = policies.workspace {
-        objects.insert(format!("workspaces/{TEST_WORKSPACE_ID}.json"), workspace);
-    }
     if let Some(sandbox) = policies.sandbox {
         objects.insert(format!("sandboxes/{TEST_SANDBOX_ID}.json"), sandbox);
     }
@@ -774,7 +657,6 @@ async fn mock_gcs_handler(State(state): State<MockGcsState>, uri: Uri) -> Respon
             body.clone(),
         )
             .into_response(),
-        Some(MockGcsResponse::Status(status)) => status.into_response(),
         None => StatusCode::NOT_FOUND.into_response(),
     }
 }
@@ -841,13 +723,6 @@ async fn http_get(addr: SocketAddr, path: &str) -> Result<String> {
     let mut response = Vec::new();
     stream.read_to_end(&mut response).await?;
     Ok(String::from_utf8(response)?)
-}
-
-fn http_response_body(response: &str) -> Result<&str> {
-    response
-        .split("\r\n\r\n")
-        .nth(1)
-        .ok_or_else(|| anyhow!("HTTP response missing body"))
 }
 
 async fn send_handshake(
@@ -933,7 +808,7 @@ fn make_token(secret: &str, exp_offset_seconds: i64) -> String {
     make_token_with_claims(
         secret,
         FullClaims {
-            sb_id: "test-egress-proxy",
+            sb_id: TEST_SANDBOX_ID,
             iss: "dust-front",
             aud: "dust-egress-proxy",
             exp_offset_seconds,
@@ -980,8 +855,6 @@ struct FullClaims<'a> {
 }
 
 fn generate_test_certs(temp_dir: &Path) -> Result<TestCerts> {
-    // TODO(sandbox-egress): Nice-to-have cleanup: generate these certificates with rcgen instead
-    // of shelling out to openssl, so tests do not need a system openssl binary.
     let ca_cert_path = temp_dir.join("ca.crt");
     let ca_key_path = temp_dir.join("ca.key");
     let server_cert_path = temp_dir.join("tls.crt");


### PR DESCRIPTION
## Description

Cutover from the dark-deploy in #24738. 
`EGRESS_PROXY_ALLOWED_DOMAINS` env-var allowlist now populates the "default" allowlist, and we also honor the GCS-backed per-sandbox/workspace policy.

Each connection now calls `evaluate(w_id, sb_id, domain)` which checks workspace policy first, then sandbox policy from the GCS bucket. This means domain authorization is driven by GCS policy files (`workspaces/{wId}.json` and `sandboxes/{sbId}.json`).

debug endpoint is gone

## Tests

- added more tests

## Risk

Low: still only used internally

Fail-closed: if GCS is unreachable or there is no default/workspace/sandbox policy, the connection is denied. Same as before.

## Deploy Plan

1. Merge this PR
2. Deploy egress proxy