### PR TITLE
Add: sidebar wake-up indicator on conversation list items

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -44,6 +44,7 @@ import {
 import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
+import { useConversations } from "@app/hooks/conversations/useConversations";
 import { useAgentMessageStream } from "@app/hooks/useAgentMessageStream";
 import { useDeleteAgentMessage } from "@app/hooks/useDeleteAgentMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -63,11 +64,13 @@ import {
   isGlobalAgentId,
   isGlobalAgentWithFeedback,
 } from "@app/types/assistant/assistant";
+import type { ConversationListItemType } from "@app/types/assistant/conversation";
 import { isLightAgentMessageType } from "@app/types/assistant/conversation";
 import type {
   RichAgentMention,
   RichMention,
 } from "@app/types/assistant/mentions";
+import { isActiveWakeUp } from "@app/types/assistant/wakeups";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import {
   isInteractiveContentType,
@@ -240,6 +243,10 @@ export function AgentMessage({
     conversationId,
     disabled: true,
   });
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
 
   const methods = useVirtuosoMethods<
     VirtuosoMessage,
@@ -374,7 +381,21 @@ export function AgentMessage({
               void mutateSandboxFiles();
             }
             if (action.internalMCPServerName === "wakeups") {
-              void mutateWakeUps();
+              void mutateWakeUps().then((updated) => {
+                const activeWakeUp =
+                  updated?.wakeUps.find(isActiveWakeUp) ?? null;
+                const nextWakeupAt =
+                  activeWakeUp?.scheduleConfig.type === "one_shot"
+                    ? activeWakeUp.scheduleConfig.fireAt
+                    : null;
+                void mutateConversations(
+                  (currentData: ConversationListItemType[] | undefined) =>
+                    currentData?.map((c) =>
+                      c.sId === conversationId ? { ...c, nextWakeupAt } : c
+                    ),
+                  { revalidate: false }
+                );
+              });
             }
             break;
           }
@@ -398,6 +419,7 @@ export function AgentMessage({
         mutateSandboxStatus,
         mutateSandboxFiles,
         mutateWakeUps,
+        mutateConversations,
       ]
     ),
     streamId,

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -56,6 +56,7 @@ import type { ProjectType, SpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import { isBuilder } from "@app/types/user";
 import {
+  ActionTimeIcon,
   Avatar,
   BoltIcon,
   BoltOffIcon,
@@ -77,6 +78,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   FolderOpenIcon,
+  Icon,
   Label,
   ListCheckIcon,
   MagicIcon,
@@ -1184,6 +1186,24 @@ const ConversationList = ({
   );
 };
 
+interface WakeUpSuffixProps {
+  nextWakeupAt: number;
+}
+
+function WakeUpSuffix({ nextWakeupAt }: WakeUpSuffixProps) {
+  const date = new Date(nextWakeupAt);
+  const hours = date.getHours() % 12 || 12;
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const timeStr = `${hours}:${minutes}`;
+
+  return (
+    <span className="copy-xs flex items-center gap-1 text-muted-foreground dark:text-muted-foreground-night">
+      <Icon visual={ActionTimeIcon} size="xs" />
+      {timeStr}
+    </span>
+  );
+}
+
 function getConversationDotStatus(
   conversation: ConversationListItemType
 ): "blocked" | "unread" | "idle" {
@@ -1278,6 +1298,11 @@ const ConversationListItem = memo(
           !conversation.spaceId
             ? "cursor-grab active:cursor-grabbing"
             : undefined
+        }
+        suffix={
+          conversation.nextWakeupAt ? (
+            <WakeUpSuffix nextWakeupAt={conversation.nextWakeupAt} />
+          ) : undefined
         }
         moreMenu={
           <ConversationMenu

--- a/front/lib/conversation_search/search.ts
+++ b/front/lib/conversation_search/search.ts
@@ -167,6 +167,9 @@ export async function listPrivateConversationsFromES({
           hasError: source.has_error,
           lastReadMs: null,
           metadata: source.metadata as ConversationMetadata,
+          nextWakeupAt: source.next_wakeup_at
+            ? new Date(source.next_wakeup_at).getTime()
+            : null,
           requestedSpaceIds: source.requested_space_ids,
           sId: source.conversation_id,
           spaceId: source.space_id ?? null,

--- a/front/lib/swr/wakeups.ts
+++ b/front/lib/swr/wakeups.ts
@@ -1,8 +1,10 @@
+import { useConversations } from "@app/hooks/conversations/useConversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetConversationWakeUpsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/wakeups";
+import type { ConversationListItemType } from "@app/types/assistant/conversation";
 import { isActiveWakeUp } from "@app/types/assistant/wakeups";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useMemo } from "react";
@@ -59,6 +61,10 @@ export function useCancelWakeUp({
     conversationId,
     disabled: true,
   });
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
 
   const cancelWakeUp = useCallback(
     async (wakeUpSId: string) => {
@@ -80,9 +86,22 @@ export function useCancelWakeUp({
 
       sendNotification({ type: "success", title: "Wake-up cancelled" });
       void mutateWakeUps();
+      void mutateConversations(
+        (currentData: ConversationListItemType[] | undefined) =>
+          currentData?.map((c) =>
+            c.sId === conversationId ? { ...c, nextWakeupAt: null } : c
+          ),
+        { revalidate: false }
+      );
       return true;
     },
-    [owner.sId, conversationId, sendNotification, mutateWakeUps]
+    [
+      owner.sId,
+      conversationId,
+      sendNotification,
+      mutateWakeUps,
+      mutateConversations,
+    ]
   );
 
   return { cancelWakeUp };

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -461,6 +461,7 @@ export type ConversationListItemType = {
   hasError: boolean;
   lastReadMs: number | null;
   metadata: ConversationMetadata;
+  nextWakeupAt?: number | null;
   requestedSpaceIds: string[];
   sId: string;
   spaceId: string | null;

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -80,6 +80,7 @@ interface NavigationListItemProps
   status?: NavigationListItemStatus;
   count?: number;
   hasActivity?: boolean;
+  suffix?: React.ReactNode;
 }
 
 const NavigationListItem = React.forwardRef<
@@ -102,6 +103,7 @@ const NavigationListItem = React.forwardRef<
       status = "idle",
       count,
       hasActivity,
+      suffix,
       ...props
     },
     ref
@@ -168,12 +170,19 @@ const NavigationListItem = React.forwardRef<
             {label && (
               <span
                 className={cn(
-                  "s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap group-focus-within/menu-item:s-pr-8 group-hover/menu-item:s-pr-8 group-data-[selected=true]/menu-item:s-pr-8",
+                  "s-overflow-hidden s-text-ellipsis s-whitespace-nowrap",
+                  !suffix &&
+                    "s-grow group-focus-within/menu-item:s-pr-8 group-hover/menu-item:s-pr-8 group-data-[selected=true]/menu-item:s-pr-8",
                   hasActivity && "s-font-semibold"
                 )}
               >
                 {label}
               </span>
+            )}
+            {suffix && (
+              <div className="s-flex s-grow s-flex-shrink-0 s-items-center">
+                {suffix}
+              </div>
             )}
             {counterValue !== undefined && !shouldHideStatusIndicators && (
               <Counter


### PR DESCRIPTION
## Description
Surfaces the scheduled wake-up time next to each conversation title in the sidebar, driven by next_wakeup_at on the ES conversation_search index so no per-row DB fetch is needed. Adds an optional suffix prop to Sparkle's NavigationListItem, rendered inline after the title with a clock icon and h:mm time (no AM/PM) when nextWakeupAt is set.

Added optimistic mutateConversations calls in AgentMessage (after the wakeups MCP action) and useCancelWakeUp, following the same { revalidate: false } + inline currentData?.map(...) pattern used by BlockedActionsProvider.removeAllBlockedActionsForMessage for actionRequired. This sidesteps the race with async ES reindexing so the sidebar clock flips on/off the moment the action resolves.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually:
<img width="309" height="185" alt="Screenshot 2026-04-23 at 2 24 04 PM" src="https://github.com/user-attachments/assets/94e5ebc9-6639-47c3-8193-58e0fa47b4c7" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, wakeups only exist behind ff
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
