### PR TITLE
Add: admin setting to control project visibility.

### DIFF
--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -3,6 +3,7 @@ import { useAppRouter } from "@app/lib/platform";
 import { useCheckProjectName } from "@app/lib/swr/projects";
 import { useCreateSpace } from "@app/lib/swr/spaces";
 import { getProjectRoute } from "@app/lib/utils/router";
+import { areOpenProjectsAllowed } from "@app/lib/workspace_policies";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -14,6 +15,7 @@ import {
   DialogTitle,
   Input,
   SliderToggle,
+  Tooltip,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useState } from "react";
 
@@ -24,12 +26,16 @@ interface CreateProjectModalProps {
   owner: LightWorkspaceType;
 }
 
+const OPEN_PROJECTS_DISABLED_TOOLTIP =
+  "Open projects are disabled by your workspace admin.";
+
 export function CreateProjectModal({
   isOpen,
   onClose,
   onCreated,
   owner,
 }: CreateProjectModalProps) {
+  const areWorkspaceOpenProjectsAllowed = areOpenProjectsAllowed(owner);
   const [projectName, setProjectName] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
   const [isPublic, setIsPublic] = useState(false);
@@ -54,15 +60,23 @@ export function CreateProjectModal({
     if (isOpen) {
       setProjectName("");
       setIsSaving(false);
+      setIsPublic(false);
       setNameToCheck("");
     }
   }, [isOpen, setNameToCheck]);
+
+  useEffect(() => {
+    if (!areWorkspaceOpenProjectsAllowed && isPublic) {
+      setIsPublic(false);
+    }
+  }, [areWorkspaceOpenProjectsAllowed, isPublic]);
 
   const handleClose = useCallback(() => {
     onClose();
     setTimeout(() => {
       setProjectName("");
       setIsSaving(false);
+      setIsPublic(false);
       setNameToCheck("");
     }, 500);
   }, [onClose, setNameToCheck]);
@@ -157,11 +171,27 @@ export function CreateProjectModal({
                   Anyone in the workspace can find and join the project.
                 </div>
               </div>
-              <SliderToggle
-                size="xs"
-                selected={isPublic}
-                onClick={() => setIsPublic((prev) => !prev)}
-              />
+              {areWorkspaceOpenProjectsAllowed ? (
+                <SliderToggle
+                  size="xs"
+                  selected={isPublic}
+                  onClick={() => setIsPublic((prev) => !prev)}
+                />
+              ) : (
+                <Tooltip
+                  label={OPEN_PROJECTS_DISABLED_TOOLTIP}
+                  trigger={
+                    <div>
+                      <SliderToggle
+                        size="xs"
+                        selected={isPublic}
+                        onClick={() => setIsPublic((prev) => !prev)}
+                        disabled
+                      />
+                    </div>
+                  }
+                />
+              )}
             </div>
           </div>
         </DialogContainer>

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -11,6 +11,7 @@ import {
   useUpdateSpace,
 } from "@app/lib/swr/spaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import { areOpenProjectsAllowed } from "@app/lib/workspace_policies";
 import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { PatchProjectMetadataBodyType } from "@app/types/api/internal/spaces";
 import { PatchProjectMetadataBodySchema } from "@app/types/api/internal/spaces";
@@ -30,6 +31,7 @@ import {
   SearchInput,
   SliderToggle,
   TextArea,
+  Tooltip,
   UserGroupIcon,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -42,6 +44,9 @@ interface SpaceAboutTabProps {
   onOpenMembersPanel?: () => void;
 }
 
+const OPEN_PROJECTS_DISABLED_TOOLTIP =
+  "Open projects are disabled by your workspace admin.";
+
 export function SpaceAboutTab({
   owner,
   space,
@@ -53,6 +58,9 @@ export function SpaceAboutTab({
     isRestricted,
   } = space;
   const isPublic = !isRestricted;
+  const areWorkspaceOpenProjectsAllowed = areOpenProjectsAllowed(owner);
+  const isVisibilityToggleDisabled =
+    !isProjectEditor || (!areWorkspaceOpenProjectsAllowed && !isPublic);
   const [searchSelectedMembers, setSearchSelectedMembers] = useState("");
 
   const confirm = useContext(ConfirmContext);
@@ -343,12 +351,30 @@ export function SpaceAboutTab({
                 Anyone in the workspace can find and join the project.
               </div>
             </div>
-            <SliderToggle
-              size="xs"
-              selected={isPublic}
-              onClick={handleVisibilityToggle}
-              disabled={!isProjectEditor}
-            />
+            {isVisibilityToggleDisabled &&
+            !areWorkspaceOpenProjectsAllowed &&
+            !isPublic ? (
+              <Tooltip
+                label={OPEN_PROJECTS_DISABLED_TOOLTIP}
+                trigger={
+                  <div>
+                    <SliderToggle
+                      size="xs"
+                      selected={isPublic}
+                      onClick={handleVisibilityToggle}
+                      disabled
+                    />
+                  </div>
+                }
+              />
+            ) : (
+              <SliderToggle
+                size="xs"
+                selected={isPublic}
+                onClick={handleVisibilityToggle}
+                disabled={isVisibilityToggleDisabled}
+              />
+            )}
           </div>
         </div>
 

--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -1,5 +1,6 @@
 import { EmailAgentsToggle } from "@app/components/workspace/settings/EmailAgentsToggle";
 import { InteractiveContentSharingToggle } from "@app/components/workspace/settings/InteractiveContentSharingToggle";
+import { OpenProjectsPolicy } from "@app/components/workspace/settings/OpenProjectsPolicy";
 import { PrivateConversationUrlsToggle } from "@app/components/workspace/settings/PrivateConversationUrlsToggle";
 import { RestrictAgentsPublishingCapability } from "@app/components/workspace/settings/RestrictAgentsPublishingCapability";
 import { VoiceTranscriptionToggle } from "@app/components/workspace/settings/VoiceTranscriptionToggle";
@@ -27,6 +28,7 @@ export function CapabilitiesSection({
         {!subscription.plan.isByok && (
           <VoiceTranscriptionToggle owner={owner} />
         )}
+        <OpenProjectsPolicy owner={owner} />
         <EmailAgentsToggle owner={owner} />
         <PrivateConversationUrlsToggle owner={owner} />
         {publishingRestrictionMessage && (

--- a/front/components/workspace/settings/OpenProjectsPolicy.tsx
+++ b/front/components/workspace/settings/OpenProjectsPolicy.tsx
@@ -1,0 +1,85 @@
+import { useOpenProjectsPolicy } from "@app/hooks/useOpenProjectsPolicy";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Button,
+  ContextItem,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+  SpaceClosedIcon,
+  SpaceOpenIcon,
+} from "@dust-tt/sparkle";
+
+const OPEN_PROJECTS_POLICIES = [
+  {
+    value: "private_and_open",
+    label: "Private and open projects",
+    description: "Members can create either private or open projects.",
+    icon: SpaceOpenIcon,
+    allowOpenProjects: true,
+  },
+  {
+    value: "private_only",
+    label: "Private projects only",
+    description: "Members can only create private projects.",
+    icon: SpaceClosedIcon,
+    allowOpenProjects: false,
+  },
+] as const;
+
+export function OpenProjectsPolicy({ owner }: { owner: WorkspaceType }) {
+  const { featureFlags } = useFeatureFlags();
+  const { allowOpenProjects, isChanging, doUpdateOpenProjectsPolicy } =
+    useOpenProjectsPolicy({ owner });
+
+  if (!featureFlags.includes("projects")) {
+    return null;
+  }
+
+  const selectedPolicy = OPEN_PROJECTS_POLICIES.find(
+    (policy) => policy.allowOpenProjects === allowOpenProjects
+  );
+
+  return (
+    <ContextItem
+      title="Project visibility policy"
+      subElement="Control whether projects can be private only or private and open."
+      visual={<SpaceClosedIcon className="h-6 w-6" />}
+      hasSeparatorIfLast={true}
+      action={
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              isSelect
+              label={selectedPolicy?.label}
+              icon={selectedPolicy?.icon}
+              disabled={isChanging}
+              className="grid grid-cols-[auto_1fr_auto] truncate"
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="max-w-[320px]">
+            <DropdownMenuRadioGroup value={selectedPolicy?.value}>
+              {OPEN_PROJECTS_POLICIES.map((policy) => (
+                <DropdownMenuRadioItem
+                  key={policy.value}
+                  value={policy.value}
+                  label={policy.label}
+                  description={policy.description}
+                  icon={policy.icon}
+                  onClick={() =>
+                    void doUpdateOpenProjectsPolicy(policy.allowOpenProjects)
+                  }
+                />
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      }
+    />
+  );
+}

--- a/front/hooks/useOpenProjectsPolicy.ts
+++ b/front/hooks/useOpenProjectsPolicy.ts
@@ -1,0 +1,55 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useState } from "react";
+
+interface UseOpenProjectsPolicyProps {
+  owner: LightWorkspaceType;
+}
+
+export function useOpenProjectsPolicy({ owner }: UseOpenProjectsPolicyProps) {
+  const [isChanging, setIsChanging] = useState(false);
+  const sendNotification = useSendNotification();
+  const [allowOpenProjects, setAllowOpenProjects] = useState(
+    owner.metadata?.allowOpenProjects !== false
+  );
+
+  const doUpdateOpenProjectsPolicy = async (nextValue: boolean) => {
+    setIsChanging(true);
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          allowOpenProjects: nextValue,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to update project visibility policy.");
+      }
+
+      setAllowOpenProjects(nextValue);
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to update project visibility policy",
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsChanging(false);
+    }
+
+    return true;
+  };
+
+  return {
+    allowOpenProjects,
+    isChanging,
+    doUpdateOpenProjectsPolicy,
+  };
+}

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -432,6 +432,7 @@ export interface WorkspaceMetadata {
   killSwitched?: WorkspaceKillSwitchValue;
   allowContentCreationFileSharing?: boolean;
   allowVoiceTranscription?: boolean;
+  allowOpenProjects?: boolean;
   privateConversationUrlsByDefault?: boolean;
   autoCreateSpaceForProvisionedGroups?: boolean;
   disableManualInvitations?: boolean;

--- a/front/lib/workspace_policies.ts
+++ b/front/lib/workspace_policies.ts
@@ -1,0 +1,5 @@
+import type { LightWorkspaceType } from "@app/types/user";
+
+export function areOpenProjectsAllowed(owner: LightWorkspaceType): boolean {
+  return owner.metadata?.allowOpenProjects !== false;
+}

--- a/front/pages/api/w/[wId]/index.test.ts
+++ b/front/pages/api/w/[wId]/index.test.ts
@@ -331,6 +331,29 @@ describe("POST /api/w/[wId]", () => {
     });
   });
 
+  it("disables open projects", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.body = {
+      allowOpenProjects: false,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      workspace: expect.objectContaining({
+        id: workspace.id,
+        metadata: expect.objectContaining({
+          allowOpenProjects: false,
+        }),
+      }),
+    });
+  });
+
   it("returns 405 for non-POST methods", async () => {
     for (const method of ["PUT", "DELETE"] as const) {
       const { req, res } = await createPrivateApiMockRequest({

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -91,6 +91,10 @@ const WorkspaceExtensionMcpToolsUpdateBodySchema = t.type({
   disableExtensionMcpTools: t.boolean,
 });
 
+const WorkspaceOpenProjectsUpdateBodySchema = t.type({
+  allowOpenProjects: t.boolean,
+});
+
 const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceAllowedDomainUpdateBodySchema,
   WorkspaceBatchDomainUpdateBodySchema,
@@ -106,6 +110,7 @@ const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceAgentReinforcementUpdateBodySchema,
   WorkspaceReinforcementBatchModeUpdateBodySchema,
   WorkspaceExtensionMcpToolsUpdateBodySchema,
+  WorkspaceOpenProjectsUpdateBodySchema,
 ]);
 
 async function handler(
@@ -267,6 +272,14 @@ async function handler(
         const newMetadata = {
           ...previousMetadata,
           disableExtensionMcpTools: body.disableExtensionMcpTools,
+        };
+        await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+        owner.metadata = newMetadata;
+      } else if ("allowOpenProjects" in body) {
+        const previousMetadata = owner.metadata ?? {};
+        const newMetadata = {
+          ...previousMetadata,
+          allowOpenProjects: body.allowOpenProjects,
         };
         await workspace.updateWorkspaceSettings({ metadata: newMetadata });
         owner.metadata = newMetadata;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.test.ts
@@ -1,0 +1,67 @@
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { describe, expect, it } from "vitest";
+
+import handler from "./members";
+
+describe("PATCH /api/w/[wId]/spaces/[spaceId]/members", () => {
+  it("blocks making a restricted project open when open projects are disabled", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      ...(workspace.metadata ?? {}),
+      allowOpenProjects: false,
+    });
+
+    const project = await SpaceFactory.project(workspace, user.id);
+    req.query.spaceId = project.sId;
+    req.body = {
+      name: project.name,
+      isRestricted: false,
+      managementMode: "manual",
+      memberIds: [],
+      editorIds: [user.sId],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message:
+          "Open projects are disabled by your workspace admin. Keep this project private.",
+      },
+    });
+  });
+
+  it("allows making a restricted project open when open projects are allowed", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const project = await SpaceFactory.project(workspace, user.id);
+    req.query.spaceId = project.sId;
+    req.body = {
+      name: project.name,
+      isRestricted: false,
+      managementMode: "manual",
+      memberIds: [],
+      editorIds: [user.sId],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().space).toEqual(
+      expect.objectContaining({
+        sId: project.sId,
+      })
+    );
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -10,6 +10,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { notifyProjectMembersAdded } from "@app/lib/notifications/workflows/project-added-as-member";
 import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { areOpenProjectsAllowed } from "@app/lib/workspace_policies";
 import { auditLog } from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -95,6 +96,23 @@ export async function handler(
       // Track current members before update to identify newly added ones.
       let currentMemberIds: Set<string> | undefined;
       const body = bodyValidation.right;
+      const owner = auth.getNonNullableWorkspace();
+
+      if (
+        space.isProjectAndRestricted() &&
+        !body.isRestricted &&
+        !areOpenProjectsAllowed(owner)
+      ) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Open projects are disabled by your workspace admin. Keep this project private.",
+          },
+        });
+      }
+
       if (space.isProject() && body.managementMode === "manual") {
         const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
           space,

--- a/front/pages/api/w/[wId]/spaces/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/index.test.ts
@@ -1,0 +1,93 @@
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockCreateSpaceAndGroup } = vi.hoisted(() => ({
+  mockCreateSpaceAndGroup: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/spaces", () => ({
+  createSpaceAndGroup: mockCreateSpaceAndGroup,
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", () => ({
+  buildAuditLogTarget: vi.fn(() => ({ type: "mock_target" })),
+  emitAuditLogEvent: vi.fn(),
+  getAuditLogContext: vi.fn(() => ({})),
+}));
+
+import handler from "./index";
+
+describe("POST /api/w/[wId]/spaces", () => {
+  it("blocks creating an open project when open projects are disabled", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      ...(workspace.metadata ?? {}),
+      allowOpenProjects: false,
+    });
+
+    req.body = {
+      name: "Open project should fail",
+      isRestricted: false,
+      spaceKind: "project",
+      managementMode: "manual",
+      memberIds: [],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(mockCreateSpaceAndGroup).not.toHaveBeenCalled();
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message:
+          "Open projects are disabled by your workspace admin. Create a private project instead.",
+      },
+    });
+  });
+
+  it("allows creating an open project when open projects are allowed", async () => {
+    mockCreateSpaceAndGroup.mockResolvedValue({
+      isErr: () => false,
+      value: {
+        sId: "vlt_mockProject",
+        name: "Open project is allowed",
+        kind: "project",
+        toJSON: () => ({
+          sId: "vlt_mockProject",
+          kind: "project",
+          isRestricted: false,
+        }),
+      },
+    });
+
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.body = {
+      name: "Open project is allowed",
+      isRestricted: false,
+      spaceKind: "project",
+      managementMode: "manual",
+      memberIds: [],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(201);
+    expect(mockCreateSpaceAndGroup).toHaveBeenCalledTimes(1);
+    expect(res._getJSONData().space).toEqual(
+      expect.objectContaining({
+        kind: "project",
+        isRestricted: false,
+      })
+    );
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -112,6 +112,7 @@ import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { areOpenProjectsAllowed } from "@app/lib/workspace_policies";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -227,6 +228,22 @@ async function handler(
       }
 
       const requestBody = bodyValidation.right;
+      const owner = auth.getNonNullableWorkspace();
+
+      if (
+        requestBody.spaceKind === "project" &&
+        !requestBody.isRestricted &&
+        !areOpenProjectsAllowed(owner)
+      ) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Open projects are disabled by your workspace admin. Create a private project instead.",
+          },
+        });
+      }
 
       const spaceRes = await createSpaceAndGroup(auth, requestBody);
       if (spaceRes.isErr()) {


### PR DESCRIPTION
## Description

Workspace admins need control over whether members can create open (workspace-visible) projects or only private ones. Without this setting any member can make a project open, which isn't appropriate for all organizations.

- Add `allowOpenProjects` to `WorkspaceMetadata` (defaults to `true`)
- Add `OpenProjectsPolicy` component — a dropdown in admin settings with two options: "Private and open projects" or "Private projects only", gated behind the `projects` feature flag
- Add `useOpenProjectsPolicy` hook to PATCH the workspace metadata
- Add `areOpenProjectsAllowed(owner)` utility in `workspace_policies.ts`
- In `CreateProjectModal`: disable the open/closed toggle with a tooltip ("Open projects are disabled by your workspace admin.") when the policy is `private_only`; reset `isPublic` to `false` on open and close
- In `SpaceAboutTab`: disable the visibility toggle with a tooltip when the policy forbids open projects and the project is already private (existing open projects can still be toggled back to private)
- Wire `OpenProjectsPolicy` into `CapabilitiesSection`

## Tests

Local

## Risk

Low — defaults to `allowOpenProjects: true`, so existing workspaces are unaffected

## Deploy Plan

Deploy `front`
