### PR TITLE
[Branching] Show source conversation on fork compactions

### DIFF
--- a/front/components/assistant/conversation/CompactionMessage.tsx
+++ b/front/components/assistant/conversation/CompactionMessage.tsx
@@ -4,12 +4,15 @@ import type {
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { truncate } from "@app/types/shared/utils/string_utils";
 import {
   AnimatedText,
   ContentMessage,
   ExclamationCircleIcon,
   Spinner,
 } from "@dust-tt/sparkle";
+
+const MAX_SOURCE_CONVERSATION_TITLE_LENGTH = 50;
 
 interface CompactionMessageProps {
   message: CompactionMessageType;
@@ -32,10 +35,10 @@ function getCompactionSuccessLabel(
     parentConversation?.parentConversationId === message.sourceConversationId;
 
   if (isParentConversation && parentConversation.parentConversationTitle) {
-    return `Summary context gathered from conversation '${parentConversation.parentConversationTitle}'`;
+    return `Summarized '${truncate(parentConversation.parentConversationTitle, MAX_SOURCE_CONVERSATION_TITLE_LENGTH)}' here`;
   }
 
-  return "Summary context gathered from another conversation";
+  return "Summarized another conversation here";
 }
 
 export function CompactionMessage({

--- a/front/components/assistant/conversation/CompactionMessage.tsx
+++ b/front/components/assistant/conversation/CompactionMessage.tsx
@@ -1,5 +1,8 @@
 import { formatTimestring } from "@app/lib/utils/timestamps";
-import type { CompactionMessageType } from "@app/types/assistant/conversation";
+import type {
+  CompactionMessageType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   AnimatedText,
@@ -10,9 +13,35 @@ import {
 
 interface CompactionMessageProps {
   message: CompactionMessageType;
+  conversation: ConversationWithoutContentType;
 }
 
-export function CompactionMessage({ message }: CompactionMessageProps) {
+function getCompactionSuccessLabel(
+  message: CompactionMessageType,
+  conversation: ConversationWithoutContentType
+): string {
+  if (
+    !message.sourceConversationId ||
+    message.sourceConversationId === conversation.sId
+  ) {
+    return "Context compacted";
+  }
+
+  const parentConversation = conversation.forkingData?.forkedFrom;
+  const isParentConversation =
+    parentConversation?.parentConversationId === message.sourceConversationId;
+
+  if (isParentConversation && parentConversation.parentConversationTitle) {
+    return `Summary context gathered from conversation '${parentConversation.parentConversationTitle}'`;
+  }
+
+  return `Summary context gathered from conversation ${message.sourceConversationId}`;
+}
+
+export function CompactionMessage({
+  message,
+  conversation,
+}: CompactionMessageProps) {
   switch (message.status) {
     case "failed":
       return (
@@ -31,7 +60,8 @@ export function CompactionMessage({ message }: CompactionMessageProps) {
       return (
         <div className="flex items-center justify-center gap-1.5">
           <span className="text-sm text-muted-foreground">
-            Context compacted · {formatTimestring(message.created)}
+            {getCompactionSuccessLabel(message, conversation)} ·{" "}
+            {formatTimestring(message.created)}
           </span>
         </div>
       );

--- a/front/components/assistant/conversation/CompactionMessage.tsx
+++ b/front/components/assistant/conversation/CompactionMessage.tsx
@@ -35,7 +35,7 @@ function getCompactionSuccessLabel(
     return `Summary context gathered from conversation '${parentConversation.parentConversationTitle}'`;
   }
 
-  return `Summary context gathered from conversation ${message.sourceConversationId}`;
+  return "Summary context gathered from another conversation";
 }
 
 export function CompactionMessage({

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -277,7 +277,10 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
             !nextData && "mb-10"
           )}
         >
-          <CompactionMessage message={data} />
+          <CompactionMessage
+            message={data}
+            conversation={context.conversation}
+          />
         </div>
       );
     }


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24789

Uses `sourceConversationId` to show `Summary context gathered from conversation ...` only when a compaction was sourced from a different conversation, such as a fork parent.

## Risks
Blast radius: compaction message rendering in the conversation UI.
Risk: low

## Deploy Plan
- pmrr
- deploy front
