### PR TITLE
[front] hide wake-up trigger user messages in conversation view

### DIFF
--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -171,6 +171,7 @@ export const isHiddenMessage = (message: VirtuosoMessage): boolean => {
       (message.context.origin === "onboarding_conversation" ||
         message.context.origin === "project_kickoff" ||
         message.context.origin === "reinforced_skill_notification" ||
+        isWakeUpOrigin(message.context.origin) ||
         isSidekickBootstrapMessage(message))) ||
     isHandoverUserMessage(message)
   );


### PR DESCRIPTION
## Description
When a wake-up fires, the temporal activity posts a <dust_system>...</dust_system> user message (origin === "wakeup") that triggers the next agent turn. That message is internal plumbing — users shouldn't see the raw <dust_system> bubble.

Extends isHiddenMessage to filter it out alongside the other system/bootstrap user message origins, reusing the existing isWakeUpOrigin helper. Affects the main conversation view, the AgentInputBar scroll navigation, and the space conversation list preview (same call sites already drop the other hidden origins).

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually - without this change you see:
<img width="833" height="622" alt="Screenshot 2026-04-23 at 12 08 50 PM" src="https://github.com/user-attachments/assets/dd080792-f5d4-47c8-b512-d19b8a569cdb" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
