### PR TITLE
[Branching] Persist compaction source conversation id

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2795,6 +2795,11 @@ export async function compactConversation(
     const compactionMessage = await createCompactionMessage(auth, {
       conversation,
       rank: nextMessageRank,
+      sourceConversationId:
+        sourceConversation?.conversationId &&
+        sourceConversation.conversationId !== conversation.sId
+          ? sourceConversation.conversationId
+          : undefined,
       transaction: t,
     });
 

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -641,10 +641,12 @@ export async function createCompactionMessage(
   {
     conversation,
     rank,
+    sourceConversationId,
     transaction,
   }: {
     conversation: ConversationWithoutContentType;
     rank: number;
+    sourceConversationId?: string;
     transaction: Transaction;
   }
 ): Promise<CompactionMessageType> {
@@ -655,6 +657,7 @@ export async function createCompactionMessage(
       status: "created",
       content: null,
       runIds: null,
+      sourceConversationId: sourceConversationId ?? null,
       workspaceId: workspace.id,
     },
     { transaction }
@@ -687,5 +690,6 @@ export async function createCompactionMessage(
     branchId: conversation.branchId,
     status: "created",
     content: null,
+    ...(sourceConversationId ? { sourceConversationId } : {}),
   };
 }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -927,6 +927,9 @@ async function batchRenderCompactionMessages(
       branchId: m.getBranchId(),
       status: compactionMessage.status,
       content: compactionMessage.content,
+      ...(compactionMessage.sourceConversationId
+        ? { sourceConversationId: compactionMessage.sourceConversationId }
+        : {}),
     };
   });
 }

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -666,6 +666,7 @@ export class CompactionMessageModel extends WorkspaceAwareModel<CompactionMessag
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runIds: string[] | null;
+  declare sourceConversationId: string | null;
 
   declare status: CompactionMessageStatus;
   declare content: string | null;
@@ -685,6 +686,10 @@ CompactionMessageModel.init(
     },
     runIds: {
       type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
+    },
+    sourceConversationId: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
     status: {

--- a/front/migrations/db/migration_601.sql
+++ b/front/migrations/db/migration_601.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."compaction_messages"
+ADD COLUMN "sourceConversationId" VARCHAR(255);

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -634,6 +634,9 @@
  *         branchId:
  *           type: string
  *           nullable: true
+ *         sourceConversationId:
+ *           type: string
+ *           nullable: true
  *         status:
  *           type: string
  *           enum: [created, succeeded, failed]

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -10462,6 +10462,10 @@
             "type": "string",
             "nullable": true
           },
+          "sourceConversationId": {
+            "type": "string",
+            "nullable": true
+          },
           "status": {
             "type": "string",
             "enum": [

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -360,6 +360,7 @@ export type CompactionMessageType = {
   version: number;
   rank: number;
   branchId: string | null;
+  sourceConversationId?: string | null;
   status: CompactionMessageStatus; // Lifecycle: created → succeeded | failed.
   content: string | null; // null while status is "created".
 };


### PR DESCRIPTION
## Description
Adds `sourceConversationId` to compaction messages so downstream renderers can distinguish in-conversation compactions from compactions sourced from another conversation.

## Risks
Blast radius: compaction message persistence and private conversation message serialization.
Risk: low

## Deploy Plan
- pmrr
- run migration_601.sql
- deploy front
