### PR TITLE
fix: zendesk edit permission

### DIFF
--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -49,6 +49,7 @@ import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { APIError } from "@app/types/error";
 import { isOAuthProvider } from "@app/types/oauth/lib";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
 import type { NotificationType } from "@dust-tt/sparkle";
 import {
@@ -301,9 +302,13 @@ function UpdateConnectionOAuthModal({
         setExtraConfig(stringMetadata);
       }
     }
-    if (isZendesk && metadata?.zendesk_subdomain) {
+    if (isZendesk) {
+      const { zendesk_subdomain } = metadata ?? {};
+      if (!isString(zendesk_subdomain)) {
+        return;
+      }
       setExtraConfig({
-        zendesk_subdomain: metadata.zendesk_subdomain as string,
+        zendesk_subdomain,
       });
     }
   }, [
@@ -478,7 +483,6 @@ function UpdateConnectionOAuthModal({
         )}
         {connectorUIConfiguration.oauthExtraConfigComponent &&
           ((isMicrosoft && !isMetadataLoading) ||
-            (isZendesk && !isMetadataLoading) ||
             showSlackOauthExtraComponent) && (
             <connectorUIConfiguration.oauthExtraConfigComponent
               extraConfig={extraConfig}

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -274,12 +274,14 @@ function UpdateConnectionOAuthModal({
 
   const isSlack = connectorProvider === "slack";
   const isMicrosoft = connectorProvider === "microsoft";
+  const isZendesk = connectorProvider === "zendesk";
 
   // Fetch existing OAuth metadata when modal is open
   const { metadata, isMetadataLoading } = useOAuthMetadata({
     dataSource,
     owner,
-    disabled: !isOpen || !dataSource.connectorId || !isMicrosoft,
+    disabled:
+      !isOpen || !dataSource.connectorId || (!isMicrosoft && !isZendesk),
   });
 
   // Populate extraConfig from metadata on first load only
@@ -299,7 +301,19 @@ function UpdateConnectionOAuthModal({
         setExtraConfig(stringMetadata);
       }
     }
-  }, [isOpen, metadata, isMetadataLoading, isMicrosoft, dataSource.sId]);
+    if (isZendesk && metadata?.zendesk_subdomain) {
+      setExtraConfig({
+        zendesk_subdomain: metadata.zendesk_subdomain as string,
+      });
+    }
+  }, [
+    isOpen,
+    metadata,
+    isMetadataLoading,
+    isMicrosoft,
+    isZendesk,
+    dataSource.sId,
+  ]);
 
   const { configValue: slackCredentialId } = useConnectorConfig({
     configKey: "privateIntegrationCredentialId",
@@ -464,6 +478,7 @@ function UpdateConnectionOAuthModal({
         )}
         {connectorUIConfiguration.oauthExtraConfigComponent &&
           ((isMicrosoft && !isMetadataLoading) ||
+            (isZendesk && !isMetadataLoading) ||
             showSlackOauthExtraComponent) && (
             <connectorUIConfiguration.oauthExtraConfigComponent
               extraConfig={extraConfig}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7759

This PR fixes the Zendesk connector's edit permissions modal to properly fetch and populate the OAuth metadata.

- Enables fetching OAuth metadata for Zendesk connectors (previously only enabled for Microsoft)
- Populates the Zendesk subdomain from metadata when editing connection

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.
