### PR TITLE
Add: tool to allow agents to start another agent on a todo task.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -503,6 +503,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_todos": "never_ask",
     "mark_todo_done": "low",
     "reopen_todo": "low",
+    "start_todo_agent": "low",
   },
   "query_tables_v2": {
     "execute_database_query": "never_ask",

--- a/front/lib/api/actions/servers/project_todos/metadata.ts
+++ b/front/lib/api/actions/servers/project_todos/metadata.ts
@@ -100,8 +100,8 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
           })
         )
         .min(1)
-        .max(20)
-        .describe("List of TODOs to create (max 20)."),
+        .max(30)
+        .describe("List of TODOs to create (max 30)."),
       dustProject: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
       ]
@@ -117,14 +117,18 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
     },
   },
   mark_todo_done: {
-    description: "Mark one of the current user's TODOs as done.",
+    description: "Mark one or more of the current user's TODOs as done.",
     schema: {
       actorType: z
         .enum(["user", "agent"])
         .describe(
           "Who has the initiative of marking the TODO as done ? Use 'user' when the user explicitely asked for it."
         ),
-      todoId: z.string().describe("The sId of the TODO to mark as done."),
+      todoIds: z
+        .array(z.string())
+        .min(1)
+        .max(50)
+        .describe("List of TODO sIds to mark as done."),
       dustProject: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
       ]
@@ -135,8 +139,8 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Marking TODO as done",
-      done: "Mark TODO as done",
+      running: "Marking TODOs as done",
+      done: "Mark TODOs as done",
     },
   },
   reopen_todo: {
@@ -156,6 +160,33 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Reopening TODO",
       done: "Reopen TODO",
+    },
+  },
+  start_todo_agent: {
+    description:
+      "Start an agent conversation to work on one of your 'to_do' TODOs. " +
+      "If already started, it reuses the existing linked conversation.",
+    schema: {
+      todoId: z.string().describe("The sId of the TODO to start working on."),
+      agentName: z
+        .string()
+        .min(3)
+        .optional()
+        .describe(
+          "Optional agent name. If provided, the tool searches matching agent configurations and uses the best match. Defaults to Dust."
+        ),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to look up the TODO in, will fallback to the conversation's project."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Starting TODO work",
+      done: "Start TODO work",
     },
   },
 });

--- a/front/lib/api/actions/servers/project_todos/tools/index.ts
+++ b/front/lib/api/actions/servers/project_todos/tools/index.ts
@@ -10,12 +10,46 @@ import {
   withErrorHandling,
 } from "@app/lib/api/actions/servers/project_manager/helpers";
 import { PROJECT_TODOS_TOOLS_METADATA } from "@app/lib/api/actions/servers/project_todos/metadata";
+import { searchAgentConfigurationsByName } from "@app/lib/api/assistant/configuration/agent";
+import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
+import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
+import { startAgentForProjectTodo } from "@app/lib/project_todo/start_agent";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { getConversationRoute } from "@app/lib/utils/router";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ProjectTodoCategory } from "@app/types/project_todo";
 import { Err, Ok } from "@app/types/shared/result";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+async function resolveAgentConfigurationIdByName(
+  auth: Authenticator,
+  agentName: string
+): Promise<string | null> {
+  const normalizedAgentName = agentName.trim().toLowerCase();
+  if (normalizedAgentName === "dust" || normalizedAgentName === "dust agent") {
+    return GLOBAL_AGENTS_SID.DUST;
+  }
+
+  const [workspaceMatches, globalAgents] = await Promise.all([
+    searchAgentConfigurationsByName(auth, agentName),
+    getGlobalAgents(auth, undefined, "light"),
+  ]);
+  const globalMatches = globalAgents.filter((a) =>
+    a.name.toLowerCase().includes(normalizedAgentName)
+  );
+  const matches = [...workspaceMatches, ...globalMatches];
+  if (matches.length === 0) {
+    return null;
+  }
+
+  // Prefer exact case-insensitive match, otherwise fallback to first result.
+  const exactMatch = matches.find(
+    (a) => a.name.trim().toLowerCase() === normalizedAgentName
+  );
+  return exactMatch?.sId ?? matches[0].sId;
+}
 
 function formatTodo(todo: ProjectTodoResource): string {
   const lines = [
@@ -32,6 +66,7 @@ export function createProjectTodosTools(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): ToolDefinition[] {
+  const owner = auth.getNonNullableWorkspace();
   const handlers: ToolHandlers<typeof PROJECT_TODOS_TOOLS_METADATA> = {
     list_todos: async ({
       status = "open",
@@ -197,7 +232,7 @@ export function createProjectTodosTools(
       }, "Failed to create TODOs");
     },
 
-    mark_todo_done: async ({ actorType, todoId, dustProject }) => {
+    mark_todo_done: async ({ actorType, todoIds, dustProject }) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,
@@ -208,43 +243,70 @@ export function createProjectTodosTools(
         }
 
         const currentUser = auth.getNonNullableUser();
-        const todo = await ProjectTodoResource.fetchBySId(auth, todoId);
+        const marked: string[] = [];
+        const alreadyDone: string[] = [];
+        const notFound: string[] = [];
+        const forbidden: string[] = [];
 
-        if (!todo) {
-          return new Err(
-            new MCPError(`TODO not found: ${todoId}`, { tracked: false })
+        for (const todoId of todoIds) {
+          const todo = await ProjectTodoResource.fetchBySId(auth, todoId);
+          if (!todo) {
+            notFound.push(todoId);
+            continue;
+          }
+
+          if (todo.userId !== currentUser.id) {
+            forbidden.push(todoId);
+            continue;
+          }
+
+          if (todo.status === "done") {
+            alreadyDone.push(todoId);
+            continue;
+          }
+
+          await todo.updateWithVersion(auth, {
+            status: "done",
+            doneAt: new Date(),
+            markedAsDoneByType: actorType,
+            markedAsDoneByUserId: actorType === "user" ? currentUser.id : null,
+            markedAsDoneByAgentConfigurationId:
+              actorType === "agent"
+                ? (agentLoopContext?.runContext?.agentConfiguration?.sId ??
+                  null)
+                : null,
+          });
+          marked.push(`${todoId} ("${todo.text}")`);
+        }
+
+        const lines: string[] = [];
+        if (marked.length > 0) {
+          lines.push(`Marked ${marked.length} TODO(s) as done:`);
+          for (const item of marked) {
+            lines.push(`- ${item}`);
+          }
+        }
+        if (alreadyDone.length > 0) {
+          lines.push(
+            `Already done (${alreadyDone.length}): ${alreadyDone.join(", ")}`
           );
         }
-
-        if (todo.userId !== currentUser.id) {
-          return new Err(
-            new MCPError("You can only mark your own TODOs as done.", {
-              tracked: false,
-            })
+        if (notFound.length > 0) {
+          lines.push(`Not found (${notFound.length}): ${notFound.join(", ")}`);
+        }
+        if (forbidden.length > 0) {
+          lines.push(
+            `Not owned by current user (${forbidden.length}): ${forbidden.join(", ")}`
           );
         }
-
-        if (todo.status === "done") {
-          return new Ok([
-            { type: "text" as const, text: `TODO ${todoId} is already done.` },
-          ]);
+        if (lines.length === 0) {
+          lines.push("No TODOs were updated.");
         }
-
-        await todo.updateWithVersion(auth, {
-          status: "done",
-          doneAt: new Date(),
-          markedAsDoneByType: actorType,
-          markedAsDoneByUserId: actorType === "user" ? currentUser.id : null,
-          markedAsDoneByAgentConfigurationId:
-            actorType === "agent"
-              ? (agentLoopContext?.runContext?.agentConfiguration?.sId ?? null)
-              : null,
-        });
 
         return new Ok([
           {
             type: "text" as const,
-            text: `TODO marked as done: "${todo.text}"`,
+            text: lines.join("\n"),
           },
         ]);
       }, "Failed to mark TODO as done");
@@ -301,6 +363,64 @@ export function createProjectTodosTools(
           },
         ]);
       }, "Failed to reopen TODO");
+    },
+
+    start_todo_agent: async ({ todoId, agentName, dustProject }) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getProjectSpace(auth, {
+          agentLoopContext,
+          dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const { space } = contextRes.value;
+        let agentConfigurationId: string | undefined;
+        if (agentName) {
+          const matchedAgentId = await resolveAgentConfigurationIdByName(
+            auth,
+            agentName
+          );
+          if (!matchedAgentId) {
+            return new Err(
+              new MCPError(`No agent found matching name: "${agentName}"`, {
+                tracked: false,
+              })
+            );
+          }
+          agentConfigurationId = matchedAgentId;
+        }
+
+        const startRes = await startAgentForProjectTodo(auth, {
+          space,
+          todoId,
+          agentConfigurationId,
+        });
+
+        if (startRes.isErr()) {
+          return new Err(
+            new MCPError(startRes.error.message, {
+              tracked: false,
+            })
+          );
+        }
+
+        const conversationUrl = `${config.getAppUrl()}${getConversationRoute(
+          owner.sId,
+          startRes.value.conversationId
+        )}`;
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text:
+              startRes.value.action === "created"
+                ? `Started TODO work for ${todoId} by creating a new conversation: ${startRes.value.conversationId}. Conversation URL: ${conversationUrl}`
+                : `Started TODO work for ${todoId} by appending a new message to existing conversation: ${startRes.value.conversationId}. Conversation URL: ${conversationUrl}`,
+          },
+        ]);
+      }, "Failed to start TODO work");
     },
   };
 

--- a/front/lib/project_todo/start_agent.ts
+++ b/front/lib/project_todo/start_agent.ts
@@ -1,0 +1,191 @@
+import {
+  createConversation,
+  postUserMessage,
+} from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { APIErrorType } from "@app/types/error";
+import type { ProjectTodoType } from "@app/types/project_todo";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+type StartProjectTodoAgentError = {
+  statusCode: number;
+  type: APIErrorType;
+  message: string;
+};
+
+function buildTodoKickoffPrompt({
+  todoId,
+  todoText,
+  sourceUrls,
+}: {
+  todoId: string;
+  todoText: string;
+  sourceUrls: string[];
+}): string {
+  const sourceLine =
+    sourceUrls.length > 0
+      ? `The item was sourced from ${sourceUrls.join(", ")}.`
+      : "No explicit source was attached to this todo item.";
+
+  return [
+    `You are working on the todo (id: ${todoId}) from the current project.`,
+    "",
+    `Todo: ${todoText}`,
+    "",
+    sourceLine,
+    "",
+    "Please execute this task end-to-end:",
+    "1. Clarify assumptions and plan the work but avoid waiting for user input if possible.",
+    "2. Use available project context and tools to complete the work.",
+    "3. Share concrete outputs and next checks.",
+    "4. Once the task is completed, mark this todo as done.",
+  ].join("\n");
+}
+
+export async function startAgentForProjectTodo(
+  auth: Authenticator,
+  {
+    space,
+    todoId,
+    agentConfigurationId,
+  }: {
+    space: SpaceResource;
+    todoId: string;
+    agentConfigurationId?: string;
+  }
+): Promise<
+  Result<
+    {
+      todo: ProjectTodoType;
+      conversationId: string;
+      userMessageId: string;
+      action: "created" | "appended";
+    },
+    StartProjectTodoAgentError
+  >
+> {
+  if (!space.isProject()) {
+    return new Err({
+      statusCode: 400,
+      type: "invalid_request_error",
+      message: "Todos are only available for project spaces.",
+    });
+  }
+
+  const todo = await ProjectTodoResource.fetchBySId(auth, todoId);
+  if (!todo || todo.spaceId !== space.id) {
+    return new Err({
+      statusCode: 404,
+      type: "project_todo_not_found",
+      message: "Todo not found.",
+    });
+  }
+
+  const user = auth.getNonNullableUser();
+  if (todo.userId !== user.id) {
+    return new Err({
+      statusCode: 403,
+      type: "invalid_request_error",
+      message: "You can only modify your own todos.",
+    });
+  }
+
+  if (todo.category !== "to_do") {
+    return new Err({
+      statusCode: 400,
+      type: "invalid_request_error",
+      message: "Only 'Need to do' items can be started.",
+    });
+  }
+
+  const sourcesByTodoId = await ProjectTodoResource.fetchSourcesForTodoIds(
+    auth,
+    {
+      sIds: [todo.sId],
+    }
+  );
+  const sources = sourcesByTodoId.get(todo.sId) ?? [];
+  const sourceUrls = sources
+    .map((source) => source.sourceUrl)
+    .filter((url): url is string => !!url);
+  const prompt = buildTodoKickoffPrompt({
+    todoId: todo.sId,
+    todoText: todo.text,
+    sourceUrls,
+  });
+
+  let conversationId = await todo.getLatestConversationId(auth);
+  let conversation;
+  let action: "created" | "appended" = "appended";
+
+  if (!conversationId) {
+    conversation = await createConversation(auth, {
+      title: `Project todo · ${todo.text.slice(0, 80)}`,
+      visibility: "unlisted",
+      spaceId: space.id,
+      metadata: {
+        projectTodoId: todo.sId,
+      },
+    });
+
+    await todo.addConversation(auth, {
+      conversationModelId: conversation.id,
+    });
+    conversationId = conversation.sId;
+    action = "created";
+  } else {
+    const conversationRes = await getConversation(auth, conversationId, false);
+    if (conversationRes.isErr()) {
+      const conversationErrorType = conversationRes.error.type;
+      return new Err({
+        statusCode:
+          conversationErrorType === "conversation_not_found" ? 404 : 403,
+        type: conversationErrorType,
+        message: conversationRes.error.message,
+      });
+    }
+    conversation = conversationRes.value;
+  }
+
+  const messageRes = await postUserMessage(auth, {
+    conversation,
+    content: prompt,
+    mentions: [
+      {
+        configurationId: agentConfigurationId ?? GLOBAL_AGENTS_SID.DUST,
+      },
+    ],
+    context: {
+      timezone: "UTC",
+      username: user.username,
+      fullName: user.fullName(),
+      email: user.email,
+      profilePictureUrl: user.imageUrl,
+      origin: "web",
+    },
+    skipToolsValidation: false,
+  });
+
+  if (messageRes.isErr()) {
+    return new Err({
+      statusCode: messageRes.error.status_code,
+      type: messageRes.error.api_error.type,
+      message: messageRes.error.api_error.message,
+    });
+  }
+
+  return new Ok({
+    todo: {
+      ...todo.toJSON(),
+      conversationId,
+    },
+    conversationId,
+    userMessageId: messageRes.value.userMessage.sId,
+    action,
+  });
+}

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.ts
@@ -1,51 +1,17 @@
 /** @ignoreswagger */
-import {
-  createConversation,
-  postUserMessage,
-} from "@app/lib/api/assistant/conversation";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { startAgentForProjectTodo } from "@app/lib/project_todo/start_agent";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
-import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { WithAPIErrorResponse } from "@app/types/error";
+import type { APIErrorType, WithAPIErrorResponse } from "@app/types/error";
 import type { ProjectTodoType } from "@app/types/project_todo";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export interface PostStartProjectTodoResponseBody {
   todo: ProjectTodoType;
-}
-
-function buildTodoKickoffPrompt({
-  todoId,
-  todoText,
-  sourceUrls,
-}: {
-  todoId: string;
-  todoText: string;
-  sourceUrls: string[];
-}): string {
-  const sourceLine =
-    sourceUrls.length > 0
-      ? `The item was sourced from ${sourceUrls.join(", ")}.`
-      : "No explicit source was attached to this todo item.";
-
-  return [
-    `Let's start working on the todo (id: ${todoId}) from the current project.`,
-    "",
-    `Todo: ${todoText}`,
-    "",
-    sourceLine,
-    "",
-    "Please execute this task end-to-end:",
-    "1. Clarify assumptions and plan the work but avoid waiting for user input if possible.",
-    "2. Use available project context and tools to complete the work.",
-    "3. Share concrete outputs and next checks.",
-    "4. Once the task is completed, mark this todo as done.",
-  ].join("\n");
 }
 
 async function handler(
@@ -75,96 +41,24 @@ async function handler(
     });
   }
 
-  const todo = await ProjectTodoResource.fetchBySId(auth, todoId);
-  if (!todo || todo.spaceId !== space.id) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "project_todo_not_found",
-        message: "Todo not found.",
-      },
-    });
-  }
-
-  const user = auth.getNonNullableUser();
-  if (todo.userId !== user.id) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "invalid_request_error",
-        message: "You can only modify your own todos.",
-      },
-    });
-  }
-
-  if (todo.category !== "to_do") {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Only 'Need to do' items can be started.",
-      },
-    });
-  }
-
   switch (req.method) {
     case "POST": {
-      let conversationId = await todo.getLatestConversationId(auth);
-
-      if (!conversationId) {
-        const sourcesByTodoId =
-          await ProjectTodoResource.fetchSourcesForTodoIds(auth, {
-            sIds: [todo.sId],
-          });
-        const sources = sourcesByTodoId.get(todo.sId) ?? [];
-        const sourceUrls = sources
-          .map((source) => source.sourceUrl)
-          .filter((url): url is string => !!url);
-        const prompt = buildTodoKickoffPrompt({
-          todoId: todo.sId,
-          todoText: todo.text,
-          sourceUrls,
-        });
-
-        const conversation = await createConversation(auth, {
-          title: `Project todo · ${todo.text.slice(0, 80)}`,
-          visibility: "unlisted",
-          spaceId: space.id,
-          metadata: {
-            projectTodoId: todo.sId,
+      const startRes = await startAgentForProjectTodo(auth, {
+        space,
+        todoId,
+      });
+      if (startRes.isErr()) {
+        return apiError(req, res, {
+          status_code: startRes.error.statusCode,
+          api_error: {
+            type: startRes.error.type as APIErrorType,
+            message: startRes.error.message,
           },
         });
-
-        const messageRes = await postUserMessage(auth, {
-          conversation,
-          content: prompt,
-          mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
-          context: {
-            timezone: "UTC",
-            username: user.username,
-            fullName: user.fullName(),
-            email: user.email,
-            profilePictureUrl: user.imageUrl,
-            origin: "web",
-          },
-          skipToolsValidation: false,
-        });
-
-        if (messageRes.isErr()) {
-          return apiError(req, res, messageRes.error);
-        }
-
-        await todo.addConversation(auth, {
-          conversationModelId: conversation.id,
-        });
-        conversationId = conversation.sId;
       }
 
       return res.status(200).json({
-        todo: {
-          ...todo.toJSON(),
-          conversationId,
-        },
+        todo: startRes.value.todo,
       });
     }
 


### PR DESCRIPTION
## Description

PR #24797 let users click "Start working" to kick off an agent on a todo. But agents orchestrating todos via `project_todos` had no equivalent capability — they couldn't programmatically delegate a sub-task to another agent. `start_todo_agent` fills that gap.

- Add `start_todo_agent` to `project_todos` — starts (or reuses) an agent conversation for a `to_do` todo; accepts `todoId`, optional `agentName` (resolved by name, defaults to `@dust`), and optional `dustProject`; returns the conversation URL so the agent can surface it to the user. Stake is `low`
- Add `resolveAgentConfigurationIdByName` — searches workspace agents + global agents by name, prefers exact case-insensitive match, fast-paths `"dust"` to `GLOBAL_AGENTS_SID.DUST`
- Extract `startAgentForProjectTodo` to `lib/project_todo/start_agent.ts` — shared between the `/start` API endpoint (user-triggered, from #24797) and the new `start_todo_agent` tool (agent-triggered), so the kickoff logic lives in one place
- Batch `mark_todo_done`: change `todoId` → `todoIds` (array, max 50) to let agents mark multiple todos done in a single call
- Bump `create_todos_batch` max from 20 → 30
- Update snapshot

## Tests

Local + green (snapshot updated)

## Risk

Low

## Deploy Plan

Deploy `front`
