### PR TITLE
Convert skill markdown to html for imports

### DIFF
--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -8,6 +8,7 @@ import {
 import type { ZipDetectedSkill } from "@app/lib/api/skills/detection/zip/types";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -190,6 +191,7 @@ export async function importSkillsFromFiles(
           agentFacingDescription: skill.description,
           userFacingDescription: skill.description,
           instructions: skill.instructions,
+          instructionsHtml: convertMarkdownToBlockHtml(skill.instructions),
           icon: existing.icon,
           mcpServerViews: existing.mcpServerViews,
           attachedKnowledge,
@@ -235,6 +237,7 @@ export async function importSkillsFromFiles(
             agentFacingDescription: skill.description,
             userFacingDescription: skill.description,
             instructions: skill.instructions,
+            instructionsHtml: convertMarkdownToBlockHtml(skill.instructions),
             editedBy: user?.id ?? null,
             requestedSpaceIds: [],
             extendedSkillId: null,

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -16,6 +16,7 @@ import { suggestMCPServersForDetectedSkill } from "@app/lib/api/skills/detection
 import { validateSkillsForImport } from "@app/lib/api/skills/detection/validate_skills";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -193,6 +194,7 @@ export async function importSkillsFromGitHub(
             agentFacingDescription: skill.description,
             userFacingDescription: skill.description,
             instructions: skill.instructions,
+            instructionsHtml: convertMarkdownToBlockHtml(skill.instructions),
             editedBy: user.id,
             requestedSpaceIds: [],
             extendedSkillId: null,

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -169,6 +169,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       icon: null,
       tools: [],
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -201,6 +202,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       icon: null,
       tools: [],
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -227,6 +229,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       icon: null,
       tools: [{ mcpServerViewId: "invalid_id" }],
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -249,6 +252,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       icon: null,
       tools: [{ mcpServerViewId: "msv_nonexistent123456" }],
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -290,6 +294,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       icon: null,
       tools: [],
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -355,6 +360,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
         { mcpServerViewId: serverView2.sId },
       ],
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -405,6 +411,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       icon: null,
       tools: [{ mcpServerViewId: serverView.sId }],
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -461,6 +468,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       instructions: skill.instructions,
       icon: null,
       tools: [],
+      instructionsHtml: null,
       attachedKnowledge: [
         {
           dataSourceViewId: dataSourceView1.sId,
@@ -528,6 +536,7 @@ describe("PATCH /api/w/[wId]/skills/[sId] - Suggested skill activation", () => {
       icon: null,
       tools: [],
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -585,6 +594,7 @@ describe("PATCH /api/w/[wId]/skills/[sId] - file attachments", () => {
       icon: null,
       tools: [],
       attachedKnowledge: [],
+      instructionsHtml: null,
       fileAttachments: [{ fileId: file.sId }],
     };
 
@@ -623,6 +633,7 @@ describe("PATCH /api/w/[wId]/skills/[sId] - file attachments", () => {
       icon: null,
       tools: [],
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -645,6 +656,7 @@ describe("PATCH /api/w/[wId]/skills/[sId] - file attachments", () => {
       icon: null,
       tools: [],
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -700,6 +712,7 @@ describe("PATCH /api/w/[wId]/skills/[sId] - file attachments", () => {
       icon: null,
       tools: [],
       attachedKnowledge: [],
+      instructionsHtml: null,
       fileAttachments: [],
     };
 

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -60,12 +60,11 @@ const PatchSkillRequestBodySchema = t.intersection([
       })
     ),
     attachedKnowledge: t.array(AttachedKnowledgeSchema),
+    instructionsHtml: t.union([t.string, t.null]),
   }),
-  // TODO(2026-03-02): make mandatory once always sent by the client.
   t.partial({
     fileAttachments: t.array(t.type({ fileId: t.string })),
     isDefault: t.boolean,
-    instructionsHtml: t.union([t.string, t.null]),
     reinforcement: t.union([
       t.literal("auto"),
       t.literal("on"),

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -504,6 +504,7 @@ describe("POST /api/w/[wId]/skills", () => {
       tools: [],
       extendedSkillId: null,
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -565,6 +566,7 @@ describe("POST /api/w/[wId]/skills", () => {
       ],
       extendedSkillId: null,
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -637,6 +639,7 @@ describe("POST /api/w/[wId]/skills", () => {
       tools: [{ mcpServerViewId: serverView.sId }],
       extendedSkillId: null,
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -683,6 +686,7 @@ describe("POST /api/w/[wId]/skills", () => {
       instructions: "Instructions",
       icon: "PuzzleIcon",
       tools: [],
+      instructionsHtml: null,
       attachedKnowledge: [
         {
           dataSourceViewId: dataSourceView.sId,
@@ -736,6 +740,7 @@ describe("POST /api/w/[wId]/skills", () => {
       instructions: `Read file: <knowledge id="${nodeId}" title="${title}" space="${regularSpace.sId}" dsv="${dataSourceView.sId}" hasChildren="false" />`,
       icon: "PuzzleIcon",
       tools: [],
+      instructionsHtml: null,
       attachedKnowledge: [
         {
           dataSourceViewId: dataSourceView.sId,
@@ -799,6 +804,7 @@ describe("POST /api/w/[wId]/skills - file attachments", () => {
       tools: [],
       extendedSkillId: null,
       attachedKnowledge: [],
+      instructionsHtml: null,
       fileAttachments: [{ fileId: file1.sId }, { fileId: file2.sId }],
     };
 
@@ -840,6 +846,7 @@ describe("POST /api/w/[wId]/skills - file attachments", () => {
       tools: [],
       extendedSkillId: null,
       attachedKnowledge: [],
+      instructionsHtml: null,
       fileAttachments: [{ fileId: file.sId }],
     };
 
@@ -862,6 +869,7 @@ describe("POST /api/w/[wId]/skills - file attachments", () => {
       tools: [],
       extendedSkillId: null,
       attachedKnowledge: [],
+      instructionsHtml: null,
     };
 
     await handler(req, res);
@@ -897,6 +905,7 @@ describe("POST /api/w/[wId]/skills - file attachments", () => {
       tools: [],
       extendedSkillId: null,
       attachedKnowledge: [],
+      instructionsHtml: null,
       fileAttachments: [{ fileId: file.sId }],
     };
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -75,11 +75,11 @@ const PostSkillRequestBodySchema = t.intersection([
     ),
     extendedSkillId: t.union([t.string, t.null]),
     attachedKnowledge: t.array(AttachedKnowledgeSchema),
+    instructionsHtml: t.union([t.string, t.null]),
   }),
   t.partial({
     fileAttachments: t.array(t.type({ fileId: t.string })),
     isDefault: t.boolean,
-    instructionsHtml: t.union([t.string, t.null]),
   }),
   t.union([
     t.type({
@@ -417,7 +417,7 @@ async function handler(
           agentFacingDescription: body.agentFacingDescription,
           userFacingDescription: body.userFacingDescription,
           instructions: body.instructions,
-          instructionsHtml: body.instructionsHtml ?? null,
+          instructionsHtml: body.instructionsHtml,
           editedBy: user.id,
           requestedSpaceIds,
           extendedSkillId: body.extendedSkillId,


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/7631
* Require html for private apis
* Convert markdown to html for skill imports

## Tests

* Imported skills from github and verified html was generated

## Risk

* Low

## Deploy Plan

* Deploy front