### PR TITLE
feat(project_todo): make takeaway descriptions self-sufficient

### DIFF
--- a/front/lib/project_todo/analyze_document/action_items.ts
+++ b/front/lib/project_todo/analyze_document/action_items.ts
@@ -58,6 +58,7 @@ export function buildPromptActionItems(
     "- Include an assignee_name only when clearly stated in the document.\n" +
     "- Include an assignee_user_id (from the project members list) when the assignee matches a known project member.\n" +
     "- Be concise: one action item per distinct task.\n" +
+    "- Make descriptions self-sufficient: include both the action AND its subject so the item is understandable without opening the source document. Prefer specific over vague — not 'Fix the bug' but 'Fix crash in batchRenderMessages when agent config is unavailable'; not 'Review PR' but 'Review PR #24679 — improves takeaway extraction prompts'.\n" +
     "- In the description, mention users and agents by their name, NOT via their id or via a generic term like User, Agent or Bot.\n" +
     "- In the description, refer to the assignee by Your pronouns (e.g., 'You', 'Your', 'Yours'), not by their name.\n\n";
   if (previousActionItems.length > 0) {

--- a/front/lib/project_todo/analyze_document/key_decisions.ts
+++ b/front/lib/project_todo/analyze_document/key_decisions.ts
@@ -52,6 +52,7 @@ export function buildPromptKeyDecisions(
     "- Write each description as an objective factual statement. Name people by their actual " +
     "name when relevant. Do not use 'You' or 'Your' — these items are shown to all project " +
     "members, not just one person.\n" +
+    "- Make descriptions self-sufficient: include the decision AND its context so it is understandable without opening the source — not 'Use monorepo' but 'Adopt monorepo structure for the SDK, replacing separate per-package repositories'.\n" +
     "- Include relevant_user_ids (from the project members list) for people involved in making this decision.\n\n";
   if (previousKeyDecisions.length > 0) {
     prompt +=

--- a/front/lib/project_todo/analyze_document/notable_facts.ts
+++ b/front/lib/project_todo/analyze_document/notable_facts.ts
@@ -47,6 +47,7 @@ export function buildPromptNotableFacts(
     "Formatting rules:\n" +
     "- Be concise and specific — one fact per distinct piece of information. Do not combine " +
     "multiple facts into a single entry.\n" +
+    "- Make descriptions self-sufficient: include enough specifics that a project member reading the list can grasp the fact without reading the original source — not 'Deadline moved' but 'Q3 launch deadline moved to October 15 due to infrastructure constraints found in the audit'.\n" +
     "- Mention users and agents by their name, NOT via their id or via a generic term " +
     "like User, Agent or Bot.\n" +
     "- Write each description as an objective factual statement. Name people by their actual " +


### PR DESCRIPTION
## Description

Adds a formatting rule to the three takeaway extractor prompts (`action_items`, `key_decisions`, `notable_facts`) requiring that generated descriptions are **self-sufficient** — understandable without navigating to the source document.

### Problem

Previously, the LLM could generate opaque descriptions like:
- `"Fix the bug"` — which bug?
- `"Review PR"` — which PR?
- `"Deadline moved"` — which deadline, to when?
- `"Use monorepo"` — for what? replacing what?

These force users to click through to the source conversation to understand the item, defeating the purpose of the TODO list.

### Solution

Added one new formatting rule per prompt:

**Action items:**
> Make descriptions self-sufficient: include both the action AND its subject so the item is understandable without opening the source document. Prefer specific over vague — not 'Fix the bug' but 'Fix crash in batchRenderMessages when agent config is unavailable'; not 'Review PR' but 'Review PR #24679 — improves takeaway extraction prompts'.

**Key decisions:**
> Make descriptions self-sufficient: include the decision AND its context so it is understandable without opening the source — not 'Use monorepo' but 'Adopt monorepo structure for the SDK, replacing separate per-package repositories'.

**Notable facts:**
> Make descriptions self-sufficient: include enough specifics that a project member reading the list can grasp the fact without reading the original source — not 'Deadline moved' but 'Q3 launch deadline moved to October 15 due to infrastructure constraints found in the audit'.

## Tests

No logic changes — prompt-only. Existing unit tests in `action_items.test.ts` and `key_decisions.test.ts` still pass unchanged.

Manual verification: run the butler on a project conversation and confirm generated descriptions are specific enough to understand standalone.