### PR TITLE
Add: new field on project metadata to track last analysis time.

### DIFF
--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -121,6 +121,13 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     await this.update({ description }, transaction);
   }
 
+  async updateLastTodoAnalysisAt(
+    lastTodoAnalysisAt: Date,
+    transaction?: Transaction
+  ) {
+    await this.update({ lastTodoAnalysisAt }, transaction);
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction }

--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -9,7 +9,7 @@ export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataMod
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare archivedAt: CreationOptional<Date | null>;
-
+  declare lastTodoAnalysisAt: CreationOptional<Date | null>;
   declare spaceId: ForeignKey<SpaceModel["id"]>;
 
   declare description: string | null;
@@ -32,6 +32,10 @@ ProjectMetadataModel.init(
       allowNull: true,
     },
     archivedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    lastTodoAnalysisAt: {
       type: DataTypes.DATE,
       allowNull: true,
     },

--- a/front/migrations/db/migration_602.sql
+++ b/front/migrations/db/migration_602.sql
@@ -1,0 +1,2 @@
+-- Migration created on Apr 24, 2026
+ALTER TABLE "public"."project_metadata" ADD COLUMN "lastTodoAnalysisAt" TIMESTAMP WITH TIME ZONE;

--- a/front/temporal/project_todo/activities.ts
+++ b/front/temporal/project_todo/activities.ts
@@ -4,6 +4,7 @@ import { buildProjectRetrieveDataSources } from "@app/lib/api/actions/servers/pr
 import { Authenticator } from "@app/lib/auth";
 import { extractDocumentTakeaways } from "@app/lib/project_todo/analyze_document";
 import { mergeTakeawaysIntoProject } from "@app/lib/project_todo/merge_into_project";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { TakeawaySourceDocument } from "@app/lib/resources/takeaways_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -13,6 +14,7 @@ import logger from "@app/logger/logger";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type { ProjectTodoSourceType } from "@app/types/project_todo";
 import { removeNulls } from "@app/types/shared/utils/general";
+import type { TimeFrame } from "@app/types/shared/utils/time_frame";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
@@ -138,13 +140,20 @@ export async function analyzeProjectTodosActivity({
     return;
   }
 
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+  let timeFrame: TimeFrame = { duration: 1, unit: "day" }; // Default to one day if no metadata is found
+  if (metadata?.lastTodoAnalysisAt) {
+    const deltaMs = Date.now() - metadata.lastTodoAnalysisAt.getTime();
+    const MS_PER_HOUR = 1000 * 60 * 60;
+    timeFrame = { duration: deltaMs / MS_PER_HOUR, unit: "hour" };
+  }
+
   // Fetch all recent documents changes from the project knowledge and conversations.
   const results = await runIncludeDataRetrieval(auth, {
     citationsOffset: 0,
     retrievalTopK: 128,
     dataSources: await buildProjectRetrieveDataSources(auth, space),
-    // TODO: compute this from the last time the project todo was analyzed.
-    timeFrame: { duration: 1, unit: "day" },
+    timeFrame,
   });
 
   if (results.isErr()) {
@@ -153,6 +162,13 @@ export async function analyzeProjectTodosActivity({
       "Failed to retrieve include data"
     );
     return;
+  }
+
+  if (metadata) {
+    await metadata.updateLastTodoAnalysisAt(new Date());
+  } else {
+    // We should always have a metadata row for a project space, but just in case.
+    logger.warn({ spaceId }, "No project metadata found for space");
   }
 
   const documents = removeNulls(

--- a/front/types/shared/utils/time_frame.ts
+++ b/front/types/shared/utils/time_frame.ts
@@ -83,15 +83,15 @@ export function timeFrameFromNow(timeFrame: TimeFrame): number {
 
   switch (timeFrame.unit) {
     case "hour":
-      return now - timeFrame.duration * 60 * 60 * 1000;
+      return Math.round(now - timeFrame.duration * 60 * 60 * 1000);
     case "day":
-      return now - timeFrame.duration * 24 * 60 * 60 * 1000;
+      return Math.round(now - timeFrame.duration * 24 * 60 * 60 * 1000);
     case "week":
-      return now - timeFrame.duration * 7 * 24 * 60 * 60 * 1000;
+      return Math.round(now - timeFrame.duration * 7 * 24 * 60 * 60 * 1000);
     case "month":
-      return now - timeFrame.duration * 30 * 24 * 60 * 60 * 1000;
+      return Math.round(now - timeFrame.duration * 30 * 24 * 60 * 60 * 1000);
     case "year":
-      return now - timeFrame.duration * 365 * 24 * 60 * 60 * 1000;
+      return Math.round(now - timeFrame.duration * 365 * 24 * 60 * 60 * 1000);
     default:
       ((x: never) => {
         throw new Error(`Unexpected time frame unit ${x}`);


### PR DESCRIPTION
## Description

The todo analysis cron was always fetching documents from a hardcoded 1-day window, regardless of when it last ran. This was wasteful when the cron fires frequently (re-analyzing the same documents) and inaccurate when it fires less often than expected.

Using the actual elapsed time since the last run as the retrieval window makes the analysis both more precise and cheaper.

- Add `lastTodoAnalysisAt` (nullable `TIMESTAMP WITH TIME ZONE`) to `ProjectMetadataModel` + `migration_602.sql`
- Add `updateLastTodoAnalysisAt` to `ProjectMetadataResource`
- In `analyzeProjectTodosActivity`: read `metadata.lastTodoAnalysisAt` and compute `timeFrame` as the delta in hours since the last run; default to `{ duration: 1, unit: "day" }` if no prior analysis timestamp exists; update `lastTodoAnalysisAt` after a successful run
- Round `timeFrameFromNow` results with `Math.round` to avoid floating-point precision issues when the duration is a fractional number of hours

## Tests

Local

## Risk

Low — nullable column, defaults gracefully to 1-day window for all existing projects

## Deploy Plan

Run migration, deploy `front`
