### PR TITLE
Add: Ability to start an agent on a todo item.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -1,3 +1,7 @@
+import {
+  useSpaceConversations,
+  useSpaceConversationsSummary,
+} from "@app/hooks/conversations";
 import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import {
@@ -5,9 +9,11 @@ import {
   useDeleteProjectTodo,
   useMarkProjectTodosRead,
   useProjectTodos,
+  useStartProjectTodoConversation,
   useUpdateProjectTodo,
 } from "@app/lib/swr/projects";
 import { timeAgoFrom } from "@app/lib/utils";
+import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetProjectTodosResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index";
 import type {
   ProjectTodoActorType,
@@ -19,6 +25,7 @@ import { PROJECT_TODO_CATEGORIES } from "@app/types/project_todo";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
+  AnimatedText,
   BookOpenIcon,
   Button,
   ChatBubbleLeftRightIcon,
@@ -31,6 +38,7 @@ import {
   IconButton,
   MicrosoftLogo,
   NotionLogo,
+  PlayIcon,
   SlackLogo,
   Spinner,
   SquareIcon,
@@ -122,8 +130,18 @@ function TodoMetadataTooltip({
       )
     : null;
 
+  const isAssistantWorkInProgress =
+    todo.category === "to_do" &&
+    !!todo.conversationId &&
+    todo.status !== "done";
+
   const label = (
     <div className="flex flex-col gap-1">
+      {isAssistantWorkInProgress && (
+        <div className="text-xs font-medium text-foreground dark:text-foreground-night">
+          An Agent is working on this todo.
+        </div>
+      )}
       <div className="text-xs">
         Created by {creatorLabel} · {formatFriendlyDate(todo.createdAt)}
       </div>
@@ -462,6 +480,7 @@ interface EditableTodoItemProps {
   todo: ProjectTodoType;
   onToggleDone: (todo: ProjectTodoType) => void;
   onDelete: (todo: ProjectTodoType) => void;
+  onStartWorking: (todo: ProjectTodoType) => void;
   owner: LightWorkspaceType;
   agentNameById: Map<string, string>;
   isExiting: boolean;
@@ -469,12 +488,14 @@ interface EditableTodoItemProps {
   isEntering: boolean;
   isTyping: boolean;
   isNewlyDone: boolean;
+  isStarting: boolean;
 }
 
 function EditableTodoItem({
   todo,
   onToggleDone,
   onDelete,
+  onStartWorking,
   owner,
   agentNameById,
   isExiting,
@@ -482,8 +503,12 @@ function EditableTodoItem({
   isEntering,
   isTyping,
   isNewlyDone,
+  isStarting,
 }: EditableTodoItemProps) {
+  const router = useAppRouter();
   const isDone = todo.status === "done";
+  const showInProgressTextAnimation =
+    todo.category === "to_do" && !!todo.conversationId && !isDone;
   const [isFlashing, setIsFlashing] = useState(isNewlyDone);
 
   useEffect(() => {
@@ -501,13 +526,13 @@ function EditableTodoItem({
   return (
     <div
       className={cn(
-        "group/todo flex items-start gap-3 overflow-hidden",
+        "group/todo flex items-start gap-3",
         "transition-all duration-200",
         isExiting
-          ? "max-h-0 opacity-0"
+          ? "max-h-0 overflow-hidden opacity-0"
           : isAdded && !isEntering
-            ? "max-h-0 opacity-0"
-            : "max-h-32 opacity-100"
+            ? "max-h-0 overflow-hidden opacity-0"
+            : "max-h-[1000px] opacity-100"
       )}
     >
       <div className="mt-1 shrink-0">
@@ -536,6 +561,8 @@ function EditableTodoItem({
           >
             {isTyping ? (
               <TypingAnimation text={todo.text} duration={16} />
+            ) : showInProgressTextAnimation ? (
+              <AnimatedText variant="muted">{todo.text}</AnimatedText>
             ) : (
               todo.text
             )}
@@ -543,11 +570,39 @@ function EditableTodoItem({
           <TodoSources sources={todo.sources} owner={owner} isDone={isDone} />
         </button>
       </TodoMetadataTooltip>
-      <div className="mt-0.5 shrink-0 opacity-0 transition-opacity group-hover/todo:opacity-100">
+      <div className="mt-0.5 flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover/todo:opacity-100">
+        {todo.category === "to_do" &&
+          (todo.conversationId ? (
+            <IconButton
+              icon={ChatBubbleLeftRightIcon}
+              size="xs"
+              variant="ghost"
+              className="!text-muted-foreground hover:!text-foreground"
+              tooltip={"Open todo conversation"}
+              onClick={() => {
+                void router.push(
+                  getConversationRoute(owner.sId, todo.conversationId),
+                  undefined,
+                  { shallow: true }
+                );
+              }}
+            />
+          ) : (
+            <IconButton
+              icon={PlayIcon}
+              size="xs"
+              variant="ghost"
+              className="!text-muted-foreground hover:!text-foreground"
+              tooltip="Start working on todo"
+              disabled={isStarting}
+              onClick={() => onStartWorking(todo)}
+            />
+          ))}
         <IconButton
           icon={TrashIcon}
           size="xs"
           variant="ghost"
+          className="!text-muted-foreground hover:!text-foreground"
           tooltip="Delete todo"
           onClick={() => onDelete(todo)}
         />
@@ -570,8 +625,26 @@ function EditableProjectTodosPanel({
   const agentNameById = useAgentNameById(owner);
   const doUpdate = useUpdateProjectTodo({ owner, spaceId });
   const doDelete = useDeleteProjectTodo({ owner, spaceId });
+  const doStartConversation = useStartProjectTodoConversation({
+    owner,
+    spaceId,
+  });
   const doCleanDone = useCleanDoneProjectTodos({ owner, spaceId });
   const markRead = useMarkProjectTodosRead({ owner, spaceId });
+
+  // Disabled subscriptions used only to invalidate the space conversations list
+  // and summary when a todo conversation is started — the parent page already
+  // owns the active fetch for these keys.
+  const { mutateConversations: mutateSpaceConversations } =
+    useSpaceConversations({
+      workspaceId: owner.sId,
+      spaceId,
+      options: { disabled: true },
+    });
+  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
   const markReadRef = useRef(markRead);
   markReadRef.current = markRead;
 
@@ -580,6 +653,9 @@ function EditableProjectTodosPanel({
     new Set()
   );
   const [isCleaning, setIsCleaning] = useState(false);
+  const [startingTodoIds, setStartingTodoIds] = useState<Set<string>>(
+    new Set()
+  );
 
   // ── Diff animation state ────────────────────────────────────────────────────
 
@@ -758,6 +834,43 @@ function EditableProjectTodosPanel({
     [doDelete, mutateTodos]
   );
 
+  const handleStartWorking = useCallback(
+    async (todo: ProjectTodoType) => {
+      setStartingTodoIds((prev) => new Set([...prev, todo.sId]));
+      const result = await doStartConversation(todo.sId);
+      if (result.isOk()) {
+        const { conversationId } = result.value;
+        // Reflect the new todo state (conversationId set) immediately.
+        // Only patch conversationId — the server-side toJSON doesn't rehydrate
+        // sources, so replacing the whole todo would transiently drop them.
+        void mutateTodos(
+          (prev: GetProjectTodosResponseBody | undefined) => ({
+            lastReadAt: prev?.lastReadAt ?? null,
+            todos: (prev?.todos ?? []).map((t) =>
+              t.sId === todo.sId ? { ...t, conversationId } : t
+            ),
+          }),
+          { revalidate: false }
+        );
+        // Revalidate the conversations list below so the new conversation
+        // appears right away.
+        void mutateSpaceConversations();
+        void mutateSpaceSummary();
+      }
+      setStartingTodoIds((prev) => {
+        const next = new Set(prev);
+        next.delete(todo.sId);
+        return next;
+      });
+    },
+    [
+      doStartConversation,
+      mutateTodos,
+      mutateSpaceConversations,
+      mutateSpaceSummary,
+    ]
+  );
+
   return (
     <div className="flex flex-col gap-3">
       {/* Header */}
@@ -830,6 +943,7 @@ function EditableProjectTodosPanel({
                       todo={todo}
                       onToggleDone={handleToggleDone}
                       onDelete={handleDelete}
+                      onStartWorking={handleStartWorking}
                       owner={owner}
                       agentNameById={agentNameById}
                       isExiting={pendingRemovalIds.has(todo.sId)}
@@ -840,6 +954,7 @@ function EditableProjectTodosPanel({
                       isEntering={enteringKeys.has(todo.sId)}
                       isTyping={typingKeys.has(todo.sId)}
                       isNewlyDone={doneFlashKeys.has(todo.sId)}
+                      isStarting={startingTodoIds.has(todo.sId)}
                     />
                   ))}
                 </div>

--- a/front/hooks/conversations/useSpaceConversations.ts
+++ b/front/hooks/conversations/useSpaceConversations.ts
@@ -41,10 +41,12 @@ export function useSpaceConversations({
   workspaceId,
   spaceId,
   limit = DEFAULT_CONVERSATIONS_PAGE_SIZE,
+  options,
 }: {
   workspaceId: string;
   spaceId: string | null;
   limit?: number;
+  options?: { disabled?: boolean };
 }) {
   const { fetcher } = useFetcher();
   const conversationsFetcher: Fetcher<GetSpaceConversationsResponseBody> =
@@ -74,6 +76,7 @@ export function useSpaceConversations({
       {
         revalidateAll: false,
         revalidateOnFocus: false,
+        disabled: options?.disabled,
       }
     );
 
@@ -94,7 +97,7 @@ export function useSpaceConversations({
 
   return {
     conversations,
-    isConversationsLoading: !error && !data,
+    isConversationsLoading: !error && !data && !options?.disabled,
     isConversationsError: error,
     isLoadingMore: isValidating && size > 1,
     isValidating,

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import {
   ProjectTodoConversationModel,
@@ -337,6 +338,84 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     return result;
   }
 
+  static async fetchConversationIdsForTodoIds(
+    auth: Authenticator,
+    { sIds }: { sIds: string[] }
+  ): Promise<Map<string, string>> {
+    if (sIds.length === 0) {
+      return new Map();
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const idToSId = new Map<number, string>();
+    for (const sId of sIds) {
+      const id = getResourceIdFromSId(sId);
+      if (id !== null) {
+        idToSId.set(id, sId);
+      }
+    }
+
+    if (idToSId.size === 0) {
+      return new Map();
+    }
+
+    const rows = await ProjectTodoConversationModel.findAll({
+      where: {
+        workspaceId,
+        projectTodoId: { [Op.in]: [...idToSId.keys()] },
+      },
+      include: [
+        {
+          model: ConversationModel,
+          as: "conversation",
+          attributes: ["sId"],
+          required: true,
+        },
+      ],
+      order: [["createdAt", "DESC"]],
+    });
+
+    const result = new Map<string, string>();
+    for (const row of rows) {
+      const todoSId = idToSId.get(row.projectTodoId);
+      const conversationSId = row.conversation?.sId;
+      if (!todoSId || !conversationSId || result.has(todoSId)) {
+        continue;
+      }
+      result.set(todoSId, conversationSId);
+    }
+
+    return result;
+  }
+
+  async getLatestConversationId(auth: Authenticator): Promise<string | null> {
+    const conversationIds =
+      await ProjectTodoResource.fetchConversationIdsForTodoIds(auth, {
+        sIds: [this.sId],
+      });
+    return conversationIds.get(this.sId) ?? null;
+  }
+
+  async addConversation(
+    auth: Authenticator,
+    { conversationModelId }: { conversationModelId: ModelId },
+    transaction?: Transaction
+  ): Promise<void> {
+    await ProjectTodoConversationModel.findOrCreate({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        projectTodoId: this.id,
+        conversationId: conversationModelId,
+      },
+      defaults: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        projectTodoId: this.id,
+        conversationId: conversationModelId,
+      },
+      transaction,
+    });
+  }
+
   // ── Source links (* => todo) ─────────────────────────────────────────────
 
   async upsertSource(
@@ -382,6 +461,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     return {
       id: this.id,
       sId: this.sId,
+      conversationId: null,
       category: this.category,
       text: this.text,
       status: this.status,

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -11,6 +11,7 @@ import type {
   PostProjectContextContentNodeResponseBody,
 } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_context";
 import type { PatchProjectTodoResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index";
+import type { PostStartProjectTodoResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start";
 import type { PostCleanDoneTodosResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/clean";
 import type { GetProjectTodosResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index";
 import type { CheckNameResponseBody } from "@app/pages/api/w/[wId]/spaces/check-name";
@@ -441,6 +442,46 @@ export function useDeleteProjectTodo({
       sendNotification({
         type: "error",
         title: "Failed to delete todo",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
+export function useStartProjectTodoConversation({
+  owner,
+  spaceId,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  return async (todoId: string): Promise<Result<ProjectTodoType, Error>> => {
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/spaces/${spaceId}/project_todos/${todoId}/start`,
+        { method: "POST" }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to start todo work",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      const responseData: PostStartProjectTodoResponseBody = await res.json();
+      return new Ok(responseData.todo);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to start todo work",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.ts
@@ -120,8 +120,14 @@ async function handler(
       }
 
       const updatedTodo = await todo.updateWithVersion(auth, updates);
+      const conversationId = await updatedTodo.getLatestConversationId(auth);
 
-      return res.status(200).json({ todo: updatedTodo.toJSON() });
+      return res.status(200).json({
+        todo: {
+          ...updatedTodo.toJSON(),
+          conversationId,
+        },
+      });
     }
 
     case "DELETE": {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+// postUserMessage eventually starts the agent loop; mock Temporal so tests do not
+// hit a real client or leave an unhandled rejection after the handler returns.
+vi.mock("@app/temporal/agent_loop/client", () => ({
+  launchAgentLoopWorkflow: vi.fn().mockResolvedValue({ isOk: () => true }),
+  launchCompactionWorkflow: vi.fn().mockResolvedValue({ isOk: () => true }),
+}));
+
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { ProjectTodoFactory } from "@app/tests/utils/ProjectTodoFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { WorkspaceType } from "@app/types/user";
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { MockRequest, MockResponse } from "node-mocks-http";
+
+import handler from "./start";
+
+describe("POST /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start", () => {
+  let req: MockRequest<NextApiRequest>;
+  let res: MockResponse<NextApiResponse>;
+  let workspace: WorkspaceType;
+
+  async function setup(method = "POST") {
+    const result = await createPrivateApiMockRequest({ method: method as any });
+    req = result.req;
+    res = result.res;
+    workspace = result.workspace;
+    return result;
+  }
+
+  it("creates and links a conversation for a to_do todo", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+      category: "to_do",
+      text: "Prepare launch checklist",
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.todoId = todo.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.todo.sId).toBe(todo.sId);
+    expect(data.todo.conversationId).toBeTruthy();
+  });
+
+  it("returns 400 when starting a non to_do todo", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+      category: "to_know",
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.todoId = todo.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 405 for unsupported methods", async () => {
+    const { user } = await setup("GET");
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+      category: "to_do",
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.todoId = todo.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.ts
@@ -1,0 +1,186 @@
+/** @ignoreswagger */
+import {
+  createConversation,
+  postUserMessage,
+} from "@app/lib/api/assistant/conversation";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { ProjectTodoType } from "@app/types/project_todo";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export interface PostStartProjectTodoResponseBody {
+  todo: ProjectTodoType;
+}
+
+function buildTodoKickoffPrompt({
+  todoId,
+  todoText,
+  sourceUrls,
+}: {
+  todoId: string;
+  todoText: string;
+  sourceUrls: string[];
+}): string {
+  const sourceLine =
+    sourceUrls.length > 0
+      ? `The item was sourced from ${sourceUrls.join(", ")}.`
+      : "No explicit source was attached to this todo item.";
+
+  return [
+    `Let's start working on the todo (id: ${todoId}) from the current project.`,
+    "",
+    `Todo: ${todoText}`,
+    "",
+    sourceLine,
+    "",
+    "Please execute this task end-to-end:",
+    "1. Clarify assumptions and plan the work but avoid waiting for user input if possible.",
+    "2. Use available project context and tools to complete the work.",
+    "3. Share concrete outputs and next checks.",
+    "4. Once the task is completed, mark this todo as done.",
+  ].join("\n");
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostStartProjectTodoResponseBody>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  if (!space.isProject()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Todos are only available for project spaces.",
+      },
+    });
+  }
+
+  const { todoId } = req.query;
+  if (!isString(todoId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid todo id.",
+      },
+    });
+  }
+
+  const todo = await ProjectTodoResource.fetchBySId(auth, todoId);
+  if (!todo || todo.spaceId !== space.id) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "project_todo_not_found",
+        message: "Todo not found.",
+      },
+    });
+  }
+
+  const user = auth.getNonNullableUser();
+  if (todo.userId !== user.id) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "You can only modify your own todos.",
+      },
+    });
+  }
+
+  if (todo.category !== "to_do") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Only 'Need to do' items can be started.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      let conversationId = await todo.getLatestConversationId(auth);
+
+      if (!conversationId) {
+        const sourcesByTodoId =
+          await ProjectTodoResource.fetchSourcesForTodoIds(auth, {
+            sIds: [todo.sId],
+          });
+        const sources = sourcesByTodoId.get(todo.sId) ?? [];
+        const sourceUrls = sources
+          .map((source) => source.sourceUrl)
+          .filter((url): url is string => !!url);
+        const prompt = buildTodoKickoffPrompt({
+          todoId: todo.sId,
+          todoText: todo.text,
+          sourceUrls,
+        });
+
+        const conversation = await createConversation(auth, {
+          title: `Project todo · ${todo.text.slice(0, 80)}`,
+          visibility: "unlisted",
+          spaceId: space.id,
+          metadata: {
+            projectTodoId: todo.sId,
+          },
+        });
+
+        const messageRes = await postUserMessage(auth, {
+          conversation,
+          content: prompt,
+          mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
+          context: {
+            timezone: "UTC",
+            username: user.username,
+            fullName: user.fullName(),
+            email: user.email,
+            profilePictureUrl: user.imageUrl,
+            origin: "web",
+          },
+          skipToolsValidation: false,
+        });
+
+        if (messageRes.isErr()) {
+          return apiError(req, res, messageRes.error);
+        }
+
+        await todo.addConversation(auth, {
+          conversationModelId: conversation.id,
+        });
+        conversationId = conversation.sId;
+      }
+
+      return res.status(200).json({
+        todo: {
+          ...todo.toJSON(),
+          conversationId,
+        },
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanRead: true },
+  })
+);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
@@ -41,18 +41,21 @@ async function handler(
       const todoIds = todos.map((t) => t.sId);
 
       // Fetch sources for all todos (across all version rows).
-      const sourcesByTodoId = await ProjectTodoResource.fetchSourcesForTodoIds(
-        auth,
-        {
+      const [sourcesByTodoId, conversationIdByTodoId] = await Promise.all([
+        ProjectTodoResource.fetchSourcesForTodoIds(auth, {
           sIds: todoIds,
-        }
-      );
+        }),
+        ProjectTodoResource.fetchConversationIdsForTodoIds(auth, {
+          sIds: todoIds,
+        }),
+      ]);
 
       // TODO: enrich todos with creator/done-by user info when supporting multiple users.
       const todosWithSources: ProjectTodoType[] = todos.map((t) => {
         const sources = sourcesByTodoId.get(t.sId) ?? [];
         return {
           ...t.toJSON(),
+          conversationId: conversationIdByTodoId.get(t.sId) ?? null,
           sources: sources.map((s) => ({
             sourceType: s.sourceType,
             sourceId: s.sourceId,

--- a/front/types/project_todo.ts
+++ b/front/types/project_todo.ts
@@ -36,6 +36,7 @@ export type ProjectTodoSourceInfo = {
 export type ProjectTodoType = {
   id: ModelId;
   sId: string;
+  conversationId: string | null;
   category: ProjectTodoCategory;
   text: string;
   status: ProjectTodoStatus;


### PR DESCRIPTION
## Description

The todos panel surfaced action items from project conversations but provided no way to act on them. Users had to navigate back to the source conversation and manually write a prompt. This PR adds a "Start working" button that creates a new project conversation pre-seeded with the todo context and a `@dust` mention, so the agent can pick up the task immediately.

- Add `POST /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start` — creates a new project conversation with a `buildTodoKickoffPrompt` (todo text, source URLs, `@dust` mention), then links the resulting conversation to the todo via the new `ProjectTodoConversationModel` join table; only works for `to_do` category todos (400 otherwise)
- Add `fetchConversationIdsForTodoIds` and `getLatestConversationId` to `ProjectTodoResource` — efficient bulk lookup of the most recent conversation per todo
- Add `addConversation` to `ProjectTodoResource` — `findOrCreate` to link a conversation
- Expose `conversationId` on `ProjectTodoType` — populated in the `GET /project_todos` bulk response and in `PATCH` responses
- In `ProjectTodosPanel`: show a `PlayIcon` (start) button for unstarted `to_do` items on hover; swap to a `ChatBubbleLeftRightIcon` (navigate) once a conversation exists; show a `Spinner` while starting; mutate `spaceConversations` and `spaceSummary` caches after start
- Fix animation overflow bug: move `overflow-hidden` to the `max-h-0` branches only, increase visible height cap from `max-h-32` to `max-h-[1000px]`
- Add `useStartProjectTodoConversation` SWR hook
- Add tests for the `start` endpoint

## Tests

Local + green (new tests added)

https://github.com/user-attachments/assets/aa88d455-bb46-4c53-93d8-571142c0cf4c

## Risk

Low

## Deploy Plan

Run migration, deploy `front`
