### PR TITLE
Add: project_todos tool to project skill

### DIFF
--- a/front/lib/actions/tool_approval_labels.ts
+++ b/front/lib/actions/tool_approval_labels.ts
@@ -6,6 +6,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { isString } from "@app/types/shared/utils/general";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
+import { isResourceSId } from "../resources/string_ids";
 
 export async function getApprovalArgsLabel({
   auth,
@@ -45,7 +46,7 @@ export async function getApprovalArgsLabel({
     if (
       inputName.toLowerCase().includes("fileid") &&
       isString(inputValue) &&
-      inputValue.startsWith("fil_")
+      isResourceSId("file", inputValue)
     ) {
       const file = await FileResource.fetchById(auth, inputValue);
       if (file) {

--- a/front/lib/api/actions/servers/project_todos/metadata.ts
+++ b/front/lib/api/actions/servers/project_todos/metadata.ts
@@ -51,6 +51,11 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
   create_todo: {
     description: "Create a new TODO for the current user in the project.",
     schema: {
+      creatorType: z
+        .enum(["user", "agent"])
+        .describe(
+          "Who has the initiative of creating the TODO ? Use 'user' when the user explicitely asked for it."
+        ),
       text: z.string().min(1).describe("The TODO description."),
       category: z
         .enum(PROJECT_TODO_CATEGORIES)
@@ -79,6 +84,11 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
       "Create multiple TODOs at once for the current user in the project. " +
       "Useful for extracting action items from meeting notes or conversation summaries.",
     schema: {
+      creatorType: z
+        .enum(["user", "agent"])
+        .describe(
+          "Who has the initiative of creating the TODOs ? Use 'user' when the user explicitely asked for it."
+        ),
       todos: z
         .array(
           z.object({
@@ -109,6 +119,11 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
   mark_todo_done: {
     description: "Mark one of the current user's TODOs as done.",
     schema: {
+      actorType: z
+        .enum(["user", "agent"])
+        .describe(
+          "Who has the initiative of marking the TODO as done ? Use 'user' when the user explicitely asked for it."
+        ),
       todoId: z.string().describe("The sId of the TODO to mark as done."),
       dustProject: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT

--- a/front/lib/api/actions/servers/project_todos/tools/index.ts
+++ b/front/lib/api/actions/servers/project_todos/tools/index.ts
@@ -116,7 +116,7 @@ export function createProjectTodosTools(
       }, "Failed to list TODOs");
     },
 
-    create_todo: async ({ text, category, dustProject }) => {
+    create_todo: async ({ creatorType, text, category, dustProject }) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,
@@ -132,13 +132,12 @@ export function createProjectTodosTools(
         const todo = await ProjectTodoResource.makeNew(auth, {
           spaceId: space.id,
           userId: currentUser.id,
-          createdByType: "agent",
-          createdByUserId: currentUser.id,
+          createdByType: creatorType,
           createdByAgentConfigurationId:
-            agentLoopContext?.runContext?.agentConfiguration?.sId ?? null,
-          markedAsDoneByType: null,
-          markedAsDoneByUserId: null,
-          markedAsDoneByAgentConfigurationId: null,
+            creatorType === "agent"
+              ? (agentLoopContext?.runContext?.agentConfiguration?.sId ?? null)
+              : null,
+          createdByUserId: creatorType === "user" ? currentUser.id : null,
           category: category ?? "to_do",
           text,
           status: "todo",
@@ -155,7 +154,7 @@ export function createProjectTodosTools(
       }, "Failed to create TODO");
     },
 
-    create_todos_batch: async ({ todos, dustProject }) => {
+    create_todos_batch: async ({ creatorType, todos, dustProject }) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,
@@ -175,12 +174,10 @@ export function createProjectTodosTools(
           const todo = await ProjectTodoResource.makeNew(auth, {
             spaceId: space.id,
             userId: currentUser.id,
-            createdByType: "agent",
-            createdByUserId: currentUser.id,
-            createdByAgentConfigurationId: agentConfigId,
-            markedAsDoneByType: null,
-            markedAsDoneByUserId: null,
-            markedAsDoneByAgentConfigurationId: null,
+            createdByType: creatorType,
+            createdByAgentConfigurationId:
+              creatorType === "agent" ? agentConfigId : null,
+            createdByUserId: creatorType === "user" ? currentUser.id : null,
             category: item.category ?? "to_do",
             text: item.text,
             status: "todo",
@@ -200,7 +197,7 @@ export function createProjectTodosTools(
       }, "Failed to create TODOs");
     },
 
-    mark_todo_done: async ({ todoId, dustProject }) => {
+    mark_todo_done: async ({ actorType, todoId, dustProject }) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,
@@ -236,10 +233,12 @@ export function createProjectTodosTools(
         await todo.updateWithVersion(auth, {
           status: "done",
           doneAt: new Date(),
-          markedAsDoneByType: "agent",
-          markedAsDoneByUserId: currentUser.id,
+          markedAsDoneByType: actorType,
+          markedAsDoneByUserId: actorType === "user" ? currentUser.id : null,
           markedAsDoneByAgentConfigurationId:
-            agentLoopContext?.runContext?.agentConfiguration?.sId ?? null,
+            actorType === "agent"
+              ? (agentLoopContext?.runContext?.agentConfiguration?.sId ?? null)
+              : null,
         });
 
         return new Ok([

--- a/front/lib/resources/skill/code_defined/projects.ts
+++ b/front/lib/resources/skill/code_defined/projects.ts
@@ -68,7 +68,7 @@ When you need to find information, uses this order (skip steps if the relevant t
 
     return instructions;
   },
-  mcpServers: [{ name: "project_manager" }],
+  mcpServers: [{ name: "project_manager" }, { name: "project_todos" }],
   version: 1,
   icon: "ActionFolderIcon",
   isRestricted: async (auth: Authenticator) => {


### PR DESCRIPTION
## Description

The `project_todos` MCP server existed but wasn't part of the `projects` skill, so agents in project conversations couldn't use it. This PR wires it in and fixes provenance tracking so todos record whether they were created by the user or the agent.

- Add `project_todos` to the `projects` skill's `mcpServers` list alongside `project_manager`
- Add `creatorType` (`"user"` | `"agent"`) to `create_todo` and `create_todos_batch` schemas — populates `createdByType`, `createdByUserId`, and `createdByAgentConfigurationId` correctly based on who initiated the action
- Add `actorType` (`"user"` | `"agent"`) to `mark_todo_done` — same pattern for `markedAsDoneByType`, `markedAsDoneByUserId`, `markedAsDoneByAgentConfigurationId`
- Use `isResourceSId("file", ...)` in `getApprovalArgsLabel` instead of the raw `startsWith("fil_")` prefix check

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`
